### PR TITLE
chore: adjust server logs of multiple routes

### DIFF
--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -54,11 +54,14 @@ export function printServerURLs(
       .join('');
   } else {
     const maxNameLength = Math.max(...routes.map((r) => r.name.length));
-    urls.forEach(({ label, url }) => {
-      message += `  ${color.bold(`> ${label}`)}\n`;
+    urls.forEach(({ label, url }, index) => {
+      if (index > 0) {
+        message += '\n';
+      }
+      message += `  ${`> ${label}`}\n`;
       routes.forEach((r) => {
-        message += `    ${color.yellow('○')}  ${color.yellow(
-          r.name.padEnd(maxNameLength + 8),
+        message += `  ${color.dim('-')} ${color.dim(
+          r.name.padEnd(maxNameLength + 4),
         )}${color.cyan(normalizeUrl(`${url}/${r.route}`))}\n`;
       });
     });


### PR DESCRIPTION
## Summary

Adjust server logs of multiple routes. We only need to highlight the link and other content can be weakened.

before:

<img width="559" alt="Screenshot 2023-12-03 at 20 34 29" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/9615c22a-af23-4c9a-9bf0-808419d692b5">

after:

<img width="499" alt="Screenshot 2023-12-03 at 20 45 51" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/a8d4a723-686c-4490-a7b2-3d5b6c61c981">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
