### PR TITLE
feat: make loadEnv a sync method

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -41,7 +41,7 @@ export async function init({
 
   try {
     const root = process.cwd();
-    const { publicVars } = await loadEnv({ cwd: root });
+    const { publicVars } = loadEnv({ cwd: root });
     const config = await loadConfig({
       cwd: root,
       path: commonOpts.config,

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -2,19 +2,18 @@ import fs from 'fs';
 import { join } from 'path';
 import { isDev, isFileSync } from '@rsbuild/shared';
 import { onBeforeRestartServer } from './server/restart';
+import { parse } from '../compiled/dotenv';
+import { expand } from '../compiled/dotenv-expand';
 
 export const getEnvFiles = () => {
   const { NODE_ENV } = process.env;
   return ['.env', '.env.local', `.env.${NODE_ENV}`, `.env.${NODE_ENV}.local`];
 };
 
-export async function loadEnv({
+export function loadEnv({
   cwd = process.cwd(),
   prefixes = ['PUBLIC_'],
 }: { cwd?: string; prefixes?: string[] } = {}) {
-  const { parse } = await import('../compiled/dotenv');
-  const { expand } = await import('../compiled/dotenv-expand');
-
   const envPaths = getEnvFiles()
     .map((filename) => join(cwd, filename))
     .filter(isFileSync);

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -76,18 +76,18 @@ function loadEnv(params: {
   cwd?: string;
   // Default is ['PUBLIC_']
   prefixes?: string[];
-}): Promise<{
+}): {
   // All environment variables in the .env file
   parsed: Record<string, string>;
   // Environment variables starting with the specified prefixes
   publicVars: Record<string, string>;
-}>;
+};
 ```
 
 - **Example:**
 
 ```ts
-const { parsed, publicVars } = await loadEnv();
+const { parsed, publicVars } = loadEnv();
 
 mergeRsbuildConfig(
   {

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -76,18 +76,18 @@ function loadEnv(params: {
   cwd?: string;
   // 默认为 ['PUBLIC_']
   prefixes?: string[];
-}): Promise<{
+}): {
   // .env 文件包含的所有环境变量
   parsed: Record<string, string>;
   // 以 prefixes 开头的环境变量
   publicVars: Record<string, string>;
-}>;
+};
 ```
 
 - **示例：**
 
 ```ts
-const { parsed, publicVars } = await loadEnv();
+const { parsed, publicVars } = loadEnv();
 
 mergeRsbuildConfig(
   {


### PR DESCRIPTION
## Summary

Make loadEnv a sync method. So users can call `loadEnv` in the `rsbuild.config.ts` file if needed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
