### PR TITLE
perf: make rspack version check 3x faster

### DIFF
--- a/.changeset/few-insects-mix.md
+++ b/.changeset/few-insects-mix.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+perf: make rspack version check 3x faster

--- a/packages/core/src/rspack-provider/core/createCompiler.ts
+++ b/packages/core/src/rspack-provider/core/createCompiler.ts
@@ -2,19 +2,21 @@ import {
   isDev,
   isProd,
   debug,
+  color,
   logger,
   prettyTime,
   formatStats,
   TARGET_ID_MAP,
-  CreateDevMiddlewareReturns,
   type RspackConfig,
   type RspackCompiler,
   type RspackMultiCompiler,
+  type CreateDevMiddlewareReturns,
 } from '@rsbuild/shared';
 import { getDevMiddleware } from './devMiddleware';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import type { Context } from '../../types';
 import type { Stats, MultiStats, StatsCompilation } from '@rspack/core';
+import { isSatisfyRspackVersion, rspackMinVersion } from '../shared';
 
 export async function createCompiler({
   context,
@@ -29,6 +31,14 @@ export async function createCompiler({
   });
 
   const { rspack } = await import('@rspack/core');
+
+  if (!(await isSatisfyRspackVersion(rspack.rspackVersion))) {
+    throw new Error(
+      `The current Rspack version does not meet the requirements, the minimum supported version of Rspack is ${color.green(
+        rspackMinVersion,
+      )}`,
+    );
+  }
 
   const compiler =
     rspackConfigs.length === 1

--- a/packages/core/src/rspack-provider/provider.ts
+++ b/packages/core/src/rspack-provider/provider.ts
@@ -1,5 +1,4 @@
 import {
-  color,
   pickRsbuildConfig,
   type RsbuildProvider,
   type RspackConfig,
@@ -10,11 +9,7 @@ import {
 import { createContext, createPublicContext } from './core/createContext';
 import { initConfigs } from './core/initConfigs';
 import { getPluginAPI } from './core/initPlugins';
-import {
-  applyDefaultPlugins,
-  isSatisfyRspackMinimumVersion,
-  supportedRspackMinimumVersion,
-} from './shared';
+import { applyDefaultPlugins } from './shared';
 import type { RsbuildConfig, NormalizedConfig } from '../types';
 
 export type RspackProvider = RsbuildProvider<
@@ -32,14 +27,6 @@ export function rspackProvider({
   const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
 
   return async ({ pluginStore, rsbuildOptions, plugins }) => {
-    if (!(await isSatisfyRspackMinimumVersion())) {
-      throw new Error(
-        `The current Rspack version does not meet the requirements, the minimum supported version of Rspack is ${color.green(
-          supportedRspackMinimumVersion,
-        )}`,
-      );
-    }
-
     const context = await createContext(rsbuildOptions, rsbuildConfig);
     const pluginAPI = getPluginAPI({ context, pluginStore });
 

--- a/packages/core/src/rspack-provider/shared.ts
+++ b/packages/core/src/rspack-provider/shared.ts
@@ -60,10 +60,9 @@ export const getRspackVersion = async (): Promise<string> => {
 };
 
 // apply builtin:swc-loader
-export const supportedRspackMinimumVersion = '0.3.6';
+export const rspackMinVersion = '0.3.6';
 
-export const isSatisfyRspackMinimumVersion = async (customVersion?: string) => {
-  let version = customVersion || (await getRspackVersion());
+export const isSatisfyRspackVersion = async (version: string) => {
   const semver = await import('semver');
 
   // The nightly version of rspack is to append `-canary-xxx` to the current version
@@ -71,7 +70,7 @@ export const isSatisfyRspackMinimumVersion = async (customVersion?: string) => {
     version = version.split('-canary')[0];
   }
 
-  return version ? semver.lte(supportedRspackMinimumVersion, version) : true;
+  return version ? semver.lte(rspackMinVersion, version) : true;
 };
 
 export const getCompiledPath = (packageName: string) => {

--- a/packages/core/tests/rspack-provider/shared/rspackVersion.test.ts
+++ b/packages/core/tests/rspack-provider/shared/rspackVersion.test.ts
@@ -1,30 +1,24 @@
 import {
-  isSatisfyRspackMinimumVersion,
-  supportedRspackMinimumVersion,
+  rspackMinVersion,
   getRspackVersion,
+  isSatisfyRspackVersion,
 } from '@/shared';
 
 describe('rspack version', () => {
-  it('isSatisfyRspackMinimumVersion', async () => {
-    expect(await isSatisfyRspackMinimumVersion()).toBeTruthy();
+  it('isSatisfyRspackVersion', async () => {
+    expect(await isSatisfyRspackVersion('0.1.0')).toBeFalsy();
 
-    expect(await isSatisfyRspackMinimumVersion('0.1.0')).toBeFalsy();
+    expect(await isSatisfyRspackVersion(rspackMinVersion)).toBeTruthy();
 
-    expect(
-      await isSatisfyRspackMinimumVersion(supportedRspackMinimumVersion),
-    ).toBeTruthy();
-
-    expect(await isSatisfyRspackMinimumVersion('1.0.0')).toBeTruthy();
+    expect(await isSatisfyRspackVersion('1.0.0')).toBeTruthy();
 
     expect(
-      await isSatisfyRspackMinimumVersion(
-        '0.2.7-canary-efa0dc6-20230817005622',
-      ),
+      await isSatisfyRspackVersion('0.2.7-canary-efa0dc6-20230817005622'),
     ).toBeFalsy();
 
     expect(
-      await isSatisfyRspackMinimumVersion(
-        `${supportedRspackMinimumVersion}-canary-efa0dc6-20230817005622`,
+      await isSatisfyRspackVersion(
+        `${rspackMinVersion}-canary-efa0dc6-20230817005622`,
       ),
     ).toBeTruthy();
   });


### PR DESCRIPTION
## Summary

Make rspack version check 3x faster.

before:

<img width="394" alt="Screenshot 2023-11-24 at 13 19 36" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/841b0879-0e31-4943-b800-38c0676bb215">

after:

<img width="397" alt="Screenshot 2023-11-24 at 13 19 39" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/224aacb5-4ae3-476b-ac69-3acc2efdcc8a">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
