### PR TITLE
chore(workflow): no longer require changesets

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,5 @@
 
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 
-- [ ] I have added changeset via `pnpm run change`.
 - [ ] I have updated the documentation.
 - [ ] I have added tests to cover my changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,16 +194,6 @@ The source code of Rspress can be found in [this repo](https://github.com/web-in
 
 ## Submitting Changes
 
-### Add a Changeset
-
-Rsbuild is using [Changesets](https://github.com/changesets/changesets) to manage the versioning and changelogs.
-
-If you've changed some packages, you need add a new changeset for the changes. Please run `change` command to select the changed packages and add the changeset info.
-
-```sh
-pnpm run change
-```
-
 ### Committing your Changes
 
 Commit your changes to your forked repo, and [create a pull request](https://help.github.com/articles/creating-a-pull-request/).


### PR DESCRIPTION
## Summary

No longer require changesets in pull request, we have switched to use GitHub release page to generate the CHANGELOG.

This means changeset is optional and only be used to bump the package version.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/473

## Checklist

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
