### PR TITLE
refactor: @rsbuild/shared no longer depend on webpack

### DIFF
--- a/.changeset/spicy-cows-swim.md
+++ b/.changeset/spicy-cows-swim.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: @rsbuild/shared no longer depend on webpack

--- a/packages/compat/webpack/src/core/build.ts
+++ b/packages/compat/webpack/src/core/build.ts
@@ -52,6 +52,7 @@ export const build = async (
   let bundlerConfigs: WebpackConfig[] | undefined;
 
   if (customCompiler) {
+    // @ts-expect-error compiler type mismatch
     compiler = customCompiler;
   } else {
     const { webpackConfigs } = await initConfigs(initOptions);

--- a/packages/compat/webpack/src/core/devMiddleware.ts
+++ b/packages/compat/webpack/src/core/devMiddleware.ts
@@ -11,6 +11,7 @@ const applyHMREntry = (
   clientPath: string,
 ) => {
   const applyEntry = (clientEntry: string, compiler: Compiler) => {
+    // @ts-expect-error compiler type mismatch
     if (isClientCompiler(compiler)) {
       new compiler.webpack.EntryPlugin(compiler.context, clientEntry, {
         name: undefined,

--- a/packages/compat/webpack/src/core/startDevServer.ts
+++ b/packages/compat/webpack/src/core/startDevServer.ts
@@ -54,5 +54,10 @@ export async function startDevServer(
   options: InitConfigsOptions,
   startDevServerOptions: StartDevServerOptions = {},
 ) {
-  return baseStartDevServer(options, createDevServer, startDevServerOptions);
+  return baseStartDevServer(
+    options,
+    // @ts-expect-error compiler type mismatch
+    createDevServer,
+    startDevServerOptions,
+  );
 }

--- a/packages/compat/webpack/src/plugins/fallback.ts
+++ b/packages/compat/webpack/src/plugins/fallback.ts
@@ -30,6 +30,7 @@ export const pluginFallback = (): RsbuildPlugin => ({
         return;
       }
 
+      // @ts-expect-error rule type mismatch
       config.module.rules = resourceRuleFallback(config.module.rules);
     });
   },

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -25,6 +25,7 @@ export function webpackProvider({
 }): WebpackProvider {
   const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
 
+  // @ts-expect-error compiler type mismatch
   return async ({ pluginStore, rsbuildOptions, plugins }) => {
     const context = await createContext(rsbuildOptions, rsbuildConfig);
     const pluginAPI = getPluginAPI({ context, pluginStore });

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -107,9 +107,6 @@ function splitByExperience(ctx: SplitChunksContext): SplitChunks {
     };
   });
 
-  assert(defaultConfig !== false);
-  assert(override !== false);
-
   return {
     ...defaultConfig,
     ...override,
@@ -124,8 +121,6 @@ function splitByExperience(ctx: SplitChunksContext): SplitChunks {
 
 function splitByModule(ctx: SplitChunksContext): SplitChunks {
   const { override, userDefinedCacheGroups, defaultConfig } = ctx;
-  assert(defaultConfig !== false);
-  assert(override !== false);
   return {
     ...defaultConfig,
     minSize: 0,
@@ -139,6 +134,7 @@ function splitByModule(ctx: SplitChunksContext): SplitChunks {
         priority: -10,
         test: NODE_MODULES_REGEX,
         // todo: not support in rspack
+        // @ts-expect-error
         name(module: { context: string | null }): string | false {
           return getPackageNameFromModulePath(module.context!);
         },
@@ -151,8 +147,6 @@ function splitByModule(ctx: SplitChunksContext): SplitChunks {
 function splitBySize(ctx: SplitChunksContext): SplitChunks {
   const { override, userDefinedCacheGroups, defaultConfig, rsbuildConfig } =
     ctx;
-  assert(defaultConfig !== false);
-  assert(override !== false);
   assert(rsbuildConfig.strategy === 'split-by-size');
   return {
     ...defaultConfig,
@@ -169,8 +163,6 @@ function splitBySize(ctx: SplitChunksContext): SplitChunks {
 
 function splitCustom(ctx: SplitChunksContext): SplitChunks {
   const { override, userDefinedCacheGroups, defaultConfig } = ctx;
-  assert(defaultConfig !== false);
-  assert(override !== false);
   return {
     ...defaultConfig,
     ...override,
@@ -184,14 +176,13 @@ function splitCustom(ctx: SplitChunksContext): SplitChunks {
 
 function allInOne(_ctx: SplitChunksContext): SplitChunks {
   // Set false to avoid chunk split.
+  // @ts-expect-error Rspack type missing
   return false;
 }
 
 // Ignore user defined cache group to get single vendor chunk.
 function singleVendor(ctx: SplitChunksContext): SplitChunks {
   const { override, defaultConfig, userDefinedCacheGroups } = ctx;
-  assert(defaultConfig !== false);
-  assert(override !== false);
 
   const singleVendorCacheGroup: CacheGroup = {
     singleVendor: {
@@ -255,6 +246,7 @@ export function pluginSplitChunks(): DefaultRsbuildPlugin {
             // Optimize both `initial` and `async` chunks
             chunks: 'all',
             // When chunk size >= 50000 bytes, split it into separate chunk
+            // @ts-expect-error Rspack type missing
             enforceSizeThreshold: 50000,
             cacheGroups: {},
           };

--- a/packages/core/src/rspack-provider/plugins/fallback.ts
+++ b/packages/core/src/rspack-provider/plugins/fallback.ts
@@ -30,8 +30,6 @@ export const pluginFallback = (): RsbuildPlugin => ({
       setConfig(
         config,
         'module.rules',
-        // Rspack RuleSetRule is not exactly aligned with webpack. But it doesn't matter in resourceRuleFallback.
-        // @ts-expect-error
         resourceRuleFallback(config.module?.rules),
       );
     });

--- a/packages/core/src/rspack-provider/rspackLoader/css-modules-typescript-pre-loader/index.ts
+++ b/packages/core/src/rspack-provider/rspackLoader/css-modules-typescript-pre-loader/index.ts
@@ -92,7 +92,5 @@ export default async function (
   // @ts-expect-error
   this.cssModuleKeys = cssModuleKeys;
 
-  // rspack loader type is not exactly the same as webpack loader type
-  // @ts-expect-error
   return cssModulesTypescriptLoader.call(this, content, ...input);
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -120,6 +120,7 @@
   "dependencies": {
     "@modern-js/prod-server": "0.0.0-next-20231103131234",
     "@modern-js/server": "0.0.0-next-20231103131234",
+    "@rspack/core": "0.3.10",
     "acorn": "^8.10.0",
     "browserslist": "^4.22.1",
     "cssnano": "6.0.1",
@@ -133,7 +134,6 @@
     "rslog": "^1.1.0",
     "semver": "^7.5.4",
     "url-join": "^4.0.1",
-    "webpack": "^5.89.0",
     "webpack-chain": "npm:webpack-5-chain@8.0.1",
     "webpack-sources": "^3.2.3"
   },
@@ -150,7 +150,8 @@
     "html-webpack-plugin": "5.5.3",
     "terser": "5.19.2",
     "terser-webpack-plugin": "5.3.9",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "webpack": "^5.89.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/src/devServer.ts
+++ b/packages/shared/src/devServer.ts
@@ -17,7 +17,7 @@ import { DEFAULT_PORT, DEFAULT_DEV_HOST } from './constants';
 import { createAsyncHook } from './createHook';
 import { mergeChainedOptions } from './mergeChainedOptions';
 import { getServerOptions, printServerURLs } from './prodServer';
-import type { Compiler } from 'webpack';
+import type { Compiler } from '@rspack/core';
 
 type ServerOptions = Exclude<StartDevServerOptions['serverOptions'], undefined>;
 

--- a/packages/shared/src/fallback.ts
+++ b/packages/shared/src/fallback.ts
@@ -1,5 +1,5 @@
 import { JS_REGEX, TS_REGEX, HTML_REGEX, JSON_REGEX } from './constants';
-import type { RuleSetRule } from 'webpack';
+import type { RuleSetRule } from '@rspack/core';
 
 type Rules = (undefined | null | false | '' | 0 | RuleSetRule | '...')[];
 
@@ -30,7 +30,7 @@ export const resourceRuleFallback = (
         rule.mimetype
       )
     ) {
-      rule.oneOf.forEach(item => {
+      rule.oneOf.forEach((item) => {
         if (item) {
           innerRules.push(item);
         }

--- a/packages/shared/src/loaders/css-modules-typescript-loader.ts
+++ b/packages/shared/src/loaders/css-modules-typescript-loader.ts
@@ -14,7 +14,7 @@ import fs from 'fs';
 import path from 'path';
 // @ts-expect-error
 import LineDiff from 'line-diff';
-import type { LoaderContext } from 'webpack';
+import type { LoaderContext } from '@rspack/core';
 import { isCssModules, CssLoaderModules, isInNodeModules } from '../css';
 
 const bannerMessage =

--- a/packages/shared/src/loaders/ignore-css-loader.ts
+++ b/packages/shared/src/loaders/ignore-css-loader.ts
@@ -1,4 +1,4 @@
-import type { LoaderContext } from 'webpack';
+import type { LoaderContext } from '@rspack/core';
 
 export default function (this: LoaderContext<unknown>, source: string) {
   this?.cacheable(true);

--- a/packages/shared/src/plugins/AssetsRetryPlugin.ts
+++ b/packages/shared/src/plugins/AssetsRetryPlugin.ts
@@ -9,12 +9,12 @@ import {
   COMPILATION_PROCESS_STAGE,
 } from './util';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { WebpackPluginInstance, Compiler, Compilation } from 'webpack';
+import type { RspackPluginInstance, Compiler, Compilation } from '@rspack/core';
 import type { AssetsRetryOptions } from '../types';
 import path from 'path';
 import { withPublicPath } from '../url';
 
-export class AssetsRetryPlugin implements WebpackPluginInstance {
+export class AssetsRetryPlugin implements RspackPluginInstance {
   readonly name: string;
 
   readonly distDir: string;
@@ -90,6 +90,7 @@ export class AssetsRetryPlugin implements WebpackPluginInstance {
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       // the behavior of inject/modify tags in afterTemplateExecution hook will not take effect when inject option is false
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
         this.name,
         async (data) => {

--- a/packages/shared/src/plugins/AutoSetRootFontSizePlugin.ts
+++ b/packages/shared/src/plugins/AutoSetRootFontSizePlugin.ts
@@ -11,7 +11,7 @@ import {
 } from './util';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { RemOptions } from '../types';
-import type { Compiler, Compilation, WebpackPluginInstance } from 'webpack';
+import type { Compiler, Compilation, RspackPluginInstance } from '@rspack/core';
 
 type AutoSetRootFontSizeOptions = Omit<
   RemOptions,
@@ -55,7 +55,7 @@ export const DEFAULT_OPTIONS: Required<AutoSetRootFontSizeOptions> = {
   useRootFontSizeBeyondMax: false,
 };
 
-export class AutoSetRootFontSizePlugin implements WebpackPluginInstance {
+export class AutoSetRootFontSizePlugin implements RspackPluginInstance {
   readonly name: string = 'AutoSetRootFontSizePlugin';
 
   readonly distDir: string;
@@ -120,6 +120,7 @@ export class AutoSetRootFontSizePlugin implements WebpackPluginInstance {
     }
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
         this.name,
         async (data) => {

--- a/packages/shared/src/plugins/HtmlAppIconPlugin.ts
+++ b/packages/shared/src/plugins/HtmlAppIconPlugin.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { Compiler, Compilation } from 'webpack';
+import type { Compiler, Compilation } from '@rspack/core';
 // @ts-expect-error
 import { RawSource } from 'webpack-sources';
 import { COMPILATION_PROCESS_STAGE } from './util';
@@ -42,9 +42,10 @@ export class HtmlAppIconPlugin {
 
     // add html asset tags
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tap(
         this.name,
-        data => {
+        (data) => {
           const { publicPath } = compiler.options.output;
 
           data.headTags.unshift({
@@ -72,7 +73,7 @@ export class HtmlAppIconPlugin {
             name: this.name,
             stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_PRE_PROCESS,
           },
-          assets => {
+          (assets) => {
             const source = fs.readFileSync(this.iconPath);
             assets[iconRelativePath] = new RawSource(source, false);
           },

--- a/packages/shared/src/plugins/HtmlCrossOriginPlugin.ts
+++ b/packages/shared/src/plugins/HtmlCrossOriginPlugin.ts
@@ -1,13 +1,13 @@
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { CrossOrigin } from '../types';
-import type { Compiler, WebpackPluginInstance } from 'webpack';
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
 type CrossOriginOptions = {
   crossOrigin: CrossOrigin;
   HtmlPlugin: typeof HtmlWebpackPlugin;
 };
 
-export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
+export class HtmlCrossOriginPlugin implements RspackPluginInstance {
   readonly name: string;
 
   readonly crossOrigin: CrossOrigin;
@@ -26,19 +26,20 @@ export class HtmlCrossOriginPlugin implements WebpackPluginInstance {
       return;
     }
 
-    compiler.hooks.compilation.tap(this.name, compilation => {
+    compiler.hooks.compilation.tap(this.name, (compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTags.tapPromise(
         this.name,
-        async alterAssetTags => {
+        async (alterAssetTags) => {
           const {
             assetTags: { scripts, styles },
           } = alterAssetTags;
 
           scripts.forEach(
-            script => (script.attributes.crossorigin = this.crossOrigin),
+            (script) => (script.attributes.crossorigin = this.crossOrigin),
           );
           styles.forEach(
-            style => (style.attributes.crossorigin = this.crossOrigin),
+            (style) => (style.attributes.crossorigin = this.crossOrigin),
           );
 
           return alterAssetTags;

--- a/packages/shared/src/plugins/HtmlFaviconUrlPlugin.ts
+++ b/packages/shared/src/plugins/HtmlFaviconUrlPlugin.ts
@@ -1,5 +1,5 @@
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { Compiler, Compilation } from 'webpack';
+import type { Compiler, Compilation } from '@rspack/core';
 
 export type FaviconUrls = Array<{
   filename: string;
@@ -27,11 +27,12 @@ export class HtmlFaviconUrlPlugin {
   apply(compiler: Compiler) {
     // add html asset tags
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tap(
         this.name,
-        data => {
+        (data) => {
           const matched = this.faviconUrls.find(
-            item => item.filename === data.outputName,
+            (item) => item.filename === data.outputName,
           );
 
           if (matched) {

--- a/packages/shared/src/plugins/HtmlMetaPlugin.ts
+++ b/packages/shared/src/plugins/HtmlMetaPlugin.ts
@@ -1,6 +1,6 @@
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { HtmlTagObject } from 'html-webpack-plugin';
-import type { Compiler, Compilation } from 'webpack';
+import type { Compiler, Compilation } from '@rspack/core';
 
 export type HtmlMetaPluginOptions = {
   meta: Array<{
@@ -25,6 +25,7 @@ export class HtmlMetaPlugin {
 
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tap(
         this.name,
         (data) => {

--- a/packages/shared/src/plugins/HtmlNetworkPerformancePlugin.ts
+++ b/packages/shared/src/plugins/HtmlNetworkPerformancePlugin.ts
@@ -1,4 +1,4 @@
-import type { Compiler, Compilation, WebpackPluginInstance } from 'webpack';
+import type { Compiler, Compilation, RspackPluginInstance } from '@rspack/core';
 import { kebabCase, upperFirst } from 'lodash';
 import {
   PreconnectOption,
@@ -25,7 +25,7 @@ function generateLinks(
   }));
 }
 
-export class HtmlNetworkPerformancePlugin implements WebpackPluginInstance {
+export class HtmlNetworkPerformancePlugin implements RspackPluginInstance {
   readonly options: DnsPrefetch | Preconnect;
 
   readonly type: NetworkPerformanceType;
@@ -46,6 +46,7 @@ export class HtmlNetworkPerformancePlugin implements WebpackPluginInstance {
     compiler.hooks.compilation.tap(
       `HTML${this.type}Plugin`,
       (compilation: Compilation) => {
+        // @ts-expect-error compilation type mismatch
         this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
           `HTML${upperFirst(this.type)}Plugin`,
           async (htmlPluginData) => {

--- a/packages/shared/src/plugins/HtmlNoncePlugin.ts
+++ b/packages/shared/src/plugins/HtmlNoncePlugin.ts
@@ -1,12 +1,12 @@
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { Compiler, WebpackPluginInstance } from 'webpack';
+import type { Compiler, RspackPluginInstance } from '@rspack/core';
 
 type NonceOptions = {
   nonce: string;
   HtmlPlugin: typeof HtmlWebpackPlugin;
 };
 
-export class HtmlNoncePlugin implements WebpackPluginInstance {
+export class HtmlNoncePlugin implements RspackPluginInstance {
   readonly name: string;
 
   readonly nonce: string;
@@ -25,15 +25,16 @@ export class HtmlNoncePlugin implements WebpackPluginInstance {
       return;
     }
 
-    compiler.hooks.compilation.tap(this.name, compilation => {
+    compiler.hooks.compilation.tap(this.name, (compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTags.tapPromise(
         this.name,
-        async alterAssetTags => {
+        async (alterAssetTags) => {
           const {
             assetTags: { scripts },
           } = alterAssetTags;
 
-          scripts.forEach(script => (script.attributes.nonce = this.nonce));
+          scripts.forEach((script) => (script.attributes.nonce = this.nonce));
           return alterAssetTags;
         },
       );

--- a/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/helpers/doesChunkBelongToHtml.ts
+++ b/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/helpers/doesChunkBelongToHtml.ts
@@ -16,7 +16,8 @@
  */
 
 import { ChunkGroup } from './extractChunks';
-import { Chunk, Compilation } from 'webpack';
+import type { Compilation } from '@rspack/core';
+import type { Chunk } from 'webpack';
 import { PreloadOrPreFetchOption } from '../../../types';
 import { BeforeAssetTagGenerationHtmlPluginData } from './type';
 import { uniq } from 'lodash';

--- a/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import type { Compiler, WebpackPluginInstance, Compilation } from 'webpack';
+import type { Compiler, RspackPluginInstance, Compilation } from '@rspack/core';
 import { upperFirst } from 'lodash';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import { PreloadOrPreFetchOption } from '../../types';
@@ -64,6 +64,7 @@ function generateLinks(
 ): HtmlWebpackPlugin.HtmlTagObject[] {
   // get all chunks
   const extractedChunks = extractChunks({
+    // @ts-expect-error compilation type mismatch
     compilation,
     includeType: options.type,
   });
@@ -151,7 +152,7 @@ function generateLinks(
   return links;
 }
 
-export class HTMLPreloadOrPrefetchPlugin implements WebpackPluginInstance {
+export class HTMLPreloadOrPrefetchPlugin implements RspackPluginInstance {
   readonly options: PreloadOrPreFetchOption;
 
   resourceHints: HtmlWebpackPlugin.HtmlTagObject[] = [];
@@ -179,6 +180,7 @@ export class HTMLPreloadOrPrefetchPlugin implements WebpackPluginInstance {
 
   apply(compiler: Compiler): void {
     compiler.hooks.compilation.tap(this.constructor.name, (compilation) => {
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).beforeAssetTagGeneration.tap(
         `HTML${upperFirst(this.type)}Plugin`,
         (htmlPluginData) => {
@@ -194,6 +196,7 @@ export class HTMLPreloadOrPrefetchPlugin implements WebpackPluginInstance {
         },
       );
 
+      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTags.tap(
         `HTML${upperFirst(this.type)}Plugin`,
         (htmlPluginData) => {

--- a/packages/shared/src/plugins/HtmlTagsPlugin.ts
+++ b/packages/shared/src/plugins/HtmlTagsPlugin.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { Compiler } from 'webpack';
+import type { Compiler } from '@rspack/core';
 import { withPublicPath } from '../url';
 import {
   HtmlInjectTag,
@@ -79,6 +79,7 @@ export class HtmlTagsPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       const compilationHash = compilation.hash || '';
+      // @ts-expect-error compilation type mismatch
       const hooks = this.ctx.HtmlPlugin.getHooks(compilation);
       hooks.alterAssetTagGroups.tap(this.name, (params) => {
         // skip unmatched file and empty tag list.

--- a/packages/shared/src/plugins/InlineChunkHtmlPlugin.ts
+++ b/packages/shared/src/plugins/InlineChunkHtmlPlugin.ts
@@ -7,7 +7,7 @@
  */
 import { join } from 'path';
 import { isFunction, addTrailingSlash } from '../utils';
-import type { Compiler, Compilation } from 'webpack';
+import type { Compiler, Compilation } from '@rspack/core';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { HtmlTagObject } from 'html-webpack-plugin';
 import { COMPILATION_PROCESS_STAGE, getPublicPathFromCompiler } from './util';
@@ -226,6 +226,7 @@ export class InlineChunkHtmlPlugin {
       const tagFunction = (tag: HtmlTagObject) =>
         this.getInlinedTag(publicPath, tag, compilation);
 
+      // @ts-expect-error compilation type mismatch
       const hooks = this.htmlPlugin.getHooks(compilation);
 
       hooks.alterAssetTagGroups.tap(this.name, (assets) => {

--- a/packages/shared/src/plugins/util.ts
+++ b/packages/shared/src/plugins/util.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import type { Compiler } from 'webpack';
+import type { Compiler } from '@rspack/core';
 import { DEFAULT_ASSET_PREFIX } from '../constants';
 import { addTrailingSlash } from '../utils';
 

--- a/packages/shared/src/types/bundlerConfig.ts
+++ b/packages/shared/src/types/bundlerConfig.ts
@@ -1,4 +1,4 @@
-import { Configuration } from 'webpack';
+import { Configuration } from '@rspack/core';
 import type WebpackChain from 'webpack-chain';
 
 export interface BundlerPluginInstance {

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -1,8 +1,7 @@
 import type { InlineChunkTest } from '../../plugins/InlineChunkHtmlPlugin';
 import type { RsbuildTarget } from '../rsbuild';
 import type { CrossOrigin } from './html';
-import type { Externals } from 'webpack';
-import type { Builtins } from '@rspack/core';
+import type { Builtins, Externals } from '@rspack/core';
 
 export type DistPathConfig = {
   /** The root directory of all files. */

--- a/packages/shared/src/types/config/performance.ts
+++ b/packages/shared/src/types/config/performance.ts
@@ -1,4 +1,4 @@
-import type webpack from 'webpack';
+import { Configuration } from '@rspack/core';
 import type { BundleAnalyzerPlugin } from '../../../compiled/webpack-bundle-analyzer';
 
 export type ConsoleType = 'log' | 'info' | 'warn' | 'error' | 'table' | 'group';
@@ -110,7 +110,7 @@ export interface NormalizedPerformanceConfig extends PerformanceConfig {
   chunkSplit: RsbuildChunkSplit;
 }
 
-export type SplitChunks = webpack.Configuration extends {
+export type SplitChunks = Configuration extends {
   optimization?: {
     splitChunks?: infer P;
   };
@@ -118,7 +118,7 @@ export type SplitChunks = webpack.Configuration extends {
   ? P
   : never;
 
-export type CacheGroup = webpack.Configuration extends {
+export type CacheGroup = Configuration extends {
   optimization?: {
     splitChunks?:
       | {

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -4,7 +4,7 @@ import { NodeEnv, PromiseOrNot } from './utils';
 import { RsbuildTarget } from './rsbuild';
 import { BundlerChain } from './bundlerConfig';
 import { mergeRsbuildConfig } from '../mergeRsbuildConfig';
-import type { WebpackPluginInstance } from 'webpack';
+import type { RspackPluginInstance } from '@rspack/core';
 
 export type OnBeforeBuildFn<BundlerConfig = unknown> = (params: {
   bundlerConfigs?: BundlerConfig[];
@@ -58,9 +58,9 @@ export type ModifyChainUtils = {
 
 export type ModifyBundlerChainUtils = ModifyChainUtils & {
   bundler: {
-    BannerPlugin: WebpackPluginInstance;
-    DefinePlugin: WebpackPluginInstance;
-    ProvidePlugin: WebpackPluginInstance;
+    BannerPlugin: RspackPluginInstance;
+    DefinePlugin: RspackPluginInstance;
+    ProvidePlugin: RspackPluginInstance;
   };
 };
 

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -56,11 +56,16 @@ export type ModifyChainUtils = {
   HtmlPlugin: typeof import('html-webpack-plugin');
 };
 
+interface PluginInstance {
+  apply: (compiler: any) => void;
+  [k: string]: any;
+}
+
 export type ModifyBundlerChainUtils = ModifyChainUtils & {
   bundler: {
-    BannerPlugin: RspackPluginInstance;
-    DefinePlugin: RspackPluginInstance;
-    ProvidePlugin: RspackPluginInstance;
+    BannerPlugin: PluginInstance;
+    DefinePlugin: PluginInstance;
+    ProvidePlugin: PluginInstance;
   };
 };
 

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,6 +1,6 @@
 import type { PluginStore, Plugins, DefaultRsbuildPluginAPI } from './plugin';
 import type { Context } from './context';
-import type { Compiler, MultiCompiler } from 'webpack';
+import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { Server, ModernDevServerOptions } from '@modern-js/server';
 import type { AddressUrl } from '../url';

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -4,7 +4,7 @@ import type {
 } from '../../compiled/sass';
 import type * as SassLoader from '../../compiled/sass-loader';
 import type Less from '../../compiled/less';
-import type { LoaderContext } from 'webpack';
+import type { LoaderContext } from '@rspack/core';
 import type TerserPlugin from 'terser-webpack-plugin';
 import type {
   Syntax,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1462,6 +1462,9 @@ importers:
       '@modern-js/server':
         specifier: 0.0.0-next-20231103131234
         version: 0.0.0-next-20231103131234
+      '@rspack/core':
+        specifier: 0.3.10
+        version: 0.3.10
       acorn:
         specifier: ^8.10.0
         version: 8.10.0
@@ -1501,9 +1504,6 @@ importers:
       url-join:
         specifier: ^4.0.1
         version: 4.0.1
-      webpack:
-        specifier: ^5.89.0
-        version: 5.89.0
       webpack-chain:
         specifier: npm:webpack-5-chain@8.0.1
         version: /webpack-5-chain@8.0.1
@@ -1520,9 +1520,6 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
-      '@rspack/core':
-        specifier: 0.3.10
-        version: 0.3.10
       '@types/fs-extra':
         specifier: ^11.0.2
         version: 11.0.2
@@ -1550,6 +1547,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+      webpack:
+        specifier: ^5.89.0
+        version: 5.89.0
 
   packages/test-helper:
     dependencies:
@@ -4733,6 +4733,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-darwin-x64@0.3.10:
@@ -4740,6 +4741,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-gnu@0.3.10:
@@ -4747,6 +4749,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-musl@0.3.10:
@@ -4754,6 +4757,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.3.10:
@@ -4761,6 +4765,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-musl@0.3.10:
@@ -4768,6 +4773,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-win32-arm64-msvc@0.3.10:
@@ -4775,6 +4781,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-win32-ia32-msvc@0.3.10:
@@ -4782,6 +4789,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding-win32-x64-msvc@0.3.10:
@@ -4789,6 +4797,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rspack/binding@0.3.10:
@@ -4803,6 +4812,7 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 0.3.10
       '@rspack/binding-win32-ia32-msvc': 0.3.10
       '@rspack/binding-win32-x64-msvc': 0.3.10
+    dev: false
 
   /@rspack/core@0.3.10:
     resolution: {integrity: sha512-1mwLC9zyF15kpOQzxsrG5zjPxOSQHnKW/MUXvx4ak0JuZCK3uJgLsK8Jn8tSqvEeh2rWvm7k0S6GJIFl2F2jvA==}
@@ -4825,6 +4835,7 @@ packages:
       webpack-sources: 3.2.3
       zod: 3.22.4
       zod-validation-error: 1.2.0(zod@3.22.4)
+    dev: false
 
   /@rspack/plugin-react-refresh@0.3.10(react-refresh@0.14.0)(webpack@5.89.0):
     resolution: {integrity: sha512-oeCsfEXRguZox5rNyV3ifbyk3G578YZ+5l0ZNCk/tDF5xQnMeJ9vRJ7iFYcHVcuZhZQhuxCwLzeXJ5RNWleqig==}
@@ -6321,6 +6332,7 @@ packages:
         optional: true
     dependencies:
       ajv: 8.12.0
+    dev: false
 
   /ajv-keywords@3.5.2(ajv@6.12.6):
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
@@ -6336,6 +6348,7 @@ packages:
     dependencies:
       ajv: 8.12.0
       fast-deep-equal: 3.1.3
+    dev: false
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -7173,6 +7186,7 @@ packages:
 
   /compare-versions@6.0.0-rc.1:
     resolution: {integrity: sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ==}
+    dev: false
 
   /compressible@2.0.18:
     resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
@@ -9023,6 +9037,7 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
+    dev: false
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -9594,6 +9609,7 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
+    dev: false
 
   /is-array-buffer@3.0.2:
     resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
@@ -9695,6 +9711,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       has-tostringtag: 1.0.0
+    dev: false
 
   /is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -9988,6 +10005,7 @@ packages:
   /json-parse-even-better-errors@3.0.0:
     resolution: {integrity: sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    dev: false
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -12307,6 +12325,7 @@ packages:
     resolution: {integrity: sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==}
     engines: {node: '>=0.4.x'}
     deprecated: The querystring API is considered Legacy. new code should use the URLSearchParams API instead.
+    dev: false
 
   /querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -12397,6 +12416,7 @@ packages:
   /react-refresh@0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
+    dev: false
 
   /react-router-dom@6.17.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-qWHkkbXQX+6li0COUUPKAUkxjNNqPJuiBd27dVwQGDNsuFBdMbrS6UZ0CLYc4CsbdLYTckn4oB4tGDuPZpPhaQ==}
@@ -12898,6 +12918,7 @@ packages:
       ajv: 8.12.0
       ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
+    dev: false
 
   /selderee@0.11.0:
     resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
@@ -13477,6 +13498,7 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
+    dev: false
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -13679,6 +13701,7 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
+    dev: false
 
   /terser-webpack-plugin@5.3.9(@swc/core@1.3.42)(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
@@ -14247,6 +14270,7 @@ packages:
       is-generator-function: 1.0.10
       is-typed-array: 1.1.12
       which-typed-array: 1.1.11
+    dev: false
 
   /utila@0.4.0:
     resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
@@ -15034,9 +15058,11 @@ packages:
       zod: ^3.18.0
     dependencies:
       zod: 3.22.4
+    dev: false
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}


### PR DESCRIPTION
## Summary

@rsbuild/shared no longer depend on webpack

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
