### PR TITLE
types: fix source.alias type

### DIFF
--- a/.changeset/thick-jokes-report.md
+++ b/.changeset/thick-jokes-report.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/document': patch
+'@rsbuild/shared': patch
+---
+
+types: fix source.alias type

--- a/packages/document/docs/en/shared/config/source/alias.md
+++ b/packages/document/docs/en/shared/config/source/alias.md
@@ -1,4 +1,9 @@
-- **Type:** `Record<string, string | string[]> | Function`
+- **Type:**
+
+```ts
+type Alias = Record<string, string | false | Array<string | false>> | Function;
+```
+
 - **Default:** `undefined`
 
 Create aliases to import or require certain modules, same as the [resolve.alias](https://www.rspack.dev/config/resolve.html#resolvealias) config of Rspack.

--- a/packages/document/docs/en/shared/config/source/alias.md
+++ b/packages/document/docs/en/shared/config/source/alias.md
@@ -1,7 +1,7 @@
 - **Type:**
 
 ```ts
-type Alias = Record<string, string | false | Array<string | false>> | Function;
+type Alias = Record<string, string | false | (string | false)[]> | Function;
 ```
 
 - **Default:** `undefined`

--- a/packages/document/docs/zh/shared/config/source/alias.md
+++ b/packages/document/docs/zh/shared/config/source/alias.md
@@ -1,4 +1,9 @@
-- **类型：** `Record<string, string | string[]> | Function`
+- **类型：**
+
+```ts
+type Alias = Record<string, string | false | Array<string | false>> | Function;
+```
+
 - **默认值：** `undefined`
 
 设置文件引用的别名，对应 Rspack 的 [resolve.alias](https://www.rspack.dev/zh/config/resolve.html#resolvealias) 配置。

--- a/packages/document/docs/zh/shared/config/source/alias.md
+++ b/packages/document/docs/zh/shared/config/source/alias.md
@@ -1,7 +1,7 @@
 - **类型：**
 
 ```ts
-type Alias = Record<string, string | false | Array<string | false>> | Function;
+type Alias = Record<string, string | false | (string | false)[]> | Function;
 ```
 
 - **默认值：** `undefined`

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -6,7 +6,7 @@ import type {
   JSONValue,
 } from '../utils';
 
-export type Alias = Record<string, string | string[]>;
+export type Alias = Record<string, string | false | Array<string | false>>;
 
 // Use a loose type to compat webpack
 export type Define = Record<string, any>;

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -6,7 +6,7 @@ import type {
   JSONValue,
 } from '../utils';
 
-export type Alias = Record<string, string | false | Array<string | false>>;
+export type Alias = Record<string, string | false | (string | false)[]>;
 
 // Use a loose type to compat webpack
 export type Define = Record<string, any>;


### PR DESCRIPTION
## Summary

Fix source.alias type, should be same as Rspack: https://www.rspack.dev/config/resolve.html#resolvealias

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
