### PR TITLE
types: using loose plugin type for appendPlugins  @chenjiahan

### DIFF
--- a/packages/document/docs/en/shared/config/tools/rspack.md
+++ b/packages/document/docs/en/shared/config/tools/rspack.md
@@ -195,7 +195,7 @@ export default {
 
 #### prependPlugins
 
-- **Type:** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
+- **Type:** `(plugins: BundlerPluginInstance | BundlerPluginInstance[]) => void`
 
 Add additional plugins to the head of the internal Rspack plugins array, and the plugin will be executed first.
 
@@ -215,7 +215,7 @@ export default {
 
 #### appendPlugins
 
-- **Type:** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
+- **Type:** `(plugins: BundlerPluginInstance | BundlerPluginInstance[]) => void`
 
 Add additional plugins at the end of the internal Rspack plugins array, the plugin will be executed last.
 

--- a/packages/document/docs/zh/shared/config/tools/rspack.md
+++ b/packages/document/docs/zh/shared/config/tools/rspack.md
@@ -195,7 +195,7 @@ export default {
 
 #### prependPlugins
 
-- **类型：** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
+- **类型：** `(plugins: BundlerPluginInstance | BundlerPluginInstance[]) => void`
 
 在内部 Rspack 插件数组头部添加额外的插件，数组头部的插件会优先执行。
 
@@ -215,7 +215,7 @@ export default {
 
 #### appendPlugins
 
-- **类型：** `(plugins: RspackPluginInstance | RspackPluginInstance[]) => void`
+- **类型：** `(plugins: BundlerPluginInstance | BundlerPluginInstance[]) => void`
 
 在内部 Rspack 插件数组尾部添加额外的插件，数组尾部的插件会在最后执行。
 

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -15,8 +15,9 @@ import type {
 } from '../thirdParty';
 import type { BundlerChain } from '../bundlerConfig';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
-import type { RspackConfig, RspackRule, RspackPluginInstance } from '../rspack';
+import type { RspackConfig, RspackRule } from '../rspack';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
+import type { BundlerPluginInstance } from '../bundlerConfig';
 
 export type { HTMLPluginOptions };
 
@@ -56,10 +57,10 @@ export type ToolsHtmlPluginConfig = ChainedConfigWithUtils<
 export type ModifyRspackConfigUtils = ModifyChainUtils & {
   addRules: (rules: RspackRule | RspackRule[]) => void;
   prependPlugins: (
-    plugins: RspackPluginInstance | RspackPluginInstance[],
+    plugins: BundlerPluginInstance | BundlerPluginInstance[],
   ) => void;
   appendPlugins: (
-    plugins: RspackPluginInstance | RspackPluginInstance[],
+    plugins: BundlerPluginInstance | BundlerPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
   mergeConfig: typeof import('../../../compiled/webpack-merge').merge;


### PR DESCRIPTION
## Summary

Using loose plugin type for appendPlugins of `tools.rspack` config, as the webpack plugins type is not the same as rspack plugins.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have added changeset via `pnpm run change`.
- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
