### PR TITLE
perf(core): remove strip-ansi dependency

### DIFF
--- a/.changeset/polite-pillows-sip.md
+++ b/.changeset/polite-pillows-sip.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+perf(core): remove strip-ansi dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,6 @@
     "rslog": "^1.1.0",
     "semver": "^7.5.4",
     "sirv": "^2.0.3",
-    "strip-ansi": "^6.0.1",
     "ws": "^8.2.0"
   },
   "devDependencies": {

--- a/packages/core/src/server/dev-middleware/hmr-client/index.ts
+++ b/packages/core/src/server/dev-middleware/hmr-client/index.ts
@@ -4,7 +4,6 @@
  *
  * Tips: this package will be bundled and running in the browser, do not import from the entry of @rsbuild/core.
  */
-import stripAnsi from 'strip-ansi';
 import type { StatsError } from '@rsbuild/shared';
 import { formatStatsMessages } from '@rsbuild/shared/format-stats';
 import { createSocketUrl } from './createSocketUrl';
@@ -96,7 +95,7 @@ function handleWarnings(warnings: StatsError[]) {
           );
           break;
         }
-        console.warn(stripAnsi(formatted.warnings[i]));
+        console.warn(formatted.warnings[i]);
       }
     }
   }
@@ -125,7 +124,7 @@ function handleErrors(errors: StatsError[]) {
   // Also log them to the console.
   if (typeof console !== 'undefined' && typeof console.error === 'function') {
     for (const error of formatted.errors) {
-      console.error(stripAnsi(error));
+      console.error(error);
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,9 +697,6 @@ importers:
       sirv:
         specifier: ^2.0.3
         version: 2.0.3
-      strip-ansi:
-        specifier: ^6.0.1
-        version: 6.0.1
       ws:
         specifier: ^8.2.0
         version: 8.14.2


### PR DESCRIPTION
## Summary

Remove strip-ansi dependency because Chrome support ansi code in console.

## Related Issue

https://developer.chrome.com/docs/devtools/console/format-style/#style-ansi

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
