### PR TITLE
fix(rsbuild-doctor): rsbuild doctor compatible with rspack canary version.

### DIFF
--- a/.changeset/nine-pumpkins-hear.md
+++ b/.changeset/nine-pumpkins-hear.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/doctor-types': patch
+'@rsbuild/doctor-core': patch
+---
+
+fix: rsbuild doctor compatible with rspack canary version

--- a/packages/doctor-core/src/inner-plugins/plugins/loader.ts
+++ b/packages/doctor-core/src/inner-plugins/plugins/loader.ts
@@ -134,7 +134,7 @@ export class InternalLoaderPlugin<
     ) {
       // webpack5 or rspack
       compiler.webpack.NormalModule.getCompilationHooks(
-        compilation as any, // TODO: compatible the @rspack/core@0.3.14-canary-f95d6cb-20231120024209
+        compilation,
       ).loader.intercept(interceptor);
     } else if ('normalModuleLoader' in compilation.hooks) {
       // webpack4

--- a/packages/doctor-core/src/inner-plugins/plugins/progress.ts
+++ b/packages/doctor-core/src/inner-plugins/plugins/progress.ts
@@ -31,7 +31,7 @@ export class InternalProgressPlugin<
           });
         },
       });
-      progress.apply(compiler as any); // TODO: compatible the @rspack/core@0.3.14-canary-f95d6cb-20231120024209
+      progress.apply(compiler);
     }
   }
 }

--- a/packages/doctor-types/src/plugin/baseCompiler.ts
+++ b/packages/doctor-types/src/plugin/baseCompiler.ts
@@ -13,7 +13,7 @@ import type {
   RuleSetRules,
 } from '@rspack/core';
 
-export type BaseCompiler = Compiler | RspackCompiler;
+export type BaseCompiler = (Compiler | RspackCompiler) & { webpack: any };
 
 export type BaseCompilation = RspackCompilation | Compilation;
 


### PR DESCRIPTION
## Summary
rsbuild doctor compatible with rspack canary version.
because rspack's compiler.webpack type  changes from:
```ts
webpack: any;

````

to

```ts
 webpack: typeof import("./rspack").rspack & typeof import("./exports");

```

## Related Issue
#607
<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
