### PR TITLE
feat: support rsbuild.createDevServer

### DIFF
--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -57,6 +57,18 @@ export function webpackProvider({
         return createCompiler({ context, webpackConfigs });
       },
 
+      async createDevServer(options) {
+        const { createDevServer } = await import('@rsbuild/core/server');
+        const { createDevMiddleware } = await import('./core/createCompiler');
+        await initRsbuildConfig({ context, pluginStore });
+        return createDevServer(
+          { context, pluginStore, rsbuildOptions },
+          // @ts-expect-error compile type mismatch
+          createDevMiddleware,
+          options,
+        );
+      },
+
       async startDevServer(options) {
         const { startDevServer } = await import('@rsbuild/core/server');
         const { createDevMiddleware } = await import('./core/createCompiler');

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -46,6 +46,7 @@ export async function createRsbuild(
     initConfigs,
     inspectConfig,
     createCompiler,
+    createDevServer,
     startDevServer,
     applyDefaultPlugins,
   } = await provider({
@@ -80,6 +81,7 @@ export async function createRsbuild(
     createCompiler,
     initConfigs,
     inspectConfig,
+    createDevServer,
     startDevServer,
     context: publicContext,
   };

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -47,6 +47,17 @@ export function rspackProvider({
         });
       },
 
+      async createDevServer(options) {
+        const { createDevServer } = await import('../server/devServer');
+        const { createDevMiddleware } = await import('./core/createCompiler');
+        await initRsbuildConfig({ context, pluginStore });
+        return createDevServer(
+          { context, pluginStore, rsbuildOptions },
+          createDevMiddleware,
+          options,
+        );
+      },
+
       async startDevServer(options) {
         const { startDevServer } = await import('../server/devServer');
         const { createDevMiddleware } = await import('./core/createCompiler');

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -172,7 +172,7 @@ export const getMiddlewares = async (
   after.forEach((fn) => middlewares.push(fn));
 
   return {
-    close: () => {
+    close: async () => {
       devMiddleware.close();
     },
     middlewares,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -15,7 +15,7 @@ import {
   RspackCompiler,
   RsbuildDevMiddlewareOptions,
   Routes,
-  DevServerApi,
+  DevServerAPI,
 } from '@rsbuild/shared';
 import type { Server } from 'http';
 import connect from '@rsbuild/shared/connect';
@@ -40,7 +40,7 @@ export async function createDevServer<
   }: StartDevServerOptions & {
     defaultPort?: number;
   } = {},
-): Promise<DevServerApi> {
+): Promise<DevServerAPI> {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
   }

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -13,12 +13,98 @@ import {
   getPublicPathFromCompiler,
   RspackMultiCompiler,
   RspackCompiler,
+  RsbuildDevMiddlewareOptions,
+  Routes,
+  DevServerApi,
 } from '@rsbuild/shared';
+import type { Server } from 'http';
 import connect from '@rsbuild/shared/connect';
 import { registerCleaner } from './restart';
 import type { Context } from '../types';
 import { createHttpServer } from './httpServer';
 import { getMiddlewares } from './devMiddlewares';
+
+export async function createDevServer<
+  Options extends {
+    context: Context;
+  },
+>(
+  options: Options,
+  createDevMiddleware: (
+    options: Options,
+    compiler: StartDevServerOptions['compiler'],
+  ) => Promise<CreateDevMiddlewareReturns>,
+  {
+    compiler: customCompiler,
+    getPortSilently,
+  }: StartDevServerOptions & {
+    defaultPort?: number;
+  } = {},
+): Promise<DevServerApi> {
+  if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'development';
+  }
+
+  const rsbuildConfig = options.context.config;
+
+  const { devServerConfig, port, host, https } = await getDevOptions({
+    rsbuildConfig,
+    getPortSilently,
+  });
+
+  const defaultRoutes = formatRoutes(
+    options.context.entry,
+    rsbuildConfig.output?.distPath?.html,
+    rsbuildConfig.html?.outputStructure,
+  );
+
+  options.context.devServer = {
+    hostname: host,
+    port,
+    https,
+  };
+
+  const { devMiddleware, compiler } = await createDevMiddleware(
+    options,
+    customCompiler,
+  );
+
+  const publicPaths = (compiler as RspackMultiCompiler).compilers
+    ? (compiler as RspackMultiCompiler).compilers.map(getPublicPathFromCompiler)
+    : [getPublicPathFromCompiler(compiler as RspackCompiler)];
+
+  return {
+    resolvedConfig: { devServerConfig, port, host, https, defaultRoutes },
+    beforeStart: async () => {
+      await options.context.hooks.onBeforeStartDevServerHook.call();
+    },
+    afterStart: async ({ port, routes }: { port: number; routes: Routes }) => {
+      await options.context.hooks.onAfterStartDevServerHook.call({
+        port,
+        routes,
+      });
+    },
+    getMiddlewares: async ({
+      dev,
+      app,
+    }: {
+      app: Server;
+      dev: RsbuildDevMiddlewareOptions['dev'];
+    }) =>
+      await getMiddlewares(
+        {
+          pwd: options.context.rootPath,
+          devMiddleware,
+          dev,
+          output: {
+            distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
+            publicPaths,
+          },
+        },
+        app,
+      ),
+  };
+}
 
 export async function startDevServer<
   Options extends {
@@ -31,7 +117,7 @@ export async function startDevServer<
     compiler: StartDevServerOptions['compiler'],
   ) => Promise<CreateDevMiddlewareReturns>,
   {
-    compiler: customCompiler,
+    compiler,
     printURLs = true,
     logger: customLogger,
     getPortSilently,
@@ -39,41 +125,20 @@ export async function startDevServer<
     defaultPort?: number;
   } = {},
 ) {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
-  }
+  debug('create dev server');
 
-  const rsbuildConfig = options.context.config;
-  const logger = customLogger ?? defaultLogger;
-  const { devServerConfig, port, host, https } = await getDevOptions({
-    rsbuildConfig,
+  const rsbuildServer = await createDevServer(options, createDevMiddleware, {
+    compiler,
+    printURLs,
+    logger: customLogger,
     getPortSilently,
   });
 
-  options.context.devServer = {
-    hostname: host,
-    port,
-    https,
-  };
+  const {
+    resolvedConfig: { devServerConfig, port, host, https, defaultRoutes },
+  } = rsbuildServer;
 
-  const protocol = https ? 'https' : 'http';
-  let urls = getAddressUrls(protocol, port, host);
-  const routes = formatRoutes(
-    options.context.entry,
-    rsbuildConfig.output?.distPath?.html,
-    rsbuildConfig.html?.outputStructure,
-  );
-
-  debug('create dev server');
-
-  const { devMiddleware, compiler } = await createDevMiddleware(
-    options,
-    customCompiler,
-  );
-
-  const publicPaths = (compiler as RspackMultiCompiler).compilers
-    ? (compiler as RspackMultiCompiler).compilers.map(getPublicPathFromCompiler)
-    : [getPublicPathFromCompiler(compiler as RspackCompiler)];
+  const logger = customLogger ?? defaultLogger;
 
   const middlewares = connect();
 
@@ -84,7 +149,10 @@ export async function startDevServer<
 
   debug('create dev server done');
 
-  await options.context.hooks.onBeforeStartDevServerHook.call();
+  await rsbuildServer.beforeStart();
+
+  const protocol = https ? 'https' : 'http';
+  let urls = getAddressUrls(protocol, port, host);
 
   // print url after http server created and before dev compile (just a short time interval)
   if (printURLs) {
@@ -96,21 +164,13 @@ export async function startDevServer<
       }
     }
 
-    printServerURLs(urls, routes, logger);
+    printServerURLs(urls, defaultRoutes, logger);
   }
 
-  const devMiddlewares = await getMiddlewares(
-    {
-      pwd: options.context.rootPath,
-      devMiddleware,
-      dev: devServerConfig,
-      output: {
-        distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
-        publicPaths,
-      },
-    },
-    httpServer,
-  );
+  const devMiddlewares = await rsbuildServer.getMiddlewares({
+    dev: devServerConfig,
+    app: httpServer,
+  });
 
   devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
 
@@ -129,13 +189,13 @@ export async function startDevServer<
 
         debug('listen dev server done');
 
-        await options.context.hooks.onAfterStartDevServerHook.call({
+        await rsbuildServer.afterStart({
           port,
-          routes,
+          routes: defaultRoutes,
         });
 
-        const onClose = () => {
-          devMiddlewares.close();
+        const onClose = async () => {
+          await devMiddlewares.close();
           httpServer.close();
         };
 
@@ -146,7 +206,7 @@ export async function startDevServer<
           urls: urls.map((item) => item.url),
           server: {
             close: async () => {
-              onClose();
+              await onClose();
             },
           },
         });

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,2 +1,2 @@
-export { startDevServer } from './devServer';
+export { startDevServer, createDevServer } from './devServer';
 export { startProdServer } from './prodServer';

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@ import type { PluginStore, Plugins, RsbuildPluginAPI } from './plugin';
 import type { Context } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
-import type { StartServerResult, DevServerApi } from './server';
+import type { StartServerResult, DevServerAPI } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
 import type { NormalizedConfig } from './config';
@@ -69,9 +69,10 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
     options?: CreateCompilerOptions,
   ) => Promise<Compiler | MultiCompiler>;
 
+  /** It is designed for high-level frameworks that require a custom server */
   createDevServer: (
     options?: Omit<StartDevServerOptions, 'printURLs'>,
-  ) => Promise<DevServerApi>;
+  ) => Promise<DevServerAPI>;
 
   startDevServer: (
     options?: StartDevServerOptions,

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@ import type { PluginStore, Plugins, RsbuildPluginAPI } from './plugin';
 import type { Context } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
-import type { StartServerResult } from './server';
+import type { StartServerResult, DevServerApi } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
 import type { NormalizedConfig } from './config';
@@ -68,6 +68,8 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   createCompiler: (
     options?: CreateCompilerOptions,
   ) => Promise<Compiler | MultiCompiler>;
+
+  createDevServer: (options?: StartDevServerOptions) => Promise<DevServerApi>;
 
   startDevServer: (
     options?: StartDevServerOptions,

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -69,7 +69,9 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
     options?: CreateCompilerOptions,
   ) => Promise<Compiler | MultiCompiler>;
 
-  createDevServer: (options?: StartDevServerOptions) => Promise<DevServerApi>;
+  createDevServer: (
+    options?: Omit<StartDevServerOptions, 'printURLs'>,
+  ) => Promise<DevServerApi>;
 
   startDevServer: (
     options?: StartDevServerOptions,

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -25,6 +25,7 @@ export type RsbuildInstance<P extends RsbuildProvider = RsbuildProvider> = {
   initConfigs: ProviderInstance['initConfigs'];
   inspectConfig: ProviderInstance['inspectConfig'];
   createCompiler: ProviderInstance['createCompiler'];
+  createDevServer: ProviderInstance['createDevServer'];
   startDevServer: ProviderInstance['startDevServer'];
 
   getHTMLPaths: Awaited<ReturnType<P>>['pluginAPI']['getHTMLPaths'];

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,7 +1,8 @@
 import type { IncomingMessage, ServerResponse, Server } from 'http';
-import { DevConfig, NextFunction } from './config/dev';
+import { DevConfig, NextFunction, RequestHandler } from './config/dev';
 import { ServerConfig } from './config/server';
 import type { Logger } from '../logger';
+import { Routes } from './hooks';
 import type { RspackCompiler, RspackMultiCompiler } from './rspack';
 
 export type Middleware = (
@@ -49,19 +50,20 @@ export type CreateDevMiddlewareReturns = {
   compiler: RspackCompiler | RspackMultiCompiler;
 };
 
+export type DevMiddlewaresConfig = Omit<
+  DevConfig & ServerConfig,
+  | 'beforeStartUrl'
+  | 'progressBar'
+  | 'startUrl'
+  | 'https'
+  | 'host'
+  | 'port'
+  | 'strictPort'
+>;
+
 export type RsbuildDevMiddlewareOptions = {
   pwd: string;
-  /** Rsbuild devConfig */
-  dev: Omit<
-    DevConfig & ServerConfig,
-    | 'beforeStartUrl'
-    | 'progressBar'
-    | 'startUrl'
-    | 'https'
-    | 'host'
-    | 'port'
-    | 'strictPort'
-  >;
+  dev: DevMiddlewaresConfig;
   devMiddleware?: DevMiddleware;
   output: {
     distPath: string;
@@ -84,4 +86,30 @@ export type StartServerResult = {
   urls: string[];
   port: number;
   server: ServerApi;
+};
+
+export type DevServerApi = {
+  resolvedConfig: {
+    devServerConfig: DevConfig & ServerConfig;
+    port: number;
+    host: string;
+    https: boolean;
+    defaultRoutes: Routes;
+  };
+  // devMiddlewareEvents: EventEmitter;
+  beforeStart: () => Promise<void>;
+  afterStart: ({
+    port,
+    routes,
+  }: {
+    port: number;
+    routes: Routes;
+  }) => Promise<void>;
+  getMiddlewares: (options: {
+    dev: RsbuildDevMiddlewareOptions['dev'];
+    app: Server;
+  }) => Promise<{
+    middlewares: RequestHandler[];
+    close: () => Promise<void>;
+  }>;
 };

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -88,7 +88,7 @@ export type StartServerResult = {
   server: ServerApi;
 };
 
-export type DevServerApi = {
+export type DevServerAPI = {
   resolvedConfig: {
     devServerConfig: DevConfig & ServerConfig;
     port: number;


### PR DESCRIPTION
## Summary

rsbuild.createDevServer provides rsbuild server api and default middleware,  it is designed for high-level frameworks that require a custom server, such as modern.js.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
