### PR TITLE
fix: allow setting empty title to override default title

### DIFF
--- a/.changeset/strong-pianos-cheer.md
+++ b/.changeset/strong-pianos-cheer.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix: allow setting empty title to override default title

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -18,6 +18,25 @@ test('should generate default title correctly', async () => {
   expect(html).toContain('<title>Rsbuild App</title>');
 });
 
+test('should allow setting empty title to override default title', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      source: {
+        entry: { foo: path.resolve(__dirname, './src/foo.js') },
+      },
+      html: {
+        title: '',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  expect(html).toContain('<title></title>');
+});
+
 test('should generate title correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -275,10 +275,7 @@ export const pluginHtml = (): RsbuildPlugin => ({
               htmlInfo.templateContent = templateContent;
             }
 
-            const title = getTitle(entryName, config);
-            if (title) {
-              pluginOptions.title = title;
-            }
+            pluginOptions.title = getTitle(entryName, config);
 
             const favicon = getFavicon(entryName, config);
             if (favicon) {

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -26,17 +26,15 @@ export class HtmlBasicPlugin {
   apply(compiler: Compiler) {
     const addTitleTag = (
       headTags: HtmlWebpackPlugin.HtmlTagObject[],
-      title?: string,
+      title = '',
     ) => {
-      if (title) {
-        headTags.unshift({
-          tagName: 'title',
-          innerHTML: title,
-          attributes: {},
-          voidTag: false,
-          meta: {},
-        });
-      }
+      headTags.unshift({
+        tagName: 'title',
+        innerHTML: title,
+        attributes: {},
+        voidTag: false,
+        meta: {},
+      });
     };
 
     const addFavicon = (


### PR DESCRIPTION
## Summary

Allow setting empty title to override the default title of html-webpack-plugin ('Webpack App').

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
