### PR TITLE
refactor: standardize the naming of official plugins

### DIFF
--- a/.changeset/soft-foxes-fry.md
+++ b/.changeset/soft-foxes-fry.md
@@ -1,0 +1,28 @@
+---
+'@rsbuild/plugin-styled-components': patch
+'@rsbuild/plugin-esbuild': patch
+'@rsbuild/plugin-image-compress': patch
+'@rsbuild/plugin-css-minimizer': patch
+'@rsbuild/plugin-node-polyfill': patch
+'@rsbuild/plugin-assets-retry': patch
+'@rsbuild/plugin-check-syntax': patch
+'@rsbuild/plugin-source-build': patch
+'@rsbuild/uni-builder': patch
+'@rsbuild/plugin-type-check': patch
+'@rsbuild/plugin-vue2-jsx': patch
+'@rsbuild/webpack': patch
+'@rsbuild/plugin-vue-jsx': patch
+'@rsbuild/plugin-stylus': patch
+'@rsbuild/plugin-svelte': patch
+'@rsbuild/plugin-babel': patch
+'@rsbuild/plugin-react': patch
+'@rsbuild/plugin-solid': patch
+'@rsbuild/plugin-svgr': patch
+'@rsbuild/plugin-vue2': patch
+'@rsbuild/plugin-pug': patch
+'@rsbuild/plugin-rem': patch
+'@rsbuild/plugin-vue': patch
+'@rsbuild/core': patch
+---
+
+refactor: standardize the naming of official plugins

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -75,6 +75,13 @@ const updateConfigForTest = <BundlerType>(
     };
   }
 
+  if (config.performance?.printFileSize === undefined) {
+    config.performance = {
+      ...(config.performance || {}),
+      printFileSize: false,
+    };
+  }
+
   // disable polyfill to make the tests faster
   if (config.output?.polyfill === undefined) {
     config.output = {
@@ -126,8 +133,6 @@ export async function build<BundlerType = 'rspack'>({
   updateConfigForTest(rsbuildConfig);
 
   const rsbuild = await createRsbuild(options, rsbuildConfig);
-
-  rsbuild.removePlugins(['plugin-file-size']);
 
   if (plugins) {
     rsbuild.addPlugins(plugins);

--- a/packages/compat/plugin-esbuild/src/index.ts
+++ b/packages/compat/plugin-esbuild/src/index.ts
@@ -14,7 +14,7 @@ export function pluginEsbuild(
   userOptions: PluginEsbuildOptions = {},
 ): RsbuildPlugin {
   return {
-    name: 'plugin-esbuild',
+    name: 'rsbuild-webpack:esbuild',
 
     setup(api) {
       api.modifyWebpackChain(async (chain, { CHAIN_ID, isProd, target }) => {

--- a/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
+++ b/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import { generateManifest } from '../../shared/manifest';
 
 export const pluginManifest = (): RsbuildPlugin => ({
-  name: 'plugin-manifest',
+  name: 'uni-builder:manifest',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/compat/uni-builder/src/shared/plugins/extensionPrefix.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/extensionPrefix.ts
@@ -4,7 +4,7 @@ import type { RsbuildTarget } from '@rsbuild/shared';
 export const pluginExtensionPrefix = (
   prefixInfo: string | Partial<Record<RsbuildTarget, string>>,
 ): RsbuildPlugin => ({
-  name: 'plugin-extension-prefix',
+  name: 'uni-builder:extension-prefix',
 
   setup(api) {
     api.modifyBundlerChain((chain, { target }) => {

--- a/packages/compat/uni-builder/src/shared/plugins/fallback.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/fallback.ts
@@ -67,7 +67,7 @@ const resourceRuleFallback = (
 };
 
 export const pluginFallback = (): RsbuildPlugin => ({
-  name: 'plugin-fallback',
+  name: 'uni-builder:fallback',
 
   setup(api) {
     if (api.context.bundlerType === 'webpack') {

--- a/packages/compat/uni-builder/src/shared/plugins/frameworkConfig.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/frameworkConfig.ts
@@ -2,7 +2,7 @@ import { fse } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginFrameworkConfig = (configPath: string): RsbuildPlugin => ({
-  name: 'plugin-framework-config',
+  name: 'uni-builder:framework-config',
 
   setup(api) {
     api.modifyBundlerChain((chain) => {

--- a/packages/compat/uni-builder/src/shared/plugins/globalVars.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/globalVars.ts
@@ -5,7 +5,7 @@ import type { ChainedGlobalVars } from '../../types';
 export const pluginGlobalVars = (
   options?: ChainedGlobalVars,
 ): RsbuildPlugin => ({
-  name: 'plugin-global-vars',
+  name: 'uni-builder:global-vars',
 
   setup(api) {
     api.modifyBundlerChain((chain, { env, target, bundler }) => {

--- a/packages/compat/uni-builder/src/shared/plugins/mainFields.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/mainFields.ts
@@ -5,7 +5,7 @@ import type { RsbuildTarget } from '@rsbuild/shared';
 export const pluginMainFields = (
   resolveMainFields: MainFields | Partial<Record<RsbuildTarget, MainFields>>,
 ): RsbuildPlugin => ({
-  name: 'plugin-main-fields',
+  name: 'uni-builder:main-fields',
 
   setup(api) {
     api.modifyBundlerChain((chain, { target }) => {

--- a/packages/compat/uni-builder/src/shared/plugins/runtimeChunk.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/runtimeChunk.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import { RUNTIME_CHUNK_NAME } from '../constants';
 
 export const pluginRuntimeChunk = (): RsbuildPlugin => ({
-  name: 'plugin-runtime-chunk',
+  name: 'uni-builder:runtime-chunk',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { target }) => {

--- a/packages/compat/uni-builder/src/shared/plugins/splitChunk.ts
+++ b/packages/compat/uni-builder/src/shared/plugins/splitChunk.ts
@@ -7,7 +7,7 @@ import {
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginSplitChunks = (): RsbuildPlugin => ({
-  name: 'uni-builder:plugin-split-chunks',
+  name: 'uni-builder:split-chunks',
 
   setup(api) {
     api.modifyBundlerChain((chain) => {

--- a/packages/compat/uni-builder/src/webpack/plugins/lazyCompilation.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/lazyCompilation.ts
@@ -10,7 +10,7 @@ export type LazyCompilationOptions =
 export const pluginLazyCompilation = (
   options: LazyCompilationOptions,
 ): RsbuildPlugin => ({
-  name: 'plugin-lazy-compilation',
+  name: 'uni-builder:lazy-compilation',
 
   setup(api) {
     api.modifyWebpackChain((chain, { isProd, isServer, isWebWorker }) => {

--- a/packages/compat/uni-builder/src/webpack/plugins/manifest.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/manifest.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '@rsbuild/webpack';
 import { generateManifest } from '../../shared/manifest';
 
 export const pluginManifest = (): RsbuildPlugin => ({
-  name: 'plugin-manifest',
+  name: 'uni-builder:manifest',
 
   setup(api) {
     api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {

--- a/packages/compat/uni-builder/src/webpack/plugins/moduleScopes.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/moduleScopes.ts
@@ -28,7 +28,7 @@ export const applyScopeChain = (
 export const pluginModuleScopes = (
   moduleScopes?: ChainedConfig<ModuleScopes>,
 ): RsbuildPlugin => ({
-  name: 'plugin-module-scopes',
+  name: 'uni-builder:module-scopes',
 
   setup(api) {
     api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {

--- a/packages/compat/uni-builder/src/webpack/plugins/sri.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/sri.ts
@@ -3,7 +3,7 @@ import type { RsbuildPlugin } from '@rsbuild/webpack';
 import type { SriOptions } from '../../types';
 
 export const pluginSRI = (options: SriOptions | boolean): RsbuildPlugin => ({
-  name: 'plugin-sri',
+  name: 'uni-builder:sri',
 
   setup(api) {
     api.modifyWebpackChain((chain, { CHAIN_ID }) => {

--- a/packages/compat/uni-builder/tests/parseConfig.test.ts
+++ b/packages/compat/uni-builder/tests/parseConfig.test.ts
@@ -176,7 +176,7 @@ describe('parseCommonConfig', () => {
   test('output.assetsRetry', () => {
     expect(
       parseCommonConfig({}).rsbuildPlugins.some(
-        (item) => item.name === 'plugin-assets-retry',
+        (item) => item.name === 'rsbuild:assets-retry',
       ),
     ).toBeFalsy();
 
@@ -185,7 +185,7 @@ describe('parseCommonConfig', () => {
         output: {
           assetsRetry: {},
         },
-      }).rsbuildPlugins.some((item) => item.name === 'plugin-assets-retry'),
+      }).rsbuildPlugins.some((item) => item.name === 'rsbuild:assets-retry'),
     ).toBeTruthy();
   });
 });

--- a/packages/compat/webpack/src/plugins/babel.ts
+++ b/packages/compat/webpack/src/plugins/babel.ts
@@ -25,7 +25,7 @@ export const getUseBuiltIns = (config: NormalizedConfig) => {
 };
 
 export const pluginBabel = (): RsbuildPlugin => ({
-  name: 'plugin-babel',
+  name: 'rsbuild-webpack:babel',
   setup(api) {
     api.modifyBundlerChain(
       async (

--- a/packages/compat/webpack/src/plugins/basic.ts
+++ b/packages/compat/webpack/src/plugins/basic.ts
@@ -6,7 +6,7 @@ import { applyBasicPlugin } from '@rsbuild/shared';
  * Provide some basic configs of webpack
  */
 export const pluginBasic = (): RsbuildPlugin => ({
-  name: 'plugin-basic',
+  name: 'rsbuild-webpack:basic',
 
   setup(api) {
     applyBasicPlugin(api);

--- a/packages/compat/webpack/src/plugins/copy.ts
+++ b/packages/compat/webpack/src/plugins/copy.ts
@@ -3,7 +3,7 @@ import type { CopyPluginOptions } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginCopy = (): RsbuildPlugin => ({
-  name: 'plugin-copy',
+  name: 'rsbuild-webpack:copy',
 
   setup(api) {
     api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {

--- a/packages/compat/webpack/src/plugins/css.ts
+++ b/packages/compat/webpack/src/plugins/css.ts
@@ -139,7 +139,7 @@ export async function applyBaseCSSRule({
 
 export const pluginCss = (): RsbuildPlugin => {
   return {
-    name: 'plugin-css',
+    name: 'rsbuild-webpack:css',
     setup(api) {
       api.modifyBundlerChain(async (chain, utils) => {
         const rule = chain.module.rule(utils.CHAIN_ID.RULE.CSS);

--- a/packages/compat/webpack/src/plugins/hmr.ts
+++ b/packages/compat/webpack/src/plugins/hmr.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '../types';
 import { isUsingHMR } from '@rsbuild/shared';
 
 export const pluginHMR = (): RsbuildPlugin => ({
-  name: 'plugin-hmr',
+  name: 'rsbuild-webpack:hmr',
 
   setup(api) {
     api.modifyWebpackChain((chain, utils) => {

--- a/packages/compat/webpack/src/plugins/less.ts
+++ b/packages/compat/webpack/src/plugins/less.ts
@@ -12,7 +12,7 @@ export type LessLoaderUtils = {
 
 export function pluginLess(): RsbuildPlugin {
   return {
-    name: 'plugin-less',
+    name: 'rsbuild-webpack:less',
     setup(api) {
       api.modifyBundlerChain(async (chain, utils) => {
         const config = api.getNormalizedConfig();

--- a/packages/compat/webpack/src/plugins/minimize.ts
+++ b/packages/compat/webpack/src/plugins/minimize.ts
@@ -18,7 +18,7 @@ async function applyJSMinimizer(chain: BundlerChain, config: NormalizedConfig) {
 }
 
 export const pluginMinimize = (): RsbuildPlugin => ({
-  name: 'plugin-minimize',
+  name: 'rsbuild-webpack:minimize',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {

--- a/packages/compat/webpack/src/plugins/output.ts
+++ b/packages/compat/webpack/src/plugins/output.ts
@@ -9,7 +9,7 @@ import {
 import type { RsbuildPlugin } from '../types';
 
 export const pluginOutput = (): RsbuildPlugin => ({
-  name: 'plugin-output',
+  name: 'rsbuild-webpack:output',
 
   setup(api) {
     applyOutputPlugin(api);

--- a/packages/compat/webpack/src/plugins/progress.ts
+++ b/packages/compat/webpack/src/plugins/progress.ts
@@ -2,7 +2,7 @@ import { TARGET_ID_MAP } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginProgress = (): RsbuildPlugin => ({
-  name: 'plugin-progress',
+  name: 'rsbuild-webpack:progress',
   setup(api) {
     api.modifyWebpackChain(async (chain, { target, CHAIN_ID }) => {
       const config = api.getNormalizedConfig();

--- a/packages/compat/webpack/src/plugins/react.ts
+++ b/packages/compat/webpack/src/plugins/react.ts
@@ -3,7 +3,7 @@ import { isProd, isUsingHMR } from '@rsbuild/shared';
 import type { RsbuildPlugin, RsbuildConfig } from '../types';
 
 export const pluginReactWebpack = (): RsbuildPlugin => ({
-  name: 'plugin-react-webpack',
+  name: 'rsbuild-webpack:react',
 
   setup(api) {
     api.modifyRsbuildConfig(async (config, { mergeRsbuildConfig }) => {

--- a/packages/compat/webpack/src/plugins/resolve.ts
+++ b/packages/compat/webpack/src/plugins/resolve.ts
@@ -50,7 +50,7 @@ const getMainFields = (chain: WebpackChain, target: RsbuildTarget) => {
 };
 
 export const pluginResolve = (): RsbuildPlugin => ({
-  name: 'plugin-resolve',
+  name: 'rsbuild-webpack:resolve',
 
   setup(api) {
     applyResolvePlugin(api);

--- a/packages/compat/webpack/src/plugins/sass.ts
+++ b/packages/compat/webpack/src/plugins/sass.ts
@@ -8,7 +8,7 @@ import type { RsbuildPlugin } from '../types';
 
 export function pluginSass(): RsbuildPlugin {
   return {
-    name: 'plugin-sass',
+    name: 'rsbuild-webpack:sass',
     setup(api) {
       api.onAfterCreateCompiler(({ compiler }) => {
         patchCompilerGlobalLocation(compiler);

--- a/packages/compat/webpack/src/plugins/tsLoader.ts
+++ b/packages/compat/webpack/src/plugins/tsLoader.ts
@@ -13,7 +13,7 @@ import type { RsbuildPlugin } from '../types';
 
 export const pluginTsLoader = (): RsbuildPlugin => {
   return {
-    name: 'plugin-ts-loader',
+    name: 'rsbuild-webpack:ts-loader',
     setup(api) {
       api.modifyWebpackChain(async (chain, { target, CHAIN_ID }) => {
         const config = api.getNormalizedConfig();

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -22,7 +22,7 @@ export function getRegExpForExts(exts: string[]): RegExp {
 }
 
 export const pluginAsset = (): RsbuildPlugin => ({
-  name: 'plugin-asset',
+  name: 'rsbuild:asset',
 
   setup(api) {
     api.modifyBundlerChain((chain, { isProd }) => {

--- a/packages/core/src/plugins/bundleAnalyzer.ts
+++ b/packages/core/src/plugins/bundleAnalyzer.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '../types';
 
 export function pluginBundleAnalyzer(): RsbuildPlugin {
   return {
-    name: 'plugin-bundle-analyzer',
+    name: 'rsbuild:bundle-analyzer',
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
         const config = api.getNormalizedConfig();

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -89,7 +89,7 @@ async function getBuildDependencies(context: Readonly<Context>) {
 }
 
 export const pluginCache = (): RsbuildPlugin => ({
-  name: 'plugin-cache',
+  name: 'rsbuild:cache',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { target, env }) => {

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -8,7 +8,7 @@ const emptyDir = async (dir: string) => {
 };
 
 export const pluginCleanOutput = (): RsbuildPlugin => ({
-  name: 'plugin-clean-output',
+  name: 'rsbuild:clean-output',
 
   setup(api) {
     const clean = async () => {

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -2,7 +2,7 @@ import { removeTailSlash, type Define } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginDefine = (): RsbuildPlugin => ({
-  name: 'plugin-define',
+  name: 'rsbuild:define',
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, bundler }) => {

--- a/packages/core/src/plugins/devtool.ts
+++ b/packages/core/src/plugins/devtool.ts
@@ -2,7 +2,7 @@ import { isUseJsSourceMap } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginDevtool = (): RsbuildPlugin => ({
-  name: 'plugin-devtool',
+  name: 'rsbuild:devtool',
 
   setup(api) {
     api.modifyBundlerChain((chain, { isProd, isServer }) => {

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -2,7 +2,7 @@ import { castArray, color } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginEntry = (): RsbuildPlugin => ({
-  name: 'plugin-entry',
+  name: 'rsbuild:entry',
 
   setup(api) {
     api.modifyBundlerChain(async (chain) => {

--- a/packages/core/src/plugins/externals.ts
+++ b/packages/core/src/plugins/externals.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '../types';
 
 export function pluginExternals(): RsbuildPlugin {
   return {
-    name: 'plugin-externals',
+    name: 'rsbuild:externals',
     setup(api) {
       api.modifyBundlerChain((chain) => {
         const { externals } = api.getNormalizedConfig().output;

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -138,7 +138,7 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
 }
 
 export const pluginFileSize = (): RsbuildPlugin => ({
-  name: 'plugin-file-size',
+  name: 'rsbuild:file-size',
 
   setup(api) {
     api.onAfterBuild(async ({ stats }) => {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -191,7 +191,7 @@ export const applyInjectTags = (api: SharedRsbuildPluginAPI) => {
 };
 
 export const pluginHtml = (): RsbuildPlugin => ({
-  name: 'plugin-html',
+  name: 'rsbuild:html',
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -8,7 +8,7 @@ import {
 import type { RsbuildPlugin } from '../types';
 
 export const pluginInlineChunk = (): RsbuildPlugin => ({
-  name: 'plugin-inline-chunk',
+  name: 'rsbuild:inline-chunk',
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/core/src/plugins/moment.ts
+++ b/packages/core/src/plugins/moment.ts
@@ -56,7 +56,7 @@ class IgnorePlugin implements RspackPluginInstance {
 }
 
 export const pluginMoment = (): RsbuildPlugin => ({
-  name: 'plugin-moment',
+  name: 'rsbuild:moment',
 
   setup(api) {
     api.modifyBundlerChain(async (chain) => {

--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -8,7 +8,7 @@ import {
 import type { RsbuildPlugin } from '../types';
 
 export const pluginNodeAddons = (): RsbuildPlugin => ({
-  name: 'plugin-node-addons',
+  name: 'rsbuild:node-addons',
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/core/src/plugins/performance.ts
+++ b/packages/core/src/plugins/performance.ts
@@ -20,7 +20,7 @@ function applyProfile({
  * Apply some configs of Rsbuild performance
  */
 export const pluginPerformance = (): RsbuildPlugin => ({
-  name: 'plugin-performance',
+  name: 'rsbuild:performance',
 
   setup(api) {
     api.modifyRsbuildConfig((rsbuildConfig) => {

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -208,7 +208,7 @@ const SPLIT_STRATEGY_DISPATCHER: Record<
 
 export function pluginSplitChunks(): RsbuildPlugin {
   return {
-    name: 'plugin-split-chunks',
+    name: 'rsbuild:split-chunks',
     setup(api) {
       api.modifyBundlerChain(
         async (chain, { isServer, isWebWorker, isServiceWorker }) => {

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -87,7 +87,7 @@ const openedURLs: string[] = [];
 
 export function pluginStartUrl(): RsbuildPlugin {
   return {
-    name: 'plugin-start-url',
+    name: 'rsbuild:start-url',
     setup(api) {
       api.onAfterStartDevServer(async (params) => {
         const { port, routes } = params;

--- a/packages/core/src/plugins/target.ts
+++ b/packages/core/src/plugins/target.ts
@@ -2,7 +2,7 @@ import { getBrowserslist } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginTarget = (): RsbuildPlugin => ({
-  name: 'plugin-target',
+  name: 'rsbuild:target',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { target }) => {

--- a/packages/core/src/plugins/toml.ts
+++ b/packages/core/src/plugins/toml.ts
@@ -2,7 +2,7 @@ import { getSharedPkgCompiledPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginToml = (): RsbuildPlugin => ({
-  name: 'plugin-toml',
+  name: 'rsbuild:toml',
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -3,7 +3,7 @@ import { getDistPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginWasm = (): RsbuildPlugin => ({
-  name: 'plugin-wasm',
+  name: 'rsbuild:wasm',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/core/src/plugins/yaml.ts
+++ b/packages/core/src/plugins/yaml.ts
@@ -2,7 +2,7 @@ import { getSharedPkgCompiledPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginYaml = (): RsbuildPlugin => ({
-  name: 'plugin-yaml',
+  name: 'rsbuild:yaml',
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/core/src/rspack-provider/plugins/basic.ts
+++ b/packages/core/src/rspack-provider/plugins/basic.ts
@@ -5,7 +5,7 @@ import { applyBasicPlugin } from '@rsbuild/shared';
  * Provide some basic configs of rspack
  */
 export const pluginBasic = (): RsbuildPlugin => ({
-  name: 'plugin-basic',
+  name: 'rsbuild:basic',
 
   setup(api) {
     applyBasicPlugin(api);

--- a/packages/core/src/rspack-provider/plugins/css.ts
+++ b/packages/core/src/rspack-provider/plugins/css.ts
@@ -196,7 +196,7 @@ export const applyCSSModuleRule = (
 
 export const pluginCss = (): RsbuildPlugin => {
   return {
-    name: 'plugin-css',
+    name: 'rsbuild:css',
     setup(api) {
       api.modifyBundlerChain(async (chain, utils) => {
         const config = api.getNormalizedConfig();

--- a/packages/core/src/rspack-provider/plugins/hmr.ts
+++ b/packages/core/src/rspack-provider/plugins/hmr.ts
@@ -3,7 +3,7 @@ import type { RsbuildPlugin } from '../../types';
 import { setConfig, isUsingHMR } from '@rsbuild/shared';
 
 export const pluginHMR = (): RsbuildPlugin => ({
-  name: 'plugin-hmr',
+  name: 'rsbuild:hmr',
 
   setup(api) {
     api.modifyRspackConfig((rspackConfig, utils) => {

--- a/packages/core/src/rspack-provider/plugins/less.ts
+++ b/packages/core/src/rspack-provider/plugins/less.ts
@@ -7,7 +7,7 @@ import {
 
 export function pluginLess(): RsbuildPlugin {
   return {
-    name: 'plugin-less',
+    name: 'rsbuild:less',
     setup(api) {
       api.modifyBundlerChain(async (chain, utils) => {
         const config = api.getNormalizedConfig();

--- a/packages/core/src/rspack-provider/plugins/minimize.ts
+++ b/packages/core/src/rspack-provider/plugins/minimize.ts
@@ -56,7 +56,7 @@ export function applyCSSMinimizer(chain: BundlerChain) {
 }
 
 export const pluginMinimize = (): RsbuildPlugin => ({
-  name: 'plugin-minimize',
+  name: 'rsbuild:minimize',
 
   setup(api) {
     api.modifyBundlerChain((chain, { isProd }) => {

--- a/packages/core/src/rspack-provider/plugins/output.ts
+++ b/packages/core/src/rspack-provider/plugins/output.ts
@@ -3,7 +3,7 @@ import { getDistPath, getFilename, applyOutputPlugin } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
 export const pluginOutput = (): RsbuildPlugin => ({
-  name: 'plugin-output',
+  name: 'rsbuild:output',
 
   setup(api) {
     applyOutputPlugin(api);

--- a/packages/core/src/rspack-provider/plugins/progress.ts
+++ b/packages/core/src/rspack-provider/plugins/progress.ts
@@ -2,7 +2,7 @@ import { TARGET_ID_MAP, isProd } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
 export const pluginProgress = (): RsbuildPlugin => ({
-  name: 'plugin-progress',
+  name: 'rsbuild:progress',
   setup(api) {
     api.modifyBundlerChain(async (chain, { target, CHAIN_ID }) => {
       const config = api.getNormalizedConfig();

--- a/packages/core/src/rspack-provider/plugins/resolve.ts
+++ b/packages/core/src/rspack-provider/plugins/resolve.ts
@@ -2,7 +2,7 @@ import type { RsbuildPlugin } from '../../types';
 import { setConfig, applyResolvePlugin } from '@rsbuild/shared';
 
 export const pluginResolve = (): RsbuildPlugin => ({
-  name: 'plugin-resolve',
+  name: 'rsbuild:resolve',
 
   setup(api) {
     applyResolvePlugin(api);

--- a/packages/core/src/rspack-provider/plugins/rspackProfile.ts
+++ b/packages/core/src/rspack-provider/plugins/rspackProfile.ts
@@ -27,7 +27,7 @@ export const stopProfiler = (
 // Reference rspack-cli
 // https://github.com/modern-js-dev/rspack/blob/509abcfc523bc20125459f5d428dc1645751700c/packages/rspack-cli/src/utils/profile.ts
 export const pluginRspackProfile = (): RsbuildPlugin => ({
-  name: 'plugin-rspack-profile',
+  name: 'rsbuild:rspack-profile',
 
   setup(api) {
     /**

--- a/packages/core/src/rspack-provider/plugins/sass.ts
+++ b/packages/core/src/rspack-provider/plugins/sass.ts
@@ -8,7 +8,7 @@ import type { RsbuildPlugin } from '../../types';
 
 export function pluginSass(): RsbuildPlugin {
   return {
-    name: 'plugin-sass',
+    name: 'rsbuild:sass',
     setup(api) {
       api.onAfterCreateCompiler(({ compiler }) => {
         patchCompilerGlobalLocation(compiler);

--- a/packages/core/src/rspack-provider/plugins/swc.ts
+++ b/packages/core/src/rspack-provider/plugins/swc.ts
@@ -56,7 +56,7 @@ export async function getDefaultSwcConfig(
  * Provide some swc configs of rspack
  */
 export const pluginSwc = (): RsbuildPlugin => ({
-  name: 'plugin-swc',
+  name: 'rsbuild:swc',
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/core/src/rspack-provider/plugins/transition.ts
+++ b/packages/core/src/rspack-provider/plugins/transition.ts
@@ -5,7 +5,7 @@ import type { RsbuildPlugin } from '../../types';
  * Provide some temporary configurations for Rspack early transition
  */
 export const pluginTransition = (): RsbuildPlugin => ({
-  name: 'plugin-transition',
+  name: 'rsbuild:transition',
 
   setup(api) {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -7,7 +7,7 @@ export type { PluginAssetsRetryOptions };
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},
 ): RsbuildPlugin => ({
-  name: 'plugin-assets-retry',
+  name: 'rsbuild:assets-retry',
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, target, HtmlPlugin }) => {
       const config = api.getNormalizedConfig();

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -20,7 +20,7 @@ export const DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS = {
 export const pluginBabel = (
   options: PluginBabelOptions = {},
 ): RsbuildPlugin => ({
-  name: 'plugin-babel',
+  name: 'rsbuild:babel',
 
   setup(api) {
     if (api.context.bundlerType === 'webpack') {

--- a/packages/plugin-check-syntax/src/index.ts
+++ b/packages/plugin-check-syntax/src/index.ts
@@ -24,7 +24,7 @@ export function pluginCheckSyntax(
   options: PluginCheckSyntaxOptions = {},
 ): RsbuildPlugin {
   return {
-    name: 'plugin-check-syntax',
+    name: 'rsbuild:check-syntax',
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { isProd, target }) => {

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -48,7 +48,7 @@ export async function applyCSSMinimizer(
 export const pluginCssMinimizer = (
   options?: PluginCssMinimizerOptions,
 ): RsbuildPlugin => ({
-  name: 'plugin-css-minimizer',
+  name: 'rsbuild:css-minimizer',
 
   setup(api) {
     if (api.context.bundlerType === 'webpack') {

--- a/packages/plugin-image-compress/src/index.ts
+++ b/packages/plugin-image-compress/src/index.ts
@@ -37,7 +37,7 @@ const normalizeOptions = (options: Options[]) => {
 export const pluginImageCompress: IPluginImageCompress = (
   ...args
 ): RsbuildPlugin => ({
-  name: 'plugin-image-compress',
+  name: 'rsbuild:image-compress',
   setup(api) {
     const opts = normalizeOptions(castOptions(args));
 

--- a/packages/plugin-node-polyfill/src/index.ts
+++ b/packages/plugin-node-polyfill/src/index.ts
@@ -26,7 +26,7 @@ const getProvideLibs = async () => {
 
 export function pluginNodePolyfill(): RsbuildPlugin {
   return {
-    name: 'plugin-node-polyfill',
+    name: 'rsbuild:node-polyfill',
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isServer, bundler }) => {

--- a/packages/plugin-pug/src/index.ts
+++ b/packages/plugin-pug/src/index.ts
@@ -8,7 +8,7 @@ export type PluginPugOptions = {
 };
 
 export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
-  name: 'plugin-pug',
+  name: 'rsbuild:pug',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -7,9 +7,9 @@ import { applyBasicReactSupport } from './react';
 export { isBeyondReact17 } from './utils';
 
 export const pluginReact = (): RsbuildPlugin => ({
-  name: 'plugin-react',
+  name: 'rsbuild:react',
 
-  pre: ['plugin-swc'],
+  pre: ['rsbuild:swc'],
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -11,9 +11,9 @@ const defaultOptions: PluginRemOptions = {
 export type { PluginRemOptions };
 
 export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
-  name: 'plugin-rem',
+  name: 'rsbuild:rem',
 
-  pre: ['plugin-css', 'plugin-less', 'plugin-sass', 'plugin-stylus'],
+  pre: ['rsbuild:css', 'rsbuild:less', 'rsbuild:sass', 'rsbuild:stylus'],
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -9,9 +9,9 @@ export function pluginSolid(
   options: PluginSolidPresetOptions = {},
 ): RsbuildPlugin {
   return {
-    name: 'plugin-solid',
+    name: 'rsbuild:solid',
 
-    pre: ['plugin-babel'],
+    pre: ['rsbuild:babel', 'rsbuild-webpack:babel'],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -10,7 +10,7 @@ import {
   type ExtraMonorepoStrategies,
 } from '@rsbuild/monorepo-utils';
 
-export const pluginName = 'plugin-source-build';
+export const pluginName = 'rsbuild:source-build';
 
 export const getSourceInclude = async (options: {
   projects: Project[];

--- a/packages/plugin-styled-components/src/index.ts
+++ b/packages/plugin-styled-components/src/index.ts
@@ -25,7 +25,7 @@ type StyledComponentsOptions = {
 export const pluginStyledComponents = (
   userConfig: ChainedConfig<StyledComponentsOptions> = {},
 ): RsbuildPlugin => ({
-  name: 'plugin-styled-components',
+  name: 'rsbuild:styled-components',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -24,7 +24,7 @@ export type PluginStylusOptions = StylusLoaderOptions;
 
 export function pluginStylus(options?: PluginStylusOptions): RsbuildPlugin {
   return {
-    name: 'plugin-stylus',
+    name: 'rsbuild:stylus',
 
     setup(api) {
       const { bundlerType } = api.context;

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -13,7 +13,7 @@ export type PluginSvelteOptions = {
 
 export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
   return {
-    name: 'plugin-svelte',
+    name: 'rsbuild:svelte',
 
     setup(api) {
       let sveltePath: string = '';

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -37,7 +37,7 @@ function getSvgoDefaultConfig() {
 }
 
 export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
-  name: 'plugin-svgr',
+  name: 'rsbuild:svgr',
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -21,7 +21,7 @@ export const pluginTypeCheck = (
   options: PluginTypeCheckerOptions = {},
 ): RsbuildPlugin => {
   return {
-    name: 'plugin-type-check',
+    name: 'rsbuild:type-check',
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { target }) => {

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -7,9 +7,9 @@ export type PluginVueJsxOptions = {
 
 export function pluginVueJsx(options: PluginVueJsxOptions = {}): RsbuildPlugin {
   return {
-    name: 'plugin-vue-jsx',
+    name: 'rsbuild:vue-jsx',
 
-    pre: ['plugin-babel'],
+    pre: ['rsbuild:babel', 'rsbuild-webpack:babel'],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -9,7 +9,7 @@ export type PluginVueOptions = {
 
 export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'plugin-vue',
+    name: 'rsbuild:vue',
 
     setup(api) {
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -14,9 +14,9 @@ export type PluginVueOptions = {
 
 export function pluginVue2Jsx(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'plugin-vue2-jsx',
+    name: 'rsbuild:vue2-jsx',
 
-    pre: ['plugin-babel'],
+    pre: ['rsbuild:babel', 'rsbuild-webpack:babel'],
 
     setup(api) {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -9,7 +9,7 @@ export type PluginVueOptions = {
 
 export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'plugin-vue2',
+    name: 'rsbuild:vue2',
 
     setup(api) {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {


### PR DESCRIPTION
## Summary

- Rsbuild plugins: `rsbuild:xxx`
- Rsbuild webpack plugins: `rsbuild-webpack:xxx`
- UniBuilder plugins: `uni-builder:xxx`

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
