### PR TITLE
fix(babel-preset): failed to resolve babel runtime for node bundles

### DIFF
--- a/.changeset/clean-sloths-rush.md
+++ b/.changeset/clean-sloths-rush.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/babel-preset': patch
+---
+
+fix(babel-preset): failed to resolve babel runtime for node bundles

--- a/packages/babel-preset/src/base.ts
+++ b/packages/babel-preset/src/base.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import type { BabelConfig, BasePresetOptions } from './types';
 
 export const generateBaseConfig = (
@@ -69,6 +70,7 @@ export const generateBaseConfig = (
   }
 
   config.plugins?.push(
+    join(__dirname, './pluginLockCorejsVersion'),
     // Stage 1
     // link: https://github.com/tc39/proposal-export-default-from
     require.resolve('@babel/plugin-proposal-export-default-from'),

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { getCoreJsVersion } from '@rsbuild/shared';
 import { deepmerge } from '@rsbuild/shared/deepmerge';
 import { generateBaseConfig } from './base';
@@ -26,8 +25,6 @@ export const getBabelConfigForWeb = (options: WebPresetOptions) => {
   );
 
   const config = generateBaseConfig(mergedOptions);
-
-  config.plugins?.push(join(__dirname, './pluginLockCorejsVersion'));
 
   return config;
 };

--- a/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
@@ -10,6 +10,7 @@ exports[`should provide node preset as expected 1`] = `
         "version": "7.23.1",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [

--- a/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should allow to enable legacy decorator 1`] = `
         "version": "legacy",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -24,7 +25,6 @@ exports[`should allow to enable legacy decorator 1`] = `
         "proposal": "minimal",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -73,6 +73,7 @@ exports[`should allow to enable specific version decorator 1`] = `
         "version": "2018-09",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -81,7 +82,6 @@ exports[`should allow to enable specific version decorator 1`] = `
         "proposal": "minimal",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -123,6 +123,7 @@ exports[`should provide web preset as expected 1`] = `
         "version": "7.23.1",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -131,7 +132,6 @@ exports[`should provide web preset as expected 1`] = `
         "proposal": "minimal",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -173,6 +173,7 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "version": "7.23.1",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -181,7 +182,6 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "proposal": "minimal",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -226,6 +226,7 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "version": "7.23.1",
       },
     ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -234,7 +235,6 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "proposal": "minimal",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [


### PR DESCRIPTION
## Summary

Fix failed to resolve babel runtime for node bundles.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
