### PR TITLE
fix: incorrect log name for service worker

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -81,6 +81,6 @@ export const TS_CONFIG_FILE = 'tsconfig.json';
 export const TARGET_ID_MAP: Record<RsbuildTarget, string> = {
   web: 'Client',
   node: 'Server',
-  'service-worker': 'Server Worker',
   'web-worker': 'Web Worker',
+  'service-worker': 'Service Worker',
 };


### PR DESCRIPTION
## Summary

Fix incorrect log name for service worker, should be `Service Worker` instead of `Server Worker`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
