### PR TITLE
chore: rename hmr path to /rsbuild-hmr

### DIFF
--- a/.changeset/fast-garlics-fail.md
+++ b/.changeset/fast-garlics-fail.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/document': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+chore: rename hmr path to /rsbuild-hmr

--- a/packages/core/src/server/dev-middleware/hmr-client/createSocketUrl.ts
+++ b/packages/core/src/server/dev-middleware/hmr-client/createSocketUrl.ts
@@ -8,7 +8,7 @@ type ParsedSearch = {
 /**
  * hmr socket connect path
  */
-export const HMR_SOCK_PATH = '/webpack-hmr';
+export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
 export function createSocketUrl(resourceQuery: string) {
   // ?host=localhost&port=8080&path=modern_js_hmr_ws

--- a/packages/document/docs/en/guide/advanced/hmr.md
+++ b/packages/document/docs/en/guide/advanced/hmr.md
@@ -34,7 +34,7 @@ The default config are as follows, Rsbuild will automatically deduce the URL of 
 export default {
   dev: {
     client: {
-      path: '/webpack-hmr',
+      path: '/rsbuild-hmr',
       // Equivalent to port of the dev server
       port: '',
       // Equivalent to location.hostname

--- a/packages/document/docs/en/guide/faq/hmr.md
+++ b/packages/document/docs/en/guide/faq/hmr.md
@@ -21,7 +21,7 @@ After understanding the principle of HMR, you can follow these steps for basic t
 Open the browser console and check for the presence of the `[HMR] connected.` log.
 
 - If it is present, the WebSocket connection is working correctly. You can continue with the following steps.
-- If it is not present, open the Network panel in Chrome and check the status of the `ws://[host]:[port]/webpack-hmr` request. If the request is failed, this indicates that the HMR failed because the WebSocket connection was not successfully established.
+- If it is not present, open the Network panel in Chrome and check the status of the `ws://[host]:[port]/rsbuild-hmr` request. If the request is failed, this indicates that the HMR failed because the WebSocket connection was not successfully established.
 
 There can be various reasons why the WebSocket connection fails to establish, such as using a network proxy that prevents the WebSocket request from reaching the development server. You can check whether the WebSocket request address matches your development server address. If it does not match, you can configure the WebSocket request address using [dev.client](/config/options/dev.html#devclient).
 

--- a/packages/document/docs/en/shared/config/dev/client.md
+++ b/packages/document/docs/en/shared/config/dev/client.md
@@ -17,7 +17,7 @@
 
 ```js
 const defaultConfig = {
-  path: '/webpack-hmr',
+  path: '/rsbuild-hmr',
   // By default it is set to the port number of the dev server
   port: '',
   // By default it is set to "location.hostname"

--- a/packages/document/docs/zh/guide/advanced/hmr.md
+++ b/packages/document/docs/zh/guide/advanced/hmr.md
@@ -34,7 +34,7 @@ export default {
 export default {
   dev: {
     client: {
-      path: '/webpack-hmr',
+      path: '/rsbuild-hmr',
       // 默认设置为 dev server 的端口号
       port: '',
       // 默认设置为 location.hostname

--- a/packages/document/docs/zh/guide/faq/hmr.md
+++ b/packages/document/docs/zh/guide/faq/hmr.md
@@ -21,7 +21,7 @@
 打开浏览器的控制台，查看是否有 `[HMR] connected.` 日志。
 
 - 如果有，说明 Web Socket 连接正常，请继续检查后续步骤。
-- 如果没有，请打开 Chrome 的 Network 面板，查看 `ws://[host]:[port]/webpack-hmr` 的请求状态，若请求异常，说明热更新失败的原因是 Web Socket 请求没有建立成功。
+- 如果没有，请打开 Chrome 的 Network 面板，查看 `ws://[host]:[port]/rsbuild-hmr` 的请求状态，若请求异常，说明热更新失败的原因是 Web Socket 请求没有建立成功。
 
 Web Socket 请求没有建立成功的原因可能有很多种，例如开启了网络代理，导致 Web Socket 请求没有正确发送到开发服务器。你可以检查 Web Socket 请求的地址是否为你的开发服务器地址，如果不是，则可以通过 [dev.client](/config/options/dev.html#devclient) 来配置 Web Socket 请求的地址。
 

--- a/packages/document/docs/zh/shared/config/dev/client.md
+++ b/packages/document/docs/zh/shared/config/dev/client.md
@@ -17,7 +17,7 @@
 
 ```js
 const defaultConfig = {
-  path: '/webpack-hmr',
+  path: '/rsbuild-hmr',
   // By default it is set to the port number of the dev server
   port: '',
   // By default it is set to "location.hostname"

--- a/packages/shared/src/devServer.ts
+++ b/packages/shared/src/devServer.ts
@@ -28,7 +28,7 @@ export function printServerURLs(
 /**
  * hmr socket connect path
  */
-export const HMR_SOCK_PATH = '/webpack-hmr';
+export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
 export const mergeDevOptions = ({
   rsbuildConfig,

--- a/packages/shared/tests/devServer.test.ts
+++ b/packages/shared/tests/devServer.test.ts
@@ -91,7 +91,7 @@ describe('test dev server', () => {
       {
         "client": {
           "host": "",
-          "path": "/webpack-hmr",
+          "path": "/rsbuild-hmr",
           "port": "8080",
           "protocol": "",
         },


### PR DESCRIPTION
## Summary

Rename hmr path to `/rsbuild-hmr`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
