### PR TITLE
fix: should not inject duplicated charset meta tag

### DIFF
--- a/.changeset/fresh-moles-promise.md
+++ b/.changeset/fresh-moles-promise.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix: should not inject duplicated charset meta tag

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { build } from '@scripts/shared';
+
+test('should not inject charset meta if template already contains it', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        template: './src/index.html',
+      },
+      output: {
+        disableFilenameHash: true,
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  expect(html).toEqual(
+    '<!doctype html><html><head><title>Page Title</title><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"><script defer="defer" src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>',
+  );
+});

--- a/e2e/cases/html/meta/src/index.html
+++ b/e2e/cases/html/meta/src/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Page Title</title>
+    <meta charset="utf-8" />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/e2e/cases/html/meta/src/index.js
+++ b/e2e/cases/html/meta/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/packages/document/docs/en/shared/config/html/meta.md
+++ b/packages/document/docs/en/shared/config/html/meta.md
@@ -14,6 +14,10 @@ const defaultMeta = {
 
 Configure the `<meta>` tag of the HTML.
 
+:::tip
+If the HTML template used in the current project already contains the charset or viewport meta tags, then the tags in the HTML template take precedence.
+:::
+
 ### String Type
 
 - **Type:**

--- a/packages/document/docs/zh/shared/config/html/meta.md
+++ b/packages/document/docs/zh/shared/config/html/meta.md
@@ -14,6 +14,10 @@ const defaultMeta = {
 
 配置 HTML 页面的 `<meta>` 标签。
 
+:::tip
+如果当前项目使用的 HTML 模板中已经包含了 `charset` 或 `viewport` meta 标签，那么 HTML 模板中的标签优先级更高。
+:::
+
 ### String 类型
 
 - **类型：**


### PR DESCRIPTION
## Summary

Should not inject duplicated charset meta tag.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/657

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
