### PR TITLE
fix: compatible loader's rule.use maybe empty array

### DIFF
--- a/.changeset/lucky-experts-dance.md
+++ b/.changeset/lucky-experts-dance.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/doctor-core': patch
+---
+
+fix: compatible loader's rule.use maybe empty array

--- a/e2e/cases/doctor-webpack/loaders/loader.test.ts
+++ b/e2e/cases/doctor-webpack/loaders/loader.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test';
+import { getSDK } from '@rsbuild/doctor-core/plugins';
+import { compileByWebpack5 } from '@rsbuild/test-helper';
+import os from 'os';
+import path from 'path';
+import { createRsbuildDoctorPlugin } from '../test-utils';
+
+const file = path.resolve(__dirname, '../fixtures/a.js');
+const loaderPath = path.resolve(
+  __dirname,
+  '../fixtures/loaders/serialize-query-to-comment.js',
+);
+
+async function webpack5(query?: string) {
+  const res = await compileByWebpack5(query ? `${file}${query}` : file, {
+    module: {
+      rules: [
+        {
+          oneOf: [
+            {
+              test: /\.js$/,
+              loader: loaderPath,
+            },
+          ],
+          use: [],
+        },
+      ],
+    },
+    // @ts-ignore
+    plugins: [createRsbuildDoctorPlugin()],
+  });
+  return res;
+}
+
+test('webpack5 loader rule.use maybe empty array with oneOf', async () => {
+  const codeTransformed =
+    os.EOL === '\n'
+      ? `console.log('a');\n\n// ${JSON.stringify('')}`
+      : `console.log('a');\r\n\n// ${JSON.stringify('')}`;
+
+  await webpack5();
+
+  const { loader } = getSDK().getStoreData();
+  expect(loader).toHaveLength(1);
+  os.EOL === '\n' &&
+    expect(loader[0].loaders[0].result).toEqual(codeTransformed);
+});

--- a/packages/doctor-core/src/build-utils/build/utils/loader.ts
+++ b/packages/doctor-core/src/build-utils/build/utils/loader.ts
@@ -88,7 +88,7 @@ export function mapEachRules<T extends Plugin.BuildRuleSetRule>(
       } as unknown as T;
     }
 
-    if (rule.use) {
+    if (rule.use && (!Array.isArray(rule.use) || rule.use.length !== 0)) {
       if (typeof rule.use === 'string') {
         return {
           ...rule,


### PR DESCRIPTION
## Summary
Compatible loader's rule.use maybe empty array.


## Related Links

#663

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
