### PR TITLE
fix(cli): output a blank line to keep the greet log nice

### DIFF
--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -3,6 +3,14 @@ const { logger } = require('rslog');
 
 async function main() {
   const { version } = require('../package.json');
+
+  // If not called through a package manager,
+  // output a blank line to keep the greet log nice.
+  const { npm_execpath } = process.env;
+  if (!npm_execpath || npm_execpath.includes('npx-cli.js')) {
+    console.log();
+  }
+
   logger.greet(`  ${`Rsbuild v${version}`}\n`);
 
   try {


### PR DESCRIPTION
## Summary

Output a blank line to keep the greet log nice.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
