### PR TITLE
docs: fix en "Use bundler Chain" block import from @zh scope.

### DIFF
--- a/packages/document/docs/en/guide/basic/configure-rspack.mdx
+++ b/packages/document/docs/en/guide/basic/configure-rspack.mdx
@@ -21,7 +21,7 @@ export default {
 
 ## Use Bundler Chain
 
-import BundlerChain from '@zh/shared/bundlerChain.md';
+import BundlerChain from '@en/shared/bundlerChain.md';
 
 <BundlerChain />
 


### PR DESCRIPTION
## Summary

https://rsbuild.dev/guide/basic/configure-rspack.html#use-bundler-chain

![image](https://github.com/web-infra-dev/rsbuild/assets/3841747/0fd23f27-2996-485d-9090-00969f0364ed)

The English documentation incorrectly references content from the Chinese documentation.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
