### PR TITLE
fix(monorepo-utils): incorrect exports path

### DIFF
--- a/.changeset/thin-shrimps-appear.md
+++ b/.changeset/thin-shrimps-appear.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/monorepo-utils': patch
+---
+
+fix(monorepo-utils): incorrect exports path

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -12,13 +12,11 @@
   "version": "0.0.1",
   "jsnext:source": "./src/index.ts",
   "types": "./src/index.ts",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
       "jsnext:source": "./src/index.ts",
-      "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js",
-      "default": "./dist/cjs/index.js"
+      "default": "./dist/index.js"
     }
   },
   "files": [
@@ -27,7 +25,7 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
     "access": "public",
-    "types": "./dist/types/index.d.ts"
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "dev": "modern build --watch",


### PR DESCRIPTION
## Summary

Fix incorrect exports path.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
