### PR TITLE
fix(rsbuild-doctor): should delete the useless cloudurl property

### DIFF
--- a/.changeset/ninety-seals-listen.md
+++ b/.changeset/ninety-seals-listen.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/doctor-types': patch
+'@rsbuild/doctor-utils': patch
+'@rsbuild/doctor-sdk': patch
+---
+
+fix: rsbuild doctor delete the cloudurl property

--- a/packages/doctor-sdk/src/sdk/multiple/controller.ts
+++ b/packages/doctor-sdk/src/sdk/multiple/controller.ts
@@ -28,7 +28,6 @@ export class DoctorSDKController {
         name: item.name,
         path: item.diskManifestPath,
         stage: item.stage,
-        cloudUrl: '', // TODO: Delete the cloud path property.
       };
 
       if (serverUrl) {

--- a/packages/doctor-sdk/src/sdk/sdk/core.ts
+++ b/packages/doctor-sdk/src/sdk/sdk/core.ts
@@ -181,7 +181,6 @@ export abstract class SDKCore<T extends DoctorSDKOptions>
     await this.hooks.afterSaveManifest.promise({
       manifestWithShardingFiles: this.cloudData!,
       manifestDiskPath,
-      manifestCloudPath: '', // TODO: Delete the cloud path property.
     });
 
     return manifestDiskPath;

--- a/packages/doctor-sdk/src/sdk/server/apis/bundle-diff.ts
+++ b/packages/doctor-sdk/src/sdk/server/apis/bundle-diff.ts
@@ -34,7 +34,6 @@ export class BundleDiffAPI extends BaseAPI {
       packageGraph,
       outputFilename,
       moduleCodeMap,
-      cloudManifestUrl: '', // TODO: Delete the cloud path property.
     };
   }
 

--- a/packages/doctor-sdk/tests/sdk/core/hooks.test.ts
+++ b/packages/doctor-sdk/tests/sdk/core/hooks.test.ts
@@ -24,13 +24,11 @@ describe('test hooks of sdk/core.ts', () => {
     expect(fn1).toHaveBeenCalledWith({
       manifestWithShardingFiles: target.sdk.cloudData,
       manifestDiskPath: target.sdk.diskManifestPath,
-      manifestCloudPath: '',
     });
     expect(fn2).toBeCalledTimes(1);
     expect(fn2).toHaveBeenCalledWith({
       manifestWithShardingFiles: target.sdk.cloudData,
       manifestDiskPath: target.sdk.diskManifestPath,
-      manifestCloudPath: '',
     });
   });
 });

--- a/packages/doctor-types/src/manifest.ts
+++ b/packages/doctor-types/src/manifest.ts
@@ -15,7 +15,6 @@ export interface DoctorManifest {
 export interface DoctorManifestSeriesData {
   name: string;
   path: string;
-  cloudUrl: string;
   stage: number;
   origin?: string;
 }

--- a/packages/doctor-types/src/sdk/hooks.ts
+++ b/packages/doctor-types/src/sdk/hooks.ts
@@ -10,7 +10,6 @@ export interface Hooks {
       {
         manifestWithShardingFiles: DoctorManifestWithShardingFiles;
         manifestDiskPath: string;
-        manifestCloudPath: string;
       },
     ]
   >;

--- a/packages/doctor-types/src/sdk/instance.ts
+++ b/packages/doctor-types/src/sdk/instance.ts
@@ -17,7 +17,7 @@ import { PlainObject } from '../common';
 import { EmoCheckData } from '../emo';
 import { Hooks } from './hooks';
 
-export type WriteStoreOptionsType = { userManifestCloudName?: string };
+export type WriteStoreOptionsType = {};
 export interface DoctorBuilderSDKInstance extends DoctorSDKInstance {
   readonly server: DoctorServerInstance;
   /** Report configuration information */

--- a/packages/doctor-types/src/sdk/server/apis/index.ts
+++ b/packages/doctor-types/src/sdk/server/apis/index.ts
@@ -108,7 +108,6 @@ export interface ResponseTypes
   [API.LoadDataByKey]: unknown;
   [API.BundleDiffManifest]: SDK.BuilderStoreData;
   [API.GetBundleDiffSummary]: {
-    cloudManifestUrl: string;
     root: string;
     hash: string;
     outputFilename: string;

--- a/packages/doctor-utils/src/common/data/index.ts
+++ b/packages/doctor-utils/src/common/data/index.ts
@@ -323,7 +323,6 @@ export class APIDataLoader {
               packageGraph,
               outputFilename,
               moduleCodeMap,
-              cloudManifestUrl: '', // TODO: Delete the cloud path property.
             } as R;
           },
         );


### PR DESCRIPTION
## Summary
rsbuild doctor don't need uploade cloud data, so delete the cloudurl property.

## Related Issue
#558
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
