### PR TITLE
fix: should not print entry error when entry is set by plugins

### DIFF
--- a/.changeset/few-carpets-wink.md
+++ b/.changeset/few-carpets-wink.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+fix: should not print entry error when entry is set by plugins

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,6 +1,7 @@
-import { castArray, type DefaultRsbuildPlugin } from '@rsbuild/shared';
+import { castArray } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '../rspack-provider/types';
 
-export const pluginEntry = (): DefaultRsbuildPlugin => ({
+export const pluginEntry = (): RsbuildPlugin => ({
   name: 'plugin-entry',
 
   setup(api) {
@@ -13,6 +14,14 @@ export const pluginEntry = (): DefaultRsbuildPlugin => ({
         preEntry.forEach(appendEntry);
         castArray(entry[entryName]).forEach(appendEntry);
       });
+    });
+
+    api.onBeforeCreateCompiler(({ bundlerConfigs }) => {
+      if (bundlerConfigs.every((config) => !config.entry)) {
+        throw new Error(
+          'Could not find any entry module, please make sure that `src/index.(ts|js|tsx|jsx|mjs|cjs)` exists, or customize entry through the `source.entry` configuration.',
+        );
+      }
     });
   },
 });

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -108,10 +108,14 @@ export function pluginStartUrl(): DefaultRsbuildPlugin {
 
         if (startUrl === true || !startUrl) {
           const protocol = https ? 'https' : 'http';
-          // auto open the first one
-          urls.push(
-            normalizeUrl(`${protocol}://localhost:${port}/${routes[0].route}`),
-          );
+          if (routes.length) {
+            // auto open the first one
+            urls.push(
+              normalizeUrl(
+                `${protocol}://localhost:${port}/${routes[0].route}`,
+              ),
+            );
+          }
         } else {
           urls.push(
             ...castArray(startUrl).map((item) =>

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -1,16 +1,17 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { logger } from './logger';
-import {
+import type {
   Context,
   SourceConfig,
   OutputConfig,
   CreateRsbuildOptions,
   BundlerType,
+  RsbuildEntry,
 } from './types';
 import { findExists, getAbsoluteDistPath } from './fs';
 
-function getDefaultEntry(root: string) {
+function getDefaultEntry(root: string): RsbuildEntry {
   const files = [
     // Most projects are using typescript now.
     // So we put `.ts` as the first one to improve performance.
@@ -30,9 +31,7 @@ function getDefaultEntry(root: string) {
     };
   }
 
-  throw new Error(
-    'Could not find the entry file, please make sure that `src/index.(ts|js|tsx|jsx|mjs|cjs)` exists, or customize entry through the `source.entry` configuration.',
-  );
+  return {};
 }
 
 /**


### PR DESCRIPTION
## Summary

Should not print entry error when entry is set by plugins.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
