### PR TITLE
chore(plugin-babel): mark addIncludes as deprecated

### DIFF
--- a/packages/compat/uni-builder/src/webpack/plugins/tsLoader.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/tsLoader.ts
@@ -22,7 +22,18 @@ export type TSLoaderOptions = Partial<RawTSLoaderOptions>;
 
 export type PluginTsLoaderOptions = ChainedConfigWithUtils<
   TSLoaderOptions,
-  { addIncludes: FileFilterUtil; addExcludes: FileFilterUtil }
+  {
+    /**
+     * use `source.include` instead
+     * @deprecated
+     */
+    addIncludes: FileFilterUtil;
+    /**
+     * use `source.exclude` instead
+     * @deprecated
+     */
+    addExcludes: FileFilterUtil;
+  }
 >;
 
 export const pluginTsLoader = (

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -54,12 +54,20 @@ export type PresetReactOptions =
 export type BabelConfigUtils = {
   addPlugins: (plugins: BabelPlugin[]) => void;
   addPresets: (presets: BabelPlugin[]) => void;
-  addIncludes: (includes: string | RegExp | (string | RegExp)[]) => void;
-  addExcludes: (excludes: string | RegExp | (string | RegExp)[]) => void;
   removePlugins: (plugins: string | string[]) => void;
   removePresets: (presets: string | string[]) => void;
   modifyPresetEnvOptions: (options: PresetEnvOptions) => void;
   modifyPresetReactOptions: (options: PresetReactOptions) => void;
+  /**
+   * use `source.include` instead
+   * @deprecated
+   */
+  addIncludes: (includes: string | RegExp | (string | RegExp)[]) => void;
+  /**
+   * use `source.exclude` instead
+   * @deprecated
+   */
+  addExcludes: (excludes: string | RegExp | (string | RegExp)[]) => void;
 };
 
 export type PluginBabelOptions = ChainedConfigWithUtils<

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -10,7 +10,7 @@ describe('plugins/babel', () => {
     });
 
     rsbuild.addPlugins([
-      pluginBabel((_config: any, { addExcludes, addIncludes }: any) => {
+      pluginBabel((_config, { addExcludes, addIncludes }) => {
         addIncludes(/\/node_modules\/query-string\//);
         addExcludes('src/example');
       }),
@@ -39,8 +39,8 @@ describe('plugins/babel', () => {
   it('should set babel-loader when config is add', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [
-        pluginBabel((config: any) => {
-          config.plugins.push([
+        pluginBabel((config) => {
+          config.plugins?.push([
             'babel-plugin-import',
             {
               libraryName: 'xxx-components',
@@ -61,7 +61,7 @@ describe('plugins/babel', () => {
   it('babel-loader addIncludes & addExcludes should works', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [
-        pluginBabel((_config: any, { addExcludes, addIncludes }: any) => {
+        pluginBabel((_config, { addExcludes, addIncludes }) => {
           addIncludes(/\/node_modules\/query-string\//);
           addExcludes('src/example');
         }),


### PR DESCRIPTION
## Summary

Mark addIncludes as deprecated, the function of `addIncludes/addExcludes` is the same as `source.include/exclude, so we do not recommend to use `addIncludes/addExcludes` anymore.

> `addIncludes/addExcludes` is also undocumented API in Rsbuild.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
