### PR TITLE
feat(core): export logger module as a helper

### DIFF
--- a/.changeset/fuzzy-paws-attend.md
+++ b/.changeset/fuzzy-paws-attend.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat(core): export logger module as a helper

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -48,6 +48,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@swc/core": "1.3.42",
     "@types/babel__core": "^7.20.3",

--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -1,6 +1,7 @@
 import { RsbuildConfig, webpack } from '@rsbuild/webpack';
 import { merge } from 'lodash';
-import { color, logger } from '@rsbuild/shared';
+import { logger } from '@rsbuild/core';
+import { color } from '@rsbuild/shared';
 import {
   Output,
   JsMinifyOptions,

--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import type { NormalizedConfig } from '@rsbuild/webpack';
+import { logger } from '@rsbuild/core';
 import { isBeyondReact17 } from '@rsbuild/plugin-react';
 import {
-  logger,
   isUsingHMR,
   getCoreJsVersion,
   getBrowserslistWithDefault,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,10 +3,12 @@
  * the public API of @rsbuild/core.
  */
 
-// Methods
+// Core Methods
 export { createRsbuild } from './createRsbuild';
-export { mergeRsbuildConfig } from '@rsbuild/shared';
 export { defineConfig } from './cli/config';
+
+// Helpers
+export { logger, mergeRsbuildConfig } from '@rsbuild/shared';
 
 // Types
 export type { Rspack } from './rspack-provider';

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -72,3 +72,41 @@ console.log(mergedConfig); // { dev: { https: true } }
 ```
 
 > This method will not modify the config object in the input parameter.
+
+## logger
+
+Used to output log information in a unified format, based on [rslog](https://github.com/rspack-contrib/rslog).
+
+- **Example**
+
+```ts
+import { logger } from '@rsbuild/core';
+
+// A gradient welcome log
+logger.greet(`\n➜ Rsbuild v1.0.0\n`);
+
+// Info
+logger.info('This is a info message');
+
+// Start
+logger.start('This is a start message');
+
+// Warn
+logger.warn('This is a warn message');
+
+// Ready
+logger.ready('This is a ready message');
+
+// Success
+logger.success('This is a success message');
+
+// Error
+logger.error('This is a error message');
+logger.error(new Error('This is a error message with stack'));
+
+// Debug
+logger.debug('This is a debug message');
+
+// Same as console.log
+logger.log('This is a log message');
+```

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -72,3 +72,41 @@ console.log(mergedConfig); // { dev: { https: true } }
 ```
 
 > 该方法不会修改入参中的 config 对象。
+
+## logger
+
+用于输出格式统一的日志信息，基于 [rslog](https://github.com/rspack-contrib/rslog)。
+
+- **Example**
+
+```ts
+import { logger } from '@rsbuild/core';
+
+// A gradient welcome log
+logger.greet(`\n➜ Rsbuild v1.0.0\n`);
+
+// Info
+logger.info('This is a info message');
+
+// Start
+logger.start('This is a start message');
+
+// Warn
+logger.warn('This is a warn message');
+
+// Ready
+logger.ready('This is a ready message');
+
+// Success
+logger.success('This is a success message');
+
+// Error
+logger.error('This is a error message');
+logger.error(new Error('This is a error message with stack'));
+
+// Debug
+logger.debug('This is a debug message');
+
+// Same as console.log
+logger.log('This is a log message');
+```

--- a/packages/plugin-check-syntax/src/helpers/printErrors.ts
+++ b/packages/plugin-check-syntax/src/helpers/printErrors.ts
@@ -1,4 +1,5 @@
-import { color, logger } from '@rsbuild/shared';
+import { logger } from '@rsbuild/core';
+import { color } from '@rsbuild/shared';
 import type { SyntaxError } from '../types';
 
 type Error = {

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -1,6 +1,6 @@
 import path from 'path';
+import { logger } from '@rsbuild/core';
 import {
-  logger,
   withPublicPath,
   generateScriptTag,
   getPublicPathFromCompiler,

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { logger, deepmerge } from '@rsbuild/shared';
+import { logger } from '@rsbuild/core';
+import { deepmerge } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export type PluginSvelteOptions = {

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -1,6 +1,5 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { logger, type RsbuildPlugin } from '@rsbuild/core';
 import {
-  logger,
   CHAIN_ID,
   deepmerge,
   mergeChainedOptions,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,6 +574,9 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
     devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../../core
       '@rsbuild/webpack':
         specifier: workspace:*
         version: link:../webpack

--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -29,6 +29,7 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     target: BUILD_TARGET,
     define,
     autoExtension: true,
+    externals: ['@rsbuild/core'],
     dts: {
       respectExternal: false,
     },
@@ -40,6 +41,7 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     define,
     autoExtension: true,
     shims: true,
+    externals: ['@rsbuild/core'],
     esbuildOptions: (option) => {
       let { inject } = option;
       const filepath = path.join(__dirname, 'requireShims.js');


### PR DESCRIPTION
## Summary

Export logger module as a helper, this allows Rsbuild plugins to use the same logger module and output with the same log format.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
