### PR TITLE
fix(plugin-babel): failed to resolve babel-loader

### DIFF
--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { cloneDeep, SCRIPT_REGEX } from '@rsbuild/shared';
 import { applyUserBabelConfig, type BabelConfig } from './helper';
@@ -93,7 +94,7 @@ export const pluginBabel = (
         .test(SCRIPT_REGEX)
         .use(CHAIN_ID.USE.BABEL)
         .after(CHAIN_ID.USE.SWC)
-        .loader(require.resolve('../compiled/babel-loader'))
+        .loader(path.resolve(__dirname, '../compiled/babel-loader'))
         .options(babelOptions);
     });
   },


### PR DESCRIPTION
## Summary

Fix failed to resolve babel-loader when using the mjs output.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/a3b529a6-5678-40f2-bdf3-7b5409b67a39)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
