### PR TITLE
feat: optimize the order of print file size

### DIFF
--- a/.changeset/gentle-years-lick.md
+++ b/.changeset/gentle-years-lick.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+feat: optimize the order of print file size

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -103,7 +103,7 @@ async function printFileSizes(
     return;
   }
 
-  assets.sort((a, b) => b.size - a.size);
+  assets.sort((a, b) => a.size - b.size);
 
   logger.info(`Production file sizes:\n`);
 


### PR DESCRIPTION
## Summary

Optimize the order of print file size, print largest file at the bottom.

This allows developers to quickly locate large files when there are many files.

<img width="645" alt="Screenshot 2023-12-02 at 21 32 38" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/7b46a7e8-aff3-4450-ae45-ee22502973c0">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
