### PR TITLE
Release v0.2.0

### DIFF
--- a/.changeset/lemon-mirrors-notice.md
+++ b/.changeset/lemon-mirrors-notice.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-chore: bump rspack to 0.4.2

--- a/.changeset/light-turtles-hammer.md
+++ b/.changeset/light-turtles-hammer.md
@@ -1,6 +1,0 @@
----
-'@rsbuild/webpack': patch
-'@rsbuild/core': patch
----
-
-fix(server-plugin): not relay on modifyRsbuildConfig

--- a/.changeset/nine-numbers-sort.md
+++ b/.changeset/nine-numbers-sort.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-chore(server): extract createHttpServer method from rsbuildServer

--- a/.changeset/seven-moles-jam.md
+++ b/.changeset/seven-moles-jam.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/uni-builder': patch
----
-
-feat(uni-builder): add postcss legacy plugins

--- a/.changeset/soft-penguins-confess.md
+++ b/.changeset/soft-penguins-confess.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/uni-builder': patch
----
-
-feat(uni-builder): compat builder default browserslist

--- a/.changeset/sweet-cows-sneeze.md
+++ b/.changeset/sweet-cows-sneeze.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/uni-builder': patch
----
-
-feat(uni-builder): apply builder default config

--- a/.changeset/warm-bears-exercise.md
+++ b/.changeset/warm-bears-exercise.md
@@ -1,6 +1,0 @@
----
-'@rsbuild/shared': minor
-'@rsbuild/core': minor
----
-
-breaking change: remove deprecated source.entries config

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @rsbuild/babel-preset
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0
+  - @rsbuild/plugin-babel@0.2.0

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-esbuild/CHANGELOG.md
+++ b/packages/compat/plugin-esbuild/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-esbuild
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/compat/plugin-esbuild/package.json
+++ b/packages/compat/plugin-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-esbuild",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Esbuild plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/CHANGELOG.md
+++ b/packages/compat/plugin-swc/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @rsbuild/plugin-swc
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0
+  - @rsbuild/plugin-react@0.2.0

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/compat/uni-builder/CHANGELOG.md
+++ b/packages/compat/uni-builder/CHANGELOG.md
@@ -1,0 +1,28 @@
+# @rsbuild/uni-builder
+
+## 0.2.0
+
+### Patch Changes
+
+- 92766c13: feat(uni-builder): add postcss legacy plugins
+- d717e32c: feat(uni-builder): compat builder default browserslist
+- e415e085: feat(uni-builder): apply builder default config
+- Updated dependencies [c11aa843]
+- Updated dependencies [42622b45]
+- Updated dependencies [4aa56abd]
+- Updated dependencies [04deba66]
+  - @rsbuild/core@0.2.0
+  - @rsbuild/webpack@0.2.0
+  - @rsbuild/shared@0.2.0
+  - @rsbuild/plugin-assets-retry@0.2.0
+  - @rsbuild/plugin-babel@0.2.0
+  - @rsbuild/plugin-check-syntax@0.2.0
+  - @rsbuild/plugin-css-minimizer@0.2.0
+  - @rsbuild/plugin-pug@0.2.0
+  - @rsbuild/plugin-react@0.2.0
+  - @rsbuild/plugin-rem@0.2.0
+  - @rsbuild/plugin-source-build@0.2.0
+  - @rsbuild/plugin-styled-components@0.2.0
+  - @rsbuild/plugin-svgr@0.2.0
+  - @rsbuild/plugin-type-check@0.2.0
+  - @rsbuild/babel-preset@0.2.0

--- a/packages/compat/uni-builder/package.json
+++ b/packages/compat/uni-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/uni-builder",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Unified builder for Modern.js",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/CHANGELOG.md
+++ b/packages/compat/webpack/CHANGELOG.md
@@ -1,0 +1,13 @@
+# @rsbuild/webpack
+
+## 0.2.0
+
+### Patch Changes
+
+- 42622b45: fix(server-plugin): not relay on modifyRsbuildConfig
+- Updated dependencies [c11aa843]
+- Updated dependencies [42622b45]
+- Updated dependencies [4aa56abd]
+- Updated dependencies [04deba66]
+  - @rsbuild/core@0.2.0
+  - @rsbuild/shared@0.2.0

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,15 @@
+# @rsbuild/core
+
+## 0.2.0
+
+### Minor Changes
+
+- 04deba66: breaking change: remove deprecated source.entries config
+
+### Patch Changes
+
+- c11aa843: chore: bump rspack to 0.4.2
+- 42622b45: fix(server-plugin): not relay on modifyRsbuildConfig
+- 4aa56abd: chore(server): extract createHttpServer method from rsbuildServer
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Unleash the power of Rspack with the out-of-the-box build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/CHANGELOG.md
+++ b/packages/create-rsbuild/CHANGELOG.md
@@ -1,0 +1,3 @@
+# create-rsbuild
+
+## 0.2.0

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/document/CHANGELOG.md
+++ b/packages/document/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @rsbuild/document
+
+## 0.2.0

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/document",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Shared documentation of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/monorepo-utils/CHANGELOG.md
+++ b/packages/monorepo-utils/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/monorepo-utils
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/monorepo-utils",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "The monorepo utils of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/CHANGELOG.md
+++ b/packages/plugin-assets-retry/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-assets-retry
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-babel/CHANGELOG.md
+++ b/packages/plugin-babel/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-babel
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-check-syntax/CHANGELOG.md
+++ b/packages/plugin-check-syntax/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-check-syntax
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-css-minimizer/CHANGELOG.md
+++ b/packages/plugin-css-minimizer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-css-minimizer
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-image-compress/CHANGELOG.md
+++ b/packages/plugin-image-compress/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-image-compress
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-node-polyfill/CHANGELOG.md
+++ b/packages/plugin-node-polyfill/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-node-polyfill
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-pug/CHANGELOG.md
+++ b/packages/plugin-pug/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-pug
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-react/CHANGELOG.md
+++ b/packages/plugin-react/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-react
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-rem/CHANGELOG.md
+++ b/packages/plugin-rem/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-rem
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-solid/CHANGELOG.md
+++ b/packages/plugin-solid/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-solid
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-source-build/CHANGELOG.md
+++ b/packages/plugin-source-build/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @rsbuild/plugin-source-build
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0
+  - @rsbuild/monorepo-utils@0.2.0

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-styled-components/CHANGELOG.md
+++ b/packages/plugin-styled-components/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-styled-components
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-stylus/CHANGELOG.md
+++ b/packages/plugin-stylus/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-stylus
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-svelte/CHANGELOG.md
+++ b/packages/plugin-svelte/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-svelte
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/CHANGELOG.md
+++ b/packages/plugin-svgr/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-svgr
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-type-check/CHANGELOG.md
+++ b/packages/plugin-type-check/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-type-check
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-umd/CHANGELOG.md
+++ b/packages/plugin-umd/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-umd
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue-jsx/CHANGELOG.md
+++ b/packages/plugin-vue-jsx/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @rsbuild/plugin-vue-jsx
+
+## 0.2.0

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue/CHANGELOG.md
+++ b/packages/plugin-vue/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-vue
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2-jsx/CHANGELOG.md
+++ b/packages/plugin-vue2-jsx/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-vue2-jsx
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2/CHANGELOG.md
+++ b/packages/plugin-vue2/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @rsbuild/plugin-vue2
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [04deba66]
+  - @rsbuild/shared@0.2.0

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @rsbuild/shared
+
+## 0.2.0
+
+### Minor Changes
+
+- 04deba66: breaking change: remove deprecated source.entries config

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/test-helper/CHANGELOG.md
+++ b/packages/test-helper/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @rsbuild/test-helper
+
+## 0.2.0
+
+### Patch Changes
+
+- Updated dependencies [c11aa843]
+- Updated dependencies [42622b45]
+- Updated dependencies [4aa56abd]
+- Updated dependencies [04deba66]
+  - @rsbuild/core@0.2.0
+  - @rsbuild/shared@0.2.0

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/test-helper",
-  "version": "0.1.9",
+  "version": "0.2.0",
   "description": "The vitest helpers of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {


### PR DESCRIPTION
## What's Changed
### New Features 🎉
- feat(uni-builder): add postcss legacy plugins
- feat(uni-builder): compat builder default browserslist
- feat(uni-builder): apply builder default config
### Bug Fixes 🐞
- fix(server-plugin): not relay on modifyRsbuildConfig
### Other Changes
- chore: bump rspack to 0.4.2
- chore(server): extract createHttpServer method from rsbuildServer
- breaking change: remove deprecated source.entries config