### PR TITLE
docs: add Vue JSX type inference guide

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-vue-jsx.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-vue-jsx.mdx
@@ -40,6 +40,20 @@ Babel compilation will introduce extra overhead, in the example above, we use `i
 
 :::
 
+## JSX Type Inference
+
+When using Vue >= 3.3, please set `"jsxImportSource": "vue"` in `tsconfig.json` to enable JSX type inference.
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "jsxImportSource": "vue"
+  }
+}
+```
+
+For more details, see [Vue - JSX Type Inference](https://vuejs.org/guide/extras/render-function.html#jsx-type-inference).
+
 ## Options
 
 If you need to customize the compilation behavior of Vue, you can use the following configs.

--- a/packages/document/docs/zh/plugins/list/plugin-vue-jsx.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-vue-jsx.mdx
@@ -40,6 +40,20 @@ Babel 编译会产生额外的编译开销，在上述例子中，我们通过 `
 
 :::
 
+## JSX 类型推导
+
+在使用 Vue >= 3.3 版本时，请在 `tsconfig.json` 中设置 `"jsxImportSource": "vue"`，以启用 JSX 类型推导。
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "jsxImportSource": "vue"
+  }
+}
+```
+
+详见 [Vue - JSX Type Inference](https://vuejs.org/guide/extras/render-function.html#jsx-type-inference)。
+
 ## 选项
 
 如果你需要自定义 Vue 的编译行为，可以使用以下配置项。


### PR DESCRIPTION
## Summary

Add Vue JSX type inference guide

## Related Links

https://vuejs.org/guide/extras/render-function.html#jsx-type-inference

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
