### PR TITLE
feat(cli): set 300ms debounce to avoid restart frequently

### DIFF
--- a/.changeset/polite-tips-melt.md
+++ b/.changeset/polite-tips-melt.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+feat(cli): set 300ms debounce to avoid restart frequently

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,8 @@
 ## Summary
 
+## Related Links
 
-## Related Issue
-
-<!--- Provide link of related issues -->
+<!--- Provide links of related issues or pages -->
 
 ## Checklist
 

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -3,6 +3,7 @@ import { isAbsolute, join } from 'path';
 import {
   color,
   logger,
+  debounce,
   type RsbuildConfig as BaseRsbuildConfig,
 } from '@rsbuild/shared';
 import { restartDevServer } from '../server/restart';
@@ -51,11 +52,20 @@ const resolveConfigPath = (customConfig?: string) => {
 
 async function watchConfig(configFile: string) {
   const chokidar = await import('@rsbuild/shared/chokidar');
-  const watcher = chokidar.watch(configFile, {});
-  const callback = async () => {
-    watcher.close();
-    await restartDevServer({ filePath: configFile });
-  };
+
+  const watcher = chokidar.watch(configFile, {
+    // If watching fails due to read permissions, the errors will be suppressed silently.
+    ignorePermissionErrors: true,
+  });
+
+  const callback = debounce(
+    async () => {
+      watcher.close();
+      await restartDevServer({ filePath: configFile });
+    },
+    // set 300ms debounce to avoid restart frequently
+    300,
+  );
 
   watcher.on('change', callback);
   watcher.on('unlink', callback);

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -180,3 +180,20 @@ export function createCacheGroups(
 
   return experienceCacheGroup;
 }
+
+export function debounce<T extends (...args: any[]) => void>(
+  func: T,
+  wait: number,
+): (...args: Parameters<T>) => void {
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+    }
+
+    timeoutId = setTimeout(() => {
+      func(...args);
+    }, wait);
+  };
+}


### PR DESCRIPTION
## Summary

Set 300ms debounce to avoid restart CLI frequently.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
