### PR TITLE
test(e2e): reduce HMR cases time

### DIFF
--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -54,9 +54,6 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
     fse.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
   );
 
-  // wait for hmr take effect
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-
   await expect(locator).toHaveText('Hello Test!');
 
   // #test-keep should unchanged when app.tsx hmr
@@ -70,9 +67,6 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
   color: rgb(0, 0, 255);
 }`,
   );
-
-  // wait for hmr take effect
-  await new Promise((resolve) => setTimeout(resolve, 2000));
 
   await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
 
@@ -183,8 +177,6 @@ rspackOnlyTest(
       fse.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
     );
 
-    // wait for hmr take effect
-    await new Promise((resolve) => setTimeout(resolve, 2000));
     await expect(locator).toHaveText('Hello Test!');
 
     // restore
@@ -263,8 +255,17 @@ test('devServer', async ({ page }) => {
   i = 0;
   reloadFn!();
 
-  // wait for page reload take effect
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  // check value of `i`
+  const maxChecks = 100;
+  let checks = 0;
+  while (checks < maxChecks) {
+    if (i === 0) {
+      checks++;
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    } else {
+      break;
+    }
+  }
 
   expect(i).toBeGreaterThanOrEqual(1);
 


### PR DESCRIPTION
## Summary

Reduce HMR cases time, avoid using long `setTimeout`.

`pnpm run e2e:rspack server/dev`

before:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/cfe0f408-0ac0-428a-b404-5db3740d2486)

after:

<img width="228" alt="Screenshot 2023-12-26 at 17 58 02" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/581f47f3-81fb-4b7b-928f-7083db77f72d">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
