### PR TITLE
fix(server): https urls not print when set https

### DIFF
--- a/.changeset/tidy-timers-lick.md
+++ b/.changeset/tidy-timers-lick.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+fix(server): remove useless serverOptions, and fix https urls not print when set https
+
+fix(server): 移除无用的 serverOptions 配置，并修复 https url 打印错误

--- a/e2e/cases/dev/dev.test.ts
+++ b/e2e/cases/dev/dev.test.ts
@@ -116,7 +116,7 @@ test('dev.port & output.distPath', async ({ page }) => {
   await fs.remove(join(fixtures, 'basic/dist-1'));
 });
 
-test.skip('hmr should work when setting dev.port & serverOptions.dev.client', async ({
+test('hmr should work when setting dev.port & devServer.client', async ({
   page,
 }) => {
   await fs.copy(join(fixtures, 'hmr/src'), join(fixtures, 'hmr/test-src-1'));
@@ -131,11 +131,11 @@ test.skip('hmr should work when setting dev.port & serverOptions.dev.client', as
       dev: {
         port: 3001,
       },
-    },
-    serverOptions: {
-      dev: {
-        client: {
-          host: '',
+      tools: {
+        devServer: {
+          client: {
+            host: '',
+          },
         },
       },
     },
@@ -168,7 +168,7 @@ test.skip('hmr should work when setting dev.port & serverOptions.dev.client', as
 });
 
 // need devcert
-test.skip('dev.https', async () => {
+test('dev.https', async () => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,7 @@
     "test:webpack-swc": "PROVIDE_TYPE=webpack playwright test swc"
   },
   "dependencies": {
+    "devcert": "1.2.2",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -8,7 +8,6 @@ import type {
   RsbuildConfig as RspackRsbuildConfig,
 } from '@rsbuild/core';
 import type { RsbuildConfig as WebpackRsbuildConfig } from '@rsbuild/webpack';
-import { StartDevServerOptions } from '@rsbuild/shared';
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
   const baseUrl = new URL(`http://localhost:${port}`);
@@ -87,7 +86,6 @@ const updateConfigForTest = <BundlerType>(
 
 export async function dev<BundlerType = 'rspack'>({
   plugins,
-  serverOptions,
   rsbuildConfig = {},
   ...options
 }: CreateRsbuildOptions & {
@@ -95,7 +93,6 @@ export async function dev<BundlerType = 'rspack'>({
   rsbuildConfig?: BundlerType extends 'webpack'
     ? WebpackRsbuildConfig
     : RspackRsbuildConfig;
-  serverOptions?: StartDevServerOptions['serverOptions'];
 }) {
   process.env.NODE_ENV = 'development';
 
@@ -109,7 +106,6 @@ export async function dev<BundlerType = 'rspack'>({
 
   return rsbuild.startDevServer({
     printURLs: false,
-    serverOptions,
   });
 }
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -35,19 +35,13 @@ export class RsbuildDevServer {
   constructor(options: RsbuildDevServerOptions) {
     this.pwd = options.pwd;
     // set dev server options, like webpack-dev-server
-    this.dev = this.getDevOptions(options);
+    this.dev = deepmerge(getDefaultDevOptions(), options.dev);
 
     // create dev middleware instance
     this.devMiddleware = new DevMiddleware({
       dev: this.dev,
       devMiddleware: options.devMiddleware,
     });
-  }
-
-  private getDevOptions(options: RsbuildDevServerOptions) {
-    const devOptions = typeof options.dev === 'boolean' ? {} : options.dev;
-    const defaultOptions = getDefaultDevOptions();
-    return deepmerge(defaultOptions, devOptions);
   }
 
   private applySetupMiddlewares() {
@@ -202,7 +196,6 @@ export async function startDevServer<
     compiler,
     printURLs = true,
     strictPort = false,
-    serverOptions = {},
     logger: customLogger,
     getPortSilently,
   }: StartDevServerOptions & {
@@ -217,7 +210,6 @@ export async function startDevServer<
   const logger = customLogger ?? defaultLogger;
   const { devServerConfig, port, host, https } = await getDevOptions({
     rsbuildConfig,
-    serverOptions,
     strictPort,
     getPortSilently,
   });

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -189,8 +189,6 @@ type StartDevServerOptions = {
   strictPort?: boolean;
   // custom Compiler object
   compiler?: Compiler | MultiCompiler;
-  // passing through the build-independent dev server configuration
-  serverOptions?: Partial<ModernDevServerOptions>;
   // Whether to get the port silently, the default is false
   getPortSliently?: boolean;
   // custom logger
@@ -252,7 +250,7 @@ You can also directly configure `printURLs` as a function to modify URLs, such a
 
 ```ts
 await rsbuild.startDevServer({
-  printURLs: urls => {
+  printURLs: (urls) => {
     return urls.map(({ label, url }) => ({
       label,
       url: `${url}/path`,

--- a/packages/document/docs/en/shared/config/tools/devServer.md
+++ b/packages/document/docs/en/shared/config/tools/devServer.md
@@ -342,10 +342,3 @@ export default {
   },
 };
 ```
-
-#### watch
-
-- **Type:** `boolean`
-- **Default:** `true`
-
-Whether to watch files change in directories such as `mock/`, `server/`, `api/`.

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -189,8 +189,6 @@ type StartDevServerOptions = {
   strictPort?: boolean;
   // 自定义 Compiler 对象
   compiler?: Compiler | MultiCompiler;
-  // 透传与构建无关的 dev server 配置
-  serverOptions?: Partial<ModernDevServerOptions>;
   // 是否在启动时静默获取端口号，默认为 false
   getPortSliently?: boolean;
   // 自定义日志输出对象
@@ -252,7 +250,7 @@ await rsbuild.startDevServer({
 
 ```ts
 await rsbuild.startDevServer({
-  printURLs: urls => {
+  printURLs: (urls) => {
     return urls.map(({ label, url }) => ({
       label,
       url: `${url}/path`,

--- a/packages/document/docs/zh/shared/config/tools/devServer.md
+++ b/packages/document/docs/zh/shared/config/tools/devServer.md
@@ -343,10 +343,3 @@ export default {
   },
 };
 ```
-
-#### watch
-
-- **类型：** `boolean`
-- **默认值：** `true`
-
-是否监听 `mock/`、`server/`、`api/` 等目录的文件变化。

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@ import type { PluginStore, Plugins, DefaultRsbuildPluginAPI } from './plugin';
 import type { Context } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
-import { StartServerResult, RsbuildDevServerOptions } from './server';
+import { StartServerResult } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
 
@@ -17,7 +17,6 @@ export type StartDevServerOptions = {
   logger?: Logger;
   strictPort?: boolean;
   getPortSilently?: boolean;
-  serverOptions?: Partial<RsbuildDevServerOptions>;
 };
 
 export type BuildOptions = {

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -45,7 +45,7 @@ export type DevMiddleware = (options: DevMiddlewareOptions) => DevMiddlewareAPI;
 
 export type RsbuildDevServerOptions = {
   pwd: string;
-  dev: boolean | Partial<DevServerOptions>;
+  dev: Partial<DevServerOptions>;
   devMiddleware?: DevMiddleware;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   e2e:
     dependencies:
+      devcert:
+        specifier: 1.2.2
+        version: 1.2.2
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -5681,6 +5684,10 @@ packages:
       '@types/express': 4.17.20
     dev: true
 
+  /@types/configstore@2.1.1:
+    resolution: {integrity: sha512-YY+hm3afkDHeSM2rsFXxeZtu0garnusBWNG1+7MknmDWQHqcH2w21/xOU9arJUi8ch4qyFklidANLCu3ihhVwQ==}
+    dev: false
+
   /@types/connect-history-api-fallback@1.5.2:
     resolution: {integrity: sha512-gX2j9x+NzSh4zOhnRPSdPPmTepS4DfxES0AvIFv3jGv5QyeAJf6u6dY5/BAoAJU9Qq1uTvwOku8SSC2GnCRl6Q==}
     dependencies:
@@ -5701,6 +5708,10 @@ packages:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
       '@types/node': 16.18.59
+
+  /@types/debug@0.0.30:
+    resolution: {integrity: sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==}
+    dev: false
 
   /@types/debug@4.1.10:
     resolution: {integrity: sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==}
@@ -5765,6 +5776,17 @@ packages:
       '@types/jsonfile': 6.1.3
       '@types/node': 16.18.59
     dev: true
+
+  /@types/get-port@3.2.0:
+    resolution: {integrity: sha512-TiNg8R1kjDde5Pub9F9vCwZA/BNW9HeXP5b9j7Qucqncy/McfPZ6xze/EyBdXS5FhMIGN6Fx3vg75l5KHy3V1Q==}
+    dev: false
+
+  /@types/glob@5.0.38:
+    resolution: {integrity: sha512-rTtf75rwyP9G2qO5yRpYtdJ6aU1QqEhWbtW55qEgquEDa6bXW0s2TWZfDm02GuppjEozOWG/F2UnPq5hAQb+gw==}
+    dependencies:
+      '@types/minimatch': 5.1.2
+      '@types/node': 16.18.59
+    dev: false
 
   /@types/hast@2.3.7:
     resolution: {integrity: sha512-EVLigw5zInURhzfXUM65eixfadfsHKomGKUakToXo84t8gGIJuTcD2xooM2See7GyQ7DRtYjhCHnSUQez8JaLw==}
@@ -5852,9 +5874,19 @@ packages:
     resolution: {integrity: sha512-i8MBln35l856k5iOhKk2XJ4SeAWg75mLIpZB4v6imOagKL6twsukBZGDMNhdOVk7yRFTMPpfILocMos59Q1otQ==}
     dev: true
 
+  /@types/minimatch@5.1.2:
+    resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+    dev: false
+
   /@types/minimist@1.2.4:
     resolution: {integrity: sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==}
     dev: true
+
+  /@types/mkdirp@0.5.2:
+    resolution: {integrity: sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==}
+    dependencies:
+      '@types/node': 16.18.59
+    dev: false
 
   /@types/ms@0.7.33:
     resolution: {integrity: sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==}
@@ -5869,6 +5901,10 @@ packages:
 
   /@types/node@16.18.59:
     resolution: {integrity: sha512-PJ1w2cNeKUEdey4LiPra0ZuxZFOGvetswE8qHRriV/sUkL5Al4tTmPV9D2+Y/TPIxTHHgxTfRjZVKWhPw/ORhQ==}
+
+  /@types/node@8.10.66:
+    resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
+    dev: false
 
   /@types/normalize-package-data@2.4.3:
     resolution: {integrity: sha512-ehPtgRgaULsFG8x0NeYJvmyH1hmlfsNLujHe9dQEia/7MAJYdzMSi19JtchUHjmBA6XC/75dK55mzZH+RyieSg==}
@@ -5925,6 +5961,13 @@ packages:
       csstype: 3.1.2
     dev: true
 
+  /@types/rimraf@2.0.5:
+    resolution: {integrity: sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==}
+    dependencies:
+      '@types/glob': 5.0.38
+      '@types/node': 16.18.59
+    dev: false
+
   /@types/scheduler@0.16.5:
     resolution: {integrity: sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==}
     dev: true
@@ -5975,6 +6018,10 @@ packages:
     resolution: {integrity: sha512-ujqOVJEeLcwpDVJPnp/k3u1UXmTKq5urJq9fO8aUKg8Vlel5RNOFbVKEfqfh6wGfF/M+HiTJlBJMLC1aDfyf0Q==}
     dependencies:
       tapable: 2.2.1
+
+  /@types/tmp@0.0.33:
+    resolution: {integrity: sha512-gVC1InwyVrO326wbBZw+AO3u2vRXz/iRWq9jYhpG4W8LXyIgDv3ZmcLQ5Q4Gs+gFMyqx+viFoFT+l3p61QFCmQ==}
+    dev: false
 
   /@types/trouter@3.1.3:
     resolution: {integrity: sha512-NNcyQHeUe3Jv09YxBF21EkKbiqCaI1480BPqaGKy0Xby993d0MBHB+XMG/cVf5lCPxm9Qd8AdEYHd1IVLwq7lA==}
@@ -6650,6 +6697,10 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  /application-config-path@0.1.1:
+    resolution: {integrity: sha512-zy9cHePtMP0YhwG+CfHm0bgwdnga2X3gZexpdCwEj//dpb+TKajtiC8REEUJUSq6Ab4f9cgNy2l8ObXzCXFkEw==}
+    dev: false
 
   /arg@5.0.2:
     resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
@@ -7372,6 +7423,10 @@ packages:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: true
 
+  /command-exists@1.2.9:
+    resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
+    dev: false
+
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -7771,7 +7826,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: true
 
   /crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
@@ -8049,8 +8103,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.3
-    dev: true
-    optional: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -8175,6 +8227,36 @@ packages:
       defined: 1.0.1
       minimist: 1.2.8
     dev: true
+
+  /devcert@1.2.2:
+    resolution: {integrity: sha512-UsLqvtJGPiGwsIZnJINUnFYaWgK7CroreGRndWHZkRD58tPFr3pVbbSyHR8lbh41+azR4jKvuNZ+eCoBZGA5kA==}
+    dependencies:
+      '@types/configstore': 2.1.1
+      '@types/debug': 0.0.30
+      '@types/get-port': 3.2.0
+      '@types/glob': 5.0.38
+      '@types/lodash': 4.14.200
+      '@types/mkdirp': 0.5.2
+      '@types/node': 8.10.66
+      '@types/rimraf': 2.0.5
+      '@types/tmp': 0.0.33
+      application-config-path: 0.1.1
+      command-exists: 1.2.9
+      debug: 3.2.7
+      eol: 0.9.1
+      get-port: 3.2.0
+      glob: 7.2.3
+      is-valid-domain: 0.1.6
+      lodash: 4.17.21
+      mkdirp: 0.5.6
+      password-prompt: 1.1.3
+      rimraf: 2.7.1
+      sudo-prompt: 8.2.5
+      tmp: 0.0.33
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /didyoumean@1.2.2:
     resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
@@ -8409,6 +8491,10 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: false
+
+  /eol@0.9.1:
+    resolution: {integrity: sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg==}
     dev: false
 
   /errno@0.1.8:
@@ -9033,6 +9119,11 @@ packages:
       has: 1.0.4
       has-proto: 1.0.1
       has-symbols: 1.0.3
+
+  /get-port@3.2.0:
+    resolution: {integrity: sha512-x5UJKlgeUiNT8nyo/AcnwLnZuZNcSjSw0kogRB+Whd1fjjFq4B1hySFxSFWWSn4mIBzg3sRNUDFYc4g5gjPoLg==}
+    engines: {node: '>=4'}
+    dev: false
 
   /get-port@5.1.1:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
@@ -9940,6 +10031,12 @@ packages:
   /is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  /is-valid-domain@0.1.6:
+    resolution: {integrity: sha512-ZKtq737eFkZr71At8NxOFcP9O1K89gW3DkdrGMpp1upr/ueWjj+Weh4l9AI4rN0Gt8W2M1w7jrG2b/Yv83Ljpg==}
+    dependencies:
+      punycode: 2.3.0
+    dev: false
 
   /is-weakref@1.0.2:
     resolution: {integrity: sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==}
@@ -11662,6 +11759,13 @@ packages:
       no-case: 3.0.4
       tslib: 2.4.1
 
+  /password-prompt@1.1.3:
+    resolution: {integrity: sha512-HkrjG2aJlvF0t2BMH0e2LB/EHf3Lcq3fNMzy4GYHcQblAvOl+QQji1Lx7WRBMqpVK8p+KR7bCg7oqAMXtdgqyw==}
+    dependencies:
+      ansi-escapes: 4.3.2
+      cross-spawn: 7.0.3
+    dev: false
+
   /path-browserify@0.0.1:
     resolution: {integrity: sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==}
     dev: false
@@ -11686,7 +11790,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: true
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -13162,7 +13265,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: true
 
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
@@ -13171,7 +13273,6 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: true
 
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
@@ -13579,6 +13680,10 @@ packages:
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
     dev: true
+
+  /sudo-prompt@8.2.5:
+    resolution: {integrity: sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw==}
+    dev: false
 
   /supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
@@ -14056,6 +14161,10 @@ packages:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+    dev: false
 
   /tslib@2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
@@ -15002,7 +15111,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: true
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}


### PR DESCRIPTION
## Summary

- remove useless serverOptions in rsbuild server, it's a legacy param for modern.js
- fix https urls not print when set https

<img width="885" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/25d5ff99-5e23-4bbd-80fd-0bfee360445b">


## Related Issue

fix: https://github.com/web-infra-dev/rsbuild/issues/431
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
