### PR TITLE
feat(plugin-svelte): allow to set options of svelte-loader

### DIFF
--- a/.changeset/afraid-steaks-agree.md
+++ b/.changeset/afraid-steaks-agree.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-svelte': patch
+---
+
+feat(plugin-svelte): allow to set options of svelte-loader

--- a/packages/document/docs/en/plugins/list/_meta.json
+++ b/packages/document/docs/en/plugins/list/_meta.json
@@ -6,6 +6,7 @@
   "plugin-vue-jsx",
   "plugin-vue2",
   "plugin-vue2-jsx",
+  "plugin-svelte",
   "plugin-babel",
   "plugin-type-check",
   "plugin-image-compress",

--- a/packages/document/docs/en/plugins/list/index.md
+++ b/packages/document/docs/en/plugins/list/index.md
@@ -36,6 +36,12 @@ Plugins available for the Vue framework:
 - [Vue2 Plugin](/plugins/list/plugin-vue2): Provides support for Vue 2 SFC (Single File Components).
 - [Vue2 JSX Plugin](/plugins/list/plugin-vue2-jsx): Provides support for Vue 2 JSX / TSX syntax.
 
+### Svelte Related
+
+Plugins available for the Svelte framework:
+
+- [Svelte Plugin](/plugins/list/plugin-svelte): Provides support for Svelte components (`.svelte` files).
+
 ### Common
 
 The following are common framework-agnostic plugins:

--- a/packages/document/docs/en/plugins/list/plugin-svelte.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-svelte.mdx
@@ -1,0 +1,61 @@
+# Svelte Plugin
+
+The Svelte plugin provides support for Svelte components (`.svelte` files). The plugin internally integrates [svelte-loader](https://github.com/sveltejs/svelte-loader).
+
+## Quick Start
+
+### Install Plugin
+
+You can install the plugin using the following command:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
+
+### Register Plugin
+
+You can register the plugin in the `rsbuild.config.ts` file:
+
+```ts title="rsbuild.config.ts"
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+
+export default {
+  plugins: [pluginSvelte()],
+};
+```
+
+If you are using Rsbuild's JavaScript API, you can register the plugin using the [addPlugins](/api/javascript-api/instance.html#rsbuildaddplugins) method.
+
+After registering the plugin, you can directly import `*.svelte` files in your code.
+
+## Options
+
+If you need to customize the compilation behavior of Svelte, you can use the following configs.
+
+### svelteLoaderOptions
+
+Options passed to `svelte-loader`, please refer to the [svelte-loader documentation](https://github.com/sveltejs/svelte-loader) for detailed usage.
+
+- **Type:** `Object`
+- **Default:**
+
+```js
+const defaultOptions = {
+  compilerOptions: {
+    dev: !isProd,
+  },
+  preprocess: require('svelte-preprocess')(),
+  emitCss: !rsbuildConfig.output.disableCssExtract,
+  hotReload: !isProd && rsbuildConfig.dev.hmr,
+}
+```
+
+- **Example:**
+
+```ts
+pluginSvelte({
+  svelteLoaderOptions: {
+    preprocess: null,
+  },
+});
+```

--- a/packages/document/docs/zh/plugins/list/_meta.json
+++ b/packages/document/docs/zh/plugins/list/_meta.json
@@ -6,6 +6,7 @@
   "plugin-vue-jsx",
   "plugin-vue2",
   "plugin-vue2-jsx",
+  "plugin-svelte",
   "plugin-babel",
   "plugin-type-check",
   "plugin-image-compress",

--- a/packages/document/docs/zh/plugins/list/index.md
+++ b/packages/document/docs/zh/plugins/list/index.md
@@ -36,6 +36,12 @@ export default defineConfig({
 - [Vue 2 插件](/plugins/list/plugin-vue2)：提供对 Vue 2 SFC（单文件组件）的支持。
 - [Vue 2 JSX 插件](/plugins/list/plugin-vue2-jsx)：提供对 Vue 2 JSX / TSX 语法的支持。
 
+## Svelte 相关
+
+适用于 Svelte 框架的插件有：
+
+- [Svelte 插件](/plugins/list/plugin-svelte)：提供对 Svelte 组件（`.svelte` 文件）的支持
+
 ### 通用插件
 
 以下是与框架无关的通用插件：

--- a/packages/document/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-svelte.mdx
@@ -1,0 +1,61 @@
+# Svelte 插件
+
+Svelte 插件提供了对 Svelte 组件（`.svelte` 文件）的支持，插件内部集成了 [svelte-loader](https://github.com/sveltejs/svelte-loader)。
+
+## 快速开始
+
+### 安装插件
+
+你可以通过如下的命令安装插件:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsbuild/plugin-svelte -D" />
+
+### 注册插件
+
+你可以在 `rsbuild.config.ts` 文件中注册插件：
+
+```ts title="rsbuild.config.ts"
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+
+export default {
+  plugins: [pluginSvelte()],
+};
+```
+
+如果你使用了 Rsbuild 的 JavaScript API，可以通过 [addPlugins](/api/javascript-api/instance.html#rsbuildaddplugins) 方法来注册插件。
+
+注册完插件后，你可以直接在代码中引入 `*.svelte` 单文件组件。
+
+## 选项
+
+如果你需要自定义 Svelte 的编译行为，可以使用以下配置项。
+
+### svelteLoaderOptions
+
+传递给 `svelte-loader` 的选项，请查阅 [svelte-loader 文档](https://github.com/sveltejs/svelte-loader) 来了解具体用法。
+
+- **类型：** `Object`
+- **默认值：**
+
+```js
+const defaultOptions = {
+  compilerOptions: {
+    dev: !isProd,
+  },
+  preprocess: require('svelte-preprocess')(),
+  emitCss: !rsbuildConfig.output.disableCssExtract,
+  hotReload: !isProd && rsbuildConfig.dev.hmr,
+}
+```
+
+- **示例：**
+
+```ts
+pluginSvelte({
+  svelteLoaderOptions: {
+    preprocess: null,
+  },
+});
+```

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,8 +1,16 @@
 import path from 'path';
 import { logger } from '@rsbuild/shared';
+import { deepmerge } from '@rsbuild/shared/deepmerge';
 import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
 
-export type PluginSvelteOptions = {};
+export type PluginSvelteOptions = {
+  /**
+   * The options of svelte-loader
+   *
+   * See https://github.com/sveltejs/svelte-loader
+   */
+  svelteLoaderOptions?: Record<string, any>;
+};
 
 export function pluginSvelte(
   options: PluginSvelteOptions = {},
@@ -58,19 +66,24 @@ export function pluginSvelte(
           },
         });
 
-        chain.module
-          .rule(CHAIN_ID.RULE.SVELTE)
-          .test(/\.svelte$/)
-          .use(CHAIN_ID.USE.SVELTE)
-          .loader(loaderPath)
-          .options({
+        const svelteLoaderOptions = deepmerge(
+          {
             compilerOptions: {
               dev: !isProd,
             },
             preprocess: sveltePreprocess(),
             emitCss: !rsbuildConfig.output.disableCssExtract,
             hotReload: !isProd && rsbuildConfig.dev.hmr,
-          });
+          },
+          options.svelteLoaderOptions ?? {},
+        );
+
+        chain.module
+          .rule(CHAIN_ID.RULE.SVELTE)
+          .test(/\.svelte$/)
+          .use(CHAIN_ID.USE.SVELTE)
+          .loader(loaderPath)
+          .options(svelteLoaderOptions);
       });
     },
   };

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -50,6 +50,52 @@ exports[`plugin-svelte > should add svelte loader properly 1`] = `
 }
 `;
 
+exports[`plugin-svelte > should override default svelte-loader options throw options.svelteLoaderOptions 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "test": /\\\\\\.svelte\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+            "options": {
+              "compilerOptions": {
+                "dev": false,
+              },
+              "emitCss": true,
+              "hotReload": false,
+              "preprocess": null,
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "resolve": {
+    "alias": {
+      "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",
+    },
+    "conditionNames": [
+      "svelte",
+      "browser",
+      "import",
+    ],
+    "extensions": [
+      ".svelte",
+    ],
+    "mainFields": [
+      "svelte",
+    ],
+  },
+  "resolveLoader": {
+    "alias": {
+      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+    },
+  },
+}
+`;
+
 exports[`plugin-svelte > should set dev and hotReload to false in production mode 1`] = `
 {
   "module": {

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -37,4 +37,20 @@ describe('plugin-svelte', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should override default svelte-loader options throw options.svelteLoaderOptions', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+      plugins: [
+        pluginSvelte({
+          svelteLoaderOptions: {
+            preprocess: null,
+          },
+        }),
+      ],
+    });
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Give a `svelteLoaderOptions` property to the options of plugin-svelte, which overrides the default options of svelte-loader.

## Related Issue

close https://github.com/web-infra-dev/rsbuild/issues/271

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
