### PR TITLE
fix: rsbuild doctor temporarily compatible with rspack canary version.

### DIFF
--- a/.changeset/brave-falcons-perform.md
+++ b/.changeset/brave-falcons-perform.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/doctor-core': patch
+---
+
+fix: sbuild doctor temporarily compatible with rspack canary version.

--- a/packages/doctor-core/src/inner-plugins/plugins/loader.ts
+++ b/packages/doctor-core/src/inner-plugins/plugins/loader.ts
@@ -134,7 +134,7 @@ export class InternalLoaderPlugin<
     ) {
       // webpack5 or rspack
       compiler.webpack.NormalModule.getCompilationHooks(
-        compilation,
+        compilation as any, // TODO: compatible the @rspack/core@0.3.14-canary-f95d6cb-20231120024209
       ).loader.intercept(interceptor);
     } else if ('normalModuleLoader' in compilation.hooks) {
       // webpack4

--- a/packages/doctor-core/src/inner-plugins/plugins/progress.ts
+++ b/packages/doctor-core/src/inner-plugins/plugins/progress.ts
@@ -31,7 +31,7 @@ export class InternalProgressPlugin<
           });
         },
       });
-      progress.apply(compiler);
+      progress.apply(compiler as any); // TODO: compatible the @rspack/core@0.3.14-canary-f95d6cb-20231120024209
     }
   }
 }


### PR DESCRIPTION
## Summary
rsbuild doctor temporarily compatible with rspack canary version.

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
