### PR TITLE
docs: add more description for writeToDisk

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -72,9 +72,9 @@ Rsbuild 具备以下特性：
 
 ## 🦀 生态
 
-- [Rspack](https://github.com/web-infra-dev/rspack): Rsbuild 的底层打包工具。
-- [Rspress](https://github.com/web-infra-dev/rspress): 基于 Rsbuild 的静态站点生成器。
-- [Modern.js](https://github.com/web-infra-dev/modern.js): 基于 Rsbuild 的渐进式 React 框架。
+- [Rspack](https://github.com/web-infra-dev/rspack)：Rsbuild 的底层打包工具。
+- [Rspress](https://github.com/web-infra-dev/rspress)：基于 Rsbuild 的静态站点生成器。
+- [Modern.js](https://github.com/web-infra-dev/modern.js)：基于 Rsbuild 的渐进式 React 框架。
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)：与 Rspack 和 Rsbuild 相关的精彩内容列表。
 
 ## 🤝 参与贡献

--- a/packages/document/docs/en/shared/config/dev/writeToDisk.md
+++ b/packages/document/docs/en/shared/config/dev/writeToDisk.md
@@ -15,7 +15,7 @@ export default {
 };
 ```
 
-You can also set `dev.writeToDisk` as a function to match part of the files.
+You can also set `dev.writeToDisk` as a function to match part of the files. When the function returns `false`, it will not write to the disk, and when it returns `true`, it will write the file to the disk.
 
 ```ts
 export default {
@@ -24,3 +24,7 @@ export default {
   },
 };
 ```
+
+:::tip
+The `writeToDisk: true` option is used to view the build artifacts in the development environment. It does not change the behavior of webpack-dev-middleware. When accessing files through the browser, the dev server will still read the file content from memory.
+:::

--- a/packages/document/docs/en/shared/config/dev/writeToDisk.md
+++ b/packages/document/docs/en/shared/config/dev/writeToDisk.md
@@ -17,6 +17,8 @@ export default {
 
 You can also set `dev.writeToDisk` as a function to match part of the files. When the function returns `false`, it will not write to the disk, and when it returns `true`, it will write the file to the disk.
 
+For example:
+
 ```ts
 export default {
   dev: {

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -41,10 +41,10 @@ type CreateRsbuildOptions = {
 
 各个选项的作用：
 
-- `cwd`: 当前执行构建的根路径，默认值为 `process.cwd()`
-- `target`: 构建产物类型，默认值为 `['web']`，详见 [构建产物类型](/api/start/build-target) 章节。
-- `provider`: 用于切换底层的打包工具。
-- `rsbuildConfig`：Rsbuild 配置对象。Rsbuild 提供了丰富的配置项，允许你对构建行为进行灵活定制，你可以在 [配置](/config/) 中找到所有可用的配置项。
+- `cwd`：当前执行构建的根路径，默认值为 `process.cwd()`
+- `target`：构建产物类型，默认值为 `['web']`，详见[构建产物类型](/api/start/build-target)章节。
+- `provider`：用于切换底层的打包工具。
+- `rsbuildConfig`：Rsbuild 配置对象。Rsbuild 提供了丰富的配置项，允许你对构建行为进行灵活定制，你可以在[配置](/config/)中找到所有可用的配置项。
 
 ## loadEnv
 

--- a/packages/document/docs/zh/api/start/build-target.md
+++ b/packages/document/docs/zh/api/start/build-target.md
@@ -14,7 +14,7 @@ Rsbuild 支持多种构建产物类型，分别适用于不同的目标运行环
 
 除了 `'web'` 外，你还可以将 `target` 设置为以下值：
 
-- `'node'`: 构建出运行在 Node.js 环境的产物，通常用于 SSR 等场景。
+- `'node'`：构建出运行在 Node.js 环境的产物，通常用于 SSR 等场景。
 - `'web-worker'`：构建出运行在 Web Worker 里的产物。
 
 比如构建出适用于 Node.js 环境的产物：

--- a/packages/document/docs/zh/shared/config/dev/writeToDisk.md
+++ b/packages/document/docs/zh/shared/config/dev/writeToDisk.md
@@ -15,7 +15,9 @@ export default {
 };
 ```
 
-你也可以将 `dev.writeToDisk` 设置为函数，来匹配一部分文件。
+你也可以将 `dev.writeToDisk` 设置为函数来匹配一部分文件，函数返回 `false` 时不会写入文件，返回值 `true` 时会将文件写入磁盘。
+
+例如：
 
 ```ts
 export default {
@@ -24,3 +26,7 @@ export default {
   },
 };
 ```
+
+:::tip
+`writeToDisk: true` 用于在开发环境下查看构建产物，它不会改变 webpack-dev-middleware 的行为，通过浏览器访问文件时，dev server 仍将从内存中读取文件内容。
+:::


### PR DESCRIPTION
## Summary

Add more description for writeToDisk config.

## Related Links

https://github.com/webpack/webpack-dev-middleware#writetodisk

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
