### PR TITLE
feat(utils): add useObjectParam option for mergeChainedOptions

### DIFF
--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -54,6 +54,53 @@ test('should generate meta tags correctly when using custom HTML template', asyn
   expect(html).toContain('<meta name="foo" content="bar">');
 });
 
+test('should generate meta tags via function correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    entry: {
+      foo: path.resolve(__dirname, './src/foo.js'),
+      bar: path.resolve(__dirname, './src/foo.js'),
+    },
+    rsbuildConfig: {
+      html: {
+        meta(val, { entryName }) {
+          if (entryName === 'bar') {
+            return {
+              ...val,
+              description: 'this is bar',
+            };
+          }
+
+          return {
+            ...val,
+            description: 'this is foo',
+            'http-equiv': {
+              'http-equiv': 'x-ua-compatible',
+              content: 'ie=edge',
+            },
+          };
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const fooHtml =
+    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+
+  expect(fooHtml).toContain('<meta name="description" content="this is foo">');
+  expect(fooHtml).toContain(
+    '<meta http-equiv="x-ua-compatible" content="ie=edge">',
+  );
+
+  const barHtml =
+    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  expect(barHtml).toContain('<meta name="description" content="this is bar">');
+  expect(barHtml).not.toContain(
+    '<meta http-equiv="x-ua-compatible" content="ie=edge">',
+  );
+});
+
 test('should generate meta tags for MPA correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -54,53 +54,6 @@ test('should generate meta tags correctly when using custom HTML template', asyn
   expect(html).toContain('<meta name="foo" content="bar">');
 });
 
-test('should generate meta tags via function correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    entry: {
-      foo: path.resolve(__dirname, './src/foo.js'),
-      bar: path.resolve(__dirname, './src/foo.js'),
-    },
-    rsbuildConfig: {
-      html: {
-        meta(val, { entryName }) {
-          if (entryName === 'bar') {
-            return {
-              ...val,
-              description: 'this is bar',
-            };
-          }
-
-          return {
-            ...val,
-            description: 'this is foo',
-            'http-equiv': {
-              'http-equiv': 'x-ua-compatible',
-              content: 'ie=edge',
-            },
-          };
-        },
-      },
-    },
-  });
-  const files = await rsbuild.unwrapOutputJSON();
-
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
-
-  expect(fooHtml).toContain('<meta name="description" content="this is foo">');
-  expect(fooHtml).toContain(
-    '<meta http-equiv="x-ua-compatible" content="ie=edge">',
-  );
-
-  const barHtml =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
-  expect(barHtml).toContain('<meta name="description" content="this is bar">');
-  expect(barHtml).not.toContain(
-    '<meta http-equiv="x-ua-compatible" content="ie=edge">',
-  );
-});
-
 test('should generate meta tags for MPA correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/compat/webpack/src/plugins/tsLoader.ts
+++ b/packages/compat/webpack/src/plugins/tsLoader.ts
@@ -64,8 +64,8 @@ export const pluginTsLoader = (): RsbuildPlugin => {
         };
 
         const tsLoaderOptions = mergeChainedOptions({
-          // @ts-expect-error ts-loader has incorrect types for compilerOptions
           defaults: tsLoaderDefaultOptions,
+          // @ts-expect-error ts-loader has incorrect types for compilerOptions
           options: config.tools.tsLoader,
           utils: tsLoaderUtils,
         });

--- a/packages/compat/webpack/src/types/config/tools.ts
+++ b/packages/compat/webpack/src/types/config/tools.ts
@@ -4,6 +4,7 @@ import type {
   FileFilterUtil,
   TerserPluginOptions,
   ToolsConfig as BaseToolsConfig,
+  ChainedConfigWithUtils,
 } from '@rsbuild/shared';
 import type {
   BabelTransformOptions,
@@ -24,7 +25,7 @@ import type { NormalizedCSSExtractOptions } from '../thirdParty/css';
 
 export type ToolsTerserConfig = ChainedConfig<TerserPluginOptions>;
 
-export type ToolsTSLoaderConfig = ChainedConfig<
+export type ToolsTSLoaderConfig = ChainedConfigWithUtils<
   TSLoaderOptions,
   { addIncludes: FileFilterUtil; addExcludes: FileFilterUtil }
 >;
@@ -33,7 +34,7 @@ export type ToolsCssExtractConfig =
   | CSSExtractOptions
   | ((options: CSSExtractOptions) => CSSExtractOptions | void);
 
-export type ToolsWebpackConfig = ChainedConfig<
+export type ToolsWebpackConfig = ChainedConfigWithUtils<
   WebpackConfig,
   ModifyWebpackConfigUtils
 >;
@@ -42,7 +43,7 @@ export type ToolsWebpackChainConfig = ArrayOrNot<
   (chain: WebpackChain, utils: ModifyWebpackChainUtils) => void
 >;
 
-export type ToolsBabelConfig = ChainedConfig<
+export type ToolsBabelConfig = ChainedConfigWithUtils<
   BabelTransformOptions,
   BabelConfigUtils
 >;

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -1,4 +1,4 @@
-import type { ChainedConfig } from '@rsbuild/shared';
+import type { ChainedConfig, ChainedConfigWithUtils } from '@rsbuild/shared';
 import type {
   PluginItem as BabelPlugin,
   PluginOptions as BabelPluginOptions,
@@ -62,7 +62,7 @@ export type BabelConfigUtils = {
   modifyPresetReactOptions: (options: PresetReactOptions) => void;
 };
 
-export type PluginBabelOptions = ChainedConfig<
+export type PluginBabelOptions = ChainedConfigWithUtils<
   BabelTransformOptions,
   BabelConfigUtils
 >;

--- a/packages/shared/src/mergeChainedOptions.ts
+++ b/packages/shared/src/mergeChainedOptions.ts
@@ -1,37 +1,42 @@
+import {
+  ChainedConfig,
+  ChainedConfigWithUtils,
+  ChainedConfigCombineUtils,
+} from './types';
 import { isFunction, isPlainObject } from './utils';
 
-export type Falsy = false | null | undefined | 0 | '';
+export type Falsy = false | null | undefined;
 
 export function mergeChainedOptions<T, U>(params: {
   defaults: T;
-  options?:
-    | T
-    | ((config: T, utils?: U) => T | void)
-    | Array<T | ((config: T, utils?: U) => T | void)>
-    | Falsy;
-  utils?: U;
+  options?: ChainedConfig<T> | Falsy;
   mergeFn?: typeof Object.assign;
 }): T;
 export function mergeChainedOptions<T, U>(params: {
   defaults: T;
-  options:
-    | T
-    | ((config: T, utils: U) => T | void)
-    | Array<T | ((config: T, utils: U) => T | void)>
-    | Falsy;
+  options: ChainedConfigWithUtils<T, U> | Falsy;
   utils: U;
   mergeFn?: typeof Object.assign;
+}): T;
+export function mergeChainedOptions<T, U>(params: {
+  defaults: T;
+  options: ChainedConfigCombineUtils<T, U> | Falsy;
+  utils: U;
+  mergeFn?: typeof Object.assign;
+  useObjectParam?: true;
 }): T;
 export function mergeChainedOptions<T extends Record<string, unknown>>({
   defaults,
   options,
   utils,
   mergeFn = Object.assign,
+  useObjectParam,
 }: {
   defaults: T;
   options?: unknown;
   utils?: unknown;
   mergeFn?: typeof Object.assign;
+  useObjectParam?: true;
 }) {
   if (!options) {
     return defaults;
@@ -42,7 +47,13 @@ export function mergeChainedOptions<T extends Record<string, unknown>>({
   }
 
   if (isFunction(options)) {
-    const ret = options(defaults, utils);
+    const ret = useObjectParam
+      ? options({
+          value: defaults,
+          ...(utils as Record<string, unknown>),
+        })
+      : options(defaults, utils);
+
     if (ret) {
       return ret;
     }
@@ -54,6 +65,7 @@ export function mergeChainedOptions<T extends Record<string, unknown>>({
           options,
           utils,
           mergeFn,
+          useObjectParam,
         }),
       defaults,
     );

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -1,6 +1,10 @@
 import type { RsbuildTarget } from '../rsbuild';
 import type { ModifyChainUtils } from '../hooks';
-import type { ChainedConfig, JSONValue } from '../utils';
+import type {
+  ChainedConfig,
+  ChainedConfigWithUtils,
+  JSONValue,
+} from '../utils';
 
 export type Alias = Record<string, string | string[]>;
 
@@ -11,7 +15,7 @@ export type MainFields = (string | string[])[];
 
 export type GlobalVars = Record<string, JSONValue>;
 
-export type ChainedGlobalVars = ChainedConfig<
+export type ChainedGlobalVars = ChainedConfigWithUtils<
   GlobalVars,
   Pick<ModifyChainUtils, 'env' | 'target'>
 >;

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -1,4 +1,9 @@
-import type { ArrayOrNot, ChainedConfig, FileFilterUtil } from '../utils';
+import type {
+  ArrayOrNot,
+  ChainedConfig,
+  FileFilterUtil,
+  ChainedConfigWithUtils,
+} from '../utils';
 import type {
   AutoprefixerOptions,
   SassLoaderOptions,
@@ -61,12 +66,12 @@ export type ToolsDevServerConfig = ChainedConfig<DevServerOptions>;
 
 export type ToolsAutoprefixerConfig = ChainedConfig<AutoprefixerOptions>;
 
-export type ToolsSassConfig = ChainedConfig<
+export type ToolsSassConfig = ChainedConfigWithUtils<
   SassLoaderOptions,
   { addExcludes: FileFilterUtil }
 >;
 
-export type ToolsLessConfig = ChainedConfig<
+export type ToolsLessConfig = ChainedConfigWithUtils<
   LessLoaderOptions,
   { addExcludes: FileFilterUtil }
 >;
@@ -75,7 +80,7 @@ export type ToolsBundlerChainConfig = ArrayOrNot<
   (chain: BundlerChain, utils: ModifyBundlerChainUtils) => void
 >;
 
-export type ToolsPostCSSLoaderConfig = ChainedConfig<
+export type ToolsPostCSSLoaderConfig = ChainedConfigWithUtils<
   PostCSSLoaderOptions,
   { addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void }
 >;
@@ -84,7 +89,7 @@ export type ToolsCSSLoaderConfig = ChainedConfig<CSSLoaderOptions>;
 
 export type ToolsStyleLoaderConfig = ChainedConfig<StyleLoaderOptions>;
 
-export type ToolsHtmlPluginConfig = ChainedConfig<
+export type ToolsHtmlPluginConfig = ChainedConfigWithUtils<
   HTMLPluginOptions,
   {
     entryName: string;
@@ -105,7 +110,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
   rspack: typeof import('@rspack/core');
 };
 
-export type ToolsRspackConfig = ChainedConfig<
+export type ToolsRspackConfig = ChainedConfigWithUtils<
   RspackConfig,
   ModifyRspackConfigUtils
 >;

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -12,11 +12,16 @@ export type PromiseOrNot<T> = T | Promise<T>;
 
 export type NodeEnv = 'development' | 'production' | 'test';
 
-export type ChainedConfig<Config, Utils = unknown> = ArrayOrNot<
-  | Config
-  | (keyof Utils extends never
-      ? (config: Config) => Config | void
-      : (config: Config, utils: Utils) => Config | void)
+export type ChainedConfig<Config> = ArrayOrNot<
+  Config | ((config: Config) => Config | void)
+>;
+
+export type ChainedConfigWithUtils<Config, Utils> = ArrayOrNot<
+  Config | ((config: Config, utils: Utils) => Config | void)
+>;
+
+export type ChainedConfigCombineUtils<Config, Utils> = ArrayOrNot<
+  Config | ((params: { value: Config } & Utils) => Config | void)
 >;
 
 export type DeepReadonly<T> = keyof T extends never

--- a/packages/shared/tests/mergeChainedOptions.test.ts
+++ b/packages/shared/tests/mergeChainedOptions.test.ts
@@ -1,0 +1,126 @@
+import { mergeChainedOptions } from '../src';
+
+describe('mergeChainedOptions', () => {
+  test(`should return default options`, () => {
+    expect(mergeChainedOptions({ defaults: { value: 'a' } })).toEqual({
+      value: 'a',
+    });
+  });
+
+  test(`should merge default options`, () => {
+    expect(
+      mergeChainedOptions({
+        defaults: { name: 'a' },
+        options: {
+          name: 'b',
+          custom: 'c',
+        },
+      }),
+    ).toEqual({
+      name: 'b',
+      custom: 'c',
+    });
+  });
+
+  test(`should support custom merge function`, () => {
+    const merge = (target: any, source: any) => {
+      for (const key in source) {
+        if (target.hasOwnProperty(key)) {
+          target[key] += source[key];
+        } else {
+          target[key] = source[key];
+        }
+      }
+      return target;
+    };
+
+    expect(
+      mergeChainedOptions({
+        defaults: {
+          a: 1,
+          b: 'b',
+        },
+        options: {
+          a: 2,
+          b: 'b',
+          c: 'c',
+        },
+        mergeFn: merge,
+      }),
+    ).toEqual({
+      a: 3,
+      b: 'bb',
+      c: 'c',
+    });
+  });
+
+  test(`should support function or object array`, () => {
+    const defaults = { a: 'a' };
+
+    const options = [
+      { b: 'b' },
+      (o: any, { add }: { add: (a: number, b: number) => number }) => {
+        o.c = add(1, 2);
+      },
+      (o: any) => ({
+        ...o,
+        d: 'd',
+      }),
+      { e: 'e' },
+    ];
+    expect(
+      mergeChainedOptions({
+        defaults,
+        options,
+        utils: {
+          add: (a: number, b: number) => a + b,
+        },
+      }),
+    ).toEqual({
+      a: 'a',
+      b: 'b',
+      c: 3,
+      d: 'd',
+      e: 'e',
+    });
+  });
+
+  test.only(`should support function and use object param`, () => {
+    const defaults = { a: 'a' };
+
+    const options = [
+      { b: 'b' },
+      ({
+        value,
+        add,
+      }: {
+        value: any;
+        add: (a: number, b: number) => number;
+      }) => {
+        value.c = add(1, 2);
+      },
+      ({ value }: { value: any }) => ({
+        ...value,
+        d: 'd',
+      }),
+      { e: 'e' },
+    ];
+
+    expect(
+      mergeChainedOptions({
+        defaults,
+        options,
+        utils: {
+          add: (a: number, b: number) => a + b,
+        },
+        useObjectParam: true,
+      }),
+    ).toEqual({
+      a: 'a',
+      b: 'b',
+      c: 3,
+      d: 'd',
+      e: 'e',
+    });
+  });
+});

--- a/packages/shared/tests/mergeChainedOptions.test.ts
+++ b/packages/shared/tests/mergeChainedOptions.test.ts
@@ -85,7 +85,7 @@ describe('mergeChainedOptions', () => {
     });
   });
 
-  test.only(`should support function and use object param`, () => {
+  test(`should support function and use object param`, () => {
     const defaults = { a: 'a' };
 
     const options = [


### PR DESCRIPTION
## Summary

Add useObjectParam option for mergeChainedOptions.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
