### PR TITLE
fix(plugin-babel): lodash breaks the mjs artifact

### DIFF
--- a/.changeset/young-guests-shop.md
+++ b/.changeset/young-guests-shop.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-babel': patch
+---
+
+fix(plugin-babel): lodash breaks the mjs artifact

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -30,13 +30,11 @@
     "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "babel-loader": "9.1.3",
-    "lodash": "^4.17.21",
     "upath": "2.0.1"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "@types/lodash": "^4.14.200",
     "@types/node": "^16",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,6 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { SCRIPT_REGEX } from '@rsbuild/shared';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, SCRIPT_REGEX } from '@rsbuild/shared';
 import { applyUserBabelConfig, type BabelConfig } from './helper';
 import type { PluginBabelOptions } from './types';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1095,9 +1095,6 @@ importers:
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.23.2)(webpack@5.89.0)
-      lodash:
-        specifier: ^4.17.21
-        version: 4.17.21
       upath:
         specifier: 2.0.1
         version: 2.0.1
@@ -1108,9 +1105,6 @@ importers:
       '@rsbuild/test-helper':
         specifier: workspace:*
         version: link:../test-helper
-      '@types/lodash':
-        specifier: ^4.14.200
-        version: 4.14.200
       '@types/node':
         specifier: ^16
         version: 16.18.59


### PR DESCRIPTION
## Summary

Fix lodash breaks the mjs artifact.

<img width="1294" alt="Screenshot 2023-12-02 at 16 46 52" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/2b035d26-5562-4b9b-ba9a-41eb589ef421">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
