### PR TITLE
docs: fix html.tags append default value

### DIFF
--- a/packages/document/docs/en/shared/config/html/tags.md
+++ b/packages/document/docs/en/shared/config/html/tags.md
@@ -14,7 +14,7 @@ export interface HtmlInjectTag {
   hash?: boolean | string | ((url: string, hash: string) => string);
   /** @default true */
   publicPath?: boolean | string | ((url: string, publicPath: string) => string);
-  /** @default false */
+  /** @default true */
   append?: boolean;
   /**
    * Enable by default only for elements that are allowed to be included in the `head` tag.

--- a/packages/document/docs/zh/shared/config/html/tags.md
+++ b/packages/document/docs/zh/shared/config/html/tags.md
@@ -14,7 +14,7 @@ export interface HtmlInjectTag {
   hash?: boolean | string | ((url: string, hash: string) => string);
   /** @default true */
   publicPath?: boolean | string | ((url: string, publicPath: string) => string);
-  /** @default false */
+  /** @default true */
   append?: boolean;
   /**
    * 仅对于允许包含在 head 中的元素会默认启用


### PR DESCRIPTION
## Summary

Fix html.tags append default value.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
