### PR TITLE
chore: rename to differentiate between two context types

### DIFF
--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -7,7 +7,7 @@ import {
   type Rspack,
   type RspackConfig,
 } from '@rsbuild/shared';
-import type { Context } from '@rsbuild/core/provider';
+import type { InternalContext } from '@rsbuild/core/provider';
 import type { WebpackConfig } from '../types';
 import { initConfigs, InitConfigsOptions } from './initConfigs';
 import type { Compiler } from 'webpack';
@@ -17,7 +17,7 @@ export async function createCompiler({
   context,
   webpackConfigs,
 }: {
-  context: Context;
+  context: InternalContext;
   webpackConfigs: WebpackConfig[];
 }) {
   debug('create compiler');

--- a/packages/compat/webpack/src/core/initConfigs.ts
+++ b/packages/compat/webpack/src/core/initConfigs.ts
@@ -4,13 +4,16 @@ import {
   type InspectConfigOptions,
   type CreateRsbuildOptions,
 } from '@rsbuild/shared';
-import { initRsbuildConfig, type Context } from '@rsbuild/core/provider';
+import {
+  initRsbuildConfig,
+  type InternalContext,
+} from '@rsbuild/core/provider';
 import { inspectConfig } from './inspectConfig';
 import { generateWebpackConfig } from './webpackConfig';
 import type { WebpackConfig } from '../types';
 
 export type InitConfigsOptions = {
-  context: Context;
+  context: InternalContext;
   pluginStore: PluginStore;
   rsbuildOptions: Required<CreateRsbuildOptions>;
 };

--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -9,14 +9,14 @@ import {
   type ModifyWebpackChainUtils,
   type ModifyWebpackConfigUtils,
 } from '@rsbuild/shared';
-import type { Context } from '@rsbuild/core/provider';
+import type { InternalContext } from '@rsbuild/core/provider';
 import { getCompiledPath } from '../shared';
 import type { RuleSetRule, WebpackPluginInstance } from 'webpack';
 import type WebpackChain from 'webpack-chain';
 import type { WebpackConfig } from '../types';
 
 async function modifyWebpackChain(
-  context: Context,
+  context: InternalContext,
   utils: ModifyWebpackChainUtils,
   chain: WebpackChain,
 ): Promise<WebpackChain> {
@@ -41,7 +41,7 @@ async function modifyWebpackChain(
 }
 
 async function modifyWebpackConfig(
-  context: Context,
+  context: InternalContext,
   webpackConfig: WebpackConfig,
   utils: ModifyWebpackConfigUtils,
 ): Promise<WebpackConfig> {
@@ -149,7 +149,7 @@ export async function generateWebpackConfig({
   context,
 }: {
   target: RsbuildTarget;
-  context: Context;
+  context: InternalContext;
 }) {
   const chainUtils = await getChainUtils(target);
   const {

--- a/packages/compat/webpack/src/plugins/css.ts
+++ b/packages/compat/webpack/src/plugins/css.ts
@@ -9,7 +9,7 @@ import {
   getBrowserslistWithDefault,
   getCssModuleLocalIdentName,
   getSharedPkgCompiledPath,
-  type Context,
+  type RsbuildContext,
   type RsbuildPlugin,
   type NormalizedConfig,
   type BundlerChainRule,
@@ -25,7 +25,7 @@ export async function applyBaseCSSRule({
 }: {
   rule: BundlerChainRule;
   config: NormalizedConfig;
-  context: Context;
+  context: RsbuildContext;
   utils: ModifyChainUtils;
   importLoaders?: number;
 }) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,10 +22,10 @@ export type {
   RsbuildPluginAPI,
 } from './types';
 export type {
-  Context as RsbuildContext,
   RsbuildMode,
   RsbuildEntry,
   RsbuildTarget,
+  RsbuildContext,
   RsbuildInstance,
   CreateRsbuildOptions,
   InspectConfigOptions,

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -4,7 +4,7 @@ import { fse } from '@rsbuild/shared';
 import {
   findExists,
   isFileExists,
-  type Context,
+  type RsbuildContext,
   type BuildCacheOptions,
 } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
@@ -43,7 +43,7 @@ function getDigestHash(digest: Array<string | undefined>) {
 
 function getCacheDirectory(
   { cacheDirectory }: BuildCacheOptions,
-  context: Context,
+  context: RsbuildContext,
 ) {
   if (cacheDirectory) {
     return isAbsolute(cacheDirectory)
@@ -57,7 +57,7 @@ function getCacheDirectory(
  * webpack can't detect the changes of framework config, tsconfig, tailwind config and browserslist config.
  * but they will affect the compilation result, so they need to be added to buildDependencies.
  */
-async function getBuildDependencies(context: Readonly<Context>) {
+async function getBuildDependencies(context: Readonly<RsbuildContext>) {
   const rootPackageJson = join(context.rootPath, 'package.json');
   const browserslistConfig = join(context.rootPath, '.browserslistrc');
 

--- a/packages/core/src/provider/core/createCompiler.ts
+++ b/packages/core/src/provider/core/createCompiler.ts
@@ -13,7 +13,7 @@ import {
   type CreateDevMiddlewareReturns,
 } from '@rsbuild/shared';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
-import type { Context } from '../../types';
+import type { InternalContext } from '../../types';
 import type { Stats, MultiStats, StatsCompilation } from '@rspack/core';
 import { isSatisfyRspackVersion, rspackMinVersion } from '../shared';
 
@@ -21,7 +21,7 @@ export async function createCompiler({
   context,
   rspackConfigs,
 }: {
-  context: Context;
+  context: InternalContext;
   rspackConfigs: RspackConfig[];
 }): Promise<RspackCompiler | RspackMultiCompiler> {
   debug('create compiler');

--- a/packages/core/src/provider/core/initConfigs.ts
+++ b/packages/core/src/provider/core/initConfigs.ts
@@ -12,9 +12,9 @@ import { updateContextByNormalizedConfig } from './createContext';
 import { inspectConfig } from './inspectConfig';
 import { generateRspackConfig } from './rspackConfig';
 import { normalizeConfig } from '../config';
-import type { Context, NormalizedConfig } from '../../types';
+import type { InternalContext, NormalizedConfig } from '../../types';
 
-async function modifyRsbuildConfig(context: Context) {
+async function modifyRsbuildConfig(context: InternalContext) {
   debug('modify Rsbuild config');
   const [modified] = await context.hooks.modifyRsbuildConfigHook.call(
     context.config,
@@ -26,7 +26,7 @@ async function modifyRsbuildConfig(context: Context) {
 }
 
 export type InitConfigsOptions = {
-  context: Context;
+  context: InternalContext;
   pluginStore: PluginStore;
   rsbuildOptions: Required<CreateRsbuildOptions>;
 };

--- a/packages/core/src/provider/core/initPlugins.ts
+++ b/packages/core/src/provider/core/initPlugins.ts
@@ -7,7 +7,7 @@ import {
   type GetRsbuildConfig,
 } from '@rsbuild/shared';
 import { createPublicContext } from './createContext';
-import type { Context, NormalizedConfig } from '../../types';
+import type { InternalContext, NormalizedConfig } from '../../types';
 
 export function getHTMLPathByEntry(
   entryName: string,
@@ -26,7 +26,7 @@ export function getPluginAPI({
   context,
   pluginStore,
 }: {
-  context: Context;
+  context: InternalContext;
   pluginStore: PluginStore;
 }): RsbuildPluginAPI {
   const { hooks } = context;

--- a/packages/core/src/provider/core/rspackConfig.ts
+++ b/packages/core/src/provider/core/rspackConfig.ts
@@ -11,11 +11,11 @@ import {
   type ModifyRspackConfigUtils,
 } from '@rsbuild/shared';
 import { getCompiledPath } from '../shared';
-import type { Context } from '../../types';
+import type { InternalContext } from '../../types';
 import { getHTMLPlugin } from '../htmlPluginUtil';
 
 async function modifyRspackConfig(
-  context: Context,
+  context: InternalContext,
   rspackConfig: RspackConfig,
   utils: ModifyRspackConfigUtils,
 ) {
@@ -110,7 +110,7 @@ export async function generateRspackConfig({
   context,
 }: {
   target: RsbuildTarget;
-  context: Context;
+  context: InternalContext;
 }): Promise<RspackConfig> {
   const chainUtils = await getChainUtils(target);
   const {

--- a/packages/core/src/provider/index.ts
+++ b/packages/core/src/provider/index.ts
@@ -7,5 +7,5 @@ export { withDefaultConfig } from './config';
 export { initRsbuildConfig } from './core/initConfigs';
 export { getPluginAPI } from './core/initPlugins';
 export { applyBaseCSSRule, applyCSSModuleRule } from './plugins/css';
-export type { Context } from '../types';
+export type { InternalContext } from '../types';
 export { setHTMLPlugin, getHTMLPlugin } from './htmlPluginUtil';

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -13,7 +13,7 @@ import {
   mergeChainedOptions,
   getSharedPkgCompiledPath,
   type BundlerChain,
-  type Context,
+  type RsbuildContext,
   type RspackRule,
   type RuleSetRule,
   type ModifyBundlerChainUtils,
@@ -32,7 +32,7 @@ export async function applyBaseCSSRule({
 }: {
   rule: ReturnType<BundlerChain['module']['rule']>;
   config: NormalizedConfig;
-  context: Context;
+  context: RsbuildContext;
   utils: ModifyBundlerChainUtils;
   importLoaders?: number;
 }) {

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -18,14 +18,14 @@ import {
 import { formatRoutes, getDevOptions, printServerURLs } from './helper';
 import connect from '@rsbuild/shared/connect';
 import { onBeforeRestartServer } from './restart';
-import type { Context } from '../types';
+import type { InternalContext } from '../types';
 import { createHttpServer } from './httpServer';
 import { getMiddlewares } from './getDevMiddlewares';
 import { notFoundMiddleware } from './middlewares';
 
 export async function getServerAPIs<
   Options extends {
-    context: Context;
+    context: InternalContext;
   },
 >(
   options: Options,
@@ -133,7 +133,7 @@ export async function getServerAPIs<
 
 export async function startDevServer<
   Options extends {
-    context: Context;
+    context: InternalContext;
   },
 >(
   options: Options,

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -14,7 +14,7 @@ import {
 } from '@rsbuild/shared';
 import { formatRoutes, getServerOptions, printServerURLs } from './helper';
 import { faviconFallbackMiddleware } from './middlewares';
-import type { Context } from '../types';
+import type { InternalContext } from '../types';
 import { createHttpServer } from './httpServer';
 
 type RsbuildProdServerOptions = {
@@ -131,7 +131,7 @@ export class RsbuildProdServer {
 }
 
 export async function startProdServer(
-  context: Context,
+  context: InternalContext,
   rsbuildConfig: RsbuildConfig,
   { printURLs = true, getPortSilently }: PreviewServerOptions = {},
 ) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,7 +1,7 @@
 import type {
-  Context as BaseContext,
   RsbuildConfig,
   RsbuildPlugin,
+  RsbuildContext,
   NormalizedConfig,
   RsbuildPluginAPI,
 } from '@rsbuild/shared';
@@ -10,7 +10,7 @@ import type { Hooks } from './provider/core/initHooks';
 export type { RsbuildPlugin, RsbuildPluginAPI };
 
 /** The inner context. */
-export type Context = BaseContext & {
+export type InternalContext = RsbuildContext & {
   /** All hooks. */
   hooks: Readonly<Hooks>;
   /** Current Rsbuild config. */

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -11,10 +11,10 @@ import {
   DEFAULT_ASSET_PREFIX,
 } from './constants';
 import type {
-  Context,
   BundlerChain,
   RsbuildConfig,
   ChainedConfig,
+  RsbuildContext,
   CreateAsyncHook,
   BundlerChainRule,
   NormalizedConfig,
@@ -33,7 +33,7 @@ export async function getBundlerChain() {
 }
 
 export async function modifyBundlerChain(
-  context: Context & {
+  context: RsbuildContext & {
     hooks: {
       modifyBundlerChainHook: CreateAsyncHook<ModifyBundlerChainFn>;
     };
@@ -251,7 +251,7 @@ export function applyScriptCondition({
 }: {
   rule: BundlerChainRule;
   config: NormalizedConfig;
-  context: Context;
+  context: RsbuildContext;
   includes: (string | RegExp)[];
   excludes: (string | RegExp)[];
 }) {
@@ -282,7 +282,7 @@ export function applyOutputPlugin(api: RsbuildPluginAPI) {
   }: {
     config: NormalizedConfig;
     isProd: boolean;
-    context: Context;
+    context: RsbuildContext;
   }) {
     const { dev, output } = config;
 

--- a/packages/shared/src/types/context.ts
+++ b/packages/shared/src/types/context.ts
@@ -3,7 +3,7 @@ import type { RsbuildEntry, RsbuildTarget } from './rsbuild';
 export type BundlerType = 'rspack' | 'webpack';
 
 /** The public context */
-export type Context = {
+export type RsbuildContext = {
   /** The Rsbuild core version. */
   version: string;
   /** The entry points object. */

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -14,7 +14,7 @@ import type {
   ModifyBundlerChainFn,
   ModifyChainUtils,
 } from './hooks';
-import { Context } from './context';
+import type { RsbuildContext } from './context';
 import {
   RsbuildConfig,
   NormalizedConfig,
@@ -126,7 +126,7 @@ export type GetRsbuildConfig = {
  * Define a generic Rsbuild plugin API that provider can extend as needed.
  */
 export type RsbuildPluginAPI = {
-  context: Readonly<Context>;
+  context: Readonly<RsbuildContext>;
   isPluginExists: PluginStore['isPluginExists'];
 
   onExit: (fn: OnExitFn) => void;

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,5 +1,5 @@
 import type { PluginStore, Plugins, RsbuildPluginAPI } from './plugin';
-import type { Context } from './context';
+import type { RsbuildContext } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { StartServerResult, DevServerAPIs } from './server';
@@ -59,7 +59,7 @@ export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
 export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   readonly bundler: Bundler;
 
-  readonly publicContext: Readonly<Context>;
+  readonly publicContext: Readonly<RsbuildContext>;
 
   pluginAPI: RsbuildPluginAPI;
 

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -1,6 +1,6 @@
-import type { Context } from './context';
 import type { PluginStore } from './plugin';
 import type { RsbuildConfig } from './config';
+import type { RsbuildContext } from './context';
 import type { RsbuildProvider, ProviderInstance } from './provider';
 import type { EntryDescription } from '@rspack/core';
 
@@ -20,7 +20,7 @@ export type CreateRsbuildOptions = {
 export type RsbuildInstance<
   P extends RsbuildProvider | RsbuildProvider<'webpack'> = RsbuildProvider,
 > = {
-  context: Context;
+  context: RsbuildContext;
 
   addPlugins: PluginStore['addPlugins'];
   removePlugins: PluginStore['removePlugins'];


### PR DESCRIPTION
## Summary

There are two Context types in Rsbuild, the internal context for Rsbuild core, and the public context for Rsbuild plugins.

This PR renames them to distinguish between the two context types.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
