### PR TITLE
fix(startUrl): failed to stringify circular error object

### DIFF
--- a/.changeset/forty-ravens-hang.md
+++ b/.changeset/forty-ravens-hang.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(startUrl): failed to stringify circular error object

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -57,10 +57,8 @@ export async function openBrowser(url: string): Promise<boolean> {
       }
       return false;
     } catch (err) {
-      logger.error(
-        'Failed to open start URL with apple script:',
-        JSON.stringify(err),
-      );
+      logger.error('Failed to open start URL with apple script.');
+      logger.error(err);
       return false;
     }
   }
@@ -72,7 +70,8 @@ export async function openBrowser(url: string): Promise<boolean> {
     await open(url);
     return true;
   } catch (err) {
-    logger.error('Failed to open start URL:', JSON.stringify(err));
+    logger.error('Failed to open start URL.');
+    logger.error(err);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

The error object is circular and can not be stringified.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
