### PR TITLE
chore(plugin-swc): use standard plugin name

### DIFF
--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -14,7 +14,7 @@ import {
 } from './utils';
 import { SwcMinimizerPlugin } from './minimizer';
 
-const PLUGIN_NAME = 'plugin-swc';
+const PLUGIN_NAME = 'rsbuild-webpack:swc';
 
 /**
  * In this plugin, we do:


### PR DESCRIPTION
## Summary

Use standard plugin name for plugin-swc.

## Related Links

https://rsbuild.dev/plugins/dev/index#naming-convention

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
