### PR TITLE
chore: decouple some methods from modern.js utils

### DIFF
--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -1,7 +1,7 @@
 import jiti from 'jiti';
 import { join } from 'path';
 import { findExists } from '@modern-js/utils';
-import { existsSync } from '@modern-js/utils/fs-extra';
+import { fs } from '@rsbuild/shared/fs-extra';
 import type { BuilderEntry, BuilderPlugin } from '@rsbuild/shared';
 // TODO webpack config type
 // import type { BuilderConfig as WebpackBuilderConfig } from '@rsbuild/webpack';
@@ -22,7 +22,7 @@ export const defineConfig = <Bundler extends 'rspack' | 'webpack' = 'webpack'>(
 export async function loadConfig(): Promise<BuilderConfig> {
   const configFile = join(process.cwd(), 'rsbuild.config.ts');
 
-  if (existsSync(configFile)) {
+  if (fs.existsSync(configFile)) {
     const loadConfig = jiti(__filename, {
       esmResolve: true,
       interopDefault: true,

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -4,6 +4,7 @@
  */
 import path from 'path';
 import { chalk } from '@rsbuild/shared/chalk';
+import { fs } from '@rsbuild/shared/fs-extra';
 import { logger, Stats, MultiStats, StatsAsset } from '@rsbuild/shared';
 import type { DefaultBuilderPlugin } from '@rsbuild/shared';
 
@@ -40,9 +41,7 @@ async function printHeader(
 }
 
 async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
-  const { fs, filesize, gzipSize, stripAnsi } = await import(
-    '@modern-js/utils'
-  );
+  const { filesize, gzipSize, stripAnsi } = await import('@modern-js/utils');
 
   const formatAsset = (asset: StatsAsset) => {
     const contents = fs.readFileSync(path.join(distPath, asset.name));

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import {
   isURL,
   isFileExists,
+  isPlainObject,
   isHtmlDisabled,
   getDistPath,
   getMinify,
@@ -10,8 +11,10 @@ import {
   getFavicon,
   getMetaTags,
   getTemplatePath,
+  ROUTE_SPEC_FILE,
   type FaviconUrls,
 } from '@rsbuild/shared';
+import { fs } from '@rsbuild/shared/fs-extra';
 import type {
   DefaultBuilderPlugin,
   SharedNormalizedConfig,
@@ -66,7 +69,6 @@ async function getTemplateParameters(
 }
 
 async function getChunks(entryName: string, entryValue: string | string[]) {
-  const { isPlainObject } = await import('@modern-js/utils');
   const dependOn = [];
 
   if (isPlainObject(entryValue)) {
@@ -260,7 +262,6 @@ export const builderPluginHtml = (): DefaultBuilderPlugin => ({
     );
 
     const emitRouteJson = async () => {
-      const { fs, ROUTE_SPEC_FILE } = await import('@modern-js/utils');
       const routeFilePath = path.join(api.context.distPath, ROUTE_SPEC_FILE);
 
       // generate a basic route.json for modern.js server

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -1,4 +1,5 @@
 import {
+  isDev,
   debug,
   logger,
   prettyTime,
@@ -20,7 +21,6 @@ export async function createCompiler({
   });
 
   const { rspack } = await import('@rspack/core');
-  const { isDev } = await import('@modern-js/utils');
 
   const compiler = rspack(rspackConfigs);
 

--- a/packages/core/src/rspack-provider/plugins/rspack-profile.ts
+++ b/packages/core/src/rspack-provider/plugins/rspack-profile.ts
@@ -5,7 +5,7 @@ import {
   experimental_cleanupGlobalTrace as cleanupGlobalTrace,
 } from '@rspack/core';
 import inspector from 'inspector';
-import { fs } from '@modern-js/utils';
+import { fs } from '@rsbuild/shared/fs-extra';
 import { logger } from '@rsbuild/shared';
 
 export const stopProfiler = (

--- a/packages/core/src/rspack-provider/plugins/swc.ts
+++ b/packages/core/src/rspack-provider/plugins/swc.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import { getCoreJsVersion } from '@rsbuild/shared';
 import {
   BuilderTarget,
   getBrowserslistWithDefault,
@@ -88,7 +89,7 @@ async function applyDefaultConfig(
     } else {
       rspackConfig.builtins.presetEnv.mode = polyfillMode;
       /* Apply core-js version and path alias */
-      await applyCoreJs(rspackConfig);
+      applyCoreJs(rspackConfig);
     }
   }
 
@@ -112,8 +113,7 @@ async function setBrowserslist(
   }
 }
 
-async function applyCoreJs(rspackConfig: RspackConfig) {
-  const { getCoreJsVersion } = await import('@modern-js/utils');
+function applyCoreJs(rspackConfig: RspackConfig) {
   const coreJsPath = require.resolve('core-js/package.json');
   const version = getCoreJsVersion(coreJsPath);
 

--- a/packages/core/src/rspack-provider/shared/fs.ts
+++ b/packages/core/src/rspack-provider/shared/fs.ts
@@ -3,7 +3,7 @@ import {
   getSharedPkgCompiledPath,
   SharedCompiledPkgNames,
 } from '@rsbuild/shared';
-import { fs } from '@modern-js/utils';
+import { fs } from '@rsbuild/shared/fs-extra';
 
 export const getCompiledPath = (packageName: string) => {
   const providerCompilerPath = join(__dirname, '../../compiled', packageName);

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "dependencies": {
-    "@modern-js/utils": "^2.36.0",
+    "@rsbuild/shared": "workspace:*",
     "@napi-rs/image": "^1.7.0",
     "svgo": "^3.0.2"
   },

--- a/packages/plugin-image-compress/src/shared/utils.ts
+++ b/packages/plugin-image-compress/src/shared/utils.ts
@@ -1,10 +1,9 @@
 import assert from 'assert';
-import _ from '@modern-js/utils/lodash';
 import { FinalOptions, Options } from '../types';
 import codecs from './codecs';
 
 export const withDefaultOptions = (opt: Options): FinalOptions => {
-  const options = _.isString(opt) ? { use: opt } : opt;
+  const options = typeof opt === 'string' ? { use: opt } : opt;
   const { defaultOptions } = codecs[options.use];
   const ret = { ...defaultOptions, ...options };
   assert('test' in ret);

--- a/packages/plugin-image-compress/tests/shared/codecs.test.ts
+++ b/packages/plugin-image-compress/tests/shared/codecs.test.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import path from 'path';
-import fs from '@modern-js/utils/fs-extra';
+import { fs } from '@rsbuild/shared/fs-extra';
 import { describe, expect, it } from 'vitest';
 import codecs from '../../src/shared/codecs';
 

--- a/packages/plugin-swc/tests/browserslist.ts
+++ b/packages/plugin-swc/tests/browserslist.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { getBrowserslist } from '@modern-js/utils';
+import { getBrowserslist } from '@rsbuild/shared';
 import { expect } from 'vitest';
 import { transformSync } from '../src/binding';
 import {

--- a/packages/shared/src/apply/output.ts
+++ b/packages/shared/src/apply/output.ts
@@ -5,9 +5,12 @@ import type {
   SharedNormalizedConfig,
 } from '../types';
 import { getDistPath, getFilename } from '../fs';
-import { DEFAULT_PORT, DEFAULT_ASSET_PREFIX } from '../constants';
+import {
+  DEFAULT_PORT,
+  DEFAULT_DEV_HOST,
+  DEFAULT_ASSET_PREFIX,
+} from '../constants';
 import { addTrailingSlash } from '../utils';
-import { DEFAULT_DEV_HOST } from '@modern-js/utils';
 
 export function applyBuilderOutputPlugin(api: SharedBuilderPluginAPI) {
   api.modifyBundlerChain(

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -40,7 +40,7 @@ import type { minify } from 'terser';
 import fs from 'fs-extra';
 
 import _ from '@modern-js/utils/lodash';
-import { DEFAULT_DEV_HOST } from '@modern-js/utils';
+import { DEFAULT_DEV_HOST } from './constants';
 import { getJSMinifyOptions } from './minimize';
 
 export const getDefaultDevConfig = (): NormalizedSharedDevConfig => ({

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -7,6 +7,7 @@ export const WEBPACK_PROVIDER = '@rsbuild/webpack';
 export const DEFAULT_PORT = 8080;
 export const DEFAULT_DATA_URL_SIZE = 10000;
 export const DEFAULT_MOUNT_ID = 'root';
+export const DEFAULT_DEV_HOST = '0.0.0.0';
 
 const DEFAULT_WEB_BROWSERSLIST = [
   'chrome >= 87',
@@ -79,6 +80,8 @@ export const MODULE_PATH_REGEX =
 
 export const RUNTIME_CHUNK_NAME = 'builder-runtime';
 export const TS_CONFIG_FILE = 'tsconfig.json';
+
+export const ROUTE_SPEC_FILE = 'route.json';
 
 export const TARGET_ID_MAP: Record<BuilderTarget, string> = {
   web: 'Client',

--- a/packages/shared/src/devServer.ts
+++ b/packages/shared/src/devServer.ts
@@ -7,10 +7,11 @@ import type {
   OnBeforeStartDevServerFn,
   CompilerTapFn,
 } from './types';
+import { isFunction } from './utils';
 import type { ModernDevServerOptions, Server } from '@modern-js/server';
 import deepmerge from 'deepmerge';
 import { logger as defaultLogger, debug } from './logger';
-import { DEFAULT_PORT } from './constants';
+import { DEFAULT_PORT, DEFAULT_DEV_HOST } from './constants';
 import { createAsyncHook } from './createHook';
 import { getServerOptions, printServerURLs } from './prodServer';
 import type { Compiler } from 'webpack';
@@ -108,9 +109,7 @@ export async function startDevServer<
     process.env.NODE_ENV = 'development';
   }
 
-  const { getPort, isFunction, DEFAULT_DEV_HOST } = await import(
-    '@modern-js/utils'
-  );
+  const { getPort } = await import('@modern-js/utils');
   const builderConfig = options.context.config;
 
   const port = await getPort(builderConfig.dev?.port || DEFAULT_PORT, {

--- a/packages/shared/src/getBrowserslist.ts
+++ b/packages/shared/src/getBrowserslist.ts
@@ -1,3 +1,4 @@
+import browserslist from 'browserslist';
 import { DEFAULT_BROWSERSLIST } from './constants';
 import type {
   BuilderTarget,
@@ -13,9 +14,6 @@ export async function getBrowserslist(path: string) {
     return browsersListCache.get(path)!;
   }
 
-  const { default: browserslist } = await import(
-    '@modern-js/utils/browserslist'
-  );
   const result = browserslist.loadConfig({ path });
 
   if (result) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,15 +1,3 @@
-import fs from 'fs-extra';
-
-export const getCoreJsVersion = (corejsPkgPath: string) => {
-  try {
-    const { version } = fs.readJSONSync(corejsPkgPath);
-    const [major, minor] = version.split('.');
-    return `${major}.${minor}`;
-  } catch (err) {
-    return '3';
-  }
-};
-
 export * from './applyDefaultBuilderOptions';
 export * from './constants';
 export * from './createHook';

--- a/packages/shared/src/mergeBuilderConfig.ts
+++ b/packages/shared/src/mergeBuilderConfig.ts
@@ -1,4 +1,5 @@
 import _ from '@modern-js/utils/lodash';
+import { isFunction, isUndefined } from './utils';
 import { isOverriddenConfigKey } from '@modern-js/utils';
 
 export const mergeBuilderConfig = <T>(...configs: T[]): T =>
@@ -7,7 +8,7 @@ export const mergeBuilderConfig = <T>(...configs: T[]): T =>
     ...configs,
     (target: unknown, source: unknown, key: string) => {
       const pair = [target, source];
-      if (pair.some(_.isUndefined)) {
+      if (pair.some(isUndefined)) {
         // fallback to lodash default merge behavior
         return undefined;
       }
@@ -17,11 +18,11 @@ export const mergeBuilderConfig = <T>(...configs: T[]): T =>
         return source ?? target;
       }
 
-      if (pair.some(_.isArray)) {
+      if (pair.some(Array.isArray)) {
         return [..._.castArray(target), ..._.castArray(source)];
       }
       // convert function to chained function
-      if (pair.some(_.isFunction)) {
+      if (pair.some(isFunction)) {
         return [target, source];
       }
       // fallback to lodash default merge behavior

--- a/packages/shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -6,8 +6,7 @@
  * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/InlineChunkHtmlPlugin.js
  */
 import { join } from 'path';
-import { isFunction, isString } from '@modern-js/utils';
-import { addTrailingSlash } from '../utils';
+import { isFunction, addTrailingSlash } from '../utils';
 import type { Compiler, Compilation } from 'webpack';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { HtmlTagObject } from 'html-webpack-plugin';
@@ -91,7 +90,7 @@ export class InlineChunkHtmlPlugin {
   }
 
   matchTests(name: string, source: string, tests: InlineChunkTest[]) {
-    return tests.some(test => {
+    return tests.some((test) => {
       if (isFunction(test)) {
         const size = source.length;
         return test({ name, size });
@@ -108,7 +107,7 @@ export class InlineChunkHtmlPlugin {
     const { assets } = compilation;
 
     // No need to inline scripts with src attribute
-    if (!(tag?.attributes.src && isString(tag.attributes.src))) {
+    if (!(tag?.attributes.src && typeof tag.attributes.src === 'string')) {
       return tag;
     }
 
@@ -155,7 +154,7 @@ export class InlineChunkHtmlPlugin {
     const { assets } = compilation;
 
     // No need to inline styles with href attribute
-    if (!(tag.attributes.href && isString(tag.attributes.href))) {
+    if (!(tag.attributes.href && typeof tag.attributes.href === 'string')) {
       return tag;
     }
 
@@ -229,7 +228,7 @@ export class InlineChunkHtmlPlugin {
 
       const hooks = this.htmlPlugin.getHooks(compilation);
 
-      hooks.alterAssetTagGroups.tap(this.name, assets => {
+      hooks.alterAssetTagGroups.tap(this.name, (assets) => {
         assets.headTags = assets.headTags.map(tagFunction);
         assets.bodyTags = assets.bodyTags.map(tagFunction);
         return assets;
@@ -247,7 +246,7 @@ export class InlineChunkHtmlPlugin {
         () => {
           const { devtool } = compiler.options;
 
-          this.inlinedAssets.forEach(name => {
+          this.inlinedAssets.forEach((name) => {
             // If the source map reference is removed,
             // we do not need to preserve the source map of inlined files
             if (devtool === 'hidden-source-map') {

--- a/packages/shared/src/prodServer.ts
+++ b/packages/shared/src/prodServer.ts
@@ -4,7 +4,7 @@ import prodServer, {
 } from '@modern-js/prod-server';
 import chalk from 'chalk';
 import { logger as defaultLogger } from './logger';
-import { DEFAULT_PORT } from './constants';
+import { DEFAULT_PORT, DEFAULT_DEV_HOST } from './constants';
 import type {
   BuilderContext,
   StartServerResult,
@@ -58,7 +58,7 @@ export async function startProdServer(
     process.env.NODE_ENV = 'production';
   }
 
-  const { getPort, DEFAULT_DEV_HOST } = await import('@modern-js/utils');
+  const { getPort } = await import('@modern-js/utils');
 
   const port = await getPort(builderConfig.dev?.port || DEFAULT_PORT);
   const server = await prodServer({

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -4,6 +4,23 @@ import type {
   SharedCompiledPkgNames,
 } from './types';
 import { join } from 'path';
+import fs from 'fs-extra';
+
+export const isDev = (): boolean => process.env.NODE_ENV === 'development';
+export const isProd = (): boolean => process.env.NODE_ENV === 'production';
+export const isTest = () => process.env.NODE_ENV === 'test';
+export const isString = (str: unknown): str is string =>
+  typeof str === 'string';
+export const isUndefined = (obj: unknown): obj is undefined =>
+  typeof obj === 'undefined';
+export const isFunction = (func: unknown): func is (...args: any[]) => any =>
+  typeof func === 'function';
+export const isObject = (obj: unknown): obj is Record<string, any> =>
+  obj !== null && typeof obj === 'object';
+export const isPlainObject = (obj: unknown): obj is Record<string, any> =>
+  isObject(obj) && Object.prototype.toString.call(obj) === '[object Object]';
+export const isRegExp = (obj: any): obj is RegExp =>
+  Object.prototype.toString.call(obj) === '[object RegExp]';
 
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
@@ -79,3 +96,13 @@ export function resolvePackage(loader: string, dirname: string) {
     ? loader
     : require.resolve(loader, { paths: [dirname] });
 }
+
+export const getCoreJsVersion = (corejsPkgPath: string) => {
+  try {
+    const { version } = fs.readJSONSync(corejsPkgPath);
+    const [major, minor] = version.split('.');
+    return `${major}.${minor}`;
+  } catch (err) {
+    return '3';
+  }
+};

--- a/packages/webpack/src/core/createCompiler.ts
+++ b/packages/webpack/src/core/createCompiler.ts
@@ -1,4 +1,4 @@
-import { logger, debug, formatStats, type Stats } from '@rsbuild/shared';
+import { isDev, logger, debug, formatStats, type Stats } from '@rsbuild/shared';
 import type { Context, WebpackConfig } from '../types';
 
 export async function createCompiler({
@@ -14,7 +14,6 @@ export async function createCompiler({
   });
 
   const { default: webpack } = await import('webpack');
-  const { isDev } = await import('@modern-js/utils');
 
   const compiler =
     webpackConfigs.length === 1

--- a/packages/webpack/src/exports/HtmlWebpackPlugin.ts
+++ b/packages/webpack/src/exports/HtmlWebpackPlugin.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 export default HtmlWebpackPlugin;

--- a/packages/webpack/src/exports/webpack.ts
+++ b/packages/webpack/src/exports/webpack.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import webpack from 'webpack';
 
 export default webpack;

--- a/packages/webpack/src/plugins/copy.ts
+++ b/packages/webpack/src/plugins/copy.ts
@@ -1,3 +1,4 @@
+import { fs } from '@rsbuild/shared/fs-extra';
 import type { CopyPluginOptions, BuilderPlugin } from '../types';
 
 export const builderPluginCopy = (): BuilderPlugin => ({
@@ -29,8 +30,6 @@ export const builderPluginCopy = (): BuilderPlugin => ({
       ) as unknown as CopyPluginOptions;
 
       if (copyPlugin) {
-        const { fs } = await import('@modern-js/utils');
-
         // If the pattern.context directory not exists, we should remove CopyPlugin.
         // Otherwise the CopyPlugin will cause the webpack to re-compile.
         const isContextNotExists = copyPlugin.patterns.every(

--- a/packages/webpack/src/plugins/react.ts
+++ b/packages/webpack/src/plugins/react.ts
@@ -1,12 +1,12 @@
 import type { BuilderConfig, BuilderPlugin } from '../types';
-import { isUsingHMR } from '@rsbuild/shared';
+import { isProd, isUsingHMR } from '@rsbuild/shared';
 
 export const builderPluginReact = (): BuilderPlugin => ({
   name: 'builder-plugin-react',
 
   setup(api) {
     api.modifyBuilderConfig(async (config, { mergeBuilderConfig }) => {
-      const { isProd, isBeyondReact17 } = await import('@modern-js/utils');
+      const { isBeyondReact17 } = await import('@modern-js/utils');
 
       const babelConfig: BuilderConfig = {
         tools: {

--- a/packages/webpack/src/shared/fs.ts
+++ b/packages/webpack/src/shared/fs.ts
@@ -1,11 +1,9 @@
 import { join } from 'path';
-
 import {
   getSharedPkgCompiledPath,
   SharedCompiledPkgNames,
 } from '@rsbuild/shared';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { fs } from '@modern-js/utils';
+import { fs } from '@rsbuild/shared/fs-extra';
 
 export const getCompiledPath = (packageName: string) => {
   const providerCompilerPath = join(__dirname, '../../compiled', packageName);

--- a/packages/webpack/src/types/config/index.ts
+++ b/packages/webpack/src/types/config/index.ts
@@ -37,7 +37,6 @@ export type NormalizedConfig = DeepReadonly<{
   experiments: NormalizedExperimentsConfig;
 }>;
 
-/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from './dev';
 export * from './experiments';
 export * from './html';
@@ -46,4 +45,3 @@ export * from './performance';
 export * from './security';
 export * from './source';
 export * from './tools';
-/* eslint-enable @typescript-eslint/no-restricted-imports */

--- a/packages/webpack/src/types/index.ts
+++ b/packages/webpack/src/types/index.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-restricted-imports */
 export * from './hooks';
 export * from './config';
 export * from './plugin';
 export * from './context';
 export * from './thirdParty';
-/* eslint-enable @typescript-eslint/no-restricted-imports */

--- a/packages/webpack/src/types/thirdParty/CopyWebpackPlugin.ts
+++ b/packages/webpack/src/types/thirdParty/CopyWebpackPlugin.ts
@@ -1,7 +1,6 @@
 /**
  * Ref: https://github.com/webpack-contrib/copy-webpack-plugin/blob/master/types/index.d.ts
  */
-import type Buffer from 'buffer';
 
 export type CopyPluginOptions = {
   patterns: Pattern[];
@@ -67,7 +66,7 @@ type Info =
 
 type ObjectPattern = {
   from: string;
-  globOptions?: import('@modern-js/utils/globby').GlobbyOptions | undefined;
+  globOptions?: Record<string, any>;
   context?: string | undefined;
   to?: To | undefined;
   toType?: ToType | undefined;

--- a/packages/webpack/src/webpackPlugins/ModuleScopePlugin.ts
+++ b/packages/webpack/src/webpackPlugins/ModuleScopePlugin.ts
@@ -6,7 +6,8 @@
  * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/ModuleScopePlugin.js
  */
 import { dirname, relative, resolve } from 'path';
-import { chalk, isRegExp, isString } from '@modern-js/utils';
+import { chalk } from '@rsbuild/shared/chalk';
+import { isRegExp, isString } from '@rsbuild/shared';
 
 export class ModuleScopePlugin {
   scopes: Array<string | RegExp>;

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -1,6 +1,5 @@
 import webpack from 'webpack';
-import { logger } from '@modern-js/utils/logger';
-import { prettyTime } from '@rsbuild/shared';
+import { logger, prettyTime } from '@rsbuild/shared';
 import { bus, createFriendlyPercentage } from './helpers';
 import { createNonTTYLogger } from './helpers/nonTty';
 import type { Props } from './helpers/type';
@@ -39,7 +38,6 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
       dependenciesCount: 10000,
       percentBy: null,
       handler: (percentage, message) => {
-        // eslint-disable-next-line no-param-reassign
         percentage = friendlyPercentage(percentage);
         const done = percentage === 1;
 

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
@@ -1,7 +1,7 @@
 import cliTruncate from '../../../../compiled/cli-truncate';
 import type { Props } from './type';
 import { clamp } from './utils';
-import chalk from '@modern-js/utils/chalk';
+import { chalk } from '@rsbuild/shared/chalk';
 
 const defaultOption: Props = {
   total: 100,

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line node/prefer-global/console
 import { Console } from 'console';
 import patchConsole from '../../../../compiled/patch-console';
 import cliTruncate from '../../../../compiled/cli-truncate';

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/nonTty.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/nonTty.ts
@@ -1,4 +1,4 @@
-import { logger } from '@modern-js/utils';
+import { logger } from '@rsbuild/shared';
 
 export function createNonTTYLogger() {
   let prevPercentage = 0;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,12 +213,12 @@ importers:
 
   packages/plugin-image-compress:
     dependencies:
-      '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
       '@napi-rs/image':
         specifier: ^1.7.0
         version: 1.7.0
+      '@rsbuild/shared':
+        specifier: workspace:*
+        version: link:../shared
       svgo:
         specifier: ^3.0.2
         version: 3.0.2


### PR DESCRIPTION
## Summary

Decouple some methods from modern.js utils.

## Related Issue

https://github.com/web-infra-dev/rsbuild/issues/22

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
