### PR TITLE
chore: remove outdated comment from preload plugin

### DIFF
--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -75,10 +75,9 @@ function generateLinks(
   const htmlChunks =
     // Handle all chunks.
     options.type === 'all-assets' || HTMLCount === 1
-      ? extractedChunks // Only handle chunks imported by this HtmlWebpackPlugin.
-      : extractedChunks.filter((chunk) =>
-          // TODO: Not yet supported in rspack, maybe we should implement it in another way
-          // https://github.com/web-infra-dev/rspack/issues/3896
+      ? extractedChunks
+      : // Only handle chunks imported by this HtmlWebpackPlugin.
+        extractedChunks.filter((chunk) =>
           doesChunkBelongToHtml({
             chunk,
             compilation,


### PR DESCRIPTION
## Summary

Remove outdated comment from preload plugin, the feature has been supported by Rspack.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/747
- https://github.com/web-infra-dev/rspack/issues/3896

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
