### PR TITLE
fix: failed to inspect rsbuild config

### DIFF
--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -145,6 +145,7 @@ export const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
 
 export async function outputInspectConfigFiles({
   rsbuildConfig,
+  rawRsbuildConfig,
   bundlerConfigs,
   inspectOptions,
   configType,
@@ -163,7 +164,7 @@ export async function outputInspectConfigFiles({
     {
       path: join(outputPath, 'rsbuild.config.js'),
       label: 'Rsbuild Config',
-      content: rsbuildConfig,
+      content: rawRsbuildConfig,
     },
     ...bundlerConfigs.map((content, index) => {
       const suffix = rsbuildConfig.output.targets[index];


### PR DESCRIPTION
## Summary

It may be need to refactor the implementation of `outputInspectConfigFiles`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
