### PR TITLE
types: proxy.context should allow function type

### DIFF
--- a/packages/document/docs/en/shared/config/server/proxy.md
+++ b/packages/document/docs/en/shared/config/server/proxy.md
@@ -55,13 +55,15 @@ The full type definition of Rsbuild Server Proxy is:
 ```ts
 import type { Options as HttpProxyOptions } from 'http-proxy-middleware';
 
+type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
+
 type ProxyDetail = HttpProxyOptions & {
   bypass?: (
     req: IncomingMessage,
     res: ServerResponse,
     proxyOptions: ProxyOptions,
   ) => string | undefined | null | false;
-  context?: string | string[];
+  context?: Filter;
 };
 
 type ProxyOptions =

--- a/packages/document/docs/zh/shared/config/server/proxy.md
+++ b/packages/document/docs/zh/shared/config/server/proxy.md
@@ -55,13 +55,15 @@ Rsbuild Server Proxy 完整类型定义为：
 ```ts
 import type { Options as HttpProxyOptions } from 'http-proxy-middleware';
 
+type Filter = string | string[] | ((pathname: string, req: Request) => boolean);
+
 type ProxyDetail = HttpProxyOptions & {
   bypass?: (
     req: IncomingMessage,
     res: ServerResponse,
     proxyOptions: ProxyOptions,
   ) => string | undefined | null | false;
-  context?: string | string[];
+  context?: Filter;
 };
 
 type ProxyOptions =

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -111,7 +111,6 @@
     "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
-    "http-proxy-middleware": "^2.0.1",
     "mini-css-extract-plugin": "2.7.6",
     "terser": "5.19.2",
     "terser-webpack-plugin": "5.3.9",

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,5 +1,8 @@
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { Options as BaseProxyOptions } from '../../../compiled/http-proxy-middleware';
+import type {
+  Options as BaseProxyOptions,
+  Filter as ProxyFilter,
+} from '../../../compiled/http-proxy-middleware';
 
 export type HtmlFallback = false | 'index';
 
@@ -9,7 +12,7 @@ export type ProxyDetail = BaseProxyOptions & {
     res: ServerResponse,
     proxyOptions: ProxyOptions,
   ) => string | undefined | null | false;
-  context?: string | string[];
+  context?: ProxyFilter;
 };
 
 export type ProxyOptions =

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1592,9 +1592,6 @@ importers:
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.5.7
         version: /html-rspack-plugin@5.5.7
-      http-proxy-middleware:
-        specifier: ^2.0.1
-        version: 2.0.6
       mini-css-extract-plugin:
         specifier: 2.7.6
         version: 2.7.6(webpack@5.89.0)
@@ -1727,7 +1724,7 @@ importers:
         specifier: 1.0.6
         version: 1.0.6
       http-proxy-middleware:
-        specifier: ^2.0.1
+        specifier: ^2.0.6
         version: 2.0.6
       jiti:
         specifier: ^1.20.0

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -36,7 +36,7 @@
     "fs-extra": "^11.1.1",
     "gzip-size": "^6.0.0",
     "http-compression": "1.0.6",
-    "http-proxy-middleware": "^2.0.1",
+    "http-proxy-middleware": "^2.0.6",
     "loader-utils2": "npm:loader-utils@2.0.4",
     "jiti": "^1.20.0",
     "json5": "^2.2.3",


### PR DESCRIPTION
## Summary

`server.proxy.context` should allow function type.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/797

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
