### PR TITLE
fix(core): failed to release static applescript

### DIFF
--- a/.changeset/hip-paws-fry.md
+++ b/.changeset/hip-paws-fry.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(core): failed to release static applescript

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,8 @@
   },
   "files": [
     "bin",
-    "dist"
+    "dist",
+    "static"
   ],
   "scripts": {
     "build": "modern build",


### PR DESCRIPTION
## Summary

Fix failed to release static applescript.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
