### PR TITLE
chore: move react utils to plugin react

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -41,6 +41,7 @@
     "@babel/preset-react": "^7.22.15",
     "@babel/preset-typescript": "^7.23.2",
     "@modern-js/swc-plugins": "0.6.5",
+    "@rsbuild/plugin-react": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.3",
     "core-js": "~3.32.2",

--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -1,9 +1,9 @@
 import _ from 'lodash';
-import { NormalizedConfig } from '@rsbuild/webpack';
+import type { NormalizedConfig } from '@rsbuild/webpack';
+import { isBeyondReact17 } from '@rsbuild/plugin-react';
 import {
   logger,
   isUsingHMR,
-  isBeyondReact17,
   getCoreJsVersion,
   getBrowserslistWithDefault,
   getDefaultStyledComponentsConfig,

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -41,6 +41,7 @@
     "@rsbuild/babel-preset": "workspace:*",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
+    "@rsbuild/plugin-react": "workspace:*",
     "@rsbuild/plugin-css-minimizer": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "babel-loader": "9.1.3",

--- a/packages/compat/webpack/src/plugins/react.ts
+++ b/packages/compat/webpack/src/plugins/react.ts
@@ -1,4 +1,5 @@
-import { isBeyondReact17, isProd, isUsingHMR } from '@rsbuild/shared';
+import { isBeyondReact17 } from '@rsbuild/plugin-react';
+import { isProd, isUsingHMR } from '@rsbuild/shared';
 import type { RsbuildPlugin, RsbuildConfig } from '../types';
 
 export const pluginReactWebpack = (): RsbuildPlugin => ({

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,12 +27,14 @@
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
     "@rspack/plugin-react-refresh": "0.3.14",
-    "react-refresh": "^0.14.0"
+    "react-refresh": "^0.14.0",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
     "@types/node": "^16",
+    "@types/semver": "^7.5.4",
     "typescript": "^5.2.2"
   },
   "publishConfig": {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -4,6 +4,8 @@ import { applyArcoSupport } from './arco';
 import { applySplitChunksRule } from './splitChunks';
 import { applyBasicReactSupport } from './react';
 
+export { isBeyondReact17 } from './utils';
+
 export const pluginReact = (): RsbuildPlugin => ({
   name: 'plugin-react',
 

--- a/packages/plugin-react/src/utils.ts
+++ b/packages/plugin-react/src/utils.ts
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import semver from 'semver';
+import { findUp } from '@rsbuild/shared';
+
+export const isBeyondReact17 = async (cwd: string) => {
+  const pkgPath = await findUp({ cwd, filename: 'package.json' });
+
+  if (!pkgPath) {
+    return false;
+  }
+
+  const pkgInfo = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  const deps = {
+    ...pkgInfo.devDependencies,
+    ...pkgInfo.dependencies,
+  };
+
+  if (typeof deps.react !== 'string') {
+    return false;
+  }
+
+  return semver.satisfies(semver.minVersion(deps.react)!, '>=17.0.0');
+};

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -101,14 +101,12 @@
     "caniuse-lite": "^1.0.30001559",
     "line-diff": "2.1.1",
     "lodash": "^4.17.21",
-    "postcss": "8.4.31",
-    "semver": "^7.5.4"
+    "postcss": "8.4.31"
   },
   "devDependencies": {
     "@rspack/core": "0.3.14",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
-    "@types/semver": "^7.5.4",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
     "http-proxy-middleware": "^2.0.1",
     "terser": "5.19.2",

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -5,8 +5,6 @@ import type {
 } from './types';
 import path from 'path';
 import fse from '../compiled/fs-extra';
-import semver from 'semver';
-import { findUp } from './fs';
 import deepmerge from '../compiled/deepmerge';
 
 export { deepmerge };
@@ -143,27 +141,6 @@ export const isPackageInstalled = (
   } catch (err) {
     return false;
   }
-};
-
-// TODO: move to react plugin
-export const isBeyondReact17 = async (cwd: string) => {
-  const pkgPath = await findUp({ cwd, filename: 'package.json' });
-
-  if (!pkgPath) {
-    return false;
-  }
-
-  const pkgInfo = JSON.parse(fse.readFileSync(pkgPath, 'utf8'));
-  const deps = {
-    ...pkgInfo.devDependencies,
-    ...pkgInfo.dependencies,
-  };
-
-  if (typeof deps.react !== 'string') {
-    return false;
-  }
-
-  return semver.satisfies(semver.minVersion(deps.react)!, '>=17.0.0');
 };
 
 export const camelCase = (input: string): string =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       '@modern-js/swc-plugins':
         specifier: 0.6.5
         version: 0.6.5(@swc/helpers@0.5.3)
+      '@rsbuild/plugin-react':
+        specifier: workspace:*
+        version: link:../../plugin-react
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../../shared
@@ -570,6 +573,9 @@ importers:
       '@rsbuild/plugin-css-minimizer':
         specifier: workspace:*
         version: link:../../plugin-css-minimizer
+      '@rsbuild/plugin-react':
+        specifier: workspace:*
+        version: link:../../plugin-react
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../../shared
@@ -1537,6 +1543,9 @@ importers:
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
+      semver:
+        specifier: ^7.5.4
+        version: 7.5.4
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1547,6 +1556,9 @@ importers:
       '@types/node':
         specifier: ^16
         version: 16.18.59
+      '@types/semver':
+        specifier: ^7.5.4
+        version: 7.5.4
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1837,9 +1849,6 @@ importers:
       postcss:
         specifier: 8.4.31
         version: 8.4.31
-      semver:
-        specifier: ^7.5.4
-        version: 7.5.4
     devDependencies:
       '@types/lodash':
         specifier: ^4.14.200
@@ -1847,9 +1856,6 @@ importers:
       '@types/node':
         specifier: ^16
         version: 16.18.59
-      '@types/semver':
-        specifier: ^7.5.4
-        version: 7.5.4
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.5.5
         version: /html-rspack-plugin@5.5.5


### PR DESCRIPTION
## Summary

Move react utils to plugin react.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
