### PR TITLE
docs(check-syntax): add enable source map tip

### DIFF
--- a/packages/document/docs/en/config/output/source-map.mdx
+++ b/packages/document/docs/en/config/output/source-map.mdx
@@ -37,7 +37,19 @@ By default, the source map generation rules for Rsbuild are as follows:
 
 The source map for JS files is controlled by `sourceMap.js` and can be configured by passing in all the source map formats supported by Rspack's [devtool](https://rspack.dev/config/devtool) option. Setting it to `false` will disable the source map.
 
-For example, if you need to generate a source map for JS files in the production environment, you can set it as follows:
+For example, if you need to generate high-quality source maps in all environments, you can set it as follows:
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: 'source-map',
+    },
+  },
+};
+```
+
+You can also set different source map formats based on the environment.
 
 ```js
 export default {

--- a/packages/document/docs/en/plugins/list/plugin-check-syntax.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-check-syntax.mdx
@@ -56,6 +56,21 @@ Currently, syntax checking is implemented based on AST parser. Each time it perf
 If the corresponding source location is not shown in the log, try setting **output.disableMinimize** to true and rebuild again.
 :::
 
+Note that displaying source code information depends on the source map file. You can configure the [output.sourceMap](/config/output/source-map) option to generate source map files during production environment builds.
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js:
+        process.env.NODE_ENV === 'production'
+          ? 'cheap-module-source-map'
+          : 'source-map',
+    },
+  },
+};
+```
+
 ### Solutions
 
 If a syntax error is detected, you can handle it in the following ways:

--- a/packages/document/docs/zh/config/output/source-map.mdx
+++ b/packages/document/docs/zh/config/output/source-map.mdx
@@ -37,7 +37,19 @@ source map 是保存源代码映射关系的信息文件，它记录了编译后
 
 JS 文件的 source map 通过 `sourceMap.js` 来控制，可以传入 Rspack [devtool](https://rspack.dev/zh/config/devtool) 选项支持的所有 source map 格式，设置为 `false` 为关闭。
 
-比如，如果需要在生产环境生成 JS 文件的 source map，可以设置为：
+比如，如果你需要在所有环境生成高质量的 source map，可以设置为：
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: 'source-map',
+    },
+  },
+};
+```
+
+你也可以根据环境来设置不同的 source map 格式：
 
 ```js
 export default {

--- a/packages/document/docs/zh/plugins/list/plugin-check-syntax.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-check-syntax.mdx
@@ -56,6 +56,21 @@ error   [Syntax Checker] Find some syntax errors after production build:
 如果日志中没有显示对应的源码位置，可以尝试将 **output.disableMinimize** 设置为 true 后再重新构建。
 :::
 
+注意，展示源代码信息依赖 source map 文件，你可以配置 [output.sourceMap](/config/output/source-map) 选项，以在生产环境构建时生成 source map 文件。
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js:
+        process.env.NODE_ENV === 'production'
+            'cheap-module-source-map'
+            'source-map',
+    },
+  },
+};
+```
+
 ### 解决方法
 
 当检测到语法错误后，你可以通过以下方式来处理：


### PR DESCRIPTION
## Summary

Add enable source map tip for plugin-check-syntax.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
