### PR TITLE
chore(workflow): remove registry in npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-registry = 'https://registry.npmjs.org/'
 strict-peer-dependencies=false


### PR DESCRIPTION
## Summary

Remove registry in npmrc as the npm registry is blocked in some regions of China.

(And pnpm do not write registry to lock file)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
