### PR TITLE
refactor: rename `dev.proxy` to `server.proxy` to support preview server

### DIFF
--- a/.changeset/neat-buckets-watch.md
+++ b/.changeset/neat-buckets-watch.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+refactor: rename `dev.proxy` to `server.proxy` to support preview server

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,9 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  server: {
-    proxy: {
-      '/api': 'https://cnodejs.org',
-    },
-  },
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,4 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  server: {
+    proxy: {
+      '/api': 'https://cnodejs.org',
+    },
+  },
 });

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -18,6 +18,7 @@ import {
   getServerOptions,
 } from '@rsbuild/shared';
 import { faviconFallbackMiddleware } from './middlewares';
+import { createProxyMiddleware } from './proxy';
 
 type RsbuildProdServerOptions = {
   pwd: string;
@@ -44,13 +45,20 @@ export class RsbuildProdServer {
   }
 
   private async applyDefaultMiddlewares() {
-    const { headers } = this.options.serverConfig;
+    const { headers, proxy } = this.options.serverConfig;
     if (headers) {
       this.middlewares.use((_req, res, next) => {
         for (const [key, value] of Object.entries(headers)) {
           res.setHeader(key, value);
         }
         next();
+      });
+    }
+
+    if (proxy) {
+      const { middlewares } = createProxyMiddleware(proxy, this.app);
+      middlewares.forEach((middleware) => {
+        this.middlewares.use(middleware);
       });
     }
 

--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -7,10 +7,10 @@ import {
   logger,
   type ProxyDetail,
   type RequestHandler as Middleware,
-  type RsbuildProxyOptions,
+  type ProxyOptions,
 } from '@rsbuild/shared';
 
-export function formatProxyOptions(proxyOptions: RsbuildProxyOptions) {
+export function formatProxyOptions(proxyOptions: ProxyOptions) {
   const ret: ProxyDetail[] = [];
 
   if (Array.isArray(proxyOptions)) {
@@ -45,7 +45,7 @@ export function formatProxyOptions(proxyOptions: RsbuildProxyOptions) {
 export type HttpUpgradeHandler = NonNullable<RequestHandler['upgrade']>;
 
 export const createProxyMiddleware = (
-  proxyOptions: RsbuildProxyOptions,
+  proxyOptions: ProxyOptions,
   app: http.Server,
 ) => {
   // If it is not an array, it may be an object that uses the context attribute

--- a/packages/document/docs/en/config/options/dev.mdx
+++ b/packages/document/docs/en/config/options/dev.mdx
@@ -50,12 +50,6 @@ import ProgressBar from '@en/shared/config/dev/progressBar.md';
 
 <ProgressBar />
 
-## dev.proxy
-
-import Proxy from '@en/shared/config/dev/proxy.md';
-
-<Proxy />
-
 ## dev.setupMiddlewares
 
 import SetupMiddlewares from '@en/shared/config/dev/setupMiddlewares.md';

--- a/packages/document/docs/en/config/options/server.mdx
+++ b/packages/document/docs/en/config/options/server.mdx
@@ -31,3 +31,9 @@ import Https from '@en/shared/config/server/https.md';
 import Port from '@en/shared/config/server/port.md';
 
 <Port />
+
+## dev.proxy
+
+import Proxy from '@en/shared/config/server/proxy.md';
+
+<Proxy />

--- a/packages/document/docs/en/config/options/server.mdx
+++ b/packages/document/docs/en/config/options/server.mdx
@@ -32,7 +32,7 @@ import Port from '@en/shared/config/server/port.md';
 
 <Port />
 
-## dev.proxy
+## server.proxy
 
 import Proxy from '@en/shared/config/server/proxy.md';
 

--- a/packages/document/docs/en/shared/config/server/proxy.md
+++ b/packages/document/docs/en/shared/config/server/proxy.md
@@ -3,6 +3,8 @@
 
 Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
 
+### Example
+
 ```js
 export default {
   server: {
@@ -13,9 +15,23 @@ export default {
 };
 ```
 
-A request to /api/users will now proxy the request to http://localhost:3000/api/users.
+A request to `/api/users` will now proxy the request to http://localhost:3000/api/users.
 
-If you don't want /api to be passed along, we need to rewrite the path:
+You can also proxy to an online domain name, such as:
+
+```js
+export default {
+  server: {
+    proxy: {
+      '/api': 'https://nodejs.org',
+    },
+  },
+};
+```
+
+### Path Rewrite
+
+If you don't want `/api` to be passed along, we need to rewrite the path:
 
 ```js
 export default {
@@ -29,6 +45,8 @@ export default {
   },
 };
 ```
+
+### Options
 
 The DevServer Proxy makes use of the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) package. Check out its documentation for more advanced usages.
 
@@ -59,7 +77,6 @@ In addition to the http-proxy-middleware option, we also support the bypass and 
   - Return `null` or `undefined` to continue processing the request with proxy.
   - Return `false` to produce a 404 error for the request.
   - Return a path to serve from, instead of continuing to proxy the request.
-- context: If you want to proxy multiple, specific paths to the same target, you can use an array of one or more objects with a context property.
 
 ```js
 // custom bypass
@@ -79,6 +96,8 @@ export default {
   },
 };
 ```
+
+- context: If you want to proxy multiple, specific paths to the same target, you can use an array of one or more objects with a context property.
 
 ```js
 // proxy multiple

--- a/packages/document/docs/en/shared/config/server/proxy.md
+++ b/packages/document/docs/en/shared/config/server/proxy.md
@@ -1,11 +1,11 @@
 - **Type:** `Record<string, string> | Record<string, ProxyDetail>`
 - **Default:** `undefined`
 
-Proxying some URLs.
+Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
 
 ```js
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': 'http://localhost:3000',
     },
@@ -19,7 +19,7 @@ If you don't want /api to be passed along, we need to rewrite the path:
 
 ```js
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
@@ -64,7 +64,7 @@ In addition to the http-proxy-middleware option, we also support the bypass and 
 ```js
 // custom bypass
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
@@ -83,7 +83,7 @@ export default {
 ```js
 // proxy multiple
 export default {
-  dev: {
+  server: {
     proxy: [
       {
         context: ['/auth', '/api'],

--- a/packages/document/docs/zh/config/options/dev.mdx
+++ b/packages/document/docs/zh/config/options/dev.mdx
@@ -52,12 +52,6 @@ import ProgressBar from '@zh/shared/config/dev/progressBar.md';
 
 <ProgressBar />
 
-## dev.proxy
-
-import Proxy from '@zh/shared/config/dev/proxy.md';
-
-<Proxy />
-
 ## dev.setupMiddlewares
 
 import SetupMiddlewares from '@zh/shared/config/dev/setupMiddlewares.md';

--- a/packages/document/docs/zh/config/options/server.mdx
+++ b/packages/document/docs/zh/config/options/server.mdx
@@ -30,7 +30,7 @@ import Https from '@zh/shared/config/server/https.md';
 
 import Port from '@zh/shared/config/server/port.md';
 
-## dev.proxy
+## server.proxy
 
 import Proxy from '@zh/shared/config/server/proxy.md';
 

--- a/packages/document/docs/zh/config/options/server.mdx
+++ b/packages/document/docs/zh/config/options/server.mdx
@@ -29,3 +29,9 @@ import Https from '@zh/shared/config/server/https.md';
 ## server.port
 
 import Port from '@zh/shared/config/server/port.md';
+
+## dev.proxy
+
+import Proxy from '@zh/shared/config/server/proxy.md';
+
+<Proxy />

--- a/packages/document/docs/zh/shared/config/server/proxy.md
+++ b/packages/document/docs/zh/shared/config/server/proxy.md
@@ -3,6 +3,8 @@
 
 为开发服务器或预览服务器配置代理规则，将请求代理到指定的服务上。
 
+### 示例
+
 ```js
 export default {
   server: {
@@ -13,9 +15,23 @@ export default {
 };
 ```
 
-此时，/api/users 请求将会代理到 http://localhost:3000/api/users。
+此时，`/api/users` 请求将会代理到 http://localhost:3000/api/users。
 
-如果你不想传递 /api，可以通过 `pathRewrite` 重写请求路径：
+你也可以代理到线上域名，比如:
+
+```js
+export default {
+  server: {
+    proxy: {
+      '/api': 'https://nodejs.org',
+    },
+  },
+};
+```
+
+### 重写路径
+
+如果你不想传递 `/api`，可以通过 `pathRewrite` 重写请求路径：
 
 ```js
 export default {
@@ -29,6 +45,8 @@ export default {
   },
 };
 ```
+
+### 选项
 
 DevServer Proxy 基于 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) 实现。你可以使用 http-proxy-middleware 的所有配置项，具体可以查看文档。
 
@@ -59,7 +77,6 @@ type ProxyOptions =
   - 返回 `null` 或 `undefined` 会继续用代理处理请求。
   - 返回 `false` 会返回 404 错误。
   - 返回一个具体的服务路径，将会使用此路径替代原请求路径。
-- context：如果你想代理多个特定的路径到同一个目标，你可以使用 context 配置项。
 
 ```js
 // 自定义 bypass 方法
@@ -79,6 +96,8 @@ export default {
   },
 };
 ```
+
+- context：如果你想代理多个特定的路径到同一个目标，你可以使用 context 配置项。
 
 ```js
 // 代理多个路径到同一个目标

--- a/packages/document/docs/zh/shared/config/server/proxy.md
+++ b/packages/document/docs/zh/shared/config/server/proxy.md
@@ -1,11 +1,11 @@
 - **类型：** `Record<string, string> | Record<string, ProxyDetail>`
 - **默认值：** `undefined`
 
-代理请求到指定的服务上。
+为开发服务器或预览服务器配置代理规则，将请求代理到指定的服务上。
 
 ```js
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': 'http://localhost:3000',
     },
@@ -19,7 +19,7 @@ export default {
 
 ```js
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
@@ -64,7 +64,7 @@ type ProxyOptions =
 ```js
 // 自定义 bypass 方法
 export default {
-  dev: {
+  server: {
     proxy: {
       '/api': {
         target: 'http://localhost:3000',
@@ -83,7 +83,7 @@ export default {
 ```js
 // 代理多个路径到同一个目标
 export default {
-  dev: {
+  server: {
     proxy: [
       {
         context: ['/auth', '/api'],

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -1,27 +1,11 @@
 import type { ArrayOrNot } from '../utils';
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { Options as ProxyOptions } from '../../../compiled/http-proxy-middleware';
 
 export type ProgressBarConfig = {
   id?: string;
 };
 
 export type NextFunction = () => void;
-
-export type ProxyDetail = ProxyOptions & {
-  bypass?: (
-    req: IncomingMessage,
-    res: ServerResponse,
-    proxyOptions: RsbuildProxyOptions,
-  ) => string | undefined | null | false;
-  context?: string | string[];
-};
-
-export type RsbuildProxyOptions =
-  | Record<string, string>
-  | Record<string, ProxyDetail>
-  | ProxyDetail[]
-  | ProxyDetail;
 
 export type RequestHandler = (
   req: IncomingMessage,
@@ -75,7 +59,6 @@ export interface DevConfig {
     writeToDisk?: boolean | ((filename: string) => boolean);
     outputFileSystem?: Record<string, any>;
   };
-  proxy?: RsbuildProxyOptions;
   /** see https://github.com/bripkens/connect-history-api-fallback */
   historyApiFallback?:
     | boolean

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,4 +1,22 @@
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Options as BaseProxyOptions } from '../../../compiled/http-proxy-middleware';
+
 export type HtmlFallback = false | 'index';
+
+export type ProxyDetail = BaseProxyOptions & {
+  bypass?: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    proxyOptions: ProxyOptions,
+  ) => string | undefined | null | false;
+  context?: string | string[];
+};
+
+export type ProxyOptions =
+  | Record<string, string>
+  | Record<string, ProxyDetail>
+  | ProxyDetail[]
+  | ProxyDetail;
 
 export interface ServerConfig {
   /**
@@ -18,6 +36,10 @@ export interface ServerConfig {
    */
   headers?: Record<string, string | string[]>;
   htmlFallback?: HtmlFallback;
+  /**
+   * Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
+   */
+  proxy?: ProxyOptions;
 }
 
 export type NormalizedServerConfig = ServerConfig &


### PR DESCRIPTION
## Summary

Rename `dev.proxy` to `server.proxy` to support preview server.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
