### PR TITLE
feat(type-check): support for typescript project reference

### DIFF
--- a/.changeset/eleven-cats-study.md
+++ b/.changeset/eleven-cats-study.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-type-check': patch
+---
+
+feat(type-check): support for typescript project reference

--- a/e2e/cases/source-build/app/rsbuild.config.ts
+++ b/e2e/cases/source-build/app/rsbuild.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
+import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginSourceBuild()],
+  plugins: [pluginSourceBuild(), pluginReact(), pluginTypeCheck()],
 });

--- a/e2e/cases/source-build/app/src/index.tsx
+++ b/e2e/cases/source-build/app/src/index.tsx
@@ -1,5 +1,4 @@
 import { Card } from '@e2e/source-build-components';
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 const rootElement = document.getElementById('root');

--- a/e2e/cases/source-build/components/src/card/index.tsx
+++ b/e2e/cases/source-build/components/src/card/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { strAdd } from '@e2e/source-build-utils';
 import './index.less';
 

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -2,8 +2,6 @@ import { join } from 'path';
 import { expect } from '@playwright/test';
 import { dev, getHrefByEntryName } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
-import { pluginSourceBuild } from '@rsbuild/plugin-source-build';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixture = join(__dirname, 'app');
 
@@ -12,7 +10,6 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: fixture,
-      plugins: [pluginSourceBuild(), pluginReact()],
     });
 
     await page.goto(getHrefByEntryName('index', rsbuild.port));

--- a/packages/document/docs/en/plugins/list/plugin-type-check.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-type-check.mdx
@@ -99,6 +99,11 @@ To modify the options of `fork-ts-checker-webpack-plugin`, please refer to [fork
 ```ts
 const defaultOptions = {
   typescript: {
+    // set 'readonly' to avoid emitting tsbuildinfo,
+    // as the generated tsbuildinfo will break fork-ts-checker
+    mode: 'readonly',
+    // enable build when using project reference
+    build: useReference,
     // avoid OOM issue
     memoryLimit: 8192,
     // use tsconfig of user project

--- a/packages/document/docs/zh/plugins/list/plugin-type-check.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-type-check.mdx
@@ -99,6 +99,11 @@ pluginTypeCheck({
 ```ts
 const defaultOptions = {
   typescript: {
+    // set 'readonly' to avoid emitting tsbuildinfo,
+    // as the generated tsbuildinfo will break fork-ts-checker
+    mode: 'readonly',
+    // enable build when using project reference
+    build: useReference,
     // avoid OOM issue
     memoryLimit: 8192,
     // use tsconfig of user project

--- a/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
@@ -23,8 +23,10 @@ exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-p
           "log": [Function],
         },
         "typescript": {
+          "build": false,
           "configFile": "<ROOT>/packages/plugin-type-check/tests/tsconfig.json",
           "memoryLimit": 8192,
+          "mode": "readonly",
           "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
         },
       },
@@ -53,8 +55,10 @@ exports[`plugin-type-check > should apply fork-ts-checker-webpack-plugin correct
           "log": [Function],
         },
         "typescript": {
+          "build": false,
           "configFile": "<ROOT>/packages/plugin-type-check/tests/tsconfig.json",
           "memoryLimit": 8192,
+          "mode": "readonly",
           "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
         },
       },
@@ -85,8 +89,10 @@ exports[`plugin-type-check > should only apply one ts-checker plugin when there 
           "log": [Function],
         },
         "typescript": {
+          "build": false,
           "configFile": "<ROOT>/packages/plugin-type-check/tests/tsconfig.json",
           "memoryLimit": 8192,
+          "mode": "readonly",
           "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
         },
       },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -27,6 +27,10 @@
       "types": "./compiled/rslog/dist/index.d.ts",
       "default": "./compiled/rslog/index.js"
     },
+    "./json5": {
+      "types": "./compiled/json5/lib/index.d.ts",
+      "default": "./compiled/json5/index.js"
+    },
     "./gzip-size": {
       "types": "./compiled/gzip-size/index.d.ts",
       "default": "./compiled/gzip-size/index.js"


### PR DESCRIPTION
## Summary

Add support for typescript project reference.

## Related Links

https://github.com/TypeStrong/fork-ts-checker-webpack-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
