### PR TITLE
feat(plugin-vue2): split vue2-jsx as standalone plugin

### DIFF
--- a/e2e/cases/vue2/index.test.ts
+++ b/e2e/cases/vue2/index.test.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { expect, test } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
+import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
 
 test('should build basic Vue sfc correctly', async ({ page }) => {
   const root = join(__dirname, 'sfc-basic');
@@ -58,7 +59,7 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
       main: join(root, 'src/index.js'),
     },
     runServer: true,
-    plugins: [pluginVue2()],
+    plugins: [pluginVue2(), pluginVue2Jsx()],
   });
 
   await page.goto(getHrefByEntryName('main', rsbuild.port));
@@ -98,7 +99,7 @@ test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
       main: join(root, 'src/index.js'),
     },
     runServer: true,
-    plugins: [pluginVue2()],
+    plugins: [pluginVue2(), pluginVue2Jsx()],
   });
 
   await page.goto(getHrefByEntryName('main', rsbuild.port));
@@ -121,7 +122,7 @@ test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
       main: join(root, 'src/index.js'),
     },
     runServer: true,
-    plugins: [pluginVue2()],
+    plugins: [pluginVue2(), pluginVue2Jsx()],
   });
 
   await page.goto(getHrefByEntryName('main', rsbuild.port));

--- a/e2e/cases/vue2/sfc-lang-ts/rsbuild.config.ts
+++ b/e2e/cases/vue2/sfc-lang-ts/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue2 } from '@rsbuild/plugin-vue2';
+
+export default defineConfig({
+  plugins: [pluginVue2()],
+});

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -25,6 +25,7 @@
     "@rsbuild/plugin-vue": "workspace:*",
     "@rsbuild/plugin-vue-jsx": "workspace:*",
     "@rsbuild/plugin-vue2": "workspace:*",
+    "@rsbuild/plugin-vue2-jsx": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@types/connect": "^3.4.37",

--- a/packages/plugin-vue2-jsx/CHANGELOG.md
+++ b/packages/plugin-vue2-jsx/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @rsbuild/plugin-vue2-jsx

--- a/packages/plugin-vue2-jsx/LICENSE
+++ b/packages/plugin-vue2-jsx/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-present Bytedance, Inc. and its affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/plugin-vue2-jsx/README.md
+++ b/packages/plugin-vue2-jsx/README.md
@@ -1,0 +1,24 @@
+<p align="center">
+  <a href="https://rsbuild.dev" target="blank"><img src="https://github.com/web-infra-dev/rsbuild/assets/7237365/84abc13e-b620-468f-a90b-dbf28e7e9427" alt="Rsbuild Logo" /></a>
+</p>
+
+# Rsbuild
+
+Unleash the power of Rspack with the out-of-the-box build tool.
+
+## Getting Started
+
+Please follow [Quick Start](https://rsbuild.dev/guides/get-started/quick-start) to get started with Rsbuild.
+
+## Documentation
+
+- [English Documentation](https://rsbuild.dev/)
+- [中文文档](https://rsbuild.dev/zh)
+
+## Contributing
+
+Please read the [Contributing Guide](https://github.com/web-infra-dev/rsbuild/blob/main/CONTRIBUTING.md).
+
+## License
+
+Rsbuild is [MIT licensed](https://github.com/web-infra-dev/rsbuild/blob/main/LICENSE).

--- a/packages/plugin-vue2-jsx/modern.config.ts
+++ b/packages/plugin-vue2-jsx/modern.config.ts
@@ -1,0 +1,3 @@
+import baseConfig from '../../scripts/modern.base.config';
+
+export default baseConfig;

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@rsbuild/plugin-vue2",
-  "description": "Vue 2 plugin of Rsbuild",
+  "name": "@rsbuild/plugin-vue2-jsx",
+  "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
-    "directory": "packages/plugin-vue2"
+    "directory": "packages/plugin-vue2-jsx"
   },
   "license": "MIT",
   "version": "0.0.7",
@@ -26,13 +26,14 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "vue-loader": "^15.11.1"
+    "@vue/babel-preset-jsx": "^1.4.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.23.2",
     "@rsbuild/core": "workspace:*",
+    "@rsbuild/webpack": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "typescript": "^5",
-    "webpack": "^5.88.1"
+    "typescript": "^5"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.0.7"

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -1,0 +1,44 @@
+import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { SharedRsbuildConfig } from '@rsbuild/shared';
+
+type VueJSXPresetOptions = {
+  compositionAPI?: boolean | string;
+  functional?: boolean;
+  injectH?: boolean;
+  vModel?: boolean;
+  vOn?: boolean;
+};
+
+export type PluginVueOptions = {
+  vueJsxOptions?: VueJSXPresetOptions;
+};
+
+export function pluginVue2Jsx(
+  options: PluginVueOptions = {},
+): RsbuildPlugin<RsbuildPluginAPI> {
+  return {
+    name: 'plugin-vue2-jsx',
+
+    async setup(api) {
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        const rsbuildConfig: SharedRsbuildConfig = {
+          tools: {
+            babel(_, { addPresets }) {
+              addPresets([
+                [
+                  require.resolve('@vue/babel-preset-jsx'),
+                  {
+                    injectH: true,
+                    ...options.vueJsxOptions,
+                  },
+                ],
+              ]);
+            },
+          },
+        };
+
+        return mergeRsbuildConfig(config, rsbuildConfig);
+      });
+    },
+  };
+}

--- a/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,387 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`plugins/vue2-jsx > should allow to configure jsx babel plugin options 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>",
+              {
+                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+              },
+            ],
+          },
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "useESModules": true,
+                    "version": "7.23.2",
+                  },
+                ],
+                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
+                [
+                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
+                  {},
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": true,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.32",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": "commonjs",
+                    "targets": [
+                      "chrome >= 87",
+                      "edge >= 88",
+                      "firefox >= 78",
+                      "safari >= 14",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
+                  {
+                    "injectH": false,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "use": [
+          {
+            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "useESModules": true,
+                    "version": "7.23.2",
+                  },
+                ],
+                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
+                [
+                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
+                  {},
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": true,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.32",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": "commonjs",
+                    "targets": [
+                      "chrome >= 87",
+                      "edge >= 88",
+                      "firefox >= 78",
+                      "safari >= 14",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
+                  {
+                    "injectH": false,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`plugins/vue2-jsx > should apply jsx babel plugin correctly 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "include": [
+          {
+            "and": [
+              "<ROOT>",
+              {
+                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+              },
+            ],
+          },
+        ],
+        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "useESModules": true,
+                    "version": "7.23.2",
+                  },
+                ],
+                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
+                [
+                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
+                  {},
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
+                  {
+                    "displayName": true,
+                    "pure": false,
+                    "ssr": false,
+                    "transpileTemplateLiterals": true,
+                  },
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": true,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.32",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": "commonjs",
+                    "targets": [
+                      "chrome >= 87",
+                      "edge >= 88",
+                      "firefox >= 78",
+                      "safari >= 14",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
+                  {
+                    "injectH": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "mimetype": {
+          "or": [
+            "text/javascript",
+            "application/javascript",
+          ],
+        },
+        "use": [
+          {
+            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+                  {
+                    "proposal": "minimal",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
+                  {
+                    "useESModules": true,
+                    "version": "7.23.2",
+                  },
+                ],
+                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
+                [
+                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
+                  {},
+                ],
+              ],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+                  {
+                    "bugfixes": true,
+                    "corejs": {
+                      "proposals": true,
+                      "version": "3.32",
+                    },
+                    "exclude": [
+                      "transform-typeof-symbol",
+                    ],
+                    "modules": "commonjs",
+                    "targets": [
+                      "chrome >= 87",
+                      "edge >= 88",
+                      "firefox >= 78",
+                      "safari >= 14",
+                    ],
+                    "useBuiltIns": "entry",
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
+                  {
+                    "injectH": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/packages/plugin-vue2-jsx/tests/index.test.ts
+++ b/packages/plugin-vue2-jsx/tests/index.test.ts
@@ -1,0 +1,36 @@
+import { expect, describe, it } from 'vitest';
+import { createStubRsbuild } from '@rsbuild/test-helper';
+import { webpackProvider } from '@rsbuild/webpack';
+import { pluginBabel } from '@rsbuild/webpack/plugin-babel';
+import { pluginVue2Jsx } from '../src';
+
+describe('plugins/vue2-jsx', () => {
+  it('should apply jsx babel plugin correctly', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginVue2Jsx(), pluginBabel()],
+      provider: webpackProvider,
+      rsbuildConfig: {},
+    });
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+
+  it('should allow to configure jsx babel plugin options', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        pluginVue2Jsx({
+          vueJsxOptions: {
+            injectH: false,
+          },
+        }),
+        pluginBabel(),
+      ],
+      provider: webpackProvider,
+      rsbuildConfig: {},
+    });
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+});

--- a/packages/plugin-vue2-jsx/tests/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tests/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "types": ["vitest/globals"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/packages/plugin-vue2-jsx/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "baseUrl": "./"
+  },
+  "include": ["src"]
+}

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -1,20 +1,9 @@
 import { deepmerge } from '@rsbuild/shared/deepmerge';
 import { VueLoaderPlugin } from 'vue-loader';
-import type { RsbuildPlugin } from '@rsbuild/core';
-import type { RsbuildPluginAPI } from '@rsbuild/webpack';
-import type { SharedRsbuildConfig } from '@rsbuild/shared';
+import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
 import type { VueLoaderOptions } from 'vue-loader';
 
-type VueJSXPresetOptions = {
-  compositionAPI?: boolean | string;
-  functional?: boolean;
-  injectH?: boolean;
-  vModel?: boolean;
-  vOn?: boolean;
-};
-
 export type PluginVueOptions = {
-  vueJsxOptions?: VueJSXPresetOptions;
   vueLoaderOptions?: VueLoaderOptions;
 };
 
@@ -24,34 +13,7 @@ export function pluginVue2(
   return {
     name: 'plugin-vue2',
 
-    // Remove built-in react plugins.
-    // These plugins should be moved to a separate package in the next major version.
-    remove: ['plugin-react', 'plugin-antd', 'plugin-arco'],
-
     async setup(api) {
-      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-        const rsbuildConfig: SharedRsbuildConfig = {
-          output: {
-            disableSvgr: true,
-          },
-          tools: {
-            babel(_, { addPresets }) {
-              addPresets([
-                [
-                  require.resolve('@vue/babel-preset-jsx'),
-                  {
-                    injectH: true,
-                    ...options.vueJsxOptions,
-                  },
-                ],
-              ]);
-            },
-          },
-        };
-
-        return mergeRsbuildConfig(config, rsbuildConfig);
-      });
-
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
         chain.resolve.extensions.add('.vue');
 
@@ -72,6 +34,27 @@ export function pluginVue2(
           .use(CHAIN_ID.USE.VUE)
           .loader(require.resolve('vue-loader'))
           .options(vueLoaderOptions);
+
+        // Handle ts syntax when using Rspack
+        if (
+          api.context.bundlerType === 'rspack' &&
+          !chain.module.rules.has(CHAIN_ID.RULE.TS)
+        ) {
+          chain.module
+            .rule(CHAIN_ID.RULE.TS)
+            .type('javascript/auto')
+            .test(/\.ts$/)
+            .use(CHAIN_ID.USE.SWC)
+            .loader('builtin:swc-loader')
+            .options({
+              sourceMap: true,
+              jsc: {
+                parser: {
+                  syntax: 'typescript',
+                },
+              },
+            });
+        }
 
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
       });

--- a/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugins/vue > should add vue-loader and VueLoaderPlugin correctly 1`] = `
+exports[`plugins/vue2 > should add vue-loader and VueLoaderPlugin correctly 1`] = `
 {
   "module": {
     "rules": [
@@ -13,7 +13,24 @@ exports[`plugins/vue > should add vue-loader and VueLoaderPlugin correctly 1`] =
               "compilerOptions": {
                 "preserveWhitespace": false,
               },
-              "experimentalInlineMatchResource": false,
+              "experimentalInlineMatchResource": true,
+            },
+          },
+        ],
+      },
+      {
+        "test": /\\\\\\.ts\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "builtin:swc-loader",
+            "options": {
+              "jsc": {
+                "parser": {
+                  "syntax": "typescript",
+                },
+              },
+              "sourceMap": true,
             },
           },
         ],
@@ -31,7 +48,7 @@ exports[`plugins/vue > should add vue-loader and VueLoaderPlugin correctly 1`] =
 }
 `;
 
-exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = `
+exports[`plugins/vue2 > should allow to configure vueLoader options 1`] = `
 {
   "module": {
     "rules": [
@@ -44,438 +61,25 @@ exports[`plugins/vue > should allow to configure jsx babel plugin options 1`] = 
               "compilerOptions": {
                 "preserveWhitespace": false,
               },
-              "experimentalInlineMatchResource": false,
-            },
-          },
-        ],
-      },
-      {
-        "include": [
-          {
-            "and": [
-              "<ROOT>",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
-          },
-        ],
-        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
-            "options": {
-              "babelrc": false,
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "legacy",
-                  },
-                ],
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
-                  {
-                    "proposal": "minimal",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-                  {
-                    "useESModules": true,
-                    "version": "7.23.2",
-                  },
-                ],
-                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
-                  {},
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
-                  {
-                    "displayName": true,
-                    "pure": false,
-                    "ssr": false,
-                    "transpileTemplateLiterals": true,
-                  },
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
-                  {
-                    "bugfixes": true,
-                    "corejs": {
-                      "proposals": true,
-                      "version": "3.32",
-                    },
-                    "exclude": [
-                      "transform-typeof-symbol",
-                    ],
-                    "modules": "commonjs",
-                    "targets": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
-                    ],
-                    "useBuiltIns": "entry",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
-                  {
-                    "injectH": false,
-                  },
-                ],
-              ],
-            },
-          },
-        ],
-      },
-      {
-        "mimetype": {
-          "or": [
-            "text/javascript",
-            "application/javascript",
-          ],
-        },
-        "use": [
-          {
-            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
-            "options": {
-              "babelrc": false,
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "legacy",
-                  },
-                ],
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
-                  {
-                    "proposal": "minimal",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-                  {
-                    "useESModules": true,
-                    "version": "7.23.2",
-                  },
-                ],
-                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
-                  {},
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
-                  {
-                    "bugfixes": true,
-                    "corejs": {
-                      "proposals": true,
-                      "version": "3.32",
-                    },
-                    "exclude": [
-                      "transform-typeof-symbol",
-                    ],
-                    "modules": "commonjs",
-                    "targets": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
-                    ],
-                    "useBuiltIns": "entry",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
-                  {
-                    "injectH": false,
-                  },
-                ],
-              ],
-            },
-          },
-        ],
-      },
-    ],
-  },
-  "plugins": [
-    VueLoaderPlugin {},
-  ],
-  "resolve": {
-    "extensions": [
-      ".vue",
-    ],
-  },
-}
-`;
-
-exports[`plugins/vue > should allow to configure vueLoader options 1`] = `
-{
-  "module": {
-    "rules": [
-      {
-        "test": /\\\\\\.vue\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/lib/index.js",
-            "options": {
-              "compilerOptions": {
-                "preserveWhitespace": false,
-              },
-              "experimentalInlineMatchResource": false,
+              "experimentalInlineMatchResource": true,
               "hotReload": false,
             },
           },
         ],
       },
-    ],
-  },
-  "plugins": [
-    VueLoaderPlugin {},
-  ],
-  "resolve": {
-    "extensions": [
-      ".vue",
-    ],
-  },
-}
-`;
-
-exports[`plugins/vue > should apply jsx babel plugin correctly 1`] = `
-{
-  "module": {
-    "rules": [
       {
-        "test": /\\\\\\.vue\\$/,
+        "test": /\\\\\\.ts\\$/,
+        "type": "javascript/auto",
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/lib/index.js",
+            "loader": "builtin:swc-loader",
             "options": {
-              "compilerOptions": {
-                "preserveWhitespace": false,
+              "jsc": {
+                "parser": {
+                  "syntax": "typescript",
+                },
               },
-              "experimentalInlineMatchResource": false,
-            },
-          },
-        ],
-      },
-      {
-        "include": [
-          {
-            "and": [
-              "<ROOT>",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
-          },
-        ],
-        "test": /\\\\\\.\\(js\\|mjs\\|cjs\\|jsx\\)\\$\\|\\\\\\.\\(ts\\|mts\\|cts\\|tsx\\)\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
-            "options": {
-              "babelrc": false,
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "legacy",
-                  },
-                ],
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
-                  {
-                    "proposal": "minimal",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-                  {
-                    "useESModules": true,
-                    "version": "7.23.2",
-                  },
-                ],
-                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
-                  {},
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-styled-components/lib/index.js",
-                  {
-                    "displayName": true,
-                    "pure": false,
-                    "ssr": false,
-                    "transpileTemplateLiterals": true,
-                  },
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
-                  {
-                    "bugfixes": true,
-                    "corejs": {
-                      "proposals": true,
-                      "version": "3.32",
-                    },
-                    "exclude": [
-                      "transform-typeof-symbol",
-                    ],
-                    "modules": "commonjs",
-                    "targets": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
-                    ],
-                    "useBuiltIns": "entry",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
-                  {
-                    "injectH": true,
-                  },
-                ],
-              ],
-            },
-          },
-        ],
-      },
-      {
-        "mimetype": {
-          "or": [
-            "text/javascript",
-            "application/javascript",
-          ],
-        },
-        "use": [
-          {
-            "loader": "<ROOT>/packages/shared/compiled/babel-loader",
-            "options": {
-              "babelrc": false,
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "legacy",
-                  },
-                ],
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
-                "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
-                  {
-                    "proposal": "minimal",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-runtime/lib/index.js",
-                  {
-                    "useESModules": true,
-                    "version": "7.23.2",
-                  },
-                ],
-                "<ROOT>/packages/babel-preset/dist/pluginLockCorejsVersion",
-                [
-                  "<ROOT>/packages/webpack/compiled/babel-plugin-lodash",
-                  {},
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
-                  {
-                    "bugfixes": true,
-                    "corejs": {
-                      "proposals": true,
-                      "version": "3.32",
-                    },
-                    "exclude": [
-                      "transform-typeof-symbol",
-                    ],
-                    "modules": "commonjs",
-                    "targets": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
-                    ],
-                    "useBuiltIns": "entry",
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-preset-jsx/dist/plugin.cjs.js",
-                  {
-                    "injectH": true,
-                  },
-                ],
-              ],
+              "sourceMap": true,
             },
           },
         ],

--- a/packages/plugin-vue2/tests/index.test.ts
+++ b/packages/plugin-vue2/tests/index.test.ts
@@ -1,14 +1,11 @@
 import { expect, describe, it } from 'vitest';
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
-import { pluginBabel } from '@rsbuild/webpack/plugin-babel';
 import { pluginVue2 } from '../src';
 
-describe('plugins/vue', () => {
+describe('plugins/vue2', () => {
   it('should add vue-loader and VueLoaderPlugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginVue2()],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const config = await rsbuild.unwrapConfig();
@@ -25,36 +22,6 @@ describe('plugins/vue', () => {
           },
         }),
       ],
-      provider: webpackProvider,
-      rsbuildConfig: {},
-    });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('should apply jsx babel plugin correctly', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginVue2(), pluginBabel()],
-      provider: webpackProvider,
-      rsbuildConfig: {},
-    });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
-  });
-
-  it('should allow to configure jsx babel plugin options', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [
-        pluginVue2({
-          vueJsxOptions: {
-            injectH: false,
-          },
-        }),
-        pluginBabel(),
-      ],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const config = await rsbuild.unwrapConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@rsbuild/plugin-vue2':
         specifier: workspace:*
         version: link:../packages/plugin-vue2
+      '@rsbuild/plugin-vue2-jsx':
+        specifier: workspace:*
+        version: link:../packages/plugin-vue2-jsx
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../packages/shared
@@ -603,12 +606,31 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
-      '@vue/babel-preset-jsx':
-        specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.23.2)
       vue-loader:
         specifier: ^15.11.1
         version: 15.11.1(css-loader@6.8.1)(prettier@3.0.3)(webpack@5.89.0)
+    devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../core
+      '@rsbuild/test-helper':
+        specifier: workspace:*
+        version: link:../test-helper
+      typescript:
+        specifier: ^5
+        version: 5.2.2
+      webpack:
+        specifier: ^5.88.1
+        version: 5.89.0
+
+  packages/plugin-vue2-jsx:
+    dependencies:
+      '@rsbuild/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@vue/babel-preset-jsx':
+        specifier: ^1.4.0
+        version: 1.4.0(@babel/core@7.23.2)
     devDependencies:
       '@babel/core':
         specifier: ^7.23.2
@@ -625,9 +647,6 @@ importers:
       typescript:
         specifier: ^5
         version: 5.2.2
-      webpack:
-        specifier: ^5.88.1
-        version: 5.89.0
 
   packages/shared:
     dependencies:


### PR DESCRIPTION
## Summary

Split vue2-jsx as a standalone plugin.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
