### PR TITLE
perf(core): remove filesize dependency

### DIFF
--- a/.changeset/stale-lizards-listen.md
+++ b/.changeset/stale-lizards-listen.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+perf(core): remove filesize dependency

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,7 +89,6 @@
     "connect-history-api-fallback": "^2.0.0",
     "commander": "^10.0.1",
     "core-js": "~3.32.2",
-    "filesize": "^8.0.7",
     "gzip-size": "^6.0.0",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
     "http-compression": "1.0.6",

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -5,7 +5,6 @@
 import path from 'path';
 import { fs } from '@rsbuild/shared/fs-extra';
 import { color, logger } from '@rsbuild/shared';
-import filesize from 'filesize';
 import gzipSize from 'gzip-size';
 import type {
   DefaultRsbuildPlugin,
@@ -46,6 +45,11 @@ async function printHeader(
   logger.log(color.bold(color.blue(headerRow)));
 }
 
+const calcFileSize = (len: number) => {
+  const val = len / 1000;
+  return `${val.toFixed(val < 1 ? 2 : 1)} kB`;
+};
+
 async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
   const formatAsset = (asset: StatsAsset) => {
     const contents = fs.readFileSync(path.join(distPath, asset.name));
@@ -57,10 +61,8 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
       folder: path.join(path.basename(distPath), path.dirname(asset.name)),
       name: path.basename(asset.name),
       gzippedSize,
-      sizeLabel: filesize(size, { round: 1 }),
-      gzipSizeLabel: getAssetColor(gzippedSize)(
-        filesize(gzippedSize, { round: 1 }),
-      ),
+      sizeLabel: calcFileSize(size),
+      gzipSizeLabel: getAssetColor(gzippedSize)(calcFileSize(gzippedSize)),
     };
   };
 
@@ -129,13 +131,12 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
     logger.log(`  ${fileNameLabel}    ${sizeLabel}    ${gzipSizeLabel}`);
   });
 
-  const totalSizeLabel = `${color.bold(color.blue('Total size:'))}  ${filesize(
-    totalSize,
-    { round: 1 },
-  )}`;
+  const totalSizeLabel = `${color.bold(
+    color.blue('Total size:'),
+  )}  ${calcFileSize(totalSize)}`;
   const gzippedSizeLabel = `${color.bold(
     color.blue('Gzipped size:'),
-  )}  ${filesize(totalGzipSize, { round: 1 })}`;
+  )}  ${calcFileSize(totalGzipSize)}`;
   logger.log(`\n  ${totalSizeLabel}\n  ${gzippedSizeLabel}\n`);
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,9 +661,6 @@ importers:
       core-js:
         specifier: ~3.32.2
         version: 3.32.2
-      filesize:
-        specifier: ^8.0.7
-        version: 8.0.7
       gzip-size:
         specifier: ^6.0.0
         version: 6.0.0
@@ -8928,11 +8925,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       escape-string-regexp: 1.0.5
-
-  /filesize@8.0.7:
-    resolution: {integrity: sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==}
-    engines: {node: '>= 0.4.0'}
-    dev: false
 
   /fill-range@7.0.1:
     resolution: {integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==}


### PR DESCRIPTION
## Summary

Remove filesize dependency, just display `kB` unit is enough.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
