### PR TITLE
perf(build): no need to load dev middleware when building

### DIFF
--- a/packages/core/src/provider/core/createCompiler.ts
+++ b/packages/core/src/provider/core/createCompiler.ts
@@ -12,7 +12,6 @@ import {
   type RspackMultiCompiler,
   type CreateDevMiddlewareReturns,
 } from '@rsbuild/shared';
-import { getDevMiddleware } from './devMiddleware';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import type { Context } from '../../types';
 import type { Stats, MultiStats, StatsCompilation } from '@rspack/core';
@@ -126,6 +125,7 @@ export async function createDevMiddleware(
     });
   }
 
+  const { getDevMiddleware } = await import('./devMiddleware');
   return {
     devMiddleware: getDevMiddleware(compiler),
     compiler,


### PR DESCRIPTION
## Summary

No need to load dev middleware when building, make build 15ms faster.

<img width="675" alt="Screenshot 2023-12-04 at 16 33 23" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/b6943c20-f140-42bc-93c5-426959a6f5ba">

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
