### PR TITLE
fix(webpack): failed to compile decorators for node target

### DIFF
--- a/packages/webpack/src/plugins/babel.ts
+++ b/packages/webpack/src/plugins/babel.ts
@@ -75,19 +75,23 @@ export const pluginBabel = (): RsbuildPlugin => ({
             },
           };
 
+          const decoratorConfig = {
+            version: config.output.enableLatestDecorators
+              ? '2018-09'
+              : 'legacy',
+          } as const;
+
           const baseBabelConfig =
             isServer || isServiceWorker
-              ? getBabelConfigForNode()
+              ? getBabelConfigForNode({
+                  pluginDecorators: decoratorConfig,
+                })
               : getBabelConfigForWeb({
                   presetEnv: {
                     targets: browserslist,
                     useBuiltIns: getUseBuiltIns(config),
                   },
-                  pluginDecorators: {
-                    version: config.output.enableLatestDecorators
-                      ? '2018-09'
-                      : 'legacy',
-                  },
+                  pluginDecorators: decoratorConfig,
                 });
 
           applyPluginImport(baseBabelConfig, config.source.transformImport);

--- a/packages/webpack/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/webpack/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -214,6 +214,12 @@ exports[`plugin-babel > should adjust browserslist when target is node 1`] = `
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [
@@ -280,6 +286,12 @@ exports[`plugin-babel > should adjust browserslist when target is node 1`] = `
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [

--- a/packages/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1902,6 +1902,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "compact": true,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [
@@ -1979,6 +1985,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "compact": true,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
                 [


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/modern.js/pull/4840

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
