### PR TITLE
fix: reload when the updated modules is empty

### DIFF
--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -145,7 +145,8 @@ function tryApplyUpdates() {
   }
 
   function handleApplyUpdates(err: any, updatedModules: any) {
-    const wantsForcedReload = err || !updatedModules || hadRuntimeError;
+    const wantsForcedReload =
+      err || !updatedModules || updatedModules.length === 0 || hadRuntimeError;
     if (wantsForcedReload) {
       window.location.reload();
       return;


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/modern.js/pull/5152

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
