### PR TITLE
fix: failed to modify server port in plugins

### DIFF
--- a/.changeset/red-walls-crash.md
+++ b/.changeset/red-walls-crash.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix: failed to modify server port in plugins

--- a/packages/compat/webpack/src/core/initConfigs.ts
+++ b/packages/compat/webpack/src/core/initConfigs.ts
@@ -1,28 +1,14 @@
 import {
-  debug,
   isDebug,
   castArray,
-  initPlugins,
-  mergeRsbuildConfig,
   type PluginStore,
   type InspectConfigOptions,
   type CreateRsbuildOptions,
 } from '@rsbuild/shared';
-import { updateContextByNormalizedConfig } from '@rsbuild/core/rspack-provider';
+import { initRsbuildConfig } from '@rsbuild/core/rspack-provider';
 import { inspectConfig } from './inspectConfig';
 import { generateWebpackConfig } from './webpackConfig';
-import { normalizeConfig } from '../config/normalize';
 import type { Context, WebpackConfig } from '../types';
-
-async function modifyRsbuildConfig(context: Context) {
-  debug('modify Rsbuild config');
-  const [modified] = await context.hooks.modifyRsbuildConfigHook.call(
-    context.config,
-    { mergeRsbuildConfig },
-  );
-  context.config = modified;
-  debug('modify Rsbuild config done');
-}
 
 export type InitConfigsOptions = {
   context: Context;
@@ -37,16 +23,11 @@ export async function initConfigs({
 }: InitConfigsOptions): Promise<{
   webpackConfigs: WebpackConfig[];
 }> {
-  await initPlugins({
-    pluginAPI: context.pluginAPI,
+  await initRsbuildConfig({
+    // @ts-expect-error context type mismatch
+    context,
     pluginStore,
   });
-
-  await modifyRsbuildConfig(context);
-
-  const normalizedConfig = normalizeConfig(context.config);
-  context.normalizedConfig = normalizedConfig;
-  updateContextByNormalizedConfig(context, context.normalizedConfig);
 
   const targets = castArray(rsbuildOptions.target);
   const webpackConfigs = await Promise.all(

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -3,8 +3,10 @@ import {
   type RsbuildProvider,
   type PreviewServerOptions,
 } from '@rsbuild/shared';
-import { startProdServer, startDevServer } from '@rsbuild/core/server';
-import { createPublicContext } from '@rsbuild/core/rspack-provider';
+import {
+  createPublicContext,
+  initRsbuildConfig,
+} from '@rsbuild/core/rspack-provider';
 import { createContext } from './core/createContext';
 import { applyDefaultPlugins } from './shared/plugin';
 import { RsbuildConfig, NormalizedConfig, WebpackConfig } from './types';
@@ -64,7 +66,13 @@ export function webpackProvider({
       },
 
       async startDevServer(options) {
+        const { startDevServer } = await import('@rsbuild/core/server');
         const { createDevMiddleware } = await import('./core/createCompiler');
+        await initRsbuildConfig({
+          // @ts-expect-error context type mismatch
+          context,
+          pluginStore,
+        });
         return startDevServer(
           {
             // @ts-expect-error context type mismatch
@@ -78,6 +86,12 @@ export function webpackProvider({
       },
 
       async preview(options?: PreviewServerOptions) {
+        const { startProdServer } = await import('@rsbuild/core/server');
+        await initRsbuildConfig({
+          // @ts-expect-error context type mismatch
+          context,
+          pluginStore,
+        });
         return startProdServer(
           // @ts-expect-error context type mismatch
           context,

--- a/packages/core/src/rspack-provider/core/initConfigs.ts
+++ b/packages/core/src/rspack-provider/core/initConfigs.ts
@@ -32,13 +32,15 @@ export type InitConfigsOptions = {
   rsbuildOptions: Required<CreateRsbuildOptions>;
 };
 
-export async function initConfigs({
+export async function initRsbuildConfig({
   context,
   pluginStore,
-  rsbuildOptions,
-}: InitConfigsOptions): Promise<{
-  rspackConfigs: RspackConfig[];
-}> {
+}: Pick<InitConfigsOptions, 'context' | 'pluginStore'>): Promise<void> {
+  // inited
+  if (context.normalizedConfig) {
+    return;
+  }
+
   await initPlugins({
     pluginAPI: context.pluginAPI,
     pluginStore,
@@ -47,6 +49,16 @@ export async function initConfigs({
   await modifyRsbuildConfig(context);
   context.normalizedConfig = normalizeConfig(context.config);
   updateContextByNormalizedConfig(context, context.normalizedConfig);
+}
+
+export async function initConfigs({
+  context,
+  pluginStore,
+  rsbuildOptions,
+}: InitConfigsOptions): Promise<{
+  rspackConfigs: RspackConfig[];
+}> {
+  await initRsbuildConfig({ context, pluginStore });
 
   const targets = castArray(rsbuildOptions.target);
   const rspackConfigs = await Promise.all(

--- a/packages/core/src/rspack-provider/index.ts
+++ b/packages/core/src/rspack-provider/index.ts
@@ -5,5 +5,5 @@ export type { Rspack, RspackConfig } from '@rsbuild/shared';
 export {
   createPublicContext,
   createContextByConfig,
-  updateContextByNormalizedConfig,
 } from './core/createContext';
+export { initRsbuildConfig } from './core/initConfigs';

--- a/packages/core/src/rspack-provider/provider.ts
+++ b/packages/core/src/rspack-provider/provider.ts
@@ -7,7 +7,7 @@ import {
   type PreviewServerOptions,
 } from '@rsbuild/shared';
 import { createContext, createPublicContext } from './core/createContext';
-import { initConfigs } from './core/initConfigs';
+import { initConfigs, initRsbuildConfig } from './core/initConfigs';
 import { getPluginAPI } from './core/initPlugins';
 import { applyDefaultPlugins } from './shared';
 import type { RsbuildConfig, NormalizedConfig } from '../types';
@@ -61,6 +61,7 @@ export function rspackProvider({
       async startDevServer(options) {
         const { startDevServer } = await import('../server/devServer');
         const { createDevMiddleware } = await import('./core/createCompiler');
+        await initRsbuildConfig({ context, pluginStore });
         return startDevServer(
           { context, pluginStore, rsbuildOptions },
           createDevMiddleware,
@@ -70,6 +71,7 @@ export function rspackProvider({
 
       async preview(options?: PreviewServerOptions) {
         const { startProdServer } = await import('../server/prodServer');
+        await initRsbuildConfig({ context, pluginStore });
         return startProdServer(context, context.config, options);
       },
 


### PR DESCRIPTION
## Summary

Fix failed to modify server port in plugins.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
