### PR TITLE
perf: switch the default polyfill mode to usage

### DIFF
--- a/.changeset/shy-taxis-ring.md
+++ b/.changeset/shy-taxis-ring.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+perf: switch the default polyfill mode to usage

--- a/e2e/cases/source/source.webpack.test.ts
+++ b/e2e/cases/source/source.webpack.test.ts
@@ -13,7 +13,7 @@ test('module-scopes', async ({ page }) => {
   };
 
   await expect(
-    build({
+    build<'webpack'>({
       ...buildOpts,
       rsbuildConfig: {
         source: {
@@ -35,7 +35,7 @@ test('module-scopes', async ({ page }) => {
   rsbuild.close();
 
   // should not throw
-  rsbuild = await build({
+  rsbuild = await build<'webpack'>({
     ...buildOpts,
     rsbuildConfig: {
       source: {

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -27,7 +27,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
               "cwd": "<ROOT>",
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -84,7 +84,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
               "cwd": "<ROOT>",
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -144,7 +144,7 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
             "cwd": "<ROOT>",
             "env": {
               "coreJs": "3.32",
-              "mode": "entry",
+              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -203,7 +203,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
             "cwd": "<ROOT>",
             "env": {
               "coreJs": "3.32",
-              "mode": "entry",
+              "mode": "usage",
               "targets": [
                 "node >= 14",
               ],
@@ -259,7 +259,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
             "cwd": "<ROOT>",
             "env": {
               "coreJs": "3.32",
-              "mode": "entry",
+              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -318,7 +318,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
             "cwd": "<ROOT>",
             "env": {
               "coreJs": "3.32",
-              "mode": "entry",
+              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -377,7 +377,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 4`] = 
             "cwd": "<ROOT>",
             "env": {
               "coreJs": "3.32",
-              "mode": "entry",
+              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -479,7 +479,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>",
           "env": {
             "coreJs": "3.32",
-            "mode": "entry",
+            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -537,7 +537,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>",
           "env": {
             "coreJs": "3.32",
-            "mode": "entry",
+            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -590,7 +590,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>",
           "env": {
             "coreJs": "3.32",
-            "mode": "entry",
+            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -677,7 +677,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
               "cwd": "<ROOT>",
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -734,7 +734,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
               "cwd": "<ROOT>",
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -269,7 +269,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [
@@ -348,7 +348,7 @@ exports[`webpackConfig > should not have any pluginImport in Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [
@@ -437,7 +437,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [
@@ -516,7 +516,7 @@ exports[`webpackConfig > should not set default pluginImport for Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [
@@ -636,7 +636,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [
@@ -723,7 +723,7 @@ exports[`webpackConfig > should set proper pluginImport option in Babel 1`] = `
                   "firefox >= 78",
                   "safari >= 14",
                 ],
-                "useBuiltIns": "entry",
+                "useBuiltIns": "usage",
               },
             ],
             [

--- a/packages/compat/webpack/tests/core/initConfigs.test.ts
+++ b/packages/compat/webpack/tests/core/initConfigs.test.ts
@@ -61,12 +61,7 @@ describe('modifyRsbuildConfig', () => {
 
     const config = await rsbuild.unwrapWebpackConfig();
     expect(config.entry).toEqual({
-      main: [
-        'data:text/javascript,import "core-js";',
-        'a.js',
-        'b.js',
-        'src/index.ts',
-      ],
+      main: ['a.js', 'b.js', 'src/index.ts'],
     });
   });
 });

--- a/packages/compat/webpack/tests/plugins/__snapshots__/babel.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/babel.test.ts.snap
@@ -79,7 +79,7 @@ exports[`plugin-babel > should add rule to compile Data URI when enable source.c
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -158,7 +158,7 @@ exports[`plugin-babel > should add rule to compile Data URI when enable source.c
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -394,7 +394,7 @@ exports[`plugin-babel > should apply exclude condition when using source.exclude
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -473,7 +473,7 @@ exports[`plugin-babel > should apply exclude condition when using source.exclude
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -571,7 +571,7 @@ exports[`plugin-babel > should override targets of babel-preset-env when using o
                     "targets": [
                       "Chrome 80",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -647,7 +647,7 @@ exports[`plugin-babel > should override targets of babel-preset-env when using o
                     "targets": [
                       "Chrome 80",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -916,7 +916,7 @@ exports[`plugin-babel > should set include/exclude 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -995,7 +995,7 @@ exports[`plugin-babel > should set include/exclude 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -222,7 +222,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -313,7 +313,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -881,7 +881,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -978,7 +978,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -2129,7 +2129,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -2226,7 +2226,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
@@ -70,7 +70,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -149,7 +149,7 @@ exports[`plugins/react > should work with babel-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -388,7 +388,7 @@ exports[`plugins/react > should work with ts-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -479,7 +479,7 @@ exports[`plugins/react > should work with ts-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -766,7 +766,7 @@ exports[`plugins/react > should work with ts-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/compat/webpack/tests/plugins/__snapshots__/tsLoader.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/tsLoader.test.ts.snap
@@ -61,7 +61,7 @@ exports[`plugin-ts-loader > should set include/exclude 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -152,7 +152,7 @@ exports[`plugin-ts-loader > should set ts-loader 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -479,7 +479,8 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -521,7 +522,8 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -479,7 +479,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -521,7 +522,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1125,7 +1127,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1167,7 +1170,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -2262,7 +2266,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -2304,7 +2309,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
@@ -36,7 +36,8 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -78,7 +79,8 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -153,7 +155,8 @@ exports[`plugin-swc > should add browserslist 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome 98",
                 ],
@@ -192,7 +195,8 @@ exports[`plugin-swc > should add browserslist 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome 98",
                 ],
@@ -264,7 +268,8 @@ exports[`plugin-swc > should add browserslist 2`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome 98",
                 ],
@@ -303,7 +308,8 @@ exports[`plugin-swc > should add browserslist 2`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome 98",
                 ],
@@ -375,7 +381,8 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -424,7 +431,8 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -506,7 +514,8 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -548,7 +557,8 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1398,7 +1408,8 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1440,7 +1451,8 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/document/docs/en/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/en/guide/advanced/browser-compatibility.md
@@ -183,25 +183,9 @@ Rsbuild compiles JavaScript code through Babel or SWC, and injects polyfill libr
 
 In different usage scenarios, you may need different polyfill solutions. Rsbuild provides [output.polyfill](/config/options/output.html#outputpolyfill) config to switch between different polyfill modes.
 
-### entry mode
+### Usage mode
 
-entry is the default mode and does not need to be set manually.
-
-When using the entry mode, Rsbuild will analyze which `core-js` methods need to be injected according to the browserslist set by the current project, and inject them to the entry file of each page. The polyfill injected in this way is more comprehensive, and there is no need to worry about the project source code and third-party dependencies polyfill issues. However, because some unused polyfill codes are included, the bundle size may increase.
-
-The config of entry mode is:
-
-```ts
-export default {
-  output: {
-    polyfill: 'entry',
-  },
-};
-```
-
-### usage mode
-
-The usage mode allows more precise control over which core-js polyfills need to be injected.
+The usage is the default mode and does not need to be set manually, it allows more precise control over which core-js polyfills need to be injected.
 
 When you enable the usage mode, Rsbuild will analyze the source code in the project and determine which polyfills need to be injected.
 
@@ -226,6 +210,20 @@ The config of usage mode is:
 export default {
   output: {
     polyfill: 'usage',
+  },
+};
+```
+
+### Entry mode
+
+When using the entry mode, Rsbuild will analyze which `core-js` methods need to be injected according to the browserslist set by the current project, and inject them to the entry file of each page. The polyfill injected in this way is more comprehensive, and there is no need to worry about the project source code and third-party dependencies polyfill issues. However, because some unused polyfill codes are included, the bundle size may increase.
+
+The config of entry mode is:
+
+```ts
+export default {
+  output: {
+    polyfill: 'entry',
   },
 };
 ```

--- a/packages/document/docs/en/shared/config/output/polyfill.md
+++ b/packages/document/docs/en/shared/config/output/polyfill.md
@@ -1,22 +1,44 @@
 - **Type:** `'entry' | 'usage' | 'off'`
-- **Default:** `'entry'`
+- **Default:** `'usage'`
 
-Via `output.polyfill` you can configure how the polyfill is injected.
+Through the `output.polyfill` option, you can control the injection mode of the polyfills.
 
-### Config
-
-#### entry
-
-Polyfill is injected in every entry file when `output.polyfill` is configured as `'entry'`.
-
-Equivalent to `useBuiltIns: 'entry'` configuration in `@babel/preset-env`.
+### Configuration Options
 
 #### usage
 
-Polyfill is injected in each file based on the API used in the code.
+When `output.polyfill` is configured as `'usage'`, Rsbuild will inject the polyfills based on the APIs used in each file.
 
-Equivalent to `useBuiltIns: 'usage'` configuration in `@babel/preset-env`.
+```ts
+export default {
+  output: {
+    polyfill: 'usage',
+  },
+};
+```
+
+#### entry
+
+When `output.polyfill` is configured as `'entry'`, Rsbuild will inject the polyfills in each entry file.
+
+```ts
+export default {
+  output: {
+    polyfill: 'entry',
+  },
+};
+```
 
 #### off
 
-Polyfill is not injected. When using this option, you need to ensure code compatibility yourself.
+When `output.polyfill` is configured as `'off'`, Rsbuild will not inject the polyfills, and developers need to ensure code compatibility themselves.
+
+```ts
+export default {
+  output: {
+    polyfill: 'off',
+  },
+};
+```
+
+> Please refer to the [Polyfill Mode](/guide/advanced/browser-compatibility.html#polyfill-mode) for more details.

--- a/packages/document/docs/zh/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/zh/guide/advanced/browser-compatibility.md
@@ -183,25 +183,9 @@ Rsbuild 底层通过 Babel 或 SWC 编译 JavaScript 代码，并注入 [core-js
 
 在不同的使用场景下，你可能会需要不同的 polyfill 方案。Rsbuild 提供了 [output.polyfill](/config/options/output.html#outputpolyfill) 配置项来切换不同的 polyfill 方案。
 
-### entry 方案
-
-entry 为默认方案，无须手动设置。
-
-在使用 entry 方案时，Rsbuild 会根据当前项目设置的浏览器范围来计算需要注入哪些 `core-js` 方法，并在每个页面的入口文件中进行注入。这种方式注入的 polyfill 较为全面，不需要再担心项目源码和第三方依赖的 polyfill 问题，但是因为包含了一些没有用到的 polyfill 代码，所以最终的包大小可能会有所增加。
-
-entry 方案对应的配置为：
-
-```ts
-export default {
-  output: {
-    polyfill: 'entry',
-  },
-};
-```
-
 ### usage 方案
 
-usage 方案可以更精确地控制需要注入哪些 core-js polyfill。
+usage 为默认方案，无须手动设置，它可以精确地控制需要注入哪些 core-js polyfill。
 
 当你开启 usage 方案时，Rsbuild 会分析项目中的源代码，并判断需要注入哪些 polyfill。
 
@@ -226,6 +210,20 @@ usage 方案对应的配置为：
 export default {
   output: {
     polyfill: 'usage',
+  },
+};
+```
+
+### entry 方案
+
+在使用 entry 方案时，Rsbuild 会根据当前项目设置的浏览器范围来计算需要注入哪些 `core-js` 方法，并在每个页面的入口文件中进行注入。这种方式注入的 polyfill 较为全面，不需要再担心项目源码和第三方依赖的 polyfill 问题，但是因为包含了一些没有用到的 polyfill 代码，所以最终的包大小可能会有所增加。
+
+entry 方案对应的配置为：
+
+```ts
+export default {
+  output: {
+    polyfill: 'entry',
   },
 };
 ```

--- a/packages/document/docs/zh/shared/config/output/polyfill.md
+++ b/packages/document/docs/zh/shared/config/output/polyfill.md
@@ -1,22 +1,44 @@
 - **类型：** `'entry' | 'usage' | 'off'`
-- **默认值：** `'entry'`
+- **默认值：** `'usage'`
 
-通过 `output.polyfill` 你可以配置 Polyfill 的注入方式。
+通过 `output.polyfill` 选项，你可以控制 polyfills 的注入方式。
 
 ### 配置项
 
-#### entry
-
-当 `output.polyfill` 配置为 `'entry'` 时，会在每个入口文件中注入 Polyfill。
-
-等价于 `@babel/preset-env` 的 `useBuiltIns: 'entry'` 配置。
-
 #### usage
 
-当 `output.polyfill` 配置为 `'usage'` 时，会在每个文件中根据代码中使用的 API 注入 Polyfill。
+当 `output.polyfill` 配置为 `'usage'` 时，Rsbuild 会在每个文件中根据代码中使用的 API 注入 polyfills。
 
-等价于 `@babel/preset-env` 的 `useBuiltIns: 'usage'` 配置。
+```ts
+export default {
+  output: {
+    polyfill: 'usage',
+  },
+};
+```
+
+#### entry
+
+当 `output.polyfill` 配置为 `'entry'` 时，Rsbuild 会在每个入口文件中注入 polyfills。
+
+```ts
+export default {
+  output: {
+    polyfill: 'entry',
+  },
+};
+```
 
 #### off
 
-不注入 Polyfill。使用此选项时，需要自行保证代码的兼容性。
+当 `output.polyfill` 配置为 `'off'` 时，Rsbuild 不会注入 polyfills，开发者需要自行保证代码的兼容性。
+
+```ts
+export default {
+  output: {
+    polyfill: 'off',
+  },
+};
+```
+
+> 请查看 [Polyfill 方案](/guide/advanced/browser-compatibility.html#polyfill-mode) 了解详细内容。

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -66,7 +66,8 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       "options": {
         "env": {
           "coreJs": "3.32",
-          "mode": "entry",
+          "mode": "usage",
+          "shippedProposals": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -97,7 +97,8 @@ exports[`transformImport > should apply antd & arco transformImport 1`] = `
       "options": {
         "env": {
           "coreJs": "3.32",
-          "mode": "entry",
+          "mode": "usage",
+          "shippedProposals": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -171,7 +172,8 @@ exports[`transformImport > should not apply antd & arco when transformImport is 
       "options": {
         "env": {
           "coreJs": "3.32",
-          "mode": "entry",
+          "mode": "usage",
+          "shippedProposals": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -496,7 +496,8 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -543,7 +544,8 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "options": {
               "env": {
                 "coreJs": "3.32",
-                "mode": "entry",
+                "mode": "usage",
+                "shippedProposals": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -77,7 +77,8 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
       "options": {
         "env": {
           "coreJs": "3.32",
-          "mode": "entry",
+          "mode": "usage",
+          "shippedProposals": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -139,7 +140,8 @@ exports[`plugins/styled-components > should works in rspack mode 1`] = `
       "options": {
         "env": {
           "coreJs": "3.32",
-          "mode": "entry",
+          "mode": "usage",
+          "shippedProposals": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -260,7 +262,7 @@ exports[`plugins/styled-components > should works in webpack babel mode 1`] = `
                 "firefox >= 78",
                 "safari >= 14",
               ],
-              "useBuiltIns": "entry",
+              "useBuiltIns": "usage",
             },
           ],
           [

--- a/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
@@ -76,7 +76,7 @@ exports[`plugin-vue-jsx > should allow to configure jsx babel plugin options 1`]
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -161,7 +161,7 @@ exports[`plugin-vue-jsx > should allow to configure jsx babel plugin options 1`]
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -258,7 +258,7 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -341,7 +341,7 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -438,7 +438,7 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly in rspack mode
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -521,7 +521,7 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly in rspack mode
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
@@ -70,7 +70,7 @@ exports[`plugin-vue2-jsx > should allow to configure jsx babel plugin options 1`
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -155,7 +155,7 @@ exports[`plugin-vue2-jsx > should allow to configure jsx babel plugin options 1`
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -254,7 +254,7 @@ exports[`plugin-vue2-jsx > should apply jsx babel plugin correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [
@@ -339,7 +339,7 @@ exports[`plugin-vue2-jsx > should apply jsx babel plugin correctly 1`] = `
                       "firefox >= 78",
                       "safari >= 14",
                     ],
-                    "useBuiltIns": "entry",
+                    "useBuiltIns": "usage",
                   },
                 ],
                 [

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -104,7 +104,7 @@ export const getDefaultOutputConfig = (): NormalizedSharedOutputConfig => ({
   assetPrefix: DEFAULT_ASSET_PREFIX,
   filename: {},
   charset: 'ascii',
-  polyfill: 'entry',
+  polyfill: 'usage',
   dataUriLimit: {
     svg: DEFAULT_DATA_URL_SIZE,
     font: DEFAULT_DATA_URL_SIZE,


### PR DESCRIPTION
## Summary

Switch the default polyfill mode to usage, this change will greatly reduce the polyfill bundle size of most projects.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
