### PR TITLE
fix(dev-server): support access page without suffix

### DIFF
--- a/.changeset/light-flowers-occur.md
+++ b/.changeset/light-flowers-occur.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+hotfix(dev-server): support access page without suffix

--- a/e2e/cases/dev/html-fallback.test.ts
+++ b/e2e/cases/dev/html-fallback.test.ts
@@ -1,0 +1,191 @@
+import { join } from 'path';
+import { expect, test } from '@playwright/test';
+import { dev } from '@scripts/shared';
+
+const fixtures = __dirname;
+
+test('access / success when entry is index', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      index: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('access /main.html success (with suffix)', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main.html`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('access /main success when outputPath is /main.html and write to disk', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main`);
+
+  const res = await page.goto(url.href);
+
+  expect(res?.status()).toBe(200);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('access /main success when outputPath is /main.html and write to memory', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: false,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('access /main success when set assetPrefix', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+        assetPrefix: '/aaaa/',
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('access /main success when outputPath is /main/index.html', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      html: {
+        outputStructure: 'nested',
+      },
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
+test('fallback failed when page is 404', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    entry: {
+      main: join(fixtures, 'basic', 'src/index.ts'),
+    },
+    rsbuildConfig: {
+      dev: {
+        devMiddleware: {
+          writeToDisk: true,
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main1`);
+
+  const res = await page.goto(url.href);
+
+  expect(res?.status()).toBe(404);
+
+  await rsbuild.server.close();
+});

--- a/e2e/cases/dev/html-fallback.test.ts
+++ b/e2e/cases/dev/html-fallback.test.ts
@@ -4,7 +4,7 @@ import { dev } from '@scripts/shared';
 
 const fixtures = __dirname;
 
-test('access / success when entry is index', async ({ page }) => {
+test('should access / success when entry is index', async ({ page }) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
@@ -29,7 +29,9 @@ test('access / success when entry is index', async ({ page }) => {
   await rsbuild.server.close();
 });
 
-test('access /main.html success (with suffix)', async ({ page }) => {
+test('should access /main.html success when entry is main', async ({
+  page,
+}) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
@@ -54,9 +56,7 @@ test('access /main.html success (with suffix)', async ({ page }) => {
   await rsbuild.server.close();
 });
 
-test('access /main success when outputPath is /main.html and write to disk', async ({
-  page,
-}) => {
+test('should access /main success when entry is main', async ({ page }) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
@@ -83,7 +83,7 @@ test('access /main success when outputPath is /main.html and write to disk', asy
   await rsbuild.server.close();
 });
 
-test('access /main success when outputPath is /main.html and write to memory', async ({
+test('should access /main success when entry is main and use memoryFs', async ({
   page,
 }) => {
   const rsbuild = await dev({
@@ -110,7 +110,9 @@ test('access /main success when outputPath is /main.html and write to memory', a
   await rsbuild.server.close();
 });
 
-test('access /main success when set assetPrefix', async ({ page }) => {
+test('should access /main success when entry is main and set assetPrefix', async ({
+  page,
+}) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {
@@ -136,7 +138,7 @@ test('access /main success when set assetPrefix', async ({ page }) => {
   await rsbuild.server.close();
 });
 
-test('access /main success when outputPath is /main/index.html', async ({
+test('should access /main success when entry is main and outputPath is /main/index.html', async ({
   page,
 }) => {
   const rsbuild = await dev({
@@ -166,7 +168,7 @@ test('access /main success when outputPath is /main/index.html', async ({
   await rsbuild.server.close();
 });
 
-test('fallback failed when page is 404', async ({ page }) => {
+test('should return 404 when page is not found', async ({ page }) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     entry: {

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,4 +1,6 @@
-import { RequestHandler as Middleware } from '@rsbuild/shared';
+import { RequestHandler as Middleware, debug, urlJoin } from '@rsbuild/shared';
+import path from 'path';
+import fs from 'fs';
 
 export const faviconFallbackMiddleware: Middleware = (req, res, next) => {
   if (req.url === '/favicon.ico') {
@@ -7,4 +9,87 @@ export const faviconFallbackMiddleware: Middleware = (req, res, next) => {
   } else {
     next();
   }
+};
+
+export const notFoundMiddleware: Middleware = (_req, res, _next) => {
+  res.statusCode = 404;
+  res.end();
+};
+
+export const getHtmlFallbackMiddleware: (params: {
+  distPath: string;
+  assetPrefix: string;
+  callback?: Middleware;
+}) => Middleware = ({ assetPrefix, distPath, callback }) => {
+  /**
+   * support access page without suffix and support fallback in some edge cases
+   */
+  return (req, res, next) => {
+    if (
+      // Only accept GET or HEAD
+      (req.method !== 'GET' && req.method !== 'HEAD') ||
+      // Require Accept header
+      !req.headers ||
+      typeof req.headers.accept !== 'string' ||
+      // Ignore JSON requests
+      req.headers.accept.includes('application/json') ||
+      // Require Accept: text/html or */*
+      !(
+        req.headers.accept.includes('text/html') ||
+        req.headers.accept.includes('*/*')
+      ) ||
+      !req.url
+    ) {
+      return next();
+    }
+
+    const { url } = req;
+    const pathname = decodeURIComponent(url);
+
+    let outputFileSystem = fs;
+
+    // support memory fs
+    // @ts-expect-error
+    if (res.locals.webpack) {
+      // reference: https://github.com/webpack/webpack-dev-middleware#server-side-rendering
+      // @ts-expect-error
+      const { devMiddleware } = res.locals.webpack;
+      outputFileSystem = devMiddleware.outputFileSystem;
+    }
+
+    const tryRewrite = (filePath: string, newUrl: string) => {
+      if (outputFileSystem.existsSync(filePath) && callback) {
+        // we need add assetPrefix(output.publicPath) for html, otherwise webpack-dev-middleware cannot find the file
+        newUrl = urlJoin(assetPrefix, newUrl);
+
+        debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`);
+
+        req.url = newUrl;
+
+        return callback(req, res, (...args) => {
+          req.url = url;
+          next(...args);
+        });
+      }
+    };
+
+    // '/' => '/index.html'
+    if (pathname.endsWith('/')) {
+      const newUrl = url + 'index.html';
+      const filePath = path.join(distPath, pathname, 'index.html');
+      tryRewrite(filePath, newUrl);
+    } else if (
+      // '/main' => '/main.html'
+      !pathname.endsWith('.html')
+    ) {
+      const newUrl = url + '.html';
+      const filePath = path.join(distPath, pathname + '.html');
+      tryRewrite(filePath, newUrl);
+    } else {
+      // when user set assetPrefix, webpack-dev-middleware can't get html file directly.
+      tryRewrite(path.join(distPath, pathname), url);
+    }
+
+    next();
+  };
 };

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -45,8 +45,13 @@ export type DevMiddleware = (options: DevMiddlewareOptions) => DevMiddlewareAPI;
 
 export type RsbuildDevServerOptions = {
   pwd: string;
+  /** Rsbuild devConfig */
   dev: DevConfig;
   devMiddleware?: DevMiddleware;
+  output: {
+    distPath: string;
+    assetPrefix: string;
+  };
 };
 
 export type CreateDevServerOptions = {

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -3,6 +3,8 @@ import { URL } from 'url';
 import urlJoin from 'url-join';
 import { DEFAULT_DEV_HOST } from './constants';
 
+export { urlJoin };
+
 export const withPublicPath = (str: string, base: string) => {
   // The use of an absolute URL without a protocol is technically legal,
   // however it cannot be parsed as a URL instance.


### PR DESCRIPTION
## Summary

support access page without suffix and the following case：
<img width="893" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/f2a9299f-0e3b-4587-97df-11330bb9124b">

TODO:
- print entries in terminal
- test prodServer

## Related Issue

#448 
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
