### PR TITLE
feat: resolve ts files by default

### DIFF
--- a/.changeset/early-kiwis-poke.md
+++ b/.changeset/early-kiwis-poke.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat: resolve ts files by default

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -680,6 +680,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   ],
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -1430,6 +1432,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   ],
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -1978,6 +1982,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   ],
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -2544,6 +2550,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   ],
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/react.test.ts.snap
@@ -950,6 +950,8 @@ exports[`plugins/react > should work with ts-loader 1`] = `
   ],
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/compat/webpack/tests/plugins/__snapshots__/resolve.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/resolve.test.ts.snap
@@ -19,6 +19,8 @@ exports[`plugin-resolve > should disable resolve.fullySpecified by default 1`] =
   },
   "resolve": {
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/compat/webpack/tests/plugins/resolve.test.ts
+++ b/packages/compat/webpack/tests/plugins/resolve.test.ts
@@ -8,6 +8,8 @@ describe('plugin-resolve', () => {
     });
     const config = await rsbuild.unwrapWebpackConfig();
     expect(config.resolve?.extensions).toEqual([
+      '.ts',
+      '.tsx',
       '.js',
       '.jsx',
       '.mjs',

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -661,6 +661,8 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -661,6 +661,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -1387,6 +1389,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -1817,6 +1821,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "node",
     ],
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",
@@ -2502,6 +2508,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/core/tests/rspack-provider/plugins/resolve.test.ts
+++ b/packages/core/tests/rspack-provider/plugins/resolve.test.ts
@@ -26,6 +26,8 @@ describe('plugin-resolve', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     expect(bundlerConfigs[0].resolve?.extensions).toEqual([
+      '.ts',
+      '.tsx',
       '.js',
       '.jsx',
       '.mjs',

--- a/packages/document/docs/en/guide/basic/typescript.md
+++ b/packages/document/docs/en/guide/basic/typescript.md
@@ -6,30 +6,6 @@ Rsbuild supports TypeScript by default, allowing you to directly use `.ts` and `
 
 Rsbuild uses SWC by default for transpiling TypeScript code, and it also supports switching to Babel for transpilation.
 
-### Configuring tsconfig.json
-
-When a `tsconfig.json` file is present in the root directory of the project, Rsbuild will enable the transpilation of TypeScript files. If there is no `tsconfig.json` file in the current project, Rsbuild will throw an exception when compiling TS files.
-
-Below is an example of a `tsconfig.json` file, which you can also adjust according to the needs of your project:
-
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
-    "module": "ESNext",
-    "strict": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "bundler"
-  },
-  "include": ["src"]
-}
-```
-
-Please note that the fields in `tsconfig.json` will not affect the compilation behavior and output of Rsbuild, but will only affect the results of type checking.
-
 ### isolatedModules
 
 Unlike the native TypeScript compiler, tools like SWC and Babel compile each file separately and cannot determine whether an imported name is a type or a value. Therefore, when using TypeScript in Rsbuild, you need to enable the [isolatedModules](https://typescriptlang.org/tsconfig/#isolatedModules) option in your `tsconfig.json` file:

--- a/packages/document/docs/en/plugins/list/plugin-type-check.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-type-check.mdx
@@ -33,6 +33,28 @@ export default {
 };
 ```
 
+### Configuring tsconfig.json
+
+The Type Check plugin by default performs checks based on the `tsconfig.json` file in the root directory of the current project. Below is an example of a `tsconfig.json` file, which you can also adjust according to the needs of your project.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}
+```
+
+Please note that the fields in `tsconfig.json` will not affect the compilation behavior and output of Rsbuild, but will only affect the results of type checking.
+
 ## Options
 
 ### enable

--- a/packages/document/docs/zh/guide/basic/typescript.md
+++ b/packages/document/docs/zh/guide/basic/typescript.md
@@ -6,30 +6,6 @@ Rsbuild 默认支持 TypeScript，你可以直接在项目中使用 `.ts` 和 `.
 
 Rsbuild 默认使用 SWC 来转译 TypeScript 代码，也支持切换到 Babel 进行转译。
 
-### 配置 tsconfig.json
-
-当项目的根目录存在 `tsconfig.json` 文件时，Rsbuild 会开启对 TypeScript 文件的转译。如果当前项目中没有 `tsconfig.json` 文件，编译 TS 文件时，Rsbuild 会抛出异常。
-
-下面是一份 `tsconfig.json` 文件的例子，你也可以根据项目的需求进行调整：
-
-```json title="tsconfig.json"
-{
-  "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
-    "module": "ESNext",
-    "strict": true,
-    "skipLibCheck": true,
-    "isolatedModules": true,
-    "resolveJsonModule": true,
-    "moduleResolution": "bundler"
-  },
-  "include": ["src"]
-}
-```
-
-注意 `tsconfig.json` 中的字段并不会影响 Rsbuild 的编译行为和产物，只会影响类型检查的结果。
-
 ### isolatedModules
 
 与 TypeScript 原生编译器不同，像 SWC 和 Babel 这样的工具会将每个文件单独编译，它无法确定导入的名称是一个类型还是一个值。因此，当你在 Rsbuild 中使用 TypeScript 时，需要启用 `tsconfig.json` 中的 [isolatedModules](https://typescriptlang.org/tsconfig/#isolatedModules) 选项：

--- a/packages/document/docs/zh/plugins/list/plugin-type-check.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-type-check.mdx
@@ -33,6 +33,28 @@ export default {
 };
 ```
 
+### 配置 tsconfig.json
+
+Type Check 插件默认基于当前项目根目录的 `tsconfig.json` 进行检查，下面是一份 `tsconfig.json` 文件的例子，你也可以根据项目的需求进行调整。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "module": "ESNext",
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "bundler"
+  },
+  "include": ["src"]
+}
+```
+
+注意 `tsconfig.json` 中的字段并不会影响 Rsbuild 的编译行为和产物，只会影响类型检查的结果。
+
 ## 选项
 
 ### enable

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -706,6 +706,8 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
+      ".ts",
+      ".tsx",
       ".js",
       ".jsx",
       ".mjs",

--- a/packages/shared/src/apply/resolve.ts
+++ b/packages/shared/src/apply/resolve.ts
@@ -12,11 +12,8 @@ import {
 export function applyResolvePlugin(api: SharedRsbuildPluginAPI) {
   api.modifyBundlerChain((chain, { CHAIN_ID }) => {
     const config = api.getNormalizedConfig();
-    const isTsProject = Boolean(api.context.tsconfigPath);
-    applyExtensions({
-      chain,
-      isTsProject,
-    });
+
+    applyExtensions({ chain });
 
     applyAlias({
       chain,
@@ -44,17 +41,11 @@ function applyFullySpecified({
     .resolve.set('fullySpecified', false);
 }
 
-function applyExtensions({
-  chain,
-  isTsProject,
-}: {
-  chain: BundlerChain;
-  isTsProject: boolean;
-}) {
+function applyExtensions({ chain }: { chain: BundlerChain }) {
   const extensions = [
-    // only resolve .ts(x) files if it's a ts project
     // most projects are using TypeScript, resolve .ts(x) files first to reduce resolve time.
-    ...(isTsProject ? ['.ts', '.tsx'] : []),
+    '.ts',
+    '.tsx',
     '.js',
     '.jsx',
     '.mjs',


### PR DESCRIPTION
## Summary

Sometimes user just forget to create a tsconfig file and the resolver will failed to resolve ts files.

This change allows user to resolve ts files without a tsconfig file.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
