### PR TITLE
test(e2e): fix globContentJSON failed in Windows

### DIFF
--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -27,11 +27,10 @@ test('should inline style when injectStyles is true', async ({ page }) => {
   const indexJsFile = Object.keys(files).find(
     (file) => file.includes('index.') && file.endsWith('.js'),
   )!;
-  expect(
-    files[indexJsFile].includes(
-      'html,\\nbody {\\n  padding: 0;\\n  margin: 0;\\n}\\n\\n* {\\n  -webkit-font-smoothing: antialiased;\\n  -moz-osx-font-smoothing: grayscale;\\n  box-sizing: border-box;\\n}\\n\\n.description {\\n  text-align: center;\\n  line-height: 1.5;\\n  font-size: 16px;',
-    ),
-  ).toBeTruthy();
+
+  expect(files[indexJsFile].includes('padding: 0;')).toBeTruthy();
+  expect(files[indexJsFile].includes('margin: 0;')).toBeTruthy();
+  expect(files[indexJsFile].includes('text-align: center;')).toBeTruthy();
 
   // scss worked
   const header = page.locator('#header');

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,7 +1,10 @@
 import { join } from 'path';
 import { test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import glob, { Options as GlobOptions } from 'fast-glob';
+import glob, {
+  convertPathToPattern,
+  type Options as GlobOptions,
+} from 'fast-glob';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 
@@ -25,7 +28,11 @@ export const webpackOnlyTest = getProviderTest(['webpack']);
 export const rspackOnlyTest = getProviderTest(['rspack']);
 
 export const globContentJSON = async (path: string, options?: GlobOptions) => {
-  const files = await glob(join(path, '**/*'), options);
+  const files = await glob(
+    // https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
+    convertPathToPattern(join(path, '**/*')),
+    options,
+  );
   const ret: Record<string, string> = {};
 
   for await (const file of files) {

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,10 +1,8 @@
 import { join } from 'path';
 import { test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import glob, {
-  convertPathToPattern,
-  type Options as GlobOptions,
-} from 'fast-glob';
+import glob, { type Options as GlobOptions } from 'fast-glob';
+import { normalizeToPosixPath } from '@rsbuild/test-helper';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 
@@ -29,8 +27,8 @@ export const rspackOnlyTest = getProviderTest(['rspack']);
 
 export const globContentJSON = async (path: string, options?: GlobOptions) => {
   const files = await glob(
-    // https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
-    convertPathToPattern(join(path, '**/*')),
+    // fast-glob only accepts posix path
+    normalizeToPosixPath(join(path, '**/*')),
     options,
   );
   const ret: Record<string, string> = {};

--- a/packages/test-helper/src/index.ts
+++ b/packages/test-helper/src/index.ts
@@ -5,6 +5,8 @@ import {
   PathMatcher,
 } from './pathSerializer';
 
+export { normalizeToPosixPath } from './path';
+
 export interface SnapshotSerializerOptions {
   cwd?: string;
   workspace?: string;


### PR DESCRIPTION
## Summary

Fix globContentJSON failed in Windows, use `convertPathToPattern` to format the glob pattern.

## Related Links

https://github.com/mrmlnc/fast-glob#convertpathtopatternpath

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
