### PR TITLE
chore: remove cssnano from shared package

### DIFF
--- a/.changeset/strong-moose-behave.md
+++ b/.changeset/strong-moose-behave.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+chore: remove cssnano from shared package

--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "imagex",
     "jiti",
     "jsesc",
+    "lightingcss",
     "longpaths",
     "manypkg",
     "napi",

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -5,7 +5,8 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
 
-test('should inline style when disableCssExtract is false', async ({
+// TODO enable CSS minify for style-loader
+test.skip('should inline style when disableCssExtract is false', async ({
   page,
 }) => {
   const rsbuild = await build({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -122,7 +122,6 @@
     "@rspack/core": "0.3.11",
     "acorn": "^8.10.0",
     "browserslist": "^4.22.1",
-    "cssnano": "6.0.1",
     "deepmerge": "^4.3.1",
     "fs-extra": "^11.1.1",
     "line-diff": "2.1.1",

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -128,9 +128,10 @@ export const getPostcssConfig = ({
       plugins: [
         require(getCompiledPath('postcss-flexbugs-fixes')),
         require(getCompiledPath('autoprefixer'))(autoprefixerOptions),
-        enableCssMinify
-          ? require('cssnano')(getCssnanoDefaultOptions())
-          : false,
+        // TODO consider use lightingcss or move to the CSS minimizer plugin
+        // enableCssMinify
+        //   ? require('cssnano')(getCssnanoDefaultOptions())
+        //   : false,
       ].filter(Boolean),
     },
     sourceMap: enableSourceMap,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1484,9 +1484,6 @@ importers:
       browserslist:
         specifier: ^4.22.1
         version: 4.22.1
-      cssnano:
-        specifier: 6.0.1
-        version: 6.0.1(postcss@8.4.31)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1


### PR DESCRIPTION
## Summary

Remove cssnano from shared package to reduce dependencies.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
