### PR TITLE
feat(plugin-vue): apply default split chunk rules

### DIFF
--- a/e2e/cases/vue/split-chunk/index.test.ts
+++ b/e2e/cases/vue/split-chunk/index.test.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { build } from '@scripts/shared';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+const fixtures = __dirname;
+
+test('should split vue chunks correctly', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginVue()],
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-vue'))).toBeTruthy();
+  expect(filesNames.find((file) => file.includes('lib-router'))).toBeTruthy();
+});
+
+test('should not split vue chunks when strategy is `all-in-one`', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginVue()],
+    rsbuildConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-vue'))).toBeFalsy();
+  expect(filesNames.find((file) => file.includes('lib-router'))).toBeFalsy();
+});

--- a/e2e/cases/vue/split-chunk/src/index.js
+++ b/e2e/cases/vue/split-chunk/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import { createRouter } from 'vue-router';
+
+console.log(createApp, createRouter);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",
-    "vue": "^3.3.4"
+    "vue": "^3.3.4",
+    "vue-router": "^4.2.5"
   },
   "devDependencies": {
     "@playwright/test": "1.33.0",

--- a/packages/compat/webpack/tests/core/initConfigs.test.ts
+++ b/packages/compat/webpack/tests/core/initConfigs.test.ts
@@ -1,5 +1,5 @@
 import { createStubRsbuild } from '../helper';
-import { RsbuildConfig, RsbuildPluginAPI } from '@/types';
+import { RsbuildConfig, RsbuildPluginAPI } from '@rsbuild/shared';
 
 describe('modifyRsbuildConfig', () => {
   it.skip('should not allow to modify Rsbuild config', async () => {
@@ -26,7 +26,7 @@ describe('modifyRsbuildConfig', () => {
       origin: { rsbuildConfig },
     } = await rsbuild.inspectConfig();
 
-    expect(rsbuildConfig.server.port).toBe(8080);
+    expect(rsbuildConfig.server?.port).toBe(8080);
   });
 
   it('should modify config by utils', async () => {

--- a/packages/compat/webpack/tests/plugins/default.test.ts
+++ b/packages/compat/webpack/tests/plugins/default.test.ts
@@ -1,5 +1,5 @@
 import { createStubRsbuild } from '../helper';
-import type { RsbuildPlugin } from '@/types';
+import type { RsbuildPlugin } from '@rsbuild/shared';
 
 describe('applyDefaultPlugins', () => {
   it('should apply default plugins correctly', async () => {

--- a/packages/document/docs/en/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-react.mdx
@@ -70,8 +70,8 @@ At the same time, the above default behavior can be turned off by manually setti
 
 When [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) set to `split-by-experience`, Rsbuild will automatically split `react` and `router` related packages into separate chunks by default:
 
-- `lib-react.js`: includes `react`, `react-dom`, `scheduler`.
-- `lib-router.js`: includes `react-router`, `react-router-dom`, `history`, `@remix-run/router`.
+- `lib-react.js`: includes react, react-dom, and react's sub-dependencies (scheduler).
+- `lib-router.js`: includes react-router, react-router-dom, and react-router's sub-dependencies (history, @remix-run/router).
 
 This option is used to control this behavior and determine whether the `react` and `router` related packages need to be split into separate chunks.
 

--- a/packages/document/docs/en/plugins/list/plugin-vue.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-vue.mdx
@@ -59,3 +59,41 @@ pluginVue({
   },
 });
 ```
+
+### splitChunks
+
+When [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) set to `split-by-experience`, Rsbuild will automatically split `vue` and `router` related packages into separate chunks by default:
+
+- `lib-vue.js`: includes vue, vue-loader, and vue's sub-dependencies (@vue/shared, @vue/reactivity, @vue/runtime-dom, @vue/runtime-core).
+- `lib-router.js`: includes vue-router.
+
+This option is used to control this behavior and determine whether the `vue` and `router` related packages need to be split into separate chunks.
+
+- **Type:**
+
+```ts
+type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
+```
+
+- **Default:**
+
+```ts
+const defaultOptions = {
+  vue: true,
+  router: true,
+};
+```
+
+- **Example:**
+
+```ts
+pluginVue({
+  splitChunks: {
+    vue: false,
+    router: false,
+  },
+});
+```

--- a/packages/document/docs/zh/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-react.mdx
@@ -70,8 +70,8 @@ const defaultArcoConfig = [
 
 在 [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `react` 和 `router` 相关的包拆分为单独的 chunk:
 
-- `lib-react.js`：包含 `react`，`react-dom`，`scheduler`。
-- `lib-router.js`：包含 `react-router`，`react-router-dom`，`history`，`@remix-run/router`。
+- `lib-react.js`：包含 react，react-dom，以及 react 的子依赖（scheduler）。
+- `lib-router.js`：包含 react-router，react-router-dom，以及 react-router 的子依赖（history，@remix-run/router）。
 
 该选项用于控制这一行为，决定是否需要将 `react` 和 `router` 相关的包拆分为单独的 chunk。
 

--- a/packages/document/docs/zh/plugins/list/plugin-vue.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-vue.mdx
@@ -59,3 +59,41 @@ pluginVue({
   },
 });
 ```
+
+### splitChunks
+
+在 [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `vue` 和 `router` 相关的包拆分为单独的 chunk:
+
+- `lib-vue.js`：包含 vue，vue-loader，以及 vue 的子依赖（@vue/shared，@vue/reactivity，@vue/runtime-dom，@vue/runtime-core）。
+- `lib-router.js`：包含 vue-router。
+
+该选项用于控制这一行为，决定是否需要将 `vue` 和 `router` 相关的包拆分为单独的 chunk。
+
+- **类型：**
+
+```ts
+type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
+```
+
+- **默认值：**
+
+```ts
+const defaultOptions = {
+  vue: true,
+  router: true,
+};
+```
+
+- **示例：**
+
+```ts
+pluginVue({
+  splitChunks: {
+    vue: false,
+    router: false,
+  },
+});
+```

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -2,9 +2,16 @@ import { deepmerge } from '@rsbuild/shared';
 import { VueLoaderPlugin } from 'vue-loader';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueLoaderOptions } from 'vue-loader';
+import { applySplitChunksRule } from './splitChunks';
+
+export type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
 
 export type PluginVueOptions = {
   vueLoaderOptions?: VueLoaderOptions;
+  splitChunks?: SplitVueChunkOptions;
 };
 
 export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
@@ -46,6 +53,8 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
 
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
       });
+
+      applySplitChunksRule(api, options.splitChunks);
     },
   };
 }

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -1,0 +1,56 @@
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+import {
+  isPlainObject,
+  createCacheGroups,
+  type SplitChunks,
+} from '@rsbuild/shared';
+import type { SplitVueChunkOptions } from '.';
+
+export const applySplitChunksRule = (
+  api: RsbuildPluginAPI,
+  options: SplitVueChunkOptions = {
+    vue: true,
+    router: true,
+  },
+) => {
+  api.modifyBundlerChain((chain) => {
+    const config = api.getNormalizedConfig();
+    if (config.performance.chunkSplit.strategy !== 'split-by-experience') {
+      return;
+    }
+
+    const currentConfig = chain.optimization.splitChunks.values();
+    if (!isPlainObject(currentConfig)) {
+      return;
+    }
+
+    const extraGroups: Record<string, (string | RegExp)[]> = {};
+
+    if (options.vue) {
+      extraGroups.vue = [
+        'vue',
+        'vue-loader',
+        '@vue/shared',
+        '@vue/reactivity',
+        '@vue/runtime-dom',
+        '@vue/runtime-core',
+      ];
+    }
+
+    if (options.router) {
+      extraGroups.router = ['vue-router'];
+    }
+
+    if (!Object.keys(extraGroups).length) {
+      return;
+    }
+
+    chain.optimization.splitChunks({
+      ...currentConfig,
+      cacheGroups: {
+        ...(currentConfig as SplitChunks).cacheGroups,
+        ...createCacheGroups(extraGroups),
+      },
+    });
+  });
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       vue:
         specifier: ^3.3.4
         version: 3.3.4
+      vue-router:
+        specifier: ^4.2.5
+        version: 4.2.5(vue@3.3.4)
     devDependencies:
       '@playwright/test':
         specifier: 1.33.0
@@ -6154,6 +6157,10 @@ packages:
       - velocityjs
       - walrus
       - whiskers
+    dev: false
+
+  /@vue/devtools-api@6.5.1:
+    resolution: {integrity: sha512-+KpckaAQyfbvshdDW5xQylLni1asvNSGme1JFs8I1+/H5pHEhqUKMEQD/qn3Nx5+/nycBq11qAEi8lk+LXI2dA==}
     dev: false
 
   /@vue/reactivity-transform@3.3.4:
@@ -14860,6 +14867,15 @@ packages:
       hash-sum: 2.0.0
       watchpack: 2.4.0
       webpack: 5.89.0
+    dev: false
+
+  /vue-router@4.2.5(vue@3.3.4):
+    resolution: {integrity: sha512-DIUpKcyg4+PTQKfFPX88UWhlagBEBEfJ5A8XDXRJLUnZOvcpMF8o/dnL90vpVkGaPbjvXazV/rC1qBKrZlFugw==}
+    peerDependencies:
+      vue: ^3.2.0
+    dependencies:
+      '@vue/devtools-api': 6.5.1
+      vue: 3.3.4
     dev: false
 
   /vue-style-loader@4.1.3:


### PR DESCRIPTION
## Summary

Apply default split chunk rules, same as the react plugin.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
