### PR TITLE
perf(plugin-react): reduce deps and fix peer dep warning

### DIFF
--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/plugin-react-refresh": "0.4.1",
+    "@rspack/plugin-react-refresh": "0.4.1-canary-10d4cb5-20231204024139",
     "react-refresh": "^0.14.0",
     "semver": "^7.5.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1252,8 +1252,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/plugin-react-refresh':
-        specifier: 0.4.1
-        version: 0.4.1(react-refresh@0.14.0)(webpack@5.89.0)
+        specifier: 0.4.1-canary-10d4cb5-20231204024139
+        version: 0.4.1-canary-10d4cb5-20231204024139(react-refresh@0.14.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -4881,24 +4881,15 @@ packages:
       zod: 3.22.4
       zod-validation-error: 1.3.1(zod@3.22.4)
 
-  /@rspack/plugin-react-refresh@0.4.1(react-refresh@0.14.0)(webpack@5.89.0):
-    resolution: {integrity: sha512-Fo6MBu4JNGqyrLXHkKG3Jhor0CG9yuXhig/a4vfrMInmKBkAyOCc5QnlGflXlyPs4bWhdViaUbl0kJaU11NLZg==}
+  /@rspack/plugin-react-refresh@0.4.1-canary-10d4cb5-20231204024139(react-refresh@0.14.0):
+    resolution: {integrity: sha512-LT0qndGXnuB4Z4W62aWXji8ZlJc/EnhkiVjnChoGbJDRjXxJXyP3Tj6WXdjGIAFo3fLz4jIzxpUKV+/ezOhS0A==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
       react-refresh:
         optional: true
     dependencies:
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.10(react-refresh@0.14.0)(webpack@5.89.0)
       react-refresh: 0.14.0
-    transitivePeerDependencies:
-      - '@types/webpack'
-      - sockjs-client
-      - type-fest
-      - webpack
-      - webpack-dev-server
-      - webpack-hot-middleware
-      - webpack-plugin-serve
     dev: false
 
   /@rspress/core@1.8.0(webpack@5.89.0):


### PR DESCRIPTION
## Summary

Reduce depdendencies of react plugin and fix peer dependency warning.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/4807
- https://github.com/web-infra-dev/rsbuild/issues/255

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
