### PR TITLE
feat(uni-builder): support disableHtmlFolder

### DIFF
--- a/.changeset/stale-hairs-check.md
+++ b/.changeset/stale-hairs-check.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/uni-builder': patch
+---
+
+feat(uni-builder): support disableHtmlFolder and outputStructure default 'nested'

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -131,6 +131,9 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
   const extraConfig: RsbuildRspackConfig | RsbuildWebpackConfig = {};
   extraConfig.html ||= {};
 
+  extraConfig.html.outputStructure = html.disableHtmlFolder ? 'flat' : 'nested';
+  delete html.disableHtmlFolder;
+
   if (html.metaByEntries) {
     extraConfig.html.meta = ({ entryName }) => html.metaByEntries![entryName];
     delete html.metaByEntries;

--- a/packages/compat/uni-builder/src/types.ts
+++ b/packages/compat/uni-builder/src/types.ts
@@ -178,6 +178,11 @@ export type UniBuilderExtraConfig = {
   };
   html?: {
     /**
+     * Remove the folder of the HTML files.
+     * When this option is enabled, the generated HTML file path will change from `[name]/index.html` to `[name].html`.
+     */
+    disableHtmlFolder?: boolean;
+    /**
      * @deprecated use `html.meta` instead
      */
     metaByEntries?: Record<string, MetaOptions>;

--- a/packages/compat/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/compat/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -6,7 +6,9 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
     "hmr": false,
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {},
   "server": {
     "compress": false,
@@ -31,7 +33,9 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
   "dev": {
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {},
   "server": {
     "publicDir": false,
@@ -47,6 +51,7 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
   },
   "html": {
     "favicon": [Function],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -65,6 +70,7 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
       "/https/www.foo.com/default.ico",
       [Function],
     ],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -80,6 +86,7 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
   },
   "html": {
     "inject": [Function],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -98,6 +105,7 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
       "body",
       [Function],
     ],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -113,6 +121,7 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
   },
   "html": {
     "meta": [Function],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -135,6 +144,7 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
       },
       [Function],
     ],
+    "outputStructure": "nested",
   },
   "output": {},
   "server": {
@@ -149,6 +159,7 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "template": [Function],
   },
   "output": {},
@@ -164,6 +175,7 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "template": [
       "static/index.html",
       [Function],
@@ -182,6 +194,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "templateParameters": [Function],
   },
   "output": {},
@@ -197,6 +210,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "templateParameters": [
       {
         "name": "jack",
@@ -217,6 +231,7 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "title": [Function],
   },
   "output": {},
@@ -232,6 +247,7 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
     "progressBar": true,
   },
   "html": {
+    "outputStructure": "nested",
     "title": [
       "Default",
       [Function],
@@ -249,7 +265,9 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
   "dev": {
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {
     "cssModules": {
       "localIdentName": "[local]-[hash:base64:6]",
@@ -266,7 +284,9 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
   "dev": {
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {
     "cssModules": {
       "auto": [Function],
@@ -284,7 +304,9 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
   "dev": {
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {
     "inlineScripts": true,
   },
@@ -299,7 +321,9 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
   "dev": {
     "progressBar": true,
   },
-  "html": {},
+  "html": {
+    "outputStructure": "nested",
+  },
   "output": {
     "inlineStyles": true,
   },

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -254,6 +254,7 @@ export async function startDevServer<
   const routes = formatRoutes(
     options.context.entry,
     rsbuildConfig.output?.distPath?.html,
+    rsbuildConfig.html?.outputStructure,
   );
 
   debug('create dev server');

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -197,6 +197,7 @@ export async function startProdServer(
         const routes = formatRoutes(
           context.entry,
           rsbuildConfig.output?.distPath?.html,
+          rsbuildConfig.html?.outputStructure,
         );
         await context.hooks.onAfterStartProdServerHook.call({
           port,

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -4,6 +4,7 @@ import type {
   RsbuildEntry,
   RsbuildConfig,
   CompilerTapFn,
+  OutputStructure,
 } from './types';
 import { getPort } from './port';
 import deepmerge from '../compiled/deepmerge';
@@ -16,12 +17,19 @@ import { normalizeUrl } from './url';
 /*
  * format route by entry and adjust the index route to be the first
  */
-export const formatRoutes = (entry: RsbuildEntry, prefix?: string): Routes => {
+export const formatRoutes = (
+  entry: RsbuildEntry,
+  prefix: string | undefined,
+  outputStructure: OutputStructure | undefined,
+): Routes => {
   return (
     Object.keys(entry)
       .map((name) => ({
         name,
-        route: (prefix ? `${prefix}/` : '') + (name === 'index' ? '' : name),
+        route:
+          (prefix ? `${prefix}/` : '') +
+          // fix case: /html/index/index.html
+          (name === 'index' && outputStructure !== 'nested' ? '' : name),
       }))
       // adjust the index route to be the first
       .sort((a) => (a.name === 'index' ? -1 : 1))

--- a/packages/shared/tests/server.test.ts
+++ b/packages/shared/tests/server.test.ts
@@ -9,11 +9,15 @@ import {
 
 test('formatRoutes', () => {
   expect(
-    formatRoutes({
-      index: 'src/index.ts',
-      foo: 'src/index.ts',
-      bar: 'src/index.ts',
-    }),
+    formatRoutes(
+      {
+        index: 'src/index.ts',
+        foo: 'src/index.ts',
+        bar: 'src/index.ts',
+      },
+      undefined,
+      undefined,
+    ),
   ).toEqual([
     {
       name: 'index',
@@ -30,11 +34,15 @@ test('formatRoutes', () => {
   ]);
 
   expect(
-    formatRoutes({
-      foo: 'src/index.ts',
-      bar: 'src/index.ts',
-      index: 'src/index.ts',
-    }),
+    formatRoutes(
+      {
+        foo: 'src/index.ts',
+        bar: 'src/index.ts',
+        index: 'src/index.ts',
+      },
+      undefined,
+      undefined,
+    ),
   ).toEqual([
     {
       name: 'index',
@@ -51,9 +59,13 @@ test('formatRoutes', () => {
   ]);
 
   expect(
-    formatRoutes({
-      foo: 'src/index.ts',
-    }),
+    formatRoutes(
+      {
+        foo: 'src/index.ts',
+      },
+      undefined,
+      undefined,
+    ),
   ).toEqual([
     {
       name: 'foo',
@@ -69,6 +81,7 @@ test('formatRoutes', () => {
         bar: 'src/index.ts',
       },
       'html',
+      undefined,
     ),
   ).toEqual([
     {
@@ -82,6 +95,21 @@ test('formatRoutes', () => {
     {
       name: 'bar',
       route: 'html/bar',
+    },
+  ]);
+
+  expect(
+    formatRoutes(
+      {
+        index: 'src/index.ts',
+      },
+      'html',
+      'nested',
+    ),
+  ).toEqual([
+    {
+      name: 'index',
+      route: 'html/index',
     },
   ]);
 });


### PR DESCRIPTION
## Summary

support html.disableHtmlFolder, and outputStructure default 'nested'

https://github.com/web-infra-dev/rsbuild/issues/14

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
