### PR TITLE
fix(plugin-umd): add globalObject to support Node.js env

### DIFF
--- a/e2e/cases/umd/index.test.ts
+++ b/e2e/cases/umd/index.test.ts
@@ -6,10 +6,15 @@ test('should generate UMD bundle correctly', async ({ page }) => {
     cwd: __dirname,
     runServer: true,
   });
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
 
+  // Browser env
+  await page.goto(getHrefByEntryName('index', rsbuild.port));
   const test = page.locator('#test');
   await expect(test).toHaveText('2');
+
+  // Node.js env
+  const { double } = require('./dist/index.js');
+  expect(double(1)).toEqual(2);
 
   await rsbuild.close();
 });

--- a/packages/plugin-umd/src/index.ts
+++ b/packages/plugin-umd/src/index.ts
@@ -35,8 +35,12 @@ export const pluginUmd = (options: PluginUmdOptions): RsbuildPlugin => ({
       chain.output.library({
         name: options.name,
         type: 'umd',
+        // name the AMD module of the UMD build
         umdNamedDefine: true,
       });
+
+      // To make UMD build available on both browsers and Node.js
+      chain.output.globalObject('this');
 
       // disable split chunks to output a single chunk
       chain.optimization.splitChunks(false);


### PR DESCRIPTION
## Summary

Add globalObject config to support Node.js env.

## Related Links

https://webpack.js.org/configuration/output/#outputglobalobject

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
