### PR TITLE
types(plugin-vue): fix SplitChunks typing error

### DIFF
--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -48,7 +48,7 @@ export const applySplitChunksRule = (
     chain.optimization.splitChunks({
       ...currentConfig,
       cacheGroups: {
-        ...(currentConfig as SplitChunks).cacheGroups,
+        ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),
       },
     });

--- a/packages/plugin-vue2/src/splitChunks.ts
+++ b/packages/plugin-vue2/src/splitChunks.ts
@@ -41,7 +41,7 @@ export const applySplitChunksRule = (
     chain.optimization.splitChunks({
       ...currentConfig,
       cacheGroups: {
-        ...(currentConfig as SplitChunks).cacheGroups,
+        ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),
       },
     });


### PR DESCRIPTION
## Summary

Fix SplitChunks typing error, should exclude the `false` type manually.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
