### PR TITLE
fix(plugin-solid): delegateEvents should be optional

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-solid.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-solid.mdx
@@ -53,9 +53,7 @@ If you need to customize the compilation behavior of Solid, you can use the foll
 Options passed to `babel-preset-solid`, please refer to the [babel-preset-solid documentation](https://github.com/solidjs/solid/tree/main/packages/babel-preset-solid) for detailed usage.
 
 - **Type:** `Object`
-
 - **Default:** `{}`
-
 - **Example:**
 
 ```ts

--- a/packages/document/docs/zh/plugins/list/plugin-solid.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-solid.mdx
@@ -49,9 +49,7 @@ Babel 编译会产生额外的编译开销，在上述例子中，我们通过 `
 传递给 `babel-preset-solid` 的选项，请查阅 [babel-preset-solid 文档](https://github.com/solidjs/solid/tree/main/packages/babel-preset-solid) 来了解具体用法。
 
 - **类型：** `Object`
-
 - **默认值：** `{}`
-
 - **示例：**
 
 ```ts

--- a/packages/plugin-solid/src/types.ts
+++ b/packages/plugin-solid/src/types.ts
@@ -24,7 +24,7 @@ export type SolidPresetOptions = {
    * Boolean to indicate whether to enable automatic event delegation on camelCase.
    * @default true
    */
-  delegateEvents: boolean;
+  delegateEvents?: boolean;
   /**
    * Boolean indicates whether smart conditional detection should be used. This optimizes simple boolean expressions and ternaries in JSX.
    * @default true


### PR DESCRIPTION
## Summary

delegateEvents should be an optional property in the plugin-solid.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
