### PR TITLE
fix(plugin-html): `inject: false` should behave as expected

### DIFF
--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -28,6 +28,8 @@ test('injection script order should be as expected', async () => {
     html.indexOf('/js/convert-rem') < html.indexOf('/js/index'),
   ).toBeTruthy();
   expect(html.indexOf('/js/index') < html.indexOf('/assets/a.js')).toBeTruthy();
+
+  expect(html.indexOf('/js/index')).toBe(html.lastIndexOf('/js/index'));
 });
 
 test('should set inject via function correctly', async () => {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -11,6 +11,7 @@ import {
   isHtmlDisabled,
   removeTailSlash,
   mergeChainedOptions,
+  isNil,
 } from '@rsbuild/shared';
 import type {
   HtmlConfig,
@@ -38,6 +39,7 @@ export function getInject(entryName: string, config: NormalizedConfig) {
     options: config.html.inject,
     utils: { entryName },
     useObjectParam: true,
+    isFalsy: isNil,
   });
 }
 

--- a/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
@@ -413,6 +413,90 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
 }
 `;
 
+exports[`plugin-html > should stop injecting <script> if inject is '() => false' 1`] = `
+{
+  "entry": {
+    "index": [
+      "src/index.js",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "index",
+        ],
+        "entryName": "index",
+        "filename": "index.html",
+        "inject": false,
+        "meta": {
+          "charset": {
+            "charset": "UTF-8",
+          },
+          "viewport": "width=device-width, initial-scale=1.0",
+        },
+        "minify": false,
+        "scriptLoading": "defer",
+        "template": "<ROOT>/packages/core/static/template.html",
+        "templateParameters": [Function],
+        "title": "Rsbuild App",
+      },
+      "version": 5,
+    },
+    HtmlBasicPlugin {
+      "name": "HtmlBasicPlugin",
+      "options": {
+        "info": {
+          "index": {},
+        },
+      },
+    },
+  ],
+}
+`;
+
+exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] = `
+{
+  "entry": {
+    "index": [
+      "src/index.js",
+    ],
+  },
+  "plugins": [
+    HtmlWebpackPlugin {
+      "userOptions": {
+        "chunks": [
+          "index",
+        ],
+        "entryName": "index",
+        "filename": "index.html",
+        "inject": false,
+        "meta": {
+          "charset": {
+            "charset": "UTF-8",
+          },
+          "viewport": "width=device-width, initial-scale=1.0",
+        },
+        "minify": false,
+        "scriptLoading": "defer",
+        "template": "<ROOT>/packages/core/static/template.html",
+        "templateParameters": [Function],
+        "title": "Rsbuild App",
+      },
+      "version": 5,
+    },
+    HtmlBasicPlugin {
+      "name": "HtmlBasicPlugin",
+      "options": {
+        "info": {
+          "index": {},
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`plugin-html > should support multi entry 1`] = `
 {
   "entry": {

--- a/packages/core/tests/plugins/html.test.ts
+++ b/packages/core/tests/plugins/html.test.ts
@@ -1,6 +1,7 @@
 import { pluginHtml } from '@src/plugins/html';
 import { pluginEntry } from '@src/plugins/entry';
 import { createStubRsbuild } from '@rsbuild/test-helper';
+import { HtmlConfig } from '@rsbuild/shared';
 
 vi.mock('@rsbuild/shared', async (importOriginal) => {
   const mod = await importOriginal<any>();
@@ -258,4 +259,19 @@ describe('plugin-html', () => {
     expect(plugins?.length).toBe(2);
     expect(config).toMatchSnapshot();
   });
+
+  it.each<{ value: HtmlConfig['inject']; message: string }>([
+    { value: false, message: 'false' },
+    { value: () => false, message: `() => false` },
+  ])(
+    'should stop injecting <script> if inject is $message',
+    async ({ value }) => {
+      const rsbuild = await createStubRsbuild({
+        plugins: [pluginEntry(), pluginHtml()],
+        rsbuildConfig: { html: { inject: value } },
+      });
+      const config = await rsbuild.unwrapConfig();
+      expect(config).toMatchSnapshot();
+    },
+  );
 });

--- a/packages/shared/src/mergeChainedOptions.ts
+++ b/packages/shared/src/mergeChainedOptions.ts
@@ -7,43 +7,74 @@ import { isFunction, isPlainObject } from './utils';
 
 export type Falsy = false | null | undefined;
 
-export function mergeChainedOptions<T, U>(params: {
+export function mergeChainedOptions<T, U = unknown, F = Falsy>(params: {
   defaults: T;
-  options?: ChainedConfig<T> | Falsy;
+  options?: ChainedConfig<T> | F;
   mergeFn?: typeof Object.assign;
+  isFalsy?: (v: T | ChainedConfig<T> | F) => v is F;
 }): T;
-export function mergeChainedOptions<T, U>(params: {
+export function mergeChainedOptions<T, U, F = Falsy>(params: {
   defaults: T;
-  options: ChainedConfigWithUtils<T, U> | Falsy;
+  options: ChainedConfigWithUtils<T, U> | F;
   utils: U;
   mergeFn?: typeof Object.assign;
+  isFalsy?: (v: T | ChainedConfigWithUtils<T, U> | F) => v is F;
 }): T;
-export function mergeChainedOptions<T, U>(params: {
+export function mergeChainedOptions<T, U, F = Falsy>(params: {
   defaults: T;
-  options: ChainedConfigCombineUtils<T, U> | Falsy;
+  options: ChainedConfigCombineUtils<T, U> | F;
   utils: U;
   mergeFn?: typeof Object.assign;
   useObjectParam?: true;
+  isFalsy?: (v: T | ChainedConfigCombineUtils<T, U> | F) => v is F;
 }): T;
-export function mergeChainedOptions<T extends Record<string, unknown>>({
+export function mergeChainedOptions<T, U = unknown, F = Falsy>({
   defaults,
   options,
   utils,
   mergeFn = Object.assign,
   useObjectParam,
+  isFalsy = (
+    v:
+      | T
+      | ChainedConfig<T>
+      | ChainedConfigWithUtils<T, U>
+      | ChainedConfigCombineUtils<T, U>
+      | F
+      | undefined,
+  ): v is F => !v,
 }: {
   defaults: T;
-  options?: unknown;
-  utils?: unknown;
+  options?:
+    | ChainedConfig<T>
+    | ChainedConfigWithUtils<T, U>
+    | ChainedConfigCombineUtils<T, U>
+    | F;
+  utils?: U;
   mergeFn?: typeof Object.assign;
   useObjectParam?: true;
+  /**
+   * To determine if current value is falsy. `false | undefined | null` as falsy by default.
+   */
+  isFalsy?: (
+    v:
+      | T
+      | ChainedConfig<T>
+      | ChainedConfigWithUtils<T, U>
+      | ChainedConfigCombineUtils<T, U>
+      | F
+      | undefined,
+  ) => v is F;
 }) {
-  if (!options) {
+  if (isFalsy(options)) {
     return defaults;
   }
 
   if (isPlainObject(options)) {
-    return mergeFn(defaults, options);
+    return mergeFn(
+      defaults /* we assume that when options is an object, defaults should be an object */ as any,
+      options,
+    );
   }
 
   if (isFunction(options)) {
@@ -54,7 +85,7 @@ export function mergeChainedOptions<T extends Record<string, unknown>>({
         })
       : options(defaults, utils);
 
-    return ret || defaults;
+    return isFalsy(ret) ? defaults : ret;
   } else if (Array.isArray(options)) {
     return options.reduce(
       (defaults, options) =>
@@ -64,6 +95,7 @@ export function mergeChainedOptions<T extends Record<string, unknown>>({
           utils,
           mergeFn,
           useObjectParam,
+          isFalsy,
         }),
       defaults,
     );

--- a/packages/shared/src/mergeChainedOptions.ts
+++ b/packages/shared/src/mergeChainedOptions.ts
@@ -34,37 +34,17 @@ export function mergeChainedOptions<T, U = unknown, F = Falsy>({
   utils,
   mergeFn = Object.assign,
   useObjectParam,
-  isFalsy = (
-    v:
-      | T
-      | ChainedConfig<T>
-      | ChainedConfigWithUtils<T, U>
-      | ChainedConfigCombineUtils<T, U>
-      | F
-      | undefined,
-  ): v is F => !v,
+  isFalsy = (v: unknown | F | undefined): v is F => !v,
 }: {
   defaults: T;
-  options?:
-    | ChainedConfig<T>
-    | ChainedConfigWithUtils<T, U>
-    | ChainedConfigCombineUtils<T, U>
-    | F;
+  options?: unknown | F;
   utils?: U;
   mergeFn?: typeof Object.assign;
   useObjectParam?: true;
   /**
    * To determine if current value is falsy. `false | undefined | null` as falsy by default.
    */
-  isFalsy?: (
-    v:
-      | T
-      | ChainedConfig<T>
-      | ChainedConfigWithUtils<T, U>
-      | ChainedConfigCombineUtils<T, U>
-      | F
-      | undefined,
-  ) => v is F;
+  isFalsy?: (v: unknown | F | undefined) => v is F;
 }) {
   if (isFalsy(options)) {
     return defaults;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -43,6 +43,9 @@ export const isPlainObject = (obj: unknown): obj is Record<string, any> =>
 export const isRegExp = (obj: any): obj is RegExp =>
   Object.prototype.toString.call(obj) === '[object RegExp]';
 
+export const isNil = (o: unknown): o is undefined | null =>
+  o === undefined || o === null;
+
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
 

--- a/packages/shared/tests/mergeChainedOptions.test.ts
+++ b/packages/shared/tests/mergeChainedOptions.test.ts
@@ -1,4 +1,4 @@
-import { mergeChainedOptions } from '../src';
+import { mergeChainedOptions, isNil } from '../src';
 
 describe('mergeChainedOptions', () => {
   test(`should return default options`, () => {
@@ -122,5 +122,31 @@ describe('mergeChainedOptions', () => {
       d: 'd',
       e: 'e',
     });
+  });
+
+  test('should allow false as options', () => {
+    expect(
+      mergeChainedOptions<'head' | false>({
+        defaults: 'head',
+        options: false,
+        isFalsy: isNil,
+      }),
+    ).toBe(false);
+
+    expect(
+      mergeChainedOptions<'head' | false>({
+        defaults: 'head',
+        options: () => false,
+        isFalsy: isNil,
+      }),
+    ).toBe(false);
+
+    expect(
+      mergeChainedOptions<'head' | false>({
+        defaults: 'head',
+        options: ['head', 'head', () => false],
+        isFalsy: isNil,
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

when `html.inject` is `false`, rsbuild must not automatically inject <script> of chunks into html.



## Related Links

<!--- Provide links of related issues or pages -->

fixes #987

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated: no need
