### PR TITLE
chore: rename dir param of loadEnv to cwd

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -41,7 +41,7 @@ export async function init({
 
   try {
     const root = process.cwd();
-    const { publicVars } = await loadEnv({ dir: root });
+    const { publicVars } = await loadEnv({ cwd: root });
     const config = await loadConfig(root, commonOpts.config);
     const { createRsbuild } = await import('../createRsbuild');
 

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -8,14 +8,14 @@ export const getEnvFiles = () => {
 };
 
 export async function loadEnv({
-  dir = process.cwd(),
+  cwd = process.cwd(),
   prefixes = ['PUBLIC_'],
-}: { dir?: string; prefixes?: string[] } = {}) {
+}: { cwd?: string; prefixes?: string[] } = {}) {
   const { parse } = await import('../compiled/dotenv');
   const { expand } = await import('../compiled/dotenv-expand');
 
   const envPaths = getEnvFiles()
-    .map((filename) => join(dir, filename))
+    .map((filename) => join(cwd, filename))
     .filter(isFileSync);
 
   const parsed: Record<string, string> = {};

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -55,7 +55,7 @@ Load the `.env` file and return all environment variables starting with the spec
 ```ts
 function loadEnv(params: {
   // Default is process.cwd()
-  dir?: string;
+  cwd?: string;
   // Default is ['PUBLIC_']
   prefixes?: string[];
 }): Promise<{

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -55,7 +55,7 @@ type CreateRsbuildOptions = {
 ```ts
 function loadEnv(params: {
   // 默认为 process.cwd()
-  dir?: string;
+  cwd?: string;
   // 默认为 ['PUBLIC_']
   prefixes?: string[];
 }): Promise<{


### PR DESCRIPTION
## Summary

Rename dir param of `loadEnv` to cwd to be consistent with `createRsbuild` method.

This can be a breaking change but I think no user is using this method/parameter yet.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
