### PR TITLE
docs: remove webpack related hooks

### DIFF
--- a/packages/document/docs/en/plugins/dev/core.mdx
+++ b/packages/document/docs/en/plugins/dev/core.mdx
@@ -172,9 +172,9 @@ import GetHTMLPaths from '@en/shared/getHTMLPaths.md';
 ```ts
 const pluginFoo = () => ({
   setup(api) {
-    api.modifyWebpackChain(() => {
+    api.modifyRspackConfig(() => {
       const htmlPaths = api.getHTMLPaths();
-      console.log(htmlPaths); // { main: 'html/main/index.html' };
+      console.log(htmlPaths); // { index: 'index.html' };
     });
   },
 });

--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -7,10 +7,8 @@ This section describes the lifetime hooks provided by Rsbuild plugin.
 **Common Hooks**
 
 - `modifyRsbuildConfig`: Modify raw config of Rsbuild.
-- `modifyBundlerChain`: Modify config of Rspack or webpack via the bundler chain api.
-- `modifyWebpackChain`: Modify webpack-chain.
-- `modifyWebpackConfig`: Modify raw config of webpack.
 - `modifyRspackConfig`: Modify raw config of Rspack.
+- `modifyBundlerChain`: Modify config of Rspack or webpack via the bundler chain api.
 - `onBeforeCreateCompiler`: Called before creating compiler instance.
 - `onAfterCreateCompiler`: Called after the compiler object is created, but before the build is executed.
 
@@ -43,14 +41,14 @@ Modify the config passed to the Rsbuild, you can directly modify the config obje
 - **Type**
 
 ```ts
-type ModifyWebpackChainUtils = {
+type ModifyRsbuildConfigUtils = {
   mergeRsbuildConfig: typeof mergeRsbuildConfig;
 };
 
 function ModifyRsbuildConfig(
   callback: (
     config: RsbuildConfig,
-    utils: ModifyWebpackChainUtils,
+    utils: ModifyRsbuildConfigUtils,
   ) => PromiseOrNot<RsbuildConfig | void>,
 ): void;
 ```
@@ -66,6 +64,45 @@ export default () => ({
       return mergeRsbuildConfig(config, {
         source: { preEntry: 'foo.js' },
       });
+    });
+  },
+});
+```
+
+### modifyRspackConfig
+
+To modify the final Rspack config object, you can directly modify the config object, or return a new object to replace the previous object.
+
+- **Type**
+
+```ts
+type ModifyRspackConfigUtils = {
+  env: NodeEnv;
+  isProd: boolean;
+  target: RsbuildTarget;
+  isServer: boolean;
+  isWebWorker: boolean;
+  getCompiledPath: (name: string) => string;
+  rspack: typeof import('@rspack/core');
+};
+
+function ModifyRspackConfig(
+  callback: (
+    config: RspackConfig,
+    utils: ModifyRspackConfigUtils,
+  ) => Promise<RspackConfig | void> | RspackConfig | void,
+): void;
+```
+
+- **Example**
+
+```ts
+export default () => ({
+  setup: (api) => {
+    api.modifyRspackConfig((config, utils) => {
+      if (utils.env === 'development') {
+        config.devtool = 'eval';
+      }
     });
   },
 });
@@ -119,45 +156,6 @@ export default () => ({
       }
 
       chain.plugin('bundle-analyze').use(BundleAnalyzerPlugin);
-    });
-  },
-});
-```
-
-### modifyRspackConfig
-
-To modify the final Rspack config object, you can directly modify the config object, or return a new object to replace the previous object.
-
-- **Type**
-
-```ts
-type ModifyRspackConfigUtils = {
-  env: NodeEnv;
-  isProd: boolean;
-  target: RsbuildTarget;
-  isServer: boolean;
-  isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
-  rspack: typeof import('@rspack/core');
-};
-
-function ModifyRspackConfig(
-  callback: (
-    config: RspackConfig,
-    utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | RspackConfig | void,
-): void;
-```
-
-- **Example**
-
-```ts
-export default () => ({
-  setup: (api) => {
-    api.modifyRspackConfig((config, utils) => {
-      if (utils.env === 'development') {
-        config.devtool = 'eval';
-      }
     });
   },
 });

--- a/packages/document/docs/zh/plugins/dev/core.mdx
+++ b/packages/document/docs/zh/plugins/dev/core.mdx
@@ -170,9 +170,9 @@ import GetHTMLPaths from '@zh/shared/getHTMLPaths.md';
 ```ts
 const pluginFoo = () => ({
   setup(api) {
-    api.modifyWebpackChain(() => {
+    api.modifyRspackConfig(() => {
       const htmlPaths = api.getHTMLPaths();
-      console.log(htmlPaths); // { main: 'html/main/index.html' };
+      console.log(htmlPaths); // { index: 'index.html' };
     });
   },
 });

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -7,10 +7,8 @@
 **Common Hooks**
 
 - `modifyRsbuildConfig`：修改传递给 Rsbuild 的配置项。
-- `modifyBundlerChain`：通过 chain api 修改 Rspack / webpack 配置。
-- `modifyWebpackChain`：修改 webpack chain 配置。
-- `modifyWebpackConfig`：修改最终的 webpack 配置对象。
 - `modifyRspackConfig`：修改最终的 Rspack 配置对象。
+- `modifyBundlerChain`：通过 chain api 修改 Rspack / webpack 配置对象。
 - `onBeforeCreateCompiler`：在创建 compiler 实例前调用。
 - `onAfterCreateCompiler`：在创建 compiler 实例后、执行构建前调用。
 
@@ -43,14 +41,14 @@
 - **类型**
 
 ```ts
-type ModifyWebpackChainUtils = {
+type ModifyRsbuildConfigUtils = {
   mergeRsbuildConfig: typeof mergeRsbuildConfig;
 };
 
 function ModifyRsbuildConfig(
   callback: (
     config: RsbuildConfig,
-    utils: ModifyWebpackChainUtils,
+    utils: ModifyRsbuildConfigUtils,
   ) => PromiseOrNot<RsbuildConfig | void>,
 ): void;
 ```
@@ -66,6 +64,45 @@ export default () => ({
       return mergeRsbuildConfig(config, {
         source: { preEntry: 'foo.js' },
       });
+    });
+  },
+});
+```
+
+### modifyRspackConfig
+
+修改最终的 Rspack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
+
+- **类型**
+
+```ts
+type ModifyRspackConfigUtils = {
+  env: NodeEnv;
+  isProd: boolean;
+  target: RsbuildTarget;
+  isServer: boolean;
+  isWebWorker: boolean;
+  getCompiledPath: (name: string) => string;
+  rspack: typeof import('@rspack/core');
+};
+
+function ModifyRspackConfig(
+  callback: (
+    config: RspackConfig,
+    utils: ModifyRspackConfigUtils,
+  ) => Promise<RspackConfig | void> | RspackConfig | void,
+): void;
+```
+
+- **Example**
+
+```ts
+export default () => ({
+  setup: (api) => {
+    api.modifyRspackConfig((config, utils) => {
+      if (utils.env === 'development') {
+        config.devtool = 'eval';
+      }
     });
   },
 });
@@ -122,45 +159,6 @@ export default () => ({
       }
 
       chain.plugin('bundle-analyze').use(BundleAnalyzerPlugin);
-    });
-  },
-});
-```
-
-### modifyRspackConfig
-
-修改最终的 Rspack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
-
-- **类型**
-
-```ts
-type ModifyRspackConfigUtils = {
-  env: NodeEnv;
-  isProd: boolean;
-  target: RsbuildTarget;
-  isServer: boolean;
-  isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
-  rspack: typeof import('@rspack/core');
-};
-
-function ModifyRspackConfig(
-  callback: (
-    config: RspackConfig,
-    utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | RspackConfig | void,
-): void;
-```
-
-- **Example**
-
-```ts
-export default () => ({
-  setup: (api) => {
-    api.modifyRspackConfig((config, utils) => {
-      if (utils.env === 'development') {
-        config.devtool = 'eval';
-      }
     });
   },
 });


### PR DESCRIPTION
## Summary

Remove webpack related hooks, modifyWebpackChain and modifyWebpackConfig hooks are only used by Modern.js.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
