### PR TITLE
feat(plugin-vue2): apply default split chunk rules

### DIFF
--- a/e2e/cases/vue2/split-chunk/index.test.ts
+++ b/e2e/cases/vue2/split-chunk/index.test.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { build } from '@scripts/shared';
+import { pluginVue2 } from '@rsbuild/plugin-vue2';
+
+const fixtures = __dirname;
+
+test('should split vue chunks correctly', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginVue2()],
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-vue'))).toBeTruthy();
+});
+
+test('should not split vue chunks when strategy is `all-in-one`', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginVue2()],
+    rsbuildConfig: {
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('lib-vue'))).toBeFalsy();
+});

--- a/e2e/cases/vue2/split-chunk/src/index.js
+++ b/e2e/cases/vue2/split-chunk/src/index.js
@@ -1,0 +1,3 @@
+import Vue from 'vue';
+
+console.log(Vue);

--- a/packages/document/docs/en/plugins/list/plugin-vue2.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-vue2.mdx
@@ -59,3 +59,41 @@ pluginVue2({
 :::tip
 The Vue 2 plugin is using the `vue-loader` v15. Please be aware that there may be configuration differences between v15 and the latest version.
 :::
+
+### splitChunks
+
+When [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) set to `split-by-experience`, Rsbuild will automatically split `vue` and `router` related packages into separate chunks by default:
+
+- `lib-vue.js`: includes vue, vue-loader.
+- `lib-router.js`: includes vue-router.
+
+This option is used to control this behavior and determine whether the `vue` and `router` related packages need to be split into separate chunks.
+
+- **Type:**
+
+```ts
+type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
+```
+
+- **Default:**
+
+```ts
+const defaultOptions = {
+  vue: true,
+  router: true,
+};
+```
+
+- **Example:**
+
+```ts
+pluginVue({
+  splitChunks: {
+    vue: false,
+    router: false,
+  },
+});
+```

--- a/packages/document/docs/zh/plugins/list/plugin-vue2.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-vue2.mdx
@@ -59,3 +59,41 @@ pluginVue2({
 :::tip
 Vue 2 插件使用的是 `vue-loader` v15 版本，请注意区分 v15 版本与最新版本之间可能存在配置差异。
 :::
+
+### splitChunks
+
+在 [chunkSplit.strategy](/config/options/performance#chunksplitstrategy) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `vue` 和 `router` 相关的包拆分为单独的 chunk:
+
+- `lib-vue.js`：包含 vue，vue-loader。
+- `lib-router.js`：包含 vue-router。
+
+该选项用于控制这一行为，决定是否需要将 `vue` 和 `router` 相关的包拆分为单独的 chunk。
+
+- **类型：**
+
+```ts
+type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
+```
+
+- **默认值：**
+
+```ts
+const defaultOptions = {
+  vue: true,
+  router: true,
+};
+```
+
+- **示例：**
+
+```ts
+pluginVue({
+  splitChunks: {
+    vue: false,
+    router: false,
+  },
+});
+```

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -2,9 +2,16 @@ import { deepmerge } from '@rsbuild/shared';
 import { VueLoaderPlugin } from 'vue-loader';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueLoaderOptions } from 'vue-loader';
+import { applySplitChunksRule } from './splitChunks';
+
+export type SplitVueChunkOptions = {
+  vue?: boolean;
+  router?: boolean;
+};
 
 export type PluginVueOptions = {
   vueLoaderOptions?: VueLoaderOptions;
+  splitChunks?: SplitVueChunkOptions;
 };
 
 export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
@@ -34,6 +41,8 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
 
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
       });
+
+      applySplitChunksRule(api, options.splitChunks);
     },
   };
 }

--- a/packages/plugin-vue2/src/splitChunks.ts
+++ b/packages/plugin-vue2/src/splitChunks.ts
@@ -1,0 +1,49 @@
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+import {
+  isPlainObject,
+  createCacheGroups,
+  type SplitChunks,
+} from '@rsbuild/shared';
+import type { SplitVueChunkOptions } from '.';
+
+export const applySplitChunksRule = (
+  api: RsbuildPluginAPI,
+  options: SplitVueChunkOptions = {
+    vue: true,
+    router: true,
+  },
+) => {
+  api.modifyBundlerChain((chain) => {
+    const config = api.getNormalizedConfig();
+    if (config.performance.chunkSplit.strategy !== 'split-by-experience') {
+      return;
+    }
+
+    const currentConfig = chain.optimization.splitChunks.values();
+    if (!isPlainObject(currentConfig)) {
+      return;
+    }
+
+    const extraGroups: Record<string, (string | RegExp)[]> = {};
+
+    if (options.vue) {
+      extraGroups.vue = ['vue', 'vue-loader'];
+    }
+
+    if (options.router) {
+      extraGroups.router = ['vue-router'];
+    }
+
+    if (!Object.keys(extraGroups).length) {
+      return;
+    }
+
+    chain.optimization.splitChunks({
+      ...currentConfig,
+      cacheGroups: {
+        ...(currentConfig as SplitChunks).cacheGroups,
+        ...createCacheGroups(extraGroups),
+      },
+    });
+  });
+};


### PR DESCRIPTION
## Summary

Apply default split chunk rules, same as the react and vue3 plugin.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [x] I have added tests to cover my changes.
