### PR TITLE
feat: add builtin assets and CSS modules types

### DIFF
--- a/.changeset/blue-seals-end.md
+++ b/.changeset/blue-seals-end.md
@@ -1,0 +1,6 @@
+---
+'create-rsbuild': patch
+'@rsbuild/core': patch
+---
+
+feat: add builtin assets and CSS modules types

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,6 +40,9 @@
     "./rspack-provider": {
       "types": "./dist/rspack-provider/index.d.ts",
       "default": "./dist/rspack-provider/index.js"
+    },
+    "./types": {
+      "types": "./types.d.ts"
     }
   },
   "main": "./dist/index.js",
@@ -72,7 +75,8 @@
   "files": [
     "bin",
     "dist",
-    "static"
+    "static",
+    "types.d.ts"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -1,0 +1,130 @@
+/**
+ * Image assets
+ */
+declare module '*.bmp' {
+  const src: string;
+  export default src;
+}
+declare module '*.bmp?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.bmp?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.gif' {
+  const src: string;
+  export default src;
+}
+declare module '*.gif?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.gif?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpg?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpg?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpeg?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.jpeg?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+declare module '*.png?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.png?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.ico' {
+  const src: string;
+  export default src;
+}
+declare module '*.ico?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.ico?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.webp' {
+  const src: string;
+  export default src;
+}
+declare module '*.webp?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.webp?inline' {
+  const src: string;
+  export default src;
+}
+declare module '*.svg' {
+  const src: string;
+  export default src;
+}
+declare module '*.svg?url' {
+  const src: string;
+  export default src;
+}
+declare module '*.svg?inline' {
+  const src: string;
+  export default src;
+}
+
+/**
+ * CSS Modules
+ */
+type CSSModuleClasses = {
+  readonly [key: string]: string;
+};
+declare module '*.module.css' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.scss' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.sass' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.less' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.styl' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}
+declare module '*.module.stylus' {
+  const classes: CSSModuleClasses;
+  export default classes;
+}

--- a/packages/create-rsbuild/template-react-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/packages/create-rsbuild/template-svelte-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-svelte-ts/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="@rsbuild/core/types" />
+/// <reference types="svelte" />

--- a/packages/create-rsbuild/template-vue2-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-vue2-ts/src/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="@rsbuild/core/types" />
+
 declare module '*.vue' {
   import Vue from 'vue';
 

--- a/packages/create-rsbuild/template-vue3-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-vue3-ts/src/env.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="@rsbuild/core/types" />
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
 


### PR DESCRIPTION
## Summary

Add builtin assets and CSS modules types.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
