### PR TITLE
chore(cli): enable jiti esmResolve option

### DIFF
--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -23,7 +23,10 @@ export async function loadConfig(): Promise<BuilderConfig> {
   const configFile = join(process.cwd(), 'rsbuild.config.ts');
 
   if (existsSync(configFile)) {
-    const loadConfig = jiti(__filename, { interopDefault: true });
+    const loadConfig = jiti(__filename, {
+      esmResolve: true,
+      interopDefault: true,
+    });
     return loadConfig(configFile);
   }
 


### PR DESCRIPTION
## Summary

enable jiti esmResolve option, it will be enabled by default in jiti v2.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
