### PR TITLE
perf(core): reduce fs overhead in getCompiledPath

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
     "icss",
     "imagex",
     "jiti",
+    "jscpuprofile",
     "jsesc",
     "lightingcss",
     "longpaths",

--- a/packages/compat/webpack/src/plugins/css.ts
+++ b/packages/compat/webpack/src/plugins/css.ts
@@ -9,6 +9,7 @@ import {
   getCssLoaderOptions,
   getBrowserslistWithDefault,
   getCssModuleLocalIdentName,
+  getSharedPkgCompiledPath,
   type Context,
   type RsbuildPlugin,
   type NormalizedConfig,
@@ -20,7 +21,7 @@ export async function applyBaseCSSRule({
   rule,
   config,
   context,
-  utils: { target, isProd, isServer, CHAIN_ID, isWebWorker, getCompiledPath },
+  utils: { target, isProd, isServer, CHAIN_ID, isWebWorker },
   importLoaders = 1,
 }: {
   rule: BundlerChainRule;
@@ -109,7 +110,7 @@ export async function applyBaseCSSRule({
 
   rule
     .use(CHAIN_ID.USE.CSS)
-    .loader(getCompiledPath('css-loader'))
+    .loader(getSharedPkgCompiledPath('css-loader'))
     .options(cssLoaderOptions)
     .end();
 
@@ -122,7 +123,7 @@ export async function applyBaseCSSRule({
 
     rule
       .use(CHAIN_ID.USE.POSTCSS)
-      .loader(getCompiledPath('postcss-loader'))
+      .loader(getSharedPkgCompiledPath('postcss-loader'))
       .options(postcssLoaderOptions)
       .end();
   }

--- a/packages/compat/webpack/src/plugins/less.ts
+++ b/packages/compat/webpack/src/plugins/less.ts
@@ -3,6 +3,7 @@ import {
   FileFilterUtil,
   isUseCssSourceMap,
   getLessLoaderOptions,
+  getSharedPkgCompiledPath,
   type RsbuildPlugin,
 } from '@rsbuild/shared';
 
@@ -40,7 +41,7 @@ export function pluginLess(): RsbuildPlugin {
 
         rule
           .use(utils.CHAIN_ID.USE.LESS)
-          .loader(utils.getCompiledPath('less-loader'))
+          .loader(getSharedPkgCompiledPath('less-loader'))
           .options(options);
       });
     },

--- a/packages/compat/webpack/src/plugins/sass.ts
+++ b/packages/compat/webpack/src/plugins/sass.ts
@@ -2,6 +2,7 @@ import {
   SASS_REGEX,
   getResolveUrlJoinFn,
   getSassLoaderOptions,
+  getSharedPkgCompiledPath,
   patchCompilerGlobalLocation,
   type RsbuildPlugin,
 } from '@rsbuild/shared';
@@ -42,7 +43,7 @@ export function pluginSass(): RsbuildPlugin {
 
         rule
           .use(utils.CHAIN_ID.USE.RESOLVE_URL_LOADER_FOR_SASS)
-          .loader(utils.getCompiledPath('resolve-url-loader'))
+          .loader(getSharedPkgCompiledPath('resolve-url-loader'))
           .options({
             join: await getResolveUrlJoinFn(),
             // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
@@ -52,7 +53,7 @@ export function pluginSass(): RsbuildPlugin {
           })
           .end()
           .use(utils.CHAIN_ID.USE.SASS)
-          .loader(utils.getCompiledPath('sass-loader'))
+          .loader(getSharedPkgCompiledPath('sass-loader'))
           .options(options);
       });
     },

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -12,6 +12,7 @@ import {
   getCssModuleLocalIdentName,
   resolvePackage,
   mergeChainedOptions,
+  getSharedPkgCompiledPath,
   type BundlerChain,
   type Context,
   type RspackRule,
@@ -19,7 +20,6 @@ import {
   type ModifyBundlerChainUtils,
 } from '@rsbuild/shared';
 import type { RsbuildPlugin, NormalizedConfig } from '../../types';
-import { getCompiledPath } from '../shared';
 
 export const enableNativeCss = (config: NormalizedConfig) =>
   !config.output.disableCssExtract;
@@ -100,7 +100,7 @@ export async function applyBaseCSSRule({
 
     rule
       .use(CHAIN_ID.USE.CSS)
-      .loader(getCompiledPath('css-loader'))
+      .loader(getSharedPkgCompiledPath('css-loader'))
       .options(cssLoaderOptions)
       .end();
   } else {
@@ -131,7 +131,7 @@ export async function applyBaseCSSRule({
 
     rule
       .use(CHAIN_ID.USE.POSTCSS)
-      .loader(getCompiledPath('postcss-loader'))
+      .loader(getSharedPkgCompiledPath('postcss-loader'))
       .options(postcssLoaderOptions)
       .end();
   }

--- a/packages/core/src/provider/plugins/less.ts
+++ b/packages/core/src/provider/plugins/less.ts
@@ -3,6 +3,7 @@ import {
   isUseCssSourceMap,
   LESS_REGEX,
   getLessLoaderOptions,
+  getSharedPkgCompiledPath,
 } from '@rsbuild/shared';
 
 export function pluginLess(): RsbuildPlugin {
@@ -43,7 +44,7 @@ export function pluginLess(): RsbuildPlugin {
 
         rule
           .use(utils.CHAIN_ID.USE.LESS)
-          .loader(utils.getCompiledPath('less-loader'))
+          .loader(getSharedPkgCompiledPath('less-loader'))
           .options(options);
       });
 

--- a/packages/core/src/provider/plugins/sass.ts
+++ b/packages/core/src/provider/plugins/sass.ts
@@ -3,6 +3,7 @@ import {
   getSassLoaderOptions,
   patchCompilerGlobalLocation,
   getResolveUrlJoinFn,
+  getSharedPkgCompiledPath,
 } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
@@ -43,7 +44,7 @@ export function pluginSass(): RsbuildPlugin {
 
         rule
           .use(utils.CHAIN_ID.USE.RESOLVE_URL_LOADER_FOR_SASS)
-          .loader(utils.getCompiledPath('resolve-url-loader'))
+          .loader(getSharedPkgCompiledPath('resolve-url-loader'))
           .options({
             join: await getResolveUrlJoinFn(),
             // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
@@ -53,7 +54,7 @@ export function pluginSass(): RsbuildPlugin {
           })
           .end()
           .use(utils.CHAIN_ID.USE.SASS)
-          .loader(utils.getCompiledPath('sass-loader'))
+          .loader(getSharedPkgCompiledPath('sass-loader'))
           .options(options);
       });
 

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -100,9 +100,8 @@ export const getCompiledPath = (packageName: string) => {
   const providerCompilerPath = join(__dirname, '../../compiled', packageName);
   if (fse.existsSync(providerCompilerPath)) {
     return providerCompilerPath;
-  } else {
-    return getSharedPkgCompiledPath(packageName as SharedCompiledPkgNames);
   }
+  return getSharedPkgCompiledPath(packageName as SharedCompiledPkgNames);
 };
 
 export const BUILTIN_LOADER = 'builtin:';

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { CSS_MODULES_REGEX, NODE_MODULES_REGEX } from './constants';
 import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 import deepmerge from '../compiled/deepmerge';
-import { getSharedPkgCompiledPath as getCompiledPath } from './utils';
+import { getSharedPkgCompiledPath } from './utils';
 import { mergeChainedOptions } from './mergeChainedOptions';
 import type {
   RsbuildTarget,
@@ -83,8 +83,8 @@ export const getPostcssConfig = ({
   const defaultPostcssConfig = {
     postcssOptions: {
       plugins: [
-        require(getCompiledPath('postcss-flexbugs-fixes')),
-        require(getCompiledPath('autoprefixer'))(autoprefixerOptions),
+        require(getSharedPkgCompiledPath('postcss-flexbugs-fixes')),
+        require(getSharedPkgCompiledPath('autoprefixer'))(autoprefixerOptions),
       ].filter(Boolean),
     },
     sourceMap: enableSourceMap,


### PR DESCRIPTION
## Summary

Reduce fs overhead in getCompiledPath.

The `getSharedPkgCompiledPath` method provides better performance as it do not need to call `fs.existsSync`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
