### PR TITLE
fix(uni-builder): generate manifest correctly when targets contain node

### DIFF
--- a/.changeset/slow-gifts-wonder.md
+++ b/.changeset/slow-gifts-wonder.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/uni-builder': patch
+---
+
+fix(uni-builder): generate manifest correctly when targets contain node

--- a/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
+++ b/packages/compat/uni-builder/src/rspack/plugins/manifest.ts
@@ -5,13 +5,16 @@ export const pluginManifest = (): RsbuildPlugin => ({
   name: 'uni-builder:manifest',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+    api.modifyBundlerChain(async (chain, { target, CHAIN_ID }) => {
       const { WebpackManifestPlugin } = await import('rspack-manifest-plugin');
       const publicPath = chain.output.get('publicPath');
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(WebpackManifestPlugin, [
         {
-          fileName: 'asset-manifest.json',
+          fileName:
+            target === 'web'
+              ? 'asset-manifest.json'
+              : `asset-manifest-${target}.json`,
           publicPath,
           generate: generateManifest,
         },

--- a/packages/compat/uni-builder/src/webpack/plugins/manifest.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/manifest.ts
@@ -5,13 +5,16 @@ export const pluginManifest = (): RsbuildPlugin => ({
   name: 'uni-builder:manifest',
 
   setup(api) {
-    api.modifyWebpackChain(async (chain, { CHAIN_ID }) => {
+    api.modifyWebpackChain(async (chain, { target, CHAIN_ID }) => {
       const { WebpackManifestPlugin } = await import('webpack-manifest-plugin');
       const publicPath = chain.output.get('publicPath');
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(WebpackManifestPlugin, [
         {
-          fileName: 'asset-manifest.json',
+          fileName:
+            target === 'web'
+              ? 'asset-manifest.json'
+              : `asset-manifest-${target}.json`,
           publicPath,
           generate: generateManifest,
         },

--- a/packages/compat/uni-builder/tests/__snapshots__/manifest.test.ts.snap
+++ b/packages/compat/uni-builder/tests/__snapshots__/manifest.test.ts.snap
@@ -1,0 +1,27 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`plugin-manifest > should register manifest plugin correctly when target is node 1`] = `
+{
+  "plugins": [
+    WebpackManifestPlugin {
+      "options": {
+        "assetHookStage": Infinity,
+        "basePath": "",
+        "fileName": "asset-manifest-node.json",
+        "filter": null,
+        "generate": [Function],
+        "map": null,
+        "publicPath": undefined,
+        "removeKeyHash": /\\(\\[a-f0-9\\]\\{16,32\\}\\\\\\.\\?\\)/gi,
+        "seed": undefined,
+        "serialize": [Function],
+        "sort": null,
+        "transformExtensions": /\\^\\(gz\\|map\\)\\$/i,
+        "useEntryKeys": false,
+        "useLegacyEmit": false,
+        "writeToFileEmit": false,
+      },
+    },
+  ],
+}
+`;

--- a/packages/compat/uni-builder/tests/manifest.test.ts
+++ b/packages/compat/uni-builder/tests/manifest.test.ts
@@ -16,4 +16,19 @@ describe('plugin-manifest', () => {
       await rsbuild.matchWebpackPlugin('WebpackManifestPlugin'),
     ).toBeTruthy();
   });
+
+  it('should register manifest plugin correctly when target is node', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginManifest()],
+      rsbuildConfig: {
+        output: {
+          enableAssetManifest: true,
+        },
+      },
+      target: ['node'],
+    });
+
+    const config = await rsbuild.unwrapWebpackConfig();
+    expect(config).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Generate manifest correctly when targets contain node.

If the current project has multiple types of build artifacts, such as including SSR build artifacts, multiple manifest.json files will be generated.

- web artifact: `asset-manifest.json`
- node artifact: `asset-manifest-node.json`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
