### PR TITLE
refactor(plugin-react): move component chunks to uni-builder

### DIFF
--- a/.changeset/three-dogs-draw.md
+++ b/.changeset/three-dogs-draw.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/uni-builder': patch
+'@rsbuild/plugin-react': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor(plugin-react): move component chunks to uni-builder

--- a/e2e/cases/import-antd-v4/index.test.ts
+++ b/e2e/cases/import-antd-v4/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { expect, test } from '@playwright/test';
 import { build } from '@scripts/shared';
 
@@ -6,6 +5,7 @@ test.setTimeout(120000);
 
 // Skipped
 // we should find a better way to test it without installing antd
+// TODO: uni-builder
 test.skip('should import antd v4 correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/e2e/cases/import-antd-v5/index.test.ts
+++ b/e2e/cases/import-antd-v5/index.test.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { expect, test } from '@playwright/test';
 import { build } from '@scripts/shared';
 
@@ -6,6 +5,7 @@ test.setTimeout(120000);
 
 // Skipped
 // we should find a better way to test it without installing antd
+// TODO: uni-builder
 test.skip('should import antd v5 correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/e2e/cases/import-arco/index.test.ts
+++ b/e2e/cases/import-arco/index.test.ts
@@ -1,9 +1,9 @@
-import path from 'path';
 import { expect, test } from '@playwright/test';
 import { build } from '@scripts/shared';
 
 // Skipped
 // we should find a better way to test it without installing antd
+// TODO: uni-builder
 test.skip('should import arco correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -18,6 +18,7 @@ import { pluginRuntimeChunk } from './plugins/runtimeChunk';
 import { pluginFrameworkConfig } from './plugins/frameworkConfig';
 import { pluginMainFields } from './plugins/mainFields';
 import { pluginExtensionPrefix } from './plugins/extensionPrefix';
+import { pluginSplitChunks } from './plugins/splitChunk';
 
 const GLOBAL_CSS_REGEX = /\.global\.\w+$/;
 
@@ -103,6 +104,7 @@ export function parseCommonConfig<B = 'rspack' | 'webpack'>(
   rsbuildConfig.output = output;
 
   const rsbuildPlugins: RsbuildPlugin[] = [
+    pluginSplitChunks(),
     pluginGlobalVars(uniBuilderConfig.source?.globalVars),
   ];
 

--- a/packages/compat/uni-builder/src/shared/plugins/splitChunk.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/splitChunk.ts
@@ -1,0 +1,55 @@
+import {
+  isPlainObject,
+  isPackageInstalled,
+  createCacheGroups,
+  type SplitChunks,
+} from '@rsbuild/shared';
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const pluginSplitChunks = (): RsbuildPlugin => ({
+  name: 'uni-builder:plugin-split-chunks',
+
+  setup(api) {
+    api.modifyBundlerChain((chain) => {
+      const config = api.getNormalizedConfig();
+      const { chunkSplit } = config.performance || {};
+
+      if (chunkSplit?.strategy !== 'split-by-experience') {
+        return;
+      }
+
+      const currentConfig = chain.optimization.splitChunks.values();
+
+      if (!isPlainObject(currentConfig)) {
+        return;
+      }
+
+      const groups: Record<string, (string | RegExp)[]> = {};
+      const { rootPath } = api.context;
+
+      // Detect if the package is installed in current project
+      // If installed, add the package to cache group
+      if (isPackageInstalled('antd', rootPath)) {
+        groups.antd = ['antd'];
+      }
+      if (isPackageInstalled('@arco-design/web-react', rootPath)) {
+        groups.arco = [/@?arco-design/];
+      }
+      if (isPackageInstalled('@douyinfe/semi-ui', rootPath)) {
+        groups.semi = [/@(ies|douyinfe)[\\/]semi-.*/];
+      }
+
+      if (!Object.keys(groups).length) {
+        return;
+      }
+
+      chain.optimization.splitChunks({
+        ...currentConfig,
+        cacheGroups: {
+          ...(currentConfig as SplitChunks).cacheGroups,
+          ...createCacheGroups(groups),
+        },
+      });
+    });
+  },
+});

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import {
   NODE_MODULES_REGEX,
+  createDependenciesRegExp,
   getPackageNameFromModulePath,
   type Polyfill,
   type CacheGroup,
@@ -63,19 +64,6 @@ function getUserDefinedCacheGroups(forceSplitting: ForceSplitting): CacheGroup {
 
   return cacheGroups;
 }
-
-const DEPENDENCY_MATCH_TEMPL = /[\\/]node_modules[\\/](<SOURCES>)[\\/]/.source;
-
-/** Expect to match path just like "./node_modules/react-router/" */
-export const createDependenciesRegExp = (
-  ...dependencies: (string | RegExp)[]
-) => {
-  const sources = dependencies.map((d) =>
-    typeof d === 'string' ? d : d.source,
-  );
-  const expr = DEPENDENCY_MATCH_TEMPL.replace('<SOURCES>', sources.join('|'));
-  return new RegExp(expr);
-};
 
 function splitByExperience(ctx: SplitChunksContext): SplitChunks {
   const { override, polyfill, defaultConfig, userDefinedCacheGroups } = ctx;

--- a/packages/core/tests/plugins/splitChunks.test.ts
+++ b/packages/core/tests/plugins/splitChunks.test.ts
@@ -1,20 +1,5 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import {
-  pluginSplitChunks,
-  createDependenciesRegExp,
-} from '@src/plugins/splitChunks';
-
-test('createDependenciesRegExp', () => {
-  const cases = {
-    'react,react-dom,history':
-      /[\\/]node_modules[\\/](react|react-dom|history)[\\/]/,
-    '@babel/runtime': /[\\/]node_modules[\\/](@babel\/runtime)[\\/]/,
-  };
-  for (const [deps, expected] of Object.entries(cases)) {
-    const actual = createDependenciesRegExp(...deps.split(','));
-    expect(actual).toEqual(expected);
-  }
-});
+import { pluginSplitChunks } from '@src/plugins/splitChunks';
 
 describe('plugin-split-chunks', () => {
   const cases = [

--- a/packages/document/docs/en/guide/optimization/split-chunk.md
+++ b/packages/document/docs/en/guide/optimization/split-chunk.md
@@ -27,9 +27,6 @@ Rsbuild adopts the `split-by-experience` strategy by default, which is a strateg
 - `lib-react.js`: includes `react`, `react-dom`, `scheduler`.
 - `lib-router.js`: includes `react-router`, `react-router-dom`, `history`, `@remix-run/router`.
 - `lib-lodash.js`: includes `lodash`, `lodash-es`.
-- `lib-antd.js`: includes `antd`.
-- `lib-arco.js`: includes `@arco-design/web-react` and related packages under the `@arco-design` organization.
-- `lib-semi.js`: includes `@douyinfe/semi-ui` and related packages under the `@ies` & `@douyinfe` organization.
 - `lib-axios.js`: includes `axios` and related packages.
 
 This strategy groups commonly used packages and then splits them into separate chunks. Generally, the number of chunks is not large, which is suitable for most applications and is also our recommended strategy.

--- a/packages/document/docs/en/shared/config/performance/chunkSplit.md
+++ b/packages/document/docs/en/shared/config/performance/chunkSplit.md
@@ -52,9 +52,7 @@ Rsbuild adopts the `split-by-experience` strategy by default, which is a strateg
 - `lib-react.js`: includes `react`, `react-dom`, `scheduler`.
 - `lib-router.js`: includes `react-router`, `react-router-dom`, `history`, `@remix-run/router`.
 - `lib-lodash.js`: includes `lodash`, `lodash-es`.
-- `lib-antd.js`: includes `antd`.
-- `lib-arco.js`: includes `@arco-design/web-react`.
-- `lib-semi.js`: includes `@douyinfe/semi-ui`.
+- `lib-axios.js`: includes `axios` and related packages.
 
 :::tip
 If the above npm packages are not installed or used in the project, the corresponding chunk will not be generated.

--- a/packages/document/docs/zh/guide/optimization/split-chunk.md
+++ b/packages/document/docs/zh/guide/optimization/split-chunk.md
@@ -27,9 +27,6 @@ Rsbuild 默认采用 `split-by-experience` 策略，这是我们根据经验制�
 - `lib-react.js`：包含 `react`，`react-dom`，`scheduler`。
 - `lib-router.js`：包含 `react-router`，`react-router-dom`，`history`，`@remix-run/router`。
 - `lib-lodash.js`：包含 `lodash`，`lodash-es`。
-- `lib-antd.js`：包含 `antd`。
-- `lib-arco.js`：包含 `@arco-design/web-react` 以及 `@arco-design` 组织下相关的包。
-- `lib-semi.js`：包含 `@douyinfe/semi-ui` 以及 `@ies` 和 `@douyinfe` 组织下相关的包。
 - `lib-axios.js`：包含 `axios` 以及相关的包。
 
 这种拆包策略将常用的包进行分组，然后拆分为单独的 chunk，一般 chunk 的数量不会很多，适合绝大部分应用，同时也是我们推荐的拆包策略。

--- a/packages/document/docs/zh/shared/config/performance/chunkSplit.md
+++ b/packages/document/docs/zh/shared/config/performance/chunkSplit.md
@@ -52,9 +52,7 @@ Rsbuild 默认采用 `split-by-experience` 策略，这是我们根据经验制�
 - `lib-react.js`：包含 `react`，`react-dom`，`scheduler`。
 - `lib-router.js`：包含 `react-router`，`react-router-dom`，`history`，`@remix-run/router`。
 - `lib-lodash.js`：包含 `lodash`，`lodash-es`。
-- `lib-antd.js`：包含 `antd`。
-- `lib-arco.js`：包含 `@arco-design/web-react`。
-- `lib-semi.js`：包含 `@douyinfe/semi-ui`。
+- `lib-axios.js`：包含 `axios` 以及相关的包。
 
 :::tip
 如果项目中没有安装或引用以上 npm 包，则不会生成相应的 chunk。

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -1,63 +1,13 @@
-import { createDependenciesRegExp } from '@rsbuild/core/plugins/splitChunks';
 import type { RsbuildPluginAPI } from '@rsbuild/core';
 import {
   isProd,
-  isPackageInstalled,
   isPlainObject,
-  type CacheGroup,
+  createCacheGroups,
   type SplitChunks,
 } from '@rsbuild/shared';
 
-export async function splitByExperience(rootPath: string): Promise<CacheGroup> {
-  const experienceCacheGroup: CacheGroup = {};
-
-  const packageRegExps: Record<string, RegExp> = {
-    react: createDependenciesRegExp(
-      'react',
-      'react-dom',
-      'scheduler',
-      ...(isProd()
-        ? []
-        : ['react-refresh', '@pmmmwh/react-refresh-webpack-plugin']),
-    ),
-    router: createDependenciesRegExp(
-      'react-router',
-      'react-router-dom',
-      '@remix-run/router',
-      'history',
-    ),
-  };
-
-  // Detect if the package is installed in current project
-  // If installed, add the package to cache group
-  if (isPackageInstalled('antd', rootPath)) {
-    packageRegExps.antd = createDependenciesRegExp('antd');
-  }
-  if (isPackageInstalled('@arco-design/web-react', rootPath)) {
-    packageRegExps.arco = createDependenciesRegExp(/@?arco-design/);
-  }
-  if (isPackageInstalled('@douyinfe/semi-ui', rootPath)) {
-    packageRegExps.semi = createDependenciesRegExp(
-      /@(ies|douyinfe)[\\/]semi-.*/,
-    );
-  }
-
-  Object.entries(packageRegExps).forEach(([name, test]) => {
-    const key = `lib-${name}`;
-
-    experienceCacheGroup[key] = {
-      test,
-      priority: 0,
-      name: key,
-      reuseExistingChunk: true,
-    };
-  });
-
-  return experienceCacheGroup;
-}
-
 export const applySplitChunksRule = (api: RsbuildPluginAPI) => {
-  api.modifyBundlerChain(async (chain) => {
+  api.modifyBundlerChain((chain) => {
     const config = api.getNormalizedConfig();
     const { chunkSplit } = config.performance || {};
 
@@ -67,15 +17,33 @@ export const applySplitChunksRule = (api: RsbuildPluginAPI) => {
 
     const currentConfig = chain.optimization.splitChunks.values();
 
-    if (isPlainObject(currentConfig)) {
-      const extraGroups = await splitByExperience(api.context.rootPath);
-      chain.optimization.splitChunks({
-        ...currentConfig,
-        cacheGroups: {
-          ...(currentConfig as SplitChunks).cacheGroups,
-          ...extraGroups,
-        },
-      });
+    if (!isPlainObject(currentConfig)) {
+      return;
     }
+
+    const extraGroups = createCacheGroups({
+      react: [
+        'react',
+        'react-dom',
+        'scheduler',
+        ...(isProd()
+          ? []
+          : ['react-refresh', '@pmmmwh/react-refresh-webpack-plugin']),
+      ],
+      router: [
+        'react-router',
+        'react-router-dom',
+        '@remix-run/router',
+        'history',
+      ],
+    });
+
+    chain.optimization.splitChunks({
+      ...currentConfig,
+      cacheGroups: {
+        ...(currentConfig as SplitChunks).cacheGroups,
+        ...extraGroups,
+      },
+    });
   });
 };

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -3,18 +3,6 @@
 exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is installed 1`] = `
 {
   "cacheGroups": {
-    "lib-antd": {
-      "name": "lib-antd",
-      "priority": 0,
-      "reuseExistingChunk": true,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(antd\\)\\[\\\\\\\\/\\]/,
-    },
-    "lib-arco": {
-      "name": "lib-arco",
-      "priority": 0,
-      "reuseExistingChunk": true,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(@\\?arco-design\\)\\[\\\\\\\\/\\]/,
-    },
     "lib-axios": {
       "name": "lib-axios",
       "priority": 0,
@@ -44,12 +32,6 @@ exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is i
       "priority": 0,
       "reuseExistingChunk": true,
       "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react-router\\|react-router-dom\\|@remix-run\\\\/router\\|history\\)\\[\\\\\\\\/\\]/,
-    },
-    "lib-semi": {
-      "name": "lib-semi",
-      "priority": 0,
-      "reuseExistingChunk": true,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(@\\(ies\\|douyinfe\\)\\[\\\\\\\\/\\]semi-\\.\\*\\)\\[\\\\\\\\/\\]/,
     },
   },
   "chunks": "all",

--- a/packages/shared/src/pluginStore.ts
+++ b/packages/shared/src/pluginStore.ts
@@ -24,7 +24,9 @@ export function createPluginStore(): PluginStore {
         );
       }
       if (plugins.find((item) => item.name === newPlugin.name)) {
-        logger.warn(`Plugin "${newPlugin.name}" already exists.`);
+        logger.warn(
+          `Rsbuild plugin "${newPlugin.name}" registered multiple times.`,
+        );
       } else if (before) {
         const index = plugins.findIndex((item) => item.name === before);
         if (index === -1) {

--- a/packages/shared/tests/utils.test.ts
+++ b/packages/shared/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { awaitableGetter, camelCase } from '../src';
+import { awaitableGetter, camelCase, createDependenciesRegExp } from '../src';
 
 describe('awaitableGetter', () => {
   it('should work', async () => {
@@ -30,4 +30,16 @@ describe('camelCase', () => {
   test('should handle single-word input', () => {
     expect(camelCase('single')).toBe('single');
   });
+});
+
+test('createDependenciesRegExp', () => {
+  const cases = {
+    'react,react-dom,history':
+      /[\\/]node_modules[\\/](react|react-dom|history)[\\/]/,
+    '@babel/runtime': /[\\/]node_modules[\\/](@babel\/runtime)[\\/]/,
+  };
+  for (const [deps, expected] of Object.entries(cases)) {
+    const actual = createDependenciesRegExp(...deps.split(','));
+    expect(actual).toEqual(expected);
+  }
 });


### PR DESCRIPTION
## Summary

Move component chunks to uni-builder.

Split UI components to chunks is not a best practice for all cases.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
