### PR TITLE
fix(create-rsbuild): missing tsconfig.json in vanilla template

### DIFF
--- a/.changeset/forty-deers-push.md
+++ b/.changeset/forty-deers-push.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+fix(create-rsbuild): missing tsconfig.json in vanilla template

--- a/.changeset/mighty-ties-glow.md
+++ b/.changeset/mighty-ties-glow.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+feat(create-rsbuild): improve next steps message

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

Fix missing tsconfig.json in vanilla template.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
