### PR TITLE
docs: update path separator examples to match Windows path

### DIFF
--- a/packages/document/docs/en/config/output/inline-scripts.mdx
+++ b/packages/document/docs/en/config/output/inline-scripts.mdx
@@ -63,7 +63,7 @@ For example, to inline `main.js` into HTML, you can add the following configurat
 ```js
 export default {
   output: {
-    inlineScripts: /\/main\.\w+\.js$/,
+    inlineScripts: /[\\/]main\.\w+\.js$/,
   },
 };
 ```

--- a/packages/document/docs/en/config/output/inline-styles.mdx
+++ b/packages/document/docs/en/config/output/inline-styles.mdx
@@ -64,7 +64,7 @@ For example, to inline `main.css` into HTML, you can add the following configura
 ```js
 export default {
   output: {
-    inlineStyles: /\/main\.\w+\.css$/,
+    inlineStyles: /[\\/]main\.\w+\.css$/,
   },
 };
 ```

--- a/packages/document/docs/en/config/performance/chunk-split.mdx
+++ b/packages/document/docs/en/config/performance/chunk-split.mdx
@@ -117,7 +117,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/document/docs/en/config/source/include.mdx
+++ b/packages/document/docs/en/config/source/include.mdx
@@ -49,13 +49,17 @@ export default {
       // Method 2:
       // Match by regular expression
       // All paths containing `/node_modules/query-string/` will be matched
-      /\/node_modules\/query-string\//,
+      /[\\/]node_modules[\\/]query-string[\\/]/,
     ],
   },
 };
 ```
 
 The above two methods match the absolute paths of files using "path prefixes" and "regular expressions" respectively. It is worth noting that all referenced modules in the project will be matched. Therefore, you should avoid using overly loose values for matching to prevent compilation performance issues or compilation errors.
+
+:::tip
+In the regular expression example above, we use `[\\/]` to match the path separator because different operating systems use different path separators. Using `[\\/]` ensures that the paths will match in both MacOS and Windows.
+:::
 
 ### Compile Sub Dependencies
 
@@ -67,8 +71,8 @@ Take `query-string` for example, it depends on the `decode-uri-component` packag
 export default {
   source: {
     include: [
-      /\/node_modules\/query-string\//,
-      /\/node_modules\/decode-uri-component\//,
+      /[\\/]node_modules[\\/]query-string[\\/]/,
+      /[\\/]node_modules[\\/]decode-uri-component[\\/]/,
     ],
   },
 };

--- a/packages/document/docs/en/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/en/guide/advanced/browser-compatibility.md
@@ -145,7 +145,7 @@ import path from 'path';
 
 export default {
   source: {
-    include: [/\/node_modules\/query-string\//],
+    include: [/[\\/]node_modules[\\/]query-string[\\/]/],
   },
 };
 ```

--- a/packages/document/docs/en/guide/optimization/optimize-bundle.md
+++ b/packages/document/docs/en/guide/optimization/optimize-bundle.md
@@ -104,7 +104,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/document/docs/en/guide/optimization/split-chunk.md
+++ b/packages/document/docs/en/guide/optimization/split-chunk.md
@@ -161,7 +161,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/document/docs/zh/config/output/inline-scripts.mdx
+++ b/packages/document/docs/zh/config/output/inline-scripts.mdx
@@ -63,7 +63,7 @@ dist/static/css/style.css
 ```js
 export default {
   output: {
-    inlineScripts: /\/main\.\w+\.js$/,
+    inlineScripts: /[\\/]main\.\w+\.js$/,
   },
 };
 ```

--- a/packages/document/docs/zh/config/output/inline-styles.mdx
+++ b/packages/document/docs/zh/config/output/inline-styles.mdx
@@ -64,7 +64,7 @@ dist/static/js/main.js
 ```js
 export default {
   output: {
-    inlineStyles: /\/main\.\w+\.css$/,
+    inlineStyles: /[\\/]main\.\w+\.css$/,
   },
 };
 ```

--- a/packages/document/docs/zh/config/performance/chunk-split.mdx
+++ b/packages/document/docs/zh/config/performance/chunk-split.mdx
@@ -117,7 +117,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/document/docs/zh/config/source/include.mdx
+++ b/packages/document/docs/zh/config/source/include.mdx
@@ -49,13 +49,17 @@ export default {
       // 方法二:
       // 通过正则表达式进行匹配
       // 所有包含 `/node_modules/query-string/` 的路径都会被匹配到
-      /\/node_modules\/query-string\//,
+      /[\\/]node_modules[\\/]query-string[\\/]/,
     ],
   },
 };
 ```
 
 上述两种方法分别通过 "路径前缀" 和 "正则表达式" 来匹配文件的绝对路径，值得留意的是，项目中所有被引用的模块都会经过匹配，因此你不能使用过于松散的值进行匹配，避免造成编译性能问题或编译异常。
+
+:::tip
+在上述正则表达式的例子中，我们使用 `[\\/]` 来匹配路径分隔符，这是因为不同的操作系统使用了不同的路径分隔符，使用 `[\\/]` 可以保证 macOS 和 Windows 的路径都被匹配到。
+:::
 
 ### 编译 npm 包的子依赖
 
@@ -67,8 +71,8 @@ export default {
 export default {
   source: {
     include: [
-      /\/node_modules\/query-string\//,
-      /\/node_modules\/decode-uri-component\//,
+      /[\\/]node_modules[\\/]query-string[\\/]/,
+      /[\\/]node_modules[\\/]decode-uri-component[\\/]/,
     ],
   },
 };
@@ -110,7 +114,7 @@ export default {
 ```ts
 export default {
   source: {
-    include: [/\/node_modules\//],
+    include: [/[\\/]node_modules[\\/]/],
   },
 };
 ```

--- a/packages/document/docs/zh/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/zh/guide/advanced/browser-compatibility.md
@@ -145,7 +145,7 @@ import path from 'path';
 
 export default {
   source: {
-    include: [/\/node_modules\/query-string\//],
+    include: [/[\\/]node_modules[\\/]query-string[\\/]/],
   },
 };
 ```

--- a/packages/document/docs/zh/guide/optimization/optimize-bundle.md
+++ b/packages/document/docs/zh/guide/optimization/optimize-bundle.md
@@ -104,7 +104,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/document/docs/zh/guide/optimization/split-chunk.md
+++ b/packages/document/docs/zh/guide/optimization/split-chunk.md
@@ -157,7 +157,7 @@ export default {
     chunkSplit: {
       strategy: 'split-by-experience',
       forceSplitting: {
-        axios: /node_modules\/axios/,
+        axios: /node_modules[\\/]axios/,
       },
     },
   },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       ],
     },
     /\\\\\\.\\(ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
-    /\\\\/node_modules\\\\/query-string\\\\//,
+    /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
   ],
   "test": /\\\\\\.\\(js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -8,7 +8,7 @@ describe('plugins/babel', () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {
         source: {
-          include: [/\/node_modules\/query-string\//],
+          include: [/[\\/]node_modules[\\/]query-string[\\/]/],
           exclude: ['src/example'],
         },
       },


### PR DESCRIPTION
## Summary

Update path separator examples to match Windows path.

Use `[\\/]` to match the path separator because different operating systems use different path separators. Using `[\\/]` ensures that the paths will match in both MacOS and Windows.

## Related Links

https://github.com/webpack/webpack/issues/2073

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
