### PR TITLE
fix: update modern && rspress workflow token

### DIFF
--- a/.github/workflows/update-modern.yml
+++ b/.github/workflows/update-modern.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
           branch: 'feat-update-modern-version'
           title: 'feat: update modern version'
           body: 'feat: update modern version'

--- a/.github/workflows/update-rspress.yml
+++ b/.github/workflows/update-rspress.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
+          token: ${{ secrets.REPO_SCOPED_TOKEN }}
           branch: 'feat-update-rspress-version'
           title: 'feat: update rspress version'
           body: 'feat: update rspress version'


### PR DESCRIPTION
## Summary
- create pull request to use REPO_SCOPED_TOKEN to trigger ci running in update-modern workflow and update-rspress workflow

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
