### PR TITLE
breaking change: remove deprecated source.entries config

### DIFF
--- a/.changeset/warm-bears-exercise.md
+++ b/.changeset/warm-bears-exercise.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': minor
+'@rsbuild/core': minor
+---
+
+breaking change: remove deprecated source.entries config

--- a/packages/core/src/provider/core/createContext.ts
+++ b/packages/core/src/provider/core/createContext.ts
@@ -65,22 +65,8 @@ export function createContextByConfig(
   const distPath = getAbsoluteDistPath(cwd, outputConfig);
   const cachePath = join(rootPath, 'node_modules', '.cache');
 
-  if (sourceConfig.entries) {
-    logger.warn(
-      '[Rsbuild] `source.entries` option has been renamed to `source.entry`, please update the Rsbuild config.',
-    );
-    logger.warn(
-      '[Rsbuild] `source.entries` option will be removed in Rsbuild v0.2.0.',
-    );
-  }
-
   const context: BaseContext = {
-    entry:
-      sourceConfig.entry ||
-      // TODO: remove sourceConfig.entries in v0.2.0
-      // compat with previous config
-      sourceConfig.entries ||
-      getDefaultEntry(rootPath),
+    entry: sourceConfig.entry || getDefaultEntry(rootPath),
     version: RSBUILD_VERSION,
     target,
     rootPath,

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -30,10 +30,6 @@ export interface SourceConfig {
    */
   entry?: RsbuildEntry;
   /**
-   * @default Use `source.entry` instead.
-   */
-  entries?: RsbuildEntry;
-  /**
    * Specifies that certain files that will be excluded from compilation.
    */
   exclude?: (string | RegExp)[];


### PR DESCRIPTION
## Summary

Remove the deprecated `source.entries` config.

`source.entries` has been renamed to `source.entry` since Rsbuild v0.1.0, and we will remove the legacy `source.entries` config in Rsbuild v0.2.0. 

- before:

```js
// rsbuild.config.ts
export default {
  source: {
    entries: {}
  }
}
```

- after:

```js
// rsbuild.config.ts
export default {
  source: {
    entry: {}
  }
}
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/813

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
