### PR TITLE
perf(plugin-vue): bump vue-loader v17.4 to reuse AST

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "vue-loader": "^17.2.2",
+    "vue-loader": "^17.4.0",
     "webpack": "^5.89.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,8 +1334,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       vue-loader:
-        specifier: ^17.2.2
-        version: 17.3.0(webpack@5.89.0)
+        specifier: ^17.4.0
+        version: 17.4.0(webpack@5.89.0)
       webpack:
         specifier: ^5.89.0
         version: 5.89.0
@@ -13924,8 +13924,8 @@ packages:
       - whiskers
     dev: false
 
-  /vue-loader@17.3.0(webpack@5.89.0):
-    resolution: {integrity: sha512-VUURABiN0TIUz0yvJJ/V/rZjGUh10JZtD+IDI5bXFslzFi9mV6ebKkPzoqiSi8e0vh8Ip7JHJx+I0AzAG0KsCA==}
+  /vue-loader@17.4.0(webpack@5.89.0):
+    resolution: {integrity: sha512-tq81JlBNWYvoYAh5PRZXg5bE7BEv0Id6W7BF5otj18MtHgu5OqiK9rQu0z73r+VGlIq0lLDoEeC7RWYynUpXlQ==}
     peerDependencies:
       '@vue/compiler-sfc': '*'
       vue: '*'


### PR DESCRIPTION
## Summary

Bump vue-loader v17.4 to reuse AST.

## Related Links

https://github.com/vuejs/vue-loader/blob/main/CHANGELOG.md#1740-2023-12-25

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
