### PR TITLE
chore(server): reorder dev server inner execution

### DIFF
--- a/.changeset/slimy-impalas-lick.md
+++ b/.changeset/slimy-impalas-lick.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+chore(server): adjust printURLs, httpServer and dev compile execution order

--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -50,7 +50,7 @@ export async function createCompiler({
   return compiler;
 }
 
-export async function startDevCompile(
+export async function createDevMiddleware(
   options: InitConfigsOptions,
   customCompiler?: Compiler | MultiCompiler,
 ) {

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -64,11 +64,11 @@ export function webpackProvider({
       },
 
       async startDevServer(options) {
-        const { startDevCompile } = await import('./core/createCompiler');
+        const { createDevMiddleware } = await import('./core/createCompiler');
         return startDevServer(
           { context, pluginStore, rsbuildOptions },
           // @ts-expect-error compiler type mismatch
-          startDevCompile,
+          createDevMiddleware,
           options,
         );
       },

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -78,7 +78,7 @@ export async function createCompiler({
   return compiler;
 }
 
-export async function startDevCompile(
+export async function createDevMiddleware(
   options: InitConfigsOptions,
   customCompiler?: RspackCompiler | RspackMultiCompiler,
 ) {

--- a/packages/core/src/rspack-provider/provider.ts
+++ b/packages/core/src/rspack-provider/provider.ts
@@ -74,10 +74,10 @@ export function rspackProvider({
       },
 
       async startDevServer(options) {
-        const { startDevCompile } = await import('./core/createCompiler');
+        const { createDevMiddleware } = await import('./core/createCompiler');
         return startDevServer(
           { context, pluginStore, rsbuildOptions },
-          startDevCompile,
+          createDevMiddleware,
           options,
         );
       },

--- a/packages/core/src/server/dev-middleware/index.ts
+++ b/packages/core/src/server/dev-middleware/index.ts
@@ -35,6 +35,8 @@ export default class DevMiddleware extends EventEmitter {
 
   private devOptions: DevConfig;
 
+  private devMiddleware?: CustomDevMiddleware;
+
   private socketServer: SocketServer;
 
   constructor({ dev, devMiddleware }: Options) {
@@ -45,13 +47,15 @@ export default class DevMiddleware extends EventEmitter {
     // init socket server
     this.socketServer = new SocketServer(dev);
 
-    if (devMiddleware) {
-      // start dev middleware
-      this.middleware = this.setupDevMiddleware(devMiddleware);
-    }
+    this.devMiddleware = devMiddleware;
   }
 
   public init(app: Server) {
+    if (this.devMiddleware) {
+      // start compiling
+      this.middleware = this.setupDevMiddleware(this.devMiddleware);
+    }
+
     app.on('listening', () => {
       this.socketServer.prepare(app);
     });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -204,7 +204,7 @@ export async function startDevServer<
   },
 >(
   options: Options,
-  startDevCompile: (
+  createDevMiddleware: (
     options: Options,
     compiler: StartDevServerOptions['compiler'],
   ) => Promise<CreateDevServerOptions['devMiddleware']>,
@@ -245,22 +245,9 @@ export async function startDevServer<
     rsbuildConfig.output?.distPath?.html,
   );
 
-  if (printURLs) {
-    if (isFunction(printURLs)) {
-      urls = printURLs(urls);
-
-      if (!Array.isArray(urls)) {
-        throw new Error('Please return an array in the `printURLs` function.');
-      }
-    }
-
-    printServerURLs(urls, routes, logger);
-  }
-
   debug('create dev server');
 
-  // TODO: reorder
-  const devMiddleware = await startDevCompile(options, compiler);
+  const devMiddleware = await createDevMiddleware(options, compiler);
 
   const server = new RsbuildDevServer({
     pwd: options.context.rootPath,
@@ -282,6 +269,19 @@ export async function startDevServer<
 
   // TODO: support customApp
   const httpServer = await server.createHTTPServer();
+
+  // print url after http server created and before dev compile (just a short time interval)
+  if (printURLs) {
+    if (isFunction(printURLs)) {
+      urls = printURLs(urls);
+
+      if (!Array.isArray(urls)) {
+        throw new Error('Please return an array in the `printURLs` function.');
+      }
+    }
+
+    printServerURLs(urls, routes, logger);
+  }
 
   await server.onInit(httpServer);
 


### PR DESCRIPTION
## Summary

adjust printURLs, httpServer and dev compile execution order:

start httpServer => printURLs => start dev compile => http.listen

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
