### PR TITLE
refactor: @rsbuild/core no longer depend on webpack

### DIFF
--- a/.changeset/sharp-panthers-hide.md
+++ b/.changeset/sharp-panthers-hide.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: @rsbuild/core no longer depend on webpack

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,8 +78,7 @@
     "open": "^8.4.0",
     "pkg-up": "^3.1.0",
     "postcss": "8.4.31",
-    "semver": "^7.5.4",
-    "webpack": "^5.89.0"
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.200",

--- a/packages/core/src/plugins/moment.ts
+++ b/packages/core/src/plugins/moment.ts
@@ -1,17 +1,72 @@
-import { DefaultRsbuildPlugin } from '@rsbuild/shared';
+import type { DefaultRsbuildPlugin } from '@rsbuild/shared';
+import type { RspackPluginInstance, Compiler } from '@rspack/core';
+
+type IgnorePluginOptions = {
+  /**
+   * A RegExp to test the context (directory) against.
+   */
+  contextRegExp?: RegExp;
+  /**
+   * A RegExp to test the request against.
+   */
+  resourceRegExp: RegExp;
+};
+
+/**
+ * modified from https://github.com/webpack/webpack/blob/main/lib/IgnorePlugin.js
+ * MIT License http://www.opensource.org/licenses/mit-license.php
+ * Author Tobias Koppers @sokra
+ * TODO: remove this plugin after Rspack provides IgnorePlugin
+ */
+class IgnorePlugin implements RspackPluginInstance {
+  options: IgnorePluginOptions;
+
+  constructor(options: IgnorePluginOptions) {
+    this.options = options;
+
+    this.checkIgnore = this.checkIgnore.bind(this);
+  }
+
+  checkIgnore(resolveData: any) {
+    if (
+      'resourceRegExp' in this.options &&
+      this.options.resourceRegExp &&
+      this.options.resourceRegExp.test(resolveData.request)
+    ) {
+      if ('contextRegExp' in this.options && this.options.contextRegExp) {
+        // if "contextRegExp" is given,
+        // both the "resourceRegExp" and "contextRegExp" have to match.
+        if (this.options.contextRegExp.test(resolveData.context)) {
+          return false;
+        }
+      } else {
+        return false;
+      }
+    }
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.normalModuleFactory.tap('IgnorePlugin', (nmf) => {
+      nmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
+    });
+    compiler.hooks.contextModuleFactory.tap('IgnorePlugin', (cmf) => {
+      cmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
+    });
+  }
+}
 
 export const pluginMoment = (): DefaultRsbuildPlugin => ({
   name: 'plugin-moment',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { webpack }) => {
+    api.modifyBundlerChain(async (chain) => {
       const config = api.getNormalizedConfig();
 
       if (config.performance.removeMomentLocale) {
         // Moment.js includes a lots of locale data by default.
         // We can using IgnorePlugin to allow the user to opt into importing specific locales.
         // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-        chain.plugin('remove-moment-locale').use(webpack.IgnorePlugin, [
+        chain.plugin('remove-moment-locale').use(IgnorePlugin, [
           {
             resourceRegExp: /^\.\/locale$/,
             contextRegExp: /moment$/,

--- a/packages/core/src/rspack-provider/core/rspackConfig.ts
+++ b/packages/core/src/rspack-provider/core/rspackConfig.ts
@@ -90,7 +90,6 @@ async function getConfigUtils(
 async function getChainUtils(target: RsbuildTarget): Promise<ModifyChainUtils> {
   const nodeEnv = process.env.NODE_ENV as NodeEnv;
   const { default: HtmlPlugin } = await import('html-webpack-plugin');
-  const { default: webpack } = await import('webpack');
 
   return {
     env: nodeEnv,
@@ -102,7 +101,6 @@ async function getChainUtils(target: RsbuildTarget): Promise<ModifyChainUtils> {
     getCompiledPath,
     CHAIN_ID,
     HtmlPlugin,
-    webpack,
   };
 }
 

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -54,10 +54,6 @@ export type ModifyChainUtils = {
   CHAIN_ID: ChainIdentifier;
   getCompiledPath: (name: string) => string;
   HtmlPlugin: typeof import('html-webpack-plugin');
-  /**
-   * @private should only used in Rsbuild
-   */
-  webpack: typeof import('webpack');
 };
 
 export type ModifyBundlerChainUtils = ModifyChainUtils & {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,9 +606,6 @@ importers:
       semver:
         specifier: ^7.5.4
         version: 7.5.4
-      webpack:
-        specifier: ^5.89.0
-        version: 5.89.0
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.200


### PR DESCRIPTION
## Summary

@rsbuild/core no longer depend on webpack.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
