### PR TITLE
test(e2e): fix Rspack builtins deprecation warning

### DIFF
--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -13,10 +13,9 @@ function getCommonBuildConfig(cwd: string): RsbuildConfig {
       overrideBrowserslist: ['ie 11'],
     },
     tools: {
-      // @ts-expect-error
       rspack: (config) => {
         config.target = ['web'];
-        config.builtins.presetEnv = undefined;
+        config.builtins!.presetEnv = undefined;
       },
     },
   };

--- a/e2e/cases/tools.rspack.test.ts
+++ b/e2e/cases/tools.rspack.test.ts
@@ -12,12 +12,9 @@ test('tools.rspack', async ({ page }) => {
     },
     runServer: true,
     rsbuildConfig: {
-      tools: {
-        rspack: (config) => {
-          config.builtins!.define = {
-            ...(config.builtins!.define || {}),
-            ENABLE_TEST: JSON.stringify(true),
-          };
+      source: {
+        define: {
+          ENABLE_TEST: JSON.stringify(true),
         },
       },
     },


### PR DESCRIPTION
## Summary

Fix Rspack builtins deprecation warning, use `source.define` instead of `builtins.define`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
