### PR TITLE
refactor: move configPath option to uni-builder

### DIFF
--- a/.changeset/late-otters-fry.md
+++ b/.changeset/late-otters-fry.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/doctor-webpack-plugin': patch
+'@rsbuild/uni-builder': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: move configPath option to uni-builder

--- a/packages/compat/uni-builder/src/rspack/index.ts
+++ b/packages/compat/uni-builder/src/rspack/index.ts
@@ -10,12 +10,15 @@ import { parseCommonConfig } from '../shared/parseCommonConfig';
 
 export async function parseConfig(
   uniBuilderConfig: UniBuilderRspackConfig,
+  frameworkConfigPath?: string,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
-  const { rsbuildConfig, rsbuildPlugins } =
-    parseCommonConfig<'rspack'>(uniBuilderConfig);
+  const { rsbuildConfig, rsbuildPlugins } = parseCommonConfig<'rspack'>(
+    uniBuilderConfig,
+    frameworkConfigPath,
+  );
 
   if (uniBuilderConfig.output?.enableAssetManifest) {
     const { pluginManifest } = await import('./plugins/manifest');
@@ -31,7 +34,10 @@ export async function parseConfig(
 export async function createRspackBuilder(
   options: CreateRspackBuilderOptions,
 ): Promise<RsbuildInstance<RspackProvider>> {
-  const { rsbuildConfig, rsbuildPlugins } = await parseConfig(options.config);
+  const { rsbuildConfig, rsbuildPlugins } = await parseConfig(
+    options.config,
+    options.frameworkConfigPath,
+  );
   const rsbuild = await createRsbuild({
     rsbuildConfig,
   });

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -15,6 +15,7 @@ import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import { pluginFallback } from './plugins/fallback';
 import { pluginGlobalVars } from './plugins/globalVars';
 import { pluginRuntimeChunk } from './plugins/runtimeChunk';
+import { pluginFrameworkConfig } from './plugins/frameworkConfig';
 
 const GLOBAL_CSS_REGEX = /\.global\.\w+$/;
 
@@ -30,6 +31,7 @@ export function parseCommonConfig<B = 'rspack' | 'webpack'>(
   uniBuilderConfig: B extends 'rspack'
     ? UniBuilderRspackConfig
     : UniBuilderWebpackConfig,
+  frameworkConfigPath?: string,
 ): {
   rsbuildConfig: B extends 'rspack'
     ? RsbuildRspackConfig
@@ -122,6 +124,10 @@ export function parseCommonConfig<B = 'rspack' | 'webpack'>(
   // Note: fallback should be the last plugin
   if (uniBuilderConfig.output?.enableAssetFallback) {
     rsbuildPlugins.push(pluginFallback());
+  }
+
+  if (frameworkConfigPath) {
+    rsbuildPlugins.push(pluginFrameworkConfig(frameworkConfigPath));
   }
 
   return {

--- a/packages/compat/uni-builder/src/shared/plugins/frameworkConfig.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/frameworkConfig.ts
@@ -1,0 +1,24 @@
+import { fse, type DefaultRsbuildPlugin } from '@rsbuild/shared';
+
+export const pluginFrameworkConfig = (
+  configPath: string,
+): DefaultRsbuildPlugin => ({
+  name: 'plugin-framework-config',
+
+  setup(api) {
+    api.modifyBundlerChain((chain) => {
+      if (!fse.existsSync(configPath)) {
+        return;
+      }
+
+      const cache = chain.get('cache');
+
+      cache.buildDependencies = {
+        ...cache.buildDependencies,
+        frameworkConfig: [configPath],
+      };
+
+      chain.cache(cache);
+    });
+  },
+});

--- a/packages/compat/uni-builder/src/types.ts
+++ b/packages/compat/uni-builder/src/types.ts
@@ -15,11 +15,13 @@ import type { PluginRemOptions } from '@rsbuild/plugin-rem';
 export type CreateWebpackBuilderOptions = {
   bundlerType: 'webpack';
   config: UniBuilderWebpackConfig;
+  frameworkConfigPath?: string;
 };
 
 export type CreateRspackBuilderOptions = {
   bundlerType: 'rspack';
   config: UniBuilderRspackConfig;
+  frameworkConfigPath?: string;
 };
 
 export type CreateUniBuilderOptions =

--- a/packages/compat/uni-builder/src/webpack/index.ts
+++ b/packages/compat/uni-builder/src/webpack/index.ts
@@ -11,12 +11,15 @@ import { pluginModuleScopes } from './plugins/moduleScopes';
 
 export async function parseConfig(
   uniBuilderConfig: UniBuilderWebpackConfig,
+  frameworkConfigPath?: string,
 ): Promise<{
   rsbuildConfig: RsbuildConfig;
   rsbuildPlugins: RsbuildPlugin[];
 }> {
-  const { rsbuildConfig, rsbuildPlugins } =
-    parseCommonConfig<'webpack'>(uniBuilderConfig);
+  const { rsbuildConfig, rsbuildPlugins } = parseCommonConfig<'webpack'>(
+    uniBuilderConfig,
+    frameworkConfigPath,
+  );
 
   if (uniBuilderConfig.output?.enableAssetManifest) {
     const { pluginManifest } = await import('./plugins/manifest');
@@ -44,7 +47,10 @@ export async function parseConfig(
 export async function createWebpackBuilder(
   options: CreateWebpackBuilderOptions,
 ): Promise<RsbuildInstance<WebpackProvider>> {
-  const { rsbuildConfig, rsbuildPlugins } = await parseConfig(options.config);
+  const { rsbuildConfig, rsbuildPlugins } = await parseConfig(
+    options.config,
+    options.frameworkConfigPath,
+  );
   const { webpackProvider } = await import('@rsbuild/webpack');
   const rsbuild = await createRsbuild({
     rsbuildConfig,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -21,7 +21,6 @@ export const getCreateRsbuildDefaultOptions =
   (): Required<CreateRsbuildOptions> => ({
     cwd: process.cwd(),
     target: ['web'],
-    configPath: null,
   });
 
 export async function createRsbuild<

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -67,10 +67,6 @@ async function getBuildDependencies(context: Readonly<Context>) {
     buildDependencies.packageJson = [rootPackageJson];
   }
 
-  if (context.configPath) {
-    buildDependencies.config = [context.configPath];
-  }
-
   if (context.tsconfigPath) {
     buildDependencies.tsconfig = [context.tsconfigPath];
   }

--- a/packages/core/tests/plugins/__snapshots__/cache.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/cache.test.ts.snap
@@ -78,24 +78,6 @@ exports[`plugin-cache > 'should not apply cacheDigest' 1`] = `
 }
 `;
 
-exports[`plugin-cache > 'should watch framework config change' 1`] = `
-{
-  "cache": {
-    "buildDependencies": {
-      "packageJson": [
-        "<ROOT>/package.json",
-      ],
-      "tailwindcss": [
-        "/root/tailwind.config.ts",
-      ],
-    },
-    "cacheDirectory": "<ROOT>/node_modules/.cache/rspack",
-    "name": "web-test",
-    "type": "filesystem",
-  },
-}
-`;
-
 exports[`plugin-cache > 'should watch tsconfig change' 1`] = `
 {
   "cache": {

--- a/packages/core/tests/plugins/cache.test.ts
+++ b/packages/core/tests/plugins/cache.test.ts
@@ -20,12 +20,6 @@ describe('plugin-cache', () => {
       name: 'should add cache config correctly',
     },
     {
-      name: 'should watch framework config change',
-      context: {
-        configPath: '/path/to/config.js',
-      },
-    },
-    {
       name: 'should watch tsconfig change',
       context: {
         tsconfigPath: '/path/to/tsconfig.json',

--- a/packages/doctor-webpack-plugin/tests/plugins/__snapshots__/plugin.test.ts.snap
+++ b/packages/doctor-webpack-plugin/tests/plugins/__snapshots__/plugin.test.ts.snap
@@ -30,34 +30,3 @@ exports[`test src/utils/plugin.ts > test plugin interceptor > webpack5 2`] = `
   },
 ]
 `;
-
-exports[`test src/utils/plugin.ts test plugin interceptor webpack5 1`] = `
-"/******/ (() => { // webpackBootstrap
-var __webpack_exports__ = {};
-console.log('a');
-
-// hello world
-/******/ })()
-;"
-`;
-
-exports[`test src/utils/plugin.ts test plugin interceptor webpack5 2`] = `
-[
-  {
-    "assets": [
-      "bundle.js",
-    ],
-    "dependencies": [],
-    "entry": true,
-    "id": "0",
-    "imported": [],
-    "initial": true,
-    "modules": [
-      1,
-    ],
-    "name": "main",
-    "parsedSize": 0,
-    "size": 33,
-  },
-]
-`;

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -27,7 +27,6 @@ type CreateRsbuildOptions = {
   cwd?: string;
   target?: RsbuildTarget | RsbuildTarget[];
   provider?: RsbuildProvider;
-  configPath?: string | null;
   rsbuildConfig?: RsbuildConfig;
 };
 ```
@@ -36,7 +35,6 @@ Description:
 
 - `cwd`: The root path of the current build, the default value is `process.cwd()`.
 - `target`: Build target type, the default value is `['web']`, see chapter [Build Target](/api/start/build-target) for details.
-- `configPath`: The path to the config file of higher-level solution (absolute path), this parameter affects the build cache update.
 - `provider`: Used to switch the underlying bundler.
 - `rsbuildConfig`: Rsbuild configuration object. Rsbuild provides a rich set of configuration options that allow you to customize the build behavior flexibly. You can find all available configuration options in the [Configuration](/config/) section.
 

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -60,16 +60,6 @@ The absolute path of the build cache files.
 type CachePath = string;
 ```
 
-### rsbuild.context.configPath
-
-The absolute path to the config file of higher-level solution, corresponding to the `configPath` option of `createRsbuild` method.
-
-- **Type**
-
-```ts
-type ConfigPath = string | undefined;
-```
-
 ### rsbuild.context.tsconfigPath
 
 The absolute path of the tsconfig.json file, or `undefined` if the tsconfig.json file does not exist in current project.

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -27,7 +27,6 @@ type CreateRsbuildOptions = {
   cwd?: string;
   target?: RsbuildTarget | RsbuildTarget[];
   provider?: RsbuildProvider;
-  configPath?: string | null;
   rsbuildConfig?: RsbuildConfig;
 };
 ```
@@ -36,7 +35,6 @@ type CreateRsbuildOptions = {
 
 - `cwd`: 当前执行构建的根路径，默认值为 `process.cwd()`
 - `target`: 构建产物类型，默认值为 `['web']`，详见 [构建产物类型](/api/start/build-target) 章节。
-- `configPath`: 上层解决方案配置文件的路径（绝对路径），该参数影响构建缓存更新
 - `provider`: 用于切换底层的打包工具。
 - `rsbuildConfig`：Rsbuild 配置对象。Rsbuild 提供了丰富的配置项，允许你对构建行为进行灵活定制，你可以在 [配置](/config/) 中找到所有可用的配置项。
 

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -60,16 +60,6 @@ type DistPath = string;
 type CachePath = string;
 ```
 
-### rsbuild.context.configPath
-
-框架配置文件的绝对路径，对应调用 `createRsbuild` 时传入的 `configPath` 选项。
-
-- **类型**
-
-```ts
-type ConfigPath = string | undefined;
-```
-
 ### rsbuild.context.tsconfigPath
 
 tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件，则为 `undefined`。

--- a/packages/shared/src/createContext.ts
+++ b/packages/shared/src/createContext.ts
@@ -44,7 +44,7 @@ export function createContextByConfig(
   sourceConfig: SourceConfig = {},
   outputConfig: OutputConfig = {},
 ): Context {
-  const { cwd, target, configPath } = options;
+  const { cwd, target } = options;
   const rootPath = cwd;
 
   const distPath = getAbsoluteDistPath(cwd, outputConfig);
@@ -72,10 +72,6 @@ export function createContextByConfig(
     cachePath,
     bundlerType,
   };
-
-  if (configPath && existsSync(configPath)) {
-    context.configPath = configPath;
-  }
 
   return context;
 }

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -14,8 +14,6 @@ export type Context = {
   distPath: string;
   /** Absolute path of cache files. */
   cachePath: string;
-  /** Absolute path to the config file of hight-level solutions. */
-  configPath?: string;
   /** Absolute path of tsconfig.json. */
   tsconfigPath?: string;
   /** Info of dev server  */

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -13,8 +13,6 @@ export type CreateRsbuildOptions = {
   cwd?: string;
   /** Type of build target. */
   target?: RsbuildTarget | RsbuildTarget[];
-  /** Absolute path to the config file of higher-level solutions. */
-  configPath?: string | null;
 };
 
 export type RsbuildInstance<P extends RsbuildProvider = RsbuildProvider> = {


### PR DESCRIPTION
## Summary

Move the configPath option of `createRsbuild` to uni-builder. This option is designed for the framework config, and maybe misleading for Rsbuild users.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
