### PR TITLE
docs: add tip for ASSET_PREFIX env var

### DIFF
--- a/packages/document/docs/en/shared/config/dev/assetPrefix.md
+++ b/packages/document/docs/en/shared/config/dev/assetPrefix.md
@@ -56,4 +56,4 @@ The differences from the native configuration are as follows:
 
 - `dev.assetPrefix` only takes effect in the development environment.
 - `dev.assetPrefix` automatically appends a trailing `/` by default.
-- The value of `dev.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable.
+- The value of `dev.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable (can only be accessed in client code).

--- a/packages/document/docs/en/shared/config/output/assetPrefix.md
+++ b/packages/document/docs/en/shared/config/output/assetPrefix.md
@@ -39,4 +39,4 @@ The differences from the native configuration are as follows:
 
 - `output.assetPrefix` only takes effect in the production environment.
 - `output.assetPrefix` automatically appends a trailing `/` by default.
-- The value of `output.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable.
+- The value of `output.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable (can only be accessed in client code).

--- a/packages/document/docs/zh/guide/advanced/env-vars.md
+++ b/packages/document/docs/zh/guide/advanced/env-vars.md
@@ -56,7 +56,7 @@ export default {
 };
 ```
 
-此时，我们可以在前端代码中通过以下方式来拼接图片 URL：
+此时，我们可以在 client 代码中通过以下方式来拼接图片 URL：
 
 ```jsx
 const Image = <img src={`${process.env.ASSET_PREFIX}/static/icon.png`} />;

--- a/packages/document/docs/zh/shared/config/dev/assetPrefix.md
+++ b/packages/document/docs/zh/shared/config/dev/assetPrefix.md
@@ -56,4 +56,4 @@ export default {
 
 - `dev.assetPrefix` 仅在开发环境下生效。
 - `dev.assetPrefix` 默认会自动补全尾部的 `/`。
-- `dev.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量。
+- `dev.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量（只能在 client 代码中访问）。

--- a/packages/document/docs/zh/shared/config/output/assetPrefix.md
+++ b/packages/document/docs/zh/shared/config/output/assetPrefix.md
@@ -39,4 +39,4 @@ export default {
 
 - `output.assetPrefix` 仅在生产环境下生效。
 - `output.assetPrefix` 默认会自动补全尾部的 `/`。
-- `output.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量。
+- `output.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量（只能在 client 代码中访问）。


### PR DESCRIPTION
## Summary

Currently, `proecss.env.ASSET_PREFIX` can only be accessed in client code, so we should mention this in the documentation.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
