### PR TITLE
fix: handle css-loader mode option correctly

### DIFF
--- a/.changeset/new-vans-think.md
+++ b/.changeset/new-vans-think.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+fix: handle css-loader mode option correctly

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -35,9 +35,11 @@ export const isCssModules = (filename: string, modules: CssLoaderModules) => {
     return modules;
   }
 
-  // todo: this configuration is not common and more complex.
+  // Same as the `mode` option
+  // https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#mode
   if (typeof modules === 'string') {
-    return true;
+    // CSS Modules will be disabled if mode is false
+    return modules !== 'global';
   }
 
   const { auto } = modules;

--- a/packages/shared/src/css.ts
+++ b/packages/shared/src/css.ts
@@ -38,7 +38,7 @@ export const isCssModules = (filename: string, modules: CssLoaderModules) => {
   // Same as the `mode` option
   // https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#mode
   if (typeof modules === 'string') {
-    // CSS Modules will be disabled if mode is false
+    // CSS Modules will be disabled if mode is 'global'
     return modules !== 'global';
   }
 


### PR DESCRIPTION
## Summary

Handle css-loader mode option correctly, CSS Modules will be disabled if mode is `global`.

## Related Links

https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#mode

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
