### PR TITLE
docs: make default entry config clearer

### DIFF
--- a/packages/document/docs/en/config/source/entry.mdx
+++ b/packages/document/docs/en/config/source/entry.mdx
@@ -10,7 +10,8 @@ type Entry = Record<string, string | string[]>;
 
 ```ts
 const defaultEntry = {
-  index: 'src/index.(ts|js|tsx|jsx|mjs|cjs)',
+  // default support for other suffixes such as ts, tsx, jsx, mjs, cjs
+  index: 'src/index.js',
 };
 ```
 
@@ -45,3 +46,5 @@ The generated directory structure is as follows:
         ├── foo.js
         └── bar.js
 ```
+
+If you do not need to generate HTML files, you can set [tools.htmlPlugin](/config/tools/html-plugin) to `false` to disable this behavior.

--- a/packages/document/docs/zh/config/source/entry.mdx
+++ b/packages/document/docs/zh/config/source/entry.mdx
@@ -10,7 +10,8 @@ type Entry = Record<string, string | string[]>;
 
 ```ts
 const defaultEntry = {
-  index: 'src/index.(ts|js|tsx|jsx|mjs|cjs)',
+  // 默认支持其他后缀，如 ts、tsx、jsx、mjs、cjs
+  index: 'src/index.js',
 };
 ```
 
@@ -45,3 +46,5 @@ export default {
         ├── foo.js
         └── bar.js
 ```
+
+如果你不需要生成 HTML 文件，可以将 [tools.htmlPlugin](/config/tools/html-plugin) 设置为 `false` 来禁用这一行为。


### PR DESCRIPTION
## Summary

Make default entry config clearer. This current default value is kind of confusing.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
