### PR TITLE
perf: reduce aggregateTimeout to speed up HMR

### DIFF
--- a/.changeset/fifty-bobcats-love.md
+++ b/.changeset/fifty-bobcats-love.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/plugin-react': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+perf: reduce aggregateTimeout to speed up HMR

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -117,6 +117,9 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
   "performance": {
     "hints": false,
   },
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 
@@ -138,6 +141,9 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
   "name": "Client",
   "performance": {
     "hints": false,
+  },
+  "watchOptions": {
+    "aggregateTimeout": 5,
   },
 }
 `;
@@ -161,6 +167,9 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
   "performance": {
     "hints": false,
   },
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 
@@ -182,6 +191,9 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
   "name": "Client",
   "performance": {
     "hints": false,
+  },
+  "watchOptions": {
+    "aggregateTimeout": 5,
   },
 }
 `;
@@ -205,6 +217,9 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
   "performance": {
     "hints": false,
   },
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 
@@ -226,6 +241,9 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
   "name": "Client",
   "performance": {
     "hints": false,
+  },
+  "watchOptions": {
+    "aggregateTimeout": 5,
   },
 }
 `;
@@ -586,6 +604,9 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
   "name": "Client",
   "performance": {
     "hints": false,
+  },
+  "watchOptions": {
+    "aggregateTimeout": 5,
   },
 }
 `;

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -693,6 +693,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 

--- a/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
@@ -963,5 +963,8 @@ exports[`plugins/react > should work with ts-loader 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -678,5 +678,8 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -678,6 +678,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 
@@ -1836,6 +1839,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     ],
   },
   "target": "node",
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;
 
@@ -2528,5 +2534,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -723,5 +723,8 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "web",
     "es5",
   ],
+  "watchOptions": {
+    "aggregateTimeout": 5,
+  },
 }
 `;

--- a/packages/shared/src/apply/basic.ts
+++ b/packages/shared/src/apply/basic.ts
@@ -15,5 +15,13 @@ export function applyBasicPlugin(api: SharedRsbuildPluginAPI) {
         level: 'error',
       },
     });
+
+    if (!isProd) {
+      chain.watchOptions({
+        // The default aggregateTimeout of WatchPack is 200ms,
+        // using smaller values can improve hmr performance
+        aggregateTimeout: 5,
+      });
+    }
   });
 }


### PR DESCRIPTION
## Summary

The default aggregateTimeout of WatchPack is 200ms, using smaller values can improve hmr performance.

## Related Issue

https://github.com/webpack/watchpack

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
