### PR TITLE
feat(babel-preset): support Jest to use node preset

### DIFF
--- a/.changeset/tender-cougars-smash.md
+++ b/.changeset/tender-cougars-smash.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/babel-preset': patch
+---
+
+feat(babel-preset): support Jest to use node preset

--- a/packages/babel-preset/src/node.ts
+++ b/packages/babel-preset/src/node.ts
@@ -8,9 +8,6 @@ export const getBabelConfigForNode = (options: NodePresetOptions = {}) => {
       presetEnv: {
         targets: ['node >= 14'],
       },
-      pluginTransformRuntime: {
-        regenerator: true,
-      },
     },
     options,
   );

--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -38,7 +38,6 @@ export type BasePresetOptions = {
   presetEnv?: PresetEnvOptions | false;
   presetTypeScript?: Record<string, unknown> | false;
   pluginDecorators?: PluginDecoratorsOptions | false;
-  pluginTransformRuntime?: Record<string, unknown> | false;
 };
 
 export type WebPresetOptions = BasePresetOptions & {
@@ -46,6 +45,7 @@ export type WebPresetOptions = BasePresetOptions & {
     targets: PresetEnvTargets;
     useBuiltIns: PresetEnvBuiltIns;
   };
+  pluginTransformRuntime?: Record<string, unknown> | false;
 };
 
 export type NodePresetOptions = BasePresetOptions & {

--- a/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
@@ -3,14 +3,6 @@
 exports[`should provide node preset as expected 1`] = `
 {
   "plugins": [
-    [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -28,7 +20,7 @@ exports[`should provide node preset as expected 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "node >= 14",
         ],

--- a/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -4,19 +4,11 @@ exports[`should allow to enable legacy decorator 1`] = `
 {
   "plugins": [
     [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    [
       "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
       {
         "version": "legacy",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -25,6 +17,14 @@ exports[`should allow to enable legacy decorator 1`] = `
         "proposal": "minimal",
       },
     ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "useESModules": true,
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -35,7 +35,7 @@ exports[`should allow to enable legacy decorator 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "Chrome >= 53",
         ],
@@ -60,20 +60,12 @@ exports[`should allow to enable specific version decorator 1`] = `
 {
   "plugins": [
     [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    [
       "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
       {
         "decoratorsBeforeExport": true,
         "version": "2018-09",
       },
     ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -82,6 +74,14 @@ exports[`should allow to enable specific version decorator 1`] = `
         "proposal": "minimal",
       },
     ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "useESModules": true,
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -92,7 +92,7 @@ exports[`should allow to enable specific version decorator 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "Chrome >= 53",
         ],
@@ -116,14 +116,6 @@ exports[`should allow to enable specific version decorator 1`] = `
 exports[`should provide web preset as expected 1`] = `
 {
   "plugins": [
-    [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -132,6 +124,14 @@ exports[`should provide web preset as expected 1`] = `
         "proposal": "minimal",
       },
     ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "useESModules": true,
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -142,7 +142,7 @@ exports[`should provide web preset as expected 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "Chrome >= 53",
         ],
@@ -166,14 +166,6 @@ exports[`should provide web preset as expected 1`] = `
 exports[`should support inject core-js polyfills by entry 1`] = `
 {
   "plugins": [
-    [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -182,6 +174,14 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "proposal": "minimal",
       },
     ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "useESModules": true,
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -195,7 +195,7 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "Chrome >= 53",
         ],
@@ -219,14 +219,6 @@ exports[`should support inject core-js polyfills by entry 1`] = `
 exports[`should support inject core-js polyfills by usage 1`] = `
 {
   "plugins": [
-    [
-      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-      {
-        "useESModules": true,
-        "version": "7.23.1",
-      },
-    ],
-    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
     "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
     [
@@ -235,6 +227,14 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "proposal": "minimal",
       },
     ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+      {
+        "useESModules": true,
+        "version": "7.23.1",
+      },
+    ],
+    "<ROOT>/packages/babel-preset/src/pluginLockCorejsVersion",
   ],
   "presets": [
     [
@@ -248,7 +248,7 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "exclude": [
           "transform-typeof-symbol",
         ],
-        "modules": false,
+        "modules": "commonjs",
         "targets": [
           "Chrome >= 53",
         ],


### PR DESCRIPTION
## Summary

Support Jest to use node preset.

https://github.com/web-infra-dev/rsbuild/issues/53

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
