### PR TITLE
chore(workflow): integrate ls-lint for filename linting

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,16 @@
+ls:
+  # .dir: kebab-case
+  packages/{*,compat/*}/src:
+    .js: camelCase
+    .ts: camelCase | PascalCase
+    .d.ts: camelCase
+
+ignore:
+  - .git
+  - .nx
+  - .husky
+  - .vscode
+  - .github
+  - .changeset
+  - compiled
+  - node_modules

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "e2e:rspack": "cd ./e2e && pnpm test:rspack",
     "e2e:webpack": "cd ./e2e && pnpm test:webpack",
     "gen-release-note": "modern gen-release-note",
-    "lint": "echo todo",
+    "lint": "ls-lint",
     "new": "modern new",
     "prepare": "pnpm run build && husky install",
     "release": "modern release",
@@ -38,6 +38,7 @@
     "package.json": "pnpm run check-dependency-version"
   },
   "devDependencies": {
+    "@ls-lint/ls-lint": "^2.2.2",
     "@modern-js/module-tools": "^2.41.0",
     "@modern-js/monorepo-tools": "^2.41.0",
     "@rsbuild/test-helper": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@ls-lint/ls-lint':
+        specifier: ^2.2.2
+        version: 2.2.2
       '@modern-js/module-tools':
         specifier: ^2.41.0
         version: 2.41.0(typescript@5.3.2)
@@ -4090,6 +4093,13 @@ packages:
       hoist-non-react-statics: 3.3.2
       react: 18.2.0
       react-is: 16.13.1
+    dev: true
+
+  /@ls-lint/ls-lint@2.2.2:
+    resolution: {integrity: sha512-gdolCgwveSHZczfKtoVFkf+NZJjd7KRQs9QnLVEiMFEJLK4H7nBrZuC/ASl/AYMZvFmtCocRt3d5E0UF/34vCQ==}
+    cpu: [x64, arm64, s390x]
+    os: [darwin, linux, win32]
+    hasBin: true
     dev: true
 
   /@manypkg/find-root@1.1.0:


### PR DESCRIPTION
## Summary

Integrate ls-lint for filename linting.

## Related Links

https://github.com/loeffel-io/ls-lint

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
