### PR TITLE
feat(CLI): support open specific URL

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -7,7 +7,7 @@ import type { RsbuildMode } from '..';
 
 export type CommonOptions = {
   config?: string;
-  open?: boolean;
+  open?: boolean | string;
   host?: string;
   port?: number;
 };
@@ -56,7 +56,7 @@ export async function init({
 
     if (commonOpts.open && !config.dev?.startUrl) {
       config.dev ||= {};
-      config.dev.startUrl = true;
+      config.dev.startUrl = commonOpts.open;
     }
 
     if (commonOpts.host) {
@@ -87,7 +87,7 @@ export function runCli() {
 
   program
     .command('dev')
-    .option('--open', 'open the page in browser on startup')
+    .option('--open [url]', 'open the page in browser on startup')
     .option(
       '--port <port>',
       'specify a port number for Rsbuild Server to listen',
@@ -135,7 +135,7 @@ export function runCli() {
 
   program
     .command('preview')
-    .option('--open', 'open the page in browser on startup')
+    .option('--open [url]', 'open the page in browser on startup')
     .option(
       '--port <port>',
       'specify a port number for Rsbuild Server to listen',

--- a/packages/document/docs/en/guide/basic/cli.mdx
+++ b/packages/document/docs/en/guide/basic/cli.mdx
@@ -39,11 +39,25 @@ The `rsbuild dev` command is used to start a local development server and compil
 Usage: rsbuild dev [options]
 
 Options:
-  --open                open the page in browser on startup
+  --open [url]          open the page in browser on startup
   --port <port>         specify a port number for Rsbuild Server to listen
   --host <host>         specify the host that the Rsbuild Server listens to
   -c --config <config>  specify the configuration file, can be a relative or absolute path
   -h, --help            display help for command
+```
+
+### Opening Page
+
+The `--open` option allows you to automatically open a page when starting the dev server, which is equivalent to setting [dev.startUrl](/config/dev/start-url) to `true`.
+
+```bash
+rsbuild dev --open
+```
+
+The `--open` option also supports specifying the URL to be opened, for example:
+
+```bash
+rsbuild dev --open http://localhost:8080/foo
 ```
 
 ---
@@ -73,7 +87,7 @@ Do not use this as a production server as it's not designed for it.
 Usage: rsbuild preview [options]
 
 Options:
-  --open                open the page in browser on startup
+  --open [url]          open the page in browser on startup
   --port <port>         specify a port number for Rsbuild Server to listen
   --host <host>         specify the host that the Rsbuild Server listens to
   -c --config <config>  specify the configuration file, can be a relative or absolute path

--- a/packages/document/docs/zh/guide/basic/cli.mdx
+++ b/packages/document/docs/zh/guide/basic/cli.mdx
@@ -39,11 +39,25 @@ Commands:
 Usage: rsbuild dev [options]
 
 Options:
-  --open                启动时是否在浏览器中打开页面
+  --open [url]          启动时是否在浏览器中打开页面
   --port <port>         设置 Rsbuild Server 监听的端口号
   --host <host>         指定 Rsbuild Server 启动时监听的 host
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径
   -h, --help            显示命令帮助
+```
+
+### 打开页面
+
+通过 `--open` 选项可以在启动 dev server 时自动打开页面，等同于将 [dev.startUrl](/config/dev/start-url) 设置为 `true`。
+
+```bash
+rsbuild dev --open
+```
+
+`--open` 选项也支持指定需要打开的 URL 地址，比如：
+
+```bash
+rsbuild dev --open http://localhost:8080/foo
 ```
 
 ---
@@ -73,7 +87,7 @@ Options:
 Usage: rsbuild preview [options]
 
 Options:
-  --open                启动时是否在浏览器中打开页面
+  --open [url]          启动时是否在浏览器中打开页面
   --port <port>         设置 Rsbuild Server 监听的端口号
   --host <host>         指定 Rsbuild Server 启动时监听的 host
   -c --config <config>  指定配置文件路径，可以为相对路径或绝对路径


### PR DESCRIPTION
## Summary

Support open specific URL:

```bash
rsbuild dev --open http://localhost:8080/foo
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
