### PR TITLE
fix(core): printFileSize throw err when set output.filename query

### DIFF
--- a/.changeset/warm-cups-cross.md
+++ b/.changeset/warm-cups-cross.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(rsbuild): printFileSize throw err when set output.filename query
+fix(rsbuild): printFileSize 报错当用户设置了 filename query 参数

--- a/.changeset/warm-cups-cross.md
+++ b/.changeset/warm-cups-cross.md
@@ -2,5 +2,5 @@
 '@rsbuild/core': patch
 ---
 
-fix(rsbuild): printFileSize throw err when set output.filename query
-fix(rsbuild): printFileSize 报错当用户设置了 filename query 参数
+fix: printFileSize throw err when set output.filename query
+

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -49,7 +49,7 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
   const { default: gzipSize } = await import('@rsbuild/shared/gzip-size');
 
   const formatAsset = (asset: StatsAsset) => {
-    const fileName = asset.name;
+    const fileName = asset.name.split('?')[0];
     const contents = fse.readFileSync(path.join(distPath, fileName));
     const size = contents.length;
     const gzippedSize = gzipSize.sync(contents);

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -49,14 +49,15 @@ async function printFileSizes(stats: Stats | MultiStats, distPath: string) {
   const { default: gzipSize } = await import('@rsbuild/shared/gzip-size');
 
   const formatAsset = (asset: StatsAsset) => {
-    const contents = fse.readFileSync(path.join(distPath, asset.name));
+    const fileName = asset.name;
+    const contents = fse.readFileSync(path.join(distPath, fileName));
     const size = contents.length;
     const gzippedSize = gzipSize.sync(contents);
 
     return {
       size,
-      folder: path.join(path.basename(distPath), path.dirname(asset.name)),
-      name: path.basename(asset.name),
+      folder: path.join(path.basename(distPath), path.dirname(fileName)),
+      name: path.basename(fileName),
       gzippedSize,
       sizeLabel: calcFileSize(size),
       gzipSizeLabel: getAssetColor(gzippedSize)(calcFileSize(gzippedSize)),


### PR DESCRIPTION
## Summary

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
