### PR TITLE
fix(webpack): display error progress bar when compile failed

### DIFF
--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/ProgressPlugin.ts
@@ -7,7 +7,6 @@ import type { Props } from './helpers/type';
 export interface ProgressOptions
   extends Omit<Partial<Props>, 'message' | 'total' | 'current' | 'done'> {
   id?: string;
-  clearOnDone?: boolean;
 }
 
 export class ProgressPlugin extends webpack.ProgressPlugin {
@@ -20,7 +19,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
   compileTime: string | null = null;
 
   constructor(options: ProgressOptions) {
-    const { id = 'Modern', clearOnDone = false } = options;
+    const { id = 'Rsbuild' } = options;
 
     const nonTTYLogger = createNonTTYLogger();
     const friendlyPercentage = createFriendlyPercentage();
@@ -47,10 +46,6 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
             hasErrors: this.hasCompileErrors,
           });
           bus.render();
-
-          if (percentage === 1 && clearOnDone) {
-            bus.clear();
-          }
         } else {
           nonTTYLogger.log({
             id,

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bar.ts
@@ -11,6 +11,8 @@ const defaultOption: Props = {
   char: '━',
   width: 25,
   buildIcon: '◯',
+  errorIcon: '✖',
+  errorInfo: 'compile failed',
   message: '',
   done: false,
   spaceWidth: 1,
@@ -40,6 +42,8 @@ export const renderBar = (option: Partial<Props>) => {
     total,
     done,
     buildIcon,
+    errorIcon,
+    errorInfo,
     width,
     current,
     color,
@@ -68,6 +72,17 @@ export const renderBar = (option: Partial<Props>) => {
   const { columns: terminalWidth = FULL_WIDTH } = process.stdout;
 
   if (done) {
+    if (hasErrors) {
+      const message = doneColor(errorInfo);
+
+      if (terminalWidth >= MIDDLE_WIDTH) {
+        return [idColor(errorIcon), id, doneColor(`${space}${message}`)].join(
+          '',
+        );
+      }
+      return [id, doneColor(`${message}`)].join('');
+    }
+
     return '';
   }
 

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/bus.ts
@@ -54,20 +54,20 @@ class Bus {
     const maxIdLen = Math.max(...this.states.map((i) => i.id?.length ?? 0)) + 2;
     const { columns = FULL_WIDTH } = process.stdout;
     this.prevOutput = this.states
-      .map((i, k) =>
-        cliTruncate(
-          renderBar({
-            maxIdLen,
-            color: i.color ?? getProgressColor(k),
-            ...i,
-          }),
-          columns,
-          {
-            position: 'end',
-          },
-        ),
-      )
+      .map((i, k) => {
+        const bar = renderBar({
+          maxIdLen,
+          color: i.color ?? getProgressColor(k),
+          ...i,
+        });
+        if (bar) {
+          return cliTruncate(bar, columns, { position: 'end' });
+        }
+        return null;
+      })
+      .filter((item) => item !== null)
       .join('\n');
+
     this.writeToStd();
   }
 

--- a/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/type.ts
+++ b/packages/webpack/src/webpackPlugins/ProgressPlugin/helpers/type.ts
@@ -10,6 +10,8 @@ export type Props = {
   char: string;
   width: number;
   buildIcon: string;
+  errorIcon: string;
+  errorInfo: string;
   message: string;
   done: boolean;
   messageWidth: number;


### PR DESCRIPTION
## Summary

- Make the error status more explicit. 
- Reduce empty lines.

<img width="1129" alt="Screenshot 2023-10-25 at 14 01 39" src="https://github.com/web-infra-dev/modern.js/assets/7237365/ed34a52f-15fd-4eb8-bb49-18ec3fcbe5cf">

<!-- The summary can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:summary" placeholder. -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c1675a</samp>

This pull request adds error handling and display to the `ProgressPlugin` for webpack. It updates the `bar.ts`, `bus.ts`, and `type.ts` files in the `@modern-js/builder-webpack-provider` package, and adds a changeset file for the patch release.

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5c1675a</samp>

*  Add a changeset file for patching `@modern-js/builder-webpack-provider` ([link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-46b76b5d3fd8d01eb46d2bcd577c96f84d2cc8e528b96709c1512f44a6a811b5R1-R7))
*  Add `errorIcon` and `errorInfo` properties to `defaultOption` and `Props` type for customizing error display in progress bar ([link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7R14-R15), [link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-29618e585d98f29e31d70ef2dc8756e7417a38bc5cd0103efde9136f26300a78R11-R12))
*  Modify `renderBar` function in `bar.ts` to return different strings based on `hasErrors` property ([link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7R45-R46), [link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-5f00a7aab1a777042d4d7f3189b7c726cc87e2df1862312d8a267b7720935ca7R75-R85))
*  Modify `render` method in `Bus` class in `bus.ts` to filter out null values and check for null before truncating ([link](https://github.com/web-infra-dev/modern.js/pull/4855/files?diff=unified&w=0#diff-a4504fca2d9827cddacdfe648cc40efb71325090e54ac8ae7b02095de4d6a17dL58-R71))

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
