### PR TITLE
refactor(utils): mergeChainedOptions accept object param

### DIFF
--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -53,12 +53,12 @@ async function modifyWebpackConfig(
   );
 
   if (context.config.tools?.webpack) {
-    modifiedConfig = mergeChainedOptions(
-      modifiedConfig,
-      context.config.tools.webpack,
+    modifiedConfig = mergeChainedOptions({
+      defaults: modifiedConfig,
+      options: context.config.tools.webpack,
       utils,
-      utils.mergeConfig,
-    );
+      mergeFn: utils.mergeConfig,
+    });
   }
 
   debug('modify webpack config done');

--- a/packages/compat/webpack/src/plugins/babel.ts
+++ b/packages/compat/webpack/src/plugins/babel.ts
@@ -92,14 +92,14 @@ export const pluginBabel = (): RsbuildPlugin => ({
             config.performance.transformLodash,
           );
 
-          const babelConfig = mergeChainedOptions(
-            baseBabelConfig,
-            config.tools.babel,
-            {
+          const babelConfig = mergeChainedOptions({
+            defaults: baseBabelConfig,
+            options: config.tools.babel,
+            utils: {
               ...getBabelUtils(baseBabelConfig),
               ...babelUtils,
             },
-          );
+          });
 
           // 3. Compute final babel config
           const finalOptions: BabelConfig = {

--- a/packages/compat/webpack/src/plugins/css.ts
+++ b/packages/compat/webpack/src/plugins/css.ts
@@ -11,7 +11,6 @@ import {
   getCssModuleLocalIdentName,
   type Context,
   type BundlerChainRule,
-  type StyleLoaderOptions,
 } from '@rsbuild/shared';
 import type {
   RsbuildPlugin,
@@ -44,19 +43,8 @@ export async function applyBaseCSSRule({
 
   const enableSourceMap = isUseCssSourceMap(config);
   const enableCSSModuleTS = Boolean(config.output.enableCssModuleTSDeclaration);
-  // 2. Prepare loader options
-  const extraCSSOptions: Required<CSSExtractOptions> =
-    typeof config.tools.cssExtract === 'object'
-      ? config.tools.cssExtract
-      : {
-          loaderOptions: {},
-          pluginOptions: {},
-        };
-  const styleLoaderOptions = mergeChainedOptions<StyleLoaderOptions, null>(
-    {},
-    config.tools.styleLoader,
-  );
 
+  // 2. Prepare loader options
   const localIdentName = getCssModuleLocalIdentName(config, isProd);
 
   const cssLoaderOptions = await getCssLoaderOptions({
@@ -73,6 +61,14 @@ export async function applyBaseCSSRule({
   if (!isServer && !isWebWorker) {
     // use mini-css-extract-plugin loader
     if (enableExtractCSS) {
+      const extraCSSOptions: Required<CSSExtractOptions> =
+        typeof config.tools.cssExtract === 'object'
+          ? config.tools.cssExtract
+          : {
+              loaderOptions: {},
+              pluginOptions: {},
+            };
+
       rule
         .use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
         .loader(require('mini-css-extract-plugin').loader)
@@ -81,6 +77,11 @@ export async function applyBaseCSSRule({
     }
     // use style-loader
     else {
+      const styleLoaderOptions = mergeChainedOptions({
+        defaults: {},
+        options: config.tools.styleLoader,
+      });
+
       rule
         .use(CHAIN_ID.USE.STYLE)
         .loader(require.resolve('style-loader'))

--- a/packages/compat/webpack/src/plugins/output.ts
+++ b/packages/compat/webpack/src/plugins/output.ts
@@ -1,5 +1,4 @@
 import { posix } from 'path';
-import { CSSExtractOptions } from '../types/thirdParty/css';
 import {
   getDistPath,
   getFilename,
@@ -25,10 +24,10 @@ export const pluginOutput = (): RsbuildPlugin => ({
         const { default: MiniCssExtractPlugin } = await import(
           'mini-css-extract-plugin'
         );
-        const extractPluginOptions = mergeChainedOptions(
-          {},
-          (config.tools.cssExtract as CSSExtractOptions)?.pluginOptions || {},
-        );
+        const extractPluginOptions = mergeChainedOptions({
+          defaults: {},
+          options: config.tools.cssExtract?.pluginOptions,
+        });
 
         const cssFilename = getFilename(config.output, 'css', isProd);
 

--- a/packages/compat/webpack/src/plugins/tsLoader.ts
+++ b/packages/compat/webpack/src/plugins/tsLoader.ts
@@ -37,11 +37,11 @@ export const pluginTsLoader = (): RsbuildPlugin => {
 
         const babelUtils = getBabelUtils(baseBabelConfig);
 
-        const babelLoaderOptions = mergeChainedOptions(
-          baseBabelConfig,
-          config.tools.babel,
-          babelUtils,
-        );
+        const babelLoaderOptions = mergeChainedOptions({
+          defaults: baseBabelConfig,
+          options: config.tools.babel,
+          utils: babelUtils,
+        });
 
         const includes: Array<string | RegExp> = [];
         const excludes: Array<string | RegExp> = [];
@@ -54,19 +54,21 @@ export const pluginTsLoader = (): RsbuildPlugin => {
             excludes.push(...castArray(items));
           },
         };
-        // @ts-expect-error ts-loader has incorrect types for compilerOptions
-        const tsLoaderOptions = mergeChainedOptions(
-          {
-            compilerOptions: {
-              target: 'esnext',
-              module: 'esnext',
-            },
-            transpileOnly: true,
-            allowTsInNodeModules: true,
+        const tsLoaderDefaultOptions = {
+          compilerOptions: {
+            target: 'esnext',
+            module: 'esnext',
           },
-          config.tools.tsLoader,
-          tsLoaderUtils,
-        );
+          transpileOnly: true,
+          allowTsInNodeModules: true,
+        };
+
+        const tsLoaderOptions = mergeChainedOptions({
+          // @ts-expect-error ts-loader has incorrect types for compilerOptions
+          defaults: tsLoaderDefaultOptions,
+          options: config.tools.tsLoader,
+          utils: tsLoaderUtils,
+        });
         const rule = chain.module.rule(CHAIN_ID.RULE.TS);
 
         applyScriptCondition({

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -24,11 +24,11 @@ export const pluginDefine = (): DefaultRsbuildPlugin => ({
           'process.env.ASSET_PREFIX': removeTailSlash(assetPrefix),
         };
         // Serialize global vars. User can customize value of `builtinVars`.
-        const globalVars = mergeChainedOptions(
-          builtinVars,
-          config.source.globalVars,
-          { env, target },
-        );
+        const globalVars = mergeChainedOptions({
+          defaults: builtinVars,
+          options: config.source.globalVars,
+          utils: { env, target },
+        });
 
         const serializedVars = mapValues(
           globalVars,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -81,7 +81,10 @@ async function getTemplateParameters(
       },
       ...baseParameters,
     };
-    return mergeChainedOptions(defaultOptions, templateParams);
+    return mergeChainedOptions({
+      defaults: defaultOptions,
+      options: templateParams,
+    });
   };
 }
 
@@ -217,14 +220,14 @@ export const pluginHtml = (): DefaultRsbuildPlugin => ({
               }
             }
 
-            const finalOptions = mergeChainedOptions(
-              pluginOptions,
-              (config.tools as { htmlPlugin?: any }).htmlPlugin,
-              {
+            const finalOptions = mergeChainedOptions({
+              defaults: pluginOptions,
+              options: config.tools.htmlPlugin,
+              utils: {
                 entryName,
                 entryValue,
               },
-            );
+            });
 
             routesInfo.push({
               urlPath: index === 0 ? '/' : `/${entryName}`,

--- a/packages/core/src/rspack-provider/core/rspackConfig.ts
+++ b/packages/core/src/rspack-provider/core/rspackConfig.ts
@@ -26,12 +26,12 @@ async function modifyRspackConfig(
   );
 
   if (context.config.tools?.rspack) {
-    modifiedConfig = mergeChainedOptions(
-      modifiedConfig,
-      context.config.tools.rspack,
+    modifiedConfig = mergeChainedOptions({
+      defaults: modifiedConfig,
+      options: context.config.tools.rspack,
       utils,
-      utils.mergeConfig,
-    );
+      mergeFn: utils.mergeConfig,
+    });
   }
 
   debug('modify Rspack config done');

--- a/packages/core/src/rspack-provider/plugins/css.ts
+++ b/packages/core/src/rspack-provider/plugins/css.ts
@@ -17,7 +17,6 @@ import {
   type Context,
   type RspackRule,
   type RuleSetRule,
-  type StyleLoaderOptions,
   type ModifyBundlerChainUtils,
 } from '@rsbuild/shared';
 import type { RsbuildPlugin, NormalizedConfig } from '../types';
@@ -66,14 +65,15 @@ export async function applyBaseCSSRule({
     });
 
     if (!isServer && !isWebWorker) {
-      const styleLoaderOptions = mergeChainedOptions<StyleLoaderOptions, null>(
-        {
+      const styleLoaderOptions = mergeChainedOptions({
+        defaults: {
           // todo: hmr does not work while esModule is true
           // @ts-expect-error
           esModule: false,
         },
-        config.tools.styleLoader,
-      );
+        options: config.tools.styleLoader,
+      });
+
       rule
         .use(CHAIN_ID.USE.STYLE)
         .loader(require.resolve('style-loader'))

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -157,11 +157,11 @@ export const applyUserBabelConfig = (
       ...extraBabelUtils,
     } as BabelConfigUtils;
 
-    return mergeChainedOptions(
-      defaultOptions,
-      userBabelConfig || {},
-      babelUtils,
-    );
+    return mergeChainedOptions({
+      defaults: defaultOptions,
+      options: userBabelConfig,
+      utils: babelUtils,
+    });
   }
 
   return defaultOptions;

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -29,12 +29,12 @@ export async function applyCSSMinimizer(
     'css-minimizer-webpack-plugin'
   );
 
-  const mergedOptions: CssMinimizerPluginOptions = mergeChainedOptions(
-    {
+  const mergedOptions: CssMinimizerPluginOptions = mergeChainedOptions({
+    defaults: {
       minimizerOptions: getCssnanoDefaultOptions(),
     },
-    options.pluginOptions,
-  );
+    options: options.pluginOptions,
+  });
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.CSS)

--- a/packages/plugin-pug/src/index.ts
+++ b/packages/plugin-pug/src/index.ts
@@ -14,12 +14,17 @@ export const pluginPug = (
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+      const pugOptions = mergeChainedOptions({
+        defaults: {},
+        options: options.pugOptions,
+      });
+
       chain.module
         .rule(CHAIN_ID.RULE.PUG)
         .test(/\.pug$/)
         .use(CHAIN_ID.USE.PUG)
         .loader(path.resolve(__dirname, './pugLoader'))
-        .options(mergeChainedOptions({}, options.pugOptions));
+        .options(pugOptions);
     });
   },
 });

--- a/packages/plugin-styled-components/src/index.ts
+++ b/packages/plugin-styled-components/src/index.ts
@@ -1,9 +1,9 @@
 import {
-  DefaultRsbuildPlugin,
-  getDefaultStyledComponentsConfig,
-  mergeChainedOptions,
-  ChainedConfig,
   useSSR,
+  mergeChainedOptions,
+  getDefaultStyledComponentsConfig,
+  type ChainedConfig,
+  type DefaultRsbuildPlugin,
 } from '@rsbuild/shared';
 
 /**
@@ -28,15 +28,15 @@ export const pluginStyledComponents = (
   name: 'plugin-styled-components',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {
       const { bundlerType } = api.context;
 
       const isSSR = useSSR(api.context.target);
 
-      const styledComponentsOptions = mergeChainedOptions<
-        StyledComponentsOptions,
-        {}
-      >(getDefaultStyledComponentsConfig(isProd, isSSR), userConfig);
+      const styledComponentsOptions = mergeChainedOptions({
+        defaults: getDefaultStyledComponentsConfig(isProd, isSSR),
+        options: userConfig,
+      });
 
       if (!styledComponentsOptions) {
         return;

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -34,17 +34,13 @@ export function pluginStylus(
       api.modifyBundlerChain(async (chain, utils) => {
         const config = api.getNormalizedConfig();
 
-        const mergedOptions = mergeChainedOptions<
-          StylusLoaderOptions,
-          undefined
-        >(
-          {
+        const mergedOptions = mergeChainedOptions({
+          defaults: {
             sourceMap: isUseCssSourceMap(config),
           },
           options,
-          undefined,
-          deepmerge,
-        );
+          mergeFn: deepmerge,
+        });
 
         const rule = chain.module
           .rule(utils.CHAIN_ID.RULE.STYLUS)

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -57,35 +57,36 @@ export const pluginTypeCheck = (
           return;
         }
 
-        const typeCheckerOptions = mergeChainedOptions(
-          {
-            typescript: {
-              // avoid OOM issue
-              memoryLimit: 8192,
-              // use tsconfig of user project
-              configFile: api.context.tsconfigPath,
-              typescriptPath,
+        const defaultOptions = {
+          typescript: {
+            // avoid OOM issue
+            memoryLimit: 8192,
+            // use tsconfig of user project
+            configFile: api.context.tsconfigPath,
+            typescriptPath,
+          },
+          issue: {
+            exclude: [
+              { file: '**/*.(spec|test).ts' },
+              { file: '**/node_modules/**/*' },
+            ],
+          },
+          logger: {
+            log() {
+              // do nothing
+              // we only want to display error messages
             },
-            issue: {
-              exclude: [
-                { file: '**/*.(spec|test).ts' },
-                { file: '**/node_modules/**/*' },
-              ],
-            },
-            logger: {
-              log() {
-                // do nothing
-                // we only want to display error messages
-              },
-              error(message: string) {
-                console.error(message.replace(/ERROR/g, 'Type Error'));
-              },
+            error(message: string) {
+              console.error(message.replace(/ERROR/g, 'Type Error'));
             },
           },
-          forkTsCheckerOptions,
-          undefined,
-          deepmerge,
-        );
+        };
+
+        const typeCheckerOptions = mergeChainedOptions({
+          defaults: defaultOptions,
+          options: forkTsCheckerOptions,
+          mergeFn: deepmerge,
+        });
 
         if (
           api.context.bundlerType === 'rspack' &&

--- a/packages/shared/src/apply/resolve.ts
+++ b/packages/shared/src/apply/resolve.ts
@@ -91,7 +91,10 @@ async function applyAlias({
     return;
   }
 
-  const mergedAlias = mergeChainedOptions({}, alias);
+  const mergedAlias = mergeChainedOptions({
+    defaults: {},
+    options: alias,
+  });
 
   /**
    * Format alias value:

--- a/packages/shared/src/devServer.ts
+++ b/packages/shared/src/devServer.ts
@@ -51,12 +51,11 @@ export const getDevServerOptions = async ({
     (serverOptions.dev as Exclude<typeof serverOptions.dev, boolean>) || {},
   );
 
-  const devConfig = mergeChainedOptions(
-    defaultDevConfig,
-    rsbuildConfig.tools?.devServer,
-    {},
-    deepmerge,
-  );
+  const devConfig = mergeChainedOptions({
+    defaults: defaultDevConfig,
+    options: rsbuildConfig.tools?.devServer,
+    mergeFn: deepmerge,
+  });
 
   const defaultConfig = getServerOptions(rsbuildConfig);
   const config = serverOptions.config

--- a/packages/shared/src/getLoaderOptions.ts
+++ b/packages/shared/src/getLoaderOptions.ts
@@ -19,24 +19,26 @@ export const getSassLoaderOptions = async (
     excludes.push(...castArray(items));
   };
 
-  const mergedOptions = mergeChainedOptions<
-    SassLoaderOptions,
-    { addExcludes: FileFilterUtil }
-  >(
-    {
+  const mergeFn = (
+    defaults: SassLoaderOptions,
+    userOptions: SassLoaderOptions,
+  ) => {
+    return {
+      ...defaults,
+      ...userOptions,
+      sassOptions: _.merge(defaults.sassOptions, userOptions.sassOptions),
+    };
+  };
+
+  const mergedOptions = mergeChainedOptions({
+    defaults: {
       sourceMap: isUseCssSourceMap,
       implementation: getSharedPkgCompiledPath('sass'),
     },
-    rsbuildSassConfig,
-    { addExcludes },
-    (defaults: SassLoaderOptions, userOptions: SassLoaderOptions) => {
-      return {
-        ...defaults,
-        ...userOptions,
-        sassOptions: _.merge(defaults.sassOptions, userOptions.sassOptions),
-      };
-    },
-  );
+    options: rsbuildSassConfig,
+    utils: { addExcludes },
+    mergeFn,
+  });
 
   return {
     options: mergedOptions,
@@ -61,21 +63,24 @@ export const getLessLoaderOptions = async (
     sourceMap: isUseCssSourceMap,
     implementation: getSharedPkgCompiledPath('less'),
   };
-  const mergedOptions = mergeChainedOptions(
-    defaultLessLoaderOptions,
-    rsbuildLessConfig,
-    { addExcludes },
-    (
-      defaults: LessLoaderOptions,
-      userOptions: LessLoaderOptions,
-    ): LessLoaderOptions => {
-      return {
-        ...defaults,
-        ...userOptions,
-        lessOptions: _.merge(defaults.lessOptions, userOptions.lessOptions),
-      };
-    },
-  );
+
+  const mergeFn = (
+    defaults: LessLoaderOptions,
+    userOptions: LessLoaderOptions,
+  ): LessLoaderOptions => {
+    return {
+      ...defaults,
+      ...userOptions,
+      lessOptions: _.merge(defaults.lessOptions, userOptions.lessOptions),
+    };
+  };
+
+  const mergedOptions = mergeChainedOptions({
+    defaults: defaultLessLoaderOptions,
+    options: rsbuildLessConfig,
+    utils: { addExcludes },
+    mergeFn,
+  });
 
   return {
     options: mergedOptions,

--- a/packages/shared/src/mergeChainedOptions.ts
+++ b/packages/shared/src/mergeChainedOptions.ts
@@ -1,34 +1,38 @@
-import { logger } from 'rslog';
 import { isFunction, isPlainObject } from './utils';
 
 export type Falsy = false | null | undefined | 0 | '';
 
-export function mergeChainedOptions<T, U>(
-  defaults: T,
+export function mergeChainedOptions<T, U>(params: {
+  defaults: T;
   options?:
     | T
     | ((config: T, utils?: U) => T | void)
     | Array<T | ((config: T, utils?: U) => T | void)>
-    | Falsy,
-  utils?: U,
-  mergeFn?: typeof Object.assign,
-): T;
-export function mergeChainedOptions<T, U>(
-  defaults: T,
+    | Falsy;
+  utils?: U;
+  mergeFn?: typeof Object.assign;
+}): T;
+export function mergeChainedOptions<T, U>(params: {
+  defaults: T;
   options:
     | T
     | ((config: T, utils: U) => T | void)
     | Array<T | ((config: T, utils: U) => T | void)>
-    | Falsy,
-  utils: U,
-  mergeFn?: typeof Object.assign,
-): T;
-export function mergeChainedOptions<T extends Record<string, unknown>>(
-  defaults: T,
-  options?: unknown,
-  utils?: unknown,
+    | Falsy;
+  utils: U;
+  mergeFn?: typeof Object.assign;
+}): T;
+export function mergeChainedOptions<T extends Record<string, unknown>>({
+  defaults,
+  options,
+  utils,
   mergeFn = Object.assign,
-) {
+}: {
+  defaults: T;
+  options?: unknown;
+  utils?: unknown;
+  mergeFn?: typeof Object.assign;
+}) {
   if (!options) {
     return defaults;
   }
@@ -40,23 +44,18 @@ export function mergeChainedOptions<T extends Record<string, unknown>>(
   if (isFunction(options)) {
     const ret = options(defaults, utils);
     if (ret) {
-      if (!isPlainObject(ret)) {
-        logger.warn(
-          `${options.name}: Function should mutate the config and return nothing, or return a cloned or merged version of config object.`,
-        );
-      }
       return ret;
     }
   } else if (Array.isArray(options)) {
     return options.reduce(
-      (memo, cur) => mergeChainedOptions(memo, cur, utils, mergeFn),
+      (defaults, options) =>
+        mergeChainedOptions({
+          defaults,
+          options,
+          utils,
+          mergeFn,
+        }),
       defaults,
-    );
-  } else {
-    throw new Error(
-      `mergeChainedOptions error:\ndefault options is: ${JSON.stringify(
-        defaults,
-      )}`,
     );
   }
 

--- a/packages/shared/src/minimize.ts
+++ b/packages/shared/src/minimize.ts
@@ -60,11 +60,11 @@ export async function getJSMinifyOptions(config: NormalizedConfig) {
       break;
   }
 
-  const mergedOptions = mergeChainedOptions(
-    DEFAULT_OPTIONS,
+  const mergedOptions = mergeChainedOptions({
+    defaults: DEFAULT_OPTIONS,
     // @ts-expect-error
-    config.tools.terser,
-  );
+    options: config.tools.terser,
+  });
 
   const finalOptions = applyRemoveConsole(mergedOptions, config);
 


### PR DESCRIPTION
## Summary

refactor the mergeChainedOptions method, accept object param.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
