### PR TITLE
chore(workflow): only run release-nightly in main repo

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   release:
     name: Release Nightly
+    if: github.repository == 'web-infra-dev/rsbuild'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
## Summary

Only run release-nightly in main repo.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
