### PR TITLE
docs(CLI): add rsbuild -h and fix title indent

### DIFF
--- a/packages/document/docs/en/guide/basic/cli.mdx
+++ b/packages/document/docs/en/guide/basic/cli.mdx
@@ -2,9 +2,36 @@
 
 Rsbuild comes with a lightweight CLI that includes commands such as `dev` and `build`.
 
-## Commands
+---
 
-### rsbuild dev
+## rsbuild -h
+
+To view all available CLI commands, run the following command in the project directory:
+
+```bash
+npx rsbuild -h
+```
+
+输出如下所示：
+
+```text
+Usage: rsbuild <command> [options]
+
+Options:
+  -V, --version      output the version number
+  -h, --help         display help for command
+
+Commands:
+  dev [options]      starting the dev server
+  build [options]    build the app for production
+  preview [options]  preview the production build locally
+  inspect [options]  inspect the Rspack and Rsbuild configs
+  help [command]     display help for command
+```
+
+---
+
+## rsbuild dev
 
 The `rsbuild dev` command is used to start a local development server and compile the source code in the development environment.
 
@@ -19,7 +46,9 @@ Options:
   -h, --help            display help for command
 ```
 
-### rsbuild build
+---
+
+## rsbuild build
 
 The `rsbuild build` command will build the outputs for production in the `dist/` directory by default.
 
@@ -32,7 +61,9 @@ Options:
   -h, --help            display help for command
 ```
 
-### rsbuild preview
+---
+
+## rsbuild preview
 
 The `rsbuild preview` command is used to preview the production build outputs locally. Note that you need to execute the `rsbuild build` command beforehand to generate the corresponding outputs.
 
@@ -48,6 +79,8 @@ Options:
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   -h, --help            display help for command
 ```
+
+---
 
 ## rsbuild inspect
 

--- a/packages/document/docs/en/guide/basic/page-route.md
+++ b/packages/document/docs/en/guide/basic/page-route.md
@@ -2,7 +2,7 @@
 
 This chapter will introduces how to access pages during local development and preview.
 
-### Default
+## Default
 
 Rsbuild Server will generate the corresponding page route based on the [source.entry](/config/source/entry) configuration.
 
@@ -19,7 +19,7 @@ export default {
 };
 ```
 
-### Default fallback logic
+## Default fallback logic
 
 By default, when the request meets the following conditions and the corresponding resource is not found, it will fallback to `index.html`:
 
@@ -34,7 +34,7 @@ export default {
 };
 ```
 
-#### Custom fallback logic
+### Custom fallback logic
 
 When Rsbuild's default [server.htmlFallback](/config/server/html-fallback) configuration cannot meet your needs, for example, if you want to be able to access `main.html` when accessing `/`, you can set it up using [server.historyApiFallback] (/config/server/history-api-fallback).
 
@@ -54,7 +54,7 @@ export default {
 };
 ```
 
-### The HTML file output path and Route
+## HTML file output path and Route
 
 Normally, `/` points to the dist root directory, and the HTML file is output to the dist root directory. At this time, the corresponding HTML page can be accessed through `/xxx`.
 

--- a/packages/document/docs/zh/guide/basic/cli.mdx
+++ b/packages/document/docs/zh/guide/basic/cli.mdx
@@ -2,9 +2,36 @@
 
 Rsbuild 内置了一个轻量的命令行工具，包含 dev、build 等命令。
 
-## 命令
+---
 
-### rsbuild dev
+## rsbuild -h
+
+如果你需要查看所有可用的 CLI 命令，请在项目目录中运行以下命令：
+
+```bash
+npx rsbuild -h
+```
+
+The output is as follows:
+
+```text
+Usage: rsbuild <command> [options]
+
+Options:
+  -V, --version      output the version number
+  -h, --help         display help for command
+
+Commands:
+  dev [options]      starting the dev server
+  build [options]    build the app for production
+  preview [options]  preview the production build locally
+  inspect [options]  inspect the Rspack and Rsbuild configs
+  help [command]     display help for command
+```
+
+---
+
+## rsbuild dev
 
 `rsbuild dev` 命令用于启动一个本地开发服务器，对源代码进行开发环境编译。
 
@@ -19,7 +46,9 @@ Options:
   -h, --help            显示命令帮助
 ```
 
-### rsbuild build
+---
+
+## rsbuild build
 
 `rsbuild build` 命令默认会在 `dist/` 目录下构建出可用于生产环境的产物。
 
@@ -32,7 +61,9 @@ Options:
   -h, --help            显示命令帮助
 ```
 
-### rsbuild preview
+---
+
+## rsbuild preview
 
 `rsbuild preview` 命令用于在本地预览生产环境构建的产物, 注意你需要提前执行 `rsbuild build` 命令构建出对应产物。
 
@@ -48,6 +79,8 @@ Options:
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help            显示命令帮助
 ```
+
+---
 
 ## rsbuild inspect
 

--- a/packages/document/docs/zh/guide/basic/page-route.md
+++ b/packages/document/docs/zh/guide/basic/page-route.md
@@ -2,7 +2,7 @@
 
 本章节介绍了如何在本地开发和预览时进行页面访问。
 
-### 默认情况
+## 默认情况
 
 Rsbuild Server 会根据 [source.entry](/config/source/entry) 配置生成对应的页面路由。
 
@@ -19,7 +19,7 @@ export default {
 };
 ```
 
-### 默认 Fallback 逻辑
+## 默认 Fallback 逻辑
 
 当请求满足以下条件且未找到对应资源时，会被 `server.htmlFallback` 处理，默认会回退到 index.html。
 
@@ -34,7 +34,7 @@ export default {
 };
 ```
 
-#### 自定义 Fallback 逻辑
+### 自定义 Fallback 逻辑
 
 当 Rsbuild 默认的 [server.htmlFallback](/config/server/html-fallback) 配置无法满足你的需求，例如，希望在访问 `/` 时可以访问 `main.html`，可通过 [server.historyApiFallback](/config/server/history-api-fallback) 进行设置。
 
@@ -54,7 +54,7 @@ export default {
 };
 ```
 
-### HTML 文件输出位置与路由的关系
+## HTML 文件输出位置与路由的关系
 
 通常情况下，`/` 指向 dist 产物根目录， 而 HTML 文件输出到 dist 根目录下，此时可通过 `/xxx` 访问对应的 HTML 页面。
 


### PR DESCRIPTION
## Summary

- Add rsbuild -h command.
- Fix title indent in the CLI document.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
