### PR TITLE
fix(create-rsbuild): incorrect title in vanilla sample code

### DIFF
--- a/.changeset/shy-weeks-destroy.md
+++ b/.changeset/shy-weeks-destroy.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+fix(create-rsbuild): incorrect title in sample code

--- a/examples/vanilla/src/index.js
+++ b/examples/vanilla/src/index.js
@@ -2,7 +2,7 @@ import './index.css';
 
 document.querySelector('#root').innerHTML = `
 <div class="content">
-  <h1>Rsbuild with React</h1>
+  <h1>Vanilla Rsbuild</h1>
   <p>Start building amazing things with Rsbuild.</p>
 </div>
 `;

--- a/packages/create-rsbuild/template-vanilla-js/src/index.js
+++ b/packages/create-rsbuild/template-vanilla-js/src/index.js
@@ -2,7 +2,7 @@ import './index.css';
 
 document.querySelector('#root').innerHTML = `
 <div class="content">
-  <h1>Rsbuild with React</h1>
+  <h1>Vanilla Rsbuild</h1>
   <p>Start building amazing things with Rsbuild.</p>
 </div>
 `;

--- a/packages/create-rsbuild/template-vanilla-ts/src/index.ts
+++ b/packages/create-rsbuild/template-vanilla-ts/src/index.ts
@@ -2,7 +2,7 @@ import './index.css';
 
 document.querySelector('#root')!.innerHTML = `
 <div class="content">
-  <h1>Rsbuild with React</h1>
+  <h1>Vanilla Rsbuild</h1>
   <p>Start building amazing things with Rsbuild.</p>
 </div>
 `;


### PR DESCRIPTION
## Summary

Fix incorrect title in vanilla sample code.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
