### PR TITLE
chore(server): route.json is no longer needed

### DIFF
--- a/.changeset/tall-chefs-pump.md
+++ b/.changeset/tall-chefs-pump.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+chore(server): route.json is no longer needed

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -77,8 +77,6 @@ export const MODULE_PATH_REGEX =
 
 export const TS_CONFIG_FILE = 'tsconfig.json';
 
-export const ROUTE_SPEC_FILE = 'route.json';
-
 export const TARGET_ID_MAP: Record<RsbuildTarget, string> = {
   web: 'Client',
   node: 'Server',


### PR DESCRIPTION
## Summary

since rsbuild use rsbuild server, we don't need output route.json at all.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
