### PR TITLE
chore: remove unused getRspackVersion fn

### DIFF
--- a/packages/core/src/provider/index.ts
+++ b/packages/core/src/provider/index.ts
@@ -1,4 +1,3 @@
-export { getRspackVersion } from './shared';
 export { rspackProvider } from './provider';
 export type { Rspack, RspackConfig } from '@rsbuild/shared';
 export {

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -5,7 +5,7 @@ import {
 } from '@rsbuild/shared';
 import { fse } from '@rsbuild/shared';
 import { RsbuildPlugin } from '../types';
-import { awaitableGetter, Plugins } from '@rsbuild/shared';
+import { awaitableGetter, type Plugins } from '@rsbuild/shared';
 
 export const applyDefaultPlugins = (plugins: Plugins) =>
   awaitableGetter<RsbuildPlugin>([
@@ -46,19 +46,6 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     plugins.server(),
     import('./plugins/rspackProfile').then((m) => m.pluginRspackProfile()),
   ]);
-
-export const getRspackVersion = async (): Promise<string> => {
-  try {
-    const core = require.resolve('@rspack/core');
-    const pkg = await import(join(core, '../../package.json'));
-
-    return pkg?.version;
-  } catch (err) {
-    // don't block build process
-    console.error(err);
-    return '';
-  }
-};
 
 // apply builtin:swc-loader
 export const rspackMinVersion = '0.4.0';

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -43,9 +43,11 @@ export const isCssModules = (filename: string, modules: CssLoaderModules) => {
 
   if (typeof auto === 'boolean') {
     return auto && CSS_MODULES_REGEX.test(filename);
-  } else if (auto instanceof RegExp) {
+  }
+  if (auto instanceof RegExp) {
     return auto.test(filename);
-  } else if (typeof auto === 'function') {
+  }
+  if (typeof auto === 'function') {
     return auto(filename);
   }
   return true;

--- a/packages/shared/src/formatStats.ts
+++ b/packages/shared/src/formatStats.ts
@@ -52,7 +52,7 @@ function formatMessage(stats: webpack.StatsError | string) {
 
   message = lines.join('\n');
 
-  // Smoosh syntax errors (commonly found in CSS)
+  // Smooth syntax errors (commonly found in CSS)
   message = message.replace(
     /SyntaxError\s+\((\d+):(\d+)\)\s*(.+?)\n/g,
     `${friendlySyntaxErrorLabel} $3 ($1:$2)\n`,


### PR DESCRIPTION
## Summary

Remove unused getRspackVersion fn, just use `rspack.rspackVersion`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
