### PR TITLE
breaking change(plugin-babel): move options to babelLoaderOptions

### DIFF
--- a/e2e/cases/babel/build.test.ts
+++ b/e2e/cases/babel/build.test.ts
@@ -8,8 +8,10 @@ rspackOnlyTest('babel', async ({ page }) => {
     cwd: __dirname,
     runServer: true,
     plugins: [
-      pluginBabel((_, { addPlugins }) => {
-        addPlugins([require('./plugins/myBabelPlugin')]);
+      pluginBabel({
+        babelLoaderOptions: (_, { addPlugins }) => {
+          addPlugins([require('./plugins/myBabelPlugin')]);
+        },
       }),
     ],
   });
@@ -25,9 +27,11 @@ rspackOnlyTest('babel exclude', async ({ page }) => {
     cwd: __dirname,
     runServer: true,
     plugins: [
-      pluginBabel((_, { addPlugins, addExcludes }) => {
-        addPlugins([require('./plugins/myBabelPlugin')]);
-        addExcludes(/aa/);
+      pluginBabel({
+        babelLoaderOptions: (_, { addPlugins, addExcludes }) => {
+          addPlugins([require('./plugins/myBabelPlugin')]);
+          addExcludes(/aa/);
+        },
       }),
     ],
   });

--- a/packages/compat/uni-builder/src/rspack/index.ts
+++ b/packages/compat/uni-builder/src/rspack/index.ts
@@ -34,7 +34,11 @@ export async function parseConfig(
 
   if (uniBuilderConfig.tools?.babel) {
     const { pluginBabel } = await import('@rsbuild/plugin-babel');
-    rsbuildPlugins.push(pluginBabel(uniBuilderConfig.tools?.babel));
+    rsbuildPlugins.push(
+      pluginBabel({
+        babelLoaderOptions: uniBuilderConfig.tools?.babel,
+      }),
+    );
   }
 
   rsbuildPlugins.push(

--- a/packages/compat/uni-builder/src/types.ts
+++ b/packages/compat/uni-builder/src/types.ts
@@ -97,7 +97,7 @@ export type UniBuilderExtraConfig = {
      * When `tools.babel`'s type is `Object`, the config will be shallow merged with default config by `Object.assign`.
      * Note that `Object.assign` is a shallow copy and will completely overwrite the built-in `presets` or `plugins` array, please use it with caution.
      */
-    babel?: PluginBabelOptions;
+    babel?: PluginBabelOptions['babelLoaderOptions'];
   };
   dev?: {
     /**

--- a/packages/compat/uni-builder/src/webpack/index.ts
+++ b/packages/compat/uni-builder/src/webpack/index.ts
@@ -30,7 +30,11 @@ export async function parseConfig(
     target,
   );
 
-  rsbuildPlugins.push(pluginBabel(uniBuilderConfig.tools?.babel));
+  rsbuildPlugins.push(
+    pluginBabel({
+      babelLoaderOptions: uniBuilderConfig.tools?.babel,
+    }),
+  );
   rsbuildPlugins.push(pluginReact());
 
   if (uniBuilderConfig.tools?.tsLoader) {

--- a/packages/compat/uni-builder/src/webpack/plugins/babel.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/babel.ts
@@ -104,7 +104,7 @@ export const pluginBabel = (options?: PluginBabelOptions): RsbuildPlugin => ({
 
           const babelConfig = mergeChainedOptions({
             defaults: baseBabelConfig,
-            options,
+            options: options?.babelLoaderOptions,
             utils: {
               ...getBabelUtils(baseBabelConfig),
               ...babelUtils,

--- a/packages/compat/uni-builder/src/webpack/plugins/tsLoader.ts
+++ b/packages/compat/uni-builder/src/webpack/plugins/tsLoader.ts
@@ -38,7 +38,7 @@ export type PluginTsLoaderOptions = ChainedConfigWithUtils<
 
 export const pluginTsLoader = (
   options?: PluginTsLoaderOptions,
-  babelOptions?: PluginBabelOptions,
+  babelOptions?: PluginBabelOptions['babelLoaderOptions'],
 ): RsbuildPlugin => {
   return {
     name: 'uni-builder:ts-loader',

--- a/packages/compat/uni-builder/tests/babel.test.ts
+++ b/packages/compat/uni-builder/tests/babel.test.ts
@@ -23,10 +23,12 @@ describe('plugin-babel', () => {
   it('should set include/exclude', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [
-        pluginBabel((options, { addIncludes, addExcludes }) => {
-          addIncludes(['src/**/*.ts']);
-          addExcludes(['src/**/*.js']);
-          return options;
+        pluginBabel({
+          babelLoaderOptions: (options, { addIncludes, addExcludes }) => {
+            addIncludes(['src/**/*.ts']);
+            addExcludes(['src/**/*.js']);
+            return options;
+          },
         }),
       ],
     });

--- a/packages/document/docs/en/plugins/list/plugin-babel.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-babel.mdx
@@ -30,53 +30,53 @@ export default {
 
 ## Options
 
-The configurations of [babel-loader](https://github.com/babel/babel-loader) can be modified through the following configuration.
+### babelLoaderOptions
+
+Options passed to `babel-loader`, please refer to the [babel-loader documentation](https://github.com/babel/babel-loader) for detailed usage.
 
 - **Type:** `Object | Function`
 - **Default:**
 
 ```ts
-{
-  "babelrc": false,
-  "compact": false,
-  "configFile": false,
-  "plugins": [],
-  "presets": [
+const defaultOptions = {
+  babelrc: false,
+  compact: false,
+  configFile: false,
+  plugins: [],
+  presets: [
     [
-      "@babel/preset-typescript",
+      '@babel/preset-typescript',
       {
-        "allExtensions": true,
-        "allowDeclareFields": true,
-        "allowNamespaces": true,
-        "isTSX": true,
-        "optimizeConstEnums": true,
+        allExtensions: true,
+        allowDeclareFields: true,
+        allowNamespaces: true,
+        isTSX: true,
+        optimizeConstEnums: true,
       },
     ],
   ],
-}
+};
 ```
 
-### Function Type
+#### Function Type
 
 When configuration is of type `Function`, the default Babel configuration will be passed as the first parameter. You can directly modify the configuration object or return an object as the final `babel-loader` configuration.
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config) => {
-      // Add a Babel plugin
-      // note: the plugin have been added to the default config to support antd load on demand
-      config.plugins.push([
-        'babel-plugin-import',
-        {
-          libraryName: 'xxx-components',
-          libraryDirectory: 'es',
-          style: true,
-        },
-      ]);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config) => {
+    // Add a Babel plugin
+    // note: the plugin have been added to the default config to support antd load on demand
+    config.plugins.push([
+      'babel-plugin-import',
+      {
+        libraryName: 'xxx-components',
+        libraryDirectory: 'es',
+        style: true,
+      },
+    ]);
+  },
+});
 ```
 
 The second parameter of the function provides some more convenient utility functions. Please continue reading the documentation below.
@@ -85,7 +85,7 @@ The second parameter of the function provides some more convenient utility funct
 The above example is just for reference, usually you don't need to manually configure `babel-plugin-import`, because the Rsbuild already provides a more general `source.transformImport` configuration.
 :::
 
-### Object Type
+#### Object Type
 
 When configuration's type is `Object`, the config will be shallow merged with default config by `Object.assign`.
 
@@ -94,102 +94,92 @@ Note that `Object.assign` is a shallow copy and will completely overwrite the bu
 :::
 
 ```js
-export default {
-  plugins: [
-    pluginBabel({
-      plugins: [
-        [
-          'babel-plugin-import',
-          {
-            libraryName: 'xxx-components',
-            libraryDirectory: 'es',
-            style: true,
-          },
-        ],
+pluginBabel({
+  babelLoaderOptions: {
+    plugins: [
+      [
+        'babel-plugin-import',
+        {
+          libraryName: 'xxx-components',
+          libraryDirectory: 'es',
+          style: true,
+        },
       ],
-    }),
-  ],
-};
+    ],
+  },
+});
 ```
 
-### Util Functions
+#### Util Functions
 
 When configuration is a Function, the tool functions available for the second parameter are as follows:
 
-#### addPlugins
+##### addPlugins
 
 - **Type:** `(plugins: BabelPlugin[]) => void`
 
 Add some Babel plugins. For example:
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { addPlugins }) => {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          {
-            libraryName: 'xxx-components',
-            libraryDirectory: 'es',
-            style: true,
-          },
-        ],
-      ]);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      [
+        'babel-plugin-import',
+        {
+          libraryName: 'xxx-components',
+          libraryDirectory: 'es',
+          style: true,
+        },
+      ],
+    ]);
+  },
+});
 ```
 
-#### addPresets
+##### addPresets
 
 - **Type:** `(presets: BabelPlugin[]) => void`
 
 Add Babel preset configuration. (No need to add presets in most cases)
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { addPresets }) => {
-      addPresets(['@babel/preset-env']);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { addPresets }) => {
+    addPresets(['@babel/preset-env']);
+  },
+});
 ```
 
-#### removePlugins
+##### removePlugins
 
 - **Type:** `(plugins: string | string[]) => void`
 
 To remove the Babel plugin, just pass in the name of the plugin to be removed, you can pass in a single string or an array of strings.
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { removePlugins }) => {
-      removePlugins('babel-plugin-import');
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { removePlugins }) => {
+    removePlugins('babel-plugin-import');
+  },
+});
 ```
 
-#### removePresets
+##### removePresets
 
 - **Type:** `(presets: string | string[]) => void`
 
 To remove the Babel preset configuration, pass in the name of the preset to be removed, you can pass in a single string or an array of strings.
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { removePresets }) => {
-      removePresets('@babel/preset-env');
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { removePresets }) => {
+    removePresets('@babel/preset-env');
+  },
+});
 ```
 
-### Debugging Babel Configuration
+#### Debugging Babel Configuration
 
 After modifying the `babel-loader` configuration, you can view the final generated configuration in [Rsbuild debug mode](https://rsbuild.dev/guide/debug/debug-mode).
 
@@ -219,9 +209,11 @@ If this problem occurs after you modify the Babel config, it is recommended to c
 
 ```ts
 // wrong example
-pluginBabel((config, { addPlugins }) => {
-  // The plugin has the wrong name or is not installed
-  addPlugins('babel-plugin-not-exists');
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    // The plugin has the wrong name or is not installed
+    addPlugins('babel-plugin-not-exists');
+  },
 });
 ```
 
@@ -229,31 +221,35 @@ pluginBabel((config, { addPlugins }) => {
 
 ```ts
 // wrong example
-pluginBabel((config, { addPlugins }) => {
-  addPlugins([
-    ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-    ],
-  ]);
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+      ],
+    ]);
+  },
 });
 ```
 
 ```ts
 // correct example
-pluginBabel((config, { addPlugins }) => {
-  addPlugins([
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd', libraryDirectory: 'es' },
-      'antd',
-    ],
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-      'antd-mobile',
-    ],
-  ]);
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd', libraryDirectory: 'es' },
+        'antd',
+      ],
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+        'antd-mobile',
+      ],
+    ]);
+  },
 });
 ```

--- a/packages/document/docs/zh/plugins/list/plugin-babel.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-babel.mdx
@@ -30,62 +30,61 @@ export default {
 
 ## 选项
 
-你可以通过以下配置修改 [babel-loader](https://github.com/babel/babel-loader) 的配置项。
+### babelLoaderOptions
+
+传递给 `babel-loader` 的选项，请查阅 [babel-loader 文档](https://github.com/babel/babel-loader) 来了解具体用法。
 
 - **类型：** `Object | Function`
-
 - **默认值：**
 
 ```ts
-{
-  "babelrc": false,
-  "compact": false,
-  "configFile": false,
-  "plugins": [],
-  "presets": [
+const defaultOptions = {
+  babelrc: false,
+  compact: false,
+  configFile: false,
+  plugins: [],
+  presets: [
     [
-      "@babel/preset-typescript",
+      '@babel/preset-typescript',
       {
-        "allExtensions": true,
-        "allowDeclareFields": true,
-        "allowNamespaces": true,
-        "isTSX": true,
-        "optimizeConstEnums": true,
+        allExtensions: true,
+        allowDeclareFields: true,
+        allowNamespaces: true,
+        isTSX: true,
+        optimizeConstEnums: true,
       },
     ],
   ],
-}
+};
 ```
 
-### Function 类型
+#### Function 类型
 
 当配置项为 Function 类型时，默认 Babel 配置会作为第一个参数传入，你可以直接修改配置对象，也可以返回一个对象作为最终的 `babel-loader` 配置。
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config) => {
-      // 添加一个插件，比如配置某个组件库的按需引入
-      config.plugins.push([
-        'babel-plugin-import',
-        {
-          libraryName: 'xxx-components',
-          libraryDirectory: 'es',
-          style: true,
-        },
-      ]);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config) => {
+    // 添加一个插件，比如配置某个组件库的按需引入
+    config.plugins.push([
+      'babel-plugin-import',
+      {
+        libraryName: 'xxx-components',
+        libraryDirectory: 'es',
+        style: true,
+      },
+    ]);
+  },
+});
 ```
 
 函数的第二个参数提供了一些方便的工具函数，请继续阅读下方文档。
 
 :::tip
-以上示例仅作为参考，通常来说，你不需要手动配置 `babel-plugin-import`，因为 Rspack SWC 编译已支持 transformImport 能力，Rsbuild 也提供了更通用的 `source.transformImport` 配置。
+以上示例仅作为参考，通常来说，你不需要手动配置 `babel-plugin-import`，因为 Rspack SWC 编译已支持 transformImport 能力，Rsbuild 也提供了更通用的 [source.transformImport](/config/source/transform-import) 配置。
 :::
 
-### Object 类型
+#### Object 类型
 
 当配置项的值为 `Object` 类型时，会与默认配置通过 `Object.assign` 浅合并。
 
@@ -94,102 +93,92 @@ export default {
 :::
 
 ```js
-export default {
-  plugins: [
-    pluginBabel({
-      plugins: [
-        [
-          'babel-plugin-import',
-          {
-            libraryName: 'xxx-components',
-            libraryDirectory: 'es',
-            style: true,
-          },
-        ],
+pluginBabel({
+  babelLoaderOptions: {
+    plugins: [
+      [
+        'babel-plugin-import',
+        {
+          libraryName: 'xxx-components',
+          libraryDirectory: 'es',
+          style: true,
+        },
       ],
-    }),
-  ],
-};
+    ],
+  },
+});
 ```
 
-### 工具函数
+#### 工具函数
 
 配置项为 Function 类型时，第二个参数可用的工具函数如下:
 
-#### addPlugins
+##### addPlugins
 
 - **类型：** `(plugins: BabelPlugin[]) => void`
 
 添加若干个 Babel 插件。
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { addPlugins }) => {
-      addPlugins([
-        [
-          'babel-plugin-import',
-          {
-            libraryName: 'xxx-components',
-            libraryDirectory: 'es',
-            style: true,
-          },
-        ],
-      ]);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      [
+        'babel-plugin-import',
+        {
+          libraryName: 'xxx-components',
+          libraryDirectory: 'es',
+          style: true,
+        },
+      ],
+    ]);
+  },
+});
 ```
 
-#### addPresets
+##### addPresets
 
 - **类型：** `(presets: BabelPlugin[]) => void`
 
 添加若干个 Babel 预设配置 (大多数情况下不需要增加预设)。
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { addPresets }) => {
-      addPresets(['@babel/preset-env']);
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { addPresets }) => {
+    addPresets(['@babel/preset-env']);
+  },
+});
 ```
 
-#### removePlugins
+##### removePlugins
 
 - **类型：** `(plugins: string | string[]) => void`
 
 移除 Babel 插件，传入需要移除的插件名称即可，你可以传入单个字符串，也可以传入一个字符串数组。
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { removePlugins }) => {
-      removePlugins('babel-plugin-import');
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { removePlugins }) => {
+    removePlugins('babel-plugin-import');
+  },
+});
 ```
 
-#### removePresets
+##### removePresets
 
 - **类型：** `(presets: string | string[]) => void`
 
 移除 Babel 预设配置，传入需要移除的预设名称即可，你可以传入单个字符串，也可以传入一个字符串数组。
 
 ```js
-export default {
-  plugins: [
-    pluginBabel((config, { removePresets }) => {
-      removePresets('@babel/preset-env');
-    }),
-  ],
-};
+pluginBabel({
+  babelLoaderOptions: (config, { removePresets }) => {
+    removePresets('@babel/preset-env');
+  },
+});
 ```
 
-### 调试 Babel 配置
+#### 调试 Babel 配置
 
 当你通过配置项修改 `babel-loader` 配置后，可以在 [Rsbuild 调试模式](https://rsbuild.dev/zh/guide/debug/debug-mode) 下查看最终生成的配置。
 
@@ -219,9 +208,11 @@ DEBUG=rsbuild pnpm build
 
 ```ts
 // 错误示例
-pluginBabel((config, { addPlugins }) => {
-  // 该插件名称错误，或者未安装
-  addPlugins('babel-plugin-not-exists');
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    // 该插件名称错误，或者未安装
+    addPlugins('babel-plugin-not-exists');
+  },
 });
 ```
 
@@ -229,31 +220,35 @@ pluginBabel((config, { addPlugins }) => {
 
 ```ts
 // 错误示例
-pluginBabel((config, { addPlugins }) => {
-  addPlugins([
-    ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-    ],
-  ]);
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      ['babel-plugin-import', { libraryName: 'antd', libraryDirectory: 'es' }],
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+      ],
+    ]);
+  },
 });
 ```
 
 ```ts
 // 正确示例
-pluginBabel((config, { addPlugins }) => {
-  addPlugins([
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd', libraryDirectory: 'es' },
-      'antd',
-    ],
-    [
-      'babel-plugin-import',
-      { libraryName: 'antd-mobile', libraryDirectory: 'es' },
-      'antd-mobile',
-    ],
-  ]);
+pluginBabel({
+  babelLoaderOptions: (config, { addPlugins }) => {
+    addPlugins([
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd', libraryDirectory: 'es' },
+        'antd',
+      ],
+      [
+        'babel-plugin-import',
+        { libraryName: 'antd-mobile', libraryDirectory: 'es' },
+        'antd-mobile',
+      ],
+    ]);
+  },
 });
 ```

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -59,7 +59,7 @@ export const pluginBabel = (
 
         const userBabelConfig = applyUserBabelConfig(
           cloneDeep(baseConfig),
-          options,
+          options.babelLoaderOptions,
           babelUtils,
         );
 

--- a/packages/plugin-babel/src/types.ts
+++ b/packages/plugin-babel/src/types.ts
@@ -70,7 +70,9 @@ export type BabelConfigUtils = {
   addExcludes: (excludes: string | RegExp | (string | RegExp)[]) => void;
 };
 
-export type PluginBabelOptions = ChainedConfigWithUtils<
-  BabelTransformOptions,
-  BabelConfigUtils
->;
+export type PluginBabelOptions = {
+  babelLoaderOptions?: ChainedConfigWithUtils<
+    BabelTransformOptions,
+    BabelConfigUtils
+  >;
+};

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -10,9 +10,11 @@ describe('plugins/babel', () => {
     });
 
     rsbuild.addPlugins([
-      pluginBabel((_config, { addExcludes, addIncludes }) => {
-        addIncludes(/\/node_modules\/query-string\//);
-        addExcludes('src/example');
+      pluginBabel({
+        babelLoaderOptions: (_config, { addExcludes, addIncludes }) => {
+          addIncludes(/\/node_modules\/query-string\//);
+          addExcludes('src/example');
+        },
       }),
     ]);
 
@@ -39,15 +41,17 @@ describe('plugins/babel', () => {
   it('should set babel-loader when config is add', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [
-        pluginBabel((config) => {
-          config.plugins?.push([
-            'babel-plugin-import',
-            {
-              libraryName: 'xxx-components',
-              libraryDirectory: 'es',
-              style: true,
-            },
-          ]);
+        pluginBabel({
+          babelLoaderOptions: (config) => {
+            config.plugins?.push([
+              'babel-plugin-import',
+              {
+                libraryName: 'xxx-components',
+                libraryDirectory: 'es',
+                style: true,
+              },
+            ]);
+          },
         }),
       ],
       rsbuildConfig: {},
@@ -61,9 +65,11 @@ describe('plugins/babel', () => {
   it('babel-loader addIncludes & addExcludes should works', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [
-        pluginBabel((_config, { addExcludes, addIncludes }) => {
-          addIncludes(/\/node_modules\/query-string\//);
-          addExcludes('src/example');
+        pluginBabel({
+          babelLoaderOptions: (_config, { addExcludes, addIncludes }) => {
+            addIncludes(/\/node_modules\/query-string\//);
+            addExcludes('src/example');
+          },
         }),
       ],
       rsbuildConfig: {},


### PR DESCRIPTION
## Summary

`@rsbuild/plugin-babel` will move all babel-loader options to `babelLoaderOptions`:

- before:

```ts
pluginBabel({
  plugins: [],
  presets: [],
});
```

- after:

```ts
pluginBabel([
  babelLoaderOptions: {
    plugins: [],
    presets: [],
  }
]);
```

This change allows us to add more options for `pluginBabel`, such as `include` and `exclude`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
