### PR TITLE
docs: add mkcert tip for https dev server

### DIFF
--- a/packages/document/docs/en/shared/config/server/https.md
+++ b/packages/document/docs/en/shared/config/server/https.md
@@ -35,3 +35,5 @@ export default {
   },
 };
 ```
+
+The certificates used for local development are typically generated using [mkcert](https://github.com/FiloSottile/mkcert). Please read ["How to use HTTPS for local development"](https://web.dev/articles/how-to-use-local-https?hl=en) to learn how to use it.

--- a/packages/document/docs/zh/shared/config/server/https.md
+++ b/packages/document/docs/zh/shared/config/server/https.md
@@ -35,3 +35,7 @@ export default {
   },
 };
 ```
+
+:::tip
+本地开发所使用的证书通常使用 [mkcert](https://github.com/FiloSottile/mkcert) 生成，请阅读 ["如何使用 HTTPS 进行本地开发"](https://web.dev/articles/how-to-use-local-https?hl=zh-cn) 来了解如何使用。
+:::


### PR DESCRIPTION
## Summary

Add mkcert tip for https dev server.

## Related Links

https://web.dev/articles/how-to-use-local-https?hl=en

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
