### PR TITLE
chore(type): update server.close as an async function

### DIFF
--- a/.changeset/afraid-zebras-deny.md
+++ b/.changeset/afraid-zebras-deny.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+chore(type): update server.close as an async function

--- a/e2e/cases/babel/build.test.ts
+++ b/e2e/cases/babel/build.test.ts
@@ -27,7 +27,7 @@ test('babel', async ({ page }) => {
   await page.goto(getHrefByEntryName('index', rsbuild.port));
   expect(await page.evaluate('window.b')).toBe(10);
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('babel exclude', async ({ page }) => {
@@ -57,5 +57,5 @@ test('babel exclude', async ({ page }) => {
   expect(await page.evaluate('window.b')).toBe(10);
   expect(await page.evaluate('window.bb')).toBeUndefined();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -79,5 +79,5 @@ test('disableCssExtract', async ({ page }) => {
   const title = page.locator('#title');
   await expect(title).toHaveCSS('font-size', '20px');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -47,5 +47,5 @@ test('should inline style when disableCssExtract is false', async ({
   const title = page.locator('#header');
   await expect(title).toHaveCSS('font-size', '20px');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/decorator/common/index.test.ts
+++ b/e2e/cases/decorator/common/index.test.ts
@@ -16,7 +16,7 @@ test('decorator legacy(default)', async ({ page }) => {
   expect(await page.evaluate('window.aaa')).toBe('hello!');
   expect(await page.evaluate('window.bbb')).toBe('world');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('decorator latest', async ({ page }) => {
@@ -37,5 +37,5 @@ test('decorator latest', async ({ page }) => {
   expect(await page.evaluate('window.aaa')).toBe('hello!');
   expect(await page.evaluate('window.bbb')).toBe('world');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/decorator/latest/index.test.ts
+++ b/e2e/cases/decorator/latest/index.test.ts
@@ -31,5 +31,5 @@ webpackOnlyTest('decorator latest', async ({ page }) => {
     );
   }
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/decorator/legacy/index.test.ts
+++ b/e2e/cases/decorator/legacy/index.test.ts
@@ -21,5 +21,5 @@ test('decorator legacy(default)', async ({ page }) => {
     );
   }
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/html/html.test.ts
+++ b/e2e/cases/html/html.test.ts
@@ -25,7 +25,7 @@ test.describe('html configure multi', () => {
     });
   });
 
-  test.afterAll(() => {
+  test.afterAll(async () => {
     await rsbuild.close();
   });
 
@@ -90,7 +90,7 @@ test.describe('html element set', () => {
     );
   });
 
-  test.afterAll(() => {
+  test.afterAll(async () => {
     await rsbuild.close();
   });
 

--- a/e2e/cases/html/html.test.ts
+++ b/e2e/cases/html/html.test.ts
@@ -26,7 +26,7 @@ test.describe('html configure multi', () => {
   });
 
   test.afterAll(() => {
-    rsbuild.close();
+    await rsbuild.close();
   });
 
   test('mountId', async ({ page }) => {
@@ -91,7 +91,7 @@ test.describe('html element set', () => {
   });
 
   test.afterAll(() => {
-    rsbuild.close();
+    await rsbuild.close();
   });
 
   test('appicon', async () => {
@@ -175,7 +175,7 @@ test('template & templateParameters', async ({ page }) => {
 
   await expect(page.evaluate(`window.foo`)).resolves.toBe('bar');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('html.outputStructure', async ({ page }) => {
@@ -198,7 +198,7 @@ test('html.outputStructure', async ({ page }) => {
 
   expect(fse.existsSync(pagePath)).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('tools.htmlPlugin', async ({ page }) => {
@@ -230,5 +230,5 @@ test('tools.htmlPlugin', async ({ page }) => {
     allScripts?.every((data) => data.includes('type="module"')),
   ).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/html/minify/index.swc.test.ts
+++ b/e2e/cases/html/minify/index.swc.test.ts
@@ -49,5 +49,5 @@ test('should minify template js & css correctly when use swc-plugin', async ({
   ).toBeTruthy();
   expect(content.includes('window.a=1,window.b=2')).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -49,7 +49,7 @@ test('should minify template js & css', async ({ page }) => {
   // keep html comments
   expect(content.includes('<!-- HTML COMMENT-->')).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 webpackOnlyTest(
@@ -93,6 +93,6 @@ webpackOnlyTest(
     ).toBeTruthy();
     expect(content.includes('window.a=1,window.b=2')).toBeTruthy();
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -47,7 +47,7 @@ test.skip('disableInlineRuntimeChunk', () => {
   });
 
   test.afterAll(async () => {
-    rsbuild.close();
+    await rsbuild.close();
   });
 
   test('should emit bundler-runtime', async ({ page }) => {
@@ -97,7 +97,7 @@ test.skip('inline runtime chunk by default', async ({ page }) => {
 
   expect(isRuntimeChunkInHtml(indexHtml)).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 // TODO: uni-builder
@@ -193,7 +193,7 @@ webpackOnlyTest(
         .length,
     ).toEqual(3);
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 

--- a/e2e/cases/legal-comments/index.test.ts
+++ b/e2e/cases/legal-comments/index.test.ts
@@ -49,7 +49,7 @@ test('legalComments linked (default)', async ({ page }) => {
 
   expect(JsContent.includes('Foo Bar')).toBeFalsy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('legalComments none', async ({ page }) => {
@@ -93,7 +93,7 @@ test('legalComments none', async ({ page }) => {
 
   expect(JsContent.includes('@license BBB')).toBeFalsy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('legalComments inline', async ({ page }) => {
@@ -138,5 +138,5 @@ test('legalComments inline', async ({ page }) => {
   expect(JsContent.includes('@license BBB')).toBeTruthy();
   expect(JsContent.includes('Foo Bar')).toBeFalsy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/manifest/index.test.ts
+++ b/e2e/cases/manifest/index.test.ts
@@ -41,5 +41,5 @@ test.skip('enableAssetManifest', async () => {
   expect(Object.keys(manifest.files).length).toBe(3);
   expect(manifest.entrypoints.length).toBe(1);
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/multi-compiler/index.test.ts
+++ b/e2e/cases/multi-compiler/index.test.ts
@@ -15,7 +15,7 @@ test('multi compiler build', async ({ page }) => {
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('multi compiler dev', async ({ page }) => {

--- a/e2e/cases/node-polyfill/index.test.ts
+++ b/e2e/cases/node-polyfill/index.test.ts
@@ -24,5 +24,5 @@ test('should add node-polyfill when add node-polyfill plugin', async ({
   const testQueryString = page.locator('#test-querystring');
   await expect(testQueryString).toHaveText('foo=bar');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/output/ascii/index.test.ts
+++ b/e2e/cases/output/ascii/index.test.ts
@@ -25,7 +25,7 @@ test('output.charset default (ascii)', async ({ page }) => {
     content.toLocaleLowerCase().includes('\\u4f60\\u597d world!'),
   ).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('output.charset (utf8)', async ({ page }) => {
@@ -53,5 +53,5 @@ test('output.charset (utf8)', async ({ page }) => {
 
   expect(content.includes('你好 world!')).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/output/assets.test.ts
+++ b/e2e/cases/output/assets.test.ts
@@ -86,6 +86,6 @@ cases.forEach((_case) => {
       ).resolves.toBeTruthy();
     }
 
-    rsbuild.close();
+    await rsbuild.close();
   });
 });

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -38,7 +38,7 @@ test('externals', async ({ page }) => {
   expect(externalVar).toBeDefined();
 
   rsbuild.clean();
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should not external dependencies when target is web worker', async () => {

--- a/e2e/cases/output/output.test.ts
+++ b/e2e/cases/output/output.test.ts
@@ -39,7 +39,7 @@ test.describe('output configure multi', () => {
   });
 
   test.afterAll(async () => {
-    rsbuild.close();
+    await rsbuild.close();
     await rsbuild.clean();
   });
 
@@ -100,7 +100,7 @@ test('cleanDistPath disable', async () => {
 
   expect(fse.existsSync(distFilePath)).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
   rsbuild.clean();
 });
 

--- a/e2e/cases/output/rem/tests/index.test.ts
+++ b/e2e/cases/output/rem/tests/index.test.ts
@@ -23,7 +23,7 @@ test('rem default (disable)', async ({ page }) => {
   const description = page.locator('#description');
   await expect(description).toHaveCSS('font-size', '16px');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('rem enable', async ({ page }) => {
@@ -54,7 +54,7 @@ test('rem enable', async ({ page }) => {
   const description = page.locator('#description');
   await expect(description).toHaveCSS('font-size', '20.48px');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should inline runtime code to html by default', async () => {

--- a/e2e/cases/polyfill/index.test.ts
+++ b/e2e/cases/polyfill/index.test.ts
@@ -45,7 +45,7 @@ test('should add polyfill when set polyfill entry (default)', async ({
 
   expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 
-  rsbuild.close();
+  await rsbuild.close();
 
   const files = await rsbuild.unwrapOutputJSON(false);
 
@@ -72,7 +72,7 @@ test('should add polyfill when set polyfill usage', async ({ page }) => {
 
   expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 
-  rsbuild.close();
+  await rsbuild.close();
 
   const files = await rsbuild.unwrapOutputJSON(false);
 

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -27,7 +27,7 @@ test('should access / success when entry is index', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should access /main.html success when entry is main', async ({
@@ -55,7 +55,7 @@ test('should access /main.html success when entry is main', async ({
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main', async ({ page }) => {
@@ -83,7 +83,7 @@ test('should access /main success when entry is main', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main and set assetPrefix', async ({
@@ -112,7 +112,7 @@ test('should access /main success when entry is main and set assetPrefix', async
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main and outputPath is /main/index.html', async ({
@@ -143,7 +143,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should return 404 when page is not found', async ({ page }) => {
@@ -168,7 +168,7 @@ test('should return 404 when page is not found', async ({ page }) => {
 
   expect(res?.status()).toBe(404);
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should access /html/main success when entry is main and outputPath is /html/main.html', async ({
@@ -205,5 +205,5 @@ test('should access /html/main success when entry is main and outputPath is /htm
 
   expect(res?.status()).toBe(404);
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/react/remove-prop-types/index.test.ts
+++ b/e2e/cases/react/remove-prop-types/index.test.ts
@@ -19,5 +19,5 @@ webpackOnlyTest('should remove prop-types by default', async ({ page }) => {
   await page.goto(getHrefByEntryName('main', rsbuild.port));
 
   expect(await page.evaluate('window.testAppPropTypes')).toBeUndefined();
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/source/resolve-extension-prefix/tests/index.test.ts
+++ b/e2e/cases/source/resolve-extension-prefix/tests/index.test.ts
@@ -20,7 +20,7 @@ test('resolve-extension-prefix', async ({ page }) => {
   await page.goto(getHrefByEntryName('main', rsbuild.port));
   await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
 
-  rsbuild.close();
+  await rsbuild.close();
 
   // ex.web.js take effect when set resolveExtensionPrefix
   rsbuild = await build({
@@ -35,5 +35,5 @@ test('resolve-extension-prefix', async ({ page }) => {
   await page.goto(getHrefByEntryName('main', rsbuild.port));
   await expect(page.innerHTML('#test-el')).resolves.toBe('web');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -26,7 +26,7 @@ test.describe('source configure multi', () => {
   });
 
   test.afterAll(() => {
-    rsbuild.close();
+    await rsbuild.close();
   });
 
   test('alias', async ({ page }) => {
@@ -65,7 +65,7 @@ test.skip('global-vars', async ({ page }) => {
   const testEl = page.locator('#test-el');
   await expect(testEl).toHaveText('aaaaa');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('define', async ({ page }) => {
@@ -89,7 +89,7 @@ test('define', async ({ page }) => {
   const testEl = page.locator('#test-el');
   await expect(testEl).toHaveText('aaaaa');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('tsconfig paths should work and override the alias config', async ({
@@ -116,7 +116,7 @@ test('tsconfig paths should work and override the alias config', async ({
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('tsconfig paths worked');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', async ({
@@ -144,5 +144,5 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('source.alias worked');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -25,7 +25,7 @@ test.describe('source configure multi', () => {
     });
   });
 
-  test.afterAll(() => {
+  test.afterAll(async () => {
     await rsbuild.close();
   });
 

--- a/e2e/cases/source/source.webpack.test.ts
+++ b/e2e/cases/source/source.webpack.test.ts
@@ -33,7 +33,7 @@ test.skip('module-scopes', async ({ page }) => {
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 
-  rsbuild.close();
+  await rsbuild.close();
 
   // should not throw
   rsbuild = await build<'webpack'>({
@@ -45,5 +45,5 @@ test.skip('module-scopes', async ({ page }) => {
     },
   });
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/sri/index.test.ts
+++ b/e2e/cases/sri/index.test.ts
@@ -32,5 +32,5 @@ test.skip('security.sri', async ({ page }) => {
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/svg/svg.test.ts
+++ b/e2e/cases/svg/svg.test.ts
@@ -31,7 +31,7 @@ test('svg (assets)', async ({ page }) => {
     ),
   ).resolves.toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('svgr (defaultExport url)', async ({ page }) => {
@@ -70,7 +70,7 @@ test('svgr (defaultExport url)', async ({ page }) => {
     ),
   ).resolves.toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('svgr (defaultExport component)', async ({ page }) => {
@@ -95,7 +95,7 @@ test('svgr (defaultExport component)', async ({ page }) => {
     page.evaluate(`document.getElementById('test-svg').tagName === 'svg'`),
   ).resolves.toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('svgr (query url)', async ({ page }) => {
@@ -129,7 +129,7 @@ test('svgr (query url)', async ({ page }) => {
     ),
   ).resolves.toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 // It's an old bug when use svgr in css and external react.
@@ -180,5 +180,5 @@ test('svgr (external react)', async ({ page }) => {
     ),
   ).resolves.toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/swc/index.swc.test.ts
+++ b/e2e/cases/swc/index.swc.test.ts
@@ -24,7 +24,7 @@ test('should run SWC compilation correctly', async ({ page }) => {
     school: 'yyy',
   });
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should optimize lodash bundle size', async ({ page }) => {
@@ -55,7 +55,7 @@ test('should optimize lodash bundle size', async ({ page }) => {
 
   expect(bundleSize < 10).toBeTruthy();
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should use define for class', async () => {
@@ -102,7 +102,7 @@ test('should use define for class', async () => {
     file.includes('_define_property(_assert_this_initialized(_this), "id", 1)'),
   ).toBe(true);
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('core-js-entry', async () => {
@@ -127,7 +127,7 @@ test('core-js-entry', async () => {
     runServer: true,
   });
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('core-js-usage', async () => {
@@ -152,5 +152,5 @@ test('core-js-usage', async () => {
     runServer: true,
   });
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/tools.rspack.test.ts
+++ b/e2e/cases/tools.rspack.test.ts
@@ -25,5 +25,5 @@ test('tools.rspack', async ({ page }) => {
   const testEl = page.locator('#test-el');
   await expect(testEl).toHaveText('aaaaa');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/tools.test.ts
+++ b/e2e/cases/tools.test.ts
@@ -30,7 +30,7 @@ test('postcss plugins overwrite', async ({ page }) => {
   const title = page.locator('#title');
   await expect(title).toHaveText('title');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('bundlerChain - set alias config', async ({ page }) => {
@@ -54,7 +54,7 @@ test('bundlerChain - set alias config', async ({ page }) => {
   await page.goto(getHrefByEntryName('main', rsbuild.port));
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 // Rspack do not support publicPath function yet

--- a/e2e/cases/tools.webpack.test.ts
+++ b/e2e/cases/tools.webpack.test.ts
@@ -29,5 +29,5 @@ test('webpackChain - register plugin', async ({ page }) => {
   const testEl = page.locator('#test-el');
   await expect(testEl).toHaveText('aaaaa');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/tools/pug/tests/index.test.ts
+++ b/e2e/cases/tools/pug/tests/index.test.ts
@@ -29,5 +29,5 @@ test('pug', async ({ page }) => {
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/top-level-await/index.swc.test.ts
+++ b/e2e/cases/top-level-await/index.swc.test.ts
@@ -19,5 +19,5 @@ test('should run top level await correctly when using SWC', async ({
 
   expect(await page.evaluate('window.foo')).toEqual('hello');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/top-level-await/index.test.ts
+++ b/e2e/cases/top-level-await/index.test.ts
@@ -15,5 +15,5 @@ test('should run top level await correctly', async ({ page }) => {
 
   expect(await page.evaluate('window.foo')).toEqual('hello');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/vue/index.test.ts
+++ b/e2e/cases/vue/index.test.ts
@@ -26,7 +26,7 @@ rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   await expect(button1).toHaveText('A: 0');
   await expect(button2).toHaveText('B: 0');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
@@ -49,7 +49,7 @@ rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const body = page.locator('body');
   await expect(body).toHaveCSS('background-color', 'rgb(0, 0, 255)');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
@@ -69,7 +69,7 @@ rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const button1 = page.locator('#button1');
   await expect(button1).toHaveText('A: 0');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest(
@@ -91,7 +91,7 @@ rspackOnlyTest(
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -117,7 +117,7 @@ rspackOnlyTest(
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('Foo');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -143,6 +143,6 @@ rspackOnlyTest(
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('Foo');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/vue2/index.test.ts
+++ b/e2e/cases/vue2/index.test.ts
@@ -26,7 +26,7 @@ rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   await expect(button1).toHaveText('A: 0');
   await expect(button2).toHaveText('B: 0');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
@@ -49,7 +49,7 @@ rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const body = page.locator('body');
   await expect(body).toHaveCSS('background-color', 'rgb(0, 0, 255)');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
@@ -69,7 +69,7 @@ rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const button1 = page.locator('#button1');
   await expect(button1).toHaveText('A: 0');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 rspackOnlyTest(
@@ -91,7 +91,7 @@ rspackOnlyTest(
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -117,7 +117,7 @@ rspackOnlyTest(
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('Foo');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -143,6 +143,6 @@ rspackOnlyTest(
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('Foo');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -27,7 +27,7 @@ test('should allow to import wasm file', async ({ page }) => {
   const locator = page.locator('#root');
   await expect(locator).toHaveText('6');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should allow to dynamic import wasm file', async () => {
@@ -74,5 +74,5 @@ test('should allow to use new URL to get path of wasm file', async ({
     page.evaluate(`document.querySelector('#root').innerHTML`),
   ).resolves.toMatch(/\/static\/wasm\/\w+\.module\.wasm/);
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -18,7 +18,7 @@ export const getHrefByEntryName = (entryName: string, port: number) => {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
-const noop = () => {};
+const noop = async () => {};
 
 export const createRsbuild = async (
   rsbuildOptions: CreateRsbuildOptions,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,12 @@ export { mergeRsbuildConfig } from '@rsbuild/shared';
 
 export { defineConfig } from './cli';
 
-export type { RsbuildPluginAPI, RsbuildConfig } from './rspack-provider';
+export type {
+  RsbuildPluginAPI,
+  RsbuildConfig,
+  Rspack,
+} from './rspack-provider';
+
 export type {
   RsbuildMode,
   RsbuildEntry,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -311,7 +311,7 @@ export async function startDevServer<
           port,
           urls: urls.map((item) => item.url),
           server: {
-            close: () => {
+            close: async () => {
               server.close();
             },
           },

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -147,7 +147,7 @@ export async function startProdServer(
           port,
           urls: urls.map((item) => item.url),
           server: {
-            close: () => {
+            close: async () => {
               server.close();
             },
           },

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,8 +1,6 @@
 import type { IncomingMessage, ServerResponse, Server } from 'http';
 import { DevConfig, NextFunction } from './config/dev';
 import type { Logger } from '../logger';
-// import type Connect from '../../compiled/connect';
-// import type { ListenOptions } from 'net';
 
 type Middleware = (
   req: IncomingMessage,
@@ -62,13 +60,7 @@ export type CreateDevServerOptions = {
 } & RsbuildDevServerOptions;
 
 export type ServerApi = {
-  // middlewares: Connect.Server;
-  // logger: Logger;
-  // listen: (
-  //   options?: number | ListenOptions,
-  //   cb?: (err: Error) => Promise<void>,
-  // ) => void;
-  close: () => void;
+  close: () => Promise<void>;
 };
 
 export type StartServerResult = {


### PR DESCRIPTION
## Summary

update server.close as an async function, convenient for add other close methods in future.


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
