### PR TITLE
fix(create-rsbuild): skip copy local files for debugging

### DIFF
--- a/.changeset/silver-radios-count.md
+++ b/.changeset/silver-radios-count.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+fix(create-rspack): skip local files for debugging

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -22,7 +22,8 @@
   },
   "scripts": {
     "dev": "modern build --watch",
-    "build": "modern build"
+    "build": "modern build",
+    "start": "node ./dist/index.js"
   },
   "dependencies": {
     "@clack/prompts": "^0.7.0",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -80,9 +80,16 @@ function copyFolder(src: string, dist: string) {
     gitignore: '.gitignore',
   };
 
+  // Skip local files
+  const skipFiles = ['node_modules', 'dist'];
+
   fs.mkdirSync(dist, { recursive: true });
 
   for (const file of fs.readdirSync(src)) {
+    if (skipFiles.includes(file)) {
+      continue;
+    }
+
     const srcFile = path.resolve(src, file);
     const distFile = renameFiles[file]
       ? path.resolve(dist, renameFiles[file])


### PR DESCRIPTION
## Summary

Skip copy local files for debugging.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
