### PR TITLE
fix(react): failed to split react chunks if override chunkSplit

### DIFF
--- a/.changeset/hip-cherries-fold.md
+++ b/.changeset/hip-cherries-fold.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/plugin-react': patch
+'@rsbuild/shared': patch
+---
+
+fix(react): failed to split react chunks if override chunkSplit

--- a/e2e/cases/react/remove-prop-types/index.test.ts
+++ b/e2e/cases/react/remove-prop-types/index.test.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { expect } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
 import { webpackOnlyTest } from '@scripts/helper';

--- a/e2e/cases/react/split-chunk/index.test.ts
+++ b/e2e/cases/react/split-chunk/index.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { build } from '@scripts/shared';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+const fixtures = __dirname;
+
+test('should split react chunks correctly', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-react'))).toBeTruthy();
+  expect(filesNames.find((file) => file.includes('lib-router'))).toBeTruthy();
+});
+
+test('should not split react chunks when strategy is `all-in-one`', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-react'))).toBeFalsy();
+  expect(filesNames.find((file) => file.includes('lib-router'))).toBeFalsy();
+});

--- a/e2e/cases/react/split-chunk/src/App.jsx
+++ b/e2e/cases/react/split-chunk/src/App.jsx
@@ -1,0 +1,3 @@
+const App = () => <div id="test">Hello Rsbuild!</div>;
+
+export default App;

--- a/e2e/cases/react/split-chunk/src/index.js
+++ b/e2e/cases/react/split-chunk/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactRouterDOM from 'react-router-dom';
+import App from './App';
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));
+
+console.log(ReactRouterDOM);

--- a/e2e/cases/react/split-chunk/src/index.js
+++ b/e2e/cases/react/split-chunk/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import ReactRouterDOM from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import App from './App';
 
 ReactDOM.render(React.createElement(App), document.getElementById('root'));
 
-console.log(ReactRouterDOM);
+console.log(Link);

--- a/packages/compat/webpack/tests/webpackConfig.test.ts
+++ b/packages/compat/webpack/tests/webpackConfig.test.ts
@@ -134,7 +134,7 @@ describe('webpackConfig', () => {
     await createStubRsbuild({
       rsbuildConfig: {
         tools: {
-          webpack(config, utils) {
+          webpack(_config, utils) {
             expect(utils.HtmlPlugin.version).toEqual(5);
             expect(utils.HtmlWebpackPlugin.version).toEqual(5);
           },
@@ -147,7 +147,7 @@ describe('webpackConfig', () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {
         tools: {
-          webpack(config, utils) {
+          webpack(_config, utils) {
             utils.appendPlugins([new utils.webpack.DefinePlugin({ foo: '1' })]);
             utils.prependPlugins([
               new utils.webpack.DefinePlugin({ foo: '2' }),
@@ -165,7 +165,7 @@ describe('webpackConfig', () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {
         tools: {
-          webpack(config, utils) {
+          webpack(_config, utils) {
             utils.appendPlugins([new utils.webpack.DefinePlugin({ foo: '1' })]);
             utils.prependPlugins([
               new utils.webpack.DefinePlugin({ foo: '2' }),
@@ -190,7 +190,7 @@ describe('webpackConfig', () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {
         tools: {
-          webpack(config, utils) {
+          webpack(_config, utils) {
             utils.addRules(newRule);
           },
         },

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -40,7 +40,8 @@ export async function applyCSSMinimizer(
     .minimizer(CHAIN_ID.MINIMIZER.CSS)
     .use(CssMinimizerPlugin, [
       // Due to css-minimizer-webpack-plugin has changed the type of class, which using a generic type in
-      // constructor, leading auto inference of parameters of plugin constructor is not possible, using any instead
+      // constructor, leading auto inference of parameters of plugin constructor is not possible
+      // @ts-expect-error
       mergedOptions,
     ])
     .end();

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,5 +1,5 @@
 import { isUsingHMR, isClientCompiler, isProd } from '@rsbuild/shared';
-import type { Rspack, RsbuildPluginAPI } from '@rsbuild/core/rspack-provider';
+import type { Rspack, RsbuildPluginAPI } from '@rsbuild/core';
 
 function getReactRefreshEntry(compiler: Rspack.Compiler) {
   const hot = compiler.options.devServer?.hot ?? true;
@@ -81,7 +81,6 @@ export const applyBasicReactSupport = (api: RsbuildPluginAPI) => {
     }
 
     const { default: ReactRefreshRspackPlugin } = await import(
-      // TODO https://github.com/web-infra-dev/rspack/issues/4471
       '@rspack/plugin-react-refresh'
     );
 

--- a/packages/shared/src/types/bundlerConfig.ts
+++ b/packages/shared/src/types/bundlerConfig.ts
@@ -165,19 +165,7 @@ export interface BundlerChain
     | 'ignoreWarnings'
   > {
   toConfig: () => BundlerConfig;
-  optimization: PickAndModifyThis<
-    WebpackChain['optimization'],
-    | 'splitChunks'
-    | 'runtimeChunk'
-    | 'minimize'
-    | 'minimizer'
-    | 'chunkIds'
-    | 'moduleIds'
-    | 'sideEffects'
-    | 'realContentHash'
-    | 'removeEmptyChunks'
-    | 'removeAvailableModules'
-  >;
+  optimization: WebpackChain['optimization'];
   externals: (value: Externals) => BundlerChain;
   resolve: PickAndModifyThis<
     WebpackChain['resolve'],


### PR DESCRIPTION
## Summary

Fix failed to split react chunks if override chunkSplit.

## Related Issue

https://github.com/web-infra-dev/rsbuild/issues/590

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
