### PR TITLE
feat(server): support use other server frameworks, like express

### DIFF
--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import { getHrefByEntryName } from '@scripts/shared';
+import { startDevServer } from './scripts/server.mjs';
+
+test('custom app', async ({ page }) => {
+  const { resolvedConfig, close } = await startDevServer(__dirname);
+
+  await page.goto(getHrefByEntryName('index', resolvedConfig.port));
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  const url1 = new URL(`http://localhost:${resolvedConfig.port}/bbb`);
+
+  const res = await page.goto(url1.href);
+
+  expect(await res?.text()).toBe('Hello Express!');
+
+  await close();
+});

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -3,14 +3,14 @@ import { getHrefByEntryName } from '@scripts/shared';
 import { startDevServer } from './scripts/server.mjs';
 
 test('custom server', async ({ page }) => {
-  const { resolvedConfig, close } = await startDevServer(__dirname);
+  const { config, close } = await startDevServer(__dirname);
 
-  await page.goto(getHrefByEntryName('index', resolvedConfig.port));
+  await page.goto(getHrefByEntryName('index', config.port));
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  const url1 = new URL(`http://localhost:${resolvedConfig.port}/bbb`);
+  const url1 = new URL(`http://localhost:${config.port}/bbb`);
 
   const res = await page.goto(url1.href);
 

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 import { getHrefByEntryName } from '@scripts/shared';
 import { startDevServer } from './scripts/server.mjs';
 
-test('custom app', async ({ page }) => {
+test('custom server', async ({ page }) => {
   const { resolvedConfig, close } = await startDevServer(__dirname);
 
   await page.goto(getHrefByEntryName('index', resolvedConfig.port));

--- a/e2e/cases/server/custom-server/package.json
+++ b/e2e/cases/server/custom-server/package.json
@@ -1,0 +1,14 @@
+{
+  "private": true,
+  "name": "@e2e/custom-server",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "node ./scripts/index.mjs"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
+  }
+}

--- a/e2e/cases/server/custom-server/scripts/index.mjs
+++ b/e2e/cases/server/custom-server/scripts/index.mjs
@@ -1,0 +1,3 @@
+import { startDevServer } from './server.mjs';
+
+startDevServer(process.cwd());

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -19,12 +19,10 @@ export async function startDevServer(fixtures) {
   const rsbuildServer = await rsbuild.createDevServer();
 
   const {
-    resolvedConfig: { host, port, defaultRoutes, devServerConfig },
+    resolvedConfig: { host, port, defaultRoutes },
   } = rsbuildServer;
 
-  const { middlewares, close, upgrade } = await rsbuildServer.getMiddlewares({
-    dev: devServerConfig,
-  });
+  const { middlewares, close, upgrade } = await rsbuildServer.getMiddlewares();
 
   app.get('/aaa', (_req, res) => {
     res.send('Hello World!');

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -8,31 +8,26 @@ export async function startDevServer(fixtures) {
     cwd: fixtures,
     rsbuildConfig: {
       plugins: [pluginReact()],
-      source: {
-        entry: {
-          index: join(fixtures, 'src/index.js'),
-        },
-      },
       server: {
         htmlFallback: false,
       },
     },
   });
 
-  const rsbuildServer = await rsbuild.createDevServer();
-
   const app = express();
+
+  const rsbuildServer = await rsbuild.createDevServer();
 
   const {
     resolvedConfig: { host, port, defaultRoutes, devServerConfig },
   } = rsbuildServer;
 
-  app.get('/aaa', (_req, res) => {
-    res.send('Hello World!');
-  });
-
   const { middlewares, close, upgrade } = await rsbuildServer.getMiddlewares({
     dev: devServerConfig,
+  });
+
+  app.get('/aaa', (_req, res) => {
+    res.send('Hello World!');
   });
 
   app.use(middlewares);

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -1,0 +1,63 @@
+import { join } from 'path';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { createRsbuild } from '@rsbuild/core';
+import express from 'express';
+
+export async function startDevServer(fixtures) {
+  const rsbuild = await createRsbuild({
+    cwd: fixtures,
+    rsbuildConfig: {
+      plugins: [pluginReact()],
+      source: {
+        entry: {
+          index: join(fixtures, 'src/index.js'),
+        },
+      },
+      server: {
+        htmlFallback: false,
+      },
+    },
+  });
+
+  const rsbuildServer = await rsbuild.createDevServer();
+
+  const app = express();
+
+  const {
+    resolvedConfig: { host, port, defaultRoutes, devServerConfig },
+  } = rsbuildServer;
+
+  app.get('/aaa', (_req, res) => {
+    res.send('Hello World!');
+  });
+
+  const { middlewares, close, upgrade } = await rsbuildServer.getMiddlewares({
+    dev: devServerConfig,
+  });
+
+  app.use(middlewares);
+
+  app.get('/bbb', (_req, res) => {
+    res.send('Hello Express!');
+  });
+
+  await rsbuildServer.beforeStart();
+
+  const httpServer = app.listen({ host, port }, async () => {
+    await rsbuildServer.afterStart({
+      port,
+      routes: defaultRoutes,
+    });
+  });
+
+  // subscribe the server's http upgrade event to handle WebSocket upgrade
+  httpServer.on('upgrade', upgrade);
+
+  return {
+    resolvedConfig: rsbuildServer.resolvedConfig,
+    close: async () => {
+      await close();
+      httpServer.close();
+    },
+  };
+}

--- a/e2e/cases/server/custom-server/src/index.js
+++ b/e2e/cases/server/custom-server/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -61,11 +61,11 @@ export function webpackProvider({
         return createCompiler({ context, webpackConfigs });
       },
 
-      async createDevServer(options) {
-        const { createDevServer } = await import('@rsbuild/core/server');
+      async getServerAPIs(options) {
+        const { getServerAPIs } = await import('@rsbuild/core/server');
         const { createDevMiddleware } = await import('./core/createCompiler');
         await initRsbuildConfig({ context, pluginStore });
-        return createDevServer(
+        return getServerAPIs(
           { context, pluginStore, rsbuildOptions },
           // @ts-expect-error compile type mismatch
           createDevMiddleware,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -46,7 +46,7 @@ export async function createRsbuild(
     initConfigs,
     inspectConfig,
     createCompiler,
-    createDevServer,
+    getServerAPIs,
     startDevServer,
     applyDefaultPlugins,
   } = await provider({
@@ -81,7 +81,7 @@ export async function createRsbuild(
     createCompiler,
     initConfigs,
     inspectConfig,
-    createDevServer,
+    getServerAPIs,
     startDevServer,
     context: publicContext,
   };

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -51,11 +51,11 @@ export function rspackProvider({
         });
       },
 
-      async createDevServer(options) {
-        const { createDevServer } = await import('../server/devServer');
+      async getServerAPIs(options) {
+        const { getServerAPIs } = await import('../server/devServer');
         const { createDevMiddleware } = await import('./core/createCompiler');
         await initRsbuildConfig({ context, pluginStore });
-        return createDevServer(
+        return getServerAPIs(
           { context, pluginStore, rsbuildOptions },
           createDevMiddleware,
           options,

--- a/packages/core/src/server/compiler-dev-middleware/index.ts
+++ b/packages/core/src/server/compiler-dev-middleware/index.ts
@@ -1,4 +1,5 @@
-import type { IncomingMessage, ServerResponse, Server } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Socket } from 'net';
 import type {
   RsbuildDevMiddlewareOptions,
   DevMiddlewareAPI,
@@ -54,7 +55,7 @@ export default class DevMiddleware {
     this.devMiddleware = devMiddleware;
   }
 
-  public init(app: Server) {
+  public init() {
     if (this.devMiddleware) {
       // start compiling
       this.middleware = this.setupDevMiddleware(
@@ -63,9 +64,11 @@ export default class DevMiddleware {
       );
     }
 
-    app.on('listening', () => {
-      this.socketServer.prepare(app);
-    });
+    this.socketServer.prepare();
+  }
+
+  public upgrade(req: IncomingMessage, sock: Socket, head: any) {
+    this.socketServer.upgrade(req, sock, head);
   }
 
   public close() {

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -51,7 +51,7 @@ const applyDefaultMiddlewares = async ({
   dev: RsbuildDevMiddlewareOptions['dev'];
   devMiddleware: DevMiddleware;
 }): Promise<{
-  upgrade: UpgradeEvent;
+  onUpgrade: UpgradeEvent;
 }> => {
   const upgradeEvents: UpgradeEvent[] = [];
   // compression should be the first middleware
@@ -143,7 +143,7 @@ const applyDefaultMiddlewares = async ({
   middlewares.push(faviconFallbackMiddleware);
 
   return {
-    upgrade: (...args) => {
+    onUpgrade: (...args) => {
       upgradeEvents.forEach((cb) => cb(...args));
     },
   };
@@ -163,7 +163,7 @@ export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
 
   before.forEach((fn) => middlewares.push(fn));
 
-  const { upgrade } = await applyDefaultMiddlewares({
+  const { onUpgrade } = await applyDefaultMiddlewares({
     middlewares,
     dev: options.dev,
     devMiddleware,
@@ -177,7 +177,7 @@ export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
     close: async () => {
       devMiddleware.close();
     },
-    upgrade,
+    onUpgrade,
     middlewares,
   };
 };

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,15 +1,14 @@
-import { Server } from 'http';
 import url from 'url';
 import {
   RequestHandler,
   ServerAPIs,
   RsbuildDevMiddlewareOptions,
+  UpgradeEvent,
 } from '@rsbuild/shared';
 import DevMiddleware from './compiler-dev-middleware';
 import {
   faviconFallbackMiddleware,
   getHtmlFallbackMiddleware,
-  notFoundMiddleware,
 } from './middlewares';
 import { join, isAbsolute } from 'path';
 
@@ -40,7 +39,6 @@ const applySetupMiddlewares = (
 };
 
 const applyDefaultMiddlewares = async ({
-  app,
   middlewares,
   dev,
   devMiddleware,
@@ -49,11 +47,13 @@ const applyDefaultMiddlewares = async ({
 }: {
   output: RsbuildDevMiddlewareOptions['output'];
   pwd: RsbuildDevMiddlewareOptions['pwd'];
-  app: Server;
   middlewares: RequestHandler[];
   dev: RsbuildDevMiddlewareOptions['dev'];
   devMiddleware: DevMiddleware;
-}) => {
+}): Promise<{
+  upgrade: UpgradeEvent;
+}> => {
+  const upgradeEvents: UpgradeEvent[] = [];
   // compression should be the first middleware
   if (dev.compress) {
     const { default: compression } = await import(
@@ -88,19 +88,20 @@ const applyDefaultMiddlewares = async ({
   // dev proxy handler, each proxy has own handler
   if (dev.proxy) {
     const { createProxyMiddleware } = await import('./proxy');
-    const { middlewares: proxyMiddlewares } = createProxyMiddleware(
+    const { middlewares: proxyMiddlewares, upgrade } = createProxyMiddleware(
       dev.proxy,
-      app,
     );
+    upgradeEvents.push(upgrade);
     proxyMiddlewares.forEach((middleware) => {
       middlewares.push(middleware);
     });
   }
 
-  // do webpack build / plugin apply / socket server when pass compiler instance
-  devMiddleware.init(app);
-
+  // do rspack build / plugin apply / socket server when pass compiler instance
+  devMiddleware.init();
   devMiddleware.middleware && middlewares.push(devMiddleware.middleware);
+  // subscribe upgrade event to handle websocket
+  upgradeEvents.push(devMiddleware.upgrade.bind(devMiddleware));
 
   if (dev.publicDir && dev.publicDir.name) {
     const { default: sirv } = await import('../../compiled/sirv');
@@ -140,13 +141,15 @@ const applyDefaultMiddlewares = async ({
   }
 
   middlewares.push(faviconFallbackMiddleware);
-  middlewares.push(notFoundMiddleware);
+
+  return {
+    upgrade: (...args) => {
+      upgradeEvents.forEach((cb) => cb(...args));
+    },
+  };
 };
 
-export const getMiddlewares = async (
-  options: RsbuildDevMiddlewareOptions,
-  app: Server,
-) => {
+export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
   const middlewares: RequestHandler[] = [];
   // create dev middleware instance
   const devMiddleware = new DevMiddleware({
@@ -160,8 +163,7 @@ export const getMiddlewares = async (
 
   before.forEach((fn) => middlewares.push(fn));
 
-  await applyDefaultMiddlewares({
-    app,
+  const { upgrade } = await applyDefaultMiddlewares({
     middlewares,
     dev: options.dev,
     devMiddleware,
@@ -175,6 +177,7 @@ export const getMiddlewares = async (
     close: async () => {
       devMiddleware.close();
     },
+    upgrade,
     middlewares,
   };
 };

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -84,15 +84,16 @@ export async function createDevServer<
         routes,
       });
     },
-    getMiddlewares: async ({
-      dev,
-    }: {
-      dev: RsbuildDevMiddlewareOptions['dev'];
-    }) =>
+    getMiddlewares: async (
+      overrides: RsbuildDevMiddlewareOptions['dev'] = {},
+    ) =>
       await getMiddlewares({
         pwd: options.context.rootPath,
         devMiddleware,
-        dev,
+        dev: {
+          ...devServerConfig,
+          ...overrides,
+        },
         output: {
           distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
           publicPaths,
@@ -162,9 +163,7 @@ export async function startDevServer<
     printServerURLs(urls, defaultRoutes, logger);
   }
 
-  const devMiddlewares = await rsbuildServer.getMiddlewares({
-    dev: devServerConfig,
-  });
+  const devMiddlewares = await rsbuildServer.getMiddlewares();
 
   devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,2 +1,2 @@
-export { startDevServer, createDevServer } from './devServer';
+export { startDevServer, getServerAPIs } from './devServer';
 export { startProdServer } from './prodServer';

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -72,10 +72,12 @@ export class RsbuildProdServer {
 
     if (proxy) {
       const { createProxyMiddleware } = await import('./proxy');
-      const { middlewares } = createProxyMiddleware(proxy, this.app);
+      const { middlewares, upgrade } = createProxyMiddleware(proxy);
       middlewares.forEach((middleware) => {
         this.middlewares.use(middleware);
       });
+
+      this.app.on('upgrade', upgrade);
     }
 
     this.applyStaticAssetMiddleware();

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -2,7 +2,7 @@ import type { PluginStore, Plugins, RsbuildPluginAPI } from './plugin';
 import type { Context } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
-import type { StartServerResult, DevServerAPI } from './server';
+import type { StartServerResult, DevServerAPIs } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
 import type { NormalizedConfig } from './config';
@@ -70,9 +70,9 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   ) => Promise<Compiler | MultiCompiler>;
 
   /** It is designed for high-level frameworks that require a custom server */
-  createDevServer: (
+  getServerAPIs: (
     options?: Omit<StartDevServerOptions, 'printURLs'>,
-  ) => Promise<DevServerAPI>;
+  ) => Promise<DevServerAPIs>;
 
   startDevServer: (
     options?: StartDevServerOptions,

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -69,7 +69,11 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
     options?: CreateCompilerOptions,
   ) => Promise<Compiler | MultiCompiler>;
 
-  /** It is designed for high-level frameworks that require a custom server */
+  /**
+   * This API is not stable
+   *
+   * It is designed for high-level frameworks that require a custom server
+   */
   getServerAPIs: (
     options?: Omit<StartDevServerOptions, 'printURLs'>,
   ) => Promise<DevServerAPIs>;

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -25,7 +25,7 @@ export type RsbuildInstance<P extends RsbuildProvider = RsbuildProvider> = {
   initConfigs: ProviderInstance['initConfigs'];
   inspectConfig: ProviderInstance['inspectConfig'];
   createCompiler: ProviderInstance['createCompiler'];
-  createDevServer: ProviderInstance['createDevServer'];
+  getServerAPIs: ProviderInstance['getServerAPIs'];
   startDevServer: ProviderInstance['startDevServer'];
 
   getHTMLPaths: Awaited<ReturnType<P>>['pluginAPI']['getHTMLPaths'];

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse, Server } from 'http';
+import type { Socket } from 'net';
 import { DevConfig, NextFunction, RequestHandler } from './config/dev';
 import { ServerConfig } from './config/server';
 import type { Logger } from '../logger';
@@ -78,15 +79,19 @@ export type CreateDevServerOptions = {
   };
 } & RsbuildDevMiddlewareOptions;
 
-export type ServerApi = {
-  close: () => Promise<void>;
-};
-
 export type StartServerResult = {
   urls: string[];
   port: number;
-  server: ServerApi;
+  server: {
+    close: () => Promise<void>;
+  };
 };
+
+export type UpgradeEvent = (
+  req: IncomingMessage,
+  socket: Socket,
+  head: any,
+) => void;
 
 export type DevServerAPI = {
   resolvedConfig: {
@@ -96,7 +101,6 @@ export type DevServerAPI = {
     https: boolean;
     defaultRoutes: Routes;
   };
-  // devMiddlewareEvents: EventEmitter;
   beforeStart: () => Promise<void>;
   afterStart: ({
     port,
@@ -107,9 +111,9 @@ export type DevServerAPI = {
   }) => Promise<void>;
   getMiddlewares: (options: {
     dev: RsbuildDevMiddlewareOptions['dev'];
-    app: Server;
   }) => Promise<{
     middlewares: RequestHandler[];
     close: () => Promise<void>;
+    upgrade: UpgradeEvent;
   }>;
 };

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -109,9 +109,9 @@ export type DevServerAPI = {
     port: number;
     routes: Routes;
   }) => Promise<void>;
-  getMiddlewares: (options: {
-    dev: RsbuildDevMiddlewareOptions['dev'];
-  }) => Promise<{
+  getMiddlewares: (
+    overridesConfig?: RsbuildDevMiddlewareOptions['dev'],
+  ) => Promise<{
     middlewares: RequestHandler[];
     close: () => Promise<void>;
     upgrade: UpgradeEvent;

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,8 +1,7 @@
-import type { IncomingMessage, ServerResponse, Server } from 'http';
+import type { IncomingMessage, ServerResponse } from 'http';
 import type { Socket } from 'net';
 import { DevConfig, NextFunction, RequestHandler } from './config/dev';
 import { ServerConfig } from './config/server';
-import type { Logger } from '../logger';
 import { Routes } from './hooks';
 import type { RspackCompiler, RspackMultiCompiler } from './rspack';
 
@@ -72,13 +71,6 @@ export type RsbuildDevMiddlewareOptions = {
   };
 };
 
-export type CreateDevServerOptions = {
-  server?: {
-    customApp?: Server;
-    logger?: Logger;
-  };
-} & RsbuildDevMiddlewareOptions;
-
 export type StartServerResult = {
   urls: string[];
   port: number;
@@ -93,8 +85,11 @@ export type UpgradeEvent = (
   head: any,
 ) => void;
 
-export type DevServerAPI = {
-  resolvedConfig: {
+export type DevServerAPIs = {
+  /**
+   * The resolved rsbuild server config
+   */
+  config: {
     devServerConfig: DevConfig & ServerConfig;
     port: number;
     host: string;
@@ -102,18 +97,13 @@ export type DevServerAPI = {
     defaultRoutes: Routes;
   };
   beforeStart: () => Promise<void>;
-  afterStart: ({
-    port,
-    routes,
-  }: {
-    port: number;
-    routes: Routes;
-  }) => Promise<void>;
-  getMiddlewares: (
-    overridesConfig?: RsbuildDevMiddlewareOptions['dev'],
-  ) => Promise<{
+  afterStart: (options?: { port?: number; routes?: Routes }) => Promise<void>;
+  getMiddlewares: (overrides?: RsbuildDevMiddlewareOptions['dev']) => Promise<{
     middlewares: RequestHandler[];
     close: () => Promise<void>;
-    upgrade: UpgradeEvent;
+    /**
+     * subscribe http upgrade event
+     */
+    onUpgrade: UpgradeEvent;
   }>;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,16 @@ importers:
         specifier: ^15
         version: 15.7.9
 
+  e2e/cases/server/custom-server:
+    dependencies:
+      express:
+        specifier: ^4.18.2
+        version: 4.18.2
+    devDependencies:
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.21
+
   e2e/cases/solid:
     dependencies:
       solid-js:
@@ -5919,7 +5929,7 @@ packages:
   /@types/compression@1.7.4:
     resolution: {integrity: sha512-sdFVnQJRkQBX83ydsLCBm4A39p45y0QkxdAR689yOtAFNbbS9Acrp86RZWJj6BHRXyZH9tX4t1dU7XDiGdY3nA==}
     dependencies:
-      '@types/express': 4.17.20
+      '@types/express': 4.17.21
     dev: true
 
   /@types/configstore@2.1.1:
@@ -5972,8 +5982,8 @@ packages:
       '@types/send': 0.17.3
     dev: true
 
-  /@types/express@4.17.20:
-    resolution: {integrity: sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==}
+  /@types/express@4.17.21:
+    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
     dependencies:
       '@types/body-parser': 1.19.2
       '@types/express-serve-static-core': 4.17.38
@@ -6129,7 +6139,7 @@ packages:
   /@types/polka@0.5.6:
     resolution: {integrity: sha512-DU+Esoykng6azh+5jOMhsPQKz9m4QFGcSCrhm9KB/cUIgspPbslrxqIpF79b/Y/+HseTHpP/E6BstlAwH5I1ig==}
     dependencies:
-      '@types/express': 4.17.20
+      '@types/express': 4.17.21
       '@types/express-serve-static-core': 4.17.38
       '@types/node': 16.18.59
       '@types/trouter': 3.1.3
@@ -6702,7 +6712,6 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: true
 
   /acorn-import-assertions@1.9.0(acorn@8.10.0):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
@@ -6873,6 +6882,10 @@ packages:
       call-bind: 1.0.2
       is-array-buffer: 3.0.2
     dev: true
+
+  /array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    dev: false
 
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -7158,6 +7171,26 @@ packages:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
     dev: false
 
+  /body-parser@1.20.1:
+    resolution: {integrity: sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.1
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /body-scroll-lock@4.0.0-beta.0:
     resolution: {integrity: sha512-a7tP5+0Mw3YlUJcGAKUqIBkYYGlYxk2fnCasq/FUph1hadxlTRjF+gAcZksxANnaMnALjxEddmSi/H3OR8ugcQ==}
     dev: true
@@ -7292,6 +7325,11 @@ packages:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
     engines: {node: '>= 0.8'}
     dev: true
+
+  /bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -7881,6 +7919,18 @@ packages:
     resolution: {integrity: sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==}
     dev: false
 
+  /content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
+
+  /content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /convert-source-map@1.8.0:
     resolution: {integrity: sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==}
     dependencies:
@@ -7889,6 +7939,15 @@ packages:
 
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  /cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    dev: false
+
+  /cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
@@ -8225,7 +8284,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
-    dev: true
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -8331,6 +8389,11 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+    dev: false
+
   /dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -8340,6 +8403,11 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+    dev: false
+
+  /destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
     dev: false
 
   /detect-indent@6.1.0:
@@ -8518,7 +8586,6 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-    dev: true
 
   /electron-to-chromium@1.4.559:
     resolution: {integrity: sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug==}
@@ -8546,7 +8613,6 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -8815,7 +8881,6 @@ packages:
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-    dev: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -8897,6 +8962,11 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  /etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
     dev: true
@@ -8941,6 +9011,45 @@ packages:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
     dev: true
+
+  /express@4.18.2:
+    resolution: {integrity: sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==}
+    engines: {node: '>= 0.10.0'}
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.1
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.5.0
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.2.0
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.1
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.7
+      proxy-addr: 2.0.7
+      qs: 6.11.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.18.0
+      serve-static: 1.15.0
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -9030,6 +9139,21 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /finalhandler@1.2.0:
+    resolution: {integrity: sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /find-cache-dir@4.0.0:
     resolution: {integrity: sha512-9ZonPT4ZAK4a+1pUPVPZJapbi7O5qbbJPdYw/NOQWZZbVLdDTYM3A4R9z/DpAM08IDaFGsvPgiGZ82WEwUDWjg==}
@@ -9139,9 +9263,19 @@ packages:
       fetch-blob: 3.2.0
     dev: true
 
+  /forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
     dev: true
+
+  /fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -9736,6 +9870,17 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
+  /http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+    dev: false
+
   /http-proxy-middleware@2.0.6:
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==}
     engines: {node: '>=12.0.0'}
@@ -9802,7 +9947,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -9912,6 +10056,11 @@ packages:
     dependencies:
       loose-envify: 1.4.0
     dev: true
+
+  /ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+    dev: false
 
   /is-absolute-url@4.0.1:
     resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
@@ -10885,6 +11034,11 @@ packages:
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
 
+  /media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
   /medium-zoom@1.0.8:
     resolution: {integrity: sha512-CjFVuFq/IfrdqesAXfg+hzlDKu6A2n80ZIq0Kl9kWjoHh9j1N9Uvk5X0/MmN0hOfm5F9YBswlClhcwnmtwz7gA==}
     dev: true
@@ -10912,6 +11066,10 @@ packages:
       yargs-parser: 18.1.3
     dev: true
 
+  /merge-descriptors@1.0.1:
+    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    dev: false
+
   /merge-source-map@1.1.0:
     resolution: {integrity: sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==}
     dependencies:
@@ -10924,6 +11082,11 @@ packages:
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  /methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /micromark-core-commonmark@1.1.0:
     resolution: {integrity: sha512-BgHO1aRbolh2hcrzL2d1La37V0Aoz73ymF8rAcKnohLy93titmv62E0gP8Hrx9PKcKrqCZ1BbLGbP3bEhoXYlw==}
@@ -11289,8 +11452,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     requiresBuild: true
-    dev: true
-    optional: true
 
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
@@ -11428,7 +11589,6 @@ packages:
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -11484,7 +11644,6 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -11698,6 +11857,13 @@ packages:
       ee-first: 1.1.1
     dev: true
 
+  /on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      ee-first: 1.1.1
+    dev: false
+
   /on-headers@1.0.2:
     resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
     engines: {node: '>= 0.8'}
@@ -11910,7 +12076,6 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
@@ -11960,6 +12125,10 @@ packages:
     dependencies:
       lru-cache: 10.0.2
       minipass: 5.0.0
+    dev: false
+
+  /path-to-regexp@0.1.7:
+    resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
     dev: false
 
   /path-type@4.0.0:
@@ -12685,6 +12854,14 @@ packages:
     resolution: {integrity: sha512-gVNZ74nqhRMiIUYWGQdosYetaKc83x8oT41a0LlV3AAFCAZwCpg4vmGkq8t34+cUhp3cnM4XDiU/7xlgK7HGrg==}
     dev: true
 
+  /proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+    dev: false
+
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
     dev: true
@@ -12815,6 +12992,13 @@ packages:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
 
+  /qs@6.11.0:
+    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
+    engines: {node: '>=0.6'}
+    dependencies:
+      side-channel: 1.0.4
+    dev: false
+
   /qs@6.11.2:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
     engines: {node: '>=0.6'}
@@ -12858,7 +13042,16 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-    dev: true
+
+  /raw-body@2.5.1:
+    resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+    dev: false
 
   /react-dom@18.2.0(react@18.2.0):
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
@@ -13438,6 +13631,27 @@ packages:
     dependencies:
       lru-cache: 6.0.0
 
+  /send@0.18.0:
+    resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /serialize-javascript@6.0.1:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
@@ -13446,6 +13660,18 @@ packages:
   /seroval@0.12.4:
     resolution: {integrity: sha512-JIsZHp98o+okpYN8HEPyI9Blr0gxAUPIGvg3waXrEMFjPz9obiLYMz0uFiUGezKiCK8loosYbn8WsqO8WtAJUA==}
     engines: {node: '>=10'}
+    dev: false
+
+  /serve-static@1.15.0:
+    resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
+    engines: {node: '>= 0.8.0'}
+    dependencies:
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /set-blocking@2.0.0:
@@ -13471,6 +13697,10 @@ packages:
 
   /setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
+    dev: false
+
+  /setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
 
   /sha.js@2.4.11:
@@ -13679,6 +13909,11 @@ packages:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
     dev: true
+
+  /statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+    dev: false
 
   /std-env@3.6.0:
     resolution: {integrity: sha512-aFZ19IgVmhdB2uX599ve2kE6BIE3YMnQ6Gp6BURhW/oIzpXGKr878TQfAQZn1+i0Flcc/UKUy1gOlcfaUBCryg==}
@@ -14336,6 +14571,11 @@ packages:
     resolution: {integrity: sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==}
     dev: true
 
+  /toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+    dev: false
+
   /token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
     dev: false
@@ -14477,6 +14717,14 @@ packages:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
     dev: true
+
+  /type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+    dev: false
 
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
@@ -14636,7 +14884,6 @@ packages:
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /upath@2.0.1:
     resolution: {integrity: sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==}
@@ -14705,7 +14952,6 @@ packages:
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-    dev: true
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -14741,7 +14987,6 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /vfile-location@4.1.0:
     resolution: {integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==}


### PR DESCRIPTION
## Summary

rsbuild supports start with other server frameworks, like [express](https://expressjs.com/) (This API is not stable)

example: /e2e/cases/server/custom-server/scripts/server.mjs
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
