### PR TITLE
fix: always use postcss-load-config to load external config

### DIFF
--- a/packages/document/docs/en/config/tools/postcss.mdx
+++ b/packages/document/docs/en/config/tools/postcss.mdx
@@ -5,7 +5,6 @@
 
 ```js
 const defaultOptions = {
-  config: false,
   postcssOptions: {
     plugins: [
       require('postcss-flexbugs-fixes'),
@@ -17,6 +16,8 @@ const defaultOptions = {
 ```
 
 Rsbuild integrates PostCSS by default, you can configure [postcss-loader](https://github.com/webpack-contrib/postcss-loader) through `tools.postcss`.
+
+Note that, for performance, Rsbuild uses [postcss-load-config](https://github.com/postcss/postcss-load-config) to load external config files and merges them with the default config.
 
 ### Function Type
 

--- a/packages/document/docs/zh/config/tools/postcss.mdx
+++ b/packages/document/docs/zh/config/tools/postcss.mdx
@@ -5,7 +5,6 @@
 
 ```js
 const defaultOptions = {
-  config: false,
   postcssOptions: {
     plugins: [
       require('postcss-flexbugs-fixes'),
@@ -17,6 +16,8 @@ const defaultOptions = {
 ```
 
 Rsbuild 默认集成 PostCSS，你可以通过 `tools.postcss` 对 [postcss-loader](https://github.com/webpack-contrib/postcss-loader) 进行配置。
+
+注意，出于性能的考虑，Rsbuild 使用 [postcss-load-config](https://github.com/postcss/postcss-load-config) 加载外部配置文件，并将其和默认配置合并。
 
 ### Function 类型
 

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -143,6 +143,10 @@ export const getPostcssLoaderOptions = async ({
     mergedConfig?.postcssOptions?.plugins!.push(...extraPlugins);
   }
 
+  // always use postcss-load-config to load external config
+  mergedConfig.postcssOptions ||= {};
+  mergedConfig.postcssOptions.config = false;
+
   return mergedConfig;
 };
 


### PR DESCRIPTION
## Summary
always use `postcss-load-config` to load external config

## Related Links

<!--- Provide links of related issues or pages -->
relate #947 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
