### PR TITLE
docs: improve typings for dev config options

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -4,7 +4,7 @@ import {
   DevConfig,
   ServerConfig,
   RequestHandler,
-  ExposeServerApis,
+  ServerAPIs,
   RsbuildDevServerOptions,
   CreateDevMiddlewareReturns,
   logger as defaultLogger,
@@ -56,7 +56,7 @@ export class RsbuildDevServer {
   private applySetupMiddlewares() {
     const setupMiddlewares = this.dev.setupMiddlewares || [];
 
-    const serverOptions: ExposeServerApis = {
+    const serverAPIs: ServerAPIs = {
       sockWrite: (type, data) => this.devMiddleware.sockWrite(type, data),
     };
 
@@ -69,7 +69,7 @@ export class RsbuildDevServer {
           unshift: (...handlers) => before.unshift(...handlers),
           push: (...handlers) => after.push(...handlers),
         },
-        serverOptions,
+        serverAPIs,
       );
     });
 

--- a/packages/document/docs/en/config/dev/asset-prefix.mdx
+++ b/packages/document/docs/en/config/dev/asset-prefix.mdx
@@ -47,7 +47,7 @@ The script URL will be:
 <script defer src="http://example.com/assets/static/js/main.js"></script>
 ```
 
-### Differences from Native Configuration
+### Compare with `publicPath`
 
 `dev.assetPrefix` corresponds to the following native configurations:
 

--- a/packages/document/docs/en/config/dev/client.mdx
+++ b/packages/document/docs/en/config/dev/client.mdx
@@ -3,16 +3,16 @@
 - **Type:**
 
 ```ts
-{
-    /** Specify a protocol to use */
-    protocol?: string;
-    /** The path which the middleware is serving the event stream on */
-    path?: string;
-    /** Specify a port number to listen for requests on */
-    port?: string;
-    /** Specify a host to use */
-    host?: string;
-}
+type Client = {
+  /** Specify a protocol to use */
+  protocol?: string;
+  /** The path which the middleware is serving the event stream on */
+  path?: string;
+  /** Specify a port number to listen for requests on */
+  port?: string;
+  /** Specify a host to use */
+  host?: string;
+};
 ```
 
 - **Default:**

--- a/packages/document/docs/en/config/dev/hmr.mdx
+++ b/packages/document/docs/en/config/dev/hmr.mdx
@@ -14,3 +14,5 @@ export default {
   },
 };
 ```
+
+See [Hot Module Replacement](/guide/advanced/hmr) for more information.

--- a/packages/document/docs/en/config/dev/setup-middlewares.mdx
+++ b/packages/document/docs/en/config/dev/setup-middlewares.mdx
@@ -2,19 +2,21 @@
 
 - **Type:**
 
-```js
-Array<
+```ts
+type ServerAPIs = {
+  sockWrite: (
+    type: string,
+    data?: string | boolean | Record<string, any>,
+  ) => void;
+};
+
+type SetupMiddlewares = Array<
   (
     middlewares: {
       unshift: (...handlers: RequestHandler[]) => void;
       push: (...handlers: RequestHandler[]) => void;
     },
-    server: {
-      sockWrite: (
-        type: string,
-        data?: string | boolean | Record<string, any>,
-      ) => void;
-    },
+    server: ServerAPIs,
   ) => void
 >;
 ```
@@ -45,7 +47,7 @@ export default {
 
 It is possible to use some server api to meet special scenario requirements:
 
-- sockWrite. Allow send some message to hmr client, and then the hmr client will take different actions depending on the message type. If you send a "content changed" message, the page will reload.
+- sockWrite. Allow send some message to HMR client, and then the HMR client will take different actions depending on the message type. If you send a "content changed" message, the page will reload.
 
 ```js
 export default {

--- a/packages/document/docs/en/config/output/asset-prefix.mdx
+++ b/packages/document/docs/en/config/output/asset-prefix.mdx
@@ -30,7 +30,7 @@ After building, you can see that the JS files are loaded from:
 ></script>
 ```
 
-### Differences from Native Configuration
+### Compare with `publicPath`
 
 `output.assetPrefix` corresponds to the following native configurations:
 

--- a/packages/document/docs/zh/config/dev/asset-prefix.mdx
+++ b/packages/document/docs/zh/config/dev/asset-prefix.mdx
@@ -47,7 +47,7 @@ export default {
 <script defer src="http://example.com/assets/static/js/main.js"></script>
 ```
 
-### 与原生配置的区别
+### 对比 `publicPath`
 
 `dev.assetPrefix` 对应以下原生配置：
 

--- a/packages/document/docs/zh/config/dev/client.mdx
+++ b/packages/document/docs/zh/config/dev/client.mdx
@@ -3,16 +3,16 @@
 - **类型：**
 
 ```ts
-{
-    /** 指定协议名称 */
-    protocol?: string;
-    /** 事件流路径 */
-    path?: string;
-    /** 指定监听请求的端口号 */
-    port?: string;
-    /** 指定要使用的 host */
-    host?: string;
-}
+type Client = {
+  /** 指定协议名称 */
+  protocol?: string;
+  /** 事件流路径 */
+  path?: string;
+  /** 指定监听请求的端口号 */
+  port?: string;
+  /** 指定要使用的 host */
+  host?: string;
+};
 ```
 
 - **默认值：**

--- a/packages/document/docs/zh/config/dev/hmr.mdx
+++ b/packages/document/docs/zh/config/dev/hmr.mdx
@@ -14,3 +14,5 @@ export default {
   },
 };
 ```
+
+查看 [模块热更新](/guide/advanced/hmr) 来了解更多内容。

--- a/packages/document/docs/zh/config/dev/setup-middlewares.mdx
+++ b/packages/document/docs/zh/config/dev/setup-middlewares.mdx
@@ -2,19 +2,21 @@
 
 - **类型：**
 
-```js
-Array<
+```ts
+type ServerAPIs = {
+  sockWrite: (
+    type: string,
+    data?: string | boolean | Record<string, any>,
+  ) => void;
+};
+
+type SetupMiddlewares = Array<
   (
     middlewares: {
       unshift: (...handlers: RequestHandler[]) => void;
       push: (...handlers: RequestHandler[]) => void;
     },
-    server: {
-      sockWrite: (
-        type: string,
-        data?: string | boolean | Record<string, any>,
-      ) => void;
-    },
+    server: ServerAPIs,
   ) => void
 >;
 ```
@@ -45,7 +47,7 @@ export default {
 
 一些特殊场景需求可能需要使用服务器 API：
 
-- sockWrite。允许向 hmr 客户端传递一些消息，hmr 客户端将根据接收到的消息类型进行不同的处理。如果你发送一个 "content-changed " 的消息，页面将会重新加载。
+- sockWrite。允许向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。如果你发送一个 "content-changed " 的消息，页面将会重新加载。
 
 ```js
 export default {

--- a/packages/document/docs/zh/config/output/asset-prefix.mdx
+++ b/packages/document/docs/zh/config/output/asset-prefix.mdx
@@ -30,7 +30,7 @@ export default {
 ></script>
 ```
 
-### 与原生配置的区别
+### 对比 `publicPath`
 
 `output.assetPrefix` 对应以下原生配置：
 

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -13,7 +13,7 @@ export type RequestHandler = (
   next: NextFunction,
 ) => void;
 
-export type ExposeServerApis = {
+export type ServerAPIs = {
   sockWrite: (
     type: string,
     data?: string | boolean | Record<string, any>,
@@ -62,7 +62,7 @@ export interface DevConfig {
         /** Use the `push` method if you want to run a middleware after all other middlewares */
         push: (...handlers: RequestHandler[]) => void;
       },
-      server: ExposeServerApis,
+      server: ServerAPIs,
     ) => void
   >;
   /**


### PR DESCRIPTION
## Summary

Improve typings for dev config options, rename `ExposeServerApis` type to `ServerAPIs`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
