### PR TITLE
fix(create-rsbuild): failed to publish tsconfig of templates

### DIFF
--- a/.changeset/olive-wolves-mate.md
+++ b/.changeset/olive-wolves-mate.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+fix(create-rsbuild): failed to publish tsconfig of templates

--- a/packages/create-rsbuild/.npmignore
+++ b/packages/create-rsbuild/.npmignore
@@ -1,6 +1,6 @@
 template-*/dist/
 template-*/node_modules/
 src/
-tsconfig.json
-modern.config.ts
-CHANGELOG.md
+./tsconfig.json
+./modern.config.ts
+./CHANGELOG.md


### PR DESCRIPTION
## Summary

Fix failed to publish tsconfig of templates.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
