### PR TITLE
fix(shared): get ipv4 interfaces should be uniq & set @types/fs-extra…

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -172,7 +172,7 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-typescript": "^7.23.2",
     "@rspack/core": "0.3.10",
-    "@types/fs-extra": "^11.0.3",
+    "@types/fs-extra": "^11.0.2",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "@types/semver": "^7.5.4",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -148,7 +148,6 @@
   "dependencies": {
     "@modern-js/prod-server": "^2.39.2",
     "@modern-js/server": "^2.39.2",
-    "@types/fs-extra": "^11.0.2",
     "acorn": "^8.10.0",
     "browserslist": "^4.22.1",
     "chalk": "^4.1.2",
@@ -173,6 +172,7 @@
     "@babel/preset-env": "^7.23.2",
     "@babel/preset-typescript": "^7.23.2",
     "@rspack/core": "0.3.10",
+    "@types/fs-extra": "^11.0.3",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "@types/semver": "^7.5.4",

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 import { URL } from 'url';
-import { uniq } from 'lodash';
 import urlJoin from 'url-join';
 import { DEFAULT_DEV_HOST } from './constants';
 
@@ -26,19 +25,22 @@ export type AddressUrl = { label: string; url: string };
 
 const getIpv4Interfaces = () => {
   const interfaces = os.networkInterfaces();
-  const ipv4Interfaces: os.NetworkInterfaceInfo[] = [];
+  const ipv4Interfaces: Map<string, os.NetworkInterfaceInfo> = new Map();
 
   Object.keys(interfaces).forEach((key) => {
     interfaces[key]!.forEach((detail) => {
       // 'IPv4' is in Node <= 17, from 18 it's a number 4 or 6
       const familyV4Value = typeof detail.family === 'string' ? 'IPv4' : 4;
 
-      if (detail.family === familyV4Value) {
-        ipv4Interfaces.push(detail);
+      if (
+        detail.family === familyV4Value &&
+        !ipv4Interfaces.has(detail.address)
+      ) {
+        ipv4Interfaces.set(detail.address, detail);
       }
     });
   });
-  return uniq(ipv4Interfaces);
+  return Array.from(ipv4Interfaces.values());
 };
 
 export const getAddressUrls = (

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import { URL } from 'url';
+import { uniq } from 'lodash';
 import urlJoin from 'url-join';
 import { DEFAULT_DEV_HOST } from './constants';
 
@@ -37,7 +38,7 @@ const getIpv4Interfaces = () => {
       }
     });
   });
-  return ipv4Interfaces;
+  return uniq(ipv4Interfaces);
 };
 
 export const getAddressUrls = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1456,9 +1456,6 @@ importers:
       '@modern-js/server':
         specifier: ^2.39.2
         version: 2.39.2(react-dom@18.2.0)(react@18.2.0)
-      '@types/fs-extra':
-        specifier: ^11.0.2
-        version: 11.0.3
       acorn:
         specifier: ^8.10.0
         version: 8.10.0
@@ -1526,6 +1523,9 @@ importers:
       '@rspack/core':
         specifier: 0.3.10
         version: 0.3.10
+      '@types/fs-extra':
+        specifier: ^11.0.3
+        version: 11.0.3
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -5620,6 +5620,7 @@ packages:
     dependencies:
       '@types/jsonfile': 6.1.3
       '@types/node': 16.18.59
+    dev: true
 
   /@types/hast@2.3.7:
     resolution: {integrity: sha512-EVLigw5zInURhzfXUM65eixfadfsHKomGKUakToXo84t8gGIJuTcD2xooM2See7GyQ7DRtYjhCHnSUQez8JaLw==}
@@ -5678,6 +5679,7 @@ packages:
     resolution: {integrity: sha512-/yqTk2SZ1wIezK0hiRZD7RuSf4B3whFxFamB1kGStv+8zlWScTMcHanzfc0XKWs5vA1TkHeckBlOyM8jxU8nHA==}
     dependencies:
       '@types/node': 16.18.59
+    dev: true
 
   /@types/lodash@4.14.200:
     resolution: {integrity: sha512-YI/M/4HRImtNf3pJgbF+W6FrXovqj+T+/HpENLTooK9PnkacBsDpeP3IpHab40CClUfhNmdM2WTNP2sa2dni5Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1524,8 +1524,8 @@ importers:
         specifier: 0.3.10
         version: 0.3.10
       '@types/fs-extra':
-        specifier: ^11.0.3
-        version: 11.0.3
+        specifier: ^11.0.2
+        version: 11.0.2
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -5613,6 +5613,13 @@ packages:
       '@types/express-serve-static-core': 4.17.38
       '@types/qs': 6.9.9
       '@types/serve-static': 1.15.4
+    dev: true
+
+  /@types/fs-extra@11.0.2:
+    resolution: {integrity: sha512-c0hrgAOVYr21EX8J0jBMXGLMgJqVf/v6yxi0dLaJboW9aQPh16Id+z6w2Tx1hm+piJOLv8xPfVKZCLfjPw/IMQ==}
+    dependencies:
+      '@types/jsonfile': 6.1.3
+      '@types/node': 16.18.59
     dev: true
 
   /@types/fs-extra@11.0.3:


### PR DESCRIPTION
… as devDeps

## Summary

Sometimes, we will get many ipv4 address.But some are same,so address should be uniq.
<img width="433" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/32590310/10c25aca-f534-4782-8bea-ff6ea5d7024d">


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
