### PR TITLE
refactor: remove context.srcPath

### DIFF
--- a/.changeset/brown-boats-tan.md
+++ b/.changeset/brown-boats-tan.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/document': patch
+'@rsbuild/shared': patch
+---
+
+refactor: remove context.srcPath

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -44,16 +44,6 @@ The root path of current build, corresponding to the `cwd` option of `createRsbu
 type RootPath = string;
 ```
 
-### rsbuild.context.srcPath
-
-The absolute path to the src directory.
-
-- **Type**
-
-```ts
-type SrcPath = string;
-```
-
 ### rsbuild.context.distPath
 
 The absolute path of the output directory, corresponding to the `output.distPath.root` config in `RsbuildConfig`.

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -44,16 +44,6 @@ type Context = {
 type RootPath = string;
 ```
 
-### rsbuild.context.srcPath
-
-src 目录的绝对路径。
-
-- **类型**
-
-```ts
-type SrcPath = string;
-```
-
 ### rsbuild.context.distPath
 
 构建产物输出目录的绝对路径，对应 `RsbuildConfig` 中的 `output.distPath.root` 配置项。

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -45,7 +45,6 @@ export function createContextByConfig(
 ): Context {
   const { cwd, target, configPath } = options;
   const rootPath = cwd;
-  const srcPath = join(rootPath, 'src');
 
   const distPath = getAbsoluteDistPath(cwd, outputConfig);
   const cachePath = join(rootPath, 'node_modules', '.cache');
@@ -67,7 +66,6 @@ export function createContextByConfig(
       sourceConfig.entries ||
       getDefaultEntry(rootPath),
     target,
-    srcPath,
     rootPath,
     distPath,
     cachePath,
@@ -85,7 +83,6 @@ export function createPublicContext(context: Context): Readonly<Context> {
   const exposedKeys = [
     'entry',
     'target',
-    'srcPath',
     'rootPath',
     'distPath',
     'devServer',

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -10,8 +10,6 @@ export type Context = {
   target: RsbuildTarget | RsbuildTarget[];
   /** The root path of current project. */
   rootPath: string;
-  /** Absolute path of source files. */
-  srcPath: string;
   /** Absolute path of output files. */
   distPath: string;
   /** Absolute path of cache files. */


### PR DESCRIPTION
## Summary

Remove context.srcPath as this value can reflect the real src path, because the `entry` can be defined by user.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
