### PR TITLE
feat: support use index.cjs or index.mjs as the default entry

### DIFF
--- a/.changeset/selfish-ants-behave.md
+++ b/.changeset/selfish-ants-behave.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+feat: support use index.cjs or index.mjs as the default entry

--- a/packages/document/docs/en/guide/faq/features.md
+++ b/packages/document/docs/en/guide/faq/features.md
@@ -34,7 +34,7 @@ export default {
     bundlerChain(chain) {
       chain.plugin('eslint-plugin').use(ESLintPlugin, [
         {
-          extensions: ['.js', '.ts', '.jsx', 'tsx', '.mjs'],
+          extensions: ['.js', '.ts', '.jsx', 'tsx', '.mjs', '.cjs'],
         },
       ]);
     },

--- a/packages/document/docs/en/shared/config/source/entry.md
+++ b/packages/document/docs/en/shared/config/source/entry.md
@@ -8,7 +8,7 @@ type Entry = Record<string, string | string[]>;
 
 ```ts
 const defaultEntry = {
-  index: 'src/index.(js|ts|jsx|tsx)',
+  index: 'src/index.(ts|js|tsx|jsx|mjs|cjs)',
 };
 ```
 

--- a/packages/document/docs/zh/guide/faq/features.md
+++ b/packages/document/docs/zh/guide/faq/features.md
@@ -34,7 +34,7 @@ export default {
     bundlerChain(chain) {
       chain.plugin('eslint-plugin').use(ESLintPlugin, [
         {
-          extensions: ['.js', '.ts', '.jsx', 'tsx', '.mjs'],
+          extensions: ['.js', '.ts', '.jsx', 'tsx', '.mjs', '.cjs'],
         },
       ]);
     },

--- a/packages/document/docs/zh/shared/config/source/entry.md
+++ b/packages/document/docs/zh/shared/config/source/entry.md
@@ -8,7 +8,7 @@ type Entry = Record<string, string | string[]>;
 
 ```ts
 const defaultEntry = {
-  index: 'src/index.(js|ts|jsx|tsx)',
+  index: 'src/index.(ts|js|tsx|jsx|mjs|cjs)',
 };
 ```
 

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -11,9 +11,16 @@ import {
 import { findExists, getAbsoluteDistPath } from './fs';
 
 function getDefaultEntry(root: string) {
-  const files = ['ts', 'tsx', 'js', 'jsx'].map((ext) =>
-    join(root, `src/index.${ext}`),
-  );
+  const files = [
+    // Most projects are using typescript now.
+    // So we put `.ts` as the first one to improve performance.
+    'ts',
+    'js',
+    'tsx',
+    'jsx',
+    '.mjs',
+    '.cjs',
+  ].map((ext) => join(root, `src/index.${ext}`));
 
   const entryFile = findExists(files);
 
@@ -24,7 +31,7 @@ function getDefaultEntry(root: string) {
   }
 
   throw new Error(
-    'Could not find the entry file, please make sure that `src/index.(js|ts|tsx|jsx)` exists, or customize entry through the `source.entry` configuration.',
+    'Could not find the entry file, please make sure that `src/index.(ts|js|tsx|jsx|mjs|cjs)` exists, or customize entry through the `source.entry` configuration.',
   );
 }
 


### PR DESCRIPTION
## Summary

Support use index.cjs or index.mjs as the default entry.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
