### PR TITLE
test(e2e): fix ERR_UNSAFE_PORT error in CI

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -79,8 +79,10 @@ export const createRsbuild = async (
 
 const portMap = new Map();
 
+// Available port ranges: 1024 ～ 65535
+// `10080` is not available in CI, so we start with `11000`.
 export function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 10000) + 10000,
+  defaultPort = Math.ceil(Math.random() * 50000) + 11000,
 ) {
   let port = defaultPort;
   while (true) {


### PR DESCRIPTION
## Summary

Port `10080` is not available in CI, so we start with `11000`

## Related Links

- https://github.com/web-infra-dev/rsbuild/actions/runs/7116541116/job/19392263962
- https://github.com/web-infra-dev/rsbuild/actions/runs/7116541116/job/19375201965

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I have updated the documentation.
- [ ] I have added tests to cover my changes.
