### PR TITLE
types: simplify BundlerChain and BundlerConfig

### DIFF
--- a/.changeset/khaki-camels-exercise.md
+++ b/.changeset/khaki-camels-exercise.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/plugin-css-minimizer': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+types: simplify BundlerChain and BundlerConfig

--- a/packages/core/src/plugins/externals.ts
+++ b/packages/core/src/plugins/externals.ts
@@ -1,4 +1,3 @@
-import type { BundlerConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export function pluginExternals(): RsbuildPlugin {
@@ -13,7 +12,7 @@ export function pluginExternals(): RsbuildPlugin {
       });
 
       api.onBeforeCreateCompiler(({ bundlerConfigs }) => {
-        (bundlerConfigs as BundlerConfig[]).forEach((config) => {
+        bundlerConfigs.forEach((config) => {
           const isWebWorker = Array.isArray(config.target)
             ? config.target.includes('webworker')
             : config.target === 'webworker';

--- a/packages/core/src/rspack-provider/core/initConfigs.ts
+++ b/packages/core/src/rspack-provider/core/initConfigs.ts
@@ -5,6 +5,7 @@ import {
   initPlugins,
   mergeRsbuildConfig,
   type PluginStore,
+  type RspackConfig,
   type InspectConfigOptions,
   type CreateRsbuildOptions,
 } from '@rsbuild/shared';
@@ -35,7 +36,9 @@ export async function initConfigs({
   context,
   pluginStore,
   rsbuildOptions,
-}: InitConfigsOptions) {
+}: InitConfigsOptions): Promise<{
+  rspackConfigs: RspackConfig[];
+}> {
   await initPlugins({
     pluginAPI: context.pluginAPI,
     pluginStore,

--- a/packages/core/src/rspack-provider/core/rspackConfig.ts
+++ b/packages/core/src/rspack-provider/core/rspackConfig.ts
@@ -2,7 +2,6 @@ import {
   debug,
   CHAIN_ID,
   castArray,
-  BundlerConfig,
   modifyBundlerChain,
   mergeChainedOptions,
   type NodeEnv,
@@ -104,24 +103,13 @@ async function getChainUtils(target: RsbuildTarget): Promise<ModifyChainUtils> {
   };
 }
 
-/**
- * BundlerConfig type is similar to WebpackConfig.
- *
- * The type is not strictly compatible with rspack, such as devtool (string or const).
- *
- * There is no need to consider it in Rsbuild, and it is handed over to rspack for verification
- */
-const convertToRspackConfig = (config: BundlerConfig): RspackConfig => {
-  return config as unknown as RspackConfig;
-};
-
 export async function generateRspackConfig({
   target,
   context,
 }: {
   target: RsbuildTarget;
   context: Context;
-}) {
+}): Promise<RspackConfig> {
   const chainUtils = await getChainUtils(target);
   const { BannerPlugin, DefinePlugin, ProvidePlugin } = await import(
     '@rspack/core'
@@ -136,7 +124,7 @@ export async function generateRspackConfig({
     },
   });
 
-  let rspackConfig = convertToRspackConfig(chain.toConfig());
+  let rspackConfig = chain.toConfig();
 
   rspackConfig = await modifyRspackConfig(
     context,

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -38,12 +38,7 @@ export async function applyCSSMinimizer(
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.CSS)
-    .use(CssMinimizerPlugin, [
-      // Due to css-minimizer-webpack-plugin has changed the type of class, which using a generic type in
-      // constructor, leading auto inference of parameters of plugin constructor is not possible
-      // @ts-expect-error
-      mergedOptions,
-    ])
+    .use(CssMinimizerPlugin, [mergedOptions])
     .end();
 }
 

--- a/packages/shared/src/types/bundlerConfig.ts
+++ b/packages/shared/src/types/bundlerConfig.ts
@@ -13,107 +13,6 @@ export interface BundlerPluginInstance {
   }) => void;
 }
 
-type SplitChunks = Configuration extends {
-  optimization?: {
-    splitChunks?: infer P;
-  };
-}
-  ? P
-  : never;
-
-type WebpackOptimization = NonNullable<Configuration['optimization']>;
-type WebpackResolve = NonNullable<Configuration['resolve']>;
-type WebpackOutput = NonNullable<Configuration['output']>;
-type WebpackInfrastructureLogging = NonNullable<
-  Configuration['infrastructureLogging']
->;
-
-// fork from the @rspack/core
-type RspackResolve = {
-  preferRelative?: boolean;
-  extensions?: string[];
-  mainFiles?: string[];
-  mainFields?: string[];
-  browserField?: boolean;
-  conditionNames?: string[];
-  alias?: Record<string, false | string | string[]>;
-  tsConfigPath?: string;
-  modules?: string[];
-  fallback?: Record<string, false | string>;
-};
-
-// fork from the @rspack/core
-type RspackOutput = {
-  libraryTarget?: string;
-  path?: string;
-  publicPath?: string;
-  assetModuleFilename?: string;
-  filename?: string;
-  chunkFilename?: string;
-  uniqueName?: string;
-  hashFunction?: string;
-  cssFilename?: string;
-  cssChunkFilename?: string;
-  library?: string;
-  chunkLoadingGlobal?: string;
-  crossOriginLoading?: false | 'anonymous' | 'use-credentials';
-};
-
-// fork from the @rspack/core
-type FilterTypes = FilterItemTypes[] | FilterItemTypes;
-type FilterItemTypes = RegExp | string | ((value: string) => boolean);
-export interface RspackInfrastructureLogging {
-  appendOnly?: boolean;
-  colors?: boolean;
-  console?: Console;
-  debug?: boolean | FilterTypes;
-  level?: 'none' | 'error' | 'warn' | 'info' | 'log' | 'verbose';
-  stream?: NodeJS.WritableStream;
-}
-
-type Overlap<
-  T extends Record<string, any>,
-  E extends Record<string, any>,
-  Key extends Extract<keyof T, keyof E> = Extract<keyof T, keyof E>,
-> = {
-  [key in Key]: Extract<E[key], T[key]>;
-};
-
-type Resolve = Overlap<WebpackResolve, RspackResolve>;
-type Output = Overlap<WebpackOutput, RspackOutput>;
-type InfrastructureLogging = Overlap<
-  WebpackInfrastructureLogging,
-  RspackInfrastructureLogging
->;
-
-type Externals = Configuration['externals'];
-
-/** The intersection of webpack and Rspack */
-export type BundlerConfig = {
-  name?: string;
-  entry?: Record<string, string | string[]>;
-  context?: Configuration['context'];
-  plugins?: BundlerPluginInstance[];
-  module?: Configuration['module'];
-  target?: Configuration['target'];
-  mode?: Configuration['mode'];
-  externals?: Externals;
-  externalsType?: Configuration['externalsType'];
-  externalsPresets?: Configuration['externalsPresets'];
-  output?: Output;
-  resolve?: Resolve;
-  devtool?: Configuration['devtool'];
-  infrastructureLogging?: InfrastructureLogging;
-  //   stats?: StatsOptions;
-  //   snapshot?: Snapshot;
-  cache?: Configuration['cache'];
-  optimization?: {
-    splitChunks: SplitChunks;
-    runtimeChunk?: WebpackOptimization['runtimeChunk'];
-  };
-  //   experiments?: RawExperiments;
-};
-
 // excludeAny: any extends boolean/string/xxx ? A : B  => A | B;
 type ExtendsExcludeAny<T, E> = T extends any
   ? T extends E
@@ -155,50 +54,22 @@ export interface BundlerChain
     | 'plugins'
     | 'entryPoints'
     | 'mode'
+    | 'module'
     | 'context'
+    | 'externals'
     | 'externalsType'
     | 'externalsPresets'
     | 'entry'
     | 'get'
+    | 'output'
+    | 'resolve'
+    | 'optimization'
     | 'experiments'
     | 'profile'
     | 'ignoreWarnings'
+    | 'infrastructureLogging'
   > {
-  toConfig: () => BundlerConfig;
-  optimization: WebpackChain['optimization'];
-  externals: (value: Externals) => BundlerChain;
-  resolve: PickAndModifyThis<
-    WebpackChain['resolve'],
-    | Extract<
-        Extract<keyof WebpackResolve, keyof RspackResolve>,
-        keyof WebpackChain['resolve']
-      >
-    | 'merge'
-    | 'get'
-  >;
-  output: PickAndModifyThis<
-    WebpackChain['output'],
-    | Extract<
-        Extract<keyof WebpackOutput, keyof RspackOutput>,
-        keyof WebpackChain['output']
-      >
-    | 'get'
-    | 'merge'
-  >;
-  infrastructureLogging: PickAndModifyThis<
-    WebpackChain['infrastructureLogging'],
-    Extract<
-      Extract<
-        keyof WebpackInfrastructureLogging,
-        keyof RspackInfrastructureLogging
-      >,
-      keyof WebpackChain['infrastructureLogging']
-    >
-  >;
-  module: PickAndModifyThis<
-    WebpackChain['module'],
-    'rules' | 'rule' | 'delete' | 'parser'
-  >;
+  toConfig: () => Configuration;
 }
 
 export type WebpackChainRule = WebpackChain.Rule;

--- a/packages/shared/src/types/rspack.ts
+++ b/packages/shared/src/types/rspack.ts
@@ -1,12 +1,25 @@
 import type * as Rspack from '@rspack/core';
 
-type RspackOptions = Rspack.RspackOptions;
+export type { Rspack };
+
+type BuiltinsOptions = NonNullable<Rspack.RspackOptions['builtins']>;
+
+export type RspackConfig = Rspack.RspackOptions & {
+  builtins?: Omit<BuiltinsOptions, 'html'>;
+};
 export type RspackCompiler = Rspack.Compiler;
 export type RspackMultiCompiler = Rspack.MultiCompiler;
 
-export type { Rspack };
+/** T[] => T */
+type GetElementType<T extends any[]> = T extends (infer U)[] ? U : never;
 
-type BuiltinsOptions = NonNullable<RspackOptions['builtins']>;
+export type RspackRule = GetElementType<
+  NonNullable<NonNullable<RspackConfig['module']>['rules']>
+>;
+export type RuleSetRule = Rspack.RuleSetRule;
+export type RspackPluginInstance = GetElementType<
+  NonNullable<RspackConfig['plugins']>
+>;
 
 export type RspackBuiltinsConfig = Omit<
   BuiltinsOptions,
@@ -116,32 +129,3 @@ export type BuiltinSwcLoaderOptions = {
     };
   };
 };
-
-export interface RspackConfig extends RspackOptions {
-  /** multi type is useless in Rsbuild and make get value difficult */
-  entry?: Record<string, string | string[]>;
-  /**
-   * `builtins.react / pluginImport / decorator / presetEnv / emotion / relay` are no longer supported by Rspack,
-   * please migrate to [builtin:swc-loader options](https://rsbuild.dev/guide/advanced/rspack-start.html#5-swc-configuration-support)
-   *
-   * `builtins.html` are no longer supported by Rspack, please use [tools.htmlPlugin](https://rsbuild.dev/api/config-tools.html#toolshtmlplugin) instead.
-   */
-  builtins?: Omit<BuiltinsOptions, 'html'>;
-  /** rspack-dev-server is not used in rsbuild */
-  devServer?: {
-    hot?: boolean;
-  };
-}
-
-/** T[] => T */
-type GetElementType<T extends any[]> = T extends (infer U)[] ? U : never;
-
-export type RspackRule = GetElementType<
-  NonNullable<NonNullable<RspackConfig['module']>['rules']>
->;
-
-export type RuleSetRule = Rspack.RuleSetRule;
-
-export type RspackPluginInstance = GetElementType<
-  NonNullable<RspackConfig['plugins']>
->;

--- a/packages/test-helper/src/rsbuild.ts
+++ b/packages/test-helper/src/rsbuild.ts
@@ -1,7 +1,7 @@
 import type {
+  RspackConfig,
   RsbuildProvider,
   RsbuildPlugin,
-  BundlerConfig,
   RsbuildInstance,
   CreateRsbuildOptions,
   BundlerPluginInstance,
@@ -27,7 +27,7 @@ export function matchLoader({
   loader,
   testFile,
 }: {
-  config: BundlerConfig;
+  config: RspackConfig;
   loader: string;
   testFile: string;
 }): boolean {
@@ -59,7 +59,7 @@ export function matchLoader({
 }
 
 /** Match plugin by constructor name. */
-export const matchPlugin = (config: BundlerConfig, pluginName: string) => {
+export const matchPlugin = (config: RspackConfig, pluginName: string) => {
   const result = config.plugins?.filter(
     (item) => item?.constructor.name === pluginName,
   );
@@ -151,7 +151,7 @@ export async function createStubRsbuild<
   const matchBundlerPlugin = async (pluginName: string) => {
     const config = await unwrapConfig();
 
-    return matchPlugin(config as BundlerConfig, pluginName);
+    return matchPlugin(config, pluginName) as BundlerPluginInstance;
   };
 
   return {


### PR DESCRIPTION
## Summary

Simplify BundlerChain and BundlerConfig, use `RspackConfig` as the default config type.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
