### PR TITLE
chore: no need to set disableTransformByDefault flag

### DIFF
--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -1,6 +1,5 @@
 import {
   logger,
-  setConfig,
   cloneDeep,
   isWebTarget,
   SCRIPT_REGEX,
@@ -127,15 +126,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
           .options(cloneDeep(swcConfig));
       },
     );
-
-    api.modifyRspackConfig(async (config) => {
-      // will default in rspack 0.4.0 / 0.5.0
-      setConfig(
-        config,
-        'experiments.rspackFuture.disableTransformByDefault',
-        true,
-      );
-    });
   },
 });
 

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -61,7 +61,7 @@ export const getRspackVersion = async (): Promise<string> => {
 };
 
 // apply builtin:swc-loader
-export const rspackMinVersion = '0.3.6';
+export const rspackMinVersion = '0.4.0';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -23,9 +23,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -23,9 +23,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -699,9 +696,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1439,9 +1433,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1868,9 +1859,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/swc.test.ts.snap
@@ -7,11 +7,6 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -126,11 +121,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -239,11 +229,6 @@ exports[`plugin-swc > should add browserslist 2`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -351,11 +336,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [
@@ -485,11 +465,6 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -604,11 +579,6 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -705,11 +675,6 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [
@@ -815,11 +780,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [
@@ -932,11 +892,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [
@@ -1052,11 +1007,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -1168,11 +1118,6 @@ exports[`plugin-swc > should has correct core-js 2`] = `
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [
@@ -1286,11 +1231,6 @@ exports[`plugin-swc > should has correct core-js 3`] = `
       "src/index.js",
     ],
   },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
-  },
   "module": {
     "rules": [
       {
@@ -1387,11 +1327,6 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
     "main": [
       "src/index.js",
     ],
-  },
-  "experiments": {
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "module": {
     "rules": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -40,9 +40,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableTransformByDefault": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary

No need to set disableTransformByDefault flag as Rspack v0.4.0 enabled that by default.

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v0.4.0

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
