### PR TITLE
chore: using exports.types to replace typesVersion

### DIFF
--- a/.changeset/eighty-rocks-shop.md
+++ b/.changeset/eighty-rocks-shop.md
@@ -1,0 +1,13 @@
+---
+'@rsbuild/plugin-swc': patch
+'@rsbuild/webpack': patch
+'@rsbuild/babel-preset': patch
+'@rsbuild/doctor-types': patch
+'@rsbuild/doctor-utils': patch
+'@rsbuild/doctor-core': patch
+'@rsbuild/doctor-sdk': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+chore: using exports.types to replace typesVersion

--- a/e2e/cases/source-build/common/package.json
+++ b/e2e/cases/source-build/common/package.json
@@ -6,14 +6,8 @@
   "source": "./src/index.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "source": "./src/index.ts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      ".": [
-        "./src/index.ts"
-      ]
     }
   }
 }

--- a/e2e/cases/source-build/components/package.json
+++ b/e2e/cases/source-build/components/package.json
@@ -6,22 +6,14 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "source": "./src/index.tsx",
       "default": "./dist/index.js"
     },
     "./card": {
+      "types": "./dist/types/card/index.d.ts",
       "source": "./src/card/index.tsx",
       "default": "./dist/card/index.js"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      ".": [
-        "./dist/types/index.d.ts"
-      ],
-      "card": [
-        "./dist/types/card/index.d.ts"
-      ]
     }
   },
   "dependencies": {

--- a/e2e/cases/source-build/utils/package.json
+++ b/e2e/cases/source-build/utils/package.json
@@ -6,20 +6,12 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "source": "./src/index.ts"
     },
     "./common": {
+      "types": "./dist/types/common/index.d.ts",
       "source": "./src/common/index.ts"
-    }
-  },
-  "typesVersions": {
-    "*": {
-      ".": [
-        "./dist/types/index.d.ts"
-      ],
-      "common": [
-        "./dist/types/common/index.d.ts"
-      ]
     }
   }
 }

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -25,16 +25,6 @@
   },
   "main": "./dist/index.js",
   "types": "./src/index.ts",
-  "typesVersions": {
-    "*": {
-      "web": [
-        "./dist/web.d.ts"
-      ],
-      "node": [
-        "./dist/node.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -28,19 +28,6 @@
   },
   "main": "./dist/index.js",
   "types": "./src/index.ts",
-  "typesVersions": {
-    "*": {
-      "loader": [
-        "./dist/loader.d.ts"
-      ],
-      "plugin": [
-        "./dist/plugin.d.ts"
-      ],
-      "binding": [
-        "./dist/binding.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -24,16 +24,6 @@
   },
   "main": "./dist/index.js",
   "types": "./src/index.ts",
-  "typesVersions": {
-    "*": {
-      "plugin-babel": [
-        "./dist/plugins/babel.d.ts"
-      ],
-      "plugin-css": [
-        "./dist/plugins/css.d.ts"
-      ]
-    }
-  },
   "files": [
     "static",
     "compiled",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,28 +47,6 @@
   },
   "main": "./dist/index.js",
   "types": "./src/index.ts",
-  "typesVersions": {
-    "*": {
-      "cli": [
-        "./dist/cli/index.d.ts"
-      ],
-      "server": [
-        "./dist/server/index.d.ts"
-      ],
-      "hmr-client": [
-        "./dist/server/dev-middleware/hmr-client/index.d.ts"
-      ],
-      "plugins/*": [
-        "./dist/plugins/*.d.ts"
-      ],
-      "rspack-plugin-css": [
-        "./dist/rspack-provider/plugins/css.d.ts"
-      ],
-      "rspack-provider": [
-        "./dist/rspack-provider/index.d.ts"
-      ]
-    }
-  },
   "bin": {
     "rsbuild": "./bin/rsbuild.js"
   },

--- a/packages/core/src/rspack-provider/core/initHooks.ts
+++ b/packages/core/src/rspack-provider/core/initHooks.ts
@@ -11,11 +11,10 @@ import {
   OnBeforeCreateCompilerFn,
   ModifyBundlerChainFn,
   type RspackConfig,
-  type RspackCompiler,
-  type RspackMultiCompiler,
   type ModifyRspackConfigFn,
 } from '@rsbuild/shared';
 import type { RsbuildConfig } from '../types';
+import type { Compiler, MultiCompiler } from '@rspack/core';
 
 export function initHooks() {
   return {
@@ -32,9 +31,7 @@ export function initHooks() {
     modifyRsbuildConfigHook:
       createAsyncHook<ModifyRsbuildConfigFn<RsbuildConfig>>(),
     onAfterCreateCompilerHook:
-      createAsyncHook<
-        OnAfterCreateCompilerFn<RspackCompiler | RspackMultiCompiler>
-      >(),
+      createAsyncHook<OnAfterCreateCompilerFn<Compiler | MultiCompiler>>(),
     onBeforeCreateCompilerHook:
       createAsyncHook<OnBeforeCreateCompilerFn<RspackConfig>>(),
 

--- a/packages/doctor-core/package.json
+++ b/packages/doctor-core/package.json
@@ -25,13 +25,6 @@
       "import": "./dist/esm/build-utils/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "utils": [
-        "./dist/type/build-utils/index.d.ts"
-      ]
-    }
-  },
   "scripts": {
     "dev": "npm run start",
     "build": "modern build",

--- a/packages/doctor-core/src/inner-plugins/loaders/proxy.ts
+++ b/packages/doctor-core/src/inner-plugins/loaders/proxy.ts
@@ -6,7 +6,8 @@ import {
   reportLoader,
   shouldSkipLoader,
 } from '../utils';
-import { ProxyLoaderOptions } from '@/types';
+import type { ProxyLoaderOptions } from '@/types';
+import type { LoaderContext } from 'webpack';
 
 const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, {}> = function (
   ...args
@@ -86,7 +87,7 @@ const loaderModule: Plugin.LoaderDefinition<ProxyLoaderOptions, {}> = function (
   this.callback(null, ...args);
 };
 
-loaderModule.pitch = function () {
+loaderModule.pitch = function (this: LoaderContext<ProxyLoaderOptions>) {
   if (shouldSkipLoader(this)) {
     return;
   }

--- a/packages/doctor-sdk/package.json
+++ b/packages/doctor-sdk/package.json
@@ -41,19 +41,6 @@
       "import": "./dist/esm/sdk/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "graph": [
-        "./dist/type/graph/index.d.ts"
-      ],
-      "error": [
-        "./dist/type/error/index.d.ts"
-      ],
-      "sdk": [
-        "./dist/type/sdk/index.d.ts"
-      ]
-    }
-  },
   "dependencies": {
     "@rsbuild/doctor-utils": "workspace:*",
     "body-parser": "1.20.1",
@@ -67,7 +54,7 @@
     "open": "^8.4.0",
     "p-limit": "3.1.0",
     "serve-static": "1.15.0",
-    "socket.io": "4.6.1",
+    "socket.io": "4.7.2",
     "source-map": "^0.7.4",
     "strip-ansi": "^6.0.1",
     "tapable": "2.2.1"

--- a/packages/doctor-types/src/plugin/baseLoader.ts
+++ b/packages/doctor-types/src/plugin/baseLoader.ts
@@ -9,6 +9,7 @@ import type {
 import {
   SourceMap,
   PitchLoaderDefinitionFunction as RspackPitchLoaderDefinitionFunction,
+  // @ts-expect-error
 } from '@rspack/core/dist/config/adapterRuleUse';
 
 export type RuleSetRule = RspackRuleSetRule | WebpackRuleSetRule;

--- a/packages/doctor-utils/package.json
+++ b/packages/doctor-utils/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "exports": {
     ".": {
-      "types": "./dist/type/common/index.d.ts",
-      "require": "./dist/cjs/common/index.js",
-      "import": "./dist/esm/common/index.js"
+      "types": "./dist/type/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
     },
     "./common": {
       "types": "./dist/type/common/index.d.ts",
@@ -36,22 +36,6 @@
   },
   "main": "dist/index.js",
   "types": "dist/type/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "common": [
-        "./dist/type/common/index.d.ts"
-      ],
-      "build": [
-        "./dist/type/build/index.d.ts"
-      ],
-      "ruleUtils": [
-        "./dist/type/rule-utils/index.d.ts"
-      ],
-      "logger": [
-        "./dist/type/logger/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist"
   ],
@@ -74,7 +58,7 @@
     "fs-extra": "^11.1.1",
     "get-port": "5.1.1",
     "json-stream-stringify": "3.0.1",
-    "lines-and-columns": "2.0.3",
+    "lines-and-columns": "2.0.4",
     "lodash": "^4.17.21",
     "strip-ansi": "^6.0.1"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -55,49 +55,12 @@
       "default": "./compiled/postcss-modules-values/index.js"
     },
     "./webpack-merge": {
-      "types": "./compiled/webpack-merge/index.d.ts",
+      "types": "./compiled/webpack-merge/types/index.d.ts",
       "default": "./compiled/webpack-merge/index.js"
     }
   },
   "main": "./dist/index.js",
   "types": "./src/index.ts",
-  "typesVersions": {
-    "*": {
-      "format-stats": [
-        "./dist/formatStats.d.ts"
-      ],
-      "webpack-bundle-analyzer": [
-        "./compiled/webpack-bundle-analyzer/index.d.ts"
-      ],
-      "webpack-dev-middleware": [
-        "./compiled/webpack-dev-middleware/types/index.d.ts"
-      ],
-      "css-modules-typescript-loader": [
-        "./dist/loaders/css-modules-typescript-loader.d.ts"
-      ],
-      "ignore-css-loader": [
-        "./dist/loaders/ignore-css-loader.d.ts"
-      ],
-      "icss-utils": [
-        "./compiled/icss-utils/index.d.ts"
-      ],
-      "postcss-modules-extract-imports": [
-        "./compiled/postcss-modules-extract-imports/index.d.ts"
-      ],
-      "postcss-modules-local-by-default": [
-        "./compiled/postcss-modules-local-by-default/index.d.ts"
-      ],
-      "postcss-modules-scope": [
-        "./compiled/postcss-modules-scope/index.d.ts"
-      ],
-      "postcss-modules-values": [
-        "./compiled/postcss-modules-values/index.d.ts"
-      ],
-      "webpack-merge": [
-        "./compiled/webpack-merge/types/index.d.ts"
-      ]
-    }
-  },
   "files": [
     "dist",
     "compiled"

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -102,7 +102,7 @@ export const getPostcssConfig = ({
   enableSourceMap: boolean;
   browserslist: string[];
   config: NormalizedConfig;
-}) => {
+}): ProcessOptions => {
   const extraPlugins: AcceptedPlugin[] = [];
 
   const utils = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -994,8 +994,8 @@ importers:
         specifier: 1.15.0
         version: 1.15.0
       socket.io:
-        specifier: 4.6.1
-        version: 4.6.1
+        specifier: 4.7.2
+        version: 4.7.2
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -1119,8 +1119,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       lines-and-columns:
-        specifier: 2.0.3
-        version: 2.0.3
+        specifier: 2.0.4
+        version: 2.0.4
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -8527,14 +8527,14 @@ packages:
     dependencies:
       once: 1.4.0
 
-  /engine.io-parser@5.0.7:
-    resolution: {integrity: sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==}
+  /engine.io-parser@5.2.1:
+    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /engine.io@6.4.2:
-    resolution: {integrity: sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==}
-    engines: {node: '>=10.0.0'}
+  /engine.io@6.5.4:
+    resolution: {integrity: sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==}
+    engines: {node: '>=10.2.0'}
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
@@ -8544,7 +8544,7 @@ packages:
       cookie: 0.4.2
       cors: 2.8.5
       debug: 4.3.4
-      engine.io-parser: 5.0.7
+      engine.io-parser: 5.2.1
       ws: 8.11.0
     transitivePeerDependencies:
       - bufferutil
@@ -10549,8 +10549,8 @@ packages:
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  /lines-and-columns@2.0.3:
-    resolution: {integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==}
+  /lines-and-columns@2.0.4:
+    resolution: {integrity: sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   /load-yaml-file@0.2.0:
@@ -11754,7 +11754,7 @@ packages:
       jest-diff: 29.7.0
       js-yaml: 4.1.0
       jsonc-parser: 3.2.0
-      lines-and-columns: 2.0.3
+      lines-and-columns: 2.0.4
       minimatch: 3.0.5
       node-machine-id: 1.1.12
       npm-run-path: 4.0.1
@@ -13619,14 +13619,15 @@ packages:
       - supports-color
     dev: false
 
-  /socket.io@4.6.1:
-    resolution: {integrity: sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==}
-    engines: {node: '>=10.0.0'}
+  /socket.io@4.7.2:
+    resolution: {integrity: sha512-bvKVS29/I5fl2FGLNHuXlQaUH/BlzX1IN6S+NKLNZpBsPZIDH+90eQmCs2Railn4YUiww4SzUedJ6+uzwFnKLw==}
+    engines: {node: '>=10.2.0'}
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
+      cors: 2.8.5
       debug: 4.3.4
-      engine.io: 6.4.2
+      engine.io: 6.5.4
       socket.io-adapter: 2.5.2
       socket.io-parser: 4.2.4
     transitivePeerDependencies:

--- a/scripts/tsconfig/base.json
+++ b/scripts/tsconfig/base.json
@@ -3,14 +3,14 @@
     "target": "ES2019",
     "lib": ["DOM", "ESNext"],
     "allowJs": true,
-    "module": "commonjs",
+    "module": "ES2020",
     "strict": true,
     "isolatedModules": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "jsx": "preserve",
     "resolveJsonModule": true,
-    "moduleResolution": "node"
+    "moduleResolution": "Bundler"
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Base"


### PR DESCRIPTION
## Summary

Using exports.types to replace typesVersion.

Supported in TypeScript v4.7, ref: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
