### PR TITLE
fix: can't get rspack util in tools.rspack

### DIFF
--- a/.changeset/forty-phones-do.md
+++ b/.changeset/forty-phones-do.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+hotfix: can't get rspack util in tools.rspack

--- a/e2e/cases/tools.rspack.test.ts
+++ b/e2e/cases/tools.rspack.test.ts
@@ -12,9 +12,13 @@ test('tools.rspack', async ({ page }) => {
     },
     runServer: true,
     rsbuildConfig: {
-      source: {
-        define: {
-          ENABLE_TEST: JSON.stringify(true),
+      tools: {
+        rspack: (config, { rspack }) => {
+          config.plugins?.push(
+            new rspack.DefinePlugin({
+              ENABLE_TEST: JSON.stringify(true),
+            }),
+          );
         },
       },
     },

--- a/packages/core/src/rspack-provider/core/rspackConfig.ts
+++ b/packages/core/src/rspack-provider/core/rspackConfig.ts
@@ -43,7 +43,7 @@ async function getConfigUtils(
   chainUtils: ModifyChainUtils,
 ): Promise<ModifyRspackConfigUtils> {
   const { merge } = await import('@rsbuild/shared/webpack-merge');
-  const { default: rspack } = await import('@rspack/core');
+  const rspack = await import('@rspack/core');
 
   return {
     ...chainUtils,


### PR DESCRIPTION
## Summary

support get rspack.xxx in tools.rspack

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
