### PR TITLE
docs: mark getCompiledPath as private

### DIFF
--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -82,7 +82,6 @@ type ModifyRspackConfigUtils = {
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
   rspack: typeof import('@rspack/core');
 };
 

--- a/packages/document/docs/en/shared/config/tools/webpack.md
+++ b/packages/document/docs/en/shared/config/tools/webpack.md
@@ -294,9 +294,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the Rsbuild built-in dependencies, same as [webpackChain#getCompiledPath](https://rsbuild.dev/config/options/tools#toolswebpackchain).

--- a/packages/document/docs/en/shared/config/tools/webpackChain.md
+++ b/packages/document/docs/en/shared/config/tools/webpackChain.md
@@ -132,37 +132,6 @@ export default {
 };
 ```
 
-#### getCompiledPath
-
-- **Type:** `(name: string) => string`
-
-Get the path to the Rsbuild built-in dependencies, such as:
-
-- sass
-- sass-loader
-- less
-- less-loader
-- css-loader
-- url-loader
-- ...
-
-This method is usually used when you need to reuse the same dependency with the Rsbuild.
-
-:::tip
-Rsbuild built-in dependencies are subject to change with version iterations, e.g. generate large version break changes. Please avoid using this API if it is not necessary.
-:::
-
-```js
-export default {
-  tools: {
-    webpackChain: (chain, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```
-
 #### CHAIN_ID
 
 Some common Chain IDs are predefined in the Rsbuild, and you can use these IDs to locate the built-in Rule or Plugin.

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -82,7 +82,6 @@ type ModifyRspackConfigUtils = {
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  getCompiledPath: (name: string) => string;
   rspack: typeof import('@rspack/core');
 };
 

--- a/packages/document/docs/zh/shared/config/tools/webpack.md
+++ b/packages/document/docs/zh/shared/config/tools/webpack.md
@@ -294,9 +294,3 @@ export default {
   },
 };
 ```
-
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 Rsbuild 内置依赖的所在路径，等价于 [webpackChain#getCompiledPath](https://rsbuild.dev/zh/config/options/tools#toolswebpackchain)。

--- a/packages/document/docs/zh/shared/config/tools/webpackChain.md
+++ b/packages/document/docs/zh/shared/config/tools/webpackChain.md
@@ -135,37 +135,6 @@ export default {
 };
 ```
 
-#### getCompiledPath
-
-- **类型：** `(name: string) => string`
-
-获取 Rsbuild 内置依赖的所在路径，例如：
-
-- sass
-- sass-loader
-- less
-- less-loader
-- css-loader
-- url-loader
-- ...
-
-该方法通常在需要与 Rsbuild 复用同一份依赖时会被用到。
-
-:::tip
-Rsbuild 内部依赖会随着版本迭代而发生变化，例如产生大版本变更。在非必要的情况下，请避免使用此 API。
-:::
-
-```js
-export default {
-  tools: {
-    webpackChain: (chain, { getCompiledPath }) => {
-      const loaderPath = getCompiledPath('less-loader');
-      // ...
-    },
-  },
-};
-```
-
 #### CHAIN_ID
 
 Rsbuild 中预先定义了一些常用的 Chain ID，你可以通过这些 ID 来定位到内置的 Rule 或 Plugin。


### PR DESCRIPTION
## Summary

Mark getCompiledPath as private, we do not want user to use this util, because the compiled dependencies are unstable and may change during Rsbuild development.

## Related Links

Same as https://github.com/web-infra-dev/rsbuild/pull/709

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
