### PR TITLE
workflow: add PR labeler

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,10 @@
+"change: feat":
+  - "/^(feat|types|style)/"
+"change: fix":
+  - "/^fix/"
+"change: perf":
+  - "/^perf/"
+"change: breaking":
+  - "/^breaking change/"
+"change: docs":
+  - "/^docs/"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,6 +12,9 @@ changelog:
     - title: New Features 🎉
       labels:
         - "change: feat"
+    - title: Performance 🚀
+      labels:
+        - "change: perf"
     - title: Bug Fixes 🐞
       labels:
         - "change: fix"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      # Ignore the release PR created by github-actions
+      - github-actions
+  categories:
+    - title: Breaking Changes 🍭
+      labels:
+        - "change: breaking"
+    - title: New Features 🎉
+      labels:
+        - "change: feat"
+    - title: Bug Fixes 🐞
+      labels:
+        - "change: fix"
+    - title: Document 📖
+      labels:
+        - "change: docs"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -1,0 +1,20 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+jobs:
+  change-labeling:
+    name: Labeling for changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v3.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/pr-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          sync-labels: 1


### PR DESCRIPTION
## Summary

Add PR labeler to workflow, this allows to:

- add label for PR
- generate CHANGELOG via GitHub release.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
