### PR TITLE
fix: get available port for a specified host

### DIFF
--- a/packages/shared/src/port.ts
+++ b/packages/shared/src/port.ts
@@ -9,17 +9,19 @@ import { logger } from './logger';
  * @param strictPort - Whether to throw an error when the port is occupied.
  * @returns Available port number.
  */
-export const getPort = async (
-  port: string | number,
-  strictPort: boolean = false,
-  {
-    tryLimits = 20,
-    silent = false,
-  }: {
-    tryLimits?: number;
-    silent?: boolean;
-  } = {},
-): Promise<number> => {
+export const getPort = async ({
+  host,
+  port,
+  strictPort,
+  tryLimits = 20,
+  silent = false,
+}: {
+  host: string;
+  port: string | number;
+  strictPort: boolean;
+  tryLimits?: number;
+  silent?: boolean;
+}): Promise<number> => {
   if (typeof port === 'string') {
     port = parseInt(port, 10);
   }
@@ -38,16 +40,10 @@ export const getPort = async (
         const server = net.createServer();
         server.unref();
         server.on('error', reject);
-        server.listen(
-          {
-            port,
-            host: '0.0.0.0',
-          },
-          () => {
-            found = true;
-            server.close(resolve);
-          },
-        );
+        server.listen({ port, host }, () => {
+          found = true;
+          server.close(resolve);
+        });
       });
     } catch (e: any) {
       if (e.code !== 'EADDRINUSE') {

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -108,15 +108,13 @@ export const getServerOptions = async ({
   rsbuildConfig: RsbuildConfig;
   getPortSilently?: boolean;
 }) => {
-  const port = await getPort(
-    rsbuildConfig.server?.port || DEFAULT_PORT,
-    rsbuildConfig.server?.strictPort || false,
-    {
-      silent: getPortSilently,
-    },
-  );
-
   const host = rsbuildConfig.server?.host || DEFAULT_DEV_HOST;
+  const port = await getPort({
+    host,
+    port: rsbuildConfig.server?.port || DEFAULT_PORT,
+    strictPort: rsbuildConfig.server?.strictPort || false,
+    silent: getPortSilently,
+  });
 
   const https = Boolean(rsbuildConfig.server?.https) || false;
 


### PR DESCRIPTION
## Summary

The original way of passing parameters was not easily extensible. Now, they are merged into one object for passing.


## Related Links

#1000 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
