### PR TITLE
fix(plugin-svelte): missing default mainFields

### DIFF
--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -39,14 +39,10 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
 
         const rsbuildConfig = api.getNormalizedConfig();
 
-        chain.resolve.alias
-          .set('svelte', path.join(sveltePath, 'src/runtime'))
-          .end()
-          .extensions.add('.svelte')
-          .end()
-          .mainFields.prepend('svelte')
-          .end()
-          .set('conditionNames', ['svelte', '...']);
+        chain.resolve.alias.set('svelte', path.join(sveltePath, 'src/runtime'));
+        chain.resolve.extensions.add('.svelte');
+        chain.resolve.mainFields.add('svelte').add('...');
+        chain.resolve.set('conditionNames', ['svelte', '...']);
 
         const loaderPath = require.resolve('svelte-loader');
 

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -39,6 +39,7 @@ exports[`plugin-svelte > should add svelte loader properly 1`] = `
     ],
     "mainFields": [
       "svelte",
+      "...",
     ],
   },
   "resolveLoader": {
@@ -84,6 +85,7 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
     ],
     "mainFields": [
       "svelte",
+      "...",
     ],
   },
   "resolveLoader": {
@@ -133,6 +135,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
     ],
     "mainFields": [
       "svelte",
+      "...",
     ],
   },
   "resolveLoader": {
@@ -182,6 +185,7 @@ exports[`plugin-svelte > should turn off hmr by hand correctly 1`] = `
     ],
     "mainFields": [
       "svelte",
+      "...",
     ],
   },
   "resolveLoader": {


### PR DESCRIPTION
## Summary

Fix missing default mainFields when using `@rsbuild/plugin-svelte`.

## Related Links

https://github.com/sailscastshq/boring-stack/pull/74

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
