### PR TITLE
fix(plugin-rem): complete postcss-pxtorem import path

### DIFF
--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -31,7 +31,7 @@ export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
 
         // handle css
         const { default: PxToRemPlugin } = (await import(
-          '../compiled/postcss-pxtorem'
+          '../compiled/postcss-pxtorem/index.js'
         )) as {
           default: (_opts: PxToRemOptions) => any;
         };


### PR DESCRIPTION
## Summary

postcss-pxtorem import error in some cases:

<img width="738" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/7a8bc87f-e04e-4dc8-afb8-0eefddc0ccd6">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
