### PR TITLE
fix(cli): missing logger require

### DIFF
--- a/.changeset/slimy-shirts-approve.md
+++ b/.changeset/slimy-shirts-approve.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(cli): missing logger require

--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -3,10 +3,12 @@ const { prepareCli } = require('../dist/cli/prepare');
 
 async function main() {
   prepareCli();
+
   try {
     const { runCli } = require('../dist/cli/commands');
     runCli();
   } catch (err) {
+    const { logger } = require('@rsbuild/shared/rslog');
     logger.error(err);
   }
 }


### PR DESCRIPTION
## Summary

Fix CLI bin file missing logger require.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
