### PR TITLE
refactor: use getMiddlewares instead of RsbuildDevServer

### DIFF
--- a/packages/core/src/server/compiler-dev-middleware/index.ts
+++ b/packages/core/src/server/compiler-dev-middleware/index.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse, Server } from 'http';
 import { EventEmitter } from 'events';
 import type {
-  RsbuildDevServerOptions,
+  RsbuildDevMiddlewareOptions,
   DevMiddlewareAPI,
   NextFunction,
   DevMiddleware as CustomDevMiddleware,
@@ -10,7 +10,7 @@ import SocketServer from './socketServer';
 
 type Options = {
   publicPaths: string[];
-  dev: RsbuildDevServerOptions['dev'];
+  dev: RsbuildDevMiddlewareOptions['dev'];
   devMiddleware?: CustomDevMiddleware;
 };
 
@@ -18,7 +18,9 @@ const noop = () => {
   // noop
 };
 
-function getHMRClientPath(client: RsbuildDevServerOptions['dev']['client']) {
+function getHMRClientPath(
+  client: RsbuildDevMiddlewareOptions['dev']['client'],
+) {
   const protocol = client?.protocol ? `&protocol=${client.protocol}` : '';
   const host = client?.host ? `&host=${client.host}` : '';
   const path = client?.path ? `&path=${client.path}` : '';
@@ -35,7 +37,7 @@ function getHMRClientPath(client: RsbuildDevServerOptions['dev']['client']) {
 export default class DevMiddleware extends EventEmitter {
   public middleware?: DevMiddlewareAPI;
 
-  private devOptions: RsbuildDevServerOptions['dev'];
+  private devOptions: RsbuildDevMiddlewareOptions['dev'];
 
   private devMiddleware?: CustomDevMiddleware;
 

--- a/packages/core/src/server/compiler-dev-middleware/socketServer.ts
+++ b/packages/core/src/server/compiler-dev-middleware/socketServer.ts
@@ -4,7 +4,7 @@ import ws from '../../../compiled/ws';
 import {
   logger,
   type Stats,
-  type RsbuildDevServerOptions,
+  type RsbuildDevMiddlewareOptions,
 } from '@rsbuild/shared';
 
 interface ExtWebSocket extends ws {
@@ -16,7 +16,7 @@ export default class SocketServer {
 
   private readonly sockets: ws[] = [];
 
-  private readonly options: RsbuildDevServerOptions['dev'];
+  private readonly options: RsbuildDevMiddlewareOptions['dev'];
 
   private app?: Server;
 
@@ -24,7 +24,7 @@ export default class SocketServer {
 
   private timer: NodeJS.Timeout | null = null;
 
-  constructor(options: RsbuildDevServerOptions['dev']) {
+  constructor(options: RsbuildDevMiddlewareOptions['dev']) {
     this.options = options;
   }
 

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -144,7 +144,7 @@ const applyDefaultMiddlewares = async ({
   middlewares.use(notFoundMiddleware);
 };
 
-export const initRsbuildDevMiddlewares = async (
+export const getMiddlewares = async (
   options: RsbuildDevMiddlewareOptions,
   app: Server,
   middlewares: connect.Server,

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,0 +1,180 @@
+import { Server } from 'http';
+import url from 'url';
+import {
+  RequestHandler,
+  ServerAPIs,
+  RsbuildDevMiddlewareOptions,
+} from '@rsbuild/shared';
+import DevMiddleware from './compiler-dev-middleware';
+import connect from '@rsbuild/shared/connect';
+import {
+  faviconFallbackMiddleware,
+  getHtmlFallbackMiddleware,
+  notFoundMiddleware,
+} from './middlewares';
+import { join, isAbsolute } from 'path';
+
+const applySetupMiddlewares = (
+  dev: RsbuildDevMiddlewareOptions['dev'],
+  devMiddleware: DevMiddleware,
+) => {
+  const setupMiddlewares = dev.setupMiddlewares || [];
+
+  const serverOptions: ServerAPIs = {
+    sockWrite: (type, data) => devMiddleware.sockWrite(type, data),
+  };
+
+  const before: RequestHandler[] = [];
+  const after: RequestHandler[] = [];
+
+  setupMiddlewares.forEach((handler) => {
+    handler(
+      {
+        unshift: (...handlers) => before.unshift(...handlers),
+        push: (...handlers) => after.push(...handlers),
+      },
+      serverOptions,
+    );
+  });
+
+  return { before, after };
+};
+
+const applyDefaultMiddlewares = async ({
+  app,
+  middlewares,
+  dev,
+  devMiddleware,
+  output,
+  pwd,
+}: {
+  output: RsbuildDevMiddlewareOptions['output'];
+  pwd: RsbuildDevMiddlewareOptions['pwd'];
+  app: Server;
+  middlewares: connect.Server;
+  dev: RsbuildDevMiddlewareOptions['dev'];
+  devMiddleware: DevMiddleware;
+}) => {
+  // compression should be the first middleware
+  if (dev.compress) {
+    const { default: compression } = await import(
+      '../../compiled/http-compression'
+    );
+    middlewares.use((req, res, next) => {
+      compression({
+        gzip: true,
+        brotli: false,
+      })(req, res, next);
+    });
+  }
+
+  middlewares.use((req, res, next) => {
+    // allow hmr request cross-domain, because the user may use global proxy
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    const path = req.url ? url.parse(req.url).pathname : '';
+    if (path?.includes('hot-update')) {
+      res.setHeader('Access-Control-Allow-Credentials', 'false');
+    }
+
+    // The headers configured by the user on devServer will not take effect on html requests. Add the following code to make the configured headers take effect on all requests.
+    const confHeaders = dev.headers;
+    if (confHeaders) {
+      for (const [key, value] of Object.entries(confHeaders)) {
+        res.setHeader(key, value);
+      }
+    }
+    next();
+  });
+
+  // dev proxy handler, each proxy has own handler
+  if (dev.proxy) {
+    const { createProxyMiddleware } = await import('./proxy');
+    const { middlewares: proxyMiddlewares } = createProxyMiddleware(
+      dev.proxy,
+      app,
+    );
+    proxyMiddlewares.forEach((middleware) => {
+      middlewares.use(middleware);
+    });
+  }
+
+  // do webpack build / plugin apply / socket server when pass compiler instance
+  devMiddleware.init(app);
+
+  devMiddleware.middleware && middlewares.use(devMiddleware.middleware);
+
+  if (dev.publicDir && dev.publicDir.name) {
+    const { default: sirv } = await import('../../compiled/sirv/sirv');
+    const { name } = dev.publicDir;
+    const publicDir = isAbsolute(name) ? name : join(pwd, name);
+
+    const assetMiddleware = sirv(publicDir, {
+      etag: true,
+      dev: true,
+    });
+
+    middlewares.use(assetMiddleware);
+  }
+
+  const { distPath } = output;
+
+  middlewares.use(
+    getHtmlFallbackMiddleware({
+      distPath: isAbsolute(distPath) ? distPath : join(pwd, distPath),
+      callback: devMiddleware.middleware,
+      htmlFallback: dev.htmlFallback,
+    }),
+  );
+
+  if (dev.historyApiFallback) {
+    const { default: connectHistoryApiFallback } = await import(
+      '../../compiled/connect-history-api-fallback'
+    );
+    const historyApiFallbackMiddleware = connectHistoryApiFallback(
+      dev.historyApiFallback === true ? {} : dev.historyApiFallback,
+    ) as RequestHandler;
+
+    middlewares.use(historyApiFallbackMiddleware);
+
+    // ensure fallback request can be handled by webpack-dev-middleware
+    devMiddleware.middleware && middlewares.use(devMiddleware.middleware);
+  }
+
+  middlewares.use(faviconFallbackMiddleware);
+  middlewares.use(notFoundMiddleware);
+};
+
+export const initRsbuildDevMiddlewares = async (
+  options: RsbuildDevMiddlewareOptions,
+  app: Server,
+  middlewares: connect.Server,
+) => {
+  // create dev middleware instance
+  const devMiddleware = new DevMiddleware({
+    dev: options.dev,
+    publicPaths: options.output.publicPaths,
+    devMiddleware: options.devMiddleware,
+  });
+
+  // Order: setupMiddlewares.unshift => internal middlewares => setupMiddlewares.push
+  const { before, after } = applySetupMiddlewares(options.dev, devMiddleware);
+
+  before.forEach((fn) => middlewares.use(fn));
+
+  await applyDefaultMiddlewares({
+    app,
+    middlewares,
+    dev: options.dev,
+    devMiddleware,
+    output: options.output,
+    pwd: options.pwd,
+  });
+
+  after.forEach((fn) => middlewares.use(fn));
+
+  return {
+    close: () => {
+      devMiddleware.close();
+    },
+  };
+};

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -104,7 +104,7 @@ const applyDefaultMiddlewares = async ({
   devMiddleware.middleware && middlewares.use(devMiddleware.middleware);
 
   if (dev.publicDir && dev.publicDir.name) {
-    const { default: sirv } = await import('../../compiled/sirv/sirv');
+    const { default: sirv } = await import('../../compiled/sirv');
     const { name } = dev.publicDir;
     const publicDir = isAbsolute(name) ? name : join(pwd, name);
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -93,8 +93,9 @@ export async function startDevServer<
       },
     },
     httpServer,
-    middlewares,
   );
+
+  devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
 
   debug('create dev server done');
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -82,21 +82,6 @@ export async function startDevServer<
     middlewares,
   });
 
-  const devMiddlewares = await getMiddlewares(
-    {
-      pwd: options.context.rootPath,
-      devMiddleware,
-      dev: devServerConfig,
-      output: {
-        distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
-        publicPaths,
-      },
-    },
-    httpServer,
-  );
-
-  devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
-
   debug('create dev server done');
 
   await options.context.hooks.onBeforeStartDevServerHook.call();
@@ -113,6 +98,21 @@ export async function startDevServer<
 
     printServerURLs(urls, routes, logger);
   }
+
+  const devMiddlewares = await getMiddlewares(
+    {
+      pwd: options.context.rootPath,
+      devMiddleware,
+      dev: devServerConfig,
+      output: {
+        distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
+        publicPaths,
+      },
+    },
+    httpServer,
+  );
+
+  devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
 
   debug('listen dev server');
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -18,7 +18,7 @@ import connect from '@rsbuild/shared/connect';
 import { registerCleaner } from './restart';
 import type { Context } from '../types';
 import { createHttpServer } from './httpServer';
-import { initRsbuildDevMiddlewares } from './devMiddlewares';
+import { getMiddlewares } from './devMiddlewares';
 
 export async function startDevServer<
   Options extends {
@@ -82,7 +82,7 @@ export async function startDevServer<
     middlewares,
   });
 
-  const devMiddlewares = await initRsbuildDevMiddlewares(
+  const devMiddlewares = await getMiddlewares(
     {
       pwd: options.context.rootPath,
       devMiddleware,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,9 +1,4 @@
-import { Server } from 'http';
-import url from 'url';
 import {
-  RequestHandler,
-  ServerAPIs,
-  RsbuildDevServerOptions,
   CreateDevMiddlewareReturns,
   logger as defaultLogger,
   StartDevServerOptions,
@@ -19,167 +14,11 @@ import {
   RspackMultiCompiler,
   RspackCompiler,
 } from '@rsbuild/shared';
-import DevMiddleware from './compiler-dev-middleware';
 import connect from '@rsbuild/shared/connect';
-import {
-  faviconFallbackMiddleware,
-  getHtmlFallbackMiddleware,
-  notFoundMiddleware,
-} from './middlewares';
-import { join, isAbsolute } from 'path';
 import { registerCleaner } from './restart';
 import type { Context } from '../types';
 import { createHttpServer } from './httpServer';
-
-export class RsbuildDevServer {
-  private readonly dev: RsbuildDevServerOptions['dev'];
-  private readonly devMiddleware: DevMiddleware;
-  private pwd: string;
-  private output: RsbuildDevServerOptions['output'];
-  public middlewares = connect();
-
-  constructor(options: RsbuildDevServerOptions) {
-    this.pwd = options.pwd;
-    this.dev = options.dev;
-    this.output = options.output;
-
-    // create dev middleware instance
-    this.devMiddleware = new DevMiddleware({
-      dev: this.dev,
-      publicPaths: options.output.publicPaths,
-      devMiddleware: options.devMiddleware,
-    });
-  }
-
-  private applySetupMiddlewares() {
-    const setupMiddlewares = this.dev.setupMiddlewares || [];
-
-    const serverAPIs: ServerAPIs = {
-      sockWrite: (type, data) => this.devMiddleware.sockWrite(type, data),
-    };
-
-    const before: RequestHandler[] = [];
-    const after: RequestHandler[] = [];
-
-    setupMiddlewares.forEach((handler) => {
-      handler(
-        {
-          unshift: (...handlers) => before.unshift(...handlers),
-          push: (...handlers) => after.push(...handlers),
-        },
-        serverAPIs,
-      );
-    });
-
-    return { before, after };
-  }
-
-  // Complete the preparation of services
-  public async onInit(app: Server) {
-    // Order: setupMiddlewares.unshift => internal middlewares => setupMiddlewares.push
-    const { before, after } = this.applySetupMiddlewares();
-
-    before.forEach((fn) => this.middlewares.use(fn));
-
-    await this.applyDefaultMiddlewares(app);
-
-    after.forEach((fn) => this.middlewares.use(fn));
-  }
-
-  private async applyDefaultMiddlewares(app: Server) {
-    const { dev, devMiddleware } = this;
-
-    // compression should be the first middleware
-    if (dev.compress) {
-      const { default: compression } = await import(
-        '../../compiled/http-compression'
-      );
-      this.middlewares.use((req, res, next) => {
-        compression({
-          gzip: true,
-          brotli: false,
-        })(req, res, next);
-      });
-    }
-
-    this.middlewares.use((req, res, next) => {
-      // allow hmr request cross-domain, because the user may use global proxy
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      const path = req.url ? url.parse(req.url).pathname : '';
-      if (path?.includes('hot-update')) {
-        res.setHeader('Access-Control-Allow-Credentials', 'false');
-      }
-
-      // The headers configured by the user on devServer will not take effect on html requests. Add the following code to make the configured headers take effect on all requests.
-      const confHeaders = dev.headers;
-      if (confHeaders) {
-        for (const [key, value] of Object.entries(confHeaders)) {
-          res.setHeader(key, value);
-        }
-      }
-      next();
-    });
-
-    // dev proxy handler, each proxy has own handler
-    if (dev.proxy) {
-      const { createProxyMiddleware } = await import('./proxy');
-      const { middlewares } = createProxyMiddleware(dev.proxy, app);
-      middlewares.forEach((middleware) => {
-        this.middlewares.use(middleware);
-      });
-    }
-
-    // do webpack build / plugin apply / socket server when pass compiler instance
-    devMiddleware.init(app);
-
-    devMiddleware.middleware && this.middlewares.use(devMiddleware.middleware);
-
-    if (dev.publicDir && dev.publicDir.name) {
-      const { default: sirv } = await import('../../compiled/sirv');
-      const { name } = dev.publicDir;
-      const publicDir = isAbsolute(name) ? name : join(this.pwd, name);
-
-      const assetMiddleware = sirv(publicDir, {
-        etag: true,
-        dev: true,
-      });
-
-      this.middlewares.use(assetMiddleware);
-    }
-
-    const { distPath } = this.output;
-
-    this.middlewares.use(
-      getHtmlFallbackMiddleware({
-        distPath: isAbsolute(distPath) ? distPath : join(this.pwd, distPath),
-        callback: devMiddleware.middleware,
-        htmlFallback: this.dev.htmlFallback,
-      }),
-    );
-
-    if (dev.historyApiFallback) {
-      const { default: connectHistoryApiFallback } = await import(
-        '../../compiled/connect-history-api-fallback'
-      );
-      const historyApiFallbackMiddleware = connectHistoryApiFallback(
-        dev.historyApiFallback === true ? {} : dev.historyApiFallback,
-      ) as RequestHandler;
-
-      this.middlewares.use(historyApiFallbackMiddleware);
-
-      // ensure fallback request can be handled by webpack-dev-middleware
-      devMiddleware.middleware &&
-        this.middlewares.use(devMiddleware.middleware);
-    }
-
-    this.middlewares.use(faviconFallbackMiddleware);
-    this.middlewares.use(notFoundMiddleware);
-  }
-
-  public close() {
-    this.devMiddleware.close();
-  }
-}
+import { initRsbuildDevMiddlewares } from './devMiddlewares';
 
 export async function startDevServer<
   Options extends {
@@ -236,24 +75,30 @@ export async function startDevServer<
     ? (compiler as RspackMultiCompiler).compilers.map(getPublicPathFromCompiler)
     : [getPublicPathFromCompiler(compiler as RspackCompiler)];
 
-  const server = new RsbuildDevServer({
-    pwd: options.context.rootPath,
-    devMiddleware,
-    dev: devServerConfig,
-    output: {
-      distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
-      publicPaths,
-    },
+  const middlewares = connect();
+
+  const httpServer = await createHttpServer({
+    https: devServerConfig.https,
+    middlewares,
   });
+
+  const devMiddlewares = await initRsbuildDevMiddlewares(
+    {
+      pwd: options.context.rootPath,
+      devMiddleware,
+      dev: devServerConfig,
+      output: {
+        distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
+        publicPaths,
+      },
+    },
+    httpServer,
+    middlewares,
+  );
 
   debug('create dev server done');
 
   await options.context.hooks.onBeforeStartDevServerHook.call();
-
-  const httpServer = await createHttpServer({
-    https: devServerConfig.https,
-    middlewares: server.middlewares,
-  });
 
   // print url after http server created and before dev compile (just a short time interval)
   if (printURLs) {
@@ -267,8 +112,6 @@ export async function startDevServer<
 
     printServerURLs(urls, routes, logger);
   }
-
-  await server.onInit(httpServer);
 
   debug('listen dev server');
 
@@ -291,7 +134,7 @@ export async function startDevServer<
         });
 
         const onClose = () => {
-          server.close();
+          devMiddlewares.close();
           httpServer.close();
         };
 

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -49,7 +49,7 @@ export type CreateDevMiddlewareReturns = {
   compiler: RspackCompiler | RspackMultiCompiler;
 };
 
-export type RsbuildDevServerOptions = {
+export type RsbuildDevMiddlewareOptions = {
   pwd: string;
   /** Rsbuild devConfig */
   dev: Omit<
@@ -74,7 +74,7 @@ export type CreateDevServerOptions = {
     customApp?: Server;
     logger?: Logger;
   };
-} & RsbuildDevServerOptions;
+} & RsbuildDevMiddlewareOptions;
 
 export type ServerApi = {
   close: () => Promise<void>;


### PR DESCRIPTION
## Summary

RsbuildDevServer is only used to init rsbuild devMiddlewares 
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
