### PR TITLE
docs: mark getCompiledPath as private

### DIFF
--- a/packages/document/docs/en/guide/basic/configure-rspack.mdx
+++ b/packages/document/docs/en/guide/basic/configure-rspack.mdx
@@ -2,7 +2,7 @@
 
 Rsbuild supports directly modifying the Rspack configuration object, and also supports modifying the built-in Rspack configuration of Rsbuild through the bundler-chain.
 
-## Modify Rspack Configuration Object
+## Modify Rspack Config
 
 You can use the `tools.rspack` option of Rsbuild to modify the Rspack configuration object. Please refer to the [tools.rspack documentation](/config/options/tools#toolsrspack) for complete usage.
 

--- a/packages/document/docs/en/guide/basic/tailwindcss.mdx
+++ b/packages/document/docs/en/guide/basic/tailwindcss.mdx
@@ -72,7 +72,7 @@ You can use Tailwind's utility classes in any component or HTML, such as:
 
 For more usage details, refer to the [Tailwind CSS documentation](https://tailwindcss.com/).
 
-## Autocompletion
+## VS Code Extension
 
 Tailwind CSS provides a [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense) plugin for VS Code to automatically complete Tailwind CSS class names, CSS functions, and directives.
 

--- a/packages/document/docs/en/guide/basic/unocss.mdx
+++ b/packages/document/docs/en/guide/basic/unocss.mdx
@@ -66,7 +66,7 @@ You can use UnoCSS's utility classes in any component or HTML, such as:
 
 For more usage details, refer to the [UnoCSS documentation](https://unocss.dev/).
 
-## Intelligent Tooltip
+## VS Code Extension
 
 UnoCSS provides a [VSCode Extension](https://unocss.dev/integrations/vscode) plugin for VS Code to decoration and tooltip for matched utilities.
 

--- a/packages/document/docs/en/shared/config/tools/rspack.md
+++ b/packages/document/docs/en/shared/config/tools/rspack.md
@@ -268,33 +268,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the Rsbuild built-in dependencies, such as:
-
-- sass
-- sass-loader
-- less
-- less-loader
-- url-loader
-- ...
-
-This method is usually used when you need to reuse the same dependency with the Rsbuild.
-
-:::tip
-Rsbuild built-in dependencies are subject to change with version iterations, e.g. generate large version break changes. Please avoid using this API if it is not necessary.
-:::
-
-```js
-export default {
-  tools: {
-    rspack: (config, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```

--- a/packages/document/docs/zh/guide/basic/tailwindcss.mdx
+++ b/packages/document/docs/zh/guide/basic/tailwindcss.mdx
@@ -72,7 +72,7 @@ module.exports = {
 
 更多用法请参考 [Tailwind CSS 文档](https://tailwindcss.com/)。
 
-## 自动补全
+## VS Code 插件
 
 Tailwind CSS 提供了 [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense) 插件，用于在 VS Code 中自动补全 Tailwind CSS 的 class names、CSS functions 和 directives。
 

--- a/packages/document/docs/zh/guide/basic/unocss.mdx
+++ b/packages/document/docs/zh/guide/basic/unocss.mdx
@@ -66,7 +66,7 @@ export default defineConfig({
 
 更多用法请参考 [UnoCSS 文档](https://unocss.dev/)。
 
-## 智能提示
+## VS Code 插件
 
 UnoCSS 提供了 [VSCode 插件](https://unocss.dev/integrations/vscode)，用于在 VS Code 中提示 UnoCSS 的 utilities classes。
 

--- a/packages/document/docs/zh/shared/config/tools/rspack.md
+++ b/packages/document/docs/zh/shared/config/tools/rspack.md
@@ -268,33 +268,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 Rsbuild 内置依赖的所在路径，例如：
-
-- sass
-- sass-loader
-- less
-- less-loader
-- url-loader
-- ...
-
-该方法通常在需要与 Rsbuild 复用同一份依赖时会被用到。
-
-:::tip
-Rsbuild 内部依赖会随着版本迭代而发生变化，例如产生大版本变更。在非必要的情况下，请避免使用此 API。
-:::
-
-```js
-export default {
-  tools: {
-    rspack: (config, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -57,8 +57,11 @@ export type ModifyChainUtils = {
   isServiceWorker: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  getCompiledPath: (name: string) => string;
   HtmlPlugin: typeof import('html-webpack-plugin');
+  /**
+   * @private internal API
+   */
+  getCompiledPath: (name: string) => string;
 };
 
 interface PluginInstance {


### PR DESCRIPTION
## Summary

Mark getCompiledPath as private, we do not want user to use this util, because the compiled dependencies are unstable and may change during Rsbuild development.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
