### PR TITLE
refactor(server): decouple startCompiler from getMiddlewares

### DIFF
--- a/e2e/cases/javascript-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/javascript-api/plugin-hooks/index.test.ts
@@ -67,9 +67,9 @@ test('should run plugin hooks correctly when running startDevServer', async () =
   const result = await rsbuild.startDevServer();
 
   expect(fse.readFileSync(distFile, 'utf-8').split(',')).toEqual([
+    'BeforeStartDevServer',
     'BeforeCreateCompiler',
     'AfterCreateCompiler',
-    'BeforeStartDevServer',
     'AfterStartDevServer',
   ]);
 

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { getHrefByEntryName } from '@scripts/shared';
 import { startDevServer } from './scripts/server.mjs';
+import { startDevServerPure } from './scripts/pure-server.mjs';
 
 test('custom server', async ({ page }) => {
   const { config, close } = await startDevServer(__dirname);
@@ -15,6 +16,28 @@ test('custom server', async ({ page }) => {
   const res = await page.goto(url1.href);
 
   expect(await res?.text()).toBe('Hello Express!');
+
+  await close();
+});
+
+test('custom server without compile', async ({ page }) => {
+  const { config, close } = await startDevServerPure(__dirname);
+
+  const indexRes = await page.goto(getHrefByEntryName('index', config.port));
+
+  expect(indexRes?.status()).toBe(404);
+
+  const url1 = new URL(`http://localhost:${config.port}/bbb`);
+
+  const res = await page.goto(url1.href);
+
+  expect(await res?.text()).toBe('Hello Express!');
+
+  const url2 = new URL(`http://localhost:${config.port}/test`);
+
+  const res2 = await page.goto(url2.href);
+
+  expect(await res2?.text()).toBe('Hello Express!');
 
   await close();
 });

--- a/e2e/cases/server/custom-server/package.json
+++ b/e2e/cases/server/custom-server/package.json
@@ -3,7 +3,8 @@
   "name": "@e2e/custom-server",
   "version": "1.0.0",
   "scripts": {
-    "dev": "node ./scripts/index.mjs"
+    "dev": "node ./scripts/index.mjs",
+    "dev:pure": "node ./scripts/index.mjs pure"
   },
   "dependencies": {
     "express": "^4.18.2"

--- a/e2e/cases/server/custom-server/scripts/index.mjs
+++ b/e2e/cases/server/custom-server/scripts/index.mjs
@@ -1,3 +1,10 @@
 import { startDevServer } from './server.mjs';
+import { startDevServerPure } from './pure-server.mjs';
 
-startDevServer(process.cwd());
+const isPure = process.argv[2] === 'pure';
+
+if (isPure) {
+  startDevServerPure(process.cwd());
+} else {
+  startDevServer(process.cwd());
+}

--- a/e2e/cases/server/custom-server/scripts/pure-server.mjs
+++ b/e2e/cases/server/custom-server/scripts/pure-server.mjs
@@ -3,13 +3,26 @@ import { pluginReact } from '@rsbuild/plugin-react';
 import { createRsbuild } from '@rsbuild/core';
 import express from 'express';
 
-export async function startDevServer(fixtures) {
+// startDevServer without compile
+export async function startDevServerPure(fixtures) {
   const rsbuild = await createRsbuild({
     cwd: fixtures,
     rsbuildConfig: {
       plugins: [pluginReact()],
       server: {
         htmlFallback: false,
+      },
+      dev: {
+        setupMiddlewares: [
+          (middlewares, server) => {
+            middlewares.unshift((req, res, next) => {
+              if (req.url === '/test') {
+                req.url = '/bbb';
+              }
+              next();
+            });
+          },
+        ],
       },
     },
   });
@@ -22,11 +35,7 @@ export async function startDevServer(fixtures) {
     config: { host, port },
   } = serverAPIs;
 
-  const compileMiddlewareAPI = await serverAPIs.startCompile();
-
-  const { middlewares, close, onUpgrade } = await serverAPIs.getMiddlewares({
-    compileMiddlewareAPI,
-  });
+  const { middlewares, close, onUpgrade } = await serverAPIs.getMiddlewares();
 
   app.get('/aaa', (_req, res) => {
     res.send('Hello World!');

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Socket } from 'net';
 import type {
-  RsbuildDevMiddlewareOptions,
+  DevMiddlewaresConfig,
   DevMiddlewareAPI,
   NextFunction,
   DevMiddleware as CustomDevMiddleware,
@@ -10,17 +10,15 @@ import { SocketServer } from './socketServer';
 
 type Options = {
   publicPaths: string[];
-  dev: RsbuildDevMiddlewareOptions['dev'];
-  devMiddleware?: CustomDevMiddleware;
+  dev: DevMiddlewaresConfig;
+  devMiddleware: CustomDevMiddleware;
 };
 
 const noop = () => {
   // noop
 };
 
-function getHMRClientPath(
-  client: RsbuildDevMiddlewareOptions['dev']['client'],
-) {
+function getHMRClientPath(client: DevMiddlewaresConfig['client']) {
   const protocol = client?.protocol ? `&protocol=${client.protocol}` : '';
   const host = client?.host ? `&host=${client.host}` : '';
   const path = client?.path ? `&path=${client.path}` : '';
@@ -40,11 +38,11 @@ function getHMRClientPath(
  * 2. establish webSocket connect
  */
 export class CompilerDevMiddleware {
-  public middleware?: DevMiddlewareAPI;
+  public middleware!: DevMiddlewareAPI;
 
-  private devOptions: RsbuildDevMiddlewareOptions['dev'];
+  private devOptions: DevMiddlewaresConfig;
 
-  private devMiddleware?: CustomDevMiddleware;
+  private devMiddleware: CustomDevMiddleware;
 
   private publicPaths: string[];
 
@@ -61,13 +59,11 @@ export class CompilerDevMiddleware {
   }
 
   public init() {
-    if (this.devMiddleware) {
-      // start compiling
-      this.middleware = this.setupDevMiddleware(
-        this.devMiddleware,
-        this.publicPaths,
-      );
-    }
+    // start compiling
+    this.middleware = this.setupDevMiddleware(
+      this.devMiddleware,
+      this.publicPaths,
+    );
 
     this.socketServer.prepare();
   }

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -3,23 +3,32 @@ import type {
   ServerAPIs,
   UpgradeEvent,
   RequestHandler,
-  RsbuildDevMiddlewareOptions,
+  DevMiddlewaresConfig,
+  CompileMiddlewareAPI,
 } from '@rsbuild/shared';
-import { CompilerDevMiddleware } from './compilerDevMiddleware';
 import {
   faviconFallbackMiddleware,
   getHtmlFallbackMiddleware,
 } from './middlewares';
 import { join, isAbsolute } from 'path';
 
+export type RsbuildDevMiddlewareOptions = {
+  pwd: string;
+  dev: DevMiddlewaresConfig;
+  compileMiddlewareAPI?: CompileMiddlewareAPI;
+  output: {
+    distPath: string;
+  };
+};
+
 const applySetupMiddlewares = (
   dev: RsbuildDevMiddlewareOptions['dev'],
-  devMiddleware: CompilerDevMiddleware,
+  compileMiddlewareAPI?: CompileMiddlewareAPI,
 ) => {
   const setupMiddlewares = dev.setupMiddlewares || [];
 
   const serverOptions: ServerAPIs = {
-    sockWrite: (type, data) => devMiddleware.sockWrite(type, data),
+    sockWrite: (type, data) => compileMiddlewareAPI?.sockWrite(type, data),
   };
 
   const before: RequestHandler[] = [];
@@ -41,7 +50,7 @@ const applySetupMiddlewares = (
 const applyDefaultMiddlewares = async ({
   middlewares,
   dev,
-  devMiddleware,
+  compileMiddlewareAPI,
   output,
   pwd,
 }: {
@@ -49,7 +58,7 @@ const applyDefaultMiddlewares = async ({
   pwd: RsbuildDevMiddlewareOptions['pwd'];
   middlewares: RequestHandler[];
   dev: RsbuildDevMiddlewareOptions['dev'];
-  devMiddleware: CompilerDevMiddleware;
+  compileMiddlewareAPI?: CompileMiddlewareAPI;
 }): Promise<{
   onUpgrade: UpgradeEvent;
 }> => {
@@ -97,11 +106,13 @@ const applyDefaultMiddlewares = async ({
     });
   }
 
-  // do rspack build / plugin apply / socket server when pass compiler instance
-  devMiddleware.init();
-  devMiddleware.middleware && middlewares.push(devMiddleware.middleware);
+  compileMiddlewareAPI?.middleware &&
+    middlewares.push(compileMiddlewareAPI.middleware);
   // subscribe upgrade event to handle websocket
-  upgradeEvents.push(devMiddleware.upgrade.bind(devMiddleware));
+  compileMiddlewareAPI?.onUpgrade &&
+    upgradeEvents.push(
+      compileMiddlewareAPI.onUpgrade.bind(compileMiddlewareAPI),
+    );
 
   if (dev.publicDir && dev.publicDir.name) {
     const { default: sirv } = await import('../../compiled/sirv');
@@ -121,7 +132,7 @@ const applyDefaultMiddlewares = async ({
   middlewares.push(
     getHtmlFallbackMiddleware({
       distPath: isAbsolute(distPath) ? distPath : join(pwd, distPath),
-      callback: devMiddleware.middleware,
+      callback: compileMiddlewareAPI?.middleware,
       htmlFallback: dev.htmlFallback,
     }),
   );
@@ -137,7 +148,8 @@ const applyDefaultMiddlewares = async ({
     middlewares.push(historyApiFallbackMiddleware);
 
     // ensure fallback request can be handled by webpack-dev-middleware
-    devMiddleware.middleware && middlewares.push(devMiddleware.middleware);
+    compileMiddlewareAPI?.middleware &&
+      middlewares.push(compileMiddlewareAPI.middleware);
   }
 
   middlewares.push(faviconFallbackMiddleware);
@@ -151,22 +163,20 @@ const applyDefaultMiddlewares = async ({
 
 export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
   const middlewares: RequestHandler[] = [];
-  // create dev middleware instance
-  const devMiddleware = new CompilerDevMiddleware({
-    dev: options.dev,
-    publicPaths: options.output.publicPaths,
-    devMiddleware: options.devMiddleware,
-  });
+  const { compileMiddlewareAPI } = options;
 
   // Order: setupMiddlewares.unshift => internal middlewares => setupMiddlewares.push
-  const { before, after } = applySetupMiddlewares(options.dev, devMiddleware);
+  const { before, after } = applySetupMiddlewares(
+    options.dev,
+    compileMiddlewareAPI,
+  );
 
   before.forEach((fn) => middlewares.push(fn));
 
   const { onUpgrade } = await applyDefaultMiddlewares({
     middlewares,
     dev: options.dev,
-    devMiddleware,
+    compileMiddlewareAPI,
     output: options.output,
     pwd: options.pwd,
   });
@@ -175,7 +185,7 @@ export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
 
   return {
     close: async () => {
-      devMiddleware.close();
+      compileMiddlewareAPI?.close();
     },
     onUpgrade,
     middlewares,

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -106,13 +106,14 @@ const applyDefaultMiddlewares = async ({
     });
   }
 
-  compileMiddlewareAPI?.middleware &&
+  if (compileMiddlewareAPI) {
     middlewares.push(compileMiddlewareAPI.middleware);
-  // subscribe upgrade event to handle websocket
-  compileMiddlewareAPI?.onUpgrade &&
+
+    // subscribe upgrade event to handle websocket
     upgradeEvents.push(
       compileMiddlewareAPI.onUpgrade.bind(compileMiddlewareAPI),
     );
+  }
 
   if (dev.publicDir && dev.publicDir.name) {
     const { default: sirv } = await import('../../compiled/sirv');
@@ -129,13 +130,14 @@ const applyDefaultMiddlewares = async ({
 
   const { distPath } = output;
 
-  middlewares.push(
-    getHtmlFallbackMiddleware({
-      distPath: isAbsolute(distPath) ? distPath : join(pwd, distPath),
-      callback: compileMiddlewareAPI?.middleware,
-      htmlFallback: dev.htmlFallback,
-    }),
-  );
+  compileMiddlewareAPI &&
+    middlewares.push(
+      getHtmlFallbackMiddleware({
+        distPath: isAbsolute(distPath) ? distPath : join(pwd, distPath),
+        callback: compileMiddlewareAPI.middleware,
+        htmlFallback: dev.htmlFallback,
+      }),
+    );
 
   if (dev.historyApiFallback) {
     const { default: connectHistoryApiFallback } = await import(

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -1,11 +1,7 @@
 import type { IncomingMessage } from 'http';
 import type { Socket } from 'net';
 import ws from '../../compiled/ws';
-import {
-  logger,
-  type Stats,
-  type RsbuildDevMiddlewareOptions,
-} from '@rsbuild/shared';
+import { logger, type Stats, type DevMiddlewaresConfig } from '@rsbuild/shared';
 
 interface ExtWebSocket extends ws {
   isAlive: boolean;
@@ -16,13 +12,13 @@ export class SocketServer {
 
   private readonly sockets: ws[] = [];
 
-  private readonly options: RsbuildDevMiddlewareOptions['dev'];
+  private readonly options: DevMiddlewaresConfig;
 
   private stats?: Stats;
 
   private timer: NodeJS.Timeout | null = null;
 
-  constructor(options: RsbuildDevMiddlewareOptions['dev']) {
+  constructor(options: DevMiddlewaresConfig) {
     this.options = options;
   }
 

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'http';
 import type { Socket } from 'net';
-import { DevConfig, NextFunction, RequestHandler } from './config/dev';
+import {
+  DevConfig,
+  NextFunction,
+  RequestHandler,
+  ServerAPIs,
+} from './config/dev';
 import { ServerConfig } from './config/server';
 import { Routes } from './hooks';
 import type { RspackCompiler, RspackMultiCompiler } from './rspack';
@@ -61,16 +66,6 @@ export type DevMiddlewaresConfig = Omit<
   | 'strictPort'
 >;
 
-export type RsbuildDevMiddlewareOptions = {
-  pwd: string;
-  dev: DevMiddlewaresConfig;
-  devMiddleware?: DevMiddleware;
-  output: {
-    distPath: string;
-    publicPaths: string[];
-  };
-};
-
 export type StartServerResult = {
   urls: string[];
   port: number;
@@ -79,11 +74,21 @@ export type StartServerResult = {
   };
 };
 
+/**
+ * It used to subscribe http upgrade event
+ */
 export type UpgradeEvent = (
   req: IncomingMessage,
   socket: Socket,
   head: any,
 ) => void;
+
+export type CompileMiddlewareAPI = {
+  middleware: RequestHandler;
+  sockWrite: ServerAPIs['sockWrite'];
+  onUpgrade: UpgradeEvent;
+  close: () => void;
+};
 
 export type DevServerAPIs = {
   /**
@@ -97,6 +102,10 @@ export type DevServerAPIs = {
     defaultRoutes: Routes;
   };
   /**
+   * Trigger rsbuild compile
+   */
+  startCompile: () => Promise<CompileMiddlewareAPI>;
+  /**
    * Trigger rsbuild onBeforeStartDevServer hook
    */
   beforeStart: () => Promise<void>;
@@ -109,7 +118,15 @@ export type DevServerAPIs = {
    *
    * Related config: proxy / publicDir / historyApiFallback / headers / ...
    */
-  getMiddlewares: (overrides?: RsbuildDevMiddlewareOptions['dev']) => Promise<{
+  getMiddlewares: (options?: {
+    compileMiddlewareAPI?: CompileMiddlewareAPI;
+    /**
+     * Overrides middleware configs
+     *
+     * By default, get config from rsbuild dev.xxx and server.xxx
+     */
+    overrides?: DevMiddlewaresConfig;
+  }) => Promise<{
     middlewares: RequestHandler[];
     close: () => Promise<void>;
     /**


### PR DESCRIPTION
## Summary

before: 
```ts
  // startCompile when calling serverAPIs.getMiddlewares(
  const { middlewares, close, onUpgrade } = await serverAPIs.getMiddlewares();
```

after:
```ts
  const compileMiddlewareAPI = await serverAPIs.startCompile();

  const { middlewares, close, onUpgrade } = await serverAPIs.getMiddlewares({
    compileMiddlewareAPI,
  });
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
