### PR TITLE
chore: bump modern.js v1.37.1 and rspress v1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@modern-js/module-tools": "^2.37.1",
-    "@modern-js/monorepo-tools": "2.36.0",
+    "@modern-js/monorepo-tools": "^2.37.1",
     "@rsbuild/tsconfig": "workspace:*",
     "@rsbuild/vitest-helper": "workspace:*",
     "vite-tsconfig-paths": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     ]
   },
   "devDependencies": {
-    "@modern-js/module-tools": "^2.36.0",
+    "@modern-js/module-tools": "^2.37.1",
     "@modern-js/monorepo-tools": "2.36.0",
     "@rsbuild/tsconfig": "workspace:*",
     "@rsbuild/vitest-helper": "workspace:*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,9 +73,9 @@
     "build": "modern build"
   },
   "dependencies": {
-    "@modern-js/utils": "^2.36.0",
-    "@modern-js/server": "^2.36.0",
-    "@modern-js/types": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
+    "@modern-js/server": "^2.37.1",
+    "@modern-js/types": "^2.37.1",
     "@rspack/core": "0.3.6",
     "@rspack/dev-client": "0.3.6",
     "@rspack/plugin-html": "0.3.6",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -25,9 +25,9 @@
     "provenance": true
   },
   "devDependencies": {
-    "@rspress/shared": "1.0.2",
+    "@rspress/shared": "^1.1.1",
     "@types/node": "^16",
-    "rspress": "1.0.2",
+    "rspress": "^1.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/plugin-esbuild/package.json
+++ b/packages/plugin-esbuild/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
     "typescript": "^5"
   },
   "sideEffects": false,

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
     "typescript": "^5"
   },
   "sideEffects": false,

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/vitest-helper": "workspace:*",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
     "typescript": "^5",
     "webpack": "^5.88.1"
   },

--- a/packages/plugin-swc/package.json
+++ b/packages/plugin-swc/package.json
@@ -53,14 +53,14 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.22.15",
     "@modern-js/swc-plugins": "0.6.4",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
     "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.1",
     "core-js": "~3.32.1"
   },
   "devDependencies": {
     "@rsbuild/webpack": "workspace:*",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
     "@swc/core": "1.3.42",
     "@types/babel__core": "^7.20.0",
     "antd": "4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -165,10 +165,10 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
-    "@modern-js/prod-server": "^2.36.0",
-    "@modern-js/server": "^2.36.0",
-    "@modern-js/types": "^2.36.0",
-    "@modern-js/utils": "^2.36.0",
+    "@modern-js/prod-server": "^2.37.1",
+    "@modern-js/server": "^2.37.1",
+    "@modern-js/types": "^2.37.1",
+    "@modern-js/utils": "^2.37.1",
     "@types/fs-extra": "^11.0.2",
     "acorn": "^8.10.0",
     "browserslist": "^4.22.1",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -38,9 +38,9 @@
     "build": "modern build"
   },
   "dependencies": {
-    "@modern-js/utils": "^2.36.0",
-    "@modern-js/server": "^2.36.0",
-    "@modern-js/types": "^2.36.0",
+    "@modern-js/utils": "^2.37.1",
+    "@modern-js/server": "^2.37.1",
+    "@modern-js/types": "^2.37.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.5.10",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/babel-preset": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.37.1
         version: 2.37.1(typescript@5.2.2)
       '@modern-js/monorepo-tools':
-        specifier: 2.36.0
-        version: 2.36.0(typescript@5.2.2)
+        specifier: ^2.37.1
+        version: 2.37.1(typescript@5.2.2)
       '@rsbuild/tsconfig':
         specifier: workspace:*
         version: link:scripts/tsconfig
@@ -2290,7 +2290,7 @@ packages:
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/config': 2.3.1
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -2308,7 +2308,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.4:
     resolution: {integrity: sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.6
       '@changesets/types': 5.2.1
@@ -2326,7 +2326,7 @@ packages:
     resolution: {integrity: sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/apply-release-plan': 6.1.4
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/changelog-git': 0.1.14
@@ -2392,7 +2392,7 @@ packages:
   /@changesets/get-release-plan@3.0.17:
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/config': 2.3.1
       '@changesets/pre': 1.0.14
@@ -2408,7 +2408,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -2433,7 +2433,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -2443,7 +2443,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -2464,7 +2464,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -3188,7 +3188,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -3197,7 +3197,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -3409,7 +3409,7 @@ packages:
     peerDependencies:
       '@modern-js/codesmith': ^2.2.5
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@formily/json-schema': 2.2.29(typescript@5.2.2)
       '@formily/validator': 2.2.29
       '@modern-js/codesmith': 2.2.5
@@ -3422,21 +3422,12 @@ packages:
   /@modern-js/codesmith@2.2.5:
     resolution: {integrity: sha512-crlaJqKT8iSLRTLOgTU7PCVWtXJ66ezM5CmKTRGdQYIEWx85Pmuj3lmupyXM3ecv4lhVzoonVs/nh3bS5ubeOQ==}
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       '@modern-js/utils': 2.37.1
       axios: 0.21.4
       tar: 6.2.0
     transitivePeerDependencies:
       - debug
-    dev: true
-
-  /@modern-js/core@2.36.0:
-    resolution: {integrity: sha512-W6pMsyqq56pXoKmbyS/c8WqnVPIe6K/x94CN4ZfMWSY3VSQPOFw8AAbSE9qyrj19Vx7BadgmG+XlYufVt3CkMQ==}
-    dependencies:
-      '@modern-js/node-bundle-require': 2.36.0
-      '@modern-js/plugin': 2.36.0
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
     dev: true
 
   /@modern-js/core@2.37.1:
@@ -3448,34 +3439,11 @@ packages:
       '@swc/helpers': 0.5.1
     dev: true
 
-  /@modern-js/generator-common@3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
-    resolution: {integrity: sha512-CoHCkrOxMg7mQIDQ53j6QpQt2/7b2fg64Ev0xxBAwFXxQG3YoHCpswRF2P2ZcY8Ic2S1biH6fw8Ey28LxzjDxA==}
-    dependencies:
-      '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
-      '@modern-js/plugin-i18n': 2.36.0
-      '@swc/helpers': 0.5.1
-    transitivePeerDependencies:
-      - '@modern-js/codesmith'
-      - typescript
-    dev: true
-
   /@modern-js/generator-common@3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
     resolution: {integrity: sha512-8qPAIOVbtr9oj+KdBTHMAEyu1uh/fxvP6sS1INV0cDw/YUu2UI7qOXzLa42Ek2WGf+W4I9evekySdkBLnnowhQ==}
     dependencies:
       '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
       '@modern-js/plugin-i18n': 2.37.1
-      '@swc/helpers': 0.5.1
-    transitivePeerDependencies:
-      - '@modern-js/codesmith'
-      - typescript
-    dev: true
-
-  /@modern-js/generator-utils@3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
-    resolution: {integrity: sha512-F+g2Eaqm9DmziVEsJPk444d15YH0GkQOcmAbSj7mnQN212PPrKQcAeUrwafH51qnSPuF3izq9LwEIqS8H8a7vg==}
-    dependencies:
-      '@modern-js/generator-common': 3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
-      '@modern-js/plugin-i18n': 2.36.0
-      '@modern-js/utils': 2.36.0
       '@swc/helpers': 0.5.1
     transitivePeerDependencies:
       - '@modern-js/codesmith'
@@ -3544,18 +3512,18 @@ packages:
       - supports-color
     dev: true
 
-  /@modern-js/monorepo-tools@2.36.0(typescript@5.2.2):
-    resolution: {integrity: sha512-7iSUmjPhzaI0RgbuU3zIW/FpeCJRu6Jl9KXMaypqLlrwNK9uBDloM9qr8iVO5epx/sNmp8fyP5HqOzgtgk+8tw==}
+  /@modern-js/monorepo-tools@2.37.1(typescript@5.2.2):
+    resolution: {integrity: sha512-zFCa/rpgcc3iiJx0QsOJO/Mvbu5EImMnGwF0qmFHi+S292wQAEbz3OXfkrz9kXsmZvzZkqNQ55fRzemuFf9Ayw==}
     hasBin: true
     dependencies:
-      '@modern-js/core': 2.36.0
-      '@modern-js/new-action': 2.36.0(typescript@5.2.2)
-      '@modern-js/plugin': 2.36.0
-      '@modern-js/plugin-changeset': 2.36.0
-      '@modern-js/plugin-i18n': 2.36.0
-      '@modern-js/plugin-lint': 2.36.0
-      '@modern-js/upgrade': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/core': 2.37.1
+      '@modern-js/new-action': 2.37.1(typescript@5.2.2)
+      '@modern-js/plugin': 2.37.1
+      '@modern-js/plugin-changeset': 2.37.1
+      '@modern-js/plugin-i18n': 2.37.1
+      '@modern-js/plugin-lint': 2.37.1
+      '@modern-js/upgrade': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@rushstack/node-core-library': 3.61.0
       '@rushstack/package-deps-hash': 3.2.67
       '@swc/helpers': 0.5.1
@@ -3564,20 +3532,6 @@ packages:
       p-map: 4.0.0
     transitivePeerDependencies:
       - '@types/node'
-      - debug
-      - typescript
-    dev: true
-
-  /@modern-js/new-action@2.36.0(typescript@5.2.2):
-    resolution: {integrity: sha512-OacUcYnqoS0WVEzsQfg6QUs7/+JPDs7clPmym4NpKXMQOYz68SHi3yzva31/Rd2yhMg8BRQSiMv411B2eP0I7w==}
-    dependencies:
-      '@modern-js/codesmith': 2.2.5
-      '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
-      '@modern-js/generator-common': 3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
-      '@modern-js/generator-utils': 3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-    transitivePeerDependencies:
       - debug
       - typescript
     dev: true
@@ -3596,35 +3550,12 @@ packages:
       - typescript
     dev: true
 
-  /@modern-js/node-bundle-require@2.36.0:
-    resolution: {integrity: sha512-NSdfNDAy6bK3X5xcW4H7eTIm1AvZXF0PT3lZHo2ZcTWX8PS+lc402fbEFws1+Z0AkIYyYAP7HKUjYFXt5JIomw==}
-    dependencies:
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-      esbuild: 0.17.19
-    dev: true
-
   /@modern-js/node-bundle-require@2.37.1:
     resolution: {integrity: sha512-TSssD8JvRk7OifYwX2UK2ZLkgLeLsDVJrVe1YFeJqxWv5+pfilJJtFhaC3vbycYbD/XXY7cwDHrorGoP+i2xEQ==}
     dependencies:
       '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
       esbuild: 0.17.19
-    dev: true
-
-  /@modern-js/plugin-changeset@2.36.0:
-    resolution: {integrity: sha512-QL1feF9i1v+wP8GmxpvHb0fWkcleqA69qbsqhpV6xo19+OjrKpcsM1vT8TcC/Vzew+4+aGgYPi3FocIRk/Wa+Q==}
-    dependencies:
-      '@changesets/cli': 2.26.2
-      '@changesets/git': 2.0.0
-      '@changesets/read': 0.5.9
-      '@modern-js/plugin-i18n': 2.36.0
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-      axios: 1.5.1
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - debug
     dev: true
 
   /@modern-js/plugin-changeset@2.37.1:
@@ -3642,28 +3573,11 @@ packages:
       - debug
     dev: true
 
-  /@modern-js/plugin-i18n@2.36.0:
-    resolution: {integrity: sha512-E7trS5dCRGCaKHhmer6gS75FA8cYBrpNXR5uLPQXPTSZJxg8cKOWWmxByJUVgcKa51Yezl41/1zQp3k0/Hlhew==}
-    dependencies:
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-    dev: true
-
   /@modern-js/plugin-i18n@2.37.1:
     resolution: {integrity: sha512-wkV4dSNnULObGv7xpUJR2lHoYxfpabXrRJwcnbpypyZiiiOVlD3Ntl/F6ehbly4M2ZsXO22PVT+z6F2EtLyuow==}
     dependencies:
       '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
-    dev: true
-
-  /@modern-js/plugin-lint@2.36.0:
-    resolution: {integrity: sha512-7eegWctp5C6YazpfC/LlI07xD0SqkqKyOcJv2CSnAI5/PWwBmImTsKMfEwy1jAjbaGoxr4Xf/UJuc1ZPIyccuA==}
-    dependencies:
-      '@modern-js/tsconfig': 2.36.0
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-      cross-spawn: 7.0.3
-      husky: 8.0.3
     dev: true
 
   /@modern-js/plugin-lint@2.37.1:
@@ -3674,13 +3588,6 @@ packages:
       '@swc/helpers': 0.5.1
       cross-spawn: 7.0.3
       husky: 8.0.3
-    dev: true
-
-  /@modern-js/plugin@2.36.0:
-    resolution: {integrity: sha512-PWRJvQ6tYpH2mviR9ZEsYYESzvYqPZQpbPiaWnJnPabIhhcg8lVhbyTKN6jNwUMKQIKBiG8a+q8nmXJYYaTcdA==}
-    dependencies:
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
     dev: true
 
   /@modern-js/plugin@2.37.1:
@@ -3877,28 +3784,12 @@ packages:
       '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.4
       '@modern-js/swc-plugins-win32-x64-msvc': 0.6.4
 
-  /@modern-js/tsconfig@2.36.0:
-    resolution: {integrity: sha512-hhiOfBP6ezwXNiEWAnZZK9wjdExew88x1qz59JkLE/pFnVvITCe0mqMsgh4GiS8UK2zLV4UcR+byz7pN+9QTog==}
-    dev: true
-
   /@modern-js/tsconfig@2.37.1:
     resolution: {integrity: sha512-O5Na0L/cmPLNc1wJ4mXox5ql5ByokhJfNQNsIOIz3If0Yceo+CUsZkdYvErWf4sKVXfH0iLGGkRUHNunUs4NAw==}
     dev: true
 
   /@modern-js/types@2.37.1:
     resolution: {integrity: sha512-PWywvs8aNMcNHE3oNZYgA912Id0sRPV3OjqI6ZLqYScgsqPuqUB0TKPghacM6/Xq6cG7ItuxTKXIzUI7w0X8jA==}
-
-  /@modern-js/upgrade@2.36.0:
-    resolution: {integrity: sha512-mEdxPIP3OQGNpX8SaVoE6BGykKzu88ijrx1Q+zrwzHncxL4syaK64gE7WSaWlrXDibbX6XhwiBs2DUevgee0pQ==}
-    hasBin: true
-    dependencies:
-      '@modern-js/codesmith': 2.2.5
-      '@modern-js/plugin-i18n': 2.36.0
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-    transitivePeerDependencies:
-      - debug
-    dev: true
 
   /@modern-js/upgrade@2.37.1:
     resolution: {integrity: sha512-vX7GHWvhPS7boguA5xeBc4W6p3LlgKWUggIrbfQ3M0SoI6YWigMdDgtW6mPgcgjAOfzyRST7UWfsSnl44RpZ/Q==}
@@ -3910,15 +3801,6 @@ packages:
       '@swc/helpers': 0.5.1
     transitivePeerDependencies:
       - debug
-    dev: true
-
-  /@modern-js/utils@2.36.0:
-    resolution: {integrity: sha512-6aCmCONrmfrhUj38b2EmThCidD3Ca7OntHZIswKVYVD6TZv9zBmVQKCN26mmom6r60CklfJqUO1IMS8C9Ez7vA==}
-    dependencies:
-      '@swc/helpers': 0.5.1
-      caniuse-lite: 1.0.30001547
-      lodash: 4.17.21
-      rslog: 1.1.0
     dev: true
 
   /@modern-js/utils@2.37.1:
@@ -7139,7 +7021,7 @@ packages:
     dev: true
 
   /crypt@0.0.2:
-    resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
+    resolution: {integrity: sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=}
     dev: true
 
   /crypto-browserify@3.12.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@modern-js/module-tools':
-        specifier: ^2.36.0
-        version: 2.36.0(typescript@5.2.2)
+        specifier: ^2.37.1
+        version: 2.37.1(typescript@5.2.2)
       '@modern-js/monorepo-tools':
         specifier: 2.36.0
         version: 2.36.0(typescript@5.2.2)
@@ -284,14 +284,14 @@ importers:
   packages/core:
     dependencies:
       '@modern-js/server':
-        specifier: ^2.36.0
-        version: 2.36.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.37.1
+        version: 2.37.1(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/types':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
@@ -336,8 +336,8 @@ importers:
   packages/document:
     devDependencies:
       '@rspress/shared':
-        specifier: 1.0.2
-        version: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+        specifier: ^1.1.1
+        version: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       '@types/node':
         specifier: ^16
         version: 16.18.58
@@ -348,8 +348,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       rspress:
-        specifier: 1.0.2
-        version: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
+        specifier: ^1.1.1
+        version: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
 
   packages/monorepo-utils:
     dependencies:
@@ -389,8 +389,8 @@ importers:
         version: 0.17.19
     devDependencies:
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
@@ -436,8 +436,8 @@ importers:
         version: 2.2.1
     devDependencies:
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
@@ -461,8 +461,8 @@ importers:
         version: 7.1.0(stylus@0.59.0)(webpack@5.89.0)
     devDependencies:
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
@@ -497,8 +497,8 @@ importers:
         specifier: 0.6.4
         version: 0.6.4(@swc/helpers@0.5.1)
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
@@ -606,17 +606,17 @@ importers:
   packages/shared:
     dependencies:
       '@modern-js/prod-server':
-        specifier: ^2.36.0
-        version: 2.36.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.37.1
+        version: 2.37.1(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/server':
-        specifier: ^2.36.0
-        version: 2.36.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.37.1
+        version: 2.37.1(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/types':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@types/fs-extra':
         specifier: ^11.0.2
         version: 11.0.2
@@ -721,14 +721,14 @@ importers:
   packages/webpack:
     dependencies:
       '@modern-js/server':
-        specifier: ^2.36.0
-        version: 2.36.0(react-dom@18.2.0)(react@18.2.0)
+        specifier: ^2.37.1
+        version: 2.37.1(react-dom@18.2.0)(react@18.2.0)
       '@modern-js/types':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@modern-js/utils':
-        specifier: ^2.36.0
-        version: 2.36.0
+        specifier: ^2.37.1
+        version: 2.37.1
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.10
         version: 0.5.10(react-refresh@0.14.0)(webpack@5.89.0)
@@ -1285,7 +1285,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-default-from': 7.22.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-proposal-partial-application@7.22.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-3FKlTrBXzQ9MGfZijsGns7CZUh6ur/NA94Aw9mYKKhL3BoHaY+nF2fWeOaGfQis+VKfLy3pw5DQjjXXFGh11Rw==}
@@ -1296,7 +1295,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-partial-application': 7.22.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-proposal-pipeline-operator@7.22.15(@babel/core@7.23.0):
     resolution: {integrity: sha512-tk81rXNA4T/AQc4zFhIIJp9OSmY8rmy46G7LXiPm4+/X8A0A0f9ri6yjEIj3fYqZQYrQnX9uuWXppPGsEesYtg==}
@@ -1307,7 +1305,6 @@ packages:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-pipeline-operator': 7.22.5(@babel/core@7.23.0)
-    dev: false
 
   /@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.0):
     resolution: {integrity: sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==}
@@ -1367,7 +1364,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.0):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -1476,7 +1472,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-pipeline-operator@7.22.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-7yuGXd+h8gpR14FnPDTTCd5TfC/1B9njNZJT29GJ7UFF/WVbzkZy7728DynrENqgImqj5xyPTQAo8si9n3QVJQ==}
@@ -1486,7 +1481,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
-    dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.0):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -2241,7 +2235,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.0
-    dev: false
 
   /@babel/template@7.22.15:
     resolution: {integrity: sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==}
@@ -2250,24 +2243,6 @@ packages:
       '@babel/code-frame': 7.22.13
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-
-  /@babel/traverse@7.22.15:
-    resolution: {integrity: sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.22.13
-      '@babel/generator': 7.23.0
-      '@babel/helper-environment-visitor': 7.22.20
-      '@babel/helper-function-name': 7.23.0
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.23.0
-      '@babel/types': 7.23.0
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
 
   /@babel/traverse@7.23.0:
     resolution: {integrity: sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==}
@@ -2285,6 +2260,24 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/traverse@7.23.2:
+    resolution: {integrity: sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.23.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.23.0
+      '@babel/types': 7.23.0
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/types@7.23.0:
     resolution: {integrity: sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==}
@@ -3186,7 +3179,7 @@ packages:
     peerDependencies:
       react: '>=16.3.0'
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
       react-is: 16.13.1
@@ -3258,17 +3251,17 @@ packages:
       react: 18.2.0
     dev: true
 
-  /@modern-js/babel-compiler@2.36.0:
-    resolution: {integrity: sha512-FhM/RGdhNHTHyG6ubQ3aZFZ+2k289h2eCnFrqqKE4E2+fvbsbe3H6mVqw7UAbDABxjmnFr/xiZ0GweUPC/cBcg==}
+  /@modern-js/babel-compiler@2.37.1:
+    resolution: {integrity: sha512-w7nAH87zHTPl1ToNX5dUVXnZC3bX6lC+tA7cwqcSoC0x1l2z7cU2o82pqVXMhIu1SsXIXzKQrFqMHTLXYz5XQQ==}
     dependencies:
       '@babel/core': 7.23.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
     transitivePeerDependencies:
       - supports-color
 
-  /@modern-js/babel-plugin-module-resolver@2.36.0:
-    resolution: {integrity: sha512-ncr6JQ4TW1l3iw7+oocW26rdEsy0nMQk6fKB8XOVg0Ld/e0TJpI3ibqdA/jzV92lxynMM7+IqyZix8xbIJvl0A==}
+  /@modern-js/babel-plugin-module-resolver@2.37.1:
+    resolution: {integrity: sha512-WFQHOotZkbff3WkQrgPaqb1GnJRnyl5vwbC29TeQQ1/5iaOIgODEcsyqbHxtaQOfHseO8vMFLI7Hh8qO7CYwZQ==}
     dependencies:
       '@swc/helpers': 0.5.1
       glob: 8.1.0
@@ -3276,37 +3269,16 @@ packages:
       reselect: 4.1.8
       resolve: 1.22.8
 
-  /@modern-js/babel-preset-base@2.36.0:
-    resolution: {integrity: sha512-+WKsFk/PLdqKjI0odDFGO0EOCyoN93ydOEABsTU8eidms0WO2ddQFzBrsomSe+Jex32uXCUrCZJChAuxvKwOpg==}
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/parser': 7.23.0
-      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.0)
-      '@babel/plugin-transform-typescript': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-env': 7.22.20(@babel/core@7.23.0)
-      '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
-      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
-      '@babel/runtime': 7.23.1
-      '@babel/template': 7.22.15
-      '@babel/traverse': 7.23.0
-      '@babel/types': 7.23.0
-      '@modern-js/utils': 2.36.0
-      '@swc/helpers': 0.5.1
-      '@types/babel__core': 7.20.2
-      lodash: 4.17.21
-    transitivePeerDependencies:
-      - supports-color
-
-  /@modern-js/builder-rspack-provider@2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-65SVBNjOBEz4F8z5JWVVWN9C7BA+apYrurx5e2RKXHwg0sNiw7rqgxfLK0TObbq85r2tbAKOr1LvnrU4nyEhEA==}
+  /@modern-js/builder-rspack-provider@2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-86k/ptIQcgbPJOd0mipC/tqTk3DGjdQbsIZOeE0rUc0MRhDlMxZwb19Ggfo2etXKSn0wdQSX6hcdTAFGSHb7dA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@babel/core': 7.23.0
       '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
-      '@modern-js/builder-shared': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@modern-js/server': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/types': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/builder-shared': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/server': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/types': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@rspack/core': 0.3.6
       '@rspack/dev-client': 0.3.6(react-refresh@0.14.0)(webpack@5.89.0)
       '@rspack/plugin-html': 0.3.6(@rspack/core@0.3.6)
@@ -3348,17 +3320,17 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@modern-js/builder-shared@2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-SS/uq2m+HTJkoIxnGreHUWZYVVAZQ63IYsXZBEhrNQYmKz6z9x5U8S5CIUUn6xcM6c6CjZr9zF5vdhZXEcujXw==}
+  /@modern-js/builder-shared@2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-MGYkHsxxNPLw/wstUlZE3B0O5BkN8cCP5uzQMzjeS0mGMxFd4PJzkuMhHLMm6dHsk2lNSQpt2A8zoCuBxN2tBw==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@babel/core': 7.23.0
       '@babel/parser': 7.23.0
       '@babel/types': 7.23.0
-      '@modern-js/prod-server': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/server': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/types': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/prod-server': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/server': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/types': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
       acorn: 8.10.0
       caniuse-lite: 1.0.30001547
@@ -3397,15 +3369,16 @@ packages:
       - webpack-cli
     dev: true
 
-  /@modern-js/builder@2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-wF+Q7PdUYrH8v8jiK4ySl53wnbShTsprub0+e1o0+pzgtt7IslSlVKEHLV3uuON0TvFucWJviMZHobxwlKChig==}
+  /@modern-js/builder@2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-1S+r4lqag8dYrCp/1+J5H4or4NYBi8Rl6sQAQ7tv+ehTbw7EkzKAg1wQEwcrUok1xdvhIoACkyXYgmUbl3lauA==}
     engines: {node: '>=14.0.0'}
     dependencies:
-      '@modern-js/builder-shared': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@modern-js/utils': 2.36.0
-      '@rsbuild/monorepo-utils': 0.0.3
+      '@modern-js/builder-shared': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/utils': 2.37.1
+      '@rsbuild/monorepo-utils': 0.0.7
       '@svgr/webpack': 8.0.1(typescript@5.2.2)
       '@swc/helpers': 0.5.1
+      deepmerge: 4.3.1
       jiti: 1.20.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -3440,7 +3413,7 @@ packages:
       '@formily/json-schema': 2.2.29(typescript@5.2.2)
       '@formily/validator': 2.2.29
       '@modern-js/codesmith': 2.2.5
-      '@modern-js/utils': 2.36.0
+      '@modern-js/utils': 2.37.1
       inquirer: 8.2.6
     transitivePeerDependencies:
       - typescript
@@ -3450,7 +3423,7 @@ packages:
     resolution: {integrity: sha512-crlaJqKT8iSLRTLOgTU7PCVWtXJ66ezM5CmKTRGdQYIEWx85Pmuj3lmupyXM3ecv4lhVzoonVs/nh3bS5ubeOQ==}
     dependencies:
       '@babel/runtime': 7.23.1
-      '@modern-js/utils': 2.36.0
+      '@modern-js/utils': 2.37.1
       axios: 0.21.4
       tar: 6.2.0
     transitivePeerDependencies:
@@ -3466,11 +3439,31 @@ packages:
       '@swc/helpers': 0.5.1
     dev: true
 
+  /@modern-js/core@2.37.1:
+    resolution: {integrity: sha512-lJ+Xnnpr5klgGhlHJBh5vxA9PIEKz7pW+pYyFNESPSJ5nLceOMCDUBtlC9iB+ysx/XFqU4zOzvLuoJH88UuRZQ==}
+    dependencies:
+      '@modern-js/node-bundle-require': 2.37.1
+      '@modern-js/plugin': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+    dev: true
+
   /@modern-js/generator-common@3.2.3(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
     resolution: {integrity: sha512-CoHCkrOxMg7mQIDQ53j6QpQt2/7b2fg64Ev0xxBAwFXxQG3YoHCpswRF2P2ZcY8Ic2S1biH6fw8Ey28LxzjDxA==}
     dependencies:
       '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
       '@modern-js/plugin-i18n': 2.36.0
+      '@swc/helpers': 0.5.1
+    transitivePeerDependencies:
+      - '@modern-js/codesmith'
+      - typescript
+    dev: true
+
+  /@modern-js/generator-common@3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
+    resolution: {integrity: sha512-8qPAIOVbtr9oj+KdBTHMAEyu1uh/fxvP6sS1INV0cDw/YUu2UI7qOXzLa42Ek2WGf+W4I9evekySdkBLnnowhQ==}
+    dependencies:
+      '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
+      '@modern-js/plugin-i18n': 2.37.1
       '@swc/helpers': 0.5.1
     transitivePeerDependencies:
       - '@modern-js/codesmith'
@@ -3489,8 +3482,20 @@ packages:
       - typescript
     dev: true
 
-  /@modern-js/module-tools@2.36.0(typescript@5.2.2):
-    resolution: {integrity: sha512-gsNF/sgJ0+RsY1A6ByvqISpQuBvCuYzeWb/40EaJ6VWs/TRDTfJ69LpnQ+Z+lHVa/R7CmryBHq9/KObSunxuMw==}
+  /@modern-js/generator-utils@3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2):
+    resolution: {integrity: sha512-Ifbd/Wnp3GfmzSINa1qCSTMz2/KE2F4U2k8zEtO6L6ADaQ0RHauHEyAIJ7n//Zs101tH1HCf8hFSSVDiPazrKA==}
+    dependencies:
+      '@modern-js/generator-common': 3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
+      '@modern-js/plugin-i18n': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+    transitivePeerDependencies:
+      - '@modern-js/codesmith'
+      - typescript
+    dev: true
+
+  /@modern-js/module-tools@2.37.1(typescript@5.2.2):
+    resolution: {integrity: sha512-FxXIOMbtg5Yer+0Fd7Q6tk1xEjTUf+tLDfxPIlI8KTAXVYNshYGbi7IQ6/rAWtG872NMGwpvfRrMyYq4SoxBJQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
     peerDependencies:
@@ -3503,18 +3508,18 @@ packages:
       '@ast-grep/napi': 0.12.0
       '@babel/generator': 7.23.0
       '@babel/parser': 7.23.0
-      '@babel/traverse': 7.22.15
+      '@babel/traverse': 7.23.2
       '@babel/types': 7.23.0
-      '@modern-js/core': 2.36.0
-      '@modern-js/new-action': 2.36.0(typescript@5.2.2)
-      '@modern-js/plugin': 2.36.0
-      '@modern-js/plugin-changeset': 2.36.0
-      '@modern-js/plugin-i18n': 2.36.0
-      '@modern-js/plugin-lint': 2.36.0
+      '@modern-js/core': 2.37.1
+      '@modern-js/new-action': 2.37.1(typescript@5.2.2)
+      '@modern-js/plugin': 2.37.1
+      '@modern-js/plugin-changeset': 2.37.1
+      '@modern-js/plugin-i18n': 2.37.1
+      '@modern-js/plugin-lint': 2.37.1
       '@modern-js/swc-plugins': 0.6.4(@swc/helpers@0.5.1)
-      '@modern-js/types': 2.36.0
-      '@modern-js/upgrade': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/types': 2.37.1
+      '@modern-js/upgrade': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@rollup/pluginutils': 4.1.1
       '@svgr/core': 8.0.0(typescript@5.2.2)
       '@svgr/plugin-jsx': 8.0.1(@svgr/core@8.0.0)
@@ -3524,7 +3529,6 @@ packages:
       enhanced-resolve: 5.8.3
       esbuild: 0.19.2
       magic-string: 0.26.4
-      picomatch: 2.3.0
       postcss: 8.4.31
       postcss-modules: 4.3.0(postcss@8.4.31)
       safe-identifier: 0.4.2
@@ -3578,10 +3582,32 @@ packages:
       - typescript
     dev: true
 
+  /@modern-js/new-action@2.37.1(typescript@5.2.2):
+    resolution: {integrity: sha512-J2jgBnMugdb2gjxP5QDlaZlhDm6lbDkazJXqEq4QNEUKz1lQjVuZESqJMPzwHOtgLsfV3Waz+RVHEEkXE9/KXw==}
+    dependencies:
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/codesmith-formily': 2.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
+      '@modern-js/generator-common': 3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
+      '@modern-js/generator-utils': 3.2.5(@modern-js/codesmith@2.2.5)(typescript@5.2.2)
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+    transitivePeerDependencies:
+      - debug
+      - typescript
+    dev: true
+
   /@modern-js/node-bundle-require@2.36.0:
     resolution: {integrity: sha512-NSdfNDAy6bK3X5xcW4H7eTIm1AvZXF0PT3lZHo2ZcTWX8PS+lc402fbEFws1+Z0AkIYyYAP7HKUjYFXt5JIomw==}
     dependencies:
       '@modern-js/utils': 2.36.0
+      '@swc/helpers': 0.5.1
+      esbuild: 0.17.19
+    dev: true
+
+  /@modern-js/node-bundle-require@2.37.1:
+    resolution: {integrity: sha512-TSssD8JvRk7OifYwX2UK2ZLkgLeLsDVJrVe1YFeJqxWv5+pfilJJtFhaC3vbycYbD/XXY7cwDHrorGoP+i2xEQ==}
+    dependencies:
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
       esbuild: 0.17.19
     dev: true
@@ -3601,10 +3627,32 @@ packages:
       - debug
     dev: true
 
+  /@modern-js/plugin-changeset@2.37.1:
+    resolution: {integrity: sha512-f+Hp+hHwXHyTGYOJ2khWIcGxxyqAwrrr7TgRjHchT58DN9V/TJRTOkM3VI192/CWajLHEjXJ6PkrWj99V+lFEg==}
+    dependencies:
+      '@changesets/cli': 2.26.2
+      '@changesets/git': 2.0.0
+      '@changesets/read': 0.5.9
+      '@modern-js/plugin-i18n': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+      axios: 1.5.1
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /@modern-js/plugin-i18n@2.36.0:
     resolution: {integrity: sha512-E7trS5dCRGCaKHhmer6gS75FA8cYBrpNXR5uLPQXPTSZJxg8cKOWWmxByJUVgcKa51Yezl41/1zQp3k0/Hlhew==}
     dependencies:
       '@modern-js/utils': 2.36.0
+      '@swc/helpers': 0.5.1
+    dev: true
+
+  /@modern-js/plugin-i18n@2.37.1:
+    resolution: {integrity: sha512-wkV4dSNnULObGv7xpUJR2lHoYxfpabXrRJwcnbpypyZiiiOVlD3Ntl/F6ehbly4M2ZsXO22PVT+z6F2EtLyuow==}
+    dependencies:
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
     dev: true
 
@@ -3618,19 +3666,36 @@ packages:
       husky: 8.0.3
     dev: true
 
+  /@modern-js/plugin-lint@2.37.1:
+    resolution: {integrity: sha512-FK7fw1keEAzq+j1dgwfEPK64yS9jYBNKBI+dPgEVJ+lmA9Wt7sVr1p3PKF3KrzeXP67Ebx17yVFxAcGbEZlV2A==}
+    dependencies:
+      '@modern-js/tsconfig': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+      cross-spawn: 7.0.3
+      husky: 8.0.3
+    dev: true
+
   /@modern-js/plugin@2.36.0:
     resolution: {integrity: sha512-PWRJvQ6tYpH2mviR9ZEsYYESzvYqPZQpbPiaWnJnPabIhhcg8lVhbyTKN6jNwUMKQIKBiG8a+q8nmXJYYaTcdA==}
     dependencies:
       '@modern-js/utils': 2.36.0
       '@swc/helpers': 0.5.1
+    dev: true
 
-  /@modern-js/prod-server@2.36.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-ULEqzkixQmVTuDnQlyKND288gSiZD4jTGErqvzc1ECjg56F00dZWiCulPzxUJf2VIqzFd9pMmzYTdsDFq/jxOg==}
+  /@modern-js/plugin@2.37.1:
+    resolution: {integrity: sha512-8xKPjR3ZRAO2BkTV0KVRU5/PQPzB1h8KKqmEMatyp2fkq0PS0IRfofCR2qzP9zcN9dvRQhK/AJjOxreniwJK4w==}
     dependencies:
-      '@modern-js/plugin': 2.36.0
-      '@modern-js/runtime-utils': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/server-core': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+
+  /@modern-js/prod-server@2.37.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-tyT0KCKd0bsBMemSKC42kw3sDOmDDCCkOFvcFC8ySvoCedzXhoFaQc6Ol9i4ifCjXuAahUcbXPe9LtJOxuzu4A==}
+    dependencies:
+      '@modern-js/plugin': 2.37.1
+      '@modern-js/runtime-utils': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/server-core': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
       cookie: 0.4.2
       etag: 1.8.1
@@ -3649,8 +3714,8 @@ packages:
       - react-dom
       - supports-color
 
-  /@modern-js/runtime-utils@2.36.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-9moJSjs7vYnui7B6I/tJkXKTMFDuK52+alepFC0dekqiqJ4QBZ18Y+iQGm8MuUVSZI55aooTZqPC06xB7Ghj+Q==}
+  /@modern-js/runtime-utils@2.37.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-k/Z6Cd441MYdWpbsYG20fPLQd9RQgyd136Yt6gw5jkxRYWwY2zNI7iK7D4o/Dcpaqwhy83BSlw6d9sT7LCj9UQ==}
     peerDependencies:
       react: '>=17.0.0'
       react-dom: '>=17.0.0'
@@ -3660,7 +3725,7 @@ packages:
       react-dom:
         optional: true
     dependencies:
-      '@modern-js/utils': 2.36.0
+      '@modern-js/utils': 2.37.1
       '@remix-run/router': 1.8.0
       '@swc/helpers': 0.5.1
       react: 18.2.0
@@ -3668,32 +3733,33 @@ packages:
       react-router-dom: 6.15.0(react-dom@18.2.0)(react@18.2.0)
       serialize-javascript: 6.0.1
 
-  /@modern-js/server-core@2.36.0:
-    resolution: {integrity: sha512-pFu3B1KMATka+8/cMzEHUIH2OFLvnQDgKXJy/G00Z48rRkuBzkeTQ8W+31TD6ln6QKWmwSFcItUxyYJ0aJZGLQ==}
+  /@modern-js/server-core@2.37.1:
+    resolution: {integrity: sha512-hbl2ubU/WnHeiFINRrWORf0QQOkenHKvgGjw5lZcxni99rbB4g1pXm8PD2gSb651PjU5oX2LrsMJ6kAGSY+QjQ==}
     dependencies:
-      '@modern-js/plugin': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/plugin': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
 
-  /@modern-js/server-utils@2.36.0:
-    resolution: {integrity: sha512-s7n2rtiYNhjFAGh14SV3lfn+HfJ89jljCF8cHGZCv5EfoNK1IrbuzJ+WkaWn9LW/QFV3frwOKf8ohqAvSbWdVA==}
+  /@modern-js/server-utils@2.37.1:
+    resolution: {integrity: sha512-d2qwa/otERedFA+d3uSceMGO64d8bqnEdllQATbfW+GkA+dxLjYjCFLViZLtOztq++0TrxF2FnEQo/ThRxZ+DQ==}
     dependencies:
       '@babel/core': 7.23.0
       '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.23.0)
       '@babel/preset-env': 7.22.20(@babel/core@7.23.0)
+      '@babel/preset-react': 7.22.15(@babel/core@7.23.0)
       '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
-      '@modern-js/babel-compiler': 2.36.0
-      '@modern-js/babel-plugin-module-resolver': 2.36.0
-      '@modern-js/babel-preset-base': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/babel-compiler': 2.37.1
+      '@modern-js/babel-plugin-module-resolver': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@rsbuild/babel-preset': 0.0.7
       '@swc/helpers': 0.5.1
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.23.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - supports-color
 
-  /@modern-js/server@2.36.0(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-8NHazXePPZAepz7ZlU+ZWBbIo8h2wMv/AoakzHzY7B6dEiZHXXIZ16vVIa+pFZLN8SFIDObVZieec5r2OaSn4Q==}
+  /@modern-js/server@2.37.1(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-KqbLMKYWmSkgBt2jrFgVCrdQqGxl2bDflqEyGM0rQNuOWjyqG/r9i90xXsyGyc19RvTaUAZv49PlmW9b7G3NoQ==}
     peerDependencies:
       devcert: ^1.0.0
       ts-node: ^10.1.0
@@ -3708,11 +3774,11 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/register': 7.22.15(@babel/core@7.23.0)
-      '@modern-js/prod-server': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/runtime-utils': 2.36.0(react-dom@18.2.0)(react@18.2.0)
-      '@modern-js/server-utils': 2.36.0
-      '@modern-js/types': 2.36.0
-      '@modern-js/utils': 2.36.0
+      '@modern-js/prod-server': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/runtime-utils': 2.37.1(react-dom@18.2.0)(react@18.2.0)
+      '@modern-js/server-utils': 2.37.1
+      '@modern-js/types': 2.37.1
+      '@modern-js/utils': 2.37.1
       '@swc/helpers': 0.5.1
       axios: 1.5.1
       connect-history-api-fallback: 2.0.0
@@ -3815,8 +3881,12 @@ packages:
     resolution: {integrity: sha512-hhiOfBP6ezwXNiEWAnZZK9wjdExew88x1qz59JkLE/pFnVvITCe0mqMsgh4GiS8UK2zLV4UcR+byz7pN+9QTog==}
     dev: true
 
-  /@modern-js/types@2.36.0:
-    resolution: {integrity: sha512-LbybU510bMM2hqBLSSmUezKfPDiZJxn+uOQOFA5hBogeX6W86cYnx8zj2t2F+NQLVCLrhCe/tF0LCVL1JsIAMg==}
+  /@modern-js/tsconfig@2.37.1:
+    resolution: {integrity: sha512-O5Na0L/cmPLNc1wJ4mXox5ql5ByokhJfNQNsIOIz3If0Yceo+CUsZkdYvErWf4sKVXfH0iLGGkRUHNunUs4NAw==}
+    dev: true
+
+  /@modern-js/types@2.37.1:
+    resolution: {integrity: sha512-PWywvs8aNMcNHE3oNZYgA912Id0sRPV3OjqI6ZLqYScgsqPuqUB0TKPghacM6/Xq6cG7ItuxTKXIzUI7w0X8jA==}
 
   /@modern-js/upgrade@2.36.0:
     resolution: {integrity: sha512-mEdxPIP3OQGNpX8SaVoE6BGykKzu88ijrx1Q+zrwzHncxL4syaK64gE7WSaWlrXDibbX6XhwiBs2DUevgee0pQ==}
@@ -3830,8 +3900,29 @@ packages:
       - debug
     dev: true
 
+  /@modern-js/upgrade@2.37.1:
+    resolution: {integrity: sha512-vX7GHWvhPS7boguA5xeBc4W6p3LlgKWUggIrbfQ3M0SoI6YWigMdDgtW6mPgcgjAOfzyRST7UWfsSnl44RpZ/Q==}
+    hasBin: true
+    dependencies:
+      '@modern-js/codesmith': 2.2.5
+      '@modern-js/plugin-i18n': 2.37.1
+      '@modern-js/utils': 2.37.1
+      '@swc/helpers': 0.5.1
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /@modern-js/utils@2.36.0:
     resolution: {integrity: sha512-6aCmCONrmfrhUj38b2EmThCidD3Ca7OntHZIswKVYVD6TZv9zBmVQKCN26mmom6r60CklfJqUO1IMS8C9Ez7vA==}
+    dependencies:
+      '@swc/helpers': 0.5.1
+      caniuse-lite: 1.0.30001547
+      lodash: 4.17.21
+      rslog: 1.1.0
+    dev: true
+
+  /@modern-js/utils@2.37.1:
+    resolution: {integrity: sha512-1oLYDSFqqJULf0Z33YdT2qokBEaCrCtUEue0C0SYnHM+6QMAbXHLVKs1w7JT2uuOLfBZnM1nSrEiX4dXPiplrA==}
     dependencies:
       '@swc/helpers': 0.5.1
       caniuse-lite: 1.0.30001547
@@ -4196,10 +4287,30 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rsbuild/monorepo-utils@0.0.3:
-    resolution: {integrity: sha512-+VXr5ow5QDCtg1F9faCpk/0g+kvN77dMAppuGCZjfXVRJX8dPE2LndTlkYkdMEqg6uuLXwiFcdjQVz4/PJK2aA==}
+  /@rsbuild/babel-preset@0.0.7:
+    resolution: {integrity: sha512-U8XzLq+FBAryfBiDzTGrWrZyEcqwVnpg5q/Af1jYBBI7o6/xaBHJcgvCmvyk1JvbciQCUGrwWthWau5qc1CJPA==}
     dependencies:
-      '@rsbuild/shared': 0.0.3
+      '@babel/core': 7.23.0
+      '@babel/plugin-proposal-decorators': 7.23.0(@babel/core@7.23.0)
+      '@babel/plugin-proposal-export-default-from': 7.22.17(@babel/core@7.23.0)
+      '@babel/plugin-proposal-partial-application': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-proposal-pipeline-operator': 7.22.15(@babel/core@7.23.0)
+      '@babel/plugin-transform-runtime': 7.22.15(@babel/core@7.23.0)
+      '@babel/preset-env': 7.22.20(@babel/core@7.23.0)
+      '@babel/preset-typescript': 7.23.0(@babel/core@7.23.0)
+      '@babel/runtime': 7.23.2
+      '@babel/types': 7.23.0
+      '@rsbuild/shared': 0.0.7
+      '@types/babel__core': 7.20.2
+      babel-plugin-dynamic-import-node: 2.3.3
+      core-js: 3.32.2
+    transitivePeerDependencies:
+      - supports-color
+
+  /@rsbuild/monorepo-utils@0.0.7:
+    resolution: {integrity: sha512-Sm/QdCm3QfvzylyxKBy+u7N6OWpuhtEFJRy9btXkiI6W/jSRAzfLpT4akrtx+o3cGP98jeR2frwxwHUbHIe8NQ==}
+    dependencies:
+      '@rsbuild/shared': 0.0.7
       '@types/js-yaml': 4.0.7
       fast-glob: 3.3.1
       js-yaml: 4.1.0
@@ -4207,15 +4318,13 @@ packages:
       p-map: 4.0.0
     dev: true
 
-  /@rsbuild/shared@0.0.3:
-    resolution: {integrity: sha512-Koifvg44AOYIvZa784rdXGdHx39NUWnQ3Qta4cLvnEs52TBlr399U/FLXDioZOH+IgpsS/JkcL6mopHigzWzLw==}
+  /@rsbuild/shared@0.0.7:
+    resolution: {integrity: sha512-r5vmIpYPM2FCcxXvjskQ7JIIRA+jY0cUplyW3/R/eL/6p/3NIKhFQEc/UBgx8FmZxNd1eRb1/Xh325vgaLHDvA==}
     dependencies:
       '@types/fs-extra': 11.0.2
-      '@types/lodash': 4.14.199
       chalk: 4.1.2
+      deepmerge: 4.3.1
       fs-extra: 11.1.1
-      lodash: 4.17.21
-    dev: true
 
   /@rspack/binding-darwin-arm64@0.3.6:
     resolution: {integrity: sha512-E2Hzfek/vNvxzvtKzo6ERP7DZbJQtgATPHUvTFK3+x4NF+1pwFEqz7/+GXjYjY61dn/+sY5jBocJxVVfmYVxdw==}
@@ -4367,23 +4476,23 @@ packages:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  /@rspress/core@1.0.2(rspress@1.0.2)(typescript@5.2.2)(webpack@5.89.0):
-    resolution: {integrity: sha512-+vKhKQuDSGeQpMU6K+0p2RDcJaGnhnWwUexAysdSIRFz/DOVrIupg+SL7Xb8/EPAWtYtBO2wosVlS4xTYQtbvA==}
+  /@rspress/core@1.1.1(rspress@1.1.1)(typescript@5.2.2)(webpack@5.89.0):
+    resolution: {integrity: sha512-LvjdG0vt3anVltU9nx2m7OlcXos6nOYzxJjDPjxiNOPn9gsxBuDk8VfMVDNM89ZGzmEfGFW6mFfIH2X52Kx1YA==}
     engines: {node: '>=14.17.6'}
     dependencies:
       '@loadable/component': 5.15.2(react@18.2.0)
       '@mdx-js/loader': 2.2.1(webpack@5.89.0)
       '@mdx-js/mdx': 2.2.1
       '@mdx-js/react': 2.2.1(react@18.2.0)
-      '@modern-js/builder': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@modern-js/builder-rspack-provider': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@modern-js/utils': 2.36.0
-      '@rspress/mdx-rs': 0.3.3
-      '@rspress/plugin-auto-nav-sidebar': 1.0.2(react-dom@18.2.0)(react@18.2.0)(rspress@1.0.2)(typescript@5.2.2)
-      '@rspress/plugin-container-syntax': 1.0.2(react-dom@18.2.0)(react@18.2.0)(rspress@1.0.2)(typescript@5.2.2)
-      '@rspress/plugin-last-updated': 1.0.2(rspress@1.0.2)
-      '@rspress/plugin-medium-zoom': 1.0.2(rspress@1.0.2)
-      '@rspress/shared': 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/builder': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/builder-rspack-provider': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/utils': 2.37.1
+      '@rspress/mdx-rs': 0.4.0
+      '@rspress/plugin-auto-nav-sidebar': 1.1.1(react-dom@18.2.0)(react@18.2.0)(rspress@1.1.1)(typescript@5.2.2)
+      '@rspress/plugin-container-syntax': 1.1.1(react-dom@18.2.0)(react@18.2.0)(rspress@1.1.1)(typescript@5.2.2)
+      '@rspress/plugin-last-updated': 1.1.1(rspress@1.1.1)
+      '@rspress/plugin-medium-zoom': 1.1.1(rspress@1.1.1)
+      '@rspress/shared': 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       '@types/compression': 1.7.3
       '@types/polka': 0.5.5
       autoprefixer: 10.4.13(postcss@8.4.21)
@@ -4460,8 +4569,8 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspress/mdx-rs-darwin-arm64@0.3.3:
-    resolution: {integrity: sha512-McPiVIPsfF5CkQuIHGmDmNuPZnWHj0UISZRYArextIwHqFgS439qFVj6yi9nmQr3ahc1/Ce4neB8Qh7SopG/Xg==}
+  /@rspress/mdx-rs-darwin-arm64@0.4.0:
+    resolution: {integrity: sha512-aiwV335odkStDnryCngcsYxFPwnsSoGoJZGqF5KegJdF6ur5gGiIQxFpF/3N0oa2E1gd8wy7O8dbA4jIBSI/FA==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
@@ -4469,8 +4578,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-darwin-x64@0.3.3:
-    resolution: {integrity: sha512-X3p5w0EQAkibynv9ZEPMXDZ8M/5zYjK579cko+DdH/ZIszNmWHdxhrawUq6jHmoEL+W9Ye5iwGZEvMDLO7007A==}
+  /@rspress/mdx-rs-darwin-x64@0.4.0:
+    resolution: {integrity: sha512-XbyNe+q8DSADdzSjlueMnuCguNus/hfIdWYOvhwl1CgkwY9RkcNVdDlzg0k8d53/I1AEYYURjJEBmrQi3uSbcQ==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
@@ -4478,8 +4587,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-linux-arm-gnueabihf@0.3.3:
-    resolution: {integrity: sha512-an3NabgqL3tu6lLLYOCi1c/e612MPyT5N+0iP/BHpcyxNeO8NM91LBhEf5M4kLP6cPdZtkyY3kgMd66VEJ2YEw==}
+  /@rspress/mdx-rs-linux-arm-gnueabihf@0.4.0:
+    resolution: {integrity: sha512-pll+LcRQyCc7k8fxZ2DfQllCSICpLc/ddO0oPysnzfopLM+E6Cu4zq63tDyEWnzLkzrMA2gLDeo1K8+0jscV8g==}
     engines: {node: '>=14.12'}
     cpu: [arm]
     os: [linux]
@@ -4487,8 +4596,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-linux-arm64-gnu@0.3.3:
-    resolution: {integrity: sha512-EPYJHib7gDJeXd/O/tuqvFZ5XJ4vGBIyaltv5wrGQpBUtA7+qHnQQ85KPRg3tT3W+GWyMU4tdlPWI+FFK2xKSg==}
+  /@rspress/mdx-rs-linux-arm64-gnu@0.4.0:
+    resolution: {integrity: sha512-WmrjeUDPQmO8IXnbMABKoEuYVB85G+cUxWdJxp5WWBn77ZWjTQhQX1X3LRE3vVjTSxXwfxoBdwP+NuTOICN8MQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -4496,8 +4605,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-linux-arm64-musl@0.3.3:
-    resolution: {integrity: sha512-jjqnm1q3oI0df8JYe9Jb83LFEhlE/97tAiBhNzU6CzZe8QVN0uHMsr1/s1GTiXen/qtA9/gbBs7Z6pVipGfJBQ==}
+  /@rspress/mdx-rs-linux-arm64-musl@0.4.0:
+    resolution: {integrity: sha512-iOfFFBdZcQJ28s4bZYMFHyXasmFW6xHBtiTGVloKcL9folh0jkG8NEweJ4hecFgGGkBxjdAk3n+quD/rK5RWPg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
@@ -4505,8 +4614,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-linux-x64-gnu@0.3.3:
-    resolution: {integrity: sha512-1aiP6G3vRRQZ7ZUPaPw7NPwy4BILIRCQq9PAVcOEy3TPTFKGtPQurvtdOePNIIgnaF0T6RFCiojb1C942bNiTQ==}
+  /@rspress/mdx-rs-linux-x64-gnu@0.4.0:
+    resolution: {integrity: sha512-RnYH2GaCI8q46T/BuVgOe9CuQuPnbJK6NQAMrQir9s6vsxQu3IAgLAAb/iXW4U4hz5CAQMOh6gd2U9DT/FGTSg==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -4514,8 +4623,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-linux-x64-musl@0.3.3:
-    resolution: {integrity: sha512-wok/JheMFytic0abD8h4XMxt52E1Xnsj/mZNq5GLckeRmznB8MpUeAIxWcLzW/RvLDQGP2Khz1tFUyDfi0k73g==}
+  /@rspress/mdx-rs-linux-x64-musl@0.4.0:
+    resolution: {integrity: sha512-cSP27jeeqk8f66rdgCpz7POYNm9R272X8TUlnm81PVu0eGRDJLhXHjL5r5EFAQfyYQ75qWUhg7B1ZKAI4r3Agw==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
@@ -4523,8 +4632,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-win32-arm64-msvc@0.3.3:
-    resolution: {integrity: sha512-aEJ5VvGHB+OB2ds589eDz4mTsVmvFihxEsYtPby/fLrzAaK8vpGqF0rhzW2oM/5uO2/e397QM7ngnWxh/5k19g==}
+  /@rspress/mdx-rs-win32-arm64-msvc@0.4.0:
+    resolution: {integrity: sha512-SHuKfU8ibgvzYUOntc6BvU2XnueFUPWZ5biRONTZ7uIzu1BwPAlQdRszqmZLJ1LRIX0GU7L5NgAE5S/iDZ2lDw==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
@@ -4532,8 +4641,8 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs-win32-x64-msvc@0.3.3:
-    resolution: {integrity: sha512-IZ5SzvKC3lCbfdlLh7Qko0uBQzWMWcn78EqPf4g1gmR6qrrOSymOVN20jzRj8oZGX2I0aGIjMmds5hAuaPakzw==}
+  /@rspress/mdx-rs-win32-x64-msvc@0.4.0:
+    resolution: {integrity: sha512-q7DPrrYovgkaf1T8nFW0ZdZ+Mz458cgJ5sj6uXxp+Wz8igmZTfowKW3OAaeoaFNOts6emk67UX/XxvVbovCjvw==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
@@ -4541,30 +4650,30 @@ packages:
     dev: true
     optional: true
 
-  /@rspress/mdx-rs@0.3.3:
-    resolution: {integrity: sha512-FcjcUN6NUrMlgVEke/zi4OcITlxc9qMU1B4RXuiBC1gGBVrbp0iRwOJgRqLonYAJOczwewGPP701APRRs3RnDQ==}
+  /@rspress/mdx-rs@0.4.0:
+    resolution: {integrity: sha512-w/Rys3Pv3meE6lEsvFnE7tjkv4LSH3m+OI5HxGxycEe/5jGYNUghEO07smImUl++CNhCMflGhRvvdv0cKdTSMQ==}
     engines: {node: '>= 10'}
     optionalDependencies:
-      '@rspress/mdx-rs-darwin-arm64': 0.3.3
-      '@rspress/mdx-rs-darwin-x64': 0.3.3
-      '@rspress/mdx-rs-linux-arm-gnueabihf': 0.3.3
-      '@rspress/mdx-rs-linux-arm64-gnu': 0.3.3
-      '@rspress/mdx-rs-linux-arm64-musl': 0.3.3
-      '@rspress/mdx-rs-linux-x64-gnu': 0.3.3
-      '@rspress/mdx-rs-linux-x64-musl': 0.3.3
-      '@rspress/mdx-rs-win32-arm64-msvc': 0.3.3
-      '@rspress/mdx-rs-win32-x64-msvc': 0.3.3
+      '@rspress/mdx-rs-darwin-arm64': 0.4.0
+      '@rspress/mdx-rs-darwin-x64': 0.4.0
+      '@rspress/mdx-rs-linux-arm-gnueabihf': 0.4.0
+      '@rspress/mdx-rs-linux-arm64-gnu': 0.4.0
+      '@rspress/mdx-rs-linux-arm64-musl': 0.4.0
+      '@rspress/mdx-rs-linux-x64-gnu': 0.4.0
+      '@rspress/mdx-rs-linux-x64-musl': 0.4.0
+      '@rspress/mdx-rs-win32-arm64-msvc': 0.4.0
+      '@rspress/mdx-rs-win32-x64-msvc': 0.4.0
     dev: true
 
-  /@rspress/plugin-auto-nav-sidebar@1.0.2(react-dom@18.2.0)(react@18.2.0)(rspress@1.0.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-z+5e87S+3TZa8wFzyoq3ARqNFKzRu1r7+wXq1maVzPMXk6LE2mTuy6ByrJmZ1edP1tIA5lpApD9EWhCznOWP8Q==}
+  /@rspress/plugin-auto-nav-sidebar@1.1.1(react-dom@18.2.0)(react@18.2.0)(rspress@1.1.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-P0zCgglDYBLrKP7g1pNJPfc9qdUmhjPuU92WccRfRByZPeSdcUXs7yNTfJpCUkLpwcDT+ueZoBWwPRGdFQfIfg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      rspress: 1.0.2
+      rspress: ^1.0.2
     dependencies:
-      '@modern-js/utils': 2.36.0
-      '@rspress/shared': 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      rspress: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
+      '@modern-js/utils': 2.37.1
+      '@rspress/shared': 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      rspress: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -4595,14 +4704,14 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspress/plugin-container-syntax@1.0.2(react-dom@18.2.0)(react@18.2.0)(rspress@1.0.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-jfVbpW4Lg95Bm5+BSRiZmxNrHDMguyvLiLUjByx8N6EdmAZ6PsVKXJu/YStXxCqOwuUq419MvhMpHX4J1NE/Jw==}
+  /@rspress/plugin-container-syntax@1.1.1(react-dom@18.2.0)(react@18.2.0)(rspress@1.1.1)(typescript@5.2.2):
+    resolution: {integrity: sha512-XA5Uq4xD3GUe4B/Rkd1Vd1Ca70U9K0ObSYAGKgA/PD0Gj6e9qO/x5DzYaVnqhnaQRl8ffVaSrRCoSapaTP5JjA==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      rspress: 1.0.2
+      rspress: ^1.0.2
     dependencies:
-      '@rspress/shared': 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      rspress: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
+      '@rspress/shared': 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      rspress: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -4633,31 +4742,31 @@ packages:
       - webpack-plugin-serve
     dev: true
 
-  /@rspress/plugin-last-updated@1.0.2(rspress@1.0.2):
-    resolution: {integrity: sha512-9XH3ZiE4RjaPd3O7+XPWUPqnHBNIPhhv6TRQUV6+Y5ARwI1ONdR5/sZTjfFuIpYdiUhzwqaiG5MPHYDR81mMAg==}
+  /@rspress/plugin-last-updated@1.1.1(rspress@1.1.1):
+    resolution: {integrity: sha512-ouBOYQU/c6yXN0LbTiB7UXbnwFCYMubu4kys0JbCgQpMtXQQd/nnpx3lVTudCJSmJdMIfG/noG4TPick+n/55Q==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      rspress: 1.0.2
+      rspress: ^1.0.2
     dependencies:
-      '@modern-js/utils': 2.36.0
-      rspress: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
+      '@modern-js/utils': 2.37.1
+      rspress: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
     dev: true
 
-  /@rspress/plugin-medium-zoom@1.0.2(rspress@1.0.2):
-    resolution: {integrity: sha512-X3rV8duPJOvWEo2puetC4S87CNulPiLWdTETGUiYKlxNL2cYNI5wL6XyM1/8sl+mdLsALDaH1alHIaV36xPGcw==}
+  /@rspress/plugin-medium-zoom@1.1.1(rspress@1.1.1):
+    resolution: {integrity: sha512-Edbf/CXO6VMqjvjFosYdU2cge0nHcoCHIF6uolnmbhePajj76O9M06TuxLOMcAR1fgWcxgzyUkgEaqs1auuZ/A==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      rspress: 1.0.2
+      rspress: ^1.0.2
     dependencies:
       medium-zoom: 1.0.8
-      rspress: 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
+      rspress: 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0)
     dev: true
 
-  /@rspress/shared@1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
-    resolution: {integrity: sha512-mWy6NXCoCXb8BllP45z5yF4ZKQ+S9BZi7x1oaWwmVm9UJ9hhHBWhra1frHpczOYL/hg1qhER523OxAxTPcC3Ug==}
+  /@rspress/shared@1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-8ncCTetVOTtncjq+vTN6mEwAdF+/MbtiakOe5yUVYYcSI0/SrFENfSNVz2Xq9+ISBbZs7Fly/iJF+rZhuKxilg==}
     dependencies:
-      '@modern-js/builder': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
-      '@modern-js/builder-rspack-provider': 2.36.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/builder': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/builder-rspack-provider': 2.37.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       chalk: 4.1.2
       rslog: 1.1.0
       unified: 10.1.2
@@ -5035,7 +5144,7 @@ packages:
   /@types/body-parser@1.19.3:
     resolution: {integrity: sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==}
     dependencies:
-      '@types/connect': 3.4.36
+      '@types/connect': 3.4.37
       '@types/node': 16.18.58
     dev: true
 
@@ -5047,12 +5156,6 @@ packages:
     resolution: {integrity: sha512-rKquEGjebqizyHNMOpaE/4FdYR5VQiWFeesqYfvJU0seSEyB4625UGhNOO/qIkH10S3wftiV7oefc8WdLZ/gCQ==}
     dependencies:
       '@types/express': 4.17.19
-    dev: true
-
-  /@types/connect@3.4.36:
-    resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
-    dependencies:
-      '@types/node': 16.18.58
     dev: true
 
   /@types/connect@3.4.37:
@@ -5103,7 +5206,7 @@ packages:
       '@types/body-parser': 1.19.3
       '@types/express-serve-static-core': 4.17.37
       '@types/qs': 6.9.8
-      '@types/serve-static': 1.15.3
+      '@types/serve-static': 1.15.4
     dev: true
 
   /@types/fs-extra@11.0.2:
@@ -5261,14 +5364,6 @@ packages:
     resolution: {integrity: sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==}
     dependencies:
       '@types/mime': 1.3.3
-      '@types/node': 16.18.58
-    dev: true
-
-  /@types/serve-static@1.15.3:
-    resolution: {integrity: sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==}
-    dependencies:
-      '@types/http-errors': 2.0.2
-      '@types/mime': 3.0.2
       '@types/node': 16.18.58
     dev: true
 
@@ -6127,7 +6222,6 @@ packages:
     resolution: {integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==}
     dependencies:
       object.assign: 4.1.4
-    dev: false
 
   /babel-plugin-import@1.13.5:
     resolution: {integrity: sha512-IkqnoV+ov1hdJVofly9pXRJmeDm9EtROfrc5i6eII0Hix2xMs5FEm8FG3ExMvazbnZBbgHIt6qdO8And6lCloQ==}
@@ -10682,11 +10776,6 @@ packages:
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
 
-  /picomatch@2.3.0:
-    resolution: {integrity: sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==}
-    engines: {node: '>=8.6'}
-    dev: true
-
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
@@ -12249,7 +12338,7 @@ packages:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.2.0
@@ -12319,7 +12408,7 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.2
       highlight.js: 10.7.3
       lowlight: 1.20.0
       prismjs: 1.29.0
@@ -12684,13 +12773,13 @@ packages:
       fs-extra: 11.1.1
     dev: true
 
-  /rspress@1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0):
-    resolution: {integrity: sha512-tdVCaIhV/VBloDIUOQxbhO4EnMXoFmOvuoHseTkcNPTtvuvKX++IgZVBZozwGCKHGFO2AemGKm2/29NqAvnUJw==}
+  /rspress@1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)(webpack@5.89.0):
+    resolution: {integrity: sha512-O724GxEojpaV4rT4hqwIpIdiikFno4T3oV5TUJwGJaIRKaLArkDw178M3zeQqTIYuNc1dzj04Fjk6zTZ4AnmsA==}
     hasBin: true
     dependencies:
-      '@modern-js/node-bundle-require': 2.36.0
-      '@rspress/core': 1.0.2(rspress@1.0.2)(typescript@5.2.2)(webpack@5.89.0)
-      '@rspress/shared': 1.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
+      '@modern-js/node-bundle-require': 2.37.1
+      '@rspress/core': 1.1.1(rspress@1.1.1)(typescript@5.2.2)(webpack@5.89.0)
+      '@rspress/shared': 1.1.1(react-dom@18.2.0)(react@18.2.0)(typescript@5.2.2)
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.5.3


### PR DESCRIPTION
## Summary

Bump modern.js v1.37.1 and rspress v1.1.1.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
