### PR TITLE
fix: should register config.plugins when using JavaScript API

### DIFF
--- a/.changeset/heavy-poems-act.md
+++ b/.changeset/heavy-poems-act.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+fix: should register config.plugins when using JavaScript API

--- a/e2e/cases/javascript-api/plugin/index.test.ts
+++ b/e2e/cases/javascript-api/plugin/index.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import { expect } from '@playwright/test';
+import { rspackOnlyTest, globContentJSON } from '../../../scripts/helper';
+import { createRsbuild } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+rspackOnlyTest(
+  'should register plugins correctly when using JavaScript API',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [pluginVue()],
+      },
+    });
+
+    await rsbuild.build();
+
+    const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+    const outputFiles = Object.keys(outputs);
+
+    expect(
+      outputFiles.find((item) => item.includes('index.html')),
+    ).toBeTruthy();
+    expect(
+      outputFiles.find((item) => item.includes('static/js/index.')),
+    ).toBeTruthy();
+  },
+);

--- a/e2e/cases/javascript-api/plugin/rsbuild.config.js
+++ b/e2e/cases/javascript-api/plugin/rsbuild.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+module.exports = defineConfig({
+  plugins: [pluginVue()],
+});

--- a/e2e/cases/javascript-api/plugin/src/A.vue
+++ b/e2e/cases/javascript-api/plugin/src/A.vue
@@ -1,0 +1,17 @@
+<template>
+  <div>The count is {{ count }}</div>
+</template>
+
+<script>
+import { ref } from 'vue';
+
+export default {
+  setup() {
+    const count = ref(0);
+
+    return {
+      count,
+    };
+  },
+};
+</script>

--- a/e2e/cases/javascript-api/plugin/src/index.js
+++ b/e2e/cases/javascript-api/plugin/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import A from './A.vue';
+
+createApp(A).mount('#root');

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -1,14 +1,10 @@
 import fs from 'fs';
 import jiti from 'jiti';
 import { join } from 'path';
-import type {
-  RsbuildPlugin,
-  RsbuildConfig as BaseRsbuildConfig,
-} from '@rsbuild/shared';
+import type { RsbuildConfig as BaseRsbuildConfig } from '@rsbuild/shared';
 import { restartDevServer } from '../server/restart';
 
 export type RsbuildConfig = BaseRsbuildConfig & {
-  plugins?: RsbuildPlugin[];
   /**
    * @private only for testing
    */

--- a/packages/core/src/cli/run.ts
+++ b/packages/core/src/cli/run.ts
@@ -4,7 +4,6 @@ import { loadConfig } from './config';
 
 type RunCliOptions = {
   isRestart?: boolean;
-  defaultPlugins?: RsbuildPlugin[];
 };
 
 export async function runCli(options: RunCliOptions = {}) {
@@ -14,14 +13,6 @@ export async function runCli(options: RunCliOptions = {}) {
     rsbuildConfig: config,
     provider: config.provider,
   });
-
-  if (options.defaultPlugins) {
-    rsbuild.addPlugins(options.defaultPlugins);
-  }
-
-  if (config.plugins) {
-    rsbuild.addPlugins(config.plugins);
-  }
 
   if (!options.isRestart) {
     setupProgram(rsbuild);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -26,7 +26,7 @@ export const getCreateRsbuildDefaultOptions =
 
 export async function createRsbuild<
   P extends ({ rsbuildConfig }: { rsbuildConfig: T }) => RsbuildProvider,
-  T = RsbuildConfig,
+  T extends RsbuildConfig,
 >(
   options: CreateRsbuildOptions & {
     rsbuildConfig: T;
@@ -65,7 +65,7 @@ export async function createRsbuild<
   await applyDefaultPlugins(pluginStore);
   debug('add default plugins done');
 
-  return {
+  const rsbuild = {
     ...pick(pluginStore, ['addPlugins', 'removePlugins', 'isPluginExists']),
     ...pick(pluginAPI, [
       'onBeforeBuild',
@@ -88,4 +88,10 @@ export async function createRsbuild<
     startDevServer,
     context: publicContext,
   };
+
+  if (rsbuildConfig.plugins) {
+    rsbuild.addPlugins(rsbuildConfig.plugins);
+  }
+
+  return rsbuild;
 }

--- a/packages/shared/src/types/config/index.ts
+++ b/packages/shared/src/types/config/index.ts
@@ -9,6 +9,7 @@ import type {
 } from './performance';
 import type { ToolsConfig, NormalizedToolsConfig } from './tools';
 import type { DeepReadonly } from '../utils';
+import type { RsbuildPlugin } from '..';
 
 /**
  * The shared Rsbuild config.
@@ -22,6 +23,7 @@ export interface RsbuildConfig {
   output?: OutputConfig;
   security?: SecurityConfig;
   performance?: PerformanceConfig;
+  plugins?: RsbuildPlugin[];
 }
 
 export type NormalizedConfig = DeepReadonly<{
@@ -32,6 +34,7 @@ export type NormalizedConfig = DeepReadonly<{
   output: NormalizedOutputConfig;
   security: NormalizedSecurityConfig;
   performance: NormalizedPerformanceConfig;
+  plugins?: RsbuildPlugin[];
 }>;
 
 export * from './dev';


### PR DESCRIPTION
## Summary

Should register config.plugins when using JavaScript API.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
