### PR TITLE
chore(deps): bump oxlint v0.0.14, fix flat map

### DIFF
--- a/e2e/cases/performance/load-resource/src/page2/App.tsx
+++ b/e2e/cases/performance/load-resource/src/page2/App.tsx
@@ -1,7 +1,3 @@
-const App = () => (
-  <>
-    <div id="test">Hello Rsbuild!</div>
-  </>
-);
+const App = () => <div id="test">Hello Rsbuild!</div>;
 
 export default App;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "is-ci": "^3.0.1",
     "nano-staged": "^0.8.0",
     "nx": "^17.0.1",
-    "oxlint": "^0.0.13",
+    "oxlint": "^0.0.14",
     "prettier": "^3.0.3",
     "vite-tsconfig-paths": "4.2.1",
     "vitest": "1.0.0-beta.1"

--- a/packages/doctor-utils/src/common/package.ts
+++ b/packages/doctor-utils/src/common/package.ts
@@ -72,23 +72,21 @@ export const getPackageMetaFromModulePath = (
   // Extract package names from module path
   // @NOTE check for uniq for pnpm cases
   const names = uniqLast(
-    paths
-      .map((packagePath) => {
-        // @ts-ignore
-        const found = packagePath.matchAll(PACKAGE_PATH_NAME);
+    paths.flatMap((packagePath) => {
+      // @ts-ignore
+      const found = packagePath.matchAll(PACKAGE_PATH_NAME);
 
-        if (!found) {
-          return [];
-        }
+      if (!found) {
+        return [];
+      }
 
-        const paksArray = compact([...found].flat());
+      const paksArray = compact([...found].flat());
 
-        return paksArray
-          .slice(1)
-          .filter(Boolean)
-          .map((name) => name.replace(/\+/g, '/'));
-      })
-      .flat(),
+      return paksArray
+        .slice(1)
+        .filter(Boolean)
+        .map((name) => name.replace(/\+/g, '/'));
+    }),
   );
 
   // If no names, skip

--- a/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/helpers/doesChunkBelongToHtml.ts
+++ b/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/helpers/doesChunkBelongToHtml.ts
@@ -35,11 +35,8 @@ function recursiveChunkGroup(
   if (!parents.length) {
     // EntryPoint
     return [chunkGroup.name];
-  } else {
-    return parents
-      .map((chunkParent) => recursiveChunkGroup(chunkParent))
-      .flat();
   }
+  return parents.flatMap((chunkParent) => recursiveChunkGroup(chunkParent));
 }
 
 function recursiveChunkEntryNames(chunk: Chunk): string[] {
@@ -49,8 +46,7 @@ function recursiveChunkEntryNames(chunk: Chunk): string[] {
   const [...chunkGroups] = chunk.groupsIterable;
   return uniq(
     chunkGroups
-      .map((chunkGroup) => recursiveChunkGroup(chunkGroup))
-      .flat()
+      .flatMap((chunkGroup) => recursiveChunkGroup(chunkGroup))
       .filter(isChunkName),
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^17.0.1
         version: 17.0.1
       oxlint:
-        specifier: ^0.0.13
-        version: 0.0.13
+        specifier: ^0.0.14
+        version: 0.0.14
       prettier:
         specifier: ^3.0.3
         version: 3.0.3
@@ -4692,48 +4692,48 @@ packages:
     dev: true
     optional: true
 
-  /@oxlint/darwin-arm64@0.0.13:
-    resolution: {integrity: sha512-m+zQ2iifuFQPKoAIIjvx5KpN0EGDOJqNHR95BjySvyiXpQPc6roh8Z6XlqyoBBOf6uGn6aDkM8UqOe74TL/5Ag==}
+  /@oxlint/darwin-arm64@0.0.14:
+    resolution: {integrity: sha512-VjDc02+WWNl17kUUFrvBX3RDl8lYC3e5c6N6TLnrlaVQyIC2vqP/KBFUJlugp9NYzceccSbQOpF7Kk7Ro95JVA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@oxlint/darwin-x64@0.0.13:
-    resolution: {integrity: sha512-yu00jYvziVDCCZpB83uPdD9nuV+bU86CWP0KNecc+/gXypBQffExB6riT/pkA/iXp56JJ1kgGOc7BJBOtnpSCw==}
+  /@oxlint/darwin-x64@0.0.14:
+    resolution: {integrity: sha512-db+OLN/zquMIxRIKLbXqiRhd5Puh4StTRZK7WZszQGb+q/3XVfacS4c2DvlL9BztiUO6pIIb1RiQnegEDTzywA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@oxlint/linux-arm64@0.0.13:
-    resolution: {integrity: sha512-fx4HKL7Up9e5E5iqeh5Cq/osahUFafkTmUmBQY9eQvkym7zBPDSvdILDdtblUPHc8h7d4qxQimf/m8olDaNp1A==}
+  /@oxlint/linux-arm64@0.0.14:
+    resolution: {integrity: sha512-b+ETOsv7YprJaJuQlzxHY1EPLfuGdmoNNgps03PTpMyDs1Q8550aAsOF2Vxoj2w3HWxgUjPWhrzOthCCDjP8eA==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@oxlint/linux-x64@0.0.13:
-    resolution: {integrity: sha512-m2A1s51ItEH6vc2Cx6ZGUNIC8Uvbx74kJYdbTjVNIc/aYFNy34SLaAEvYMw6gVZJWqGiVjY5aqESyToHhIpVuQ==}
+  /@oxlint/linux-x64@0.0.14:
+    resolution: {integrity: sha512-p+4NOoNcSBs6NE3yETyIqNUCCRLbV8gZI/2ZQxvfU+ZMXhdDXV/DcVB0lLwQ/+eHohmyrw43A80y0YVD5LMRLg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@oxlint/win32-arm64@0.0.13:
-    resolution: {integrity: sha512-OUGy/D+TjteNkljDMa6xLfS7CCsPufXJqlmJPWH90sJA5fbTTrHOsDgkqcfy/CxWAnsCOiuX/MTpeLVWpxFjCQ==}
+  /@oxlint/win32-arm64@0.0.14:
+    resolution: {integrity: sha512-/X09LIbM6XHWa3t1VhEkiAP242ZYalpAgLbo0isr1VFL3N4eZYcirEpzGNYeqqAEZ5C2AjtEZ+ZvC8glqEqDfQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /@oxlint/win32-x64@0.0.13:
-    resolution: {integrity: sha512-jKoZm8aS8485aoxdSOfXMDzWPc0ues7qIzwG7buMGYSCeoYYeR1Hylwzfa2DjqVuf9GKc/cNLytULMpb9xiukA==}
+  /@oxlint/win32-x64@0.0.14:
+    resolution: {integrity: sha512-zI0NfJJHrCjFFpIphmu7VvGzAMsQ7k29gKnAhocWJulyGITcdeuV66oIglDmh+ctBwiKP8CUfkkKunq/hIyB3g==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -11357,17 +11357,17 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
-  /oxlint@0.0.13:
-    resolution: {integrity: sha512-n3l787WTTrsb4cp8pNL/Pr3sHUPXRsWYWt3qM2EEyLiW/JQjhjZgHNY/NTdN4lwidObXSlzP3x1llsGc6Ofj3g==}
+  /oxlint@0.0.14:
+    resolution: {integrity: sha512-9+YYaTNBjVWocsgc+20XfzSZm22VcAAh7bNGkTZF9UGJlKH/q/csHeXokIaPSNBQlK0a2p9aXOLnvMi/rY6vCg==}
     engines: {node: '>=14.*'}
     hasBin: true
     optionalDependencies:
-      '@oxlint/darwin-arm64': 0.0.13
-      '@oxlint/darwin-x64': 0.0.13
-      '@oxlint/linux-arm64': 0.0.13
-      '@oxlint/linux-x64': 0.0.13
-      '@oxlint/win32-arm64': 0.0.13
-      '@oxlint/win32-x64': 0.0.13
+      '@oxlint/darwin-arm64': 0.0.14
+      '@oxlint/darwin-x64': 0.0.14
+      '@oxlint/linux-arm64': 0.0.14
+      '@oxlint/linux-x64': 0.0.14
+      '@oxlint/win32-arm64': 0.0.14
+      '@oxlint/win32-x64': 0.0.14
     dev: true
 
   /p-filter@2.1.0:


### PR DESCRIPTION
## Summary

Bump oxlint v0.0.14, fix flat map.

## Related Issue

https://github.com/web-infra-dev/oxc/releases/tag/oxlint_v0.0.14

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
