### PR TITLE
Release v0.0.8

### DIFF
--- a/.changeset/blue-mugs-refuse.md
+++ b/.changeset/blue-mugs-refuse.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-react': patch
----
-
-feat(plugin-react): extract antd/arco/splitChunks logics into react plugin

--- a/.changeset/chilled-plums-lie.md
+++ b/.changeset/chilled-plums-lie.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-styled-components': patch
----
-
-feat(plugin-styled-components): support styled-components in rspack mode

--- a/.changeset/clean-shoes-return.md
+++ b/.changeset/clean-shoes-return.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/shared': patch
----
-
-feat(rsbuild/shared): init @rsbuild/shared

--- a/.changeset/flat-eagles-battle.md
+++ b/.changeset/flat-eagles-battle.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-feat(rsbuild): init rsbuild pkg

--- a/.changeset/fresh-terms-invent.md
+++ b/.changeset/fresh-terms-invent.md
@@ -1,7 +1,0 @@
----
-'@rsbuild/webpack': patch
-'@rsbuild/shared': patch
-'@rsbuild/core': patch
----
-
-chore: remove modern-web target

--- a/.changeset/good-vans-jam.md
+++ b/.changeset/good-vans-jam.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/webpack': patch
----
-
-feat(rsbuild/webpack): init

--- a/.changeset/healthy-rockets-greet.md
+++ b/.changeset/healthy-rockets-greet.md
@@ -1,7 +1,0 @@
----
-'@rsbuild/doctor-types': patch
-'@rsbuild/doctor-utils': patch
-'@rsbuild/doctor-sdk': patch
----
-
-feat: rsbuild doctor add doctor-types,doctor-utils, doctor-sdk

--- a/.changeset/lovely-rabbits-count.md
+++ b/.changeset/lovely-rabbits-count.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/document': patch
----
-
-fix homepage of chinese jump to english version

--- a/.changeset/many-adults-smash.md
+++ b/.changeset/many-adults-smash.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-feat: Use Rspack `builtin:swc-loader` instead of Rspack's built-in translation behavior

--- a/.changeset/metal-moose-complain.md
+++ b/.changeset/metal-moose-complain.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-styled-components': patch
----
-
-feat(plugin-styled-components): extract the styledComponents plugin as a standalone package

--- a/.changeset/modern-candles-float.md
+++ b/.changeset/modern-candles-float.md
@@ -1,6 +1,0 @@
----
-'@rsbuild/document': patch
-'@rsbuild/core': patch
----
-
-feat(cli): support rsbuild inspect command

--- a/.changeset/nasty-pianos-beg.md
+++ b/.changeset/nasty-pianos-beg.md
@@ -1,6 +1,0 @@
----
-'@rsbuild/document': patch
-'@rsbuild/shared': patch
----
-
-feat: flatten the output html files

--- a/.changeset/popular-humans-lie.md
+++ b/.changeset/popular-humans-lie.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/document': patch
----
-
-fix(@rsbuild/document): correct api content about outputStructure

--- a/.changeset/serious-berries-cheat.md
+++ b/.changeset/serious-berries-cheat.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-feat(core): add basic implementation of CLI

--- a/.changeset/shy-houses-allow.md
+++ b/.changeset/shy-houses-allow.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-react': patch
----
-
-feat(plugin-react): extract the React plugin as a standalone package

--- a/.changeset/silent-windows-add.md
+++ b/.changeset/silent-windows-add.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-svgr': patch
----
-
-feat(plugin-svgr): extract svgr as a standalone package

--- a/.changeset/sixty-cows-breathe.md
+++ b/.changeset/sixty-cows-breathe.md
@@ -1,9 +1,0 @@
----
-'@rsbuild/plugin-swc': patch
-'@rsbuild/document': patch
-'@rsbuild/webpack': patch
-'@rsbuild/shared': patch
-'@rsbuild/core': patch
----
-
-feat: adjust the default browserslist config

--- a/.changeset/warm-planets-remain.md
+++ b/.changeset/warm-planets-remain.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/shared': patch
----
-
-chore: replace modern.js logger with rslog

--- a/.changeset/yellow-masks-bake.md
+++ b/.changeset/yellow-masks-bake.md
@@ -1,6 +1,0 @@
----
-'@rsbuild/doctor-utils': patch
-'@rsbuild/doctor-sdk': patch
----
-
-feat: rsbuild doctor add rule-utils package

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rsbuild/babel-preset
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/babel-preset"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,1 +1,18 @@
 # @rsbuild/core
+
+## 0.0.8
+
+### Patch Changes
+
+- d6755bf: feat(rsbuild): init rsbuild pkg
+- af1da01: chore: remove modern-web target
+- b1a1327: feat: Use Rspack `builtin:swc-loader` instead of Rspack's built-in translation behavior
+- 290427a: feat(cli): support rsbuild inspect command
+- 3936afc: feat(core): add basic implementation of CLI
+- 349df6f: feat: adjust the default browserslist config
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.0.0"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/doctor-sdk/CHANGELOG.md
+++ b/packages/doctor-sdk/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @rsbuild/doctor-sdk
+
+## 0.0.2
+
+### Patch Changes
+
+- 5fe8de3: feat: rsbuild doctor add doctor-types,doctor-utils, doctor-sdk
+- f16cba2: feat: rsbuild doctor add rule-utils package
+- Updated dependencies [5fe8de3]
+- Updated dependencies [f16cba2]
+  - @rsbuild/doctor-utils@0.0.2

--- a/packages/doctor-sdk/package.json
+++ b/packages/doctor-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/doctor-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/type/index.d.ts",

--- a/packages/doctor-types/CHANGELOG.md
+++ b/packages/doctor-types/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @rsbuild/doctor-types
+
+## 0.0.2
+
+### Patch Changes
+
+- 5fe8de3: feat: rsbuild doctor add doctor-types,doctor-utils, doctor-sdk

--- a/packages/doctor-types/package.json
+++ b/packages/doctor-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/doctor-types",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/packages/doctor-utils/CHANGELOG.md
+++ b/packages/doctor-utils/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/doctor-utils
+
+## 0.0.2
+
+### Patch Changes
+
+- 5fe8de3: feat: rsbuild doctor add doctor-types,doctor-utils, doctor-sdk
+- f16cba2: feat: rsbuild doctor add rule-utils package

--- a/packages/doctor-utils/package.json
+++ b/packages/doctor-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/doctor-utils",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "dist/index.js",
   "types": "dist/type/index.d.ts",
   "files": [

--- a/packages/document/CHANGELOG.md
+++ b/packages/document/CHANGELOG.md
@@ -1,1 +1,11 @@
 # @rsbuild/document
+
+## 0.0.8
+
+### Patch Changes
+
+- 9f4b6e7: fix homepage of chinese jump to english version
+- 290427a: feat(cli): support rsbuild inspect command
+- ce80b80: feat: flatten the output html files
+- f6b0c20: fix(@rsbuild/document): correct api content about outputStructure
+- 349df6f: feat: adjust the default browserslist config

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/document",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Shared documentation of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/monorepo-utils/CHANGELOG.md
+++ b/packages/monorepo-utils/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @rsbuild/monorepo-utils
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+
 ## 0.0.7
 
 ### Patch Changes

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/monorepo-utils"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/plugin-esbuild/CHANGELOG.md
+++ b/packages/plugin-esbuild/CHANGELOG.md
@@ -1,1 +1,12 @@
 # @rsbuild/plugin-esbuild
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-esbuild/package.json
+++ b/packages/plugin-esbuild/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-esbuild"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/plugin-image-compress/CHANGELOG.md
+++ b/packages/plugin-image-compress/CHANGELOG.md
@@ -1,1 +1,12 @@
 # @rsbuild/plugin-image-compress
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-image-compress"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "scripts": {

--- a/packages/plugin-node-polyfill/CHANGELOG.md
+++ b/packages/plugin-node-polyfill/CHANGELOG.md
@@ -1,1 +1,12 @@
 # @rsbuild/plugin-node-polyfill
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-node-polyfill"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -1,1 +1,14 @@
 # @rsbuild/plugin-react
+
+## 0.0.8
+
+### Patch Changes
+
+- 52da9c6: feat(plugin-react): extract antd/arco/splitChunks logics into react plugin
+- 52da9c6: feat(plugin-react): extract the React plugin as a standalone package
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-source-build/CHANGELOG.md
+++ b/packages/plugin-source-build/CHANGELOG.md
@@ -1,1 +1,18 @@
 # @rsbuild/plugin-source-build
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8
+  - @rsbuild/monorepo-utils@0.0.8

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-source-build"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -36,7 +36,7 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugin-styled-components/CHANGELOG.md
+++ b/packages/plugin-styled-components/CHANGELOG.md
@@ -1,1 +1,14 @@
 # @rsbuild/plugin-styled-components
+
+## 0.0.8
+
+### Patch Changes
+
+- 19a2a0d: feat(plugin-styled-components): support styled-components in rspack mode
+- 19a2a0d: feat(plugin-styled-components): extract the styledComponents plugin as a standalone package
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-stylus/CHANGELOG.md
+++ b/packages/plugin-stylus/CHANGELOG.md
@@ -1,1 +1,17 @@
 # @rsbuild/plugin-stylus
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-stylus"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -37,7 +37,7 @@
     "webpack": "^5.88.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svgr/CHANGELOG.md
+++ b/packages/plugin-svgr/CHANGELOG.md
@@ -1,1 +1,13 @@
 # @rsbuild/plugin-svgr
+
+## 0.0.8
+
+### Patch Changes
+
+- 52da9c6: feat(plugin-svgr): extract svgr as a standalone package
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-swc/CHANGELOG.md
+++ b/packages/plugin-swc/CHANGELOG.md
@@ -1,1 +1,13 @@
 # @rsbuild/plugin-swc
+
+## 0.0.8
+
+### Patch Changes
+
+- 349df6f: feat: adjust the default browserslist config
+- Updated dependencies [90cf710]
+- Updated dependencies [af1da01]
+- Updated dependencies [ce80b80]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8

--- a/packages/plugin-swc/package.json
+++ b/packages/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-type-check/CHANGELOG.md
+++ b/packages/plugin-type-check/CHANGELOG.md
@@ -1,1 +1,17 @@
 # @rsbuild/plugin-type-check
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-type-check"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -34,7 +34,7 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugin-vue-jsx/CHANGELOG.md
+++ b/packages/plugin-vue-jsx/CHANGELOG.md
@@ -1,1 +1,13 @@
 # @rsbuild/plugin-vue-jsx
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-vue-jsx"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -35,7 +35,7 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugin-vue/CHANGELOG.md
+++ b/packages/plugin-vue/CHANGELOG.md
@@ -1,1 +1,17 @@
 # @rsbuild/plugin-vue
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-vue"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -35,7 +35,7 @@
     "webpack": "^5.88.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugin-vue2-jsx/CHANGELOG.md
+++ b/packages/plugin-vue2-jsx/CHANGELOG.md
@@ -1,1 +1,17 @@
 # @rsbuild/plugin-vue2-jsx
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-vue2-jsx"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -36,7 +36,7 @@
     "typescript": "^5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/plugin-vue2/CHANGELOG.md
+++ b/packages/plugin-vue2/CHANGELOG.md
@@ -1,1 +1,17 @@
 # @rsbuild/plugin-vue2
+
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/plugin-vue2"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {
@@ -35,7 +35,7 @@
     "webpack": "^5.88.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.0.7"
+    "@rsbuild/core": "workspace:^0.0.8"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @rsbuild/shared
 
+## 0.0.8
+
+### Patch Changes
+
+- 90cf710: feat(rsbuild/shared): init @rsbuild/shared
+- af1da01: chore: remove modern-web target
+- ce80b80: feat: flatten the output html files
+- 349df6f: feat: adjust the default browserslist config
+- d57dcec: chore: replace modern.js logger with rslog
+
 ## 0.0.7
 
 ## 0.0.6

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/shared"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {

--- a/packages/test-helper/CHANGELOG.md
+++ b/packages/test-helper/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @rsbuild/test-helper
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8
+
 ## 0.0.7
 
 ## 0.0.6

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/test-helper"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -1,1 +1,21 @@
 # @rsbuild/webpack
+
+## 0.0.8
+
+### Patch Changes
+
+- af1da01: chore: remove modern-web target
+- 0fe1acb: feat(rsbuild/webpack): init
+- 349df6f: feat: adjust the default browserslist config
+- Updated dependencies [90cf710]
+- Updated dependencies [d6755bf]
+- Updated dependencies [af1da01]
+- Updated dependencies [b1a1327]
+- Updated dependencies [290427a]
+- Updated dependencies [ce80b80]
+- Updated dependencies [3936afc]
+- Updated dependencies [349df6f]
+- Updated dependencies [d57dcec]
+  - @rsbuild/shared@0.0.8
+  - @rsbuild/core@0.0.8
+  - @rsbuild/babel-preset@0.0.8

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -13,7 +13,7 @@
     "node": ">=14.0.0"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "exports": {


### PR DESCRIPTION
## What's Changed
### New Features 🎉
- feat(plugin-react): extract antd/arco/splitChunks logics into react plugin
- feat(plugin-styled-components): support styled-components in rspack mode
- feat(rsbuild/shared): init @rsbuild/shared
- feat(rsbuild): init rsbuild pkg
- feat(rsbuild/webpack): init
- feat: rsbuild doctor add doctor-types,doctor-utils, doctor-sdk
- feat: Use Rspack `builtin:swc-loader` instead of Rspack's built-in translation behavior
- feat(plugin-styled-components): extract the styledComponents plugin as a standalone package
- feat(cli): support rsbuild inspect command
- feat: flatten the output html files
- feat(core): add basic implementation of CLI
- feat(plugin-react): extract the React plugin as a standalone package
- feat(plugin-svgr): extract svgr as a standalone package
- feat: adjust the default browserslist config
- feat: rsbuild doctor add rule-utils package
### Bug Fixes 🐞
- fix homepage of chinese jump to english version
- fix(@rsbuild/document): correct api content about outputStructure
### Other Changes
- chore: remove modern-web target
- chore: replace modern.js logger with rslog