### PR TITLE
refactor: rename source.entries to source.entry

### DIFF
--- a/.changeset/rotten-tables-turn.md
+++ b/.changeset/rotten-tables-turn.md
@@ -1,0 +1,9 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/test-helper': patch
+'@rsbuild/document': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: rename source.entries to source.entry

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -27,7 +27,7 @@ test('should compile CSS modules composes with external correctly', async () => 
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { external: path.resolve(__dirname, './src/external.js') },
+        entry: { external: path.resolve(__dirname, './src/external.js') },
       },
     },
   });

--- a/e2e/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/e2e/cases/css/css-modules-ts-declaration/index.test.ts
@@ -20,7 +20,7 @@ test('should generator ts declaration correctly for css modules auto true', asyn
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { index: resolve(testDir, 'index.js') },
+        entry: { index: resolve(testDir, 'index.js') },
       },
       output: {
         disableSourceMap: true,
@@ -54,7 +54,7 @@ test('should generator ts declaration correctly for css modules auto function', 
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { index: resolve(testDir, 'index.js') },
+        entry: { index: resolve(testDir, 'index.js') },
       },
       output: {
         disableSourceMap: true,
@@ -84,7 +84,7 @@ test('should generator ts declaration correctly for css modules auto Regexp', as
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { index: resolve(testDir, 'index.js') },
+        entry: { index: resolve(testDir, 'index.js') },
       },
       output: {
         disableSourceMap: true,
@@ -112,7 +112,7 @@ test('should generator ts declaration correctly for custom exportLocalsConventio
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { index: resolve(testDir, 'index.js') },
+        entry: { index: resolve(testDir, 'index.js') },
       },
       output: {
         disableSourceMap: true,

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -7,7 +7,7 @@ test('should emit multiple css files correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           entry1: path.resolve(__dirname, './src/entry1/index.js'),
           entry2: path.resolve(__dirname, './src/entry2/index.js'),
           entry3: path.resolve(__dirname, './src/entry3/index.js'),

--- a/e2e/cases/dev/dev.test.ts
+++ b/e2e/cases/dev/dev.test.ts
@@ -14,7 +14,7 @@ test('default & hmr (default true)', async ({ page }) => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'hmr', 'test-src/index.ts'),
         },
       },
@@ -134,7 +134,7 @@ test('hmr should work when setting dev.port & client', async ({ page }) => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(cwd, 'test-src-1/index.ts'),
         },
       },

--- a/e2e/cases/dev/history-api-fallback.test.ts
+++ b/e2e/cases/dev/history-api-fallback.test.ts
@@ -11,7 +11,7 @@ test('should provide history api fallback correctly', async ({ page }) => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(cwd, 'src/index.tsx'),
         },
       },

--- a/e2e/cases/dev/html-fallback.test.ts
+++ b/e2e/cases/dev/html-fallback.test.ts
@@ -38,7 +38,7 @@ test('should access /main.html success when entry is main', async ({
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -70,7 +70,7 @@ test('should access /main success when entry is main', async ({ page }) => {
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -106,7 +106,7 @@ test('should access /main success when entry is main and use memoryFs', async ({
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -140,7 +140,7 @@ test('should access /main success when entry is main and set assetPrefix', async
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -175,7 +175,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -210,7 +210,7 @@ test('should return 404 when page is not found', async ({ page }) => {
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },
@@ -243,7 +243,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'basic', 'src/index.ts'),
         },
       },

--- a/e2e/cases/external-helpers/index.test.ts
+++ b/e2e/cases/external-helpers/index.test.ts
@@ -10,7 +10,7 @@ test('should externalHelpers by default', async () => {
     plugins: providerType === 'rspack' ? [] : [pluginSwc()],
     rsbuildConfig: {
       source: {
-        entries: { index: path.resolve(__dirname, './src/main.ts') },
+        entry: { index: path.resolve(__dirname, './src/main.ts') },
       },
     },
   });

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -67,7 +67,7 @@ test('should generate favicon via function correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
           bar: path.resolve(__dirname, './src/foo.js'),
         },

--- a/e2e/cases/html/html.test.ts
+++ b/e2e/cases/html/html.test.ts
@@ -62,7 +62,7 @@ test.describe('html element set', () => {
       runServer: true,
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: join(join(fixtures, 'template'), 'src/index.ts'),
             foo: join(fixtures, 'template/src/index.ts'),
           },

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -36,7 +36,7 @@ test('should set inject via function correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.resolve(__dirname, './src/index.js'),
           foo: path.resolve(__dirname, './src/foo.js'),
         },

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -7,7 +7,7 @@ test('should generate meta tags correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { foo: path.resolve(__dirname, './src/foo.js') },
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
       html: {
         meta: {
@@ -40,7 +40,7 @@ test('should generate meta tags correctly when using custom HTML template', asyn
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { foo: path.resolve(__dirname, './src/foo.js') },
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
       html: {
         meta: {
@@ -63,7 +63,7 @@ test('should generate meta tags via function correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
           bar: path.resolve(__dirname, './src/foo.js'),
         },
@@ -115,7 +115,7 @@ test.skip('should generate meta tags for MPA correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
           bar: path.resolve(__dirname, './src/foo.js'),
         },

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -7,7 +7,7 @@ test('should set template via function correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.resolve(__dirname, './src/index.ts'),
           foo: path.resolve(__dirname, './src/foo.js'),
         },

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -7,7 +7,7 @@ test('should generate default title correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { foo: path.resolve(__dirname, './src/foo.js') },
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
     },
   });
@@ -23,7 +23,7 @@ test('should generate title correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { foo: path.resolve(__dirname, './src/foo.js') },
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
       html: {
         title: 'foo',
@@ -42,7 +42,7 @@ test('should generate title correctly when using custom HTML template', async ()
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: { foo: path.resolve(__dirname, './src/foo.js') },
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
       html: {
         title: 'foo',
@@ -62,7 +62,7 @@ test('should generate title via function correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
           bar: path.resolve(__dirname, './src/foo.js'),
         },
@@ -91,7 +91,7 @@ test.skip('should generate title for MPA correctly', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
           bar: path.resolve(__dirname, './src/foo.js'),
         },

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -128,7 +128,7 @@ test.skip('inline runtime chunk by default with multiple entries', async () => {
     cwd: __dirname,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.resolve(__dirname, './src/index.js'),
           another: path.resolve(__dirname, './src/another.js'),
         },
@@ -162,7 +162,7 @@ webpackOnlyTest(
       runServer: true,
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             index: path.resolve(__dirname, './src/index.js'),
             another: path.resolve(__dirname, './src/another.js'),
           },

--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -12,7 +12,7 @@ test('should generate prefetch link when prefetch is defined', async () => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/page1/index.ts'),
         },
       },
@@ -52,7 +52,7 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/page1/index.ts'),
         },
       },
@@ -89,7 +89,7 @@ test('should generate prefetch link with filter', async () => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/page1/index.ts'),
         },
       },
@@ -130,7 +130,7 @@ webpackOnlyTest(
       plugins: [pluginReact()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             page1: join(fixtures, 'src/page1/index.ts'),
             page2: join(fixtures, 'src/page2/index.ts'),
           },
@@ -179,7 +179,7 @@ test('should generate preload link when preload is defined', async () => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/page1/index.ts'),
         },
       },

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -35,7 +35,7 @@ test('should access /main.html success when entry is main', async ({
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },
@@ -63,7 +63,7 @@ test('should access /main success when entry is main', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },
@@ -95,7 +95,7 @@ test('should access /main success when entry is main and set assetPrefix', async
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },
@@ -126,7 +126,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },
@@ -157,7 +157,7 @@ test('should return 404 when page is not found', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },
@@ -186,7 +186,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           main: join(fixtures, 'src/index.ts'),
         },
       },

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -72,7 +72,7 @@ export function shareTest(
   };
   const config: RsbuildConfig = {
     source: {
-      entries: {
+      entry: {
         index: entry,
       },
       transformImport: [transformImport],

--- a/e2e/cases/source/plugin-import/index.webpack.test.ts
+++ b/e2e/cases/source/plugin-import/index.webpack.test.ts
@@ -45,7 +45,7 @@ test('should import with function customName', async () => {
 
         // @ts-expect-error rspack and webpack all support this
         disableDefaultEntries: true,
-        entries: {
+        entry: {
           index: './src/index.js',
         },
       },

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -13,7 +13,7 @@ test.describe('source configure multi', () => {
       runServer: true,
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             index: join(fixtures, 'basic/src/index.js'),
           },
           alias: {
@@ -50,7 +50,7 @@ test.skip('global-vars', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'global-vars/src/index.ts'),
         },
         // globalVars: {

--- a/e2e/cases/source/source.webpack.test.ts
+++ b/e2e/cases/source/source.webpack.test.ts
@@ -15,7 +15,7 @@ test.skip('module-scopes', async ({ page }) => {
       ...buildOpts,
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             index: join(fixtures, 'module-scopes/src/index.js'),
           },
           //   moduleScopes: ['./src'],

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -17,7 +17,7 @@ const buildFixture = (
     plugins: [pluginSvelte()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.join(root, entry),
         },
       },
@@ -48,7 +48,7 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
     plugins: [pluginSvelte()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.join(root, 'src/index.js'),
         },
       },

--- a/e2e/cases/svg/svg.test.ts
+++ b/e2e/cases/svg/svg.test.ts
@@ -12,7 +12,7 @@ test('svg (assets)', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'svg-assets', 'src/index.js'),
         },
       },
@@ -44,7 +44,7 @@ test('svgr (defaultExport url)', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'svg', 'src/index.js'),
         },
       },

--- a/e2e/cases/swc/index.swc.test.ts
+++ b/e2e/cases/swc/index.swc.test.ts
@@ -109,7 +109,7 @@ test('core-js-entry', async () => {
     ],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.resolve(__dirname, './src/core-js-entry.ts'),
         },
       },
@@ -136,7 +136,7 @@ test('core-js-usage', async () => {
     ],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: path.resolve(__dirname, './src/core-js-usage.ts'),
         },
       },

--- a/e2e/cases/tools.rspack.test.ts
+++ b/e2e/cases/tools.rspack.test.ts
@@ -10,7 +10,7 @@ test('tools.rspack', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'source/global-vars/src/index.ts'),
         },
       },

--- a/e2e/cases/tools.test.ts
+++ b/e2e/cases/tools.test.ts
@@ -13,7 +13,7 @@ test('postcss plugins overwrite', async ({ page }) => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'output/rem/src/index.ts'),
         },
       },
@@ -41,7 +41,7 @@ test('bundlerChain - set alias config', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'source/basic/src/index.js'),
         },
       },
@@ -68,7 +68,7 @@ webpackOnlyTest('bundlerChain - custom publicPath function', async () => {
     plugins: [pluginReact()],
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'output/rem/src/index.ts'),
         },
       },

--- a/e2e/cases/tools.webpack.test.ts
+++ b/e2e/cases/tools.webpack.test.ts
@@ -10,7 +10,7 @@ test('webpackChain - register plugin', async ({ page }) => {
     runServer: true,
     rsbuildConfig: {
       source: {
-        entries: {
+        entry: {
           index: join(fixtures, 'source/global-vars/src/index.ts'),
         },
       },

--- a/e2e/cases/web-worker/index.test.ts
+++ b/e2e/cases/web-worker/index.test.ts
@@ -21,7 +21,7 @@ test('should build web-worker target with dynamicImport correctly', async () => 
     target: 'web-worker',
     rsbuildConfig: {
       source: {
-        entries: { index: path.resolve(__dirname, './src/index2.js') },
+        entry: { index: path.resolve(__dirname, './src/index2.js') },
       },
     },
   });

--- a/packages/compat/webpack/tests/core/initConfigs.test.ts
+++ b/packages/compat/webpack/tests/core/initConfigs.test.ts
@@ -33,7 +33,7 @@ describe('modifyRsbuildConfig', () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: 'src/index.ts',
           },
           preEntry: 'a.js',

--- a/packages/compat/webpack/tests/createCompiler.test.ts
+++ b/packages/compat/webpack/tests/createCompiler.test.ts
@@ -13,7 +13,7 @@ describe('build hooks', () => {
       cwd: fixturesDir,
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: join(fixturesDir, 'src/index.js'),
           },
         },
@@ -58,7 +58,7 @@ describe('build hooks', () => {
   const createDefaultContext = () =>
     createPrimaryContext(getCreateRsbuildDefaultOptions(), {
       source: {
-        entries: {
+        entry: {
           index: './src/index.js',
         },
       },

--- a/packages/compat/webpack/tests/helper.ts
+++ b/packages/compat/webpack/tests/helper.ts
@@ -23,9 +23,9 @@ export async function createStubRsbuild({
   plugins?: RsbuildPlugin[];
 }) {
   // mock default entry
-  if (!rsbuildConfig.source?.entries) {
+  if (!rsbuildConfig.source?.entry) {
     rsbuildConfig.source ||= {};
-    rsbuildConfig.source.entries = {
+    rsbuildConfig.source.entry = {
       index: './src/index.js',
     };
   }

--- a/packages/compat/webpack/tests/plugins/babel.test.ts
+++ b/packages/compat/webpack/tests/plugins/babel.test.ts
@@ -57,7 +57,7 @@ describe('plugin-babel', () => {
       plugins: [pluginEntry(), pluginBabel()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './index.js',
           },
         },
@@ -75,7 +75,7 @@ describe('plugin-babel', () => {
       plugins: [pluginEntry(), pluginBabel()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './index.js',
           },
         },

--- a/packages/compat/webpack/tests/plugins/html.test.ts
+++ b/packages/compat/webpack/tests/plugins/html.test.ts
@@ -172,7 +172,7 @@ describe('plugin-html', () => {
       plugins: [pluginEntry(), pluginHtml()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/main.ts',
             foo: './src/foo.ts',
           },
@@ -194,7 +194,7 @@ describe('plugin-html', () => {
       plugins: [pluginEntry(), pluginHtml()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/main.ts',
             foo: './src/foo.ts',
           },
@@ -216,7 +216,7 @@ describe('plugin-html', () => {
       plugins: [pluginEntry(), pluginHtml()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/main.ts',
             foo: './src/foo.ts',
           },

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -213,7 +213,7 @@ export const pluginHtml = (): DefaultRsbuildPlugin => ({
         const htmlInfoMap: Record<string, HtmlInfo> = {};
 
         await Promise.all(
-          entryNames.map(async (entryName, index) => {
+          entryNames.map(async (entryName) => {
             const entryValue = entries[entryName].values() as string | string[];
             const chunks = getChunks(entryName, entryValue);
             const inject = getInject(entryName, config);

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -7,7 +7,7 @@ describe('should use rspack as default bundler', () => {
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             index: './src/index.js',
           },
         },

--- a/packages/core/tests/plugins/entry.test.ts
+++ b/packages/core/tests/plugins/entry.test.ts
@@ -50,7 +50,7 @@ describe('plugin-entry', () => {
       plugins: [pluginEntry()],
       rsbuildConfig: {
         source: {
-          entries: item.entry as unknown as Record<string, string | string[]>,
+          entry: item.entry as unknown as Record<string, string | string[]>,
           preEntry: item.preEntry,
         },
       },

--- a/packages/core/tests/rspack-provider/plugins/html.test.ts
+++ b/packages/core/tests/rspack-provider/plugins/html.test.ts
@@ -143,7 +143,7 @@ describe('plugin-html', () => {
       plugins: [pluginEntry(), pluginHtml()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/main.ts',
             foo: './src/foo.ts',
           },

--- a/packages/core/tests/rspack-provider/plugins/swc.test.ts
+++ b/packages/core/tests/rspack-provider/plugins/swc.test.ts
@@ -95,7 +95,7 @@ describe('plugin-swc', () => {
       plugins: [pluginSwc(), pluginEntry()],
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/index.js',
           },
           transformImport: false,
@@ -115,7 +115,7 @@ describe('plugin-swc', () => {
       target: 'web',
       rsbuildConfig: {
         source: {
-          entries: {
+          entry: {
             main: './src/index.js',
           },
         },
@@ -136,7 +136,7 @@ async function matchConfigSnapshot(
   rsbuildConfig: RsbuildConfig,
 ) {
   rsbuildConfig.source ||= {};
-  rsbuildConfig.source.entries = {
+  rsbuildConfig.source.entry = {
     main: './src/index.js',
   };
 

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -12,7 +12,7 @@ This section describes all the properties and methods on the Rsbuild instance ob
 
 ### rsbuild.context.entry
 
-The entry object from the `source.entries` option.
+The entry object from the `source.entry` option.
 
 - **Type**
 

--- a/packages/document/docs/en/config/options/source.mdx
+++ b/packages/document/docs/en/config/options/source.mdx
@@ -24,11 +24,11 @@ import Include from '@en/shared/config/source/include.md';
 
 <Include />
 
-## source.entries
+## source.entry
 
-import Entries from '@en/shared/config/source/entries.md';
+import Entry from '@en/shared/config/source/entry.md';
 
-<Entries />
+<Entry />
 
 ## source.exclude
 

--- a/packages/document/docs/en/guide/start/quick-start.mdx
+++ b/packages/document/docs/en/guide/start/quick-start.mdx
@@ -46,7 +46,7 @@ Refer to the [CLI Tool](/guide/basic/cli) to learn about all available commands 
 
 ## Entry Module
 
-By default, Rsbuild CLI uses `src/index.(js|ts|jsx|tsx)` as the entry module. You can modify the entry module using the [source.entries](/config/options/source#sourceentries) option.
+By default, Rsbuild CLI uses `src/index.(js|ts|jsx|tsx)` as the entry module. You can modify the entry module using the [source.entry](/config/options/source#sourceentry) option.
 
 ## Next Step
 

--- a/packages/document/docs/en/shared/config/source/entry.md
+++ b/packages/document/docs/en/shared/config/source/entry.md
@@ -1,7 +1,7 @@
 - **Type:**
 
 ```ts
-type Entries = Record<string, string | string[]>;
+type Entry = Record<string, string | string[]>;
 ```
 
 - **Default:**
@@ -19,7 +19,7 @@ Used to set the entry modules for building, the usage is the as same the [entry]
 ```ts
 export default {
   source: {
-    entries: {
+    entry: {
       foo: './src/pages/foo/index.ts',
       bar: './src/pages/bar/index.ts',
     },

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -12,7 +12,7 @@ extractApiHeaders: [2]
 
 ### rsbuild.context.entry
 
-构建入口对象，对应 `source.entries` 选项。
+构建入口对象，对应 `source.entry` 选项。
 
 - **类型**
 

--- a/packages/document/docs/zh/config/options/source.mdx
+++ b/packages/document/docs/zh/config/options/source.mdx
@@ -24,11 +24,11 @@ import Include from '@zh/shared/config/source/include.md';
 
 <Include />
 
-## source.entries
+## source.entry
 
-import Entries from '@zh/shared/config/source/entries.md';
+import Entry from '@zh/shared/config/source/entry.md';
 
-<Entries />
+<Entry />
 
 ## source.exclude
 

--- a/packages/document/docs/zh/guide/start/quick-start.mdx
+++ b/packages/document/docs/zh/guide/start/quick-start.mdx
@@ -46,7 +46,7 @@ Rsbuild 内置了一个轻量的命令行工具，包含 dev、build 等命令�
 
 ## 入口模块
 
-Rsbuild CLI 默认会使用 `src/index.(js|ts|jsx|tsx)` 作为入口模块，你可以使用 [source.entries](/config/options/source#sourceentries) 配置项来修改入口模块。
+Rsbuild CLI 默认会使用 `src/index.(js|ts|jsx|tsx)` 作为入口模块，你可以使用 [source.entry](/config/options/source#sourceentry) 配置项来修改入口模块。
 
 ## 下一步
 

--- a/packages/document/docs/zh/shared/config/source/entry.md
+++ b/packages/document/docs/zh/shared/config/source/entry.md
@@ -1,7 +1,7 @@
 - **类型：**
 
 ```ts
-type Entries = Record<string, string | string[]>;
+type Entry = Record<string, string | string[]>;
 ```
 
 - **默认值：**
@@ -19,7 +19,7 @@ const defaultEntry = {
 ```ts
 export default {
   source: {
-    entries: {
+    entry: {
       foo: './src/pages/foo/index.ts',
       bar: './src/pages/bar/index.ts',
     },

--- a/packages/shared/src/coreJs.ts
+++ b/packages/shared/src/coreJs.ts
@@ -7,7 +7,7 @@ const enableCoreJsEntry = (
   isServiceWorker: boolean,
 ) => config.output.polyfill === 'entry' && !isServer && !isServiceWorker;
 
-/** Add core-js-entry to every entries. */
+/** Add core-js-entry to every entry. */
 export function addCoreJsEntry({
   chain,
   config,

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -10,7 +10,7 @@ import {
 } from './types';
 import { findExists, getAbsoluteDistPath } from './fs';
 
-function getDefaultEntries(root: string) {
+function getDefaultEntry(root: string) {
   const files = ['ts', 'tsx', 'js', 'jsx'].map((ext) =>
     join(root, `src/index.${ext}`),
   );
@@ -24,7 +24,7 @@ function getDefaultEntries(root: string) {
   }
 
   throw new Error(
-    'Could not find the entry file, please make sure that `src/index.(js|ts|tsx|jsx)` exists, or customize entry through the `source.entries` configuration.',
+    'Could not find the entry file, please make sure that `src/index.(js|ts|tsx|jsx)` exists, or customize entry through the `source.entry` configuration.',
   );
 }
 
@@ -44,8 +44,19 @@ export function createContextByConfig(
   const distPath = getAbsoluteDistPath(cwd, outputConfig);
   const cachePath = join(rootPath, 'node_modules', '.cache');
 
+  if (sourceConfig.entries) {
+    logger.warn(
+      '[Rsbuild] The `source.entries` option has been renamed to `source.entry`, please update the Rsbuild config.',
+    );
+  }
+
   const context: Context = {
-    entry: sourceConfig.entries || getDefaultEntries(rootPath),
+    entry:
+      sourceConfig.entry ||
+      // TODO: remove sourceConfig.entries in v0.2.0
+      // compat with previous config
+      sourceConfig.entries ||
+      getDefaultEntry(rootPath),
     target,
     srcPath,
     rootPath,

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -46,7 +46,10 @@ export function createContextByConfig(
 
   if (sourceConfig.entries) {
     logger.warn(
-      '[Rsbuild] The `source.entries` option has been renamed to `source.entry`, please update the Rsbuild config.',
+      '[Rsbuild] `source.entries` option has been renamed to `source.entry`, please update the Rsbuild config.',
+    );
+    logger.warn(
+      '[Rsbuild] `source.entries` option will be removed in Rsbuild v0.2.0.',
     );
   }
 

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -30,6 +30,10 @@ export interface SourceConfig {
   /**
    * Set the entry modules.
    */
+  entry?: RsbuildEntry;
+  /**
+   * @default Use `source.entry` instead.
+   */
   entries?: RsbuildEntry;
   /**
    * Specifies that certain files that will be excluded from compilation.

--- a/packages/test-helper/src/rsbuild.ts
+++ b/packages/test-helper/src/rsbuild.ts
@@ -110,9 +110,9 @@ export async function createStubRsbuild<
   };
 
   // mock default entry
-  if (!rsbuildConfig.source?.entries) {
+  if (!rsbuildConfig.source?.entry) {
     rsbuildConfig.source ||= {};
-    rsbuildConfig.source.entries = {
+    rsbuildConfig.source.entry = {
       index: './src/index.js',
     };
   }


### PR DESCRIPTION
## Summary

Rename source.entries to source.entry, to be consistent with Rspack / webpack entry.

The `source.entries` option will be removed in v0.2.0.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
