### PR TITLE
docs: add register Rspack plugins guide

### DIFF
--- a/packages/document/docs/en/config/plugins.mdx
+++ b/packages/document/docs/en/config/plugins.mdx
@@ -52,3 +52,20 @@ export default defineConfig({
   ],
 });
 ```
+
+## Rspack Plugins
+
+The `plugins` option is used to register Rsbuild plugins. If you need to register Rspack or Webpack plugins, please use [tools.rspack](/config/tools/rspack).
+
+```ts title="rsbuild.config.ts"
+export default {
+  // Rsbuild Plugins
+  plugins: [pluginStylus()],
+  tools: {
+    rspack: {
+      // Rspack or Webpack Plugins
+      plugins: [new SomeWebpackPlugin()],
+    },
+  },
+};
+```

--- a/packages/document/docs/zh/config/plugins.mdx
+++ b/packages/document/docs/zh/config/plugins.mdx
@@ -15,13 +15,13 @@ export default defineConfig({
 });
 ```
 
-### 执行顺序
+## 执行顺序
 
 默认情况下，插件会按照 `plugins` 数组的顺序依次执行，Rsbuild 内置插件的执行时机早于用户注册的插件。
 
 当插件内部使用了控制顺序的相关字段，比如 `pre`、`post` 时，执行顺序会基于它们进行调整，详见 [前置插件](/plugins/dev/core#前置插件)。
 
-### 本地插件
+## 本地插件
 
 如果本地代码仓库中包含了一些 Rsbuild 插件，你可以直接通过相对路径引入。
 
@@ -34,7 +34,7 @@ export default defineConfig({
 });
 ```
 
-### 插件选项
+## 插件选项
 
 如果插件提供了一些选项，你可以通过插件函数的参数传入配置。
 
@@ -51,4 +51,21 @@ export default defineConfig({
     }),
   ],
 });
+```
+
+## Rspack 插件
+
+`plugins` 选项用于注册 Rsbuild 插件，如果你需要注册 Rspack 或 Webpack 插件，请使用 [tools.rspack](/config/tools/rspack)。
+
+```ts title="rsbuild.config.ts"
+export default {
+  // Rsbuild 插件
+  plugins: [pluginStylus()],
+  tools: {
+    rspack: {
+      // Rspack 或 Webpack 插件
+      plugins: [new SomeWebpackPlugin()],
+    },
+  },
+};
 ```


### PR DESCRIPTION
## Summary

Add register Rspack plugins guide to the `plugins` page.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
