### PR TITLE
fix(babel-preset): not register dynamic-import-node plugin for web

### DIFF
--- a/.changeset/silent-brooms-run.md
+++ b/.changeset/silent-brooms-run.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/babel-preset': patch
+'@rsbuild/shared': patch
+---
+
+fix(babel-preset): should not register dynamic-import-node plugin for web

--- a/packages/babel-preset/src/base.ts
+++ b/packages/babel-preset/src/base.ts
@@ -43,11 +43,10 @@ export const generateBaseConfig = (
   }
 
   if (pluginTransformRuntime) {
-    config.plugins?.push(require.resolve('babel-plugin-dynamic-import-node'), [
+    config.plugins?.push([
       require.resolve('@babel/plugin-transform-runtime'),
       {
         version: require('@babel/runtime/package.json').version,
-        regenerator: true,
       },
     ]);
   }

--- a/packages/babel-preset/src/node.ts
+++ b/packages/babel-preset/src/node.ts
@@ -8,11 +8,16 @@ export const getBabelPresetForNode = (options: NodePresetOptions = {}) => {
       presetEnv: {
         targets: ['node >= 14'],
       },
+      pluginTransformRuntime: {
+        regenerator: true,
+      },
     },
     options,
   );
 
   const config = generateBaseConfig(mergedOptions);
+
+  config.plugins?.push(require.resolve('babel-plugin-dynamic-import-node'));
 
   return config;
 };

--- a/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
@@ -1,0 +1,47 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should provide node preset as expected 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-dynamic-import-node/lib/index.js",
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "node >= 14",
+        ],
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;

--- a/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -1,0 +1,261 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`should allow to enable legacy decorator 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+      {
+        "decoratorsBeforeExport": false,
+        "version": "legacy",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "bugfixes": true,
+        "corejs": undefined,
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "Chrome >= 53",
+        ],
+        "useBuiltIns": false,
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`should allow to enable specific version decorator 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+      {
+        "decoratorsBeforeExport": true,
+        "version": "2018-09",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "bugfixes": true,
+        "corejs": undefined,
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "Chrome >= 53",
+        ],
+        "useBuiltIns": false,
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`should provide web preset as expected 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "bugfixes": true,
+        "corejs": undefined,
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "Chrome >= 53",
+        ],
+        "useBuiltIns": false,
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`should support inject core-js polyfills by entry 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "bugfixes": true,
+        "corejs": {
+          "proposals": true,
+          "version": "3.32",
+        },
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "Chrome >= 53",
+        ],
+        "useBuiltIns": "entry",
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;
+
+exports[`should support inject core-js polyfills by usage 1`] = `
+{
+  "plugins": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "bugfixes": true,
+        "corejs": {
+          "proposals": true,
+          "version": "3.32",
+        },
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": false,
+        "targets": [
+          "Chrome >= 53",
+        ],
+        "useBuiltIns": "usage",
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;

--- a/packages/babel-preset/tests/a.test.ts
+++ b/packages/babel-preset/tests/a.test.ts
@@ -1,3 +1,0 @@
-test('foo', () => {
-  expect(1).toEqual(1);
-});

--- a/packages/babel-preset/tests/node.test.ts
+++ b/packages/babel-preset/tests/node.test.ts
@@ -1,0 +1,5 @@
+import { getBabelPresetForNode } from '../src/node';
+
+test('should provide node preset as expected', () => {
+  expect(getBabelPresetForNode()).toMatchSnapshot();
+});

--- a/packages/babel-preset/tests/tsconfig.json
+++ b/packages/babel-preset/tests/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["vitest/globals"]
   },
-  "include": ["*.test.ts"]
+  "include": ["./*.test.ts"]
 }

--- a/packages/babel-preset/tests/web.test.ts
+++ b/packages/babel-preset/tests/web.test.ts
@@ -1,0 +1,62 @@
+import { getBabelPresetForWeb } from '../src/web';
+
+test('should provide web preset as expected', () => {
+  expect(
+    getBabelPresetForWeb({
+      presetEnv: {
+        targets: ['Chrome >= 53'],
+        useBuiltIns: false,
+      },
+    }),
+  ).toMatchSnapshot();
+});
+
+test('should support inject core-js polyfills by entry', () => {
+  expect(
+    getBabelPresetForWeb({
+      presetEnv: {
+        targets: ['Chrome >= 53'],
+        useBuiltIns: 'entry',
+      },
+    }),
+  ).toMatchSnapshot();
+});
+
+test('should support inject core-js polyfills by usage', () => {
+  expect(
+    getBabelPresetForWeb({
+      presetEnv: {
+        targets: ['Chrome >= 53'],
+        useBuiltIns: 'usage',
+      },
+    }),
+  ).toMatchSnapshot();
+});
+
+test('should allow to enable legacy decorator', () => {
+  expect(
+    getBabelPresetForWeb({
+      presetEnv: {
+        targets: ['Chrome >= 53'],
+        useBuiltIns: false,
+      },
+      pluginDecorators: {
+        version: 'legacy',
+      },
+    }),
+  ).toMatchSnapshot();
+});
+
+test('should allow to enable specific version decorator', () => {
+  expect(
+    getBabelPresetForWeb({
+      presetEnv: {
+        targets: ['Chrome >= 53'],
+        useBuiltIns: false,
+      },
+      pluginDecorators: {
+        version: '2018-09',
+      },
+    }),
+  ).toMatchSnapshot();
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,8 @@
   "main": "./dist/index.js",
   "exports": {
     ".": {
-      "node": "./dist/index.js"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     },
     "./chalk": {
       "types": "./dist/re-exports/chalk.d.ts",

--- a/packages/shared/tests/a.test.ts
+++ b/packages/shared/tests/a.test.ts
@@ -1,5 +1,3 @@
-import { test, expect } from 'vitest';
-
 test('foo', () => {
   expect(1).toEqual(1);
 });

--- a/packages/shared/tests/tsconfig.json
+++ b/packages/shared/tests/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["vitest/globals"]
   },
-  "include": ["*.test.ts"]
+  "include": ["./*.test.ts"]
 }

--- a/packages/vitest-helper/CHANGELOG.md
+++ b/packages/vitest-helper/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @rsbuild/vitest-helper

--- a/packages/vitest-helper/LICENSE
+++ b/packages/vitest-helper/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Bytedance, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vitest-helper/README.md
+++ b/packages/vitest-helper/README.md
@@ -1,0 +1,26 @@
+<p align="center">
+  <a href="https://rsbuild.dev" target="blank"><img src="https://lf3-static.bytednsdoc.com/obj/eden-cn/ylaelkeh7nuhfnuhf/modernjs-cover.png" width="300" alt="Rsbuild Logo" /></a>
+</p>
+
+<h1 align="center">Rsbuild</h1>
+
+<p align="center">
+  An Rspack-based build tool for the web
+</p>
+
+## Getting Started
+
+Please follow [Quick Start](https://rsbuild.dev/guides/get-started/quick-start) to get started with Rsbuild.
+
+## Documentation
+
+- [English Documentation](https://rsbuild.dev/)
+- [中文文档](https://rsbuild.dev/zh)
+
+## Contributing
+
+Please read the [Contributing Guide](https://github.com/web-infra-dev/rsbuild/blob/main/CONTRIBUTING.md).
+
+## License
+
+Rsbuild is [MIT licensed](https://github.com/web-infra-dev/rsbuild/blob/main/LICENSE).

--- a/packages/vitest-helper/package.json
+++ b/packages/vitest-helper/package.json
@@ -1,5 +1,13 @@
 {
   "name": "@rsbuild/vitest-helper",
+  "description": "The vitest helpers of Rsbuild.",
+  "homepage": "https://rsbuild.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-infra-dev/rsbuild",
+    "directory": "packages/vitest-helper"
+  },
+  "license": "MIT",
   "version": "0.0.3",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,6 +24,12 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true,
+    "types": "./dist/index.d.ts"
+  },
   "dependencies": {
     "@types/node": "^16",
     "@types/lodash": "^4.14.195",


### PR DESCRIPTION
## Summary

- Should not register dynamic-import-node plugin for web
- Add some test cases

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
