### PR TITLE
chore(workflow): fix npm scope name for envinfo

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.en-US.yml
@@ -16,7 +16,7 @@ body:
     id: versions
     attributes:
       label: Version
-      description: Run `npx envinfo --system --browsers --npmPackages '@modern-js/*'` in your project, and paste the output into the textarea below.
+      description: Run `npx envinfo --system --browsers --npmPackages '@rsbuild/*'` in your project, and paste the output into the textarea below.
       placeholder: |
         System:
         Browsers:

--- a/.github/ISSUE_TEMPLATE/3-bug-report.zh-Hans.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report.zh-Hans.yml
@@ -16,7 +16,7 @@ body:
     id: versions
     attributes:
       label: 版本信息
-      description: 在你的项目中运行 `npx envinfo --system --browsers --npmPackages '@modern-js/*'` 命令，并将内容粘贴到下方输入框。
+      description: 在你的项目中运行 `npx envinfo --system --browsers --npmPackages '@rsbuild/*'` 命令，并将内容粘贴到下方输入框。
       placeholder: |
         System:
         Browsers:


### PR DESCRIPTION
## Summary

Fix npm scope name for envinfo.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
