### PR TITLE
refactor(server): extract createHttpServer method from rsbuildServer

### DIFF
--- a/.changeset/nine-numbers-sort.md
+++ b/.changeset/nine-numbers-sort.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+chore(server): extract createHttpServer method from rsbuildServer

--- a/packages/core/src/server/httpServer.ts
+++ b/packages/core/src/server/httpServer.ts
@@ -1,0 +1,18 @@
+import type { ServerConfig } from '@rsbuild/shared';
+import type connect from '@rsbuild/shared/connect';
+
+export const createHttpServer = async (options: {
+  https?: ServerConfig['https'];
+  middlewares: connect.Server;
+}) => {
+  let app;
+  if (options.https) {
+    const { createServer } = await import('https');
+    app = createServer(options.https, options.middlewares);
+  } else {
+    const { createServer } = await import('http');
+    app = createServer(options.middlewares);
+  }
+
+  return app;
+};


### PR DESCRIPTION
## Summary

createHttpServer is not used in middleware mode, so createHttpServer should independent with rsbuildServer.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
