### PR TITLE
docs: update rem usage

### DIFF
--- a/packages/document/docs/en/guide/advanced/rem.md
+++ b/packages/document/docs/en/guide/advanced/rem.md
@@ -39,7 +39,7 @@ h1 {
 }
 ```
 
-By default, Rsbuild converts all CSS properties from px to rem. If you want to convert only the `font-size` property, you can setting pxtorem.propList is `['font-size']`.
+By default, Rsbuild converts all CSS properties from px to rem. If you want to convert only the `font-size` property, you can setting `pxtorem.propList` is `['font-size']`.
 
 ```ts
 export default {
@@ -52,6 +52,39 @@ export default {
   },
 };
 ```
+
+### How to ignore some CSS properties converted to REM?
+
+[pxtorem.propList](https://github.com/cuth/postcss-pxtorem#options) in addition to specifying which attributes need to be converted, you also can specify which elements are not converted through `!`:
+
+```ts
+export default {
+  output: {
+    convertToRem: {
+      pxtorem: {
+        propList: ['*', '!border-width'], // not convert 'border-width'
+      },
+    },
+  },
+};
+```
+
+If you only want some individual CSS properties not to be converted to REM, you can also refer to the following writing method:
+
+```css
+/* `px` is converted to `rem` */
+.convert {
+    font-size: 16px; // converted to 1rem
+}
+
+/* `Px` or `PX` is ignored by `postcss-pxtorem` but still accepted by browsers */
+.ignore {
+    border: 1Px solid; // ignored
+    border-width: 2PX; // ignored
+}
+```
+
+More info about [postcss-pxtorem](https://github.com/cuth/postcss-pxtorem#a-message-about-ignoring-properties)。
 
 ## Setting the page rootFontSize
 
@@ -78,7 +111,7 @@ export default {
 };
 ```
 
-## Customize maxRootFontSize
+### Customize maxRootFontSize
 
 In the desktop browser, the page rootFontSize obtained from the calculation formula is often too large. When the calculated result large than the maxRootFontSize, the maxRootFontSize will used as the page rootFontSize.
 
@@ -94,11 +127,28 @@ export default {
 };
 ```
 
+### How to get the rootFontSize value that is actually in effect on the page?
+
+The actual rootFontSize in effect for the page is calculated dynamically based on the current page. It can be seen by printing `document.documentElement.style.fontSize` or obtained by `window.ROOT_FONT_SIZE`.
+
+### How to specify the actual rootFontSize value of the page?
+
+By default, the actual rootFontSize of the page will be dynamically calculated based on the situation of the current page. If you want to specify the actual rootFontSize of the page, you can turn off the `enableRuntime` configuration and set it in [Customized html template](/config/options/html.html#htmltemplate) and inject `document.documentElement.style.fontSize = '64px'` by yourself.
+
+```ts
+export default {
+  html: {
+    template: './static/index.html',
+  },
+  output: {
+    convertToRem: {
+      enableRuntime: false,
+    },
+  },
+};
+```
+
 ## How to determine if REM is in effect？
 
 1. CSS: Check the generated `.css` file to see if the value of the corresponding property is converted from px to rem.
 2. HTML: Open the Page Console to see if a valid value exists for `document.documentElement.style.fontSize`.
-
-## How to get the rootFontSize value that is actually in effect on the page?
-
-The actual rootFontSize in effect for the page is calculated dynamically based on the current page. It can be seen by printing `document.documentElement.style.fontSize` or obtained by `window.ROOT_FONT_SIZE`.

--- a/packages/document/docs/zh/guide/advanced/rem.md
+++ b/packages/document/docs/zh/guide/advanced/rem.md
@@ -130,7 +130,7 @@ export default {
 
 ### 如何获取页面实际生效的 rootFontSize 值？
 
-页面实际生效的 rootFontSize 会根据当前页面的情况动态计算。 可通过打印 `document.documentElement.style.fontSize` 查看，也可通过 `window.ROOT_FONT_SIZE` 获取。
+页面实际生效的 rootFontSize 会根据当前页面的情况动态计算。你可以通过打印 `document.documentElement.style.fontSize` 查看，也可通过 `window.ROOT_FONT_SIZE` 获取。
 
 ### 如何指定页面实际生效的 rootFontSize 值？
 

--- a/packages/document/docs/zh/guide/advanced/rem.md
+++ b/packages/document/docs/zh/guide/advanced/rem.md
@@ -39,7 +39,7 @@ h1 {
 }
 ```
 
-Rsbuild 默认会对所有 CSS 属性进行转换，如果希望仅对 font-size 属性进行转换，可通过设置 pxtorem.propList 实现。
+Rsbuild 默认会对所有 CSS 属性进行转换，如果希望仅对 font-size 属性进行转换，可通过设置 `pxtorem.propList` 实现。
 
 ```ts
 export default {
@@ -52,6 +52,39 @@ export default {
   },
 };
 ```
+
+### 如何实现一些 CSS 属性不被转换为 REM？
+
+[pxtorem.propList](https://github.com/cuth/postcss-pxtorem#options) 除了可以指定哪些属性需要被转换外，可以通过 `!` 方式指定哪些元素不被转换：
+
+```ts
+export default {
+  output: {
+    convertToRem: {
+      pxtorem: {
+        propList: ['*', '!border-width'], // 不转换 border-width 属性
+      },
+    },
+  },
+};
+```
+
+如果只希望一些个别 CSS 属性不被转换为 REM 时，也可参考如下写法：
+
+```css
+/* `px` 转换为 `rem` */
+.convert {
+    font-size: 16px; // 转换为 1rem
+}
+
+/* `Px` 或 `PX` 会被 `postcss-pxtorem` 忽略，但是可以被浏览器正常识别 */
+.ignore {
+    border: 1Px solid; // 忽略
+    border-width: 2PX; // 忽略
+}
+```
+
+更多信息可参考 [postcss-pxtorem](https://github.com/cuth/postcss-pxtorem#a-message-about-ignoring-properties)。
 
 ## 根元素字体大小计算
 
@@ -79,7 +112,7 @@ export default {
 };
 ```
 
-## 自定义最大根元素字体值
+### 设置根元素字体最大值
 
 在桌面浏览器端，根据计算公式得到的页面根元素字体值往往过大，当计算出的结果超出了默认的最大根元素字体值时，则采用当前设置的最大根元素字体值为当前根元素字体值。
 
@@ -95,11 +128,28 @@ export default {
 };
 ```
 
+### 如何获取页面实际生效的 rootFontSize 值？
+
+页面实际生效的 rootFontSize 会根据当前页面的情况动态计算。 可通过打印 `document.documentElement.style.fontSize` 查看，也可通过 `window.ROOT_FONT_SIZE` 获取。
+
+### 如何指定页面实际生效的 rootFontSize 值？
+
+默认情况下，页面实际生效的 rootFontSize 会根据当前页面的情况动态计算，如果希望指定页面实际生效的 rootFontSize，可关闭 `enableRuntime` 配置，并在[自定义 html 模版](/config/options/html.html#htmltemplate) 中自行注入 `document.documentElement.style.fontSize = '64px'`。
+
+```ts
+export default {
+  html: {
+    template: './static/index.html',
+  },
+  output: {
+    convertToRem: {
+      enableRuntime: false,
+    },
+  },
+};
+```
+
 ## 如何判断 REM 是否生效？
 
 1. CSS：查看生成的 `.css` 文件中对应属性的值是否从 px 转换成 rem。
 2. HTML：打开页面控制台查看 `document.documentElement.style.fontSize` 是否存在有效值。
-
-## 如何获取页面实际生效的 rootFontSize 值？
-
-页面实际生效的 rootFontSize 会根据当前页面的情况动态计算。 可通过打印 `document.documentElement.style.fontSize` 查看，也可通过 `window.ROOT_FONT_SIZE` 获取。


### PR DESCRIPTION
## Summary

update rem document about `How to ignore some CSS properties converted to REM?` and `How to specify the actual rootFontSize value of the page?`, and reorder them.

before:
<img width="322" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/6abf84e2-7554-4142-892a-ea728ddd6d75">

after:
<img width="323" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/147032e7-1502-4c56-ade7-5dea7deea147">



## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
