### PR TITLE
chore: disable nightly release

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,9 +2,9 @@ name: Release Nightly
 
 on:
   workflow_dispatch:
-  schedule:
+  # schedule:
     # 00:00 AM Beijing Time.
-    - cron: "0 16 * * *"
+    # - cron: "0 16 * * *"
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

Disable nightly release, because:

- Now we release stable version every day.
- Too many versions will slow down the install process.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
