### PR TITLE
fix(startUrl): fallback to node.js open if applescript failed

### DIFF
--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -59,11 +59,10 @@ export async function openBrowser(url: string): Promise<boolean> {
 
         return true;
       }
-      return false;
+      logger.debug('Failed to find the target browser.');
     } catch (err) {
-      logger.error('Failed to open start URL with apple script.');
-      logger.error(err);
-      return false;
+      logger.debug('Failed to open start URL with apple script.');
+      logger.debug(err);
     }
   }
 


### PR DESCRIPTION
## Summary

applescript may fail in some cases, such as:

1. unknown reason:
![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/43c1a2ae-462a-4773-8843-0425b68c7323)

2. no permission:
![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/e7cd3ff9-c544-4910-bf8c-6b39721dcaa3)


Rsbuild will fallback to node.js `open` package if applescript failed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
