### PR TITLE
fix(plugin-swc): output.charset not work

### DIFF
--- a/e2e/cases/legal-comments/index.test.ts
+++ b/e2e/cases/legal-comments/index.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from '@playwright/test';
 import { build, getHrefByEntryName } from '@scripts/shared';
+import { rspackOnlyTest } from '@scripts/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
 
-test('legalComments linked (default)', async ({ page }) => {
+rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
     runServer: true,

--- a/packages/compat/plugin-swc/src/types.ts
+++ b/packages/compat/plugin-swc/src/types.ts
@@ -11,7 +11,6 @@ export type {
   Output,
   TransformConfig,
   JsMinifyOptions,
-  TerserCompressOptions,
 } from '@modern-js/swc-plugins';
 
 export type OuterExtensions = Omit<Extensions, 'ssrLoaderId' | 'configRoutes'>;

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -488,6 +488,9 @@ exports[`plugin-swc > should set correct swc minimizer options in production 1`]
         "cssMinify": {},
         "jsMinify": {
           "compress": false,
+          "format": {
+            "asciiOnly": true,
+          },
           "mangle": false,
         },
       },
@@ -505,6 +508,9 @@ exports[`plugin-swc > should set correct swc minimizer options using raw swc con
         "cssMinify": {},
         "jsMinify": {
           "compress": false,
+          "format": {
+            "asciiOnly": true,
+          },
           "mangle": false,
         },
       },
@@ -701,7 +707,9 @@ exports[`plugin-swc > should set swc minimizer in production 1`] = `
       "minifyOptions": {
         "cssMinify": {},
         "jsMinify": {
-          "compress": {},
+          "format": {
+            "asciiOnly": true,
+          },
           "mangle": true,
         },
       },

--- a/packages/compat/plugin-swc/tsconfig.json
+++ b/packages/compat/plugin-swc/tsconfig.json
@@ -2,8 +2,15 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../../shared"
+    }
+  ],
   "include": ["src"],
   "exclude": ["./tests/fixtures"]
 }

--- a/packages/compat/webpack/src/plugins/minimize.ts
+++ b/packages/compat/webpack/src/plugins/minimize.ts
@@ -1,7 +1,7 @@
 import {
   CHAIN_ID,
   BundlerChain,
-  getJSMinifyOptions,
+  getTerserMinifyOptions,
   type RsbuildPlugin,
   type NormalizedConfig,
 } from '@rsbuild/shared';
@@ -9,7 +9,7 @@ import {
 async function applyJSMinimizer(chain: BundlerChain, config: NormalizedConfig) {
   const { default: TerserPlugin } = await import('terser-webpack-plugin');
 
-  const finalOptions = await getJSMinifyOptions(config);
+  const finalOptions = await getTerserMinifyOptions(config);
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.JS)

--- a/packages/core/src/provider/plugins/minimize.ts
+++ b/packages/core/src/provider/plugins/minimize.ts
@@ -1,46 +1,5 @@
-import { CHAIN_ID, isObject, type RspackBuiltinsConfig } from '@rsbuild/shared';
-import type { RsbuildPlugin, NormalizedConfig } from '../../types';
-
-const getJsMinimizerOptions = (config: NormalizedConfig) => {
-  const options: RspackBuiltinsConfig['minifyOptions'] = {};
-
-  const { removeConsole } = config.performance;
-
-  if (removeConsole === true) {
-    options.compress = {
-      ...(isObject(options.compress) ? options.compress : {}),
-      drop_console: true,
-    };
-  } else if (Array.isArray(removeConsole)) {
-    const pureFuncs = removeConsole.map((method) => `console.${method}`);
-    options.compress = {
-      ...(isObject(options.compress) ? options.compress : {}),
-      pure_funcs: pureFuncs,
-    };
-  }
-
-  options.format ||= {};
-
-  switch (config.output.legalComments) {
-    case 'inline':
-      options.format.comments = 'some';
-      options.extractComments = false;
-      break;
-    case 'linked':
-      options.extractComments = true;
-      break;
-    case 'none':
-      options.format.comments = false;
-      options.extractComments = false;
-      break;
-    default:
-      break;
-  }
-
-  options.format.asciiOnly = config.output.charset === 'ascii';
-
-  return options;
-};
+import { CHAIN_ID, getSwcMinimizerOptions } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '../../types';
 
 export const pluginMinimize = (): RsbuildPlugin => ({
   name: 'rsbuild:minimize',
@@ -62,7 +21,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
 
       chain.optimization
         .minimizer(CHAIN_ID.MINIMIZER.JS)
-        .use(SwcJsMinimizerRspackPlugin, [getJsMinimizerOptions(config)])
+        .use(SwcJsMinimizerRspackPlugin, [getSwcMinimizerOptions(config)])
         .end()
         .minimizer(CHAIN_ID.MINIMIZER.CSS)
         .use(SwcCssMinimizerRspackPlugin, [])

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -37,7 +37,7 @@ import { pick, color, upperFirst } from './utils';
 
 import _ from 'lodash';
 import { DEFAULT_DEV_HOST } from './constants';
-import { getJSMinifyOptions } from './minimize';
+import { getTerserMinifyOptions } from './minimize';
 
 export const getDefaultDevConfig = (): NormalizedDevConfig => ({
   hmr: true,
@@ -231,7 +231,7 @@ export async function getMinify(isProd: boolean, config: NormalizedConfig) {
   if (config.output.disableMinimize || !isProd) {
     return false;
   }
-  const minifyJS: MinifyOptions = (await getJSMinifyOptions(config))
+  const minifyJS: MinifyOptions = (await getTerserMinifyOptions(config))
     .terserOptions!;
 
   return {


### PR DESCRIPTION
## Summary

Fix output.charset not work when using `@rsbuild/webpack` and `@rsbuild/plugin-swc`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
