### PR TITLE
chore: get compilation stage constant from compiler

### DIFF
--- a/packages/core/src/rspack/HtmlAppIconPlugin.ts
+++ b/packages/core/src/rspack/HtmlAppIconPlugin.ts
@@ -2,11 +2,7 @@ import fs from 'fs';
 import { posix, basename } from 'path';
 import type { Compiler, Compilation } from '@rspack/core';
 import WebpackSources from '@rsbuild/shared/webpack-sources';
-import {
-  withPublicPath,
-  getPublicPathFromCompiler,
-  COMPILATION_PROCESS_STAGE,
-} from '@rsbuild/shared';
+import { withPublicPath, getPublicPathFromCompiler } from '@rsbuild/shared';
 import { getHTMLPlugin } from '../provider/htmlPluginUtil';
 
 type AppIconOptions = {
@@ -66,7 +62,8 @@ export class HtmlAppIconPlugin {
         compilation.hooks.processAssets.tap(
           {
             name: this.name,
-            stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+            stage:
+              compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
           },
           (assets) => {
             const source = fs.readFileSync(this.iconPath);

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -9,7 +9,6 @@ import { join } from 'path';
 import {
   isFunction,
   addTrailingSlash,
-  COMPILATION_PROCESS_STAGE,
   getPublicPathFromCompiler,
   type InlineChunkTest,
 } from '@rsbuild/shared';
@@ -239,7 +238,7 @@ export class InlineChunkHtmlPlugin {
            * Remove marked inline assets in summarize stage,
            * which should be later than the emitting of html-webpack-plugin
            */
-          stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_SUMMARIZE,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         () => {
           const { devtool } = compiler.options;

--- a/packages/core/src/rspack/RemoveCssSourcemapPlugin.ts
+++ b/packages/core/src/rspack/RemoveCssSourcemapPlugin.ts
@@ -1,5 +1,4 @@
 import type { Compiler, Compilation } from '@rspack/core';
-import { COMPILATION_PROCESS_STAGE } from '@rsbuild/shared';
 
 export class RemoveCssSourcemapPlugin {
   name: string;
@@ -13,7 +12,7 @@ export class RemoveCssSourcemapPlugin {
       compilation.hooks.processAssets.tap(
         {
           name: this.name,
-          stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_SUMMARIZE,
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },
         () => {
           Object.keys(compilation.assets).forEach((name) => {

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -5,7 +5,6 @@ import {
   withPublicPath,
   generateScriptTag,
   getPublicPathFromCompiler,
-  COMPILATION_PROCESS_STAGE,
   type Rspack,
 } from '@rsbuild/shared';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
@@ -71,7 +70,8 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
           compilation.hooks.processAssets.tapPromise(
             {
               name: this.name,
-              stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+              stage:
+                compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
             },
             async (assets) => {
               const scriptPath = await this.getScriptPath();

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -4,7 +4,6 @@ import {
   withPublicPath,
   generateScriptTag,
   getPublicPathFromCompiler,
-  COMPILATION_PROCESS_STAGE,
   type Rspack,
 } from '@rsbuild/shared';
 import WebpackSources from '@rsbuild/shared/webpack-sources';
@@ -108,7 +107,8 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
           compilation.hooks.processAssets.tapPromise(
             {
               name: this.name,
-              stage: COMPILATION_PROCESS_STAGE.PROCESS_ASSETS_STAGE_PRE_PROCESS,
+              stage:
+                compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_PRE_PROCESS,
             },
             async (assets) => {
               const scriptPath = await this.getScriptPath();

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -204,15 +204,6 @@ export function debounce<T extends (...args: any[]) => void>(
 export const upperFirst = (str: string) =>
   str ? str.charAt(0).toUpperCase() + str.slice(1) : '';
 
-/** The intersection of webpack and Rspack */
-export const COMPILATION_PROCESS_STAGE = {
-  PROCESS_ASSETS_STAGE_ADDITIONAL: -2000,
-  PROCESS_ASSETS_STAGE_PRE_PROCESS: -1000,
-  PROCESS_ASSETS_STAGE_OPTIMIZE_INLINE: 700,
-  PROCESS_ASSETS_STAGE_SUMMARIZE: 1000,
-  PROCESS_ASSETS_STAGE_REPORT: 5000,
-};
-
 export const generateScriptTag = () => ({
   tagName: 'script',
   attributes: {


### PR DESCRIPTION
## Summary

Get compilation stage constant from compiler, we should not maintain `COMPILATION_PROCESS_STAGE` in the Rsbuild codebase.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
