### PR TITLE
 fix(core): failed to read NODE_ENV for config file

### DIFF
--- a/.changeset/metal-lemons-unite.md
+++ b/.changeset/metal-lemons-unite.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(core): failed to read NODE_ENV in config file

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,0 +1,15 @@
+import path from 'path';
+import { execSync } from 'child_process';
+import { expect, test } from '@playwright/test';
+import { globContentJSON } from '../../../scripts/helper';
+
+test('should set NODE_ENV correctly when running build command', async () => {
+  execSync('npx rsbuild build', {
+    cwd: __dirname,
+  });
+
+  const outputs = await globContentJSON(path.join(__dirname, 'dist-prod'));
+  const outputFiles = Object.keys(outputs);
+
+  expect(outputFiles.length > 1).toBeTruthy();
+});

--- a/e2e/cases/cli/node-env/rsbuild.config.mjs
+++ b/e2e/cases/cli/node-env/rsbuild.config.mjs
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    distPath: {
+      root: process.env.NODE_ENV === 'production' ? 'dist-prod' : 'dist-dev',
+    },
+  },
+});

--- a/e2e/cases/cli/node-env/src/index.js
+++ b/e2e/cases/cli/node-env/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -1,7 +1,18 @@
 #!/usr/bin/env node
 const { logger } = require('rslog');
 
+function initNodeEnv() {
+  if (!process.env.NODE_ENV) {
+    const command = process.argv[2];
+    process.env.NODE_ENV = ['build', 'preview'].includes(command)
+      ? 'production'
+      : 'development';
+  }
+}
+
 async function main() {
+  initNodeEnv();
+
   const { version } = require('../package.json');
 
   // If not called through a package manager,


### PR DESCRIPTION
## Summary

Fix failed to read NODE_ENV in config file.

## Related Issue

https://github.com/web-infra-dev/modern.js/discussions/4936

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
