### PR TITLE
 refactor: replace @rspack/html-plugin with html-webpack-plugin

### DIFF
--- a/.changeset/gorgeous-cheetahs-look.md
+++ b/.changeset/gorgeous-cheetahs-look.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/document': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: replace @rspack/html-plugin with html-webpack-plugin

--- a/e2e/cases/manifest/index.test.ts
+++ b/e2e/cases/manifest/index.test.ts
@@ -1,11 +1,13 @@
 import { join } from 'path';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { build } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-test('enableAssetManifest', async () => {
+// TODO: https://github.com/web-infra-dev/rspack/issues/4395
+webpackOnlyTest('enableAssetManifest', async () => {
   const rsbuild = await build({
     cwd: fixtures,
     entry: {

--- a/e2e/cases/manifest/index.test.ts
+++ b/e2e/cases/manifest/index.test.ts
@@ -1,13 +1,11 @@
 import { join } from 'path';
-import { expect } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 import { build } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = __dirname;
 
-// TODO: https://github.com/web-infra-dev/rspack/issues/4395
-webpackOnlyTest('enableAssetManifest', async () => {
+test('enableAssetManifest', async () => {
   const rsbuild = await build({
     cwd: fixtures,
     entry: {

--- a/e2e/cases/tools/pug/tests/index.test.ts
+++ b/e2e/cases/tools/pug/tests/index.test.ts
@@ -1,11 +1,13 @@
 import { join, resolve } from 'path';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { webpackOnlyTest } from '@scripts/helper';
 
 const fixtures = resolve(__dirname, '../');
 
-test('pug', async ({ page }) => {
+// TODO unify pug plugin
+webpackOnlyTest('pug', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
     entry: {

--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -69,7 +69,7 @@ async function getChainUtils(
   target: RsbuildTarget,
 ): Promise<ModifyWebpackChainUtils> {
   const { default: webpack } = await import('webpack');
-  const { default: HtmlWebpackPlugin } = await import('html-webpack-plugin');
+  const { default: HtmlPlugin } = await import('html-webpack-plugin');
   const nodeEnv = process.env.NODE_ENV as NodeEnv;
 
   const nameMap = {
@@ -90,8 +90,8 @@ async function getChainUtils(
     isWebWorker: target === 'web-worker',
     CHAIN_ID,
     getCompiledPath,
-    HtmlWebpackPlugin,
-    HtmlPlugin: HtmlWebpackPlugin,
+    HtmlPlugin,
+    HtmlWebpackPlugin: HtmlPlugin,
   };
 }
 

--- a/packages/compat/webpack/src/exports/HtmlWebpackPlugin.ts
+++ b/packages/compat/webpack/src/exports/HtmlWebpackPlugin.ts
@@ -1,3 +1,0 @@
-import HtmlWebpackPlugin from 'html-webpack-plugin';
-
-export default HtmlWebpackPlugin;

--- a/packages/compat/webpack/src/types/hooks.ts
+++ b/packages/compat/webpack/src/types/hooks.ts
@@ -3,10 +3,15 @@ import type { WebpackChain, WebpackConfig } from './thirdParty';
 import type { RuleSetRule, WebpackPluginInstance } from 'webpack';
 
 export type ModifyWebpackChainUtils = ModifyChainUtils & {
-  /** @deprecated Use target instead. */
-  name: string;
   webpack: typeof import('webpack');
   CHAIN_ID: ChainIdentifier;
+  /**
+   * @deprecated Use target instead.
+   * */
+  name: string;
+  /**
+   * @deprecated Use HtmlPlugin instead.
+   */
   HtmlWebpackPlugin: typeof import('html-webpack-plugin');
 };
 

--- a/packages/compat/webpack/tests/webpackConfig.test.ts
+++ b/packages/compat/webpack/tests/webpackConfig.test.ts
@@ -135,6 +135,7 @@ describe('webpackConfig', () => {
       rsbuildConfig: {
         tools: {
           webpack(config, utils) {
+            expect(utils.HtmlPlugin.version).toEqual(5);
             expect(utils.HtmlWebpackPlugin.version).toEqual(5);
           },
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,6 @@
     "@modern-js/server": "^2.39.2",
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.3.10",
-    "@rspack/plugin-html": "0.3.10",
     "commander": "^10.0.1",
     "filesize": "^8.0.7",
     "gzip-size": "^6.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "commander": "^10.0.1",
     "filesize": "^8.0.7",
     "gzip-size": "^6.0.0",
+    "html-webpack-plugin": "5.5.3",
     "jiti": "^1.20.0",
     "lodash": "^4.17.21",
     "open": "^8.4.0",

--- a/packages/core/src/rspack-provider/core/rspackConfig.ts
+++ b/packages/core/src/rspack-provider/core/rspackConfig.ts
@@ -89,7 +89,7 @@ async function getConfigUtils(
 
 async function getChainUtils(target: RsbuildTarget): Promise<ModifyChainUtils> {
   const nodeEnv = process.env.NODE_ENV as NodeEnv;
-  const { default: HtmlPlugin } = await import('@rspack/plugin-html');
+  const { default: HtmlPlugin } = await import('html-webpack-plugin');
   const { default: webpack } = await import('webpack');
 
   return {

--- a/packages/core/src/rspack-provider/rspackPlugin/removeCssSourcemapPlugin.ts
+++ b/packages/core/src/rspack-provider/rspackPlugin/removeCssSourcemapPlugin.ts
@@ -1,5 +1,5 @@
 import type { Compiler, Compilation } from '@rspack/core';
-import type HtmlPlugin from '@rspack/plugin-html';
+import type HtmlPlugin from 'html-webpack-plugin';
 import { COMPILATION_PROCESS_STAGE } from '@rsbuild/shared';
 
 export class RemoveCssSourcemapPlugin {

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/html.test.ts.snap
@@ -8,11 +8,11 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "inject": true,
       },
+      "version": 5,
     },
   ],
 }
@@ -26,8 +26,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -40,6 +39,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
         "template": "<ROOT>/packages/shared/static/template.html",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }
@@ -53,8 +53,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -66,6 +65,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
         "template": "<ROOT>/packages/shared/static/template.html",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }
@@ -79,8 +79,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -111,6 +110,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
         "template": "<ROOT>/packages/shared/static/template.html",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }
@@ -124,8 +124,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -137,6 +136,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
         "template": "<ROOT>/packages/shared/static/template.html",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }
@@ -153,8 +153,7 @@ exports[`plugin-html > should support multi entry 1`] = `
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -166,9 +165,9 @@ exports[`plugin-html > should support multi entry 1`] = `
         "template": "foo",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "foo",
@@ -180,6 +179,7 @@ exports[`plugin-html > should support multi entry 1`] = `
         "template": "bar",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/pug.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/pug.test.ts.snap
@@ -11,8 +11,7 @@ exports[`plugin-pug > should add pug correctly when tools.pug is used 1`] = `
     ],
   },
   "plugins": [
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "main",
@@ -27,9 +26,9 @@ exports[`plugin-pug > should add pug correctly when tools.pug is used 1`] = `
         },
         "templateParameters": [Function],
       },
+      "version": 5,
     },
-    HtmlRspackPlugin {
-      "name": "HtmlRspackPlugin",
+    HtmlWebpackPlugin {
       "userOptions": {
         "chunks": [
           "foo",
@@ -41,6 +40,7 @@ exports[`plugin-pug > should add pug correctly when tools.pug is used 1`] = `
         "template": "bar.html",
         "templateParameters": [Function],
       },
+      "version": 5,
     },
   ],
 }

--- a/packages/document/docs/en/shared/config/tools/bundlerChain.mdx
+++ b/packages/document/docs/en/shared/config/tools/bundlerChain.mdx
@@ -107,9 +107,9 @@ export default {
 
 ### HtmlPlugin
 
-- **Type:** `typeof import('html-webpack-plugin') | import('@rspack/plugin-html') `
+- **Type:** `typeof import('html-webpack-plugin')`
 
-The HtmlPlugin instance in webpack or Rspack:
+The instance of `html-webpack-plugin`:
 
 ```js
 export default {

--- a/packages/document/docs/en/shared/config/tools/htmlPlugin.md
+++ b/packages/document/docs/en/shared/config/tools/htmlPlugin.md
@@ -26,7 +26,7 @@ const defaultHtmlPluginOptions = {
 };
 ```
 
-The configs of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) or [@rspack/plugin-html](https://github.com/web-infra-dev/rspack/tree/main/packages/rspack-plugin-html) can be modified through `tools.htmlPlugin`.
+The configs of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) can be modified through `tools.htmlPlugin`.
 
 ### Object Type
 

--- a/packages/document/docs/en/shared/config/tools/webpack.md
+++ b/packages/document/docs/en/shared/config/tools/webpack.md
@@ -161,17 +161,17 @@ export default {
 };
 ```
 
-#### HtmlWebpackPlugin
+#### HtmlPlugin
 
 - **Type:** `typeof import('html-webpack-plugin')`
 
-The HtmlWebpackPlugin instance:
+The instance of `html-webpack-plugin`:
 
 ```js
 export default {
   tools: {
-    webpack: (chain, { HtmlWebpackPlugin }) => {
-      console.log(HtmlWebpackPlugin);
+    webpack: (chain, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
     },
   },
 };

--- a/packages/document/docs/en/shared/config/tools/webpackChain.md
+++ b/packages/document/docs/en/shared/config/tools/webpackChain.md
@@ -116,17 +116,17 @@ export default {
 };
 ```
 
-#### HtmlWebpackPlugin
+#### HtmlPlugin
 
 - **Type:** `typeof import('html-webpack-plugin')`
 
-The HtmlWebpackPlugin instance:
+The instance of `html-webpack-plugin`:
 
 ```js
 export default {
   tools: {
-    webpackChain: (chain, { HtmlWebpackPlugin }) => {
-      console.log(HtmlWebpackPlugin);
+    webpackChain: (chain, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
     },
   },
 };

--- a/packages/document/docs/zh/shared/config/tools/bundlerChain.mdx
+++ b/packages/document/docs/zh/shared/config/tools/bundlerChain.mdx
@@ -110,9 +110,9 @@ export default {
 
 ### HtmlPlugin
 
-- **类型：** `typeof import('html-webpack-plugin') | import('@rspack/plugin-html') `
+- **类型：** `typeof import('html-webpack-plugin')`
 
-通过这个参数你可以拿到 webpack 或 Rspack 中的 HtmlPlugin 实例。
+通过这个参数你可以拿到 `html-webpack-plugin` 插件的实例。
 
 ```js
 export default {

--- a/packages/document/docs/zh/shared/config/tools/htmlPlugin.md
+++ b/packages/document/docs/zh/shared/config/tools/htmlPlugin.md
@@ -26,7 +26,7 @@ const defaultHtmlPluginOptions = {
 };
 ```
 
-通过 `tools.htmlPlugin` 可以修改 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 或 [@rspack/plugin-html](https://github.com/web-infra-dev/rspack/tree/main/packages/rspack-plugin-html) 的配置项。
+通过 `tools.htmlPlugin` 可以修改 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的配置项。
 
 ### Object 类型
 

--- a/packages/document/docs/zh/shared/config/tools/webpack.md
+++ b/packages/document/docs/zh/shared/config/tools/webpack.md
@@ -161,17 +161,17 @@ export default {
 };
 ```
 
-#### HtmlWebpackPlugin
+#### HtmlPlugin
 
 - **类型：** `typeof import('html-webpack-plugin')`
 
-通过这个参数你可以拿到 HtmlWebpackPlugin 实例。
+通过这个参数你可以拿到 `html-webpack-plugin` 实例。
 
 ```js
 export default {
   tools: {
-    webpack: (chain, { HtmlWebpackPlugin }) => {
-      console.log(HtmlWebpackPlugin);
+    webpack: (chain, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
     },
   },
 };

--- a/packages/document/docs/zh/shared/config/tools/webpackChain.md
+++ b/packages/document/docs/zh/shared/config/tools/webpackChain.md
@@ -119,17 +119,17 @@ export default {
 };
 ```
 
-#### HtmlWebpackPlugin
+#### HtmlPlugin
 
 - **类型：** `typeof import('html-webpack-plugin')`
 
-通过这个参数你可以拿到 HtmlWebpackPlugin 实例。
+通过这个参数你可以拿到 `html-webpack-plugin` 实例。
 
 ```js
 export default {
   tools: {
-    webpackChain: (chain, { HtmlWebpackPlugin }) => {
-      console.log(HtmlWebpackPlugin);
+    webpackChain: (chain, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
     },
   },
 };

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -53,8 +53,7 @@ export type ModifyChainUtils = {
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
   getCompiledPath: (name: string) => string;
-  // todo: html plugin type declare
-  HtmlPlugin: any;
+  HtmlPlugin: typeof import('html-webpack-plugin');
   /**
    * @private should only used in Rsbuild
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,9 +561,6 @@ importers:
       '@rspack/core':
         specifier: 0.3.10
         version: 0.3.10
-      '@rspack/plugin-html':
-        specifier: 0.3.10
-        version: 0.3.10(@rspack/core@0.3.10)
       commander:
         specifier: ^10.0.1
         version: 10.0.1
@@ -573,6 +570,9 @@ importers:
       gzip-size:
         specifier: ^6.0.0
         version: 6.0.0
+      html-webpack-plugin:
+        specifier: 5.5.3
+        version: 5.5.3(webpack@5.89.0)
       jiti:
         specifier: ^1.20.0
         version: 1.20.0
@@ -4878,22 +4878,6 @@ packages:
       zod: 3.22.4
       zod-validation-error: 1.2.0(zod@3.22.4)
 
-  /@rspack/plugin-html@0.3.10(@rspack/core@0.3.10):
-    resolution: {integrity: sha512-zTbcoigqKG8UChq4nBcr47dUZiIBiWwKhqXX++6k7AocyUbBwcVL6tGOtBeSXTMH8IHDazgCACLfbzX+FyKMaw==}
-    peerDependencies:
-      '@rspack/core': 0.3.10
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-    dependencies:
-      '@rspack/core': 0.3.10
-      '@types/html-minifier-terser': 7.0.0
-      html-minifier-terser: 7.0.0
-      lodash.template: 4.5.0
-      parse5: 7.1.1
-      tapable: 2.2.1
-    dev: false
-
   /@rspack/plugin-react-refresh@0.3.10(react-refresh@0.14.0)(webpack@5.89.0):
     resolution: {integrity: sha512-oeCsfEXRguZox5rNyV3ifbyk3G578YZ+5l0ZNCk/tDF5xQnMeJ9vRJ7iFYcHVcuZhZQhuxCwLzeXJ5RNWleqig==}
     peerDependencies:
@@ -5636,10 +5620,6 @@ packages:
 
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
-
-  /@types/html-minifier-terser@7.0.0:
-    resolution: {integrity: sha512-hw3bhStrg5e3FQT8qZKCJTrzt/UbEaunU1xRWJ+aNOTmeBMvE3S4Ml2HiiNnZgL8izu0LFVkHUoPFXL1s5QNpQ==}
-    dev: false
 
   /@types/http-errors@2.0.3:
     resolution: {integrity: sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==}
@@ -7086,13 +7066,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /clean-css@5.2.0:
-    resolution: {integrity: sha512-2639sWGa43EMmG7fn8mdVuBSs6HuWaSor+ZPoFWzenBc6oN+td8YhTfghWXZ25G1NiiSvz8bOFBS7PdSbTiqEA==}
-    engines: {node: '>= 10.0'}
-    dependencies:
-      source-map: 0.6.1
-    dev: false
-
   /clean-css@5.3.2:
     resolution: {integrity: sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==}
     engines: {node: '>= 10.0'}
@@ -7241,6 +7214,9 @@ packages:
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -9389,20 +9365,6 @@ packages:
       relateurl: 0.2.7
       terser: 5.19.2
 
-  /html-minifier-terser@7.0.0:
-    resolution: {integrity: sha512-Adqk0b/pWKIQiGvEAuzPKpBKNHiwblr3QSGS7TTr6v+xXKV9AI2k4vWW+6Oytt6Z5SeBnfvYypKOnz8r75pz3Q==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      camel-case: 4.1.2
-      clean-css: 5.2.0
-      commander: 9.5.0
-      entities: 4.5.0
-      param-case: 3.0.4
-      relateurl: 0.2.7
-      terser: 5.19.2
-    dev: false
-
   /html-tags@2.0.0:
     resolution: {integrity: sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==}
     engines: {node: '>=4'}
@@ -10254,10 +10216,6 @@ packages:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
     dev: true
 
-  /lodash._reinterpolate@3.0.0:
-    resolution: {integrity: sha512-xYHt68QRoYGjeeM/XOE1uJtvXQAgvszfBhjV4yvsQH0u2i9I6cI6c6/eG4Hh3UAOVn0y/xAXwmTzEay49Q//HA==}
-    dev: false
-
   /lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
     dev: true
@@ -10284,19 +10242,6 @@ packages:
   /lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
     dev: true
-
-  /lodash.template@4.5.0:
-    resolution: {integrity: sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-      lodash.templatesettings: 4.2.0
-    dev: false
-
-  /lodash.templatesettings@4.2.0:
-    resolution: {integrity: sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==}
-    dependencies:
-      lodash._reinterpolate: 3.0.0
-    dev: false
 
   /lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -11612,12 +11557,6 @@ packages:
   /parse5@6.0.1:
     resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
     dev: true
-
-  /parse5@7.1.1:
-    resolution: {integrity: sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==}
-    dependencies:
-      entities: 4.5.0
-    dev: false
 
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}


### PR DESCRIPTION
## Summary

Replace @rspack/html-plugin with html-webpack-plugin.

## Related Issue

https://github.com/web-infra-dev/rsbuild/pull/246
https://github.com/web-infra-dev/rspack/discussions/4393

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
