### PR TITLE
types: improve defineConfig typing

### DIFF
--- a/.changeset/slow-badgers-love.md
+++ b/.changeset/slow-badgers-love.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+types: improve defineConfig typing

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -20,15 +20,21 @@ export type ConfigParams = {
   command: string;
 };
 
-export type UserConfigExport =
-  | RsbuildConfig
-  | ((env: ConfigParams) => RsbuildConfig | Promise<RsbuildConfig>);
+export type RsbuildConfigFn = (
+  env: ConfigParams,
+) => RsbuildConfig | Promise<RsbuildConfig>;
+
+export type RsbuildConfigExport = RsbuildConfig | RsbuildConfigFn;
 
 /**
  * This function helps you to autocomplete configuration types.
  * It accepts a Rsbuild config object, or a function that returns a config.
  */
-export const defineConfig = (config: UserConfigExport) => config;
+export function defineConfig(config: RsbuildConfig): RsbuildConfig;
+export function defineConfig(config: RsbuildConfigFn): RsbuildConfigFn;
+export function defineConfig(config: RsbuildConfigExport) {
+  return config;
+}
 
 const resolveConfigPath = (customConfig?: string) => {
   const root = process.cwd();
@@ -107,7 +113,7 @@ export async function loadConfig(
       watchConfig(configFile);
     }
 
-    const configExport = loadConfig(configFile) as UserConfigExport;
+    const configExport = loadConfig(configFile) as RsbuildConfigExport;
 
     if (typeof configExport === 'function') {
       const params: ConfigParams = {


### PR DESCRIPTION
## Summary

Improve defineConfig typing to make the following types correct:

```ts
const config = defineConfig({});

console.log(config.html?.appIcon);
```

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
