### PR TITLE
fix: preload resource can't be used if crossOrigin attr not match

### DIFF
--- a/.changeset/plenty-grapes-peel.md
+++ b/.changeset/plenty-grapes-peel.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+fix: preload resource cannot be used when crossOrigin attr does not match

--- a/e2e/cases/html/combined/html.test.ts
+++ b/e2e/cases/html/combined/html.test.ts
@@ -27,7 +27,6 @@ test.describe('should combine multiple html config correctly', () => {
             description: 'a description of the page',
           },
           inject: 'body',
-          crossorigin: 'anonymous',
           appIcon: './src/assets/icon.png',
           favicon: './src/assets/icon.png',
         },
@@ -90,14 +89,6 @@ test.describe('should combine multiple html config correctly', () => {
       /<meta name="description" content="a description of the page">/.test(
         mainContent,
       ),
-    ).toBeTruthy();
-  });
-
-  test('custom crossorigin', async () => {
-    const allScripts = /(<script [\s\S]*?>)/g.exec(mainContent);
-
-    expect(
-      allScripts?.every((data) => data.includes('crossorigin="anonymous"')),
     ).toBeTruthy();
   });
 });

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+import { build } from '@scripts/shared';
+
+test('should not apply crossOrigin by default', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        scriptLoading: 'blocking',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).not.toContain('crossorigin');
+});
+
+test('should not apply crossOrigin when same origin', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        scriptLoading: 'blocking',
+        crossorigin: 'anonymous',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).not.toContain('crossorigin');
+});
+
+test('should apply crossOrigin when crossorigin is "anonymous" and not same origin', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        scriptLoading: 'blocking',
+        crossorigin: 'anonymous',
+      },
+      output: {
+        assetPrefix: '//aaaa.com',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).toContain('crossorigin="anonymous"></script>');
+});

--- a/e2e/cases/html/cross-origin/src/index.js
+++ b/e2e/cases/html/cross-origin/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -209,3 +209,86 @@ test('should generate preload link when preload is defined', async () => {
     ),
   ).toBeTruthy();
 });
+
+test('should generate preload link with crossOrigin', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      html: {
+        crossorigin: 'anonymous',
+      },
+      output: {
+        assetPrefix: '//aaa.com',
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const asyncFileName = Object.keys(files).find((file) =>
+    file.includes('/static/js/async/'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // test.js、test.css、test.png
+  expect(content.match(/rel="preload"/g)?.length).toBe(3);
+
+  expect(
+    content.includes(
+      `<link href="//aaa.com${asyncFileName.slice(
+        asyncFileName.indexOf('/static/js/async/'),
+      )}" rel="preload" as="script" crossorigin="">`,
+    ),
+  ).toBeTruthy();
+});
+
+test('should generate preload link without crossOrigin when same origin', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      html: {
+        crossorigin: 'anonymous',
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const asyncFileName = Object.keys(files).find((file) =>
+    file.includes('/static/js/async/'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // test.js、test.css、test.png
+  expect(content.match(/rel="preload"/g)?.length).toBe(3);
+
+  expect(
+    content.includes(
+      `<link href="${asyncFileName.slice(
+        asyncFileName.indexOf('/static/js/async/'),
+      )}" rel="preload" as="script">`,
+    ),
+  ).toBeTruthy();
+});

--- a/packages/shared/src/plugins/HtmlCrossOriginPlugin.ts
+++ b/packages/shared/src/plugins/HtmlCrossOriginPlugin.ts
@@ -22,7 +22,13 @@ export class HtmlCrossOriginPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
-    if (!this.crossOrigin) {
+    if (
+      !this.crossOrigin ||
+      // align with crossOriginLoading logic
+      // https://github.com/web-infra-dev/rspack/blob/bc8e67b5419adda15c2b389517c9b37d02c8240f/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs#L39
+      (compiler.options.output.publicPath === '/' &&
+        this.crossOrigin !== ('use-credentials' as const))
+    ) {
       return;
     }
 

--- a/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
+++ b/packages/shared/src/plugins/HtmlPreloadOrPrefetchPlugin/index.ts
@@ -117,6 +117,7 @@ function generateLinks(
   const sortedFilteredFiles = filteredFiles.sort();
   const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
   const publicPath = getPublicPathFromCompiler(compilation.compiler);
+  const { crossOriginLoading } = compilation.compiler.options.output;
 
   for (const file of sortedFilteredFiles) {
     const href = withPublicPath(file, publicPath);
@@ -138,6 +139,16 @@ function generateLinks(
       // fonts can't be used.
       if (attributes.as === 'font') {
         attributes.crossorigin = '';
+      }
+
+      if (attributes.as === 'script' || attributes.as === 'style') {
+        if (
+          crossOriginLoading &&
+          !(crossOriginLoading !== 'use-credentials' && publicPath === '/')
+        ) {
+          attributes.crossorigin =
+            crossOriginLoading === 'anonymous' ? '' : crossOriginLoading;
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

fix preload resource can't be used when crossOrigin attr does not match.
<img width="1553" alt="image" src="https://github.com/web-infra-dev/modern.js/assets/22373761/00168084-42c7-4674-9879-5c7c101f5e38">

![20231127-160456](https://github.com/web-infra-dev/modern.js/assets/22373761/6113309e-cb55-4719-9550-2f865e7b0338)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
