### PR TITLE
chore(hmr-client): remove unused variable

### DIFF
--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -11,15 +11,6 @@ import { createSocketUrl } from './createSocketUrl';
 // declare any to fix the type of `module.hot`
 declare const module: any;
 
-// TODO hadRuntimeError should be fixed.
-// We need to keep track of if there has been a runtime error.
-// Essentially, we cannot guarantee application state was not corrupted by the
-// runtime error. To prevent confusing behavior, we forcibly reload the entire
-// application. This is handled below when we are notified of a compile (code
-// change).
-// See https://github.com/facebook/create-react-app/issues/3096
-const hadRuntimeError = false;
-
 // Connect to Dev Server
 const socketUrl = createSocketUrl(__resourceQuery);
 
@@ -145,7 +136,7 @@ function tryApplyUpdates() {
   }
 
   function handleApplyUpdates(err: any, updatedModules: any) {
-    const wantsForcedReload = err || !updatedModules || hadRuntimeError;
+    const wantsForcedReload = err || !updatedModules;
     if (wantsForcedReload) {
       window.location.reload();
       return;


### PR DESCRIPTION
## Summary

Remove unused `hadRuntimeError` variable from hmr client (the value is always `false`).

For React apps, react refresh can handle hot-reloading over errors, see [this comment](https://github.com/charrondev/create-react-app/blob/572d14c19cc9626656450de6ec545d90e460142e/packages/react-dev-utils/webpackHotDevClient.js#L248).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
