### PR TITLE
fix(plugin-source-build): should after babel/ts-loader/swc

### DIFF
--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -43,6 +43,13 @@ export function pluginSourceBuild(
   return {
     name: pluginName,
 
+    pre: [
+      'rsbuild:babel',
+      'uni-builder:babel',
+      'uni-builder:ts-loader',
+      'rsbuild-webpack:swc',
+    ],
+
     setup(api) {
       const projectRootPath = api.context.rootPath;
 


### PR DESCRIPTION
## Summary

source build plugin depends on js/ts rule, so it should be after babel/ts-loader/swc plugin.
<img width="732" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/0e8311ed-7bc6-4b49-b179-d8459b416411">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
