### PR TITLE
types: unify compiler type, use Rspack compiler by default

### DIFF
--- a/.changeset/perfect-queens-carry.md
+++ b/.changeset/perfect-queens-carry.md
@@ -1,0 +1,7 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+types: unify compiler type, use Rspack compiler by default

--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -1,4 +1,11 @@
-import { isDev, logger, debug, formatStats, type Stats } from '@rsbuild/shared';
+import {
+  isDev,
+  logger,
+  debug,
+  formatStats,
+  type Stats,
+  type Rspack,
+} from '@rsbuild/shared';
 import type { Context, WebpackConfig } from '../types';
 import { initConfigs, InitConfigsOptions } from './initConfigs';
 import type { Compiler, MultiCompiler } from 'webpack';
@@ -44,7 +51,9 @@ export async function createCompiler({
     isFirstCompile = false;
   });
 
-  await context.hooks.onAfterCreateCompilerHook.call({ compiler });
+  await context.hooks.onAfterCreateCompilerHook.call({
+    compiler: compiler as unknown as Rspack.Compiler | Rspack.MultiCompiler,
+  });
   debug('create compiler done');
 
   return compiler;

--- a/packages/compat/webpack/src/core/initHooks.ts
+++ b/packages/compat/webpack/src/core/initHooks.ts
@@ -15,7 +15,6 @@ import {
   OnBeforeCreateCompilerFn,
 } from '@rsbuild/shared';
 import type { ModifyBundlerChainFn } from '@rsbuild/shared';
-import type { Compiler, MultiCompiler } from 'webpack';
 import type { WebpackConfig, RsbuildConfig } from '../types';
 
 export function initHooks() {
@@ -28,8 +27,7 @@ export function initHooks() {
     modifyWebpackConfigHook: createAsyncHook<ModifyWebpackConfigFn>(),
     modifyRsbuildConfigHook:
       createAsyncHook<ModifyRsbuildConfigFn<RsbuildConfig>>(),
-    onAfterCreateCompilerHook:
-      createAsyncHook<OnAfterCreateCompilerFn<Compiler | MultiCompiler>>(),
+    onAfterCreateCompilerHook: createAsyncHook<OnAfterCreateCompilerFn>(),
     onBeforeCreateCompilerHook:
       createAsyncHook<OnBeforeCreateCompilerFn<WebpackConfig>>(),
     onAfterStartDevServerHook: createAsyncHook<OnAfterStartDevServerFn>(),

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -12,13 +12,11 @@ import { applyDefaultPlugins } from './shared/plugin';
 import { RsbuildConfig, NormalizedConfig, WebpackConfig } from './types';
 import { initConfigs } from './core/initConfigs';
 import { getPluginAPI } from './core/initPlugins';
-import type { Compiler, MultiCompiler } from 'webpack';
 
 export type WebpackProvider = RsbuildProvider<
   RsbuildConfig,
   WebpackConfig,
-  NormalizedConfig,
-  Compiler | MultiCompiler
+  NormalizedConfig
 >;
 
 export function webpackProvider({

--- a/packages/compat/webpack/src/types/plugin.ts
+++ b/packages/compat/webpack/src/types/plugin.ts
@@ -2,7 +2,6 @@ import type {
   DefaultRsbuildPluginAPI,
   RsbuildPlugin as BaseRsbuildPlugin,
 } from '@rsbuild/shared';
-import type { Compiler, MultiCompiler } from 'webpack';
 import type { RsbuildConfig, NormalizedConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
 
@@ -10,8 +9,7 @@ export interface RsbuildPluginAPI
   extends DefaultRsbuildPluginAPI<
     RsbuildConfig,
     NormalizedConfig,
-    WebpackConfig,
-    Compiler | MultiCompiler
+    WebpackConfig
   > {}
 
 export type RsbuildPlugin = BaseRsbuildPlugin<RsbuildPluginAPI>;

--- a/packages/core/src/rspack-provider/core/initHooks.ts
+++ b/packages/core/src/rspack-provider/core/initHooks.ts
@@ -16,7 +16,6 @@ import {
   type ModifyRspackConfigFn,
 } from '@rsbuild/shared';
 import type { RsbuildConfig } from '../../types';
-import type { Compiler, MultiCompiler } from '@rspack/core';
 
 export function initHooks() {
   return {
@@ -34,8 +33,7 @@ export function initHooks() {
     modifyRspackConfigHook: createAsyncHook<ModifyRspackConfigFn>(),
     modifyRsbuildConfigHook:
       createAsyncHook<ModifyRsbuildConfigFn<RsbuildConfig>>(),
-    onAfterCreateCompilerHook:
-      createAsyncHook<OnAfterCreateCompilerFn<Compiler | MultiCompiler>>(),
+    onAfterCreateCompilerHook: createAsyncHook<OnAfterCreateCompilerFn>(),
     onBeforeCreateCompilerHook:
       createAsyncHook<OnBeforeCreateCompilerFn<RspackConfig>>(),
 

--- a/packages/core/src/rspack-provider/provider.ts
+++ b/packages/core/src/rspack-provider/provider.ts
@@ -2,8 +2,6 @@ import {
   pickRsbuildConfig,
   type RsbuildProvider,
   type RspackConfig,
-  type RspackCompiler,
-  type RspackMultiCompiler,
   type PreviewServerOptions,
 } from '@rsbuild/shared';
 import { createContext, createPublicContext } from './core/createContext';
@@ -15,8 +13,7 @@ import type { RsbuildConfig, NormalizedConfig } from '../types';
 export type RspackProvider = RsbuildProvider<
   RsbuildConfig,
   RspackConfig,
-  NormalizedConfig,
-  RspackCompiler | RspackMultiCompiler
+  NormalizedConfig
 >;
 
 export function rspackProvider({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,18 +6,13 @@ import type {
   RsbuildPlugin as BaseRsbuildPlugin,
 } from '@rsbuild/shared';
 import type { Hooks } from './rspack-provider/core/initHooks';
-import type {
-  RspackConfig,
-  RspackCompiler,
-  RspackMultiCompiler,
-} from '@rsbuild/shared';
+import type { RspackConfig } from '@rsbuild/shared';
 
 export interface RsbuildPluginAPI
   extends DefaultRsbuildPluginAPI<
     RsbuildConfig,
     NormalizedConfig,
-    RspackConfig,
-    RspackCompiler | RspackMultiCompiler
+    RspackConfig
   > {}
 
 export type RsbuildPlugin<T = RsbuildPluginAPI> = BaseRsbuildPlugin<T>;

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -4,6 +4,7 @@ import { NodeEnv, PromiseOrNot } from './utils';
 import { RsbuildTarget } from './rsbuild';
 import { BundlerChain } from './bundlerConfig';
 import { mergeRsbuildConfig } from '../mergeRsbuildConfig';
+import type { Rspack } from './rspack';
 
 export type OnBeforeBuildFn<BundlerConfig = unknown> = (params: {
   bundlerConfigs?: BundlerConfig[];
@@ -40,9 +41,9 @@ export type OnBeforeCreateCompilerFn<BundlerConfig = unknown> = (params: {
   bundlerConfigs: BundlerConfig[];
 }) => PromiseOrNot<void>;
 
-export type OnAfterCreateCompilerFn<Compiler = unknown> = (params: {
-  compiler: Compiler;
-}) => PromiseOrNot<void>;
+export type OnAfterCreateCompilerFn<
+  Compiler = Rspack.Compiler | Rspack.MultiCompiler,
+> = (params: { compiler: Compiler }) => PromiseOrNot<void>;
 
 export type OnExitFn = () => void;
 

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -122,7 +122,6 @@ export type DefaultRsbuildPluginAPI<
   Config extends Record<string, any> = Record<string, any>,
   NormalizedConfig extends Record<string, any> = Record<string, any>,
   BundlerConfig = unknown,
-  Compiler = unknown,
 > = {
   context: Readonly<Context>;
   isPluginExists: PluginStore['isPluginExists'];
@@ -135,7 +134,7 @@ export type DefaultRsbuildPluginAPI<
   onBeforeStartDevServer: (fn: OnBeforeStartDevServerFn) => void;
   onAfterStartProdServer: (fn: OnAfterStartProdServerFn) => void;
   onBeforeStartProdServer: (fn: OnBeforeStartProdServerFn) => void;
-  onAfterCreateCompiler: (fn: OnAfterCreateCompilerFn<Compiler>) => void;
+  onAfterCreateCompiler: (fn: OnAfterCreateCompilerFn) => void;
   onBeforeCreateCompiler: (fn: OnBeforeCreateCompilerFn<BundlerConfig>) => void;
 
   /**

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -41,20 +41,16 @@ export type RsbuildProvider<
   RsbuildConfig extends Record<string, any> = Record<string, any>,
   BundlerConfig extends Record<string, any> = Record<string, any>,
   NormalizedConfig extends Record<string, any> = Record<string, any>,
-  Compiler extends Record<string, any> = Record<string, any>,
 > = (options: {
   pluginStore: PluginStore;
   rsbuildOptions: Required<CreateRsbuildOptions>;
   plugins: Plugins;
-}) => Promise<
-  ProviderInstance<RsbuildConfig, BundlerConfig, NormalizedConfig, Compiler>
->;
+}) => Promise<ProviderInstance<RsbuildConfig, BundlerConfig, NormalizedConfig>>;
 
 export type ProviderInstance<
   RsbuildConfig extends Record<string, any> = Record<string, any>,
   BundlerConfig extends Record<string, any> = Record<string, any>,
   NormalizedConfig extends Record<string, any> = Record<string, any>,
-  CommonCompiler extends Record<string, any> = Record<string, any>,
 > = {
   readonly bundler: Bundler;
 
@@ -63,8 +59,7 @@ export type ProviderInstance<
   pluginAPI: DefaultRsbuildPluginAPI<
     RsbuildConfig,
     NormalizedConfig,
-    BundlerConfig,
-    CommonCompiler
+    BundlerConfig
   >;
 
   applyDefaultPlugins: (pluginStore: PluginStore) => Promise<void>;


### PR DESCRIPTION
## Summary

Unify compiler type, use Rspack compiler by default.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
