### PR TITLE
fix: bundle analyzer failed to read assets during dev

### DIFF
--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -1,0 +1,37 @@
+import { join } from 'path';
+import { expect, test } from '@playwright/test';
+import { dev, build } from '@scripts/shared';
+import { globContentJSON } from '@scripts/helper';
+
+test('should emit bundle analyze report correctly when dev', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+
+  const files = await globContentJSON(join(__dirname, 'dist'));
+  const filePaths = Object.keys(files).filter((file) =>
+    file.endsWith('report-web.html'),
+  );
+  expect(filePaths.length).toBe(1);
+
+  await rsbuild.server.close();
+});
+
+test('should emit bundle analyze report correctly when build', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filePaths = Object.keys(files).filter((file) =>
+    file.endsWith('report-web.html'),
+  );
+
+  expect(filePaths.length).toBe(1);
+});

--- a/e2e/cases/performance/bundle-analyzer/rsbuild.config.ts
+++ b/e2e/cases/performance/bundle-analyzer/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  performance: {
+    bundleAnalyze: {},
+  },
+});

--- a/e2e/cases/performance/bundle-analyzer/rsbuild.config.ts
+++ b/e2e/cases/performance/bundle-analyzer/rsbuild.config.ts
@@ -1,8 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
   performance: {
     bundleAnalyze: {},
   },

--- a/e2e/cases/performance/bundle-analyzer/src/App.jsx
+++ b/e2e/cases/performance/bundle-analyzer/src/App.jsx
@@ -1,0 +1,3 @@
+const App = () => <div id="test">Hello Rsbuild!</div>;
+
+export default App;

--- a/e2e/cases/performance/bundle-analyzer/src/App.jsx
+++ b/e2e/cases/performance/bundle-analyzer/src/App.jsx
@@ -1,3 +1,0 @@
-const App = () => <div id="test">Hello Rsbuild!</div>;
-
-export default App;

--- a/e2e/cases/performance/bundle-analyzer/src/index.js
+++ b/e2e/cases/performance/bundle-analyzer/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/e2e/cases/performance/bundle-analyzer/src/index.js
+++ b/e2e/cases/performance/bundle-analyzer/src/index.js
@@ -1,5 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
 
-ReactDOM.render(React.createElement(App), document.getElementById('root'));
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);
+
+console.log(React, ReactDOM);

--- a/e2e/cases/performance/performance.test.ts
+++ b/e2e/cases/performance/performance.test.ts
@@ -20,7 +20,6 @@ test.describe('performance configure multi', () => {
           },
         },
         performance: {
-          bundleAnalyze: {},
           chunkSplit: {
             strategy: 'all-in-one',
           },
@@ -29,14 +28,6 @@ test.describe('performance configure multi', () => {
     });
 
     files = await rsbuild.unwrapOutputJSON();
-  });
-
-  test('bundleAnalyze', async () => {
-    const filePaths = Object.keys(files).filter((file) =>
-      file.endsWith('report-web.html'),
-    );
-
-    expect(filePaths.length).toBe(1);
   });
 
   test('chunkSplit all-in-one', async () => {

--- a/packages/core/src/plugins/bundleAnalyzer.ts
+++ b/packages/core/src/plugins/bundleAnalyzer.ts
@@ -1,20 +1,40 @@
-import type { RsbuildPlugin } from '../types';
+import { isProd } from '@rsbuild/shared';
+import type { RsbuildConfig, RsbuildPlugin, NormalizedConfig } from '../types';
+
+// There are two ways to enable the bundle analyzer:
+// 1. Set environment variable `BUNDLE_ANALYZE`
+// 2. Set performance.bundleAnalyze config
+const isUseAnalyzer = (config: RsbuildConfig | NormalizedConfig) =>
+  process.env.BUNDLE_ANALYZE || config.performance?.bundleAnalyze;
 
 export function pluginBundleAnalyzer(): RsbuildPlugin {
   return {
     name: 'rsbuild:bundle-analyzer',
+
     setup(api) {
-      api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
-        const config = api.getNormalizedConfig();
-        // There are two ways to open the bundle analyzer:
-        // 1. Set environment variable `BUNDLE_ANALYZE`
-        // 2. Set performance.bundleAnalyze config
-        if (!process.env.BUNDLE_ANALYZE && !config.performance.bundleAnalyze) {
+      api.modifyRsbuildConfig((config) => {
+        if (isProd() || !isUseAnalyzer(config)) {
           return;
         }
+
+        // webpack-bundle-analyze needs to read assets from disk
+        config.dev ||= {};
+        config.dev.writeToDisk = true;
+
+        return config;
+      });
+
+      api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
+        const config = api.getNormalizedConfig();
+
+        if (!isUseAnalyzer(config)) {
+          return;
+        }
+
         const { default: BundleAnalyzer } = await import(
           '@rsbuild/shared/webpack-bundle-analyzer'
         );
+
         chain
           .plugin(CHAIN_ID.PLUGIN.BUNDLE_ANALYZER)
           .use(BundleAnalyzer.BundleAnalyzerPlugin, [

--- a/packages/document/docs/en/config/performance/bundle-analyze.mdx
+++ b/packages/document/docs/en/config/performance/bundle-analyze.mdx
@@ -89,3 +89,4 @@ export default {
 1. Enabling the server mode will cause the `build` process to not exit normally.
 2. Enabling `bundleAnalyzer` will reduce build speed. Therefore, this configuration should not be enabled during daily development, and it is recommended to enable it on demand through the `BUNDLE_ANALYZE` environment variable.
 3. Since no code minification and other optimizations are performed in the `dev` phase, the real output size cannot be reflected, so it is recommended to analyze the output size in the `build` phase.
+4. If the bundleAnalyzer is enabled during the `dev` phase, in order to ensure that webpack-bundle-analyzer can access the contents of static assets, Rsbuild will automatically enable the [dev.writeToDisk](/config/dev/write-to-disk) option.

--- a/packages/document/docs/zh/config/performance/bundle-analyze.mdx
+++ b/packages/document/docs/zh/config/performance/bundle-analyze.mdx
@@ -89,3 +89,4 @@ export default {
 1. 开启 Server 模式会导致 `build` 进程不能正常退出。
 2. 开启 bundleAnalyzer 会降低构建性能。因此，在日常开发过程中不应该开启此配置项，建议通过 `BUNDLE_ANALYZE` 环境变量来按需开启。
 3. 由于 `dev` 阶段不会进行代码压缩等优化，无法反映真实的产物体积，因此建议在 `build` 阶段分析产物体积。
+4. 如果在 `dev` 阶段开启 bundleAnalyzer，为了保证 webpack-bundle-analyzer 可以读取到静态资源的内容，Rsbuild 会自动开启 [dev.writeToDisk](/config/dev/write-to-disk) 选项。


### PR DESCRIPTION
## Summary

Fix bundle analyzer failed to read assets during dev:

<img width="1179" alt="Screenshot 2023-12-28 at 14 53 21" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/f96c5481-85c3-46df-ba8f-74a4f8eeb879">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
