### PR TITLE
feat(create-rsbuild): configure jsxImportSource vue by default

### DIFF
--- a/packages/create-rsbuild/template-vue2-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue2-ts/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2020",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
+    "jsx": "preserve",
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,

--- a/packages/create-rsbuild/template-vue3-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue3-ts/tsconfig.json
@@ -3,6 +3,8 @@
     "target": "ES2020",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

Configure jsxImportSource: vue in the tsconfig.json by default:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/5777e2ac-d633-4439-bc68-ab3654baeefd)

## Related Links

See https://vuejs.org/guide/extras/render-function.html#jsx-type-inference for more informantion.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
