### PR TITLE
chore: update deprecated minimizer options

### DIFF
--- a/packages/core/src/provider/plugins/minimize.ts
+++ b/packages/core/src/provider/plugins/minimize.ts
@@ -1,4 +1,4 @@
-import { CHAIN_ID, type RspackBuiltinsConfig } from '@rsbuild/shared';
+import { CHAIN_ID, isObject, type RspackBuiltinsConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin, NormalizedConfig } from '../../types';
 
 const getJsMinimizerOptions = (config: NormalizedConfig) => {
@@ -7,29 +7,37 @@ const getJsMinimizerOptions = (config: NormalizedConfig) => {
   const { removeConsole } = config.performance;
 
   if (removeConsole === true) {
-    options.dropConsole = true;
+    options.compress = {
+      ...(isObject(options.compress) ? options.compress : {}),
+      drop_console: true,
+    };
   } else if (Array.isArray(removeConsole)) {
     const pureFuncs = removeConsole.map((method) => `console.${method}`);
-    options.pureFuncs = pureFuncs;
+    options.compress = {
+      ...(isObject(options.compress) ? options.compress : {}),
+      pure_funcs: pureFuncs,
+    };
   }
+
+  options.format ||= {};
 
   switch (config.output.legalComments) {
     case 'inline':
-      options.comments = 'some';
+      options.format.comments = 'some';
       options.extractComments = false;
       break;
     case 'linked':
       options.extractComments = true;
       break;
     case 'none':
-      options.comments = false;
+      options.format.comments = false;
       options.extractComments = false;
       break;
     default:
       break;
   }
 
-  options.asciiOnly = config.output.charset === 'ascii';
+  options.format.asciiOnly = config.output.charset === 'ascii';
 
   return options;
 };


### PR DESCRIPTION
## Summary

Rspack has deprecated some JS minimizer options, this PR updates them.

<img width="844" alt="Screenshot 2023-12-20 at 14 24 31" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/4771e407-87af-4cbb-8bad-aeaa2b093afa">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
