### PR TITLE
chore: should external compiled packages

### DIFF
--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -23,13 +23,15 @@ export const baseBuildConfig = {
 
 export default defineConfig(baseBuildConfig);
 
+const externals = ['@rsbuild/core', /[\\/]compiled[\\/]/];
+
 export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
   {
     format: 'cjs',
     target: BUILD_TARGET,
     define,
     autoExtension: true,
-    externals: ['@rsbuild/core'],
+    externals,
     dts: {
       respectExternal: false,
     },
@@ -41,7 +43,7 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     define,
     autoExtension: true,
     shims: true,
-    externals: ['@rsbuild/core'],
+    externals,
     esbuildOptions: (option) => {
       let { inject } = option;
       const filepath = path.join(__dirname, 'requireShims.js');


### PR DESCRIPTION
## Summary

Should external compiled code when bundle packages. 

Fix:

<img width="1220" alt="Screenshot 2023-12-04 at 14 51 55" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/7e2d2ade-d7ce-42de-9ce7-28b931e701eb">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
