### PR TITLE
refactor(webpack): remove builtin CSS minimizer

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -8,6 +8,7 @@ import type {
   RsbuildConfig as RspackRsbuildConfig,
 } from '@rsbuild/core';
 import type { RsbuildConfig as WebpackRsbuildConfig } from '@rsbuild/webpack';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
   const baseUrl = new URL(`http://localhost:${port}`);
@@ -34,11 +35,16 @@ export const createRsbuild = async (
   }
 
   const { webpackProvider } = await import('@rsbuild/webpack');
-  return createRsbuild({
+  const rsbuild = await createRsbuild({
     ...rsbuildOptions,
     rsbuildConfig: rsbuildConfig as WebpackRsbuildConfig,
     provider: webpackProvider,
   });
+
+  // @rsbuild/webpack has no built-in CSS minimizer,
+  rsbuild.addPlugins([pluginCssMinimizer()]);
+
+  return rsbuild;
 };
 
 const portMap = new Map();

--- a/examples/react-webpack/package.json
+++ b/examples/react-webpack/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
+    "@rsbuild/plugin-css-minimizer": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*",
     "typescript": "^5.3.0"
   }

--- a/examples/react-webpack/rsbuild.config.ts
+++ b/examples/react-webpack/rsbuild.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 import { webpackProvider } from '@rsbuild/webpack';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [pluginReact(), pluginCssMinimizer()],
   provider: webpackProvider,
 });

--- a/packages/compat/uni-builder/src/rspack/index.ts
+++ b/packages/compat/uni-builder/src/rspack/index.ts
@@ -9,7 +9,6 @@ import type { UniBuilderRspackConfig } from '../types';
 import type { CreateRspackBuilderOptions } from '../types';
 import { parseCommonConfig } from '../shared/parseCommonConfig';
 import { pluginStyledComponents } from '@rsbuild/plugin-styled-components';
-import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 export async function parseConfig(
   uniBuilderConfig: UniBuilderRspackConfig,
@@ -37,12 +36,6 @@ export async function parseConfig(
 
   rsbuildPlugins.push(
     pluginStyledComponents(uniBuilderConfig.tools?.styledComponents),
-  );
-
-  rsbuildPlugins.push(
-    pluginCssMinimizer({
-      pluginOptions: uniBuilderConfig.tools?.minifyCss,
-    }),
   );
 
   return {

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -32,6 +32,7 @@ import { pluginExtensionPrefix } from './plugins/extensionPrefix';
 import { pluginSplitChunks } from './plugins/splitChunk';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 const GLOBAL_CSS_REGEX = /\.global\.\w+$/;
 
@@ -310,6 +311,12 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   if (frameworkConfigPath) {
     rsbuildPlugins.push(pluginFrameworkConfig(frameworkConfigPath));
   }
+
+  rsbuildPlugins.push(
+    pluginCssMinimizer({
+      pluginOptions: uniBuilderConfig.tools?.minifyCss,
+    }),
+  );
 
   return {
     rsbuildConfig: mergeRsbuildConfig(rsbuildConfig, extraConfig),

--- a/packages/compat/uni-builder/src/types.ts
+++ b/packages/compat/uni-builder/src/types.ts
@@ -90,6 +90,10 @@ export type UniBuilderExtraConfig = {
      * Modify the options of [fork-ts-checker-webpack-plugin](https://github.com/TypeStrong/fork-ts-checker-webpack-plugin).
      */
     tsChecker?: PluginTypeCheckerOptions['forkTsCheckerOptions'];
+    /**
+     * Modify the options of [css-minimizer-webpack-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
+     */
+    minifyCss?: PluginCssMinimizerOptions['pluginOptions'];
   };
   dev?: {
     /**
@@ -250,10 +254,6 @@ export type UniBuilderRspackConfig = RsbuildRspackConfig &
        * Modify the options of [babel-loader](https://github.com/babel/babel-loader)
        */
       babel?: PluginBabelOptions;
-      /**
-       * Modify the options of [css-minimizer-webpack-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
-       */
-      minifyCss?: PluginCssMinimizerOptions['pluginOptions'];
     };
   };
 

--- a/packages/compat/webpack/README.md
+++ b/packages/compat/webpack/README.md
@@ -13,9 +13,15 @@ Note that this package is mainly used for compatibility with Modern.js and Rsbui
 ```ts
 import { defineConfig } from '@rsbuild/core';
 import { webpackProvider } from '@rsbuild/webpack';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 export default defineConfig({
   provider: webpackProvider,
+  plugins: [
+    // @rsbuild/webpack has no built-in CSS minimizer,
+    // so you need to register the plugin-css-minimizer.
+    pluginCssMinimizer(),
+  ],
 });
 ```
 

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -42,7 +42,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*",
-    "@rsbuild/plugin-css-minimizer": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "babel-loader": "9.1.3",
     "babel-plugin-import": "1.13.5",

--- a/packages/compat/webpack/src/plugins/minimize.ts
+++ b/packages/compat/webpack/src/plugins/minimize.ts
@@ -1,5 +1,4 @@
 import { CHAIN_ID, BundlerChain, getJSMinifyOptions } from '@rsbuild/shared';
-import { applyCSSMinimizer } from '@rsbuild/plugin-css-minimizer';
 import type { RsbuildPlugin, NormalizedConfig } from '../types';
 
 async function applyJSMinimizer(chain: BundlerChain, config: NormalizedConfig) {
@@ -21,7 +20,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
   name: 'rsbuild-webpack:minimize',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {
+    api.modifyBundlerChain(async (chain, { isProd }) => {
       const config = api.getNormalizedConfig();
       const isMinimize = isProd && !config.output.disableMinimize;
 
@@ -30,9 +29,6 @@ export const pluginMinimize = (): RsbuildPlugin => ({
 
       if (isMinimize) {
         await applyJSMinimizer(chain, config);
-        await applyCSSMinimizer(chain, CHAIN_ID, {
-          pluginOptions: config.tools.minifyCss,
-        });
       }
     });
   },

--- a/packages/compat/webpack/src/types/config/tools.ts
+++ b/packages/compat/webpack/src/types/config/tools.ts
@@ -11,7 +11,6 @@ import type {
   BabelTransformOptions,
   BabelConfigUtils,
 } from '@rsbuild/plugin-babel';
-import type { PluginCssMinimizerOptions } from '@rsbuild/plugin-css-minimizer';
 import type {
   WebpackChain,
   WebpackConfig,
@@ -63,10 +62,6 @@ export interface ToolsConfig extends BaseToolsConfig {
    * Configure webpack by [webpack-chain](https://github.com/neutrinojs/webpack-chain).
    */
   webpackChain?: ToolsWebpackChainConfig;
-  /**
-   * Modify the options of [css-minimizer-webpack-plugin](https://github.com/webpack-contrib/css-minimizer-webpack-plugin).
-   */
-  minifyCss?: PluginCssMinimizerOptions['pluginOptions'];
 }
 
 export interface NormalizedToolsConfig extends ToolsConfig {

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1280,26 +1280,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
         },
       },
-      CssMinimizerPlugin {
-        "options": {
-          "exclude": undefined,
-          "include": undefined,
-          "minimizer": {
-            "implementation": [Function],
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false,
-                },
-              ],
-            },
-          },
-          "parallel": true,
-          "test": /\\\\\\.css\\(\\\\\\?\\.\\*\\)\\?\\$/i,
-          "warningsFilter": [Function],
-        },
-      },
     ],
     "splitChunks": {
       "cacheGroups": {
@@ -1928,26 +1908,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
         },
       },
-      CssMinimizerPlugin {
-        "options": {
-          "exclude": undefined,
-          "include": undefined,
-          "minimizer": {
-            "implementation": [Function],
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false,
-                },
-              ],
-            },
-          },
-          "parallel": true,
-          "test": /\\\\\\.css\\(\\\\\\?\\.\\*\\)\\?\\$/i,
-          "warningsFilter": [Function],
-        },
-      },
     ],
     "splitChunks": false,
   },
@@ -2505,26 +2465,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           },
           "parallel": true,
           "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
-        },
-      },
-      CssMinimizerPlugin {
-        "options": {
-          "exclude": undefined,
-          "include": undefined,
-          "minimizer": {
-            "implementation": [Function],
-            "options": {
-              "preset": [
-                "default",
-                {
-                  "mergeLonghand": false,
-                },
-              ],
-            },
-          },
-          "parallel": true,
-          "test": /\\\\\\.css\\(\\\\\\?\\.\\*\\)\\?\\$/i,
-          "warningsFilter": [Function],
         },
       },
     ],

--- a/packages/compat/webpack/tests/plugins/__snapshots__/minimize.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/minimize.test.ts.snap
@@ -24,26 +24,6 @@ exports[`plugin-minimize > should apply minimizer in production 1`] = `
         "test": /\\\\\\.\\[cm\\]\\?js\\(\\\\\\?\\.\\*\\)\\?\\$/i,
       },
     },
-    CssMinimizerPlugin {
-      "options": {
-        "exclude": undefined,
-        "include": undefined,
-        "minimizer": {
-          "implementation": [Function],
-          "options": {
-            "preset": [
-              "default",
-              {
-                "mergeLonghand": false,
-              },
-            ],
-          },
-        },
-        "parallel": true,
-        "test": /\\\\\\.css\\(\\\\\\?\\.\\*\\)\\?\\$/i,
-        "warningsFilter": [Function],
-      },
-    },
   ],
 }
 `;

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -21,9 +21,6 @@
     },
     {
       "path": "../../babel-preset"
-    },
-    {
-      "path": "../../plugin-css-minimizer"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -62,10 +62,6 @@ export const pluginCssMinimizer = (
   name: 'rsbuild:css-minimizer',
 
   setup(api) {
-    if (api.context.bundlerType === 'webpack') {
-      return;
-    }
-
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {
       const config = api.getNormalizedConfig();
       const isMinimize = isProd && !config.output.disableMinimize;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -353,6 +353,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@rsbuild/plugin-css-minimizer':
+        specifier: workspace:*
+        version: link:../../packages/plugin-css-minimizer
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
@@ -708,9 +711,6 @@ importers:
       '@rsbuild/plugin-babel':
         specifier: workspace:*
         version: link:../../plugin-babel
-      '@rsbuild/plugin-css-minimizer':
-        specifier: workspace:*
-        version: link:../../plugin-css-minimizer
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../plugin-react


### PR DESCRIPTION
## Summary

Remove builtin CSS minimizer from `@rsbuild/webpack`.

This allows us to align the `RsbuildConfig` typing of `@rsbuild/core` and `@rsbuild/webpack`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
