### PR TITLE
fix: inspect config not works in dev

### DIFF
--- a/e2e/cases/javascript-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/javascript-api/plugin-hooks/index.test.ts
@@ -67,9 +67,9 @@ test('should run plugin hooks correctly when running startDevServer', async () =
   const result = await rsbuild.startDevServer();
 
   expect(fse.readFileSync(distFile, 'utf-8').split(',')).toEqual([
-    'BeforeStartDevServer',
     'BeforeCreateCompiler',
     'AfterCreateCompiler',
+    'BeforeStartDevServer',
     'AfterStartDevServer',
   ]);
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -177,8 +177,6 @@ export async function startDevServer<
 
   debug('create dev server done');
 
-  await serverAPIs.beforeStart();
-
   const protocol = https ? 'https' : 'http';
   let urls = getAddressUrls(protocol, port, host);
 
@@ -204,6 +202,8 @@ export async function startDevServer<
   devMiddlewares.middlewares.forEach((m) => middlewares.use(m));
 
   middlewares.use(notFoundMiddleware);
+
+  await serverAPIs.beforeStart();
 
   debug('listen dev server');
 

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -107,10 +107,14 @@ export type DevServerAPIs = {
   startCompile: () => Promise<CompileMiddlewareAPI>;
   /**
    * Trigger rsbuild onBeforeStartDevServer hook
+   *
+   * It should called before listen and after compile
    */
   beforeStart: () => Promise<void>;
   /**
    * Trigger rsbuild onAfterStartDevServer hook
+   *
+   * It should called after listen
    */
   afterStart: (options?: { port?: number; routes?: Routes }) => Promise<void>;
   /**


### PR DESCRIPTION
## Summary

onBeforeStartDevServer should called before listen and after compile, so inspect config  can works.

<img width="642" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/de2543ee-ddb5-49a0-98eb-2cbfab8221d2">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
