### PR TITLE
perf(server): load proxy module on demand

### DIFF
--- a/packages/core/src/provider/plugins/minimize.ts
+++ b/packages/core/src/provider/plugins/minimize.ts
@@ -1,18 +1,7 @@
-import {
-  CHAIN_ID,
-  type BundlerChain,
-  type RspackBuiltinsConfig,
-} from '@rsbuild/shared';
+import { CHAIN_ID, type RspackBuiltinsConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin, NormalizedConfig } from '../../types';
-import {
-  SwcJsMinimizerRspackPlugin,
-  SwcCssMinimizerRspackPlugin,
-} from '@rspack/core';
 
-export function applyJSMinimizer(
-  chain: BundlerChain,
-  config: NormalizedConfig,
-) {
+const getJsMinimizerOptions = (config: NormalizedConfig) => {
   const options: RspackBuiltinsConfig['minifyOptions'] = {};
 
   const { removeConsole } = config.performance;
@@ -42,34 +31,34 @@ export function applyJSMinimizer(
 
   options.asciiOnly = config.output.charset === 'ascii';
 
-  chain.optimization
-    .minimizer(CHAIN_ID.MINIMIZER.JS)
-    .use(SwcJsMinimizerRspackPlugin, [options])
-    .end();
-}
-
-export function applyCSSMinimizer(chain: BundlerChain) {
-  chain.optimization
-    .minimizer(CHAIN_ID.MINIMIZER.CSS)
-    .use(SwcCssMinimizerRspackPlugin, [])
-    .end();
-}
+  return options;
+};
 
 export const pluginMinimize = (): RsbuildPlugin => ({
   name: 'rsbuild:minimize',
 
   setup(api) {
-    api.modifyBundlerChain((chain, { isProd }) => {
+    api.modifyBundlerChain(async (chain, { isProd }) => {
       const config = api.getNormalizedConfig();
       const isMinimize = isProd && !config.output.disableMinimize;
 
       // set minimize to allow users to disable minimize
       chain.optimization.minimize(isMinimize);
 
-      if (isMinimize) {
-        applyJSMinimizer(chain, config);
-        applyCSSMinimizer(chain);
+      if (!isMinimize) {
+        return;
       }
+
+      const { SwcJsMinimizerRspackPlugin, SwcCssMinimizerRspackPlugin } =
+        await import('@rspack/core');
+
+      chain.optimization
+        .minimizer(CHAIN_ID.MINIMIZER.JS)
+        .use(SwcJsMinimizerRspackPlugin, [getJsMinimizerOptions(config)])
+        .end()
+        .minimizer(CHAIN_ID.MINIMIZER.CSS)
+        .use(SwcCssMinimizerRspackPlugin, [])
+        .end();
     });
   },
 });

--- a/packages/core/src/provider/plugins/rspackProfile.ts
+++ b/packages/core/src/provider/plugins/rspackProfile.ts
@@ -1,9 +1,5 @@
 import type { RsbuildPlugin } from '../../types';
 import path from 'path';
-import {
-  experimental_registerGlobalTrace as registerGlobalTrace,
-  experimental_cleanupGlobalTrace as cleanupGlobalTrace,
-} from '@rspack/core';
 import inspector from 'inspector';
 import { fse } from '@rsbuild/shared';
 import { logger } from '@rsbuild/shared';
@@ -29,7 +25,7 @@ export const stopProfiler = (
 export const pluginRspackProfile = (): RsbuildPlugin => ({
   name: 'rsbuild:rspack-profile',
 
-  setup(api) {
+  async setup(api) {
     /**
      * RSPACK_PROFILE=ALL
      * RSPACK_PROFILE=TRACE|CPU|LOGGING
@@ -39,6 +35,11 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     if (!RSPACK_PROFILE) {
       return;
     }
+
+    const {
+      experimental_registerGlobalTrace: registerGlobalTrace,
+      experimental_cleanupGlobalTrace: cleanupGlobalTrace,
+    } = await import('@rspack/core');
 
     const timestamp = Date.now();
     const profileDir = path.join(

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -25,7 +25,6 @@ import {
 } from '@rsbuild/shared';
 import DevMiddleware from './dev-middleware';
 import connect from '@rsbuild/shared/connect';
-import { createProxyMiddleware } from './proxy';
 import {
   faviconFallbackMiddleware,
   getHtmlFallbackMiddleware,
@@ -129,6 +128,7 @@ export class RsbuildDevServer {
 
     // dev proxy handler, each proxy has own handler
     if (dev.proxy) {
+      const { createProxyMiddleware } = await import('./proxy');
       const { middlewares } = createProxyMiddleware(dev.proxy, app);
       middlewares.forEach((middleware) => {
         this.middlewares.use(middleware);

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -18,7 +18,6 @@ import {
   type PreviewServerOptions,
 } from '@rsbuild/shared';
 import { faviconFallbackMiddleware } from './middlewares';
-import { createProxyMiddleware } from './proxy';
 import type { Context } from '../types';
 
 type RsbuildProdServerOptions = {
@@ -73,6 +72,7 @@ export class RsbuildProdServer {
     }
 
     if (proxy) {
+      const { createProxyMiddleware } = await import('./proxy');
       const { middlewares } = createProxyMiddleware(proxy, this.app);
       middlewares.forEach((middleware) => {
         this.middlewares.use(middleware);


### PR DESCRIPTION
## Summary

Load proxy module on demand, make dev server startup 5ms faster.

<img width="543" alt="Screenshot 2023-12-04 at 16 12 49" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/cdab2c18-0a46-4e57-bb30-619b865f57f3">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
