### PR TITLE
feat: support get target in tools.postcss

### DIFF
--- a/packages/compat/webpack/src/plugins/css.ts
+++ b/packages/compat/webpack/src/plugins/css.ts
@@ -116,6 +116,7 @@ export async function applyBaseCSSRule({
       browserslist,
       config,
       root: context.rootPath,
+      target,
     });
 
     rule

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -124,6 +124,7 @@ export async function applyBaseCSSRule({
       browserslist,
       config,
       root: context.rootPath,
+      target,
     });
 
     rule

--- a/packages/document/docs/en/config/tools/bundler-chain.mdx
+++ b/packages/document/docs/en/config/tools/bundler-chain.mdx
@@ -55,7 +55,7 @@ export default {
 
 #### target
 
-- **Type:** `'web' | 'node' | 'web-worker'`
+- **Type:** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 The `target` parameter can be used to determine the current environment. For example:
 

--- a/packages/document/docs/en/config/tools/postcss.mdx
+++ b/packages/document/docs/en/config/tools/postcss.mdx
@@ -110,7 +110,7 @@ Rsbuild uses the PostCSS v8 version. When you use third-party PostCSS plugins, p
 
 #### target
 
-- **Type:** `'web' | 'node' | 'web-worker'`
+- **Type:** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 The `target` parameter can be used to determine the current target. For example:
 

--- a/packages/document/docs/en/config/tools/postcss.mdx
+++ b/packages/document/docs/en/config/tools/postcss.mdx
@@ -107,3 +107,22 @@ export default {
 :::tip
 Rsbuild uses the PostCSS v8 version. When you use third-party PostCSS plugins, please pay attention to whether the PostCSS version is compatible. Some legacy plugins may not work in PostCSS v8.
 :::
+
+#### target
+
+- **Type:** `'web' | 'node' | 'web-worker'`
+
+The `target` parameter can be used to determine the current target. For example:
+
+```js
+export default {
+  tools: {
+    postcss: (config, { target }) => {
+      if (target === 'node') {
+        // ...
+      }
+      return config;
+    },
+  },
+};
+```

--- a/packages/document/docs/en/config/tools/rspack.mdx
+++ b/packages/document/docs/en/config/tools/rspack.mdx
@@ -89,7 +89,7 @@ export default {
 
 #### target
 
-- **Type:** `'web' | 'node' | 'web-worker'`
+- **Type:** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 The `target` parameter can be used to determine the current target. For example:
 

--- a/packages/document/docs/zh/config/tools/bundler-chain.mdx
+++ b/packages/document/docs/zh/config/tools/bundler-chain.mdx
@@ -58,7 +58,7 @@ export default {
 
 #### target
 
-- **类型：** `'web' | 'node' | 'web-worker'`
+- **类型：** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 通过 target 参数可以判断当前构建的目标运行时环境。比如：
 

--- a/packages/document/docs/zh/config/tools/postcss.mdx
+++ b/packages/document/docs/zh/config/tools/postcss.mdx
@@ -107,3 +107,21 @@ export default {
 :::tip
 Rsbuild 中使用的 PostCSS 版本为 v8，当你引入社区中的 PostCSS 插件时，请注意版本是否适配，部分旧版本插件可能无法在 PostCSS v8 下运行。
 :::
+
+#### target
+
+- **类型：** `'web' | 'node' | 'web-worker'`
+
+通过 target 参数可以判断当前构建的目标运行时环境。比如：
+
+```js
+export default {
+  tools: {
+    postcss: (config, { target }) => {
+      if (target === 'node') {
+        // ...
+      }
+    },
+  },
+};
+```

--- a/packages/document/docs/zh/config/tools/postcss.mdx
+++ b/packages/document/docs/zh/config/tools/postcss.mdx
@@ -110,7 +110,7 @@ Rsbuild 中使用的 PostCSS 版本为 v8，当你引入社区中的 PostCSS 插
 
 #### target
 
-- **类型：** `'web' | 'node' | 'web-worker'`
+- **类型：** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 通过 target 参数可以判断当前构建的目标运行时环境。比如：
 

--- a/packages/document/docs/zh/config/tools/rspack.mdx
+++ b/packages/document/docs/zh/config/tools/rspack.mdx
@@ -89,7 +89,7 @@ export default {
 
 #### target
 
-- **类型：** `'web' | 'node' | 'web-worker'`
+- **类型：** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
 通过 target 参数可以判断当前构建的目标运行时环境。比如：
 

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -91,10 +91,12 @@ export const getPostcssLoaderOptions = async ({
   browserslist,
   config,
   root,
+  target,
 }: {
   browserslist: string[];
   config: NormalizedConfig;
   root: string;
+  target: RsbuildTarget;
 }): Promise<PostCSSLoaderOptions> => {
   const extraPlugins: AcceptedPlugin[] = [];
 
@@ -106,6 +108,7 @@ export const getPostcssLoaderOptions = async ({
         extraPlugins.push(plugins);
       }
     },
+    target,
   };
 
   const autoprefixerOptions = mergeChainedOptions({

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -22,6 +22,7 @@ import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
 import type { RspackConfig, RspackRule } from '../rspack';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
 import type { BundlerPluginInstance } from '../bundlerConfig';
+import type { RsbuildTarget } from '../rsbuild';
 import type {
   ModifyWebpackChainUtils,
   ModifyWebpackConfigUtils,
@@ -47,7 +48,10 @@ export type ToolsBundlerChainConfig = ArrayOrNot<
 
 export type ToolsPostCSSLoaderConfig = ChainedConfigWithUtils<
   PostCSSLoaderOptions,
-  { addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void }
+  {
+    addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void;
+    target: RsbuildTarget;
+  }
 >;
 
 export type ToolsCSSLoaderConfig = ChainedConfig<CSSLoaderOptions>;


### PR DESCRIPTION
## Summary

sometimes, user need to judge the build environment by target when they want to add plugins.
 
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
