### PR TITLE
chore: remove unused context.framework property

### DIFF
--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -63,7 +63,6 @@ type CreateRsbuildOptions = {
   cwd?: string;
   entry?: RsbuildEntry;
   target?: RsbuildTarget | RsbuildTarget[];
-  framework?: string;
   configPath?: string | null;
 };
 ```
@@ -73,8 +72,7 @@ Description:
 - `cwd`: The root path of the current build, the default value is `process.cwd()`.
 - `entry`: Build entry object.
 - `target`: Build target type, the default value is `['web']`, see chapter [Build Target](/api/start/build-target.html) for details.
-- `framework`: The name of the framework, a unique identifier, the default value is `'modern.js'`.
-- `configPath`: The path to the framework config file (absolute path), this parameter affects the build cache update.
+- `configPath`: The path to the config file of higher-level solution (absolute path), this parameter affects the build cache update.
 
 ## mergeRsbuildConfig
 

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -76,7 +76,7 @@ type CachePath = string;
 
 ### rsbuild.context.configPath
 
-The absolute path to the framework config file, corresponding to the `configPath` option of `createRsbuild` method.
+The absolute path to the config file of higher-level solution, corresponding to the `configPath` option of `createRsbuild` method.
 
 - **Type**
 
@@ -92,16 +92,6 @@ The absolute path of the tsconfig.json file, or `undefined` if the tsconfig.json
 
 ```ts
 type TsconfigPath = string | undefined;
-```
-
-### rsbuild.context.framework
-
-The name of the framework, a unique identifier, the default value is `'modern.js'`.
-
-- **Type**
-
-```ts
-type Framework = string | undefined;
 ```
 
 ### rsbuild.context.devServer

--- a/packages/document/docs/en/guide/basic/html-template.md
+++ b/packages/document/docs/en/guide/basic/html-template.md
@@ -6,7 +6,7 @@ Rsbuild provides some configs to set the HTML template. Through this chapter, yo
 
 ## Set Template
 
-HTML templates are usually predefined by the upper framework.
+HTML templates are usually predefined by the higher level solutions.
 
 For example, in the Modern.js framework, the HTML template is preset by default, and users can also customize the content of the template. You can read the ["Modern.js - HTML Template"](https://modernjs.dev/en/guides/basic-features/html.html) chapter to learn about it.
 

--- a/packages/document/docs/en/guide/basic/output-files.md
+++ b/packages/document/docs/en/guide/basic/output-files.md
@@ -92,7 +92,7 @@ dist
 
 ## Node.js Output Directory
 
-When the [Build Target](/api/start/build-target.html) of Rsbuild contains `'node'`, or you have enabled server-side features such as SSR in the upper framework, Rsbuild will generate some output files for Node.js and output them to the `bundles` directory:
+When the [Build Target](/api/start/build-target.html) of Rsbuild contains `'node'`, or you have enabled server-side features such as SSR in the higher level solutions, Rsbuild will generate some output files for Node.js and output them to the `bundles` directory:
 
 ```bash
 dist

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -63,7 +63,6 @@ type CreateRsbuildOptions = {
   cwd?: string;
   entry?: RsbuildEntry;
   target?: RsbuildTarget | RsbuildTarget[];
-  framework?: string;
   configPath?: string | null;
 };
 ```
@@ -73,8 +72,7 @@ type CreateRsbuildOptions = {
 - `cwd`: 当前执行构建的根路径，默认值为 `process.cwd()`
 - `entry`: 构建入口对象
 - `target`: 构建产物类型，默认值为 `['web']`，详见 [构建产物类型](/api/start/build-target.html) 章节。
-- `framework`: 框架的英文名称，唯一标识符，默认值为 `'modern.js'`
-- `configPath`: 框架配置文件的路径（绝对路径），该参数影响构建缓存更新
+- `configPath`: 上层解决方案配置文件的路径（绝对路径），该参数影响构建缓存更新
 
 ## mergeRsbuildConfig
 

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -94,16 +94,6 @@ tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件
 type TsconfigPath = string | undefined;
 ```
 
-### rsbuild.context.framework
-
-框架的英文名称，唯一标识符，默认值为 `'modern.js'`。
-
-- **类型**
-
-```ts
-type Framework = string | undefined;
-```
-
 ### rsbuild.context.devServer
 
 Dev Server 相关信息，包含了当前 Dev Server 的 hostname 和端口号。

--- a/packages/shared/src/applyDefaultBuilderOptions.ts
+++ b/packages/shared/src/applyDefaultBuilderOptions.ts
@@ -6,7 +6,6 @@ export function applyDefaultBuilderOptions(options?: CreateBuilderOptions) {
     entry: {},
     target: ['web'],
     configPath: null,
-    framework: 'modern-js',
     ...options,
   } as Required<CreateBuilderOptions>;
 }

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -17,7 +17,7 @@ export function createContextByConfig(
   outputConfig: NormalizedSharedOutputConfig,
   bundlerType: BundlerType,
 ): BuilderContext {
-  const { cwd, target, configPath, framework } = options;
+  const { cwd, target, configPath } = options;
   const rootPath = cwd;
   const srcPath = join(rootPath, 'src');
 
@@ -31,7 +31,6 @@ export function createContextByConfig(
     rootPath,
     distPath,
     cachePath,
-    framework,
     bundlerType,
   };
 
@@ -52,7 +51,6 @@ export function createPublicContext(
     'rootPath',
     'distPath',
     'devServer',
-    'framework',
     'cachePath',
     'configPath',
     'tsconfigPath',

--- a/packages/shared/src/types/builder.ts
+++ b/packages/shared/src/types/builder.ts
@@ -15,9 +15,7 @@ export type CreateBuilderOptions = {
   entry?: BuilderEntry;
   /** Type of build target. */
   target?: BuilderTarget | BuilderTarget[];
-  /** Framework name, such as 'modern.js' */
-  framework?: string;
-  /** Absolute path of framework config file. */
+  /** Absolute path to the config file of higher-level solutions. */
   configPath?: string | null;
 };
 

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -14,11 +14,9 @@ export type BuilderContext = {
   srcPath: string;
   /** Absolute path of output files. */
   distPath: string;
-  /** The name of framework, such as `modern-js`. */
-  framework: string;
   /** Absolute path of cache files. */
   cachePath: string;
-  /** Absolute path of framework config file. */
+  /** Absolute path to the config file of hight-level solutions. */
   configPath?: string;
   /** Absolute path of tsconfig.json. */
   tsconfigPath?: string;

--- a/packages/webpack/src/plugins/babel.ts
+++ b/packages/webpack/src/plugins/babel.ts
@@ -147,7 +147,7 @@ export const builderPluginBabel = (): BuilderPlugin => ({
 
         /**
          * If a script is imported with data URI, it can be compiled by babel too.
-         * This is used by some frameworks to create virtual entry.
+         * This is used by some higher-level solutions to create virtual entry.
          * https://webpack.js.org/api/module-methods/#import
          * @example: import x from 'data:text/javascript,export default 1;';
          */


### PR DESCRIPTION
## Summary

Remove unused `context.framework` property.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
