### PR TITLE
fix(plugin-react): missing react-refresh dependency

### DIFF
--- a/.changeset/strange-rice-dress.md
+++ b/.changeset/strange-rice-dress.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-react': patch
+---
+
+fix(plugin-react): missing react-refresh dependency

--- a/packages/compat/webpack/src/types/config/source.ts
+++ b/packages/compat/webpack/src/types/config/source.ts
@@ -27,7 +27,7 @@ export interface SourceConfig extends SharedSourceConfig {
    */
   moduleScopes?: ChainedConfig<ModuleScopes>;
   /**
-   * Configurare babel-plugin-import or swc-plugin-import or Rspack builtins plugin import
+   * Configure babel-plugin-import or swc-plugin-import or Rspack builtins plugin import
    */
   transformImport?: false | TransformImport[];
 }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -25,7 +25,8 @@
   "license": "MIT",
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/plugin-react-refresh": "0.3.8"
+    "@rspack/plugin-react-refresh": "0.3.8",
+    "react-refresh": "^0.14.0"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,6 +1043,9 @@ importers:
       '@rspack/plugin-react-refresh':
         specifier: 0.3.8
         version: 0.3.8(react-refresh@0.14.0)(webpack@5.89.0)
+      react-refresh:
+        specifier: ^0.14.0
+        version: 0.14.0
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Fix missing react-refresh dependency.

## Related Issue

https://github.com/web-infra-dev/rsbuild/issues/255

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
