### PR TITLE
chore: bump rspack to 0.4.4

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,7 +61,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/core": "0.4.4-canary-5eb224a-20231220085045",
+    "@rspack/core": "0.4.4",
     "core-js": "~3.32.2",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "postcss": "8.4.31"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/plugin-react-refresh": "0.4.4-canary-5eb224a-20231220085045",
+    "@rspack/plugin-react-refresh": "0.4.4",
     "react-refresh": "^0.14.0"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -114,7 +114,7 @@
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "@rspack/core": "0.4.4-canary-5eb224a-20231220085045",
+    "@rspack/core": "0.4.4",
     "caniuse-lite": "^1.0.30001559",
     "lodash": "^4.17.21",
     "postcss": "8.4.31"

--- a/packages/test-helper/package.json
+++ b/packages/test-helper/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/shared": "workspace:*",
-    "@rspack/core": "0.4.4-canary-5eb224a-20231220085045",
+    "@rspack/core": "0.4.4",
     "@types/lodash": "^4.14.200",
     "@types/node": "16.x",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -620,8 +620,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.4.4-canary-5eb224a-20231220085045
-        version: 0.4.4-canary-5eb224a-20231220085045
+        specifier: 0.4.4
+        version: 0.4.4
       core-js:
         specifier: ~3.32.2
         version: 3.32.2
@@ -1105,8 +1105,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/plugin-react-refresh':
-        specifier: 0.4.4-canary-5eb224a-20231220085045
-        version: 0.4.4-canary-5eb224a-20231220085045(react-refresh@0.14.0)
+        specifier: 0.4.4
+        version: 0.4.4(react-refresh@0.14.0)
       react-refresh:
         specifier: ^0.14.0
         version: 0.14.0
@@ -1422,8 +1422,8 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/core':
-        specifier: 0.4.4-canary-5eb224a-20231220085045
-        version: 0.4.4-canary-5eb224a-20231220085045
+        specifier: 0.4.4
+        version: 0.4.4
       caniuse-lite:
         specifier: ^1.0.30001559
         version: 1.0.30001559
@@ -1468,8 +1468,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.4.4-canary-5eb224a-20231220085045
-        version: 0.4.4-canary-5eb224a-20231220085045
+        specifier: 0.4.4
+        version: 0.4.4
       '@types/lodash':
         specifier: ^4.14.200
         version: 4.14.200
@@ -4441,53 +4441,97 @@ packages:
     dev: true
     optional: true
 
-  /@rspack/binding-darwin-arm64@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-zpXOPnyvg/CQnOkbLKJcEg0+CwjcugGIBTwpaON5IgP+vZCx68l6WrppSzznjSVOVhCgjzYi+qQoo8lbl4DmBQ==}
+  /@rspack/binding-darwin-arm64@0.4.4:
+    resolution: {integrity: sha512-40HUmnT/zHBcajcdTtIzorI1zpGZCpJBnis2rR3DzmBnD1fDLgu7PcW7iE11/MPmdwOYAZbCSzTZwe8hv0Skxw==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-darwin-x64@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-Biy50wlAR3sXo/Q8NBRQMKHPWHlPPjw2d7pUjjsbMnEpBqIgccuoBPjwj29aY4h58FnAwn8e0/a3GrbcdRRSmA==}
+  /@rspack/binding-darwin-x64@0.4.4:
+    resolution: {integrity: sha512-8vXoqA0S+D7LnwGAsO5dEpxKV3np/iONPvwRhVl2cBtsFKYmnh3jG0oxtDamCUUw38Jc3VZQTeH7kUt5F8HB5g==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-linux-x64-gnu@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-kFnT+laLBL5rS3VgXipJ1xVYeLRfmLg/yXTbjkofpStYAANYSVaCNjrB/pya8S9LOMHf5xEItLS1a+nXLydsng==}
-    cpu: [x64]
+  /@rspack/binding-linux-arm64-gnu@0.4.4:
+    resolution: {integrity: sha512-lmLy9W14WcVjI1PuZVeq0TAGNFoeYjQswQHl0KCDURcxaBbVqGcNjPovhbib+5w9Gj4jQqqnVIUHs86vIqDwHQ==}
+    cpu: [arm64]
     os: [linux]
-    libc: [glibc]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding-win32-x64-msvc@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-sYKxOXxRibKvX5ubwzGzXIzJsu5vEFEGxGO9w8XCE89hHPatOZuTq0CNScq60ZDc1BHz0J6owDLNMYj86wy+aQ==}
+  /@rspack/binding-linux-arm64-musl@0.4.4:
+    resolution: {integrity: sha512-wnranY+QPbGzrkfNneZkq839imrt+pfup1RpynfgrvjiWApDwvagTi9S8M7Og3u9m1CmJDrBq6yXgy4ffweygQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rspack/binding-linux-x64-gnu@0.4.4:
+    resolution: {integrity: sha512-J0n+91NL9quEWYaStFitXC3+rbM+wklxCEHvkwfuzC46fGcG9673aTVfcrod1fx2jTHHaftXKb5Hpru77W0JAA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rspack/binding-linux-x64-musl@0.4.4:
+    resolution: {integrity: sha512-ulIhvLzimHB5Ggp9TRJEFvyak/7OPzeVxFdP8nYNBHzPoYiqnK2MQUVOK7CT2hTpco1QJbh3jZTZxzdKIY5asw==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rspack/binding-win32-arm64-msvc@0.4.4:
+    resolution: {integrity: sha512-t4u3jlx+0LDOY7Y8m9tLDHAsPN9aiyz/5NDHKqdDeke5NJZ2A4jbv+h/dvcyGH+Nxj056XW1aa9wzvzT9jb//A==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rspack/binding-win32-ia32-msvc@0.4.4:
+    resolution: {integrity: sha512-ijw4bmB8Zh8BkawPqIc8Q7VWr6bSw9trMqTtXwHrXAyKYCdyXMCYsGnj7Rc6CKKrV6D6nsDXtA8ANFqoKCuvyw==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rspack/binding-win32-x64-msvc@0.4.4:
+    resolution: {integrity: sha512-jpJPjfNTEbHBCOuZotXhpBpR0C1jTvHh6wlgPjP286JXaAhGv/PEzriuRdXw0RSet1tf1vqn/V4lFU5hZbXZIA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /@rspack/binding@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-QbYabOdT6JoEseoEJ+Q02UxN2cBJkhNrEXDlIkuUGiXntrMtBBMOfN7hxRQqw09STW/XZfbgtgXhA2T8aM2gWQ==}
+  /@rspack/binding@0.4.4:
+    resolution: {integrity: sha512-CrZH2Vpf4Axi23GlD8qesyxmpplkYo6o5MlPuUtqNGrIA3JpPSRtBVLOE1NsMZ3+hnDHJ5GWtWoWkEB0p3beBA==}
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.4.4-canary-5eb224a-20231220085045
-      '@rspack/binding-darwin-x64': 0.4.4-canary-5eb224a-20231220085045
-      '@rspack/binding-linux-x64-gnu': 0.4.4-canary-5eb224a-20231220085045
-      '@rspack/binding-win32-x64-msvc': 0.4.4-canary-5eb224a-20231220085045
+      '@rspack/binding-darwin-arm64': 0.4.4
+      '@rspack/binding-darwin-x64': 0.4.4
+      '@rspack/binding-linux-arm64-gnu': 0.4.4
+      '@rspack/binding-linux-arm64-musl': 0.4.4
+      '@rspack/binding-linux-x64-gnu': 0.4.4
+      '@rspack/binding-linux-x64-musl': 0.4.4
+      '@rspack/binding-win32-arm64-msvc': 0.4.4
+      '@rspack/binding-win32-ia32-msvc': 0.4.4
+      '@rspack/binding-win32-x64-msvc': 0.4.4
     dev: false
 
-  /@rspack/core@0.4.4-canary-5eb224a-20231220085045:
-    resolution: {integrity: sha512-pTTOfBHBfs99q9a2Ny9yfyH5hVZfbGfO8vRUahQ7cs/uFLi/dofOBOmVBk/kRTxorSiFvfealJFFpnCB5cSNNA==}
+  /@rspack/core@0.4.4:
+    resolution: {integrity: sha512-SL6g6ZPPOqPI1wuQrZlSXD73HUg7GO5+wFRSATRak9hZ3wzSvYmD0kRGSCc6Kpndn21pmMLeOXNHbk2bL+x37g==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      '@rspack/binding': 0.4.4-canary-5eb224a-20231220085045
+      '@rspack/binding': 0.4.4
       '@swc/helpers': 0.5.1
       browserslist: 4.22.1
       compare-versions: 6.0.0-rc.1
@@ -4504,8 +4548,8 @@ packages:
       zod-validation-error: 1.3.1(zod@3.22.4)
     dev: false
 
-  /@rspack/plugin-react-refresh@0.4.4-canary-5eb224a-20231220085045(react-refresh@0.14.0):
-    resolution: {integrity: sha512-Cxq4x9NJPPOTNF+uc2reRVtyNV8w6OcC/ksUwcHuqLcKYaczaSwCLRhZwfo5Cr7D6HNRvbfLViSVKqT0liIhDw==}
+  /@rspack/plugin-react-refresh@0.4.4(react-refresh@0.14.0):
+    resolution: {integrity: sha512-AWC1VirWqKalVJpUi0i09cjYf7bfSG0qCoMNOym45bs9D2Hi3mxqrGEaMupTfkaSDdmJ/9VsUgUCHpgxAshJuw==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:


### PR DESCRIPTION
## Summary

bump rspack to 0.4.4

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v0.4.4

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
