### PR TITLE
fix: clear the assigned env vars for reloading

### DIFF
--- a/.changeset/early-panthers-reflect.md
+++ b/.changeset/early-panthers-reflect.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix: clear the assigned env vars for reloading

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -14,7 +14,7 @@ test('should restart dev server when .env file is changed', async () => {
   fse.removeSync(configFile);
   fse.removeSync(envLocalFile);
 
-  fse.writeFileSync(envLocalFile, ``);
+  fse.writeFileSync(envLocalFile, `PUBLIC_NAME=jack`);
   fse.writeFileSync(
     configFile,
     `export default {
@@ -22,9 +22,6 @@ test('should restart dev server when .env file is changed', async () => {
         writeToDisk: true,
       },
       output: {
-        distPath: {
-          root: 'dist',
-        },
         disableFilenameHash: true,
       },
       server: { port: ${getRandomPort()} }
@@ -36,12 +33,12 @@ test('should restart dev server when .env file is changed', async () => {
   });
 
   await awaitFileExists(distIndex);
-  expect(fse.readFileSync(distIndex, 'utf-8')).not.toContain('jack');
-  fse.removeSync(distIndex);
-
-  fse.writeFileSync(envLocalFile, `PUBLIC_NAME=jack`);
-  await awaitFileExists(distIndex);
   expect(fse.readFileSync(distIndex, 'utf-8')).toContain('jack');
+
+  fse.removeSync(distIndex);
+  fse.writeFileSync(envLocalFile, `PUBLIC_NAME=rose`);
+  await awaitFileExists(distIndex);
+  expect(fse.readFileSync(distIndex, 'utf-8')).toContain('rose');
 
   process.kill();
 });

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -7,6 +7,8 @@ export const getEnvFiles = () => {
   return ['.env', '.env.local', `.env.${NODE_ENV}`, `.env.${NODE_ENV}.local`];
 };
 
+let lastParsed: Record<string, string>;
+
 export async function loadEnv({
   cwd = process.cwd(),
   prefixes = ['PUBLIC_'],
@@ -23,6 +25,15 @@ export async function loadEnv({
     Object.assign(parsed, parse(fs.readFileSync(envPath)));
   });
 
+  // clear the assigned env vars for reloading
+  if (lastParsed) {
+    Object.keys(lastParsed).forEach((key) => {
+      if (process.env[key] === lastParsed[key]) {
+        delete process.env[key];
+      }
+    });
+  }
+
   expand({ parsed });
 
   const publicVars: Record<string, string> = {};
@@ -33,6 +44,8 @@ export async function loadEnv({
       publicVars[`process.env.${key}`] = JSON.stringify(val);
     }
   });
+
+  lastParsed = parsed;
 
   return {
     parsed,


### PR DESCRIPTION
## Summary

Clear the assigned env vars for reloading, dotenv will not override process.env by default.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
