### PR TITLE
feat(create-rsbuild): templates depend on latest version of Rsbuild

### DIFF
--- a/.changeset/late-points-yell.md
+++ b/.changeset/late-points-yell.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+feat(create-rsbuild): templates depend on latest version of Rsbuild

--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-react": "nightly"
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-react": "^0.0.10"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -12,8 +12,8 @@
     "react-dom": "^18"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-react": "nightly",
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-react": "^0.0.10",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "typescript": "^5.0.0"

--- a/packages/create-rsbuild/template-vue2-js/package.json
+++ b/packages/create-rsbuild/template-vue2-js/package.json
@@ -11,7 +11,7 @@
     "vue": "^2.7.14"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-vue2": "nightly"
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-vue2": "^0.0.10"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -11,8 +11,8 @@
     "vue": "^2.7.14"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-vue2": "nightly",
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-vue2": "^0.0.10",
     "typescript": "^5.0.0"
   }
 }

--- a/packages/create-rsbuild/template-vue3-js/package.json
+++ b/packages/create-rsbuild/template-vue3-js/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.0.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-vue": "nightly"
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-vue": "^0.0.10"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -11,8 +11,8 @@
     "vue": "^3.0.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "nightly",
-    "@rsbuild/plugin-vue": "nightly",
+    "@rsbuild/core": "^0.0.10",
+    "@rsbuild/plugin-vue": "^0.0.10",
     "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary

Templates depend on latest version of Rsbuild.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
