### PR TITLE
 refactor: simplify provider params

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -42,10 +42,11 @@ export const createRsbuild = async (
   }
 
   const { webpackProvider } = await import('@rsbuild/webpack');
-  const rsbuild = await createRsbuild({
-    ...rsbuildOptions,
-    provider: webpackProvider,
-  });
+
+  rsbuildOptions.rsbuildConfig ||= {};
+  rsbuildOptions.rsbuildConfig.provider = webpackProvider;
+
+  const rsbuild = await createRsbuild(rsbuildOptions);
 
   if (plugins) {
     rsbuild.addPlugins(plugins);

--- a/packages/compat/uni-builder/src/webpack/index.ts
+++ b/packages/compat/uni-builder/src/webpack/index.ts
@@ -83,9 +83,10 @@ export async function createWebpackBuilder(
   );
 
   const { webpackProvider } = await import('@rsbuild/webpack');
+  rsbuildConfig.provider = webpackProvider;
+
   const rsbuild = await createRsbuild({
     rsbuildConfig,
-    provider: webpackProvider,
     cwd,
   });
 

--- a/packages/compat/webpack/src/core/build.ts
+++ b/packages/compat/webpack/src/core/build.ts
@@ -3,12 +3,13 @@ import { initConfigs, InitConfigsOptions } from './initConfigs';
 import {
   logger,
   type Stats,
+  type Rspack,
   type BuildOptions,
   type RspackConfig,
 } from '@rsbuild/shared';
 import type {
-  MultiStats,
   Compiler,
+  MultiStats,
   MultiCompiler,
   Configuration as WebpackConfig,
 } from 'webpack';
@@ -53,11 +54,10 @@ export const build = async (
 
   const { context } = initOptions;
 
-  let compiler: Compiler | MultiCompiler;
+  let compiler: Rspack.Compiler | Rspack.MultiCompiler;
   let bundlerConfigs: WebpackConfig[] | undefined;
 
   if (customCompiler) {
-    // @ts-expect-error compiler type mismatch
     compiler = customCompiler;
   } else {
     const { webpackConfigs } = await initConfigs(initOptions);
@@ -81,7 +81,7 @@ export const build = async (
       }
     });
   } else {
-    const executeResult = await executer?.(compiler);
+    const executeResult = await executer?.(compiler as unknown as Compiler);
     await context.hooks.onAfterBuildHook.call({
       stats: executeResult?.stats as Stats,
     });

--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -10,7 +10,7 @@ import {
 import type { Context } from '@rsbuild/core/provider';
 import type { WebpackConfig } from '../types';
 import { initConfigs, InitConfigsOptions } from './initConfigs';
-import type { Compiler, MultiCompiler } from 'webpack';
+import type { Compiler } from 'webpack';
 import { getDevMiddleware } from './devMiddleware';
 
 export async function createCompiler({
@@ -27,10 +27,11 @@ export async function createCompiler({
 
   const { default: webpack } = await import('webpack');
 
-  const compiler =
-    webpackConfigs.length === 1
-      ? webpack(webpackConfigs[0])
-      : webpack(webpackConfigs);
+  const compiler = (webpackConfigs.length === 1
+    ? webpack(webpackConfigs[0])
+    : webpack(webpackConfigs)) as unknown as
+    | Rspack.Compiler
+    | Rspack.MultiCompiler;
 
   let isFirstCompile = true;
 
@@ -55,7 +56,7 @@ export async function createCompiler({
   });
 
   await context.hooks.onAfterCreateCompilerHook.call({
-    compiler: compiler as unknown as Rspack.Compiler | Rspack.MultiCompiler,
+    compiler,
   });
   debug('create compiler done');
 
@@ -64,9 +65,9 @@ export async function createCompiler({
 
 export async function createDevMiddleware(
   options: InitConfigsOptions,
-  customCompiler?: Compiler | MultiCompiler,
+  customCompiler?: Rspack.Compiler | Rspack.MultiCompiler,
 ) {
-  let compiler: Compiler | MultiCompiler;
+  let compiler: Rspack.Compiler | Rspack.MultiCompiler;
   if (customCompiler) {
     compiler = customCompiler;
   } else {
@@ -78,7 +79,7 @@ export async function createDevMiddleware(
   }
 
   return {
-    devMiddleware: getDevMiddleware(compiler),
+    devMiddleware: getDevMiddleware(compiler as unknown as Compiler),
     compiler,
   };
 }

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -13,12 +13,11 @@ import { applyDefaultPlugins } from './shared';
 import { initConfigs } from './core/initConfigs';
 
 export const webpackProvider: RsbuildProvider<'webpack'> = async ({
+  plugins,
   pluginStore,
   rsbuildOptions,
-  rsbuildConfig: originalRsbuildConfig,
-  plugins,
 }) => {
-  const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
+  const rsbuildConfig = pickRsbuildConfig(rsbuildOptions.rsbuildConfig);
   const context = await createContext(rsbuildOptions, rsbuildConfig, 'webpack');
   const pluginAPI = getPluginAPI({ context, pluginStore });
 

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -60,7 +60,6 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
       await initRsbuildConfig({ context, pluginStore });
       return getServerAPIs(
         { context, pluginStore, rsbuildOptions },
-        // @ts-expect-error compile type mismatch
         createDevMiddleware,
         options,
       );
@@ -79,7 +78,6 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
           pluginStore,
           rsbuildOptions,
         },
-        // @ts-expect-error compile type mismatch
         createDevMiddleware,
         options,
       );

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -1,6 +1,5 @@
 import {
   pickRsbuildConfig,
-  type RsbuildConfig,
   type RsbuildProvider,
   type PreviewServerOptions,
 } from '@rsbuild/shared';
@@ -13,112 +12,105 @@ import {
 import { applyDefaultPlugins } from './shared';
 import { initConfigs } from './core/initConfigs';
 
-export function webpackProvider({
+export const webpackProvider: RsbuildProvider<'webpack'> = async ({
+  pluginStore,
+  rsbuildOptions,
   rsbuildConfig: originalRsbuildConfig,
-}: {
-  rsbuildConfig: RsbuildConfig;
-}): RsbuildProvider {
+  plugins,
+}) => {
   const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
+  const context = await createContext(rsbuildOptions, rsbuildConfig, 'webpack');
+  const pluginAPI = getPluginAPI({ context, pluginStore });
 
-  // @ts-expect-error compiler type mismatch
-  return async ({ pluginStore, rsbuildOptions, plugins }) => {
-    const context = await createContext(
-      rsbuildOptions,
-      rsbuildConfig,
-      'webpack',
-    );
-    const pluginAPI = getPluginAPI({ context, pluginStore });
+  context.pluginAPI = pluginAPI;
 
-    context.pluginAPI = pluginAPI;
+  return {
+    bundler: 'webpack',
 
-    return {
-      bundler: 'webpack',
+    pluginAPI,
 
-      pluginAPI,
+    publicContext: createPublicContext(context),
 
-      publicContext: createPublicContext(context),
+    async applyDefaultPlugins() {
+      pluginStore.addPlugins(await applyDefaultPlugins(plugins));
+    },
 
-      async applyDefaultPlugins() {
-        pluginStore.addPlugins(await applyDefaultPlugins(plugins));
-      },
+    async initConfigs() {
+      const { webpackConfigs } = await initConfigs({
+        context,
+        pluginStore,
+        rsbuildOptions,
+      });
+      return webpackConfigs;
+    },
 
-      async initConfigs() {
-        const { webpackConfigs } = await initConfigs({
+    async createCompiler() {
+      const { createCompiler } = await import('./core/createCompiler');
+      const { webpackConfigs } = await initConfigs({
+        context,
+        pluginStore,
+        rsbuildOptions,
+      });
+      return createCompiler({ context, webpackConfigs });
+    },
+
+    async getServerAPIs(options) {
+      const { getServerAPIs } = await import('@rsbuild/core/server');
+      const { createDevMiddleware } = await import('./core/createCompiler');
+      await initRsbuildConfig({ context, pluginStore });
+      return getServerAPIs(
+        { context, pluginStore, rsbuildOptions },
+        // @ts-expect-error compile type mismatch
+        createDevMiddleware,
+        options,
+      );
+    },
+
+    async startDevServer(options) {
+      const { startDevServer } = await import('@rsbuild/core/server');
+      const { createDevMiddleware } = await import('./core/createCompiler');
+      await initRsbuildConfig({
+        context,
+        pluginStore,
+      });
+      return startDevServer(
+        {
           context,
           pluginStore,
           rsbuildOptions,
-        });
-        return webpackConfigs;
-      },
+        },
+        // @ts-expect-error compile type mismatch
+        createDevMiddleware,
+        options,
+      );
+    },
 
-      async createCompiler() {
-        const { createCompiler } = await import('./core/createCompiler');
-        const { webpackConfigs } = await initConfigs({
-          context,
-          pluginStore,
-          rsbuildOptions,
-        });
-        return createCompiler({ context, webpackConfigs });
-      },
+    async preview(options?: PreviewServerOptions) {
+      const { startProdServer } = await import('@rsbuild/core/server');
+      await initRsbuildConfig({
+        context,
+        pluginStore,
+      });
+      return startProdServer(context, context.config, options);
+    },
 
-      async getServerAPIs(options) {
-        const { getServerAPIs } = await import('@rsbuild/core/server');
-        const { createDevMiddleware } = await import('./core/createCompiler');
-        await initRsbuildConfig({ context, pluginStore });
-        return getServerAPIs(
-          { context, pluginStore, rsbuildOptions },
-          // @ts-expect-error compile type mismatch
-          createDevMiddleware,
-          options,
-        );
-      },
+    async build(options) {
+      const { build: buildImpl, webpackBuild } = await import('./core/build');
+      return buildImpl(
+        { context, pluginStore, rsbuildOptions },
+        options,
+        webpackBuild,
+      );
+    },
 
-      async startDevServer(options) {
-        const { startDevServer } = await import('@rsbuild/core/server');
-        const { createDevMiddleware } = await import('./core/createCompiler');
-        await initRsbuildConfig({
-          context,
-          pluginStore,
-        });
-        return startDevServer(
-          {
-            context,
-            pluginStore,
-            rsbuildOptions,
-          },
-          // @ts-expect-error compile type mismatch
-          createDevMiddleware,
-          options,
-        );
-      },
-
-      async preview(options?: PreviewServerOptions) {
-        const { startProdServer } = await import('@rsbuild/core/server');
-        await initRsbuildConfig({
-          context,
-          pluginStore,
-        });
-        return startProdServer(context, context.config, options);
-      },
-
-      async build(options) {
-        const { build: buildImpl, webpackBuild } = await import('./core/build');
-        return buildImpl(
-          { context, pluginStore, rsbuildOptions },
-          options,
-          webpackBuild,
-        );
-      },
-
-      async inspectConfig(inspectOptions) {
-        const { inspectConfig } = await import('./core/inspectConfig');
-        return await inspectConfig({
-          context,
-          pluginStore,
-          rsbuildOptions,
-          inspectOptions,
-        });
-      },
-    };
+    async inspectConfig(inspectOptions) {
+      const { inspectConfig } = await import('./core/inspectConfig');
+      return await inspectConfig({
+        context,
+        pluginStore,
+        rsbuildOptions,
+        inspectOptions,
+      });
+    },
   };
-}
+};

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -72,7 +72,6 @@ export async function init({
     return await createRsbuild({
       cwd: root,
       rsbuildConfig: config,
-      provider: config.provider,
     });
   } catch (err) {
     if (isRestart) {

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -1,20 +1,8 @@
 import fs from 'fs';
 import { isAbsolute, join } from 'path';
-import {
-  color,
-  logger,
-  debounce,
-  type RsbuildConfig as BaseRsbuildConfig,
-} from '@rsbuild/shared';
+import { color, logger, debounce, type RsbuildConfig } from '@rsbuild/shared';
 import { getEnvFiles } from '../loadEnv';
 import { restartDevServer } from '../server/restart';
-
-export type RsbuildConfig = BaseRsbuildConfig & {
-  /**
-   * @private only for testing
-   */
-  provider?: any;
-};
 
 export type ConfigParams = {
   env: string;

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -40,10 +40,9 @@ export async function createRsbuild(
     startDevServer,
     applyDefaultPlugins,
   } = await provider({
-    pluginStore,
-    rsbuildConfig,
-    rsbuildOptions,
     plugins,
+    pluginStore,
+    rsbuildOptions,
   });
 
   debug('add default plugins');

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -14,13 +14,12 @@ const getRspackProvider = async () => {
 };
 
 export async function createRsbuild(
-  options: CreateRsbuildOptions & {
-    provider?: RsbuildProvider;
-  },
+  options: CreateRsbuildOptions,
 ): Promise<RsbuildInstance> {
   const { rsbuildConfig = {} } = options;
 
-  const provider = options.provider || (await getRspackProvider());
+  const provider = (rsbuildConfig.provider ||
+    (await getRspackProvider())) as RsbuildProvider;
 
   const rsbuildOptions: Required<CreateRsbuildOptions> = {
     cwd: process.cwd(),

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -7,29 +7,20 @@ import {
   type CreateRsbuildOptions,
 } from '@rsbuild/shared';
 import { plugins } from './plugins';
-import type { RsbuildConfig } from './types';
 
-const getRspackProvider = async (rsbuildConfig: RsbuildConfig) => {
+const getRspackProvider = async () => {
   const { rspackProvider } = await import('./provider');
-  return rspackProvider({
-    rsbuildConfig,
-  });
+  return rspackProvider;
 };
 
 export async function createRsbuild(
   options: CreateRsbuildOptions & {
-    provider?: ({
-      rsbuildConfig,
-    }: {
-      rsbuildConfig: RsbuildConfig;
-    }) => RsbuildProvider;
+    provider?: RsbuildProvider;
   },
 ): Promise<RsbuildInstance> {
   const { rsbuildConfig = {} } = options;
 
-  const provider = options.provider
-    ? options.provider({ rsbuildConfig })
-    : await getRspackProvider(rsbuildConfig as RsbuildConfig);
+  const provider = options.provider || (await getRspackProvider());
 
   const rsbuildOptions: Required<CreateRsbuildOptions> = {
     cwd: process.cwd(),
@@ -51,6 +42,7 @@ export async function createRsbuild(
     applyDefaultPlugins,
   } = await provider({
     pluginStore,
+    rsbuildConfig,
     rsbuildOptions,
     plugins,
   });

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -12,9 +12,8 @@ export const rspackProvider: RsbuildProvider = async ({
   pluginStore,
   rsbuildOptions,
   plugins,
-  rsbuildConfig: originalRsbuildConfig,
 }) => {
-  const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
+  const rsbuildConfig = pickRsbuildConfig(rsbuildOptions.rsbuildConfig);
 
   const context = await createContext(rsbuildOptions, rsbuildConfig, 'rspack');
   const pluginAPI = getPluginAPI({ context, pluginStore });

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -7,105 +7,99 @@ import { createContext, createPublicContext } from './core/createContext';
 import { initConfigs, initRsbuildConfig } from './core/initConfigs';
 import { getPluginAPI } from './core/initPlugins';
 import { applyDefaultPlugins } from './shared';
-import type { RsbuildConfig } from '../types';
 
-export function rspackProvider({
+export const rspackProvider: RsbuildProvider = async ({
+  pluginStore,
+  rsbuildOptions,
+  plugins,
   rsbuildConfig: originalRsbuildConfig,
-}: {
-  rsbuildConfig: RsbuildConfig;
-}): RsbuildProvider {
+}) => {
   const rsbuildConfig = pickRsbuildConfig(originalRsbuildConfig);
 
-  return async ({ pluginStore, rsbuildOptions, plugins }) => {
-    const context = await createContext(
-      rsbuildOptions,
-      rsbuildConfig,
-      'rspack',
-    );
-    const pluginAPI = getPluginAPI({ context, pluginStore });
+  const context = await createContext(rsbuildOptions, rsbuildConfig, 'rspack');
+  const pluginAPI = getPluginAPI({ context, pluginStore });
 
-    context.pluginAPI = pluginAPI;
+  context.pluginAPI = pluginAPI;
 
-    return {
-      bundler: 'rspack',
+  return {
+    bundler: 'rspack',
 
-      pluginAPI,
+    pluginAPI,
 
-      publicContext: createPublicContext(context),
+    publicContext: createPublicContext(context),
 
-      async applyDefaultPlugins() {
-        pluginStore.addPlugins(await applyDefaultPlugins(plugins));
-      },
+    async applyDefaultPlugins() {
+      pluginStore.addPlugins(await applyDefaultPlugins(plugins));
+    },
 
-      async createCompiler() {
-        const { createCompiler } = await import('./core/createCompiler');
-        const { rspackConfigs } = await initConfigs({
-          context,
-          pluginStore,
-          rsbuildOptions,
-        });
+    async createCompiler() {
+      const { createCompiler } = await import('./core/createCompiler');
+      const { rspackConfigs } = await initConfigs({
+        context,
+        pluginStore,
+        rsbuildOptions,
+      });
 
-        return createCompiler({
-          context,
-          rspackConfigs,
-        });
-      },
+      return createCompiler({
+        context,
+        rspackConfigs,
+      });
+    },
 
-      async getServerAPIs(options) {
-        const { getServerAPIs } = await import('../server/devServer');
-        const { createDevMiddleware } = await import('./core/createCompiler');
-        await initRsbuildConfig({ context, pluginStore });
-        return getServerAPIs(
-          { context, pluginStore, rsbuildOptions },
-          createDevMiddleware,
-          options,
-        );
-      },
+    async getServerAPIs(options) {
+      const { getServerAPIs } = await import('../server/devServer');
+      const { createDevMiddleware } = await import('./core/createCompiler');
+      await initRsbuildConfig({ context, pluginStore });
+      return getServerAPIs(
+        { context, pluginStore, rsbuildOptions },
+        createDevMiddleware,
+        options,
+      );
+    },
 
-      async startDevServer(options) {
-        const { startDevServer } = await import('../server/devServer');
-        const { createDevMiddleware } = await import('./core/createCompiler');
-        await initRsbuildConfig({ context, pluginStore });
-        return startDevServer(
-          { context, pluginStore, rsbuildOptions },
-          createDevMiddleware,
-          options,
-        );
-      },
+    async startDevServer(options) {
+      const { startDevServer } = await import('../server/devServer');
+      const { createDevMiddleware } = await import('./core/createCompiler');
+      await initRsbuildConfig({ context, pluginStore });
+      return startDevServer(
+        { context, pluginStore, rsbuildOptions },
+        createDevMiddleware,
+        options,
+      );
+    },
 
-      async preview(options?: PreviewServerOptions) {
-        const { startProdServer } = await import('../server/prodServer');
-        await initRsbuildConfig({ context, pluginStore });
-        return startProdServer(context, context.config, options);
-      },
+    async preview(options?: PreviewServerOptions) {
+      const { startProdServer } = await import('../server/prodServer');
+      await initRsbuildConfig({ context, pluginStore });
+      return startProdServer(context, context.config, options);
+    },
 
-      async build(options) {
-        const { build: buildImpl, rspackBuild } = await import('./core/build');
-        return buildImpl(
-          { context, pluginStore, rsbuildOptions },
-          options,
-          rspackBuild,
-        );
-      },
+    async build(options) {
+      const { build: buildImpl, rspackBuild } = await import('./core/build');
+      return buildImpl(
+        { context, pluginStore, rsbuildOptions },
+        options,
+        rspackBuild,
+      );
+    },
 
-      async initConfigs() {
-        const { rspackConfigs } = await initConfigs({
-          context,
-          pluginStore,
-          rsbuildOptions,
-        });
-        return rspackConfigs;
-      },
+    async initConfigs() {
+      const { rspackConfigs } = await initConfigs({
+        context,
+        pluginStore,
+        rsbuildOptions,
+      });
+      return rspackConfigs;
+    },
 
-      async inspectConfig(inspectOptions) {
-        const { inspectConfig } = await import('./core/inspectConfig');
-        return inspectConfig({
-          context,
-          pluginStore,
-          rsbuildOptions,
-          inspectOptions,
-        });
-      },
-    };
+    async inspectConfig(inspectOptions) {
+      const { inspectConfig } = await import('./core/inspectConfig');
+      return inspectConfig({
+        context,
+        pluginStore,
+        rsbuildOptions,
+        inspectOptions,
+      });
+    },
   };
-}
+};

--- a/packages/shared/src/types/config/index.ts
+++ b/packages/shared/src/types/config/index.ts
@@ -10,7 +10,7 @@ import type {
 } from './performance';
 import type { ToolsConfig, NormalizedToolsConfig } from './tools';
 import type { DeepReadonly } from '../utils';
-import type { RsbuildPlugin } from '..';
+import type { RsbuildPlugin, RsbuildProvider } from '..';
 
 /**
  * The shared Rsbuild config.
@@ -26,6 +26,7 @@ export interface RsbuildConfig {
   security?: SecurityConfig;
   performance?: PerformanceConfig;
   plugins?: RsbuildPlugin[];
+  provider?: RsbuildProvider<'rspack'> | RsbuildProvider<'webpack'>;
 }
 
 export type NormalizedConfig = DeepReadonly<{
@@ -38,6 +39,7 @@ export type NormalizedConfig = DeepReadonly<{
   security: NormalizedSecurityConfig;
   performance: NormalizedPerformanceConfig;
   plugins?: RsbuildPlugin[];
+  provider?: RsbuildProvider<'rspack'> | RsbuildProvider<'webpack'>;
 }>;
 
 export * from './dev';

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -5,7 +5,7 @@ import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { StartServerResult, DevServerAPIs } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
-import type { NormalizedConfig, RsbuildConfig } from './config';
+import type { NormalizedConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
 import type { RspackConfig } from './rspack';
 
@@ -51,10 +51,9 @@ export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {
 
 export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
   (options: {
-    pluginStore: PluginStore;
-    rsbuildConfig: RsbuildConfig;
-    rsbuildOptions: Required<CreateRsbuildOptions>;
     plugins: Plugins;
+    pluginStore: PluginStore;
+    rsbuildOptions: Required<CreateRsbuildOptions>;
   }) => Promise<ProviderInstance<B>>;
 
 export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -5,7 +5,7 @@ import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { StartServerResult, DevServerAPIs } from './server';
 import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
-import type { NormalizedConfig } from './config';
+import type { NormalizedConfig, RsbuildConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
 import type { RspackConfig } from './rspack';
 
@@ -52,6 +52,7 @@ export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {
 export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
   (options: {
     pluginStore: PluginStore;
+    rsbuildConfig: RsbuildConfig;
     rsbuildOptions: Required<CreateRsbuildOptions>;
     plugins: Plugins;
   }) => Promise<ProviderInstance<B>>;

--- a/packages/test-helper/src/rsbuild.ts
+++ b/packages/test-helper/src/rsbuild.ts
@@ -122,7 +122,6 @@ export async function createStubRsbuild<P extends RsbuildProvider>({
     initConfigs,
   } = await provider({
     pluginStore,
-    rsbuildConfig,
     rsbuildOptions,
     plugins: await getRsbuildPlugins(),
   });

--- a/packages/test-helper/src/rsbuild.ts
+++ b/packages/test-helper/src/rsbuild.ts
@@ -6,19 +6,14 @@ import type {
   CreateRsbuildOptions,
   BundlerPluginInstance,
 } from '@rsbuild/shared';
-import type { RsbuildConfig } from '@rsbuild/core';
 
-const getRspackProvider = async (rsbuildConfig: RsbuildConfig) => {
+const getRspackProvider = async () => {
   const { rspackProvider } = await import('@rsbuild/core/provider');
-
-  return rspackProvider({
-    rsbuildConfig,
-  });
+  return rspackProvider;
 };
 
 export const getRsbuildPlugins = async () => {
   const { plugins } = await import('@rsbuild/core/plugins/index');
-
   return plugins;
 };
 
@@ -73,13 +68,7 @@ export const matchPlugin = (config: RspackConfig, pluginName: string) => {
 /**
  * different with rsbuild createRsbuild. support add custom plugins instead of applyDefaultPlugins.
  */
-export async function createStubRsbuild<
-  P extends ({
-    rsbuildConfig,
-  }: {
-    rsbuildConfig: RsbuildConfig;
-  }) => RsbuildProvider,
->({
+export async function createStubRsbuild<P extends RsbuildProvider>({
   rsbuildConfig = {},
   plugins,
   ...options
@@ -88,7 +77,7 @@ export async function createStubRsbuild<
   plugins?: RsbuildPlugin[];
 }): Promise<
   Pick<
-    RsbuildInstance<ReturnType<P>>,
+    RsbuildInstance<P>,
     | 'build'
     | 'createCompiler'
     | 'inspectConfig'
@@ -119,8 +108,8 @@ export async function createStubRsbuild<
   }
 
   const provider = options.provider
-    ? options.provider({ rsbuildConfig })
-    : await getRspackProvider(rsbuildConfig as RsbuildConfig);
+    ? options.provider
+    : await getRspackProvider();
 
   const pluginStore = createPluginStore();
   const {
@@ -133,6 +122,7 @@ export async function createStubRsbuild<
     initConfigs,
   } = await provider({
     pluginStore,
+    rsbuildConfig,
     rsbuildOptions,
     plugins: await getRsbuildPlugins(),
   });


### PR DESCRIPTION
## Summary

Simplify provider params, no need to passing `rsbuildConfig` to the provider function any more.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
