### PR TITLE
refactor: replace @rspack/dev-client with @rspack/plugin-react-refresh

### DIFF
--- a/.changeset/plenty-trains-laugh.md
+++ b/.changeset/plenty-trains-laugh.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/plugin-react': patch
+'@rsbuild/core': patch
+---
+
+refactor: replace @rspack/dev-client with @rspack/plugin-react-refresh

--- a/packages/compat/webpack/src/core/devMiddleware.ts
+++ b/packages/compat/webpack/src/core/devMiddleware.ts
@@ -11,17 +11,17 @@ const applyHMREntry = (
   clientPath: string,
 ) => {
   const applyEntry = (clientEntry: string, compiler: Compiler) => {
-    new compiler.webpack.EntryPlugin(compiler.context, clientEntry, {
-      name: undefined,
-    }).apply(compiler);
+    if (isClientCompiler(compiler)) {
+      new compiler.webpack.EntryPlugin(compiler.context, clientEntry, {
+        name: undefined,
+      }).apply(compiler);
+    }
   };
 
   // apply dev server to client compiler, add hmr client to entry.
   if ((compiler as MultiCompiler).compilers) {
     (compiler as MultiCompiler).compilers.forEach((target) => {
-      if (isClientCompiler(target)) {
-        applyEntry(clientPath, target);
-      }
+      applyEntry(clientPath, target);
     });
   } else {
     applyEntry(clientPath, compiler as Compiler);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,6 @@
   "dependencies": {
     "@modern-js/server": "^2.39.0",
     "@rspack/core": "0.3.8",
-    "@rspack/dev-client": "0.3.8",
     "@rspack/plugin-html": "0.3.8",
     "@rsbuild/shared": "workspace:*",
     "commander": "^10.0.1",

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,10 +1,10 @@
-import { DefaultRsbuildPlugin } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { applyAntdSupport } from './antd';
 import { applyArcoSupport } from './arco';
 import { applySplitChunksRule } from './splitChunks';
 import { applyBasicReactSupport } from './react';
 
-export const pluginReact = (): DefaultRsbuildPlugin => ({
+export const pluginReact = (): RsbuildPlugin => ({
   name: 'plugin-react',
 
   pre: ['plugin-swc'],

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,6 +1,51 @@
-import { isUsingHMR, type SharedRsbuildPluginAPI } from '@rsbuild/shared';
+import { isUsingHMR, isClientCompiler, isProd } from '@rsbuild/shared';
+import type { Rspack, RsbuildPluginAPI } from '@rsbuild/core/rspack-provider';
 
-export const applyBasicReactSupport = (api: SharedRsbuildPluginAPI) => {
+function getReactRefreshEntry(compiler: Rspack.Compiler) {
+  const hot = compiler.options.devServer?.hot ?? true;
+  const refresh = compiler.options.builtins?.react?.refresh ?? true;
+
+  if (hot && refresh) {
+    const reactRefreshEntryPath = require.resolve(
+      '@rspack/plugin-react-refresh/react-refresh-entry',
+    );
+    return reactRefreshEntryPath;
+  }
+
+  return null;
+}
+
+const setupCompiler = (compiler: Rspack.Compiler) => {
+  if (!isClientCompiler(compiler)) {
+    return;
+  }
+
+  const reactRefreshEntry = getReactRefreshEntry(compiler);
+  if (!reactRefreshEntry) {
+    return;
+  }
+
+  for (const key in compiler.options.entry) {
+    compiler.options.entry[key].import = [
+      reactRefreshEntry,
+      ...(compiler.options.entry[key].import || []),
+    ];
+  }
+};
+
+export const applyBasicReactSupport = (api: RsbuildPluginAPI) => {
+  api.onAfterCreateCompiler(({ compiler: multiCompiler }) => {
+    if (isProd()) {
+      return;
+    }
+
+    if ((multiCompiler as Rspack.MultiCompiler).compilers) {
+      (multiCompiler as Rspack.MultiCompiler).compilers.forEach(setupCompiler);
+    } else {
+      setupCompiler(multiCompiler as Rspack.Compiler);
+    }
+  });
+
   api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {
     const config = api.getNormalizedConfig();
     const usingHMR = isUsingHMR(config, { isProd, target });

--- a/packages/shared/src/apply/html.ts
+++ b/packages/shared/src/apply/html.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { RsbuildTarget, SharedNormalizedConfig } from '../types';
+import { isWebTarget } from '../utils';
 
 export function getTemplatePath(
   entryName: string,
@@ -23,8 +24,6 @@ export const isHtmlDisabled = (
   return (
     htmlPlugin === false ||
     (Array.isArray(htmlPlugin) && htmlPlugin.includes(false)) ||
-    target === 'node' ||
-    target === 'web-worker' ||
-    target === 'service-worker'
+    !isWebTarget(target)
   );
 };

--- a/packages/shared/src/apply/html.ts
+++ b/packages/shared/src/apply/html.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import { RsbuildTarget, SharedNormalizedConfig } from '../types';
-import { isWebTarget } from '../utils';
 
 export function getTemplatePath(
   entryName: string,
@@ -24,6 +23,6 @@ export const isHtmlDisabled = (
   return (
     htmlPlugin === false ||
     (Array.isArray(htmlPlugin) && htmlPlugin.includes(false)) ||
-    !isWebTarget(target)
+    target !== 'web'
   );
 };

--- a/packages/shared/src/devServer.ts
+++ b/packages/shared/src/devServer.ts
@@ -210,17 +210,12 @@ export const isClientCompiler = (compiler: {
   options: {
     target?: Compiler['options']['target'];
   };
-  name?: Compiler['name'];
 }) => {
   const { target } = compiler.options;
 
-  // if target not contains `node` or `webworker`, it's a client compiler
   if (target) {
-    if (Array.isArray(target)) {
-      return !target.includes('node') && !target.includes('webworker');
-    }
-    return target !== 'node' && target !== 'webworker';
+    return Array.isArray(target) ? target.includes('web') : target === 'web';
   }
 
-  return compiler.name === 'client';
+  return false;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -502,9 +502,6 @@ importers:
       '@rspack/core':
         specifier: 0.3.8
         version: 0.3.8
-      '@rspack/dev-client':
-        specifier: 0.3.8
-        version: 0.3.8(react-refresh@0.14.0)(webpack@5.89.0)
       '@rspack/plugin-html':
         specifier: 0.3.8
         version: 0.3.8(@rspack/core@0.3.8)
@@ -4924,6 +4921,7 @@ packages:
       - webpack-dev-server
       - webpack-hot-middleware
       - webpack-plugin-serve
+    dev: true
 
   /@rspack/plugin-html@0.3.8(@rspack/core@0.3.8):
     resolution: {integrity: sha512-eHZo+Ah2vrsS9pxT5Xue7SjSMN8joSNHDLui95Pnni1oj1ESuCojhxPCRxUhbort7xwsGYpnhfhsJZoHL8qN4w==}


### PR DESCRIPTION
## Summary

Replace @rspack/dev-client with @rspack/plugin-react-refresh.

## Related Issue

resolve https://github.com/web-infra-dev/rsbuild/issues/257

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
