### PR TITLE
feat: support use entry description object

### DIFF
--- a/e2e/cases/source/entry-description-object/index.test.ts
+++ b/e2e/cases/source/entry-description-object/index.test.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import { expect, test } from '@playwright/test';
+import { build } from '@scripts/shared';
+import { globContentJSON } from '@scripts/helper';
+
+test('should allow to set entry description object', async () => {
+  await build({
+    cwd: __dirname,
+  });
+
+  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
+
+  expect(
+    outputFiles.find((item) => item.includes('static/js/foo.')),
+  ).toBeTruthy();
+  expect(
+    outputFiles.find((item) => item.includes('static/js/bar.')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/source/entry-description-object/rsbuild.config.ts
+++ b/e2e/cases/source/entry-description-object/rsbuild.config.ts
@@ -1,0 +1,10 @@
+export default {
+  source: {
+    entry: {
+      foo: {
+        import: './src/foo.js',
+      },
+      bar: './src/bar.js',
+    },
+  },
+};

--- a/e2e/cases/source/entry-description-object/rsbuild.config.ts
+++ b/e2e/cases/source/entry-description-object/rsbuild.config.ts
@@ -4,7 +4,10 @@ export default {
       foo: {
         import: './src/foo.js',
       },
-      bar: './src/bar.js',
+      bar: {
+        import: ['./src/bar.js', './src/baz.js'],
+      },
+      baz: './src/baz.js',
     },
   },
 };

--- a/e2e/cases/source/entry-description-object/src/bar.js
+++ b/e2e/cases/source/entry-description-object/src/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/e2e/cases/source/entry-description-object/src/baz.js
+++ b/e2e/cases/source/entry-description-object/src/baz.js
@@ -1,0 +1,1 @@
+console.log('baz');

--- a/e2e/cases/source/entry-description-object/src/foo.js
+++ b/e2e/cases/source/entry-description-object/src/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -27,8 +27,6 @@ const rsbuild = await createRsbuild({
 The first parameter of `createRsbuild` is a options object, you can pass in the following options:
 
 ```ts
-type RsbuildEntry = Record<string, string | string[]>;
-
 type CreateRsbuildOptions = {
   cwd?: string;
   rsbuildConfig?: RsbuildConfig;

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -23,7 +23,7 @@ The entry object from the `source.entry` option.
 - **Type:**
 
 ```ts
-type RsbuildEntry = Record<string, string | string[]>;
+type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
 ```
 
 ### context.targets

--- a/packages/document/docs/en/config/source/entry.mdx
+++ b/packages/document/docs/en/config/source/entry.mdx
@@ -3,7 +3,7 @@
 - **Type:**
 
 ```ts
-type Entry = Record<string, string | string[]>;
+type Entry = Record<string, string | string[] | EntryDescription>;
 ```
 
 - **Default:**
@@ -48,3 +48,26 @@ The generated directory structure is as follows:
 ```
 
 If you do not need to generate HTML files, you can set [tools.htmlPlugin](/config/tools/html-plugin) to `false` to disable this behavior.
+
+## Description Object
+
+`source.entry` also supports Rspack's entry description object. For example:
+
+```ts
+export default {
+  source: {
+    entry: {
+      foo: {
+        import: './src/foo.js',
+        runtime: 'foo',
+      },
+      bar: {
+        import: './src/bar.js',
+        runtime: 'bar',
+      },
+    },
+  },
+};
+```
+
+For the complete usage of the description object, please refer to [Rspack - Entry Description Object](https://rspack.dev/config/entry#entry-description-object).

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -27,8 +27,6 @@ const rsbuild = await createRsbuild({
 `createRsbuild` 的第一个参数是一个配置对象，你可以传入以下选项：
 
 ```ts
-type RsbuildEntry = Record<string, string | string[]>;
-
 type CreateRsbuildOptions = {
   cwd?: string;
   rsbuildConfig?: RsbuildConfig;

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -23,7 +23,7 @@ type Version = string;
 - **类型：**
 
 ```ts
-type RsbuildEntry = Record<string, string | string[]>;
+type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
 ```
 
 ### context.targets

--- a/packages/document/docs/zh/config/source/entry.mdx
+++ b/packages/document/docs/zh/config/source/entry.mdx
@@ -3,7 +3,7 @@
 - **类型：**
 
 ```ts
-type Entry = Record<string, string | string[]>;
+type Entry = Record<string, string | string[] | EntryDescription>;
 ```
 
 - **默认值：**
@@ -48,3 +48,26 @@ export default {
 ```
 
 如果你不需要生成 HTML 文件，可以将 [tools.htmlPlugin](/config/tools/html-plugin) 设置为 `false` 来禁用这一行为。
+
+## 描述对象
+
+`source.entry` 同样支持 Rspack 的 entry 描述对象写法，比如：
+
+```ts
+export default {
+  source: {
+    entry: {
+      foo: {
+        import: './src/foo.js',
+        runtime: 'foo',
+      },
+      bar: {
+        import: './src/bar.js',
+        runtime: 'bar',
+      },
+    },
+  },
+};
+```
+
+关于描述对象的完整用法，请参考 [Rspack - 入口描述对象](https://rspack.dev/config/entry#%E5%85%A5%E5%8F%A3%E6%8F%8F%E8%BF%B0%E5%AF%B9%E8%B1%A1)。

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -2,10 +2,11 @@ import type { Context } from './context';
 import type { PluginStore } from './plugin';
 import type { RsbuildConfig } from './config';
 import type { RsbuildProvider, ProviderInstance } from './provider';
+import type { EntryDescription } from '@rspack/core';
 
 export type RsbuildTarget = 'web' | 'node' | 'web-worker' | 'service-worker';
 
-export type RsbuildEntry = Record<string, string | string[]>;
+export type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
 
 export type RsbuildMode = 'development' | 'production';
 


### PR DESCRIPTION
## Summary

`source.entry` supports the use of entry description object.

## Related Links

https://www.rspack.dev/config/entry.html#entry-description-object

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
