### PR TITLE
chore(deps): bump tsx from v3 to v4

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -26,8 +26,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        # Rsbuild need to compat Node.js 16
-        node-version: [16.x] 
+        node-version: [18.x] 
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -66,8 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Rsbuild need to compat Node.js 16
-        node-version: [16.x] 
+        node-version: [18.x] 
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1648,8 +1648,8 @@ importers:
         specifier: ^16
         version: 16.18.59
       tsx:
-        specifier: ^3.12.7
-        version: 3.14.0
+        specifier: ^4.6.1
+        version: 4.6.1
 
   scripts/prebundle:
     dependencies:
@@ -1790,8 +1790,8 @@ importers:
         specifier: ^16
         version: 16.18.59
       tsx:
-        specifier: ^3.12.7
-        version: 3.14.0
+        specifier: ^4.6.1
+        version: 4.6.1
 
 packages:
 
@@ -14129,13 +14129,13 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsx@3.14.0:
-    resolution: {integrity: sha512-xHtFaKtHxM9LOklMmJdI3BEnQq/D5F73Of2E1GDrITi9sgoVkvIsrQUTY1G8FlmGtA+awCI4EBlTRRYxkL2sRg==}
+  /tsx@4.6.1:
+    resolution: {integrity: sha512-OQ4TAPHXAPUo/NZAmmIybl0o8LFOTlycQxFepLBAp6EV87U88fOKYGCQI2viGAEOVU9UW/cgQcxcOMnfEKVY3Q==}
+    engines: {node: '>=18.0.0'}
     hasBin: true
     dependencies:
       esbuild: 0.18.20
       get-tsconfig: 4.7.2
-      source-map-support: 0.5.21
     optionalDependencies:
       fsevents: 2.3.3
     dev: true

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@types/node": "^16",
-    "tsx": "^3.12.7"
+    "tsx": "^4.6.1"
   }
 }

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -17,6 +17,6 @@
   "devDependencies": {
     "@types/fs-extra": "^11.0.2",
     "@types/node": "^16",
-    "tsx": "^3.12.7"
+    "tsx": "^4.6.1"
   }
 }


### PR DESCRIPTION
## Summary

Bump tsx from v3 to v4.

ref: https://github.com/privatenumber/tsx/releases/tag/v4.0.0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
