### PR TITLE
fix(workflow): should bump create-rsbuild version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
-  "fixed": [["@rsbuild/!(doctor-*)"], ["@rsbuild/doctor-*"]],
+  "fixed": [["@rsbuild/!(doctor-*)", "create-rsbuild"], ["@rsbuild/doctor-*"]],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "always"

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/create-rsbuild"
   },
   "license": "MIT",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "types": "./src/index.ts",
   "main": "./dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Should bump create-rsbuild version.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
