### PR TITLE
perf: create Compiler instead of MultiCompiler when target length is 1

### DIFF
--- a/.changeset/witty-taxis-beam.md
+++ b/.changeset/witty-taxis-beam.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+perf: create Compiler instead of MultiCompiler when target length is 1

--- a/packages/core/tests/rspack-provider/createCompiler.test.ts
+++ b/packages/core/tests/rspack-provider/createCompiler.test.ts
@@ -1,0 +1,34 @@
+import { createCompiler } from '@/core/createCompiler';
+import { createContext } from '@/core/createContext';
+
+describe('createCompiler', () => {
+  const createDefaultContext = () =>
+    createContext(
+      {
+        cwd: process.cwd(),
+        target: ['web'],
+      },
+      {
+        source: {
+          entry: {
+            index: './src/index.js',
+          },
+        },
+      },
+    );
+
+  test('should return Compiler when passing single rspack config', async () => {
+    const compiler = await createCompiler({
+      context: await createDefaultContext(),
+      rspackConfigs: [{}],
+    });
+    expect(compiler.constructor.name).toEqual('Compiler');
+  });
+  test('should return MultiCompiler when passing multiple rspack configs', async () => {
+    const compiler = await createCompiler({
+      context: await createDefaultContext(),
+      rspackConfigs: [{}, {}],
+    });
+    expect(compiler.constructor.name).toEqual('MultiCompiler');
+  });
+});


### PR DESCRIPTION
## Summary

create Compiler instead of MultiCompiler when target length is 1:
<img width="1342" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/5c904723-4b5c-44ef-9586-69f2c4ddd9ee">


## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
