### PR TITLE
chore: move cssModuleLocalIdentName compat code to uni-builder

### DIFF
--- a/packages/compat/uni-builder/src/rspack/index.ts
+++ b/packages/compat/uni-builder/src/rspack/index.ts
@@ -6,7 +6,7 @@ import type {
 } from '@rsbuild/core/rspack-provider';
 import type { UniBuilderRspackConfig } from '../types';
 import type { CreateRspackBuilderOptions } from '../types';
-import { parseCommonConfig } from 'src/shared';
+import { parseCommonConfig } from '../shared';
 
 export function parseConfig(uniBuilderConfig: UniBuilderRspackConfig): {
   rsbuildConfig: RsbuildConfig;

--- a/packages/compat/uni-builder/src/rspack/index.ts
+++ b/packages/compat/uni-builder/src/rspack/index.ts
@@ -6,15 +6,13 @@ import type {
 } from '@rsbuild/core/rspack-provider';
 import type { UniBuilderRspackConfig } from '../types';
 import type { CreateRspackBuilderOptions } from '../types';
+import { parseCommonConfig } from 'src/shared';
 
 export function parseConfig(uniBuilderConfig: UniBuilderRspackConfig): {
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 } {
-  return {
-    rsbuildConfig: uniBuilderConfig,
-    rsbuildPlugins: [],
-  };
+  return parseCommonConfig<'rspack'>(uniBuilderConfig);
 }
 
 export async function createRspackBuilder(

--- a/packages/compat/uni-builder/src/shared.ts
+++ b/packages/compat/uni-builder/src/shared.ts
@@ -1,0 +1,32 @@
+import { deepmerge } from '@rsbuild/shared/deepmerge';
+import type {
+  RsbuildPlugin,
+  RsbuildConfig as RsbuildRspackConfig,
+} from '@rsbuild/core';
+import type { RsbuildConfig as RsbuildWebpackConfig } from '@rsbuild/webpack';
+import type { UniBuilderRspackConfig, UniBuilderWebpackConfig } from './types';
+
+export function parseCommonConfig<B = 'rspack' | 'webpack'>(
+  uniBuilderConfig: B extends 'rspack'
+    ? UniBuilderRspackConfig
+    : UniBuilderWebpackConfig,
+): {
+  rsbuildConfig: B extends 'rspack'
+    ? RsbuildRspackConfig
+    : RsbuildWebpackConfig;
+  rsbuildPlugins: RsbuildPlugin[];
+} {
+  const rsbuildConfig = deepmerge({}, uniBuilderConfig);
+
+  if (rsbuildConfig.output.cssModuleLocalIdentName) {
+    rsbuildConfig.output.cssModules ||= {};
+    rsbuildConfig.output.cssModules.localIdentName =
+      rsbuildConfig.output.cssModuleLocalIdentName;
+    delete rsbuildConfig.output.cssModuleLocalIdentName;
+  }
+
+  return {
+    rsbuildConfig: rsbuildConfig,
+    rsbuildPlugins: [],
+  };
+}

--- a/packages/compat/uni-builder/src/shared.ts
+++ b/packages/compat/uni-builder/src/shared.ts
@@ -17,12 +17,12 @@ export function parseCommonConfig<B = 'rspack' | 'webpack'>(
   rsbuildPlugins: RsbuildPlugin[];
 } {
   const rsbuildConfig = deepmerge({}, uniBuilderConfig);
+  const { output } = rsbuildConfig;
 
-  if (rsbuildConfig.output.cssModuleLocalIdentName) {
-    rsbuildConfig.output.cssModules ||= {};
-    rsbuildConfig.output.cssModules.localIdentName =
-      rsbuildConfig.output.cssModuleLocalIdentName;
-    delete rsbuildConfig.output.cssModuleLocalIdentName;
+  if (output.cssModuleLocalIdentName) {
+    output.cssModules ||= {};
+    output.cssModules.localIdentName = output.cssModuleLocalIdentName;
+    delete output.cssModuleLocalIdentName;
   }
 
   return {

--- a/packages/compat/uni-builder/src/types.ts
+++ b/packages/compat/uni-builder/src/types.ts
@@ -19,9 +19,20 @@ export type RsbuildConfig<B = 'rspack'> = B extends 'rspack'
   ? RsbuildRspackConfig
   : RsbuildWebpackConfig;
 
-export type UniBuilderWebpackConfig = RsbuildWebpackConfig & {};
+export type UniBuilderExtraConfig = {
+  output: {
+    /**
+     * @deprecated use output.cssModules.localIdentName instead
+     */
+    cssModuleLocalIdentName?: string;
+  };
+};
 
-export type UniBuilderRspackConfig = RsbuildRspackConfig & {};
+export type UniBuilderWebpackConfig = RsbuildWebpackConfig &
+  UniBuilderExtraConfig;
+
+export type UniBuilderRspackConfig = RsbuildRspackConfig &
+  UniBuilderExtraConfig;
 
 export type BuilderConfig<B = 'rspack'> = B extends 'rspack'
   ? UniBuilderRspackConfig

--- a/packages/compat/uni-builder/src/webpack/index.ts
+++ b/packages/compat/uni-builder/src/webpack/index.ts
@@ -6,15 +6,13 @@ import type {
 } from '@rsbuild/webpack';
 import type { UniBuilderWebpackConfig } from '../types';
 import type { CreateWebpackBuilderOptions } from '../types';
+import { parseCommonConfig } from 'src/shared';
 
 export function parseConfig(uniBuilderConfig: UniBuilderWebpackConfig): {
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 } {
-  return {
-    rsbuildConfig: uniBuilderConfig,
-    rsbuildPlugins: [],
-  };
+  return parseCommonConfig<'webpack'>(uniBuilderConfig);
 }
 
 export async function createWebpackBuilder(

--- a/packages/compat/uni-builder/src/webpack/index.ts
+++ b/packages/compat/uni-builder/src/webpack/index.ts
@@ -6,7 +6,7 @@ import type {
 } from '@rsbuild/webpack';
 import type { UniBuilderWebpackConfig } from '../types';
 import type { CreateWebpackBuilderOptions } from '../types';
-import { parseCommonConfig } from 'src/shared';
+import { parseCommonConfig } from '../shared';
 
 export function parseConfig(uniBuilderConfig: UniBuilderWebpackConfig): {
   rsbuildConfig: RsbuildConfig;

--- a/packages/compat/uni-builder/tests/parseConfig.test.ts
+++ b/packages/compat/uni-builder/tests/parseConfig.test.ts
@@ -1,0 +1,19 @@
+import { parseCommonConfig } from '../src/shared';
+
+describe('parseCommonConfig', () => {
+  test('output.cssModuleLocalIdentName', () => {
+    expect(
+      parseCommonConfig({
+        output: {
+          cssModuleLocalIdentName: '[local]-[hash:base64:6]',
+        },
+      }).rsbuildConfig,
+    ).toEqual({
+      output: {
+        cssModules: {
+          localIdentName: '[local]-[hash:base64:6]',
+        },
+      },
+    });
+  });
+});

--- a/packages/compat/webpack/tests/plugins/css.test.ts
+++ b/packages/compat/webpack/tests/plugins/css.test.ts
@@ -256,23 +256,6 @@ describe('plugin-css', () => {
     );
   });
 
-  it('should allow to custom cssModuleLocalIdentName', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginCss()],
-      rsbuildConfig: {
-        output: {
-          cssModuleLocalIdentName: '[hash:base64]',
-        },
-      },
-    });
-
-    const config = await rsbuild.unwrapWebpackConfig();
-
-    expect(JSON.stringify(config)).toContain(
-      '"localIdentName":"[hash:base64]"',
-    );
-  });
-
   it('should remove some postcss plugins based on browserslist', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],

--- a/packages/core/src/rspack-provider/plugins/css.ts
+++ b/packages/core/src/rspack-provider/plugins/css.ts
@@ -254,7 +254,6 @@ export const pluginCss = (): RsbuildPlugin => {
 
           let localIdentName =
             config.output.cssModules.localIdentName ||
-            config.output.cssModuleLocalIdentName ||
             // Using shorter classname in production to reduce bundle size
             (isProd ? '[local]-[hash:6]' : '[path][name]__[local]-[hash:6]');
 

--- a/packages/core/tests/rspack-provider/plugins/css.test.ts
+++ b/packages/core/tests/rspack-provider/plugins/css.test.ts
@@ -83,29 +83,14 @@ describe('plugin-css', () => {
     );
   });
 
-  it('should allow to custom cssModuleLocalIdentName', async () => {
+  it('should ignore hashDigest when custom cssModules.localIdentName', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
       rsbuildConfig: {
         output: {
-          cssModuleLocalIdentName: '[hash]',
-        },
-      },
-    });
-
-    const bundlerConfigs = await rsbuild.initConfigs();
-
-    expect(JSON.stringify(bundlerConfigs[0])).toContain(
-      '"localIdentName":"[hash]"',
-    );
-  });
-
-  it('should ignore hashDigest when custom cssModuleLocalIdentName', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginCss()],
-      rsbuildConfig: {
-        output: {
-          cssModuleLocalIdentName: '[hash:base64:5]',
+          cssModules: {
+            localIdentName: '[hash:base64:5]',
+          },
         },
       },
     });

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -20,8 +20,6 @@ export const getCssModuleLocalIdentName = (
   isProd: boolean,
 ) =>
   config.output.cssModules.localIdentName ||
-  // compatible with the deprecated config
-  config.output.cssModuleLocalIdentName ||
   // Using shorter classname in production to reduce bundle size
   (isProd
     ? '[local]-[hash:base64:6]'

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -205,10 +205,6 @@ export interface OutputConfig {
    */
   cleanDistPath?: boolean;
   /**
-   * @deprecated use output.cssModules.localIdentName instead
-   */
-  cssModuleLocalIdentName?: string;
-  /**
    * Allow to custom CSS Modules options.
    */
   cssModules?: CssModules;


### PR DESCRIPTION
## Summary

Move cssModuleLocalIdentName compat code to uni-builder.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
