### PR TITLE
test(e2e): adjust port range to avoid permission denied

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -75,29 +75,30 @@ export const createRsbuild = async (
 };
 
 function isPortAvailable(port: number) {
-  const server = net.createServer().listen(port);
-  return new Promise((resolve, reject) => {
-    server.on('listening', () => {
-      server.close();
-      resolve(true);
-    });
+  try {
+    const server = net.createServer().listen(port);
+    return new Promise((resolve) => {
+      server.on('listening', () => {
+        server.close();
+        resolve(true);
+      });
 
-    server.on('error', (err: { code: string }) => {
-      if (err.code === 'EADDRINUSE') {
+      server.on('error', () => {
         resolve(false);
-      } else {
-        reject(err);
-      }
+      });
     });
-  });
+  } catch (err) {
+    return false;
+  }
 }
 
 const portMap = new Map();
 
 // Available port ranges: 1024 ～ 65535
-// `10080` is not available in CI, so we start with `11000`.
+// `10080` is not available in macOS CI, `> 50000` get 'permission denied' in Windows.
+// so we use `15000` ~ `45000`.
 export async function getRandomPort(
-  defaultPort = Math.ceil(Math.random() * 50000) + 11000,
+  defaultPort = Math.ceil(Math.random() * 30000) + 15000,
 ) {
   let port = defaultPort;
   while (true) {


### PR DESCRIPTION
## Summary

Adjust port range to avoid permission denied error in Windows:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/85ed6333-a696-4499-8d04-13718bb05580)

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/7249576923/job/19747831590

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
