### PR TITLE
breaking change: writeToDisk defaults to false

### DIFF
--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -16,6 +16,9 @@ test('should restart dev server and reload config when config file changed', asy
   fse.writeFileSync(
     configFile,
     `export default {
+      dev: {
+        writeToDisk: true,
+      },
       output: {
         distPath: {
           root: 'dist',
@@ -34,6 +37,9 @@ test('should restart dev server and reload config when config file changed', asy
   fse.writeFileSync(
     configFile,
     `export default {
+      dev: {
+        writeToDisk: true,
+      },
       output: {
         distPath: {
           root: 'dist-2',

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -18,6 +18,9 @@ test('should restart dev server when .env file is changed', async () => {
   fse.writeFileSync(
     configFile,
     `export default {
+      dev: {
+        writeToDisk: true,
+      },
       output: {
         distPath: {
           root: 'dist',

--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -94,6 +94,9 @@ test('dev.port & output.distPath', async ({ page }) => {
     cwd: join(fixtures, 'basic'),
     plugins: [pluginReact()],
     rsbuildConfig: {
+      dev: {
+        writeToDisk: true,
+      },
       server: {
         port: 3000,
       },

--- a/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
+++ b/packages/compat/uni-builder/src/shared/parseCommonConfig.ts
@@ -238,7 +238,7 @@ export async function parseCommonConfig<B = 'rspack' | 'webpack'>(
       };
 
   dev.client = tools.devServer?.client;
-  dev.writeToDisk = tools.devServer?.devMiddleware?.writeToDisk;
+  dev.writeToDisk = tools.devServer?.devMiddleware?.writeToDisk ?? true;
 
   if (tools.devServer?.hot === false) {
     dev.hmr = false;

--- a/packages/compat/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
+++ b/packages/compat/uni-builder/tests/__snapshots__/parseConfig.test.ts.snap
@@ -5,6 +5,7 @@ exports[`parseCommonConfig > dev.xxx 1`] = `
   "dev": {
     "hmr": false,
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -40,6 +41,7 @@ exports[`parseCommonConfig > dev.xxx 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -64,6 +66,7 @@ exports[`parseCommonConfig > html.faviconByEntries 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "favicon": [Function],
@@ -88,6 +91,7 @@ exports[`parseCommonConfig > html.faviconByEntries 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "favicon": [
@@ -115,6 +119,7 @@ exports[`parseCommonConfig > html.faviconByEntries 3`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "inject": [Function],
@@ -139,6 +144,7 @@ exports[`parseCommonConfig > html.faviconByEntries 4`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "inject": [
@@ -166,6 +172,7 @@ exports[`parseCommonConfig > html.metaByEntries 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "meta": [Function],
@@ -190,6 +197,7 @@ exports[`parseCommonConfig > html.metaByEntries 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "meta": [
@@ -221,6 +229,7 @@ exports[`parseCommonConfig > html.templateByEntries 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -245,6 +254,7 @@ exports[`parseCommonConfig > html.templateByEntries 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -272,6 +282,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -296,6 +307,7 @@ exports[`parseCommonConfig > html.templateParametersByEntries 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -325,6 +337,7 @@ exports[`parseCommonConfig > html.titleByEntries 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -349,6 +362,7 @@ exports[`parseCommonConfig > html.titleByEntries 2`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -376,6 +390,7 @@ exports[`parseCommonConfig > output.cssModuleLocalIdentName 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -402,6 +417,7 @@ exports[`parseCommonConfig > output.disableCssModuleExtension 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -429,6 +445,7 @@ exports[`parseCommonConfig > output.enableInlineScripts 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",
@@ -453,6 +470,7 @@ exports[`parseCommonConfig > output.enableInlineStyles 1`] = `
 {
   "dev": {
     "progressBar": true,
+    "writeToDisk": true,
   },
   "html": {
     "outputStructure": "nested",

--- a/packages/document/docs/en/config/dev/write-to-disk.mdx
+++ b/packages/document/docs/en/config/dev/write-to-disk.mdx
@@ -1,25 +1,35 @@
 # writeToDisk
 
 - **Type:** `boolean | ((filename: string) => boolean)`
-- **Default:** `(file: string) => !file.includes('.hot-update.')`
+- **Default:** `false`
 
 Used to control whether the build artifacts of the development environment are written to the disk.
 
-By default, Rsbuild will write the build artifacts to the output directory (excluding hot update temporary files). In the development environment, you can choose to save the build artifacts in the memory of the dev server to reduce the overhead of file operations.
+Rsbuild by default saves the build artifacts in the memory of the dev server, thereby reducing the overhead caused by file operations.
 
-You only need to set the `dev.writeToDisk` configuration option to `false`:
+## Writing to Disk
+
+You can choose to write the build output to disk, which is usually used for inspecting the content of the build output or configuring proxy rules for static assets.
+
+Simply set the `dev.writeToDisk` option to `true`:
 
 ```ts
 export default {
   dev: {
-    writeToDisk: false,
+    writeToDisk: true,
   },
 };
 ```
 
-You can also set `dev.writeToDisk` as a function to match part of the files. When the function returns `false`, it will not write to the disk, and when it returns `true`, it will write the file to the disk.
+:::tip
+Setting `writeToDisk: true` is used for viewing the build artifacts in a development environment. It does not change the behavior of the dev server. When accessing files through a browser, the dev server will still read the file content from memory.
+:::
 
-For example:
+## Matching Specific Files
+
+You can also set `dev.writeToDisk` to a function to match only certain files. When the function returns `false`, the file will not be written; when it returns `true`, the file will be written to disk.
+
+For example, to write files to disk while excluding hot-update temporary files:
 
 ```ts
 export default {
@@ -28,7 +38,3 @@ export default {
   },
 };
 ```
-
-:::tip
-The `writeToDisk: true` option is used to view the build artifacts in the development environment. It does not change the behavior of webpack-dev-middleware. When accessing files through the browser, the dev server will still read the file content from memory.
-:::

--- a/packages/document/docs/en/guide/basic/output-files.md
+++ b/packages/document/docs/en/guide/basic/output-files.md
@@ -146,18 +146,18 @@ dist
 └── [name].html
 ```
 
-## Not Written to Disk
+## Writing Outputs to Disk
 
-By default, Rsbuild will write the generated files to disk, so developers can view the file content or configure proxy rules for static assets.
+By default, Rsbuild does not write the output files to disk in the development environment. Instead, the files are stored in the memory of the dev server to reduce the overhead of file operations.
 
-In development, you can choose to keep the generated files in the Dev Server's memory to reduce the overhead of file operations.
+You can write the output files to disk, which is typically used for inspecting the contents of the build artifacts or configuring proxy rules for static assets.
 
-Just set the `dev.writeToDisk` config to `false`:
+Set the [dev.writeToDisk](/config/dev/write-to-disk) configuration option to `true` as follows:
 
 ```ts
 export default {
   dev: {
-    writeToDisk: false,
+    writeToDisk: true,
   },
 };
 ```

--- a/packages/document/docs/zh/config/dev/write-to-disk.mdx
+++ b/packages/document/docs/zh/config/dev/write-to-disk.mdx
@@ -1,25 +1,35 @@
 # writeToDisk
 
 - **类型：** `boolean | ((filename: string) => boolean)`
-- **默认值：** `(file: string) => !file.includes('.hot-update.')`
+- **默认值：** `false`
 
 用于控制是否将开发环境的构建产物写入到磁盘上。
 
-Rsbuild 默认会将构建产物写入到产物目录（热更新临时文件除外）。在开发环境，你可以选择将构建产物保存在 dev server 的内存中，从而减少文件操作产生的开销。
+Rsbuild 默认会将构建产物构建产物保存在 dev server 的内存中，从而减少文件操作产生的开销。
 
-只需要将 `dev.writeToDisk` 配置项设置为 `false` 即可：
+## 写入磁盘
+
+你可以选择将构建产物写入到磁盘，这通常用于排查构建产物的内容，或是配置静态资源的代理规则。
+
+只需要将 `dev.writeToDisk` 配置项设置为 `true` 即可：
 
 ```ts
 export default {
   dev: {
-    writeToDisk: false,
+    writeToDisk: true,
   },
 };
 ```
 
+:::tip
+`writeToDisk: true` 用于在开发环境下查看构建产物，它不会改变 dev server 的行为，通过浏览器访问文件时，dev server 仍将从内存中读取文件内容。
+:::
+
+## 匹配部分文件
+
 你也可以将 `dev.writeToDisk` 设置为函数来匹配一部分文件，函数返回 `false` 时不会写入文件，返回值 `true` 时会将文件写入磁盘。
 
-例如：
+例如将文件写入磁盘，并排除热更新临时文件：
 
 ```ts
 export default {
@@ -28,7 +38,3 @@ export default {
   },
 };
 ```
-
-:::tip
-`writeToDisk: true` 用于在开发环境下查看构建产物，它不会改变 webpack-dev-middleware 的行为，通过浏览器访问文件时，dev server 仍将从内存中读取文件内容。
-:::

--- a/packages/document/docs/zh/guide/basic/output-files.md
+++ b/packages/document/docs/zh/guide/basic/output-files.md
@@ -146,18 +146,18 @@ dist
 └── [name].html
 ```
 
-## 产物不写入磁盘
+## 产物写入磁盘
 
-默认情况下，Rsbuild 会将构建产物写入磁盘，以方便开发者查看产物的内容，或是配置静态资源的代理规则。
+默认情况下，Rsbuild 在开发环境不会将构建产物写入磁盘，而是将文件保存在 dev server 的内存中，从而减少文件操作产生的开销。
 
-在开发环境，你可以选择将构建产物保存在 Dev Server 的内存中，从而减少文件操作产生的开销。
+你可以选择将构建产物写入磁盘，这通常用于排查构建产物的内容，或是配置静态资源的代理规则。
 
-将 `dev.writeToDisk` 配置项设置为 `false` 即可：
+将 [dev.writeToDisk](/config/dev/write-to-disk) 配置项设置为 `true` 即可：
 
 ```ts
 export default {
   dev: {
-    writeToDisk: false,
+    writeToDisk: true,
   },
 };
 ```

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -91,7 +91,7 @@ export const mergeDevOptions = ({
       // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
       protocol: '',
     },
-    writeToDisk: (file: string) => !file.includes('.hot-update.'),
+    writeToDisk: false,
   };
 
   const devConfig = rsbuildConfig.dev

--- a/packages/shared/tests/server.test.ts
+++ b/packages/shared/tests/server.test.ts
@@ -282,7 +282,7 @@ describe('test dev server', () => {
           "port": "8080",
           "protocol": "",
         },
-        "writeToDisk": [Function],
+        "writeToDisk": false,
       }
     `);
 
@@ -308,7 +308,7 @@ describe('test dev server', () => {
           "protocol": "",
         },
         "hmr": false,
-        "writeToDisk": [Function],
+        "writeToDisk": false,
       }
     `);
   });


### PR DESCRIPTION
## Summary

`dev.writeToDisk` defaults to `false`.

Motivation:

- Reduce fs overhead and improve dev server performance.
- Avoid trigger watcher of UnoCSS and other tools. See https://github.com/web-infra-dev/rsbuild/issues/654.
- Align the default behavior with webpack-dev-middleware and other community dev servers.

User can enable writeToDisk manually:

```js
export default {
  dev: {
    writeToDisk: true,
  }
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/813

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have updated the documentation.
- [ ] I have added tests to cover my changes.
