### PR TITLE
docs: fix Overview component missing style

### DIFF
--- a/packages/document/src/components/Overview.tsx
+++ b/packages/document/src/components/Overview.tsx
@@ -1,3 +1,4 @@
+import { NoSSR } from 'rspress/runtime';
 import { useUrl } from '../utils';
 import styles from './Overview.module.scss';
 
@@ -31,5 +32,9 @@ export default function Overview() {
     </>
   ));
 
-  return <div className={styles.root}>{Nodes}</div>;
+  return (
+    <NoSSR>
+      <div className={styles.root}>{Nodes}</div>
+    </NoSSR>
+  );
 }


### PR DESCRIPTION
## Summary

Fix Overview component missing style after SSG:

<img width="1000" alt="Screenshot 2023-12-08 at 14 15 22" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/f8c58a4a-e9ce-4580-93ef-6c37e28ee4e6">

A better solution is extracting all styles to a single chunks, relies on https://github.com/web-infra-dev/rspack/issues/2936

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
