### PR TITLE
docs(plugin-babel): fix outdated examples

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-babel.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-babel.mdx
@@ -219,56 +219,41 @@ If this problem occurs after you modify the Babel config, it is recommended to c
 
 ```ts
 // wrong example
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      // The plugin has the wrong name or is not installed
-      addPlugins('babel-plugin-not-exists');
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  // The plugin has the wrong name or is not installed
+  addPlugins('babel-plugin-not-exists');
+});
 ```
 
 2. Whether multiple babel-plugin-imports are configured, but the name of each babel-plugin-import is not declared in the third item of the array.
 
 ```ts
 // wrong example
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd', libraryDirectory: 'es' },
-        ],
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-        ],
-      ]);
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  addPlugins([
+    ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+    ],
+  ]);
+});
 ```
 
 ```ts
 // correct example
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd', libraryDirectory: 'es' },
-          'antd',
-        ],
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-          'antd-mobile',
-        ],
-      ]);
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  addPlugins([
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd', libraryDirectory: 'es' },
+      'antd',
+    ],
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+      'antd-mobile',
+    ],
+  ]);
+});
 ```

--- a/packages/document/docs/zh/plugins/list/plugin-babel.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-babel.mdx
@@ -219,56 +219,41 @@ DEBUG=rsbuild pnpm build
 
 ```ts
 // 错误示例
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      // 该插件名称错误，或者未安装
-      addPlugins('babel-plugin-not-exists');
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  // 该插件名称错误，或者未安装
+  addPlugins('babel-plugin-not-exists');
+});
 ```
 
 2. 是否配置了多个 babel-plugin-import，但是没有在数组的第三项声明每一个 babel-plugin-import 的名称。
 
 ```ts
 // 错误示例
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd', libraryDirectory: 'es' },
-        ],
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-        ],
-      ]);
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  addPlugins([
+    ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+    ],
+  ]);
+});
 ```
 
 ```ts
 // 正确示例
-export default {
-  tools: {
-    babel(config, { addPlugins }) {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd', libraryDirectory: 'es' },
-          'antd',
-        ],
-        [
-          'babel-plugin-import',
-          { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-          'antd-mobile',
-        ],
-      ]);
-    },
-  },
-};
+pluginBabel((config, { addPlugins }) => {
+  addPlugins([
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd', libraryDirectory: 'es' },
+      'antd',
+    ],
+    [
+      'babel-plugin-import',
+      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+      'antd-mobile',
+    ],
+  ]);
+});
 ```


### PR DESCRIPTION
## Summary

Fix outdated examples, use `pluginBabel()` instead of `tools.babel`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
