### PR TITLE
fix: context should be updated after modifyRsbuildConfig hook

### DIFF
--- a/.changeset/grumpy-donuts-eat.md
+++ b/.changeset/grumpy-donuts-eat.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+fix: context should be updated after modifyRsbuildConfig hook

--- a/packages/compat/webpack/src/core/initConfigs.ts
+++ b/packages/compat/webpack/src/core/initConfigs.ts
@@ -4,6 +4,7 @@ import {
   castArray,
   initPlugins,
   mergeRsbuildConfig,
+  updateContextByNormalizedConfig,
   type PluginStore,
   type InspectConfigOptions,
   type CreateRsbuildOptions,
@@ -42,7 +43,10 @@ export async function initConfigs({
   });
 
   await modifyRsbuildConfig(context);
-  context.normalizedConfig = normalizeConfig(context.config);
+
+  const normalizedConfig = normalizeConfig(context.config);
+  context.normalizedConfig = normalizedConfig;
+  updateContextByNormalizedConfig(context, context.normalizedConfig);
 
   const targets = castArray(rsbuildOptions.target);
   const webpackConfigs = await Promise.all(

--- a/packages/core/src/rspack-provider/core/initConfigs.ts
+++ b/packages/core/src/rspack-provider/core/initConfigs.ts
@@ -4,6 +4,7 @@ import {
   castArray,
   initPlugins,
   mergeRsbuildConfig,
+  updateContextByNormalizedConfig,
   type PluginStore,
   type InspectConfigOptions,
   type CreateRsbuildOptions,
@@ -42,6 +43,7 @@ export async function initConfigs({
 
   await modifyRsbuildConfig(context);
   context.normalizedConfig = normalizeConfig(context.config);
+  updateContextByNormalizedConfig(context, context.normalizedConfig);
 
   const targets = castArray(rsbuildOptions.target);
   const rspackConfigs = await Promise.all(

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -3,11 +3,12 @@ import { join } from 'path';
 import { logger } from './logger';
 import type {
   Context,
+  BundlerType,
   SourceConfig,
   OutputConfig,
-  CreateRsbuildOptions,
-  BundlerType,
   RsbuildEntry,
+  NormalizedConfig,
+  CreateRsbuildOptions,
 } from './types';
 import { findExists, getAbsoluteDistPath } from './fs';
 
@@ -79,6 +80,17 @@ export function createContextByConfig(
   return context;
 }
 
+export function updateContextByNormalizedConfig(
+  context: Context,
+  config: NormalizedConfig,
+) {
+  context.distPath = getAbsoluteDistPath(context.rootPath, config.output);
+
+  if (config.source.entry) {
+    context.entry = config.source.entry;
+  }
+}
+
 export function createPublicContext(context: Context): Readonly<Context> {
   const exposedKeys = [
     'entry',
@@ -100,7 +112,7 @@ export function createPublicContext(context: Context): Readonly<Context> {
       }
       return undefined;
     },
-    set(target, prop: keyof Context) {
+    set(_, prop: keyof Context) {
       logger.error(
         `Context is readonly, you can not assign to the "context.${prop}" prop.`,
       );


### PR DESCRIPTION
## Summary

context should be updated after running modifyRsbuildConfig hook.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
