### PR TITLE
fix(plugin-react): split react-refresh utils to lib-react chunk

### DIFF
--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -5,47 +5,38 @@ import {
   createCacheGroups,
   type SplitChunks,
 } from '@rsbuild/shared';
-import { SplitReactChunkOptions } from 'src';
+import type { SplitReactChunkOptions } from '.';
 
 export const applySplitChunksRule = (
   api: RsbuildPluginAPI,
-  options: SplitReactChunkOptions | undefined,
+  options: SplitReactChunkOptions = {
+    react: true,
+    router: true,
+  },
 ) => {
   api.modifyBundlerChain((chain) => {
     const config = api.getNormalizedConfig();
-    const { chunkSplit } = config.performance || {};
-
-    if (chunkSplit?.strategy !== 'split-by-experience') {
+    if (config.performance.chunkSplit.strategy !== 'split-by-experience') {
       return;
     }
 
-    if (!options) {
-      options = {
-        react: true,
-        router: true,
-      };
-    }
-
     const currentConfig = chain.optimization.splitChunks.values();
-
     if (!isPlainObject(currentConfig)) {
       return;
     }
 
     const extraGroups: Record<string, (string | RegExp)[]> = {};
 
-    if (options.react !== false) {
+    if (options.react) {
       extraGroups.react = [
         'react',
         'react-dom',
         'scheduler',
-        ...(isProd()
-          ? []
-          : ['react-refresh', '@pmmmwh/react-refresh-webpack-plugin']),
+        ...(isProd() ? [] : ['react-refresh', '@rspack/plugin-react-refresh']),
       ];
     }
 
-    if (options.router !== false) {
+    if (options.router) {
       extraGroups.router = [
         'react-router',
         'react-router-dom',

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -25,7 +25,7 @@ exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is i
       "name": "lib-react",
       "priority": 0,
       "reuseExistingChunk": true,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|react-refresh\\|@pmmmwh\\\\/react-refresh-webpack-plugin\\)\\[\\\\\\\\/\\]/,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|react-refresh\\|@rspack\\\\/plugin-react-refresh\\)\\[\\\\\\\\/\\]/,
     },
     "lib-router": {
       "name": "lib-router",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -632,7 +632,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           "name": "lib-react",
           "priority": 0,
           "reuseExistingChunk": true,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|react-refresh\\|@pmmmwh\\\\/react-refresh-webpack-plugin\\)\\[\\\\\\\\/\\]/,
+          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|react-refresh\\|@rspack\\\\/plugin-react-refresh\\)\\[\\\\\\\\/\\]/,
         },
         "lib-router": {
           "name": "lib-router",


### PR DESCRIPTION
## Summary

Split react-refresh utils to lib-react chunk.

## Related Links

https://github.com/web-infra-dev/rspack/pull/4807

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [x] I have added tests to cover my changes.
