### PR TITLE
fix(plugin-svelte): use wildcard in conditionNames

### DIFF
--- a/.changeset/poor-buses-brush.md
+++ b/.changeset/poor-buses-brush.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-svelte': patch
+---
+
+fix(plugin-svelte): use wildcard in conditionNames

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -41,12 +41,11 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
         chain.resolve.alias
           .set('svelte', path.join(sveltePath, 'src/runtime'))
           .end()
-          // TODO: change to use `...` wildcard
           .extensions.add('.svelte')
           .end()
           .mainFields.prepend('svelte')
           .end()
-          .set('conditionNames', ['svelte', 'browser', 'import']);
+          .set('conditionNames', ['svelte', '...']);
 
         const loaderPath = require.resolve('svelte-loader');
 

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -32,8 +32,7 @@ exports[`plugin-svelte > should add svelte loader properly 1`] = `
     },
     "conditionNames": [
       "svelte",
-      "browser",
-      "import",
+      "...",
     ],
     "extensions": [
       ".svelte",
@@ -78,8 +77,7 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
     },
     "conditionNames": [
       "svelte",
-      "browser",
-      "import",
+      "...",
     ],
     "extensions": [
       ".svelte",
@@ -128,8 +126,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
     },
     "conditionNames": [
       "svelte",
-      "browser",
-      "import",
+      "...",
     ],
     "extensions": [
       ".svelte",
@@ -178,8 +175,7 @@ exports[`plugin-svelte > should turn off hmr by hand correctly 1`] = `
     },
     "conditionNames": [
       "svelte",
-      "browser",
-      "import",
+      "...",
     ],
     "extensions": [
       ".svelte",


### PR DESCRIPTION
## Summary

Use wildcard in conditionNames.

## Related Links

https://www.rspack.dev/config/resolve.html#resolveconditionnames

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
