### PR TITLE
chore: no need to set newResolver config

### DIFF
--- a/.changeset/empty-dots-greet.md
+++ b/.changeset/empty-dots-greet.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+chore: no need to set newResolver config

--- a/packages/core/src/rspack-provider/plugins/transition.ts
+++ b/packages/core/src/rspack-provider/plugins/transition.ts
@@ -1,4 +1,3 @@
-import { setConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
 /**
@@ -14,10 +13,6 @@ export const pluginTransition = (): RsbuildPlugin => ({
       if (isProd) {
         chain.optimization.chunkIds('deterministic');
       }
-    });
-
-    api.modifyRspackConfig((config) => {
-      setConfig(config, 'experiments.rspackFuture.newResolver', true);
     });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -25,7 +25,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -25,7 +25,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -706,7 +705,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -1433,7 +1431,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {
@@ -1864,7 +1861,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -42,7 +42,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableTransformByDefault": true,
-      "newResolver": true,
     },
   },
   "infrastructureLogging": {


### PR DESCRIPTION
## Summary

No need to set newResolver config in Rspack v0.4.0, the newResolver is enabled by default.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v0.4.0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
