### PR TITLE
Revert "chore(deps): bump html-rspack-plugin v5.6.0 (#1039)"

### DIFF
--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/shared": "workspace:*",
     "fast-glob": "^3.3.1",
     "globby": "^11.1.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "mini-css-extract-plugin": "2.7.6",
     "postcss": "8.4.31",
     "style-loader": "3.3.3",

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -26,36 +26,6 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
     "options": {},
   },
   HtmlWebpackPlugin {
-    "options": {
-      "base": false,
-      "cache": true,
-      "chunks": [
-        "index",
-      ],
-      "chunksSortMode": "auto",
-      "compile": true,
-      "entryName": "index",
-      "excludeChunks": [],
-      "favicon": false,
-      "filename": "index.html",
-      "hash": false,
-      "inject": "head",
-      "meta": {
-        "charset": {
-          "charset": "UTF-8",
-        },
-        "viewport": "width=device-width, initial-scale=1.0",
-      },
-      "minify": false,
-      "publicPath": "auto",
-      "scriptLoading": "defer",
-      "showErrors": true,
-      "template": "<ROOT>/packages/core/static/template.html",
-      "templateContent": false,
-      "templateParameters": [Function],
-      "title": "Rsbuild App",
-      "xhtml": false,
-    },
     "userOptions": {
       "chunks": [
         "index",

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -428,36 +428,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "options": {},
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -972,55 +942,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
       },
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": {
-          "collapseWhitespace": true,
-          "keepClosingSlash": true,
-          "minifyCSS": true,
-          "minifyJS": {
-            "format": {
-              "ascii_only": true,
-            },
-            "mangle": {
-              "safari10": true,
-            },
-          },
-          "minifyURLs": true,
-          "removeComments": false,
-          "removeEmptyAttributes": true,
-          "removeRedundantAttributes": true,
-          "removeScriptTypeAttributes": true,
-          "removeStyleLinkTypeAttributes": true,
-          "useShortDoctype": true,
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,7 @@
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.4.4",
     "core-js": "~3.32.2",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "postcss": "8.4.31"
   },
   "devDependencies": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -629,36 +629,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",

--- a/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/html.test.ts.snap
@@ -12,36 +12,6 @@ exports[`plugin-html > should add one tags plugin instance 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "main",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "main",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "main.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "main",
@@ -64,36 +34,6 @@ exports[`plugin-html > should add one tags plugin instance 1`] = `
       "version": 5,
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "foo",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "foo",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "foo.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "foo",
@@ -159,36 +99,6 @@ exports[`plugin-html > should add tags plugin instances for each entries 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "main",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "main",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "main.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "main",
@@ -211,36 +121,6 @@ exports[`plugin-html > should add tags plugin instances for each entries 1`] = `
       "version": 5,
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "foo",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "foo",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "foo.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "foo",
@@ -328,28 +208,6 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": "all",
-        "chunksSortMode": "auto",
-        "compile": true,
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": true,
-        "meta": {},
-        "minify": "auto",
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "auto",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Webpack App",
-        "xhtml": false,
-      },
       "userOptions": {
         "inject": true,
       },
@@ -376,36 +234,6 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": "src/favicon.ico",
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -449,36 +277,6 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "body",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -521,55 +319,6 @@ exports[`plugin-html > should enable minify in production 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": {
-          "collapseWhitespace": true,
-          "keepClosingSlash": true,
-          "minifyCSS": true,
-          "minifyJS": {
-            "format": {
-              "ascii_only": true,
-            },
-            "mangle": {
-              "safari10": true,
-            },
-          },
-          "minifyURLs": true,
-          "removeComments": false,
-          "removeEmptyAttributes": true,
-          "removeRedundantAttributes": true,
-          "removeScriptTypeAttributes": true,
-          "removeStyleLinkTypeAttributes": true,
-          "useShortDoctype": true,
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -631,36 +380,6 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -703,36 +422,6 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": false,
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -775,36 +464,6 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": false,
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -850,36 +509,6 @@ exports[`plugin-html > should support multi entry 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "main",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "main",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "main.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "main",
@@ -902,36 +531,6 @@ exports[`plugin-html > should support multi entry 1`] = `
       "version": 5,
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "foo",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "foo",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "foo.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "foo",

--- a/packages/core/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/core/tests/plugins/__snapshots__/inlineChunk.test.ts.snap
@@ -9,55 +9,6 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineScrip
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": {
-          "collapseWhitespace": true,
-          "keepClosingSlash": true,
-          "minifyCSS": true,
-          "minifyJS": {
-            "format": {
-              "ascii_only": true,
-            },
-            "mangle": {
-              "safari10": true,
-            },
-          },
-          "minifyURLs": true,
-          "removeComments": false,
-          "removeEmptyAttributes": true,
-          "removeRedundantAttributes": true,
-          "removeScriptTypeAttributes": true,
-          "removeStyleLinkTypeAttributes": true,
-          "useShortDoctype": true,
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -131,55 +82,6 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineStyle
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": {
-          "collapseWhitespace": true,
-          "keepClosingSlash": true,
-          "minifyCSS": true,
-          "minifyJS": {
-            "format": {
-              "ascii_only": true,
-            },
-            "mangle": {
-              "safari10": true,
-            },
-          },
-          "minifyURLs": true,
-          "removeComments": false,
-          "removeEmptyAttributes": true,
-          "removeRedundantAttributes": true,
-          "removeScriptTypeAttributes": true,
-          "removeStyleLinkTypeAttributes": true,
-          "useShortDoctype": true,
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -629,36 +629,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -1370,55 +1340,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": {
-          "collapseWhitespace": true,
-          "keepClosingSlash": true,
-          "minifyCSS": true,
-          "minifyJS": {
-            "format": {
-              "ascii_only": true,
-            },
-            "mangle": {
-              "safari10": true,
-            },
-          },
-          "minifyURLs": true,
-          "removeComments": false,
-          "removeEmptyAttributes": true,
-          "removeRedundantAttributes": true,
-          "removeScriptTypeAttributes": true,
-          "removeStyleLinkTypeAttributes": true,
-          "useShortDoctype": true,
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",
@@ -2582,36 +2503,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "name": "TestPlugin",
     },
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
     "@types/serialize-javascript": "^5.0.1",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "terser": "5.19.2",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -667,36 +667,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "plugins": [
     HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": false,
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "<ROOT>/packages/core/static/template.html",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
       "userOptions": {
         "chunks": [
           "index",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "typescript": "^5.3.0"
   },
   "publishConfig": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -122,7 +122,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.200",
     "@types/node": "16.x",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "mini-css-extract-plugin": "2.7.6",
     "terser": "5.19.2",
     "terser-webpack-plugin": "5.3.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -580,8 +580,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       mini-css-extract-plugin:
         specifier: 2.7.6
         version: 2.7.6(webpack@5.89.0)
@@ -626,8 +626,8 @@ importers:
         specifier: ~3.32.2
         version: 3.32.2
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       postcss:
         specifier: 8.4.31
         version: 8.4.31
@@ -934,8 +934,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.4
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       terser:
         specifier: 5.19.2
         version: 5.19.2
@@ -1140,8 +1140,8 @@ importers:
         specifier: workspace:*
         version: link:../test-helper
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       typescript:
         specifier: ^5.3.0
         version: 5.3.2
@@ -1441,8 +1441,8 @@ importers:
         specifier: 16.x
         version: 16.18.59
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.5.7
+        version: /html-rspack-plugin@5.5.7
       mini-css-extract-plugin:
         specifier: 2.7.6
         version: 2.7.6(webpack@5.89.0)
@@ -8708,8 +8708,8 @@ packages:
     resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
     dev: true
 
-  /html-rspack-plugin@5.6.0:
-    resolution: {integrity: sha512-4jrAQEEt9JCcGbeP7dFV1d42RF6IA9nYWoqK5i+rncdPPMz6eVHt1scPy9722brams7/SndzJhoIxN0Hw7T4ZA==}
+  /html-rspack-plugin@5.5.7:
+    resolution: {integrity: sha512-7dNAURj9XBHWoYg59F8VU6hT7J7w+od4Lr5hc/rrgN6sy6QfqVpoPqW9Qw4IGFOgit8Pul7iQp1yysBSIhOlsg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       lodash: 4.17.21


### PR DESCRIPTION
This reverts commit 9030c719142d511bfe200d359576833576a61c73.

## Summary

Fix the Windows path issue.

```text
start   Compiling...
error   Compile error: 
Failed to compile, check the errors for troubleshooting.
SyntaxError
  × [html-rspack-plugin]: Invalid Unicode escape sequence
  │ C:\userCode\23-2-2\vue-app6\node_modules\@rsbuild\core\static\template.html:74
  │ var installedChunks = {"HtmlWebpackPlugin_0-C:\userCode\23-2-2\vue-app6\node_modules\html-webpack-plugin\lib\loader.js!C:\userCode\23-2-2\vue-
  │ app6\node_modules\@rsbuild\core\static\template.html": 0,};
  │                                               ^^^^^^
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
