### PR TITLE
types: server.https supports all server options

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,8 @@
     "**/coverage": true,
     "**/compiled": true,
     "**/doc_build": true,
-    "**/node_modules": true
+    "**/node_modules": true,
+    "**/tsconfig.tsbuildinfo": true
   },
   "files.exclude": {
     "**/.DS_Store": true

--- a/packages/document/docs/en/config/server/https.mdx
+++ b/packages/document/docs/en/config/server/https.mdx
@@ -1,6 +1,6 @@
 # https
 
-- **Type:** `{ key: string; cert: string }`
+- **Type:** `import('https').ServerOptions`
 - **Default:** `undefined`
 
 After configuring this option, you can enable HTTPS Server, and disabling the HTTP Server.
@@ -19,9 +19,9 @@ HTTPS:
   > Network: https://192.168.0.1:8080/
 ```
 
-#### Manually set the certificate
+#### Set Certificate
 
-You can manually pass in the certificate and the private key required in the `server.https` option. This parameter will be directly passed to the createServer method of the https module in Node.js.
+You can manually pass in the certificate and the private key required in the `server.https` option. This parameter will be directly passed to the `createServer` method of the https module in Node.js.
 
 For details, please refer to [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener).
 

--- a/packages/document/docs/zh/config/server/https.mdx
+++ b/packages/document/docs/zh/config/server/https.mdx
@@ -1,6 +1,6 @@
 # https
 
-- **类型：** `{ key: string; cert: string }`
+- **类型：** `import('https').ServerOptions`
 - **默认值：** `undefined`
 
 配置该选项后，可以开启 Rsbuild Server 对 HTTPS 的支持，同时会禁用 HTTP 服务器。
@@ -19,9 +19,9 @@
   > Network:  https://192.168.0.1:8080/
 ```
 
-#### 手动设置证书
+## 设置证书
 
-你可以在 `server.https` 选项中手动传入 HTTPS 服务器所需要的证书和对应的私钥，这个参数将直接传递给 Node.js 中 https 模块的 createServer。
+你可以在 `server.https` 选项中手动传入 HTTPS 服务器所需要的证书和对应的私钥，这个参数将直接传递给 Node.js 中 https 模块的 `createServer` 方法。
 
 具体可以参考 [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)。
 

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'http';
+import type { ServerOptions as HttpsServerOptions } from 'https';
 import type {
   Options as BaseProxyOptions,
   Filter as ProxyFilter,
@@ -64,7 +65,7 @@ export interface ServerConfig {
   /**
    * After configuring this option, you can enable HTTPS Server, and disabling the HTTP Server.
    */
-  https?: { key: string; cert: string };
+  https?: HttpsServerOptions;
   /**
    * Used to set the host of Rsbuild Server.
    */


### PR DESCRIPTION
## Summary

The server.https typing should supports all server options of `https.createServer`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
