### PR TITLE
fix: should not print stats object

### DIFF
--- a/packages/core/src/rspack-provider/core/build.ts
+++ b/packages/core/src/rspack-provider/core/build.ts
@@ -9,20 +9,11 @@ export type BuildExecuter = {
   (compiler: Compiler | MultiCompiler): Promise<{ stats?: Stats | MultiStats }>;
 };
 
-export interface RspackBuildError extends Error {
-  stats?: Stats | MultiStats;
-}
-
-/**
- * @throws {RspackBuildError}
- */
 export const rspackBuild: BuildExecuter = async (compiler) => {
   return new Promise((resolve, reject) => {
     compiler.run((err: any, stats?: Stats) => {
       if (err || stats?.hasErrors()) {
-        const buildError: RspackBuildError =
-          err || new Error('Rspack build failed!');
-        buildError.stats = stats;
+        const buildError = err || new Error('Rspack build failed!');
         reject(buildError);
       }
       // If there is a compilation error, the close method should not be called.

--- a/packages/webpack/src/core/build.ts
+++ b/packages/webpack/src/core/build.ts
@@ -14,20 +14,11 @@ export interface BuildExecuter {
   (compiler: Compiler | MultiCompiler): Promise<{ stats: Stats | MultiStats }>;
 }
 
-export interface WebpackBuildError extends Error {
-  stats?: Stats | MultiStats;
-}
-
-/**
- * @throws {WebpackBuildError}
- */
 export const webpackBuild: BuildExecuter = async (compiler) => {
   return new Promise((resolve, reject) => {
     compiler.run((err, stats) => {
       if (err || stats?.hasErrors()) {
-        const buildError: WebpackBuildError =
-          err || new Error('webpack build failed!');
-        buildError.stats = stats as Stats;
+        const buildError = err || new Error('Webpack build failed!');
         reject(buildError);
       }
       // If there is a compilation error, the close method should not be called.

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -1,7 +1,6 @@
 export { webpackProvider } from './provider';
 export type { WebpackProvider } from './provider';
 export { webpackBuild } from './core/build';
-export type { WebpackBuildError } from './core/build';
 export { createDefaultConfig } from './config/defaults';
 export type {
   LessLoaderOptions,


### PR DESCRIPTION
## Summary

<img width="1138" alt="Screenshot 2023-10-25 at 11 15 42" src="https://github.com/web-infra-dev/modern.js/assets/7237365/0c5cae4d-902b-40d2-84f3-d83059f9f12e">



<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee85691</samp>

This pull request fixes a bug that caused the builder to print the full stats object when an error occurred during compilation. It also removes unnecessary error types and stats assignments from the `builder-webpack-provider` and `builder-rspack-provider` packages, and updates the changeset file accordingly.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee85691</samp>

*  Remove unnecessary stats property from build errors and simplify error handling logic in `builder-webpack-provider` and `builder-rspack-provider` packages ([link](https://github.com/web-infra-dev/modern.js/pull/4849/files?diff=unified&w=0#diff-f47bddcf07465bcfd8fcd68c22a5650ef42be0dd3f58c0943c4411219ff89f7bL17-R21), [link](https://github.com/web-infra-dev/modern.js/pull/4849/files?diff=unified&w=0#diff-db347cc1c3cfe7c244466a6c30bf7087a932e21eb7e6b5d93cb664d776211e14L21-R25), [link](https://github.com/web-infra-dev/modern.js/pull/4849/files?diff=unified&w=0#diff-0e2a50b1200aadc5bd1c15db903a4c5cdcde0a101aa14e06eeff3e7598df48b3L4))
* Add changeset file to document patch updates and bug fix for the two packages ([link](https://github.com/web-infra-dev/modern.js/pull/4849/files?diff=unified&w=0#diff-0be2759138c9502579436bb5a12d7870d952536ac0c1d6b6ca000f0d5182a6ebR1-R8))

## Reproduce

```js
const path = require('path');
const { createBuilder } = require('@modern-js/builder');
const {
  builderWebpackProvider,
} = require('@modern-js/builder-webpack-provider');

const provider = builderWebpackProvider({
  builderConfig: {
    output: {
      polyfill: 'off',
    },
  },
});

createBuilder(provider, {
  entry: {
    // an unexist path
    contentScript: path.resolve(__dirname, './test.ts'),
  },
}).then(builder => {
  try {
    builder.build();
  } catch (err) {
    console.log(err);
  }
});
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
