### PR TITLE
docs: add loadEnv method to JavaScript API document

### DIFF
--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -46,8 +46,6 @@ Description:
 - `provider`: Used to switch the underlying bundler.
 - `rsbuildConfig`: Rsbuild configuration object. Rsbuild provides a rich set of configuration options that allow you to customize the build behavior flexibly. You can find all available configuration options in the [Configuration](/config/) section.
 
-Sure, here's the translation of the software documentation from Chinese to English:
-
 ## loadEnv
 
 Load the `.env` file and return all environment variables starting with the specified prefixes.

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -46,6 +46,45 @@ Description:
 - `provider`: Used to switch the underlying bundler.
 - `rsbuildConfig`: Rsbuild configuration object. Rsbuild provides a rich set of configuration options that allow you to customize the build behavior flexibly. You can find all available configuration options in the [Configuration](/config/) section.
 
+Sure, here's the translation of the software documentation from Chinese to English:
+
+## loadEnv
+
+Load the `.env` file and return all environment variables starting with the specified prefixes.
+
+- **Type:**
+
+```ts
+function loadEnv(params: {
+  // Default is process.cwd()
+  dir?: string;
+  // Default is ['PUBLIC_']
+  prefixes?: string[];
+}): Promise<{
+  // All environment variables in the .env file
+  parsed: Record<string, string>;
+  // Environment variables starting with the specified prefixes
+  publicVars: Record<string, string>;
+}>;
+```
+
+- **Example:**
+
+```ts
+const { parsed, publicVars } = await loadEnv();
+
+mergeRsbuildConfig(
+  {
+    source: {
+      define: publicVars,
+    },
+  },
+  userConfig,
+);
+```
+
+This method will also load files such as `.env.local` and `.env.[mode]`, see [Environment Variables](/guide/advanced/env-vars) for details.
+
 ## mergeRsbuildConfig
 
 Used to merge multiple Rsbuild configuration objects.

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -46,6 +46,43 @@ type CreateRsbuildOptions = {
 - `provider`: 用于切换底层的打包工具。
 - `rsbuildConfig`：Rsbuild 配置对象。Rsbuild 提供了丰富的配置项，允许你对构建行为进行灵活定制，你可以在 [配置](/config/) 中找到所有可用的配置项。
 
+## loadEnv
+
+加载 `.env` 文件，并返回所有以 prefixes 开头的环境变量。
+
+- **类型：**
+
+```ts
+function loadEnv(params: {
+  // 默认为 process.cwd()
+  dir?: string;
+  // 默认为 ['PUBLIC_']
+  prefixes?: string[];
+}): Promise<{
+  // .env 文件包含的所有环境变量
+  parsed: Record<string, string>;
+  // 以 prefixes 开头的环境变量
+  publicVars: Record<string, string>;
+}>;
+```
+
+- **示例：**
+
+```ts
+const { parsed, publicVars } = await loadEnv();
+
+mergeRsbuildConfig(
+  {
+    source: {
+      define: publicVars,
+    },
+  },
+  userConfig,
+);
+```
+
+该方法也会加载 `.env.local` 和 `.env.[mode]` 等文件，详见 [环境变量](/guide/advanced/env-vars)。
+
 ## mergeRsbuildConfig
 
 用于合并多份 Rsbuild 配置对象。


### PR DESCRIPTION
## Summary

Add loadEnv method to JavaScript API document.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
