### PR TITLE
feat(cli): support build --watch option

### DIFF
--- a/e2e/cases/cli/build-watch/.gitignore
+++ b/e2e/cases/cli/build-watch/.gitignore
@@ -1,0 +1,1 @@
+src/index.js

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import { exec } from 'child_process';
+import { test, expect } from '@playwright/test';
+import { fse } from '@rsbuild/shared';
+import { awaitFileExists } from '@scripts/helper';
+
+test('should support watch mode for build command', async () => {
+  const indexFile = path.join(__dirname, 'src/index.js');
+  const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
+  await fse.remove(indexFile);
+  await fse.remove(distIndexFile);
+
+  fse.outputFileSync(indexFile, `console.log('hello!');`);
+
+  const process = exec('npx rsbuild build --watch', {
+    cwd: __dirname,
+  });
+
+  await awaitFileExists(distIndexFile);
+  expect(fse.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
+  await fse.remove(distIndexFile);
+
+  fse.outputFileSync(indexFile, `console.log('hello2!');`);
+  await awaitFileExists(distIndexFile);
+  expect(fse.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
+
+  process.kill();
+});

--- a/e2e/cases/cli/build-watch/rsbuild.config.mjs
+++ b/e2e/cases/cli/build-watch/rsbuild.config.mjs
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    disableFilenameHash: true,
+  },
+});

--- a/e2e/cases/cli/build-watch/tsconfig.json
+++ b/e2e/cases/cli/build-watch/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@scripts/*": ["../../../scripts/*"]
+    }
+  },
+  "include": ["src", "*.test.ts"]
+}

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -9,6 +9,10 @@ export type CommonOptions = {
   config?: string;
 };
 
+export type BuildOptions = CommonOptions & {
+  watch?: boolean;
+};
+
 export type InspectOptions = CommonOptions & {
   env: RsbuildMode;
   output: string;
@@ -76,15 +80,18 @@ export function runCli() {
 
   program
     .command('build')
+    .option(`-w --watch`, 'turn on watch mode, watch for changes and rebuild')
     .option(
       '-c --config <config>',
       'specify the configuration file, can be a relative or absolute path',
     )
     .description('build the app for production')
-    .action(async (options: CommonOptions) => {
+    .action(async (options: BuildOptions) => {
       try {
         const rsbuild = await init({ cliOptions: options });
-        await rsbuild?.build();
+        await rsbuild?.build({
+          watch: options.watch,
+        });
       } catch (err) {
         logger.error('Failed to build.');
         logger.error(err);

--- a/packages/document/docs/en/guide/basic/cli.mdx
+++ b/packages/document/docs/en/guide/basic/cli.mdx
@@ -25,6 +25,7 @@ The `rsbuild build` command will build the outputs for production in the `dist/`
 Usage: rsbuild build [options]
 
 Options:
+  -w --watch            turn on watch mode, watch for changes and rebuild
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   -h, --help            display help for command
 ```

--- a/packages/document/docs/zh/guide/basic/cli.mdx
+++ b/packages/document/docs/zh/guide/basic/cli.mdx
@@ -25,6 +25,7 @@ Options:
 Usage: rsbuild build [options]
 
 Options:
+  -w --watch            开启 watch 模式, 监听文件变更并重新构建
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help            显示命令帮助
 ```


### PR DESCRIPTION
## Summary

Support `rsbuild build --watch` and `rsbuild build -w`

<img width="790" alt="Screenshot 2023-11-24 at 11 48 42" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/52506850-312d-4014-8f21-7d4e0a9a6aa7">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
