### PR TITLE
perf: enable new Oxc resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "ut": "vitest run",
     "ut:watch": "vitest",
     "e2e": "cd ./e2e && pnpm test",
+    "e2e:rspack": "cd ./e2e && pnpm test:rspack",
+    "e2e:webpack": "cd ./e2e && pnpm test:webpack",
     "new": "modern new",
     "test": "pnpm run ut",
     "bump": "modern bump",

--- a/packages/core/src/rspack-provider/plugins/transition.ts
+++ b/packages/core/src/rspack-provider/plugins/transition.ts
@@ -1,3 +1,4 @@
+import { setConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 /**
@@ -13,6 +14,10 @@ export const pluginTransition = (): RsbuildPlugin => ({
       if (isProd) {
         chain.optimization.chunkIds('deterministic');
       }
+    });
+
+    api.modifyRspackConfig((config) => {
+      setConfig(config, 'experiments.rspackFuture.newResolver', true);
     });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -20,6 +20,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
+      "newResolver": true,
     },
   },
   "infrastructureLogging": {

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -20,6 +20,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
+      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -771,6 +772,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
+      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -1572,6 +1574,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctyly when targ
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
+      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -2068,6 +2071,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
+      "newResolver": true,
     },
   },
   "infrastructureLogging": {


### PR DESCRIPTION
## Summary

Enable new Oxc resolver.

## Related Issue

https://github.com/web-infra-dev/rspack/releases/tag/v0.3.7

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
