### PR TITLE
workflow: configure typescript project reference

### DIFF
--- a/packages/babel-preset/tests/tsconfig.json
+++ b/packages/babel-preset/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/babel-preset/tsconfig.json
+++ b/packages/babel-preset/tsconfig.json
@@ -2,7 +2,20 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    },
+    {
+      "path": "../plugin-babel"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/compat/plugin-esbuild/tests/tsconfig.json
+++ b/packages/compat/plugin-esbuild/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/plugin-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-swc/tests/plugin.test.ts
@@ -3,10 +3,8 @@ import { pluginSwc } from '../src';
 import { pluginBabel } from '@rsbuild/webpack/plugin-babel';
 import { webpackProvider } from '@rsbuild/webpack';
 import { applyPluginConfig } from '../src/utils';
-import type {
-  ModifyWebpackChainUtils,
-  NormalizedConfig,
-} from '@rsbuild/webpack';
+import type { NormalizedConfig } from '@rsbuild/webpack';
+import type { ModifyWebpackChainUtils } from '@rsbuild/shared';
 
 const TEST_BUILDER_CONFIG = {
   output: {},

--- a/packages/compat/plugin-swc/tests/tsconfig.json
+++ b/packages/compat/plugin-swc/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/uni-builder/tests/tsconfig.json
+++ b/packages/compat/uni-builder/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/webpack/tests/tsconfig.json
+++ b/packages/compat/webpack/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"],

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -2,7 +2,29 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../../core"
+    },
+    {
+      "path": "../../shared"
+    },
+    {
+      "path": "../../plugin-babel"
+    },
+    {
+      "path": "../../plugin-react"
+    },
+    {
+      "path": "../../babel-preset"
+    },
+    {
+      "path": "../../plugin-css-minimizer"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"],

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,14 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/doctor-core/tests/tsconfig.json
+++ b/packages/doctor-core/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {

--- a/packages/doctor-webpack-plugin/tests/tsconfig.json
+++ b/packages/doctor-webpack-plugin/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {

--- a/packages/monorepo-utils/tsconfig.json
+++ b/packages/monorepo-utils/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-assets-retry/tests/tsconfig.json
+++ b/packages/plugin-assets-retry/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-assets-retry/tsconfig.json
+++ b/packages/plugin-assets-retry/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -1,9 +1,18 @@
 {
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ""
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["tests/fixtures"]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/plugin-check-syntax/tests/tsconfig.json
+++ b/packages/plugin-check-syntax/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-check-syntax/tsconfig.json
+++ b/packages/plugin-check-syntax/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-css-minimizer/tsconfig.json
+++ b/packages/plugin-css-minimizer/tsconfig.json
@@ -1,9 +1,18 @@
 {
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
-    "outDir": "dist",
-    "baseUrl": ""
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["tests/fixtures"]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/plugin-image-compress/src/index.ts
+++ b/packages/plugin-image-compress/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/webpack';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import assert from 'assert';
 import { ModernJsImageMinimizerPlugin } from './minimizer';
 import { withDefaultOptions } from './shared/utils';

--- a/packages/plugin-image-compress/tests/index.test.ts
+++ b/packages/plugin-image-compress/tests/index.test.ts
@@ -5,25 +5,12 @@ import { pluginImageCompress } from '../src';
 
 process.env.NODE_ENV = 'production';
 
-const ASSET_EXTS = [
-  'png',
-  'jpg',
-  'jpeg',
-  'gif',
-  'bmp',
-  'webp',
-  'ico',
-  'apng',
-  'avif',
-  'tiff',
-];
-
 describe('plugin-image-compress', () => {
   it('should generate correct options', async () => {
     const rsbuild = await createStubRsbuild({
       provider: webpackProvider,
       rsbuildConfig: {},
-      plugins: [pluginAsset('image', ASSET_EXTS), pluginImageCompress()],
+      plugins: [pluginAsset(), pluginImageCompress()],
     });
     expect(await rsbuild.unwrapConfig()).toMatchSnapshot();
   });
@@ -32,10 +19,7 @@ describe('plugin-image-compress', () => {
     const rsbuild = await createStubRsbuild({
       provider: webpackProvider,
       rsbuildConfig: {},
-      plugins: [
-        pluginAsset('image', ASSET_EXTS),
-        pluginImageCompress('jpeg', { use: 'png' }),
-      ],
+      plugins: [pluginAsset(), pluginImageCompress('jpeg', { use: 'png' })],
     });
     const config = await rsbuild.unwrapConfig();
     expect(config.optimization?.minimizer).toMatchInlineSnapshot(`
@@ -62,10 +46,7 @@ describe('plugin-image-compress', () => {
     const rsbuild = await createStubRsbuild({
       provider: webpackProvider,
       rsbuildConfig: {},
-      plugins: [
-        pluginAsset('image', ASSET_EXTS),
-        pluginImageCompress(['jpeg', { use: 'png' }]),
-      ],
+      plugins: [pluginAsset(), pluginImageCompress(['jpeg', { use: 'png' }])],
     });
     const config = await rsbuild.unwrapConfig();
     expect(config.optimization?.minimizer).toMatchInlineSnapshot(`

--- a/packages/plugin-image-compress/tests/tsconfig.json
+++ b/packages/plugin-image-compress/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-image-compress/tsconfig.json
+++ b/packages/plugin-image-compress/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-node-polyfill/tests/tsconfig.json
+++ b/packages/plugin-node-polyfill/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-node-polyfill/tsconfig.json
+++ b/packages/plugin-node-polyfill/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-pug/tests/tsconfig.json
+++ b/packages/plugin-pug/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-pug/tsconfig.json
+++ b/packages/plugin-pug/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -2,8 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["./tests/fixtures"]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/plugin-rem/tests/tsconfig.json
+++ b/packages/plugin-rem/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-rem/tsconfig.json
+++ b/packages/plugin-rem/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-solid/tests/tsconfig.json
+++ b/packages/plugin-solid/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-source-build/tests/tsconfig.json
+++ b/packages/plugin-source-build/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-source-build/tsconfig.json
+++ b/packages/plugin-source-build/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-styled-components/tsconfig.json
+++ b/packages/plugin-styled-components/tsconfig.json
@@ -2,8 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["./tests/fixtures"]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/plugin-stylus/tests/tsconfig.json
+++ b/packages/plugin-stylus/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-svelte/tests/tsconfig.json
+++ b/packages/plugin-svelte/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -2,8 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
-  "include": ["src"],
-  "exclude": ["./tests/fixtures"]
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
+  "include": ["src"]
 }

--- a/packages/plugin-type-check/tests/tsconfig.json
+++ b/packages/plugin-type-check/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-type-check/tsconfig.json
+++ b/packages/plugin-type-check/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-vue-jsx/tests/tsconfig.json
+++ b/packages/plugin-vue-jsx/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue-jsx/tsconfig.json
+++ b/packages/plugin-vue-jsx/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-vue/tests/tsconfig.json
+++ b/packages/plugin-vue/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-vue2-jsx/tests/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue2-jsx/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/plugin-vue2/tests/tsconfig.json
+++ b/packages/plugin-vue2/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue2/tsconfig.json
+++ b/packages/plugin-vue2/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/shared/tests/tsconfig.json
+++ b/packages/shared/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../tsconfig.json",
+  "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
   "include": ["src"]
 }

--- a/packages/test-helper/tsconfig.json
+++ b/packages/test-helper/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../shared"
+    }
+  ],
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Configure typescript project reference, this can allow us to jump to source code and improve DX.

## Links

https://www.typescriptlang.org/docs/handbook/project-references.html

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
