### PR TITLE
fix: only clear env vars when restart server

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -20,7 +20,7 @@ import {
 } from '@rsbuild/shared';
 
 import connect from '@rsbuild/shared/connect';
-import { registerCleaner } from './restart';
+import { onBeforeRestartServer } from './restart';
 import type { Context } from '../types';
 import { createHttpServer } from './httpServer';
 import { getMiddlewares } from './getDevMiddlewares';
@@ -224,20 +224,18 @@ export async function startDevServer<
 
         await serverAPIs.afterStart();
 
-        const onClose = async () => {
+        const closeServer = async () => {
           await devMiddlewares.close();
           httpServer.close();
         };
 
-        registerCleaner(onClose);
+        onBeforeRestartServer(closeServer);
 
         resolve({
           port,
           urls: urls.map((item) => item.url),
           server: {
-            close: async () => {
-              await onClose();
-            },
+            close: closeServer,
           },
         });
       },

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -4,12 +4,12 @@ import { init } from '../cli/commands';
 
 type Cleaner = () => Promise<unknown> | unknown;
 
-const cleaners: Cleaner[] = [];
+let cleaners: Cleaner[] = [];
 
 /**
  * Add a cleaner to handle side effects
  */
-export const registerCleaner = (cleaner: Cleaner) => {
+export const onBeforeRestartServer = (cleaner: Cleaner) => {
   cleaners.push(cleaner);
 };
 
@@ -27,6 +27,7 @@ export const restartDevServer = async ({ filePath }: { filePath: string }) => {
 
   for (const cleaner of cleaners) {
     await cleaner();
+    cleaners = [];
   }
 
   const rsbuild = await init({ isRestart: true });


### PR DESCRIPTION
## Summary

Only clear env vars when restart server, this change allows us to call `loadEnv` multiple times.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
