### PR TITLE
test: add e2e cases for plugin-source-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist-*
 coverage/
 doc_build/
 playwright-report/
+tsconfig.tsbuildinfo
 
 .vscode/**/*
 !.vscode/settings.json

--- a/e2e/cases/import-antd-v4/package.json
+++ b/e2e/cases/import-antd-v4/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-webpack-import-antd-v4",
+  "name": "@e2e/webpack-import-antd-v4",
   "version": "1.0.0",
   "dependencies": {
     "react": "^18",

--- a/e2e/cases/import-antd-v5/package.json
+++ b/e2e/cases/import-antd-v5/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-webpack-import-antd-v5",
+  "name": "@e2e/webpack-import-antd-v5",
   "version": "1.0.0",
   "dependencies": {
     "react": "^18",

--- a/e2e/cases/import-arco/package.json
+++ b/e2e/cases/import-arco/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-webpack-import-arco",
+  "name": "@e2e/webpack-import-arco",
   "version": "1.0.0",
   "dependencies": {
     "react": "^18",

--- a/e2e/cases/moment/package.json
+++ b/e2e/cases/moment/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-webpack-test-moment",
+  "name": "@e2e/webpack-test-moment",
   "version": "1.0.0",
   "dependencies": {
     "moment": "^2"

--- a/e2e/cases/react/remove-prop-types/package.json
+++ b/e2e/cases/react/remove-prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-remove-prop-types",
+  "name": "@e2e/remove-prop-types",
   "version": "1.0.0",
   "dependencies": {
     "prop-types": "^15"

--- a/e2e/cases/source-build/app-ts-loader/package.json
+++ b/e2e/cases/source-build/app-ts-loader/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/source-build-app-ts-loader",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "@e2e/source-build-common": "workspace:*"
+  }
+}

--- a/e2e/cases/source-build/app-ts-loader/rsbuild.config.ts
+++ b/e2e/cases/source-build/app-ts-loader/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
+import { webpackProvider } from '@rsbuild/webpack';
+
+export default defineConfig({
+  provider: webpackProvider,
+  plugins: [pluginSourceBuild()],
+  tools: {
+    tsLoader: {},
+  },
+});

--- a/e2e/cases/source-build/app-ts-loader/src/index.tsx
+++ b/e2e/cases/source-build/app-ts-loader/src/index.tsx
@@ -1,0 +1,16 @@
+import { VERSION, type Plugin } from '@e2e/source-build-common';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const rootElement = document.getElementById('root');
+const root = ReactDOM.createRoot(rootElement!);
+
+const App = () => (
+  <div className="container">
+    <main>{VERSION}</main>
+  </div>
+);
+
+root.render(<App />);
+
+export const plugin = { some: true } as Plugin;

--- a/e2e/cases/source-build/app-ts-loader/tsconfig.json
+++ b/e2e/cases/source-build/app-ts-loader/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../common/tsconfig.json"
+    }
+  ]
+}

--- a/e2e/cases/source-build/app/package.json
+++ b/e2e/cases/source-build/app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@e2e/source-build-app",
+  "private": true,
+  "version": "1.0.0",
+  "dependencies": {
+    "@e2e/source-build-components": "workspace:*"
+  }
+}

--- a/e2e/cases/source-build/app/rsbuild.config.ts
+++ b/e2e/cases/source-build/app/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rsbuild/core';
+import { webpackProvider } from '@rsbuild/webpack';
+import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
+
+export default defineConfig({
+  provider: webpackProvider,
+  plugins: [pluginSourceBuild()],
+});

--- a/e2e/cases/source-build/app/src/index.tsx
+++ b/e2e/cases/source-build/app/src/index.tsx
@@ -1,0 +1,15 @@
+import { Card } from '@e2e/source-build-components';
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+const rootElement = document.getElementById('root');
+const root = ReactDOM.createRoot(rootElement!);
+const App = () => (
+  <div className="container">
+    <main>
+      <Card title="App" content="hello world"></Card>
+    </main>
+  </div>
+);
+
+root.render(<App />);

--- a/e2e/cases/source-build/app/tsconfig.json
+++ b/e2e/cases/source-build/app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "declaration": false,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../components/tsconfig.json"
+    }
+  ]
+}

--- a/e2e/cases/source-build/common/package.json
+++ b/e2e/cases/source-build/common/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@e2e/source-build-common",
+  "private": true,
+  "version": "1.0.0",
+  "types": "./dist/types/index.d.ts",
+  "source": "./src/index.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./src/index.ts"
+      ]
+    }
+  }
+}

--- a/e2e/cases/source-build/common/src/index.ts
+++ b/e2e/cases/source-build/common/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+
+export const VERSION = '1.0.0';

--- a/e2e/cases/source-build/common/src/types/index.ts
+++ b/e2e/cases/source-build/common/src/types/index.ts
@@ -1,0 +1,1 @@
+export type Plugin = Record<string, any>;

--- a/e2e/cases/source-build/common/tsconfig.json
+++ b/e2e/cases/source-build/common/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "rootDir": "src",
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/source-build/components/package.json
+++ b/e2e/cases/source-build/components/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@e2e/source-build-components",
+  "private": true,
+  "version": "1.0.0",
+  "source": "./src/index.tsx",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.tsx",
+      "default": "./dist/index.js"
+    },
+    "./card": {
+      "source": "./src/card/index.tsx",
+      "default": "./dist/card/index.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/types/index.d.ts"
+      ],
+      "card": [
+        "./dist/types/card/index.d.ts"
+      ]
+    }
+  },
+  "dependencies": {
+    "@e2e/source-build-utils": "workspace:*"
+  }
+}

--- a/e2e/cases/source-build/components/src/card/index.less
+++ b/e2e/cases/source-build/components/src/card/index.less
@@ -1,0 +1,15 @@
+.card-comp {
+  border: 1px solid #000;
+  border-radius: 6px;
+
+  & > h2 {
+    font-size: 32px;
+    font-weight: bold;
+  }
+
+  & > article {
+    display: block;
+    font-size: 16px;
+    background-color: aqua;
+  }
+}

--- a/e2e/cases/source-build/components/src/card/index.tsx
+++ b/e2e/cases/source-build/components/src/card/index.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { strAdd } from '@e2e/source-build-utils';
+import './index.less';
+
+export interface CardProps {
+  title: string;
+  content?: string;
+}
+
+export const Card = (props: CardProps) => {
+  const { title, content = '' } = props;
+  return (
+    <div className="card-comp">
+      <h2>Card Comp Title: {title}</h2>
+      <article>{strAdd('Card Comp Content:', content)}</article>
+    </div>
+  );
+};

--- a/e2e/cases/source-build/components/src/index.tsx
+++ b/e2e/cases/source-build/components/src/index.tsx
@@ -1,0 +1,1 @@
+export * from '@/card/index';

--- a/e2e/cases/source-build/components/tsconfig.json
+++ b/e2e/cases/source-build/components/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@card/*": ["./src/card/*"]
+    },
+    "rootDir": "src",
+    "outDir": "./dist"
+  },
+  "references": [
+    {
+      "path": "../utils"
+    }
+  ],
+  "include": ["src"]
+}

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -1,0 +1,29 @@
+import { join } from 'path';
+import { expect } from '@playwright/test';
+import { webpackOnlyTest } from '@scripts/helper';
+import { dev, getHrefByEntryName } from '@scripts/shared';
+import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
+
+const fixture = join(__dirname, 'app');
+
+webpackOnlyTest(
+  'should build succeed with source build plugin',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: fixture,
+      entry: {
+        index: join(fixture, 'src/index.tsx'),
+      },
+      plugins: [pluginSourceBuild()],
+    });
+
+    await page.goto(getHrefByEntryName('index', rsbuild.port));
+
+    const locator = page.locator('#root');
+    await expect(locator).toHaveText(
+      'Card Comp Title: AppCARD COMP CONTENT:hello world',
+    );
+
+    await rsbuild.server.close();
+  },
+);

--- a/e2e/cases/source-build/ts-loader.test.ts
+++ b/e2e/cases/source-build/ts-loader.test.ts
@@ -1,0 +1,27 @@
+import { join } from 'path';
+import { expect } from '@playwright/test';
+import { webpackOnlyTest } from '@scripts/helper';
+import { dev, getHrefByEntryName } from '@scripts/shared';
+import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
+
+const fixture = join(__dirname, 'app-ts-loader');
+
+webpackOnlyTest(
+  'should build succeed with default ts-loader options',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: fixture,
+      entry: {
+        index: join(fixture, 'src/index.tsx'),
+      },
+      plugins: [pluginSourceBuild()],
+    });
+
+    await page.goto(getHrefByEntryName('index', rsbuild.port));
+
+    const locator = page.locator('#root');
+    await expect(locator).toHaveText('1.0.0');
+
+    await rsbuild.server.close();
+  },
+);

--- a/e2e/cases/source-build/utils/package.json
+++ b/e2e/cases/source-build/utils/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@e2e/source-build-utils",
+  "private": true,
+  "version": "1.0.0",
+  "source": "./src/index.ts",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts"
+    },
+    "./common": {
+      "source": "./src/common/index.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/types/index.d.ts"
+      ],
+      "common": [
+        "./dist/types/common/index.d.ts"
+      ]
+    }
+  }
+}

--- a/e2e/cases/source-build/utils/src/common/index.ts
+++ b/e2e/cases/source-build/utils/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './toUpperCase';
+export * from './toLowerCase';

--- a/e2e/cases/source-build/utils/src/common/toLowerCase.ts
+++ b/e2e/cases/source-build/utils/src/common/toLowerCase.ts
@@ -1,0 +1,1 @@
+export const toLowerCase = (s: string) => s.toLowerCase();

--- a/e2e/cases/source-build/utils/src/common/toUpperCase.ts
+++ b/e2e/cases/source-build/utils/src/common/toUpperCase.ts
@@ -1,0 +1,1 @@
+export const toUpperCase = (s: string) => s.toUpperCase();

--- a/e2e/cases/source-build/utils/src/index.ts
+++ b/e2e/cases/source-build/utils/src/index.ts
@@ -1,0 +1,5 @@
+import { toLowerCase, toUpperCase } from '@common/index';
+
+export const strAdd = (str1: string, str2: string) => {
+  return `${toUpperCase(str1)}${toLowerCase(str2)}`;
+};

--- a/e2e/cases/source-build/utils/tsconfig.json
+++ b/e2e/cases/source-build/utils/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "./dist/types",
+    "declarationMap": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@common/*": ["./src/common/*"]
+    },
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/source-map/package.json
+++ b/e2e/cases/source-map/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-webpack-source-map",
+  "name": "@e2e/webpack-source-map",
   "version": "1.0.0",
   "dependencies": {
     "source-map": "0.7.4",

--- a/e2e/cases/source-map/source.test.ts
+++ b/e2e/cases/source-map/source.test.ts
@@ -68,7 +68,7 @@ test('source-map', async () => {
     ])
   ).map((o) => ({
     ...o,
-    source: o.source!.split('@rsbuild/e2e-webpack-source-map/')[1] || o.source,
+    source: o.source!.split('source-map/')[1] || o.source,
   }));
 
   expect(originalPositions[0]).toEqual({

--- a/e2e/cases/styled-component/package.json
+++ b/e2e/cases/styled-component/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@rsbuild/e2e-styled-component",
+  "name": "@e2e/styled-component",
   "private": true,
   "dependencies": {
     "styled-components": "^6.0.0"

--- a/e2e/cases/ts-loader/index.test.ts
+++ b/e2e/cases/ts-loader/index.test.ts
@@ -4,7 +4,7 @@ import { webpackOnlyTest } from '@scripts/helper';
 import { build } from '@scripts/shared';
 
 webpackOnlyTest('build pass with default ts-loader options', async () => {
-  const rsbuild = await build({
+  const rsbuild = await build<'webpack'>({
     cwd: __dirname,
     entry: { index: path.resolve(__dirname, './src/index.ts') },
     rsbuildConfig: {

--- a/e2e/cases/vue/package.json
+++ b/e2e/cases/vue/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-vue3",
+  "name": "@e2e/vue3",
   "version": "1.0.0",
   "dependencies": {
     "vue": "^3.3.4"

--- a/e2e/cases/vue2/package.json
+++ b/e2e/cases/vue2/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "name": "@rsbuild/e2e-vue2",
+  "name": "@e2e/vue2",
   "version": "1.0.0",
   "dependencies": {
     "vue": "^2.7.14"

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -21,6 +21,7 @@
     "@rsbuild/plugin-image-compress": "workspace:*",
     "@rsbuild/plugin-node-polyfill": "workspace:*",
     "@rsbuild/plugin-stylus": "workspace:*",
+    "@rsbuild/plugin-source-build": "workspace:*",
     "@rsbuild/plugin-swc": "workspace:*",
     "@rsbuild/plugin-type-check": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -86,10 +86,12 @@ const updateConfigForTest = <BundlerType>(
 };
 
 export async function dev<BundlerType = 'rspack'>({
+  plugins,
   serverOptions,
   rsbuildConfig = {},
   ...options
 }: CreateRsbuildOptions & {
+  plugins?: any[];
   rsbuildConfig?: BundlerType extends 'webpack'
     ? WebpackRsbuildConfig
     : RspackRsbuildConfig;
@@ -100,6 +102,11 @@ export async function dev<BundlerType = 'rspack'>({
   updateConfigForTest(rsbuildConfig);
 
   const rsbuild = await createRsbuild(options, rsbuildConfig);
+
+  if (plugins) {
+    rsbuild.addPlugins(plugins);
+  }
+
   return rsbuild.startDevServer({
     printURLs: false,
     serverOptions,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "pnpm run ut",
     "bump": "modern bump",
     "lint": "oxlint .",
-    "build": "nx run-many -t build --exclude @examples/* @scripts/*",
+    "build": "nx run-many -t build --exclude @examples/* @scripts/* @e2e/*",
     "change": "modern change",
     "release": "modern release",
     "prepare": "pnpm run build && husky install",

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -108,8 +108,7 @@ export function pluginSourceBuild(
               chain.resolve.plugin(TS_CONFIG_PATHS).tap((options) => {
                 const references = projects
                   .map((project) => path.join(project.dir, TS_CONFIG_FILE))
-                  .filter((filePath) => fs.existsSync(filePath))
-                  .map((filePath) => path.relative(projectRootPath, filePath));
+                  .filter((filePath) => fs.existsSync(filePath));
 
                 return options.map((option) => ({
                   ...option,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@rsbuild/plugin-node-polyfill':
         specifier: workspace:*
         version: link:../packages/plugin-node-polyfill
+      '@rsbuild/plugin-source-build':
+        specifier: workspace:*
+        version: link:../packages/plugin-source-build
       '@rsbuild/plugin-stylus':
         specifier: workspace:*
         version: link:../packages/plugin-stylus
@@ -181,6 +184,28 @@ importers:
       '@types/prop-types':
         specifier: ^15
         version: 15.7.9
+
+  e2e/cases/source-build/app:
+    dependencies:
+      '@e2e/source-build-components':
+        specifier: workspace:*
+        version: link:../components
+
+  e2e/cases/source-build/app-ts-loader:
+    dependencies:
+      '@e2e/source-build-common':
+        specifier: workspace:*
+        version: link:../common
+
+  e2e/cases/source-build/common: {}
+
+  e2e/cases/source-build/components:
+    dependencies:
+      '@e2e/source-build-utils':
+        specifier: workspace:*
+        version: link:../utils
+
+  e2e/cases/source-build/utils: {}
 
   e2e/cases/source-map:
     dependencies:


### PR DESCRIPTION
## Summary

Add e2e cases for plugin-source-build.

## Related Issue

https://github.com/web-infra-dev/rsbuild/issues/23

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
