### PR TITLE
types: fix RsbuildPlugin do not provide API type by default

### DIFF
--- a/.changeset/tame-seas-roll.md
+++ b/.changeset/tame-seas-roll.md
@@ -1,0 +1,20 @@
+---
+'@rsbuild/plugin-esbuild': patch
+'@rsbuild/plugin-node-polyfill': patch
+'@rsbuild/plugin-assets-retry': patch
+'@rsbuild/plugin-check-syntax': patch
+'@rsbuild/plugin-source-build': patch
+'@rsbuild/uni-builder': patch
+'@rsbuild/plugin-type-check': patch
+'@rsbuild/plugin-vue2-jsx': patch
+'@rsbuild/plugin-vue-jsx': patch
+'@rsbuild/plugin-stylus': patch
+'@rsbuild/plugin-svelte': patch
+'@rsbuild/plugin-vue2': patch
+'@rsbuild/plugin-pug': patch
+'@rsbuild/plugin-vue': patch
+'@rsbuild/document': patch
+'@rsbuild/core': patch
+---
+
+types: fix RsbuildPlugin do not provide API type by default

--- a/packages/compat/plugin-esbuild/src/index.ts
+++ b/packages/compat/plugin-esbuild/src/index.ts
@@ -1,6 +1,5 @@
 import { JS_REGEX, TS_REGEX, applyScriptCondition } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import type { RsbuildPluginAPI } from '@rsbuild/webpack';
 import type {
   LoaderOptions,
   MinifyPluginOptions,
@@ -13,7 +12,7 @@ export interface PluginEsbuildOptions {
 
 export function pluginEsbuild(
   userOptions: PluginEsbuildOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+): RsbuildPlugin {
   return {
     name: 'plugin-esbuild',
 

--- a/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
+++ b/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
@@ -1,7 +1,7 @@
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { generateManifest } from '../../shared/manifest';
 
-export const pluginManifest = (): RsbuildPlugin<RsbuildPluginAPI> => ({
+export const pluginManifest = (): RsbuildPlugin => ({
   name: 'plugin-manifest',
 
   setup(api) {

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -34,7 +34,7 @@ export function parseCommonConfig<B = 'rspack' | 'webpack'>(
   rsbuildConfig: B extends 'rspack'
     ? RsbuildRspackConfig
     : RsbuildWebpackConfig;
-  rsbuildPlugins: RsbuildPlugin[];
+  rsbuildPlugins: RsbuildPlugin<any>[];
 } {
   const rsbuildConfig = deepmerge({}, uniBuilderConfig);
   const { dev = {}, html = {}, output = {} } = rsbuildConfig;

--- a/packages/compat/uni-builder/src/shared/plugins/fallback.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/fallback.ts
@@ -9,7 +9,7 @@ import {
   setConfig,
   type Rspack,
 } from '@rsbuild/shared';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 type RuleSetRule = Rspack.RuleSetRule;
 
@@ -66,7 +66,7 @@ const resourceRuleFallback = (
   return [...outerRules, { oneOf: [...innerRules, fileLoader] }];
 };
 
-export const pluginFallback = (): RsbuildPlugin<RsbuildPluginAPI> => ({
+export const pluginFallback = (): RsbuildPlugin => ({
   name: 'plugin-fallback',
 
   setup(api) {

--- a/packages/compat/uni-builder/tests/fallback.test.ts
+++ b/packages/compat/uni-builder/tests/fallback.test.ts
@@ -1,9 +1,9 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { pluginFallback } from '../src/shared/plugins/fallback';
-import { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
 import { createStubRsbuild } from '../../webpack/tests/helper';
 
 describe('plugin-fallback', () => {
-  const testPlugin: RsbuildPlugin<RsbuildPluginAPI> = {
+  const testPlugin: RsbuildPlugin = {
     name: 'test-plugin',
     setup(api) {
       api.modifyWebpackChain((chain) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,17 +4,17 @@ export { mergeRsbuildConfig } from '@rsbuild/shared';
 export { defineConfig } from './cli';
 
 export type {
-  RsbuildPluginAPI,
-  RsbuildConfig,
   Rspack,
+  RsbuildConfig,
+  RsbuildPlugin,
+  RsbuildPluginAPI,
 } from './rspack-provider';
 
 export type {
+  Context,
   RsbuildMode,
   RsbuildEntry,
   RsbuildTarget,
-  RsbuildPlugin,
-  Context,
   RsbuildInstance,
   CreateRsbuildOptions,
   InspectConfigOptions,

--- a/packages/core/src/rspack-provider/index.ts
+++ b/packages/core/src/rspack-provider/index.ts
@@ -7,6 +7,7 @@ export type {
   RsbuildConfig,
   NormalizedConfig,
   // Plugin Types
+  RsbuildPlugin,
   RsbuildPluginAPI,
 } from './types';
 

--- a/packages/core/src/rspack-provider/types/plugin.ts
+++ b/packages/core/src/rspack-provider/types/plugin.ts
@@ -18,4 +18,4 @@ export interface RsbuildPluginAPI
     RspackCompiler | RspackMultiCompiler
   > {}
 
-export type RsbuildPlugin = BaseRsbuildPlugin<RsbuildPluginAPI>;
+export type RsbuildPlugin<T = RsbuildPluginAPI> = BaseRsbuildPlugin<T>;

--- a/packages/document/docs/en/api/javascript-api/types.mdx
+++ b/packages/document/docs/en/api/javascript-api/types.mdx
@@ -28,12 +28,12 @@ const context: Context = rsbuild.context;
 
 ## RsbuildPlugin
 
-The type of Rsbuild plugin, should be used with the `RsbuildPluginAPI` type exported from the provider.
+The type of Rsbuild plugin.
 
 ```ts
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
-const myPlugin: RsbuildPlugin<RsbuildPluginAPI> = {
+const myPlugin: RsbuildPlugin = {
   name: 'my-plugin',
   setup() {},
 };

--- a/packages/document/docs/en/plugins/dev/core.mdx
+++ b/packages/document/docs/en/plugins/dev/core.mdx
@@ -7,7 +7,7 @@ This section describes the core plugin types and APIs.
 The type of the plugin object. The plugin object contains the following properties:
 
 - `name`: The name of the plugin, a unique identifier.
-- `setup`: The setup function of the plugin, which can be an asynchronous function. This function will only be executed once when the plugin is initialized.
+- `setup`: The setup function of the plugin, which can be an asynchronous function. This function will only be executed once when the plugin is initialized. The plugin API provides the context info, utility functions and lifecycle hooks. For a complete introduction to lifecycle hooks, please read the [Plugin Hooks](/plugins/dev/hooks) chapter.
 - `pre`: Specifies the preceding plugins for the current plugin. You can pass an array of preceding plugin names, and the current plugin will be executed after these plugins.
 - `post`: Specifies the succeeding plugins for the current plugin. You can pass an array of succeeding plugin names, and the current plugin will be executed before these plugins.
 - `remove`: Specifies the plugins to be removed. You can pass an array of plugin names to be removed.
@@ -94,26 +94,6 @@ const pluginBar = {
 ```
 
 For example, if you register both the Foo and Bar plugins mentioned above, the Foo plugin will not take effect because the Bar plugin declares the removal of the Foo plugin.
-
-## RsbuildPluginAPI
-
-The type of plugin API. The plugin API provides the context info, utility functions and lifecycle hooks.
-
-For a complete introduction to lifecycle hooks, please read the [Plugin Hooks](/plugins/dev/hooks) chapter.
-
-```ts
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
-
-export default (): RsbuildPlugin<RsbuildPluginAPI> => ({
-  name: 'plugin-foo',
-
-  setup: api => {
-    api.modifyRspackConfig(config => {
-      config.devtool = false;
-    });
-  },
-});
-```
 
 ## api.context
 

--- a/packages/document/docs/en/plugins/dev/index.md
+++ b/packages/document/docs/en/plugins/dev/index.md
@@ -22,7 +22,7 @@ export type PluginFooOptions = {
   message?: string;
 };
 
-export const pluginFoo = (options?: PluginFooOptions): RsbuildPlugin => ({
+export const pluginFoo = (options: PluginFooOptions = {}): RsbuildPlugin => ({
   name: 'plugin-foo',
 
   setup(api) {

--- a/packages/document/docs/zh/api/javascript-api/types.mdx
+++ b/packages/document/docs/zh/api/javascript-api/types.mdx
@@ -28,12 +28,12 @@ const context: Context = rsbuild.context;
 
 ## RsbuildPlugin
 
-Rsbuild 插件的类型，需要配合 provider 中提供的 `RsbuildPluginAPI` 类型来使用。
+Rsbuild 插件的类型。
 
 ```ts
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
-const myPlugin: RsbuildPlugin<RsbuildPluginAPI> = {
+const myPlugin: RsbuildPlugin = {
   name: 'my-plugin',
   setup() {},
 };

--- a/packages/document/docs/zh/plugins/dev/core.mdx
+++ b/packages/document/docs/zh/plugins/dev/core.mdx
@@ -7,7 +7,7 @@
 插件对象的类型，插件对象包含以下属性：
 
 - `name`：插件的名称，唯一标识符。
-- `setup`：插件逻辑的主入口函数，可以是一个异步函数。该函数仅会在初始化插件时执行一次。
+- `setup`：插件逻辑的主入口函数，可以是一个异步函数。该函数仅会在初始化插件时执行一次。插件 API 对象上挂载了提供给插件使用的上下文数据、工具函数和注册生命周期钩子的函数，关于生命周期钩子的完整介绍，请阅读 [Plugin Hooks](/plugins/dev/hooks) 章节。
 - `pre`：指定当前插件的前置插件有哪些，可以传入前置插件 name 的数组，当前插件会被调整到这些插件之后执行。
 - `post`：指定当前插件的后置插件有哪些，可以传入后置插件 name 的数组，当前插件会被调整到这些插件之前执行。
 - `remove`：指定需要移除的插件，可以传入插件 name 的数组。
@@ -92,26 +92,6 @@ const pluginBar = {
 ```
 
 比如同时注册上述的 Foo 和 Bar 插件，由于 Bar 插件声明 remove 了 Foo 插件，因此 Foo 插件不会生效。
-
-## RsbuildPluginAPI
-
-插件 API 对象的类型。插件 API 对象上挂载了提供给插件使用的上下文数据、工具函数和注册生命周期钩子的函数。
-
-关于生命周期钩子的完整介绍，请阅读 [Plugin Hooks](/plugins/dev/hooks) 章节。
-
-```ts
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
-
-export default (): RsbuildPlugin<RsbuildPluginAPI> => ({
-  name: 'plugin-foo',
-
-  setup: api => {
-    api.modifyRspackConfig(config => {
-      config.devtool = false;
-    });
-  },
-});
-```
 
 ## api.context
 

--- a/packages/document/docs/zh/plugins/dev/index.md
+++ b/packages/document/docs/zh/plugins/dev/index.md
@@ -22,7 +22,7 @@ export type PluginFooOptions = {
   message?: string;
 };
 
-export const pluginFoo = (options?: PluginFooOptions): RsbuildPlugin => ({
+export const pluginFoo = (options: PluginFooOptions = {}): RsbuildPlugin => ({
   name: 'plugin-foo',
 
   setup(api) {

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,12 +1,12 @@
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
 
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> => ({
+): RsbuildPlugin => ({
   name: 'plugin-assets-retry',
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, target, HtmlPlugin }) => {

--- a/packages/plugin-check-syntax/src/index.ts
+++ b/packages/plugin-check-syntax/src/index.ts
@@ -1,10 +1,9 @@
 import {
   getBrowserslistWithDefault,
   type RsbuildTarget,
-  type RsbuildPlugin,
   type NormalizedConfig,
 } from '@rsbuild/shared';
-import type { RsbuildPluginAPI } from '@rsbuild/core/rspack-provider';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { CheckSyntaxOptions } from './types';
 
 export type PluginCheckSyntaxOptions = CheckSyntaxOptions;
@@ -23,7 +22,7 @@ async function getTargets(
 
 export function pluginCheckSyntax(
   options: PluginCheckSyntaxOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+): RsbuildPlugin {
   return {
     name: 'plugin-check-syntax',
 

--- a/packages/plugin-node-polyfill/src/index.ts
+++ b/packages/plugin-node-polyfill/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 const getResolveFallback = (nodeLibs: Record<string, any>) =>
   Object.keys(nodeLibs).reduce<Record<string, string | false>>(
@@ -24,14 +24,7 @@ const getProvideLibs = async () => {
   };
 };
 
-/**
- * Usage:
- *
- *   const { pluginNodePolyfill } = await import('@rsbuild/plugin-node-polyfill');
- *
- *   rsbuild.addPlugins([ pluginNodePolyfill() ]);
- */
-export function pluginNodePolyfill(): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginNodePolyfill(): RsbuildPlugin {
   return {
     name: 'plugin-node-polyfill',
 

--- a/packages/plugin-pug/src/index.ts
+++ b/packages/plugin-pug/src/index.ts
@@ -1,15 +1,13 @@
 import path from 'path';
 import { mergeChainedOptions } from '@rsbuild/shared';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { Options as PugOptions } from 'pug';
 
 export type PluginPugOptions = {
   pugOptions?: PugOptions;
 };
 
-export const pluginPug = (
-  options: PluginPugOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> => ({
+export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
   name: 'plugin-pug',
 
   setup(api) {

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { TS_CONFIG_FILE } from '@rsbuild/shared';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { RsbuildPluginAPI as RsbuildWebpackPluginAPI } from '@rsbuild/webpack';
 import {
   filterByField,
@@ -34,7 +34,7 @@ export interface PluginSourceBuildOptions {
 
 export function pluginSourceBuild(
   options?: PluginSourceBuildOptions,
-): RsbuildPlugin<RsbuildPluginAPI> {
+): RsbuildPlugin {
   const {
     projectName,
     sourceField = 'source',

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -5,7 +5,6 @@ import {
   isUseCssSourceMap,
   mergeChainedOptions,
 } from '@rsbuild/shared';
-import type { RsbuildPluginAPI } from '@rsbuild/webpack';
 
 type StylusOptions = {
   use?: string[];
@@ -23,9 +22,7 @@ type StylusLoaderOptions = {
 
 export type PluginStylusOptions = StylusLoaderOptions;
 
-export function pluginStylus(
-  options?: PluginStylusOptions,
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginStylus(options?: PluginStylusOptions): RsbuildPlugin {
   return {
     name: 'plugin-stylus',
 

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { logger, deepmerge } from '@rsbuild/shared';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 export type PluginSvelteOptions = {
   /**
@@ -11,9 +11,7 @@ export type PluginSvelteOptions = {
   svelteLoaderOptions?: Record<string, any>;
 };
 
-export function pluginSvelte(
-  options: PluginSvelteOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
   return {
     name: 'plugin-svelte',
 

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -1,4 +1,4 @@
-import { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import {
   logger,
   CHAIN_ID,
@@ -19,7 +19,7 @@ export type PluginTypeCheckerOptions = {
 
 export const pluginTypeCheck = (
   options: PluginTypeCheckerOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> => {
+): RsbuildPlugin => {
   return {
     name: 'plugin-type-check',
 

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -1,13 +1,11 @@
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueJSXPluginOptions } from '@vue/babel-plugin-jsx';
 
 export type PluginVueJsxOptions = {
   vueJsxOptions?: VueJSXPluginOptions;
 };
 
-export function pluginVueJsx(
-  options: PluginVueJsxOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginVueJsx(options: PluginVueJsxOptions = {}): RsbuildPlugin {
   return {
     name: 'plugin-vue-jsx',
 

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -1,15 +1,13 @@
 import { deepmerge } from '@rsbuild/shared';
 import { VueLoaderPlugin } from 'vue-loader';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueLoaderOptions } from 'vue-loader';
 
 export type PluginVueOptions = {
   vueLoaderOptions?: VueLoaderOptions;
 };
 
-export function pluginVue(
-  options: PluginVueOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: 'plugin-vue',
 

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 type VueJSXPresetOptions = {
   compositionAPI?: boolean | string;
@@ -12,9 +12,7 @@ export type PluginVueOptions = {
   vueJsxOptions?: VueJSXPresetOptions;
 };
 
-export function pluginVue2Jsx(
-  options: PluginVueOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginVue2Jsx(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: 'plugin-vue2-jsx',
 

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -1,15 +1,13 @@
 import { deepmerge } from '@rsbuild/shared';
 import { VueLoaderPlugin } from 'vue-loader';
-import type { RsbuildPlugin, RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueLoaderOptions } from 'vue-loader';
 
 export type PluginVueOptions = {
   vueLoaderOptions?: VueLoaderOptions;
 };
 
-export function pluginVue2(
-  options: PluginVueOptions = {},
-): RsbuildPlugin<RsbuildPluginAPI> {
+export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: 'plugin-vue2',
 


### PR DESCRIPTION
## Summary

Fix RsbuildPlugin do not provide API type by default.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
