### PR TITLE
feat: allow to read htmlWebpackPlugin.options.title in template

### DIFF
--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -57,6 +57,26 @@ test('should generate title correctly when using custom HTML template', async ()
   expect(html).toContain('<title>foo</title>');
 });
 
+test('should generate title correctly when using htmlWebpackPlugin.options.title', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      source: {
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
+      },
+      html: {
+        title: 'foo',
+        template: path.resolve(__dirname, './src/plugin-options-title.html'),
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  expect(html).toContain('<title>foo</title>');
+});
+
 test('should generate title via function correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/e2e/cases/html/title/src/plugin-options-title.html
+++ b/e2e/cases/html/title/src/plugin-options-title.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<head>
+  <title><%= htmlWebpackPlugin.options.title %></title>
+</head>
+</html>

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -43,6 +43,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "scriptLoading": "defer",
       "template": "<ROOT>/packages/core/static/template.html",
       "templateParameters": [Function],
+      "title": "Rsbuild App",
     },
     "version": 5,
   },
@@ -50,9 +51,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
     "name": "HtmlBasicPlugin",
     "options": {
       "info": {
-        "index": {
-          "title": "Rsbuild App",
-        },
+        "index": {},
       },
     },
   },

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -445,6 +445,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -452,9 +453,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -979,6 +978,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -986,9 +986,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -277,7 +277,7 @@ export const pluginHtml = (): RsbuildPlugin => ({
 
             const title = getTitle(entryName, config);
             if (title) {
-              htmlInfo.title = title;
+              pluginOptions.title = title;
             }
 
             const favicon = getFavicon(entryName, config);

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -2,7 +2,6 @@ import HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { Compiler, Compilation } from '@rspack/core';
 
 export type HtmlInfo = {
-  title?: string;
   favicon?: string;
   templateContent?: string;
 };
@@ -27,9 +26,8 @@ export class HtmlBasicPlugin {
   apply(compiler: Compiler) {
     const addTitleTag = (
       headTags: HtmlWebpackPlugin.HtmlTagObject[],
-      entryName: string,
+      title?: string,
     ) => {
-      const { title } = this.options.info[entryName];
       if (title) {
         headTags.unshift({
           tagName: 'title',
@@ -74,7 +72,7 @@ export class HtmlBasicPlugin {
           const { templateContent } = this.options.info[entryName];
 
           if (!hasTitle(templateContent)) {
-            addTitleTag(headTags, entryName);
+            addTitleTag(headTags, data.plugin.options?.title);
           }
 
           addFavicon(headTags, entryName);

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -646,6 +646,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -653,9 +654,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },

--- a/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
@@ -29,6 +29,7 @@ exports[`plugin-html > should add one tags plugin instance 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -50,6 +51,7 @@ exports[`plugin-html > should add one tags plugin instance 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -57,12 +59,8 @@ exports[`plugin-html > should add one tags plugin instance 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "foo": {
-            "title": "Rsbuild App",
-          },
-          "main": {
-            "title": "Rsbuild App",
-          },
+          "foo": {},
+          "main": {},
         },
       },
     },
@@ -118,6 +116,7 @@ exports[`plugin-html > should add tags plugin instances for each entries 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -139,6 +138,7 @@ exports[`plugin-html > should add tags plugin instances for each entries 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -146,12 +146,8 @@ exports[`plugin-html > should add tags plugin instances for each entries 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "foo": {
-            "title": "Rsbuild App",
-          },
-          "main": {
-            "title": "Rsbuild App",
-          },
+          "foo": {},
+          "main": {},
         },
       },
     },
@@ -221,9 +217,7 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -258,6 +252,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -265,9 +260,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -301,6 +294,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -308,9 +302,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -363,6 +355,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -370,9 +363,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -406,6 +397,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -413,9 +405,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -452,6 +442,7 @@ exports[`plugin-html > should support multi entry 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -473,6 +464,7 @@ exports[`plugin-html > should support multi entry 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -480,12 +472,8 @@ exports[`plugin-html > should support multi entry 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "foo": {
-            "title": "Rsbuild App",
-          },
-          "main": {
-            "title": "Rsbuild App",
-          },
+          "foo": {},
+          "main": {},
         },
       },
     },

--- a/packages/core/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
@@ -45,6 +45,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineScrip
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -52,9 +53,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineScrip
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -119,6 +118,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineStyle
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -126,9 +126,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineStyle
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -646,6 +646,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -653,9 +654,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -1374,6 +1373,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -1381,9 +1381,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },
@@ -2516,6 +2514,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -2523,9 +2522,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -684,6 +684,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
         "scriptLoading": "defer",
         "template": "<ROOT>/packages/core/static/template.html",
         "templateParameters": [Function],
+        "title": "Rsbuild App",
       },
       "version": 5,
     },
@@ -691,9 +692,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "name": "HtmlBasicPlugin",
       "options": {
         "info": {
-          "index": {
-            "title": "Rsbuild App",
-          },
+          "index": {},
         },
       },
     },


### PR DESCRIPTION
## Summary

Allow to read htmlWebpackPlugin.options.title in template.

Compatible with the html-webpack-plugin official usage:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/ae6e2d56-896e-473d-b405-243452cc1fe4)

## Related Links

https://github.com/jantimon/html-webpack-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
