### PR TITLE
feat: enable preserveAllComments & dynamicImportMode

### DIFF
--- a/.changeset/gold-rocks-travel.md
+++ b/.changeset/gold-rocks-travel.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat: support dynamicImportMode.eager and preserveAllComments'

--- a/e2e/cases/web-worker/index.test.ts
+++ b/e2e/cases/web-worker/index.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
 import { build } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
 
 test('should build web-worker target correctly', async () => {
   const rsbuild = await build({
@@ -17,20 +16,16 @@ test('should build web-worker target correctly', async () => {
   expect(jsFiles[0].includes('index')).toBeTruthy();
 });
 
-// TODO: needs dynamicImportMode: 'eager',
-webpackOnlyTest(
-  'should build web-worker target with dynamicImport correctly',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      entry: { index: path.resolve(__dirname, './src/index2.js') },
-      target: 'web-worker',
-    });
-    const files = await rsbuild.unwrapOutputJSON();
-    const filenames = Object.keys(files);
-    const jsFiles = filenames.filter((item) => item.endsWith('.js'));
+test('should build web-worker target with dynamicImport correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    entry: { index: path.resolve(__dirname, './src/index2.js') },
+    target: 'web-worker',
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+  const jsFiles = filenames.filter((item) => item.endsWith('.js'));
 
-    expect(jsFiles.length).toEqual(1);
-    expect(jsFiles[0].includes('index')).toBeTruthy();
-  },
-);
+  expect(jsFiles.length).toEqual(1);
+  expect(jsFiles[0].includes('index')).toBeTruthy();
+});

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -230,7 +230,6 @@ export function pluginSplitChunks(): DefaultRsbuildPlugin {
 
             // web worker does not support dynamic imports, dynamicImportMode need set to eager
             if (isWebWorker || isServiceWorker) {
-              // todo: not support in rspack
               chain.module.parser.merge({
                 javascript: {
                   dynamicImportMode: 'eager',

--- a/packages/core/src/rspack-provider/plugins/swc.ts
+++ b/packages/core/src/rspack-provider/plugins/swc.ts
@@ -39,10 +39,9 @@ export async function getDefaultSwcConfig(
         syntax: 'typescript',
         decorators: true,
       },
-      // TODO: Enabling it will cause performance degradation
       // Avoid the webpack magic comment to be removed
       // https://github.com/swc-project/swc/issues/6403
-      // preserveAllComments: true,
+      preserveAllComments: true,
     },
     isModule: 'unknown',
     minify: false, // for loader, we don't need to minify, we do minification using plugin

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -498,6 +498,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -541,6 +542,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -498,6 +498,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -541,6 +542,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1154,6 +1156,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1197,6 +1200,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1662,6 +1666,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1699,6 +1704,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -2285,6 +2291,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -2328,6 +2335,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
@@ -55,6 +55,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -98,6 +99,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -171,6 +173,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -211,6 +214,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -284,6 +288,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -324,6 +329,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -400,6 +406,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -450,6 +457,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -533,6 +541,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -576,6 +585,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -643,6 +653,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -680,6 +691,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -746,6 +758,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -787,6 +800,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -857,6 +871,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -899,6 +914,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -975,6 +991,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1018,6 +1035,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1093,6 +1111,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1135,6 +1154,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1210,6 +1230,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1252,6 +1273,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1319,6 +1341,7 @@ exports[`plugin-swc > should has correct core-js 3`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1356,6 +1379,7 @@ exports[`plugin-swc > should has correct core-js 3`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1427,6 +1451,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -1470,6 +1495,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -85,6 +85,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -116,6 +116,7 @@ exports[`transformImport > should apply antd & arco transformImport 1`] = `
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,
@@ -191,6 +192,7 @@ exports[`transformImport > should not apply antd & arco when transformImport is 
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -515,6 +515,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,
@@ -563,6 +564,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
+                "preserveAllComments": true,
                 "transform": {
                   "decoratorMetadata": true,
                   "legacyDecorator": true,

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -33,6 +33,7 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,
@@ -96,6 +97,7 @@ exports[`plugins/styled-components > should enable ssr when target contain node 
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,
@@ -159,6 +161,7 @@ exports[`plugins/styled-components > should works in rspack mode 1`] = `
             "syntax": "typescript",
             "tsx": true,
           },
+          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,


### PR DESCRIPTION
## Summary
since rspack release 0.3.11, we can support  preserveAllComments and dynamicImportMode.eager in rsbuild

https://github.com/web-infra-dev/rspack/releases/tag/v0.3.11

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
