### PR TITLE
fix(webpack): disable webpack performance hints

### DIFF
--- a/.changeset/light-hairs-bathe.md
+++ b/.changeset/light-hairs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/webpack': patch
+---
+
+fix(webpack): disable webpack performance hints

--- a/packages/compat/webpack/src/plugins/basic.ts
+++ b/packages/compat/webpack/src/plugins/basic.ts
@@ -11,16 +11,10 @@ export const pluginBasic = (): RsbuildPlugin => ({
   setup(api) {
     applyBasicPlugin(api);
 
-    api.modifyWebpackChain(async (chain, { env, isServer, isWebWorker }) => {
-      /**
-       * If the chunk size exceeds 3MB, we will throw a warning.
-       * If the target is server or web-worker, we will increase
-       * the limit to 30MB because they are only single file.
-       */
-      const maxAssetSize =
-        isServer || isWebWorker ? 30 * 1000 * 1000 : 3 * 1000 * 1000;
-      chain.performance.maxAssetSize(maxAssetSize);
-      chain.performance.maxEntrypointSize(maxAssetSize);
+    api.modifyWebpackChain(async (chain, { env }) => {
+      // Disable webpack performance hints.
+      // These logs are too complex
+      chain.performance.hints(false);
 
       // This will be futureDefaults in webpack 6
       chain.module.parser.merge({

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -88,8 +88,7 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -111,8 +110,7 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -134,8 +132,7 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -157,8 +154,7 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -180,8 +176,7 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -203,8 +198,7 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;
@@ -562,8 +556,7 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
   },
   "name": "Client",
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
 }
 `;

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -591,8 +591,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
   "plugins": [
     HtmlBasicPlugin {
@@ -1305,8 +1304,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
   "plugins": [
     HtmlBasicPlugin {
@@ -1884,8 +1882,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "performance": {
-    "maxAssetSize": 30000000,
-    "maxEntrypointSize": 30000000,
+    "hints": false,
   },
   "plugins": [
     DefinePlugin {
@@ -2445,8 +2442,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "performance": {
-    "maxAssetSize": 30000000,
-    "maxEntrypointSize": 30000000,
+    "hints": false,
   },
   "plugins": [
     DefinePlugin {

--- a/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
@@ -859,8 +859,7 @@ exports[`plugins/react > should work with ts-loader 1`] = `
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "performance": {
-    "maxAssetSize": 3000000,
-    "maxEntrypointSize": 3000000,
+    "hints": false,
   },
   "plugins": [
     HtmlBasicPlugin {


### PR DESCRIPTION
## Summary

Disable webpack performance hints.

These logs are too complex, we can provide some hints in the Rsbuild fileSize plugin in the future.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
