### PR TITLE
fix(plugin-vue): remove compat logic for webpack and swc

### DIFF
--- a/e2e/cases/vue/index.test.ts
+++ b/e2e/cases/vue/index.test.ts
@@ -1,11 +1,12 @@
 import { join } from 'path';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
 import { pluginBabel } from '@rsbuild/plugin-babel';
+import { rspackOnlyTest } from '@scripts/helper';
 
-test('should build basic Vue sfc correctly', async ({ page }) => {
+rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const root = join(__dirname, 'sfc-basic');
 
   const rsbuild = await build({
@@ -28,7 +29,7 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build Vue sfc style correctly', async ({ page }) => {
+rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const root = join(__dirname, 'sfc-style');
 
   const rsbuild = await build({
@@ -51,7 +52,7 @@ test('should build Vue sfc style correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build basic Vue jsx correctly', async ({ page }) => {
+rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const root = join(__dirname, 'jsx-basic');
 
   const rsbuild = await build({
@@ -71,68 +72,77 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build Vue sfc with lang="ts" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-ts');
+rspackOnlyTest(
+  'should build Vue sfc with lang="ts" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-ts');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginVue()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginVue()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('count: 0 foo: bar');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('count: 0 foo: bar');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);
 
-test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-jsx');
+rspackOnlyTest(
+  'should build Vue sfc with lang="jsx" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-jsx');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginBabel(), pluginVue(), pluginVueJsx()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginBabel(), pluginVue(), pluginVueJsx()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('0');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('0');
 
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('Foo');
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('Foo');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);
 
-test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-tsx');
+rspackOnlyTest(
+  'should build Vue sfc with lang="tsx" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-tsx');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginVue(), pluginVueJsx(), pluginBabel()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginVue(), pluginVueJsx(), pluginBabel()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('0');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('0');
 
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('Foo');
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('Foo');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);

--- a/e2e/cases/vue2/index.test.ts
+++ b/e2e/cases/vue2/index.test.ts
@@ -1,11 +1,12 @@
 import { join } from 'path';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
 import { pluginBabel } from '@rsbuild/plugin-babel';
+import { rspackOnlyTest } from '@scripts/helper';
 
-test('should build basic Vue sfc correctly', async ({ page }) => {
+rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const root = join(__dirname, 'sfc-basic');
 
   const rsbuild = await build({
@@ -28,7 +29,7 @@ test('should build basic Vue sfc correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build Vue sfc style correctly', async ({ page }) => {
+rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const root = join(__dirname, 'sfc-style');
 
   const rsbuild = await build({
@@ -51,7 +52,7 @@ test('should build Vue sfc style correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build basic Vue jsx correctly', async ({ page }) => {
+rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const root = join(__dirname, 'jsx-basic');
 
   const rsbuild = await build({
@@ -71,68 +72,77 @@ test('should build basic Vue jsx correctly', async ({ page }) => {
   rsbuild.close();
 });
 
-test('should build Vue sfc with lang="ts" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-ts');
+rspackOnlyTest(
+  'should build Vue sfc with lang="ts" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-ts');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginBabel(), pluginVue2()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginBabel(), pluginVue2()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('count: 0 foo: bar');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('count: 0 foo: bar');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);
 
-test('should build Vue sfc with lang="jsx" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-jsx');
+rspackOnlyTest(
+  'should build Vue sfc with lang="jsx" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-jsx');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginBabel(), pluginVue2(), pluginVue2Jsx()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginBabel(), pluginVue2(), pluginVue2Jsx()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('0');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('0');
 
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('Foo');
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('Foo');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);
 
-test('should build Vue sfc with lang="tsx" correctly', async ({ page }) => {
-  const root = join(__dirname, 'sfc-lang-tsx');
+rspackOnlyTest(
+  'should build Vue sfc with lang="tsx" correctly',
+  async ({ page }) => {
+    const root = join(__dirname, 'sfc-lang-tsx');
 
-  const rsbuild = await build({
-    cwd: root,
-    entry: {
-      main: join(root, 'src/index.js'),
-    },
-    runServer: true,
-    plugins: [pluginBabel(), pluginVue2(), pluginVue2Jsx()],
-  });
+    const rsbuild = await build({
+      cwd: root,
+      entry: {
+        main: join(root, 'src/index.js'),
+      },
+      runServer: true,
+      plugins: [pluginBabel(), pluginVue2(), pluginVue2Jsx()],
+    });
 
-  await page.goto(getHrefByEntryName('main', rsbuild.port));
+    await page.goto(getHrefByEntryName('main', rsbuild.port));
 
-  const button = page.locator('#button');
-  await expect(button).toHaveText('0');
+    const button = page.locator('#button');
+    await expect(button).toHaveText('0');
 
-  const foo = page.locator('#foo');
-  await expect(foo).toHaveText('Foo');
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('Foo');
 
-  rsbuild.close();
-});
+    rsbuild.close();
+  },
+);

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -34,8 +34,7 @@ export function pluginVue(
             compilerOptions: {
               preserveWhitespace: false,
             },
-            experimentalInlineMatchResource:
-              api.context.bundlerType === 'rspack',
+            experimentalInlineMatchResource: true,
           },
           options.vueLoaderOptions ?? {},
         );

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -22,8 +22,7 @@ export function pluginVue2(
             compilerOptions: {
               preserveWhitespace: false,
             },
-            experimentalInlineMatchResource:
-              api.context.bundlerType === 'rspack',
+            experimentalInlineMatchResource: true,
           },
           options.vueLoaderOptions ?? {},
         );
@@ -34,27 +33,6 @@ export function pluginVue2(
           .use(CHAIN_ID.USE.VUE)
           .loader(require.resolve('vue-loader'))
           .options(vueLoaderOptions);
-
-        // Handle ts syntax when using Rspack
-        if (
-          api.context.bundlerType === 'rspack' &&
-          !chain.module.rules.has(CHAIN_ID.RULE.TS)
-        ) {
-          chain.module
-            .rule(CHAIN_ID.RULE.TS)
-            .type('javascript/auto')
-            .test(/\.ts$/)
-            .use(CHAIN_ID.USE.SWC)
-            .loader('builtin:swc-loader')
-            .options({
-              sourceMap: true,
-              jsc: {
-                parser: {
-                  syntax: 'typescript',
-                },
-              },
-            });
-        }
 
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
       });


### PR DESCRIPTION
## Summary

Remove compat logic for webpack and swc.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
