### PR TITLE
fix(cli): should not exit process when editing config file

### DIFF
--- a/.changeset/swift-days-kiss.md
+++ b/.changeset/swift-days-kiss.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(cli): should not exit process when editing config file

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -77,20 +77,25 @@ export async function loadConfig(
   const configFile = resolveConfigPath(customConfig);
 
   if (configFile) {
-    const { default: jiti } = await import('../../compiled/jiti');
-    const loadConfig = jiti(__filename, {
-      esmResolve: true,
-      // disable require cache to support restart CLI and read the new config
-      requireCache: false,
-      interopDefault: true,
-    });
+    try {
+      const { default: jiti } = await import('../../compiled/jiti');
+      const loadConfig = jiti(__filename, {
+        esmResolve: true,
+        // disable require cache to support restart CLI and read the new config
+        requireCache: false,
+        interopDefault: true,
+      });
 
-    const command = process.argv[2];
-    if (command === 'dev') {
-      watchConfig(configFile);
+      const command = process.argv[2];
+      if (command === 'dev') {
+        watchConfig(configFile);
+      }
+
+      return loadConfig(configFile);
+    } catch (err) {
+      logger.error(`Failed to load file: ${color.dim(configFile)}`);
+      throw err;
     }
-
-    return loadConfig(configFile);
   }
 
   return {};

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -29,7 +29,13 @@ export const restartDevServer = async ({ filePath }: { filePath: string }) => {
     await cleaner();
   }
 
-  const rsbuild = await init();
+  const rsbuild = await init({ isRestart: true });
+
+  // Skip the following logic if restart failed,
+  // maybe user is editing config file and write some invalid config
+  if (!rsbuild) {
+    return;
+  }
 
   await rsbuild.startDevServer();
 };


### PR DESCRIPTION
## Summary

Do not exit process when editing config file.

Maybe user is editing config file and write some invalid config, this should not break the process.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
