### PR TITLE
perf: bump html-rspack-plugin v5.5.7 to reduce deps

### DIFF
--- a/.changeset/warm-donuts-compete.md
+++ b/.changeset/warm-donuts-compete.md
@@ -1,0 +1,10 @@
+---
+'@rsbuild/plugin-assets-retry': patch
+'@rsbuild/plugin-source-build': patch
+'@rsbuild/webpack': patch
+'@rsbuild/plugin-rem': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+perf: bump html-rspack-plugin v5.5.7 to reduce deps

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -51,7 +51,7 @@
     "fast-glob": "^3.3.1",
     "glob": "^9.3.5",
     "globby": "^11.1.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "lodash": "^4.17.21",
     "mini-css-extract-plugin": "2.7.6",
     "postcss": "8.4.31",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,7 @@
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.3.14",
     "core-js": "~3.32.2",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "http-proxy-middleware": "^2.0.1",
     "postcss": "8.4.31",
     "semver": "^7.5.4",

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -36,7 +36,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
     "@types/serialize-javascript": "^5.0.1",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "terser": "5.19.2",
     "typescript": "^5.2.2"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "typescript": "^5.2.2"
   },
   "publishConfig": {

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -88,7 +88,7 @@ export function pluginSourceBuild(
           // webpack.js.org/configuration/module/#ruleresolve
           chain.module
             .rule(useTsLoader ? CHAIN_ID.RULE.TS : CHAIN_ID.RULE.JS)
-            // source > webpack default mainFiedls.
+            // source > webpack default mainFields.
             // when source is not exist, other mainFields will effect.
             .resolve.mainFields.merge([sourceField, '...']);
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -107,7 +107,7 @@
     "@rspack/core": "0.3.14",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.5",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "http-proxy-middleware": "^2.0.1",
     "terser": "5.19.2",
     "terser-webpack-plugin": "5.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,8 +601,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.5.5
-        version: /html-rspack-plugin@5.5.5
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -662,8 +662,8 @@ importers:
         specifier: ~3.32.2
         version: 3.32.2
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.5.5
-        version: /html-rspack-plugin@5.5.5
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       http-proxy-middleware:
         specifier: ^2.0.1
         version: 2.0.6
@@ -1355,8 +1355,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.4
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.5.5
-        version: /html-rspack-plugin@5.5.5
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       terser:
         specifier: 5.19.2
         version: 5.19.2
@@ -1579,8 +1579,8 @@ importers:
         specifier: workspace:*
         version: link:../test-helper
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.5.5
-        version: /html-rspack-plugin@5.5.5
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -1857,8 +1857,8 @@ importers:
         specifier: ^16
         version: 16.18.59
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.5.5
-        version: /html-rspack-plugin@5.5.5
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       http-proxy-middleware:
         specifier: ^2.0.1
         version: 2.0.6
@@ -7609,12 +7609,6 @@ packages:
       safe-buffer: 5.2.1
     dev: false
 
-  /clean-css@5.3.2:
-    resolution: {integrity: sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==}
-    engines: {node: '>= 10.0'}
-    dependencies:
-      source-map: 0.6.1
-
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -7726,6 +7720,7 @@ packages:
   /commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
+    dev: true
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -9926,23 +9921,10 @@ packages:
   /html-entities@2.4.0:
     resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
 
-  /html-minifier-terser@7.2.0:
-    resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
-    engines: {node: ^14.13.1 || >=16.0.0}
-    dependencies:
-      camel-case: 4.1.2
-      clean-css: 5.3.2
-      commander: 10.0.1
-      entities: 4.5.0
-      param-case: 3.0.4
-      relateurl: 0.2.7
-      terser: 5.19.2
-
-  /html-rspack-plugin@5.5.5:
-    resolution: {integrity: sha512-IXwQK2HcH2GYdqlW4lwzhXStXNqhvOjd0fwOto7H4wBE+xN8F2b9aVCR2zkhxTxs1G09b4tBqehD7cOWiAhNeQ==}
+  /html-rspack-plugin@5.5.7:
+    resolution: {integrity: sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==}
     engines: {node: '>=10.13.0'}
     dependencies:
-      html-minifier-terser: 7.2.0
       lodash: 4.17.21
       tapable: 2.2.1
 
@@ -13318,10 +13300,6 @@ packages:
       hast-util-to-html: 8.0.4
       unified: 10.1.2
     dev: true
-
-  /relateurl@0.2.7:
-    resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
-    engines: {node: '>= 0.10'}
 
   /remark-gfm@3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}


### PR DESCRIPTION
## Summary

Bump html-rspack-plugin v5.5.7 to reduce deps.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
