### PR TITLE
chore(server): compat html without publicPath by warp dev-middleware

### DIFF
--- a/.changeset/breezy-days-cry.md
+++ b/.changeset/breezy-days-cry.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+chore(server): compat html publicPath by warp dev-middleware

--- a/.changeset/breezy-days-cry.md
+++ b/.changeset/breezy-days-cry.md
@@ -2,4 +2,4 @@
 '@rsbuild/core': patch
 ---
 
-chore(server): compat html publicPath by warp dev-middleware
+chore(server): compat html without publicPath by warp dev-middleware

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -51,6 +51,7 @@ export class RsbuildDevServer {
     // create dev middleware instance
     this.devMiddleware = new DevMiddleware({
       dev: this.dev,
+      publicPaths: options.output.publicPaths,
       devMiddleware: options.devMiddleware,
     });
   }
@@ -144,7 +145,6 @@ export class RsbuildDevServer {
     this.middlewares.use(
       getHtmlFallbackMiddleware({
         distPath: isAbsolute(distPath) ? distPath : join(this.pwd, distPath),
-        publicPath: this.output.publicPath,
         callback: devMiddleware.middleware,
         htmlFallback: this.dev.htmlFallback,
       }),
@@ -254,9 +254,9 @@ export async function startDevServer<
     customCompiler,
   );
 
-  const publicPath = (compiler as RspackMultiCompiler).compilers
-    ? getPublicPathFromCompiler((compiler as RspackMultiCompiler).compilers[0])
-    : getPublicPathFromCompiler(compiler as RspackCompiler);
+  const publicPaths = (compiler as RspackMultiCompiler).compilers
+    ? (compiler as RspackMultiCompiler).compilers.map(getPublicPathFromCompiler)
+    : [getPublicPathFromCompiler(compiler as RspackCompiler)];
 
   const server = new RsbuildDevServer({
     pwd: options.context.rootPath,
@@ -264,7 +264,7 @@ export async function startDevServer<
     dev: devServerConfig,
     output: {
       distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
-      publicPath,
+      publicPaths,
     },
   });
 

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,7 +1,6 @@
 import {
   RequestHandler as Middleware,
   debug,
-  urlJoin,
   HtmlFallback,
 } from '@rsbuild/shared';
 import path from 'path';
@@ -23,10 +22,9 @@ export const notFoundMiddleware: Middleware = (_req, res, _next) => {
 
 export const getHtmlFallbackMiddleware: (params: {
   distPath: string;
-  publicPath: string;
   callback?: Middleware;
   htmlFallback?: HtmlFallback;
-}) => Middleware = ({ htmlFallback, publicPath, distPath, callback }) => {
+}) => Middleware = ({ htmlFallback, distPath, callback }) => {
   /**
    * support access page without suffix and support fallback in some edge cases
    */
@@ -65,8 +63,6 @@ export const getHtmlFallbackMiddleware: (params: {
     }
 
     const rewrite = (newUrl: string) => {
-      // we need add assetPrefix(output.publicPath) for html, otherwise webpack-dev-middleware cannot find the file
-      newUrl = urlJoin(publicPath, newUrl);
       debug?.(`Rewriting ${req.method} ${req.url} to ${newUrl}`);
 
       req.url = newUrl;
@@ -97,11 +93,6 @@ export const getHtmlFallbackMiddleware: (params: {
 
       if (outputFileSystem.existsSync(filePath)) {
         return rewrite(newUrl);
-      }
-    } else {
-      // when user set publicPath, webpack-dev-middleware can't get html file directly.
-      if (outputFileSystem.existsSync(path.join(distPath, pathname))) {
-        return rewrite(url);
       }
     }
 

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -3,7 +3,7 @@ import { DevConfig, NextFunction } from './config/dev';
 import type { Logger } from '../logger';
 import type { RspackCompiler, RspackMultiCompiler } from './rspack';
 
-type Middleware = (
+export type Middleware = (
   req: IncomingMessage,
   res: ServerResponse,
   next: NextFunction,
@@ -21,6 +21,7 @@ export type MiddlewareCallbacks = {
 export type DevMiddlewareOptions = {
   /** To ensure HMR works, the devMiddleware need inject the hmr client path into page when HMR enable. */
   hmrClientPath?: string;
+  publicPath?: string;
 
   /** The options need by compiler middleware (like webpackMiddleware) */
   headers?: Record<string, string | string[]>;
@@ -54,7 +55,7 @@ export type RsbuildDevServerOptions = {
   devMiddleware?: DevMiddleware;
   output: {
     distPath: string;
-    publicPath: string;
+    publicPaths: string[];
   };
 };
 


### PR DESCRIPTION
## Summary
when we set `dev.assetPrefix`, we will transform it as webpack `output.publicPath`, and webpack-dev-middleware only find file startsWith publicPath, but html file without publicPath.

![image](https://github.com/web-infra-dev/rsbuild/assets/22373761/a1bd5426-8686-424d-a87a-811c997d3b75)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
