### PR TITLE
fix(server): should fallback success when distPath is absolute

### DIFF
--- a/.changeset/rude-buttons-carry.md
+++ b/.changeset/rude-buttons-carry.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(server): should fallback success when distPath is absolute

--- a/e2e/cases/dev/html-fallback.test.ts
+++ b/e2e/cases/dev/html-fallback.test.ts
@@ -330,3 +330,33 @@ test('should access /main success when modify publicPath in compiler', async ({
 
   await rsbuild.server.close();
 });
+
+test('should access /main success when distPath is absolute', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'basic', 'src/index.ts'),
+        },
+      },
+      output: {
+        distPath: {
+          root: join(fixtures, 'basic', 'dist-html-fallback-7'),
+        },
+      },
+    },
+  });
+
+  // access /main success
+  const url = new URL(`http://localhost:${rsbuild.port}/main`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -31,7 +31,7 @@ import {
   getHtmlFallbackMiddleware,
   notFoundMiddleware,
 } from './middlewares';
-import { join } from 'path';
+import { join, isAbsolute } from 'path';
 import { registerCleaner } from './restart';
 
 export class RsbuildDevServer {
@@ -138,9 +138,11 @@ export class RsbuildDevServer {
 
     devMiddleware.middleware && this.middlewares.use(devMiddleware.middleware);
 
+    const { distPath } = this.output;
+
     this.middlewares.use(
       getHtmlFallbackMiddleware({
-        distPath: join(this.pwd, this.output.distPath),
+        distPath: isAbsolute(distPath) ? distPath : join(this.pwd, distPath),
         publicPath: this.output.publicPath,
         callback: devMiddleware.middleware,
       }),


### PR DESCRIPTION
## Summary

should not join pwd and distPath when distPath is absolute
<img width="776" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/1e342020-27cd-4a3c-9874-b9ac582164cc">

## Related Issue

<!--- Provide link of related issues -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
