### PR TITLE
chore(shared): remove unused CHAIN_ID

### DIFF
--- a/.changeset/beige-lies-deny.md
+++ b/.changeset/beige-lies-deny.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+chore(shared): remove unused CHAIN_ID

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -117,8 +117,6 @@ export const CHAIN_ID = {
     YAML: 'yaml',
     /** toml-loader */
     TOML: 'toml',
-    /** html-loader */
-    HTML: 'html',
     /** node-loader */
     NODE: 'node',
     /** babel-loader */
@@ -160,14 +158,12 @@ export const CHAIN_ID = {
     IGNORE: 'ignore',
     /** BannerPlugin */
     BANNER: 'banner',
-    /** Webpackbar */
+    /** ProgressPlugin */
     PROGRESS: 'progress',
     /** Inspector */
     INSPECTOR: 'inspector',
     /** AppIconPlugin */
     APP_ICON: 'app-icon',
-    /** FaviconUrlPlugin */
-    FAVICON_URL: 'favicon-url',
     /** WebpackManifestPlugin */
     MANIFEST: 'webpack-manifest',
     /** ForkTsCheckerWebpackPlugin */


### PR DESCRIPTION
## Summary

Remove unused CHAIN_ID, `html-loader` and `FaviconUrlPlugin` are no longer used in Rsbuild.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
