### PR TITLE
chore(workflow): exclude all md files from nx cache

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,7 @@
       "dependsOn": ["^build"],
       "inputs": [
         "{projectRoot}/src/**/*",
+        "!{projectRoot}/**/*.{md,mdx}",
         "{projectRoot}/tsconfig.json",
         "{projectRoot}/package.json",
         "{projectRoot}/modern.config.*",


### PR DESCRIPTION
## Summary

Exclude all md files from nx cache.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
