### PR TITLE
feat: add stats params in onDevCompileDone hook

### DIFF
--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -47,6 +47,7 @@ export async function createCompiler({
     if (isDev()) {
       await context.hooks.onDevCompileDoneHook.call({
         isFirstCompile,
+        stats: stats as Stats,
       });
     }
 

--- a/packages/core/src/provider/core/createCompiler.ts
+++ b/packages/core/src/provider/core/createCompiler.ts
@@ -104,6 +104,7 @@ export async function createCompiler({
     if (isDev()) {
       await context.hooks.onDevCompileDoneHook.call({
         isFirstCompile,
+        stats: stats,
       });
     }
 

--- a/packages/core/src/server/compiler-dev-middleware/index.ts
+++ b/packages/core/src/server/compiler-dev-middleware/index.ts
@@ -1,5 +1,4 @@
 import type { IncomingMessage, ServerResponse, Server } from 'http';
-import { EventEmitter } from 'events';
 import type {
   RsbuildDevMiddlewareOptions,
   DevMiddlewareAPI,
@@ -34,7 +33,7 @@ function getHMRClientPath(
   return clientEntry;
 }
 
-export default class DevMiddleware extends EventEmitter {
+export default class DevMiddleware {
   public middleware?: DevMiddlewareAPI;
 
   private devOptions: RsbuildDevMiddlewareOptions['dev'];
@@ -46,8 +45,6 @@ export default class DevMiddleware extends EventEmitter {
   private socketServer: SocketServer;
 
   constructor({ dev, devMiddleware, publicPaths }: Options) {
-    super();
-
     this.devOptions = dev;
     this.publicPaths = publicPaths;
 
@@ -96,7 +93,6 @@ export default class DevMiddleware extends EventEmitter {
       },
       onDone: (stats: any) => {
         this.socketServer.updateStats(stats);
-        this.emit('change', stats);
       },
     };
 

--- a/packages/document/docs/en/shared/onDevCompileDone.md
+++ b/packages/document/docs/en/shared/onDevCompileDone.md
@@ -4,6 +4,9 @@ Called after each development environment build, you can use `isFirstCompile` to
 
 ```ts
 function OnDevCompileDone(
-  callback: (params: { isFirstCompile: boolean }) => Promise<void> | void,
+  callback: (params: {
+    isFirstCompile: boolean;
+    stats: Stats | MultiStats;
+  }) => Promise<void> | void,
 ): void;
 ```

--- a/packages/document/docs/zh/shared/onDevCompileDone.md
+++ b/packages/document/docs/zh/shared/onDevCompileDone.md
@@ -4,6 +4,9 @@
 
 ```ts
 function OnDevCompileDone(
-  callback: (params: { isFirstCompile: boolean }) => Promise<void> | void,
+  callback: (params: {
+    isFirstCompile: boolean;
+    stats: Stats | MultiStats;
+  }) => Promise<void> | void,
 ): void;
 ```

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -18,6 +18,7 @@ export type OnAfterBuildFn = (params: {
 
 export type OnDevCompileDoneFn = (params: {
   isFirstCompile: boolean;
+  stats: Stats | MultiStats;
 }) => PromiseOrNot<void>;
 
 export type OnBeforeStartDevServerFn = () => PromiseOrNot<void>;


### PR DESCRIPTION
## Summary

- feat: add stats params in onDevCompileDone hook
- chore: remove useless onChange event (it is equal with rsbuild.onDevCompileDone hook)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
