### PR TITLE
test(ut): remove webpack provider in plugin tests

### DIFF
--- a/packages/plugin-image-compress/tests/index.test.ts
+++ b/packages/plugin-image-compress/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginAsset } from '@rsbuild/core/plugins/asset';
 import { pluginImageCompress } from '../src';
 
@@ -8,7 +7,6 @@ process.env.NODE_ENV = 'production';
 describe('plugin-image-compress', () => {
   it('should generate correct options', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [pluginAsset(), pluginImageCompress()],
     });
@@ -17,7 +15,6 @@ describe('plugin-image-compress', () => {
 
   it('should accept `...options: Options[]` as parameter', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [pluginAsset(), pluginImageCompress('jpeg', { use: 'png' })],
     });
@@ -44,7 +41,6 @@ describe('plugin-image-compress', () => {
 
   it('should accept `options: Options[]` as parameter', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [pluginAsset(), pluginImageCompress(['jpeg', { use: 'png' }])],
     });

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/webpack": "workspace:*",
     "typescript": "^5.3.0"
   },
   "publishConfig": {

--- a/packages/plugin-node-polyfill/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-node-polyfill/tests/__snapshots__/index.test.ts.snap
@@ -65,7 +65,7 @@ exports[`plugin-node-polyfill > should add node-polyfill config when use webpack
 {
   "plugins": [
     ProvidePlugin {
-      "definitions": {
+      "_options": {
         "Buffer": [
           "<ROOT>/node_modules/<PNPM_INNER>/buffer/index.js",
           "Buffer",
@@ -74,6 +74,7 @@ exports[`plugin-node-polyfill > should add node-polyfill config when use webpack
           "<ROOT>/node_modules/<PNPM_INNER>/process/browser.js",
         ],
       },
+      "name": "ProvidePlugin",
     },
   ],
   "resolve": {

--- a/packages/plugin-node-polyfill/tests/index.test.ts
+++ b/packages/plugin-node-polyfill/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginNodePolyfill } from '../src';
 
 describe('plugin-node-polyfill', () => {
@@ -15,7 +14,6 @@ describe('plugin-node-polyfill', () => {
   it('should add node-polyfill config when use webpack', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginNodePolyfill()],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const configs = await rsbuild.initConfigs();

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "@rsbuild/webpack": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '../src';
 
@@ -16,7 +15,6 @@ describe('plugin-solid', () => {
 
   it('should apply solid preset correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [pluginSolid(), pluginBabel()],
     });
@@ -27,7 +25,6 @@ describe('plugin-solid', () => {
 
   it('should allow to configure solid preset options', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [
         pluginSolid({

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -5,65 +5,102 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
   "module": {
     "rules": [
       {
-        "resolve": {
-          "preferRelative": true,
-        },
-        "sideEffects": true,
-        "test": /\\\\\\.styl\\(us\\)\\?\\$/,
-        "use": [
+        "oneOf": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/mini-css-extract-plugin/dist/loader.js",
-          },
-          {
-            "loader": "<ROOT>/packages/shared/compiled/css-loader",
-            "options": {
-              "importLoaders": 2,
-              "modules": {
-                "auto": true,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-              },
-              "sourceMap": false,
+            "resolve": {
+              "preferRelative": true,
             },
-          },
-          {
-            "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
-            "options": {
-              "postcssOptions": {
-                "plugins": [
-                  [Function],
-                  {
-                    "browsers": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
+            "sideEffects": true,
+            "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
+            "type": "css/module",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
+                "options": {
+                  "postcssOptions": {
+                    "plugins": [
+                      [Function],
+                      {
+                        "browsers": [
+                          "chrome >= 87",
+                          "edge >= 88",
+                          "firefox >= 78",
+                          "safari >= 14",
+                        ],
+                        "info": [Function],
+                        "options": {
+                          "flexbox": "no-2009",
+                          "overrideBrowserslist": [
+                            "chrome >= 87",
+                            "edge >= 88",
+                            "firefox >= 78",
+                            "safari >= 14",
+                          ],
+                        },
+                        "postcssPlugin": "autoprefixer",
+                        "prepare": [Function],
+                      },
                     ],
-                    "info": [Function],
-                    "options": {
-                      "flexbox": "no-2009",
-                      "overrideBrowserslist": [
-                        "chrome >= 87",
-                        "edge >= 88",
-                        "firefox >= 78",
-                        "safari >= 14",
-                      ],
-                    },
-                    "postcssPlugin": "autoprefixer",
-                    "prepare": [Function],
                   },
-                ],
+                  "sourceMap": false,
+                },
               },
-              "sourceMap": false,
-            },
+              {
+                "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
+                "options": {
+                  "sourceMap": false,
+                },
+              },
+            ],
           },
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
-            "options": {
-              "sourceMap": false,
+            "resolve": {
+              "preferRelative": true,
             },
+            "sideEffects": true,
+            "type": "css",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
+                "options": {
+                  "postcssOptions": {
+                    "plugins": [
+                      [Function],
+                      {
+                        "browsers": [
+                          "chrome >= 87",
+                          "edge >= 88",
+                          "firefox >= 78",
+                          "safari >= 14",
+                        ],
+                        "info": [Function],
+                        "options": {
+                          "flexbox": "no-2009",
+                          "overrideBrowserslist": [
+                            "chrome >= 87",
+                            "edge >= 88",
+                            "firefox >= 78",
+                            "safari >= 14",
+                          ],
+                        },
+                        "postcssPlugin": "autoprefixer",
+                        "prepare": [Function],
+                      },
+                    ],
+                  },
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
+                "options": {
+                  "sourceMap": false,
+                },
+              },
+            ],
           },
         ],
+        "test": /\\\\\\.styl\\(us\\)\\?\\$/,
       },
     ],
   },
@@ -75,68 +112,108 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
   "module": {
     "rules": [
       {
-        "resolve": {
-          "preferRelative": true,
-        },
-        "sideEffects": true,
-        "test": /\\\\\\.styl\\(us\\)\\?\\$/,
-        "use": [
+        "oneOf": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/mini-css-extract-plugin/dist/loader.js",
-          },
-          {
-            "loader": "<ROOT>/packages/shared/compiled/css-loader",
-            "options": {
-              "importLoaders": 2,
-              "modules": {
-                "auto": true,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-              },
-              "sourceMap": false,
+            "resolve": {
+              "preferRelative": true,
             },
-          },
-          {
-            "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
-            "options": {
-              "postcssOptions": {
-                "plugins": [
-                  [Function],
-                  {
-                    "browsers": [
-                      "chrome >= 87",
-                      "edge >= 88",
-                      "firefox >= 78",
-                      "safari >= 14",
+            "sideEffects": true,
+            "test": /\\\\\\.module\\\\\\.\\\\w\\+\\$/i,
+            "type": "css/module",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
+                "options": {
+                  "postcssOptions": {
+                    "plugins": [
+                      [Function],
+                      {
+                        "browsers": [
+                          "chrome >= 87",
+                          "edge >= 88",
+                          "firefox >= 78",
+                          "safari >= 14",
+                        ],
+                        "info": [Function],
+                        "options": {
+                          "flexbox": "no-2009",
+                          "overrideBrowserslist": [
+                            "chrome >= 87",
+                            "edge >= 88",
+                            "firefox >= 78",
+                            "safari >= 14",
+                          ],
+                        },
+                        "postcssPlugin": "autoprefixer",
+                        "prepare": [Function],
+                      },
                     ],
-                    "info": [Function],
-                    "options": {
-                      "flexbox": "no-2009",
-                      "overrideBrowserslist": [
-                        "chrome >= 87",
-                        "edge >= 88",
-                        "firefox >= 78",
-                        "safari >= 14",
-                      ],
-                    },
-                    "postcssPlugin": "autoprefixer",
-                    "prepare": [Function],
                   },
-                ],
+                  "sourceMap": false,
+                },
               },
-              "sourceMap": false,
-            },
+              {
+                "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
+                "options": {
+                  "sourceMap": false,
+                  "stylusOptions": {
+                    "lineNumbers": false,
+                  },
+                },
+              },
+            ],
           },
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
-            "options": {
-              "sourceMap": false,
-              "stylusOptions": {
-                "lineNumbers": false,
-              },
+            "resolve": {
+              "preferRelative": true,
             },
+            "sideEffects": true,
+            "type": "css",
+            "use": [
+              {
+                "loader": "<ROOT>/packages/shared/compiled/postcss-loader",
+                "options": {
+                  "postcssOptions": {
+                    "plugins": [
+                      [Function],
+                      {
+                        "browsers": [
+                          "chrome >= 87",
+                          "edge >= 88",
+                          "firefox >= 78",
+                          "safari >= 14",
+                        ],
+                        "info": [Function],
+                        "options": {
+                          "flexbox": "no-2009",
+                          "overrideBrowserslist": [
+                            "chrome >= 87",
+                            "edge >= 88",
+                            "firefox >= 78",
+                            "safari >= 14",
+                          ],
+                        },
+                        "postcssPlugin": "autoprefixer",
+                        "prepare": [Function],
+                      },
+                    ],
+                  },
+                  "sourceMap": false,
+                },
+              },
+              {
+                "loader": "<ROOT>/node_modules/<PNPM_INNER>/stylus-loader/dist/cjs.js",
+                "options": {
+                  "sourceMap": false,
+                  "stylusOptions": {
+                    "lineNumbers": false,
+                  },
+                },
+              },
+            ],
           },
         ],
+        "test": /\\\\\\.styl\\(us\\)\\?\\$/,
       },
     ],
   },

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -1,12 +1,10 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginStylus } from '../src';
 
 describe('plugin-stylus', () => {
   it('should add stylus loader config correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginStylus()],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const config = await rsbuild.unwrapConfig();
@@ -16,7 +14,6 @@ describe('plugin-stylus', () => {
 
   it('should allow to configure stylus options', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [
         pluginStylus({

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -34,7 +34,6 @@
     "@babel/core": "^7.23.2",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "@rsbuild/webpack": "workspace:*",
     "typescript": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/plugin-vue-jsx/tests/index.test.ts
+++ b/packages/plugin-vue-jsx/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVueJsx } from '../src';
 
@@ -16,7 +15,6 @@ describe('plugin-vue-jsx', () => {
 
   it('should apply jsx babel plugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [pluginVueJsx(), pluginBabel()],
     });
@@ -27,7 +25,6 @@ describe('plugin-vue-jsx', () => {
 
   it('should allow to configure jsx babel plugin options', async () => {
     const rsbuild = await createStubRsbuild({
-      provider: webpackProvider,
       rsbuildConfig: {},
       plugins: [
         pluginVueJsx({

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -35,7 +35,6 @@
     "@babel/core": "^7.23.2",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "@rsbuild/webpack": "workspace:*",
     "typescript": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/plugin-vue2-jsx/tests/index.test.ts
+++ b/packages/plugin-vue2-jsx/tests/index.test.ts
@@ -1,5 +1,4 @@
 import { createStubRsbuild } from '@rsbuild/test-helper';
-import { webpackProvider } from '@rsbuild/webpack';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginVue2Jsx } from '../src';
 
@@ -7,7 +6,6 @@ describe('plugin-vue2-jsx', () => {
   it('should apply jsx babel plugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginVue2Jsx(), pluginBabel()],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const config = await rsbuild.unwrapConfig();
@@ -25,7 +23,6 @@ describe('plugin-vue2-jsx', () => {
         }),
         pluginBabel(),
       ],
-      provider: webpackProvider,
       rsbuildConfig: {},
     });
     const config = await rsbuild.unwrapConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1248,9 +1248,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
-      '@rsbuild/webpack':
-        specifier: workspace:*
-        version: link:../compat/webpack
       typescript:
         specifier: ^5.3.0
         version: 5.3.2
@@ -1555,9 +1552,6 @@ importers:
       '@rsbuild/test-helper':
         specifier: workspace:*
         version: link:../test-helper
-      '@rsbuild/webpack':
-        specifier: workspace:*
-        version: link:../compat/webpack
       typescript:
         specifier: ^5.3.0
         version: 5.3.2
@@ -1605,9 +1599,6 @@ importers:
       '@rsbuild/test-helper':
         specifier: workspace:*
         version: link:../test-helper
-      '@rsbuild/webpack':
-        specifier: workspace:*
-        version: link:../compat/webpack
       typescript:
         specifier: ^5.3.0
         version: 5.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1348,9 +1348,6 @@ importers:
       '@rsbuild/test-helper':
         specifier: workspace:*
         version: link:../test-helper
-      '@rsbuild/webpack':
-        specifier: workspace:*
-        version: link:../compat/webpack
       '@types/babel__core':
         specifier: ^7.20.3
         version: 7.20.3


### PR DESCRIPTION
## Summary

Remove webpack provider in plugin tests because we do not need it.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
