### PR TITLE
 feat(core): log the current used Rspack version

### DIFF
--- a/.changeset/grumpy-toys-sin.md
+++ b/.changeset/grumpy-toys-sin.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat(core): log the current used Rspack version

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -13,9 +13,8 @@ import {
 } from '@rsbuild/shared';
 import { getDevMiddleware } from './devMiddleware';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
-
 import type { Context } from '../../types';
-import { Stats, MultiStats, StatsCompilation } from '@rspack/core';
+import type { Stats, MultiStats, StatsCompilation } from '@rspack/core';
 
 export async function createCompiler({
   context,

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -1,12 +1,13 @@
 import {
   isDev,
+  isProd,
   debug,
   logger,
   prettyTime,
   formatStats,
   TARGET_ID_MAP,
-  type RspackConfig,
   CreateDevMiddlewareReturns,
+  type RspackConfig,
   type RspackCompiler,
   type RspackMultiCompiler,
 } from '@rsbuild/shared';
@@ -44,9 +45,11 @@ export async function createCompiler({
     logger.start('Compiling...');
   });
 
-  compiler.hooks.run.tap('rsbuild:run', () => {
-    logger.start(`Use Rspack v${rspack.rspackVersion}`);
-  });
+  if (isProd()) {
+    compiler.hooks.run.tap('rsbuild:run', () => {
+      logger.start(`Use Rspack v${rspack.rspackVersion}`);
+    });
+  }
 
   compiler.hooks.done.tap('rsbuild:done', async (stats: Stats | MultiStats) => {
     const obj = stats.toJson({

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -16,6 +16,16 @@ import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import type { Context } from '../../types';
 import { Stats, MultiStats, StatsCompilation } from '@rspack/core';
 
+const logRspackVersion = () => {
+  try {
+    const rspackPkg = require.resolve('@rspack/core/package.json');
+    const { version } = require(rspackPkg);
+    if (version) {
+      logger.start(`Use Rspack v${version}`);
+    }
+  } catch (err) {}
+};
+
 export async function createCompiler({
   context,
   rspackConfigs,
@@ -38,8 +48,13 @@ export async function createCompiler({
   let isFirstCompile = true;
 
   compiler.hooks.watchRun.tap('rsbuild:compiling', () => {
+    if (isFirstCompile) {
+      logRspackVersion();
+    }
     logger.start('Compiling...');
   });
+
+  compiler.hooks.run.tap('rsbuild:run', logRspackVersion);
 
   compiler.hooks.done.tap('rsbuild:done', async (stats: Stats | MultiStats) => {
     const obj = stats.toJson({

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -16,16 +16,6 @@ import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import type { Context } from '../../types';
 import { Stats, MultiStats, StatsCompilation } from '@rspack/core';
 
-const logRspackVersion = () => {
-  try {
-    const rspackPkg = require.resolve('@rspack/core/package.json');
-    const { version } = require(rspackPkg);
-    if (version) {
-      logger.start(`Use Rspack v${version}`);
-    }
-  } catch (err) {}
-};
-
 export async function createCompiler({
   context,
   rspackConfigs,
@@ -49,12 +39,14 @@ export async function createCompiler({
 
   compiler.hooks.watchRun.tap('rsbuild:compiling', () => {
     if (isFirstCompile) {
-      logRspackVersion();
+      logger.start(`Use Rspack v${rspack.rspackVersion}`);
     }
     logger.start('Compiling...');
   });
 
-  compiler.hooks.run.tap('rsbuild:run', logRspackVersion);
+  compiler.hooks.run.tap('rsbuild:run', () => {
+    logger.start(`Use Rspack v${rspack.rspackVersion}`);
+  });
 
   compiler.hooks.done.tap('rsbuild:done', async (stats: Stats | MultiStats) => {
     const obj = stats.toJson({


### PR DESCRIPTION
## Summary

Log the current used Rspack version:

<img width="557" alt="Screenshot 2023-11-24 at 12 53 53" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/55558c5c-3f76-478c-8174-df01b996bc4a">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
