### PR TITLE
fix(plugin-source-build): not work when use Rspack

### DIFF
--- a/.changeset/popular-pants-refuse.md
+++ b/.changeset/popular-pants-refuse.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-source-build': patch
+---
+
+fix(plugin-source-build): not work when use Rspack

--- a/e2e/cases/source-build/app/rsbuild.config.ts
+++ b/e2e/cases/source-build/app/rsbuild.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
 
 export default defineConfig({
-  provider: webpackProvider,
   plugins: [pluginSourceBuild()],
 });

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -1,27 +1,23 @@
 import { join } from 'path';
-import { expect } from '@playwright/test';
-import { webpackOnlyTest } from '@scripts/helper';
+import { test, expect } from '@playwright/test';
 import { dev, getHrefByEntryName } from '@scripts/shared';
 import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixture = join(__dirname, 'app');
 
-webpackOnlyTest(
-  'should build succeed with source build plugin',
-  async ({ page }) => {
-    const rsbuild = await dev({
-      cwd: fixture,
-      plugins: [pluginSourceBuild(), pluginReact()],
-    });
+test('should build succeed with source build plugin', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: fixture,
+    plugins: [pluginSourceBuild(), pluginReact()],
+  });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await page.goto(getHrefByEntryName('index', rsbuild.port));
 
-    const locator = page.locator('#root');
-    await expect(locator).toHaveText(
-      'Card Comp Title: AppCARD COMP CONTENT:hello world',
-    );
+  const locator = page.locator('#root');
+  await expect(locator).toHaveText(
+    'Card Comp Title: AppCARD COMP CONTENT:hello world',
+  );
 
-    await rsbuild.server.close();
-  },
-);
+  await rsbuild.server.close();
+});


### PR DESCRIPTION
## Summary

Fix plugin-source-build not work when use Rspack.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/203

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
