### PR TITLE
feat(deps): bump Rspack to v0.4.1

### DIFF
--- a/.changeset/four-hats-pretend.md
+++ b/.changeset/four-hats-pretend.md
@@ -1,0 +1,8 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/plugin-react': patch
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+feat(deps): bump Rspack to v0.4.1

--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "systemjs",
     "transpiling",
     "tsbuildinfo",
+    "unocss",
     "vitest"
   ]
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -49,7 +49,7 @@
     "@rsbuild/shared": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@rspack/core": "0.4.0",
+    "@rspack/core": "0.4.1",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "@types/react": "^18",

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -114,9 +114,6 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
   "performance": {
     "hints": false,
   },
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 
@@ -138,9 +135,6 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
   "name": "Client",
   "performance": {
     "hints": false,
-  },
-  "watchOptions": {
-    "aggregateTimeout": 5,
   },
 }
 `;
@@ -164,9 +158,6 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
   "performance": {
     "hints": false,
   },
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 
@@ -188,9 +179,6 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
   "name": "Client",
   "performance": {
     "hints": false,
-  },
-  "watchOptions": {
-    "aggregateTimeout": 5,
   },
 }
 `;
@@ -214,9 +202,6 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
   "performance": {
     "hints": false,
   },
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 
@@ -238,9 +223,6 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
   "name": "Client",
   "performance": {
     "hints": false,
-  },
-  "watchOptions": {
-    "aggregateTimeout": 5,
   },
 }
 `;
@@ -601,9 +583,6 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
   "name": "Client",
   "performance": {
     "hints": false,
-  },
-  "watchOptions": {
-    "aggregateTimeout": 5,
   },
 }
 `;

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -692,9 +692,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es5",
   ],
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "core-js": "~3.32.2",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "postcss": "8.4.31",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -673,8 +673,5 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "web",
     "es5",
   ],
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -673,9 +673,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es5",
   ],
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 
@@ -1830,9 +1827,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     ],
   },
   "target": "node",
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;
 
@@ -2520,8 +2514,5 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "web",
     "es5",
   ],
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;

--- a/packages/doctor-core/package.json
+++ b/packages/doctor-core/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@rsbuild/doctor-sdk": "workspace:*",
     "@rsbuild/doctor-utils": "workspace:*",
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "axios": "^1.6.1",
     "bytes": "3.1.2",
     "enhanced-resolve": "5.12.0",

--- a/packages/doctor-rspack-plugin/package.json
+++ b/packages/doctor-rspack-plugin/package.json
@@ -21,7 +21,7 @@
     "@rsbuild/doctor-core": "workspace:*",
     "@rsbuild/doctor-sdk": "workspace:*",
     "@rsbuild/doctor-utils": "workspace:*",
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "lodash": "^4.17.21",
     "webpack": "^5.89.0"
   },

--- a/packages/doctor-types/package.json
+++ b/packages/doctor-types/package.json
@@ -18,7 +18,7 @@
     "start": "npm run build -- -w"
   },
   "dependencies": {
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "@types/connect": "3.4.35",
     "@types/estree": "1.0.0",
     "@types/tapable": "2.2.2",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/plugin-react-refresh": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/plugin-react-refresh": "0.4.1",
     "react-refresh": "^0.14.0",
     "semver": "^7.5.4"
   },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -718,8 +718,5 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "web",
     "es5",
   ],
-  "watchOptions": {
-    "aggregateTimeout": 5,
-  },
 }
 `;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -101,14 +101,13 @@
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "caniuse-lite": "^1.0.30001559",
     "line-diff": "2.1.1",
     "lodash": "^4.17.21",
     "postcss": "8.4.31"
   },
   "devDependencies": {
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",

--- a/packages/shared/src/apply/basic.ts
+++ b/packages/shared/src/apply/basic.ts
@@ -15,13 +15,5 @@ export function applyBasicPlugin(api: SharedRsbuildPluginAPI) {
         level: 'error',
       },
     });
-
-    if (!isProd) {
-      chain.watchOptions({
-        // The default aggregateTimeout of WatchPack is 200ms,
-        // using smaller values can improve hmr performance
-        aggregateTimeout: 5,
-      });
-    }
   });
 }

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/shared": "workspace:*",
-    "@rspack/core": "0.4.0-canary-d45e3e0-20231128075052",
+    "@rspack/core": "0.4.1",
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/compat/webpack
       '@rspack/core':
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.4.1
+        version: 0.4.1
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -794,8 +794,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       core-js:
         specifier: ~3.32.2
         version: 3.32.2
@@ -1702,8 +1702,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/plugin-react-refresh':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052(react-refresh@0.14.0)(webpack@5.89.0)
+        specifier: 0.4.1
+        version: 0.4.1(react-refresh@0.14.0)(webpack@5.89.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -2018,8 +2018,8 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       caniuse-lite:
         specifier: ^1.0.30001559
         version: 1.0.30001559
@@ -2067,8 +2067,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -5265,14 +5265,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rspack/binding-darwin-arm64@0.4.0:
-    resolution: {integrity: sha512-iQ6ERHXzY58zgHIZZAC7L7hrosO7BZXH3RpOTTibiZdTVex4Bq10CVmy6q6m88iQuqAQS2BHOXzAYLJtZlZRRw==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: true
-    optional: true
-
   /@rspack/binding-darwin-arm64@0.4.0-canary-d45e3e0-20231128075052:
     resolution: {integrity: sha512-53VBxIlJZ4gjWQZ5lkRuQk9tSba571WuGr8QgHpBNu/jNygXTh8m52kukQEw1aDml/BI6+22KjPvxkO9fMGk5g==}
     cpu: [arm64]
@@ -5281,12 +5273,11 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-darwin-x64@0.4.0:
-    resolution: {integrity: sha512-LRCiMPCbAIwwo0euqao7+8peUXj+qPDSi0nSK2y6wjaXfUVi8FwpWQ+O+B3RH3rpyFBU63IqatC8razalt8JgQ==}
-    cpu: [x64]
+  /@rspack/binding-darwin-arm64@0.4.1:
+    resolution: {integrity: sha512-oGosukPLEycihtFq+sfx4NOCYJW6+LBbdwlj9hNW8s7mqSshkKBTEkzGgEA+tsyQODOD13Qvg9R4dhUkXnMFJg==}
+    cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rspack/binding-darwin-x64@0.4.0-canary-d45e3e0-20231128075052:
@@ -5297,28 +5288,25 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-arm64-gnu@0.4.0:
-    resolution: {integrity: sha512-trfEUQ7awu6dLWUlIXmSJmwW48lSxEl7kW4FUas/UMNH3/B/wim8TPx6ZuDrCzVhYk5HP7ccjbQg7mnbJ+E48w==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-arm64-musl@0.4.0:
-    resolution: {integrity: sha512-ubIcXmRopSJ6n+F/cRXDfGSgK847OX0CPeSSL4tiJ4dah5lz8iISZ9GLrNHJQ+SvphOH8F9lDpp8h2iwVt0Pbw==}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-linux-x64-gnu@0.4.0:
-    resolution: {integrity: sha512-Q3mqjgV2k68F8VuzZwaqhHggBhcSlD0N+vvtFP8BxXIX4Pdkmk2shwwVjniZmY+oKB16dbSmXxShdMlCE3CCng==}
+  /@rspack/binding-darwin-x64@0.4.1:
+    resolution: {integrity: sha512-k7PbuNXxeqTL+5JONH+5PWk0iwiztT3zXej12qgy2joddWXpxkZJPjTxy8sNFV2tMQ7T0UqbWZaB3ZUFvPu5IA==}
     cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-gnu@0.4.1:
+    resolution: {integrity: sha512-dunS6sTH14cbDIbt4gs7Bd/tHLS/D87dhgEu9GUH+oVR8niSzXKyhJayOOefxr7L1/tSUtEVGJAbYFXgz5LvNg==}
+    cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
+    optional: true
+
+  /@rspack/binding-linux-arm64-musl@0.4.1:
+    resolution: {integrity: sha512-d/iUGx/uLy6eJ5OpFWH+ALcdgMiTgktq0UNbPN69lKkDctvfGCyi5tPHwbIh1g6WrpbROq7EPldNAxYAIAH8aw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.4.0-canary-d45e3e0-20231128075052:
@@ -5329,36 +5317,32 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-musl@0.4.0:
-    resolution: {integrity: sha512-5l6Q00yZDIeT8T1ruxEfF1Wj3m3SqnSHrPFiUqYydmgmNll1iCCRC2AmGVsmAACDQ7rg9z8BhhHtKukNBvmwTQ==}
+  /@rspack/binding-linux-x64-gnu@0.4.1:
+    resolution: {integrity: sha512-bDLwt2D5dSQlJPfbzdtANvaZfaQrRAU/g6wmFF12RX2rZjPTipihMi5gywdGaDzAfCryRy8JE2CLqECI5sxKNw==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@rspack/binding-win32-arm64-msvc@0.4.0:
-    resolution: {integrity: sha512-k96/PSkVT/VEvqHygenzgr8Z7n4SuCSKONVFB5zazWDPaJwCqaqANQuvX0PbuazVy6PbiLE/YI0+4TDjL7dHCw==}
+  /@rspack/binding-linux-x64-musl@0.4.1:
+    resolution: {integrity: sha512-lROn0GNzSjVBjILfeaoy5fLhVvjaY6bHGXit6EecDsd3BsruvlOVMaru+gU5otZO/o4ndTqFcA6xwCmXNn6Atg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@rspack/binding-win32-arm64-msvc@0.4.1:
+    resolution: {integrity: sha512-PKIQDu4vRADPqQtnkiJwqDmgT5kuRj8oJgx6tb6D8kR+SFq2Y26zadNPu/LulfUTgQmxJSyQEvz4su3Gp1tAsQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
-  /@rspack/binding-win32-ia32-msvc@0.4.0:
-    resolution: {integrity: sha512-DmC7MumePZuss1AigT4FaIbFPZFtZXdcWBhD7dF88CvsvQRVtOcMujtByWkkNJ6ZDp+IUHyXOtPQWr1iRjDOCQ==}
+  /@rspack/binding-win32-ia32-msvc@0.4.1:
+    resolution: {integrity: sha512-RqcW+kedZoNlWXUdZiyuxHEQKerDx6zGjoCg5GSMZpCxFZsNMwq65Ok5WCH8WI+hzFXzphq06FgjpB5Y8K3zsQ==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
-    optional: true
-
-  /@rspack/binding-win32-x64-msvc@0.4.0:
-    resolution: {integrity: sha512-F3pAxz1GakFkyq8S+iPTqVkvIFnHG9te36wLW+tIzY4oC0vNPsEVunBp6NrYHzTaOf3aBZ+bvsLZyfvg+pKxqA==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: true
     optional: true
 
   /@rspack/binding-win32-x64-msvc@0.4.0-canary-d45e3e0-20231128075052:
@@ -5369,19 +5353,12 @@ packages:
     dev: false
     optional: true
 
-  /@rspack/binding@0.4.0:
-    resolution: {integrity: sha512-SpjaySPGmyRnRHrQItl9W9NGE2WoHsUPnererZaLK+pfVgO92q9uoEoKl3EBNNI9uttG132SCz4cx1zXwN394w==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.4.0
-      '@rspack/binding-darwin-x64': 0.4.0
-      '@rspack/binding-linux-arm64-gnu': 0.4.0
-      '@rspack/binding-linux-arm64-musl': 0.4.0
-      '@rspack/binding-linux-x64-gnu': 0.4.0
-      '@rspack/binding-linux-x64-musl': 0.4.0
-      '@rspack/binding-win32-arm64-msvc': 0.4.0
-      '@rspack/binding-win32-ia32-msvc': 0.4.0
-      '@rspack/binding-win32-x64-msvc': 0.4.0
-    dev: true
+  /@rspack/binding-win32-x64-msvc@0.4.1:
+    resolution: {integrity: sha512-eNvamV92pt0lP9o43HdtpiD7Oo7lHeQqwNnaKAetN4BHVSPLtOjkHFS/aM1SKMtxCayEdzXYU7UZGPQvmdcXqQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
 
   /@rspack/binding@0.4.0-canary-d45e3e0-20231128075052:
     resolution: {integrity: sha512-RgjCSE/fZHoeUwfQjotBZNZyw9jThdt3tHYxxLLwIJy+jPT7scA0npKx7Lulr2ym7Co1WPFvcw/0r9/2pQy8rA==}
@@ -5392,27 +5369,18 @@ packages:
       '@rspack/binding-win32-x64-msvc': 0.4.0-canary-d45e3e0-20231128075052
     dev: false
 
-  /@rspack/core@0.4.0:
-    resolution: {integrity: sha512-GY8lsCGRzj1mj5q1Ss5kjazpSisT/HJdXpIU730pG4Os6mE2sGYVUJ0ncYRv/DEBcL1c2dVr5vtMKTHlNYRlfg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@rspack/binding': 0.4.0
-      '@swc/helpers': 0.5.1
-      browserslist: 4.22.1
-      compare-versions: 6.0.0-rc.1
-      enhanced-resolve: 5.12.0
-      fast-querystring: 1.1.2
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 3.0.0
-      neo-async: 2.6.2
-      react-refresh: 0.14.0
-      tapable: 2.2.1
-      terminal-link: 2.1.1
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-      zod: 3.22.4
-      zod-validation-error: 1.2.0(zod@3.22.4)
-    dev: true
+  /@rspack/binding@0.4.1:
+    resolution: {integrity: sha512-tPETZWbP9VYzmdCIKmaxWWx0z2c//acd5eV2kgKOSWt29MH2wo+EFySfvWKWVCTwjBkuVrqaULUxcIJB3vUCTg==}
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 0.4.1
+      '@rspack/binding-darwin-x64': 0.4.1
+      '@rspack/binding-linux-arm64-gnu': 0.4.1
+      '@rspack/binding-linux-arm64-musl': 0.4.1
+      '@rspack/binding-linux-x64-gnu': 0.4.1
+      '@rspack/binding-linux-x64-musl': 0.4.1
+      '@rspack/binding-win32-arm64-msvc': 0.4.1
+      '@rspack/binding-win32-ia32-msvc': 0.4.1
+      '@rspack/binding-win32-x64-msvc': 0.4.1
 
   /@rspack/core@0.4.0-canary-d45e3e0-20231128075052:
     resolution: {integrity: sha512-lMVJyoziBavPpldTkAoNE2ItExIGgNFAZCBK0wmkLaDNfAZu5uQzi6dp0qs4RX/0NPpVjXbOfbfJQMwk/K6nxg==}
@@ -5436,8 +5404,29 @@ packages:
       zod-validation-error: 1.3.1(zod@3.22.4)
     dev: false
 
-  /@rspack/plugin-react-refresh@0.4.0-canary-d45e3e0-20231128075052(react-refresh@0.14.0)(webpack@5.89.0):
-    resolution: {integrity: sha512-4EHUACEqVa0QPavFK//xy2Tzj/UzpIqUoSWl7dludBt9VsthgvPyHF28J16nICSeiHOui/rDjREZ/zIIM/sRuQ==}
+  /@rspack/core@0.4.1:
+    resolution: {integrity: sha512-g502i0fHMj0lCr1Y/Bh5iwsEGB1BTiN+H06Oc39qEgs4bwQqnkGg/iQSBoR7q1886lAK8yIIDQeyCxF/6qI7EA==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@rspack/binding': 0.4.1
+      '@swc/helpers': 0.5.1
+      browserslist: 4.22.1
+      compare-versions: 6.0.0-rc.1
+      enhanced-resolve: 5.12.0
+      fast-querystring: 1.1.2
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 3.0.0
+      neo-async: 2.6.2
+      react-refresh: 0.14.0
+      tapable: 2.2.1
+      terminal-link: 2.1.1
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+      zod: 3.22.4
+      zod-validation-error: 1.3.1(zod@3.22.4)
+
+  /@rspack/plugin-react-refresh@0.4.1(react-refresh@0.14.0)(webpack@5.89.0):
+    resolution: {integrity: sha512-Fo6MBu4JNGqyrLXHkKG3Jhor0CG9yuXhig/a4vfrMInmKBkAyOCc5QnlGflXlyPs4bWhdViaUbl0kJaU11NLZg==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -16278,15 +16267,6 @@ packages:
       commander: 9.5.0
     dev: true
 
-  /zod-validation-error@1.2.0(zod@3.22.4):
-    resolution: {integrity: sha512-laJkD/ugwEh8CpuH+xXv5L9Z+RLz3lH8alNxolfaHZJck611OJj97R4Rb+ZqA7WNly2kNtTo4QwjdjXw9scpiw==}
-    engines: {node: ^14.17 || >=16.0.0}
-    peerDependencies:
-      zod: ^3.18.0
-    dependencies:
-      zod: 3.22.4
-    dev: true
-
   /zod-validation-error@1.3.1(zod@3.22.4):
     resolution: {integrity: sha512-cNEXpla+tREtNdAnNKY4xKY1SGOn2yzyuZMu4O0RQylX9apRpUjNcPkEc3uHIAr5Ct7LenjZt6RzjEH6+JsqVQ==}
     engines: {node: '>=16.0.0'}
@@ -16294,7 +16274,6 @@ packages:
       zod: ^3.18.0
     dependencies:
       zod: 3.22.4
-    dev: false
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1043,8 +1043,8 @@ importers:
         specifier: workspace:*
         version: link:../doctor-utils
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       axios:
         specifier: ^1.6.1
         version: 1.6.1
@@ -1137,8 +1137,8 @@ importers:
         specifier: workspace:*
         version: link:../doctor-utils
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1256,8 +1256,8 @@ importers:
   packages/doctor-types:
     dependencies:
       '@rspack/core':
-        specifier: 0.4.0-canary-d45e3e0-20231128075052
-        version: 0.4.0-canary-d45e3e0-20231128075052
+        specifier: 0.4.1
+        version: 0.4.1
       '@types/connect':
         specifier: 3.4.35
         version: 3.4.35
@@ -5265,27 +5265,11 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rspack/binding-darwin-arm64@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-53VBxIlJZ4gjWQZ5lkRuQk9tSba571WuGr8QgHpBNu/jNygXTh8m52kukQEw1aDml/BI6+22KjPvxkO9fMGk5g==}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@rspack/binding-darwin-arm64@0.4.1:
     resolution: {integrity: sha512-oGosukPLEycihtFq+sfx4NOCYJW6+LBbdwlj9hNW8s7mqSshkKBTEkzGgEA+tsyQODOD13Qvg9R4dhUkXnMFJg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /@rspack/binding-darwin-x64@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-jPA6v2rrn3cVFRbwN2FDuVwUYQbHOSy5l5q6F0rjvJmU+jmbMnDKuNTe32O4mTdo3na1F4KmX2QcWwmQmiiR/w==}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-darwin-x64@0.4.1:
@@ -5307,14 +5291,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /@rspack/binding-linux-x64-gnu@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-sOSX7x+mAN+/tZpGSXopVDgepINLANdl2slU1aJkrD/ORfMTlsERU09wWrul814bMb8epAXajZWjuxiqxD+fTg==}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.4.1:
@@ -5345,29 +5321,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-ip1yuB/We1eW5MQkQ2LCLoMx2F59zTcoEoVB77H+8jM9f3BcTSZFXakWiXkCwAhnVLwLIRhyLPMFUBTVAZnzYA==}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /@rspack/binding-win32-x64-msvc@0.4.1:
     resolution: {integrity: sha512-eNvamV92pt0lP9o43HdtpiD7Oo7lHeQqwNnaKAetN4BHVSPLtOjkHFS/aM1SKMtxCayEdzXYU7UZGPQvmdcXqQ==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     optional: true
-
-  /@rspack/binding@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-RgjCSE/fZHoeUwfQjotBZNZyw9jThdt3tHYxxLLwIJy+jPT7scA0npKx7Lulr2ym7Co1WPFvcw/0r9/2pQy8rA==}
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.4.0-canary-d45e3e0-20231128075052
-      '@rspack/binding-darwin-x64': 0.4.0-canary-d45e3e0-20231128075052
-      '@rspack/binding-linux-x64-gnu': 0.4.0-canary-d45e3e0-20231128075052
-      '@rspack/binding-win32-x64-msvc': 0.4.0-canary-d45e3e0-20231128075052
-    dev: false
 
   /@rspack/binding@0.4.1:
     resolution: {integrity: sha512-tPETZWbP9VYzmdCIKmaxWWx0z2c//acd5eV2kgKOSWt29MH2wo+EFySfvWKWVCTwjBkuVrqaULUxcIJB3vUCTg==}
@@ -5381,28 +5340,6 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 0.4.1
       '@rspack/binding-win32-ia32-msvc': 0.4.1
       '@rspack/binding-win32-x64-msvc': 0.4.1
-
-  /@rspack/core@0.4.0-canary-d45e3e0-20231128075052:
-    resolution: {integrity: sha512-lMVJyoziBavPpldTkAoNE2ItExIGgNFAZCBK0wmkLaDNfAZu5uQzi6dp0qs4RX/0NPpVjXbOfbfJQMwk/K6nxg==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@rspack/binding': 0.4.0-canary-d45e3e0-20231128075052
-      '@swc/helpers': 0.5.1
-      browserslist: 4.22.1
-      compare-versions: 6.0.0-rc.1
-      enhanced-resolve: 5.12.0
-      fast-querystring: 1.1.2
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 3.0.0
-      neo-async: 2.6.2
-      react-refresh: 0.14.0
-      tapable: 2.2.1
-      terminal-link: 2.1.1
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-      zod: 3.22.4
-      zod-validation-error: 1.3.1(zod@3.22.4)
-    dev: false
 
   /@rspack/core@0.4.1:
     resolution: {integrity: sha512-g502i0fHMj0lCr1Y/Bh5iwsEGB1BTiN+H06Oc39qEgs4bwQqnkGg/iQSBoR7q1886lAK8yIIDQeyCxF/6qI7EA==}


### PR DESCRIPTION
## Summary

Bump Rspack to v0.4.1.

ref: https://github.com/web-infra-dev/rspack/releases/tag/untagged-b8f2eaffa446dddecc66

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
