### PR TITLE
doc(plugins): added jsdoc comments for some plugins options

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -7,11 +7,24 @@ import { applyBasicReactSupport } from './react';
 export { isBeyondReact17 } from './utils';
 
 export type SplitReactChunkOptions = {
+  /**
+   * Whether to enable split chunking for React-related dependencies (e.g., react, react-dom, scheduler).
+   *
+   * @default true
+   */
   react?: boolean;
+  /**
+   * Whether to enable split chunking for routing-related dependencies (e.g., react-router, react-router-dom, history).
+   *
+   * @default true
+   */
   router?: boolean;
 };
 
 export type PluginReactOptions = {
+  /**
+   * Configuration for chunk splitting of React-related dependencies.
+   */
   splitChunks?: SplitReactChunkOptions;
 };
 

--- a/packages/plugin-rem/src/types.ts
+++ b/packages/plugin-rem/src/types.ts
@@ -3,13 +3,53 @@
  * https://github.com/cuth/postcss-pxtorem#options
  */
 export type PxToRemOptions = {
+  /**
+   * (Number | Function) Represents the root element font size or returns the root element font size based on the input parameter
+   */
   rootValue?: number;
+  /**
+   * (Number) The decimal numbers to allow the REM units to grow to.
+   */
   unitPrecision?: number;
+  /**
+   * (Array) The properties that can change from px to rem.
+   * * Values need to be exact matches.
+   * * Use wildcard * to enable all properties. Example: ['*']
+   * * Use * at the start or end of a word. (['*position*'] will match background-position-y)
+   * * Use ! to not match a property. Example: ['*', '!letter-spacing']
+   * * Combine the "not" prefix with the other prefixes. Example: ['*', '!font*']
+   */
   propList?: Array<string>;
+  /**
+   * (Array) The selectors to ignore and leave as px.
+   * * If value is string, it checks to see if selector contains the string.
+   * * ['body'] will match .body-class
+   * * If value is regexp, it checks to see if the selector matches the regexp.
+   * * [/^body$/] will match body but not .body
+   */
   selectorBlackList?: Array<string>;
+  /**
+   * (Boolean) Replaces rules containing rems instead of adding fallbacks.
+   */
   replace?: boolean;
+  /**
+   * (Boolean) Allow px to be converted in media queries.
+   */
   mediaQuery?: boolean;
+  /**
+   * (Number) Set the minimum pixel value to replace.
+   */
   minPixelValue?: number;
+  /**
+   *  (String, Regexp, Function) The file path to ignore and leave as px.
+   * * If value is string, it checks to see if file path contains the string.
+   * * 'exclude' will match \project\postcss-pxtorem\exclude\path
+   * * If value is regexp, it checks to see if file path matches the regexp.
+   * * /exclude/i will match \project\postcss-pxtorem\exclude\path
+   * * If value is function, you can use exclude function to return a true and the file will be ignored.
+   * * the callback will pass the file path as a parameter, it should returns a Boolean result.
+   * * function (file) { return file.indexOf('exclude') !== -1; }
+   */
   exclude?: string | RegExp | ((filePath: string) => boolean);
 };
 
@@ -26,7 +66,15 @@ export type PluginRemOptions = {
   inlineRuntime?: boolean;
   /** Usually, `fontSize = (clientWidth * rootFontSize) / screenWidth` */
   screenWidth?: number;
+  /**
+   * Used to calculate the font size of the document.
+   * `documentElement.style.fontSize = (clientWidth * rootFontSize) / screenWidth`
+   * @default 50
+   */
   rootFontSize?: number;
+  /**
+   * If the `rootFontSize` exceeds the `maxRootFontSize`, the `maxRootFontSize` value will be used instead.
+   */
   maxRootFontSize?: number;
   /** Get clientWidth from the url query based on widthQueryKey */
   widthQueryKey?: string;

--- a/packages/plugin-rem/src/types.ts
+++ b/packages/plugin-rem/src/types.ts
@@ -4,15 +4,15 @@
  */
 export type PxToRemOptions = {
   /**
-   * (Number | Function) Represents the root element font size or returns the root element font size based on the input parameter
+   * Represents the root element font size or returns the root element font size based on the input parameter
    */
   rootValue?: number;
   /**
-   * (Number) The decimal numbers to allow the REM units to grow to.
+   * The decimal numbers to allow the REM units to grow to.
    */
   unitPrecision?: number;
   /**
-   * (Array) The properties that can change from px to rem.
+   * The properties that can change from px to rem.
    * * Values need to be exact matches.
    * * Use wildcard * to enable all properties. Example: ['*']
    * * Use * at the start or end of a word. (['*position*'] will match background-position-y)
@@ -21,7 +21,7 @@ export type PxToRemOptions = {
    */
   propList?: Array<string>;
   /**
-   * (Array) The selectors to ignore and leave as px.
+   * The selectors to ignore and leave as px.
    * * If value is string, it checks to see if selector contains the string.
    * * ['body'] will match .body-class
    * * If value is regexp, it checks to see if the selector matches the regexp.
@@ -29,19 +29,19 @@ export type PxToRemOptions = {
    */
   selectorBlackList?: Array<string>;
   /**
-   * (Boolean) Replaces rules containing rems instead of adding fallbacks.
+   * Replaces rules containing rems instead of adding fallbacks.
    */
   replace?: boolean;
   /**
-   * (Boolean) Allow px to be converted in media queries.
+   * Allow px to be converted in media queries.
    */
   mediaQuery?: boolean;
   /**
-   * (Number) Set the minimum pixel value to replace.
+   * Set the minimum pixel value to replace.
    */
   minPixelValue?: number;
   /**
-   *  (String, Regexp, Function) The file path to ignore and leave as px.
+   *  The file path to ignore and leave as px.
    * * If value is string, it checks to see if file path contains the string.
    * * 'exclude' will match \project\postcss-pxtorem\exclude\path
    * * If value is regexp, it checks to see if file path matches the regexp.

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -5,7 +5,17 @@ import type { VueLoaderOptions } from 'vue-loader';
 import { applySplitChunksRule } from './splitChunks';
 
 export type SplitVueChunkOptions = {
+  /**
+   * Whether to enable split chunking for Vue-related dependencies (e.g., vue, vue-loader).
+   *
+   * @default true
+   */
   vue?: boolean;
+  /**
+   * Whether to enable split chunking for vue-router.
+   *
+   * @default true
+   */
   router?: boolean;
 };
 

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -2,10 +2,25 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
 type VueJSXPresetOptions = {
+  /**
+   * Whether to enable the Composition API in Vue.js JSX.
+   */
   compositionAPI?: boolean | string;
+  /**
+   * Whether to enable stateless functional components in Vue.js JSX.
+   */
   functional?: boolean;
+  /**
+   * Whether to enable automatic 'h' injection syntactic sugar.
+   */
   injectH?: boolean;
+  /**
+   * Whether to enable `vModel` syntactic sugar
+   */
   vModel?: boolean;
+  /**
+   * Whether to enable `vOn` syntactic sugar
+   */
   vOn?: boolean;
 };
 


### PR DESCRIPTION
## Summary

## Related Links

Added jsdoc comments for some plugins options: https://github.com/web-infra-dev/rsbuild/issues/181

covering `plugin-react`, `plugin-vue`, `plugin-rem`, `plugin-vue2-jsx`

