### PR TITLE
feat(server): should print correct urls by html entry

### DIFF
--- a/.changeset/proud-meals-tell.md
+++ b/.changeset/proud-meals-tell.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+hotfix(server): should print correct urls by html entry

--- a/.changeset/proud-meals-tell.md
+++ b/.changeset/proud-meals-tell.md
@@ -2,4 +2,4 @@
 '@rsbuild/core': patch
 ---
 
-hotfix(server): should print correct urls by html entry
+feat(server): should print urls by html entry

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -4,7 +4,7 @@ import {
   castArray,
   type DefaultRsbuildPlugin,
   normalizeUrl,
-  getRoutesName,
+  formatRoutes,
 } from '@rsbuild/shared';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -109,11 +109,11 @@ export function pluginStartUrl(): DefaultRsbuildPlugin {
 
         if (startUrl === true || !startUrl) {
           const { entry } = api.context;
-          const names = getRoutesName(entry);
+          const routes = formatRoutes(entry);
           const protocol = https ? 'https' : 'http';
-          // auto open first entry
+          // auto open the first one
           urls.push(
-            normalizeUrl(`${protocol}://localhost:${port}/${names[0]}`),
+            normalizeUrl(`${protocol}://localhost:${port}/${routes[0].route}`),
           );
         } else {
           urls.push(

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -1,5 +1,11 @@
 import { join } from 'path';
-import { logger, castArray, type DefaultRsbuildPlugin } from '@rsbuild/shared';
+import {
+  logger,
+  castArray,
+  type DefaultRsbuildPlugin,
+  normalizeUrl,
+  getRoutesName,
+} from '@rsbuild/shared';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
@@ -102,8 +108,13 @@ export function pluginStartUrl(): DefaultRsbuildPlugin {
         const urls: string[] = [];
 
         if (startUrl === true || !startUrl) {
+          const { entry } = api.context;
+          const names = getRoutesName(entry);
           const protocol = https ? 'https' : 'http';
-          urls.push(`${protocol}://localhost:${port}`);
+          // auto open first entry
+          urls.push(
+            normalizeUrl(`${protocol}://localhost:${port}/${names[0]}`),
+          );
         } else {
           urls.push(
             ...castArray(startUrl).map((item) =>

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -249,7 +249,7 @@ export async function startDevServer<
       }
     }
 
-    printServerURLs(urls, logger);
+    printServerURLs(urls, options.context.entry, logger);
   }
 
   debug('create dev server');

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -127,7 +127,7 @@ export async function startProdServer(
       () => {
         const urls = getAddressUrls('http', port);
 
-        printServerURLs(urls);
+        printServerURLs(urls, context.entry);
         resolve({
           port,
           urls: urls.map((item) => item.url),

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -5,6 +5,9 @@ import { DEFAULT_DEV_HOST } from './constants';
 
 export { urlJoin };
 
+// remove repeat '/'
+export const normalizeUrl = (url: string) => url.replace(/([^:]\/)\/+/g, '$1');
+
 export const withPublicPath = (str: string, base: string) => {
   // The use of an absolute URL without a protocol is technically legal,
   // however it cannot be parsed as a URL instance.

--- a/packages/shared/tests/devServer.test.ts
+++ b/packages/shared/tests/devServer.test.ts
@@ -3,7 +3,129 @@ import {
   setupServerHooks,
   isClientCompiler,
   mergeDevOptions,
+  formatRoutes,
+  printServerURLs,
 } from '../src/devServer';
+
+test('formatRoutes', () => {
+  expect(
+    formatRoutes({
+      index: 'src/index.ts',
+      foo: 'src/index.ts',
+      bar: 'src/index.ts',
+    }),
+  ).toEqual([
+    {
+      name: 'index',
+      route: '',
+    },
+    {
+      name: 'foo',
+      route: 'foo',
+    },
+    {
+      name: 'bar',
+      route: 'bar',
+    },
+  ]);
+
+  expect(
+    formatRoutes({
+      foo: 'src/index.ts',
+      bar: 'src/index.ts',
+      index: 'src/index.ts',
+    }),
+  ).toEqual([
+    {
+      name: 'index',
+      route: '',
+    },
+    {
+      name: 'foo',
+      route: 'foo',
+    },
+    {
+      name: 'bar',
+      route: 'bar',
+    },
+  ]);
+
+  expect(
+    formatRoutes({
+      foo: 'src/index.ts',
+    }),
+  ).toEqual([
+    {
+      name: 'foo',
+      route: 'foo',
+    },
+  ]);
+});
+
+test('printServerURLs', () => {
+  let message: string;
+  const logger = {
+    log: (msg: string) => {
+      message = msg;
+    },
+  };
+
+  printServerURLs(
+    [
+      {
+        url: 'http://localhost:8080',
+        label: 'local',
+      },
+      {
+        url: 'http://10.94.62.193:8080/',
+        label: 'network',
+      },
+    ],
+    {
+      index: 'src/index.ts',
+    },
+    // @ts-expect-error
+    logger,
+  );
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  > local     http:/localhost:8080/
+      > network   http:/10.94.62.193:8080/
+    "
+  `);
+
+  printServerURLs(
+    [
+      {
+        url: 'http://localhost:8080',
+        label: 'local',
+      },
+      {
+        url: 'http://10.94.62.193:8080/',
+        label: 'network',
+      },
+    ],
+    {
+      foo: 'src/index.ts',
+      bar: 'src/index.ts',
+      index: 'src/index.ts',
+    },
+    // @ts-expect-error
+    logger,
+  );
+
+  expect(message!).toMatchInlineSnapshot(`
+    "  > local
+        ○  index        http:/localhost:8080/
+        ○  foo          http:/localhost:8080/foo
+        ○  bar          http:/localhost:8080/bar
+      > network
+        ○  index        http:/10.94.62.193:8080/
+        ○  foo          http:/10.94.62.193:8080/foo
+        ○  bar          http:/10.94.62.193:8080/bar
+    "
+  `);
+});
 
 describe('test dev server', () => {
   test('should setupServerHooks correctly', () => {

--- a/packages/shared/tests/url.test.ts
+++ b/packages/shared/tests/url.test.ts
@@ -1,6 +1,20 @@
-import { withPublicPath } from '../src/url';
+import { withPublicPath, normalizeUrl } from '../src/url';
 
 const PUBLIC_PATH = 'https://www.example.com/static';
+
+it('normalizeUrl', () => {
+  expect(normalizeUrl('https://www.example.com/static//a')).toBe(
+    'https://www.example.com/static/a',
+  );
+
+  expect(normalizeUrl('https://www.example.com/static/a')).toBe(
+    'https://www.example.com/static/a',
+  );
+
+  expect(normalizeUrl('https://www.example.com/static/')).toBe(
+    'https://www.example.com/static/',
+  );
+});
 
 describe('withPublicPath', () => {
   it('should handle relative url', () => {


### PR DESCRIPTION
## Summary

entry (single): index
<img width="468" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/07e3c651-8fff-4d6a-a7e1-98027aa35e25">

entry (single): foo
<img width="487" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/6c414c52-1c46-46d5-b6c0-91d4c5b31f6d">

entry(multiple): foo、bar
<img width="458" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/13d8819b-3642-45d9-8238-6203d3ea5f10">


## Related Issue

fix: #448 

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
