### PR TITLE
feat(server): support htmlFallback

### DIFF
--- a/.changeset/heavy-bulldogs-bow.md
+++ b/.changeset/heavy-bulldogs-bow.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat(server): support htmlFallback

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -4,7 +4,9 @@ import { build } from '@scripts/shared';
 
 const fixtures = __dirname;
 
-test('should access / success when entry is index', async ({ page }) => {
+test('should access / and htmlFallback success by default', async ({
+  page,
+}) => {
   const rsbuild = await build({
     cwd: fixtures,
     runServer: true,
@@ -23,6 +25,37 @@ test('should access / success when entry is index', async ({ page }) => {
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
+
+  const url1 = new URL(`http://localhost:${rsbuild.port}/aaaa`);
+
+  await page.goto(url1.href);
+
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});
+
+test('should return 404 when htmlFallback false', async ({ page }) => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    runServer: true,
+    rsbuildConfig: {
+      server: {
+        htmlFallback: false,
+      },
+      output: {
+        distPath: {
+          root: 'dist-0',
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/aaaaa`);
+
+  const res = await page.goto(url.href);
+
+  expect(res?.status()).toBe(404);
 
   await rsbuild.close();
 });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -146,6 +146,7 @@ export class RsbuildDevServer {
         distPath: isAbsolute(distPath) ? distPath : join(this.pwd, distPath),
         publicPath: this.output.publicPath,
         callback: devMiddleware.middleware,
+        htmlFallback: this.dev.htmlFallback,
       }),
     );
 

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -63,13 +63,15 @@ export class RsbuildProdServer {
   private applyStaticAssetMiddleware() {
     const {
       output: { path, assetPrefix },
+      serverConfig: { htmlFallback },
       pwd,
     } = this.options;
 
     const assetMiddleware = sirv(join(pwd, path), {
       etag: true,
       dev: true,
-      ignores: false,
+      ignores: ['favicon.ico'],
+      single: htmlFallback === 'index',
     });
 
     this.middlewares.use((req, res, next) => {

--- a/packages/document/docs/en/config/options/server.mdx
+++ b/packages/document/docs/en/config/options/server.mdx
@@ -7,3 +7,9 @@ This section describes some server configurations in Rsbuild，which will take e
 import Headers from '@en/shared/config/server/headers.md';
 
 <Headers />
+
+## server.htmlFallback
+
+import HtmlFallback from '@en/shared/config/server/htmlFallback.md';
+
+<HtmlFallback />

--- a/packages/document/docs/en/shared/config/server/htmlFallback.md
+++ b/packages/document/docs/en/shared/config/server/htmlFallback.md
@@ -1,0 +1,12 @@
+- **Type:** `false | 'index'`
+- **Default:** `'index'`
+
+Whether to support html fallback. By default, it will fallback to `index.html` when the requested page is not found.
+
+```js
+export default {
+  server: {
+    htmlFallback: 'index',
+  },
+};
+```

--- a/packages/document/docs/zh/config/options/server.mdx
+++ b/packages/document/docs/zh/config/options/server.mdx
@@ -7,3 +7,9 @@
 import Headers from '@zh/shared/config/server/headers.md';
 
 <Headers />
+
+## server.htmlFallback
+
+import HtmlFallback from '@zh/shared/config/server/htmlFallback.md';
+
+<HtmlFallback />

--- a/packages/document/docs/zh/shared/config/server/htmlFallback.md
+++ b/packages/document/docs/zh/shared/config/server/htmlFallback.md
@@ -1,0 +1,12 @@
+- **类型：** `false | 'index'`
+- **默认值：** `'index'`
+
+是否支持页面回退。默认情况下，当请求的页面找不到时会回退到 `index.html`。
+
+```js
+export default {
+  server: {
+    htmlFallback: 'index',
+  },
+};
+```

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -50,7 +50,9 @@ export const getDefaultDevConfig = (): NormalizedDevConfig => ({
   host: DEFAULT_DEV_HOST,
 });
 
-export const getDefaultServerConfig = (): NormalizedServerConfig => ({});
+export const getDefaultServerConfig = (): NormalizedServerConfig => ({
+  htmlFallback: 'index',
+});
 
 export const getDefaultSourceConfig = (): NormalizedSourceConfig => ({
   alias: {},

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,5 +1,9 @@
+export type HtmlFallback = false | 'index';
+
 export interface ServerConfig {
   headers?: Record<string, string | string[]>;
+  htmlFallback?: HtmlFallback;
 }
 
-export type NormalizedServerConfig = ServerConfig;
+export type NormalizedServerConfig = ServerConfig &
+  Required<Pick<ServerConfig, 'htmlFallback'>>;


### PR DESCRIPTION
## Summary

support fallback to `index.html` by default when the requested page is not found.

TODO: support htmlFallback to 'closest'

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
