### PR TITLE
Allow the generation of either 0 or more than 1 html files for per entry

### DIFF
--- a/e2e/cases/html/multiple-output/index.test.ts
+++ b/e2e/cases/html/multiple-output/index.test.ts
@@ -1,0 +1,119 @@
+import { basename, relative } from 'path';
+import { expect, test } from '@playwright/test';
+import { build } from '@scripts/shared';
+
+test.describe('tools.htmlPlugin for multiple outputs', async () => {
+  let rsbuild: Awaited<ReturnType<typeof build>> | undefined = undefined;
+  let htmls: Record<string, string> = {};
+  test.beforeAll(async () => {
+    const _rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      rsbuildConfig: {
+        source: {
+          entry: {
+            ibmPreOnly: './src/ibm-only.js',
+            app: './src/app.js',
+            landing: './src/landing.js',
+          },
+        },
+        tools: {
+          htmlPlugin(config, { entryName }) {
+            if (entryName === 'ibmPreOnly') {
+              return { disabled: true };
+            }
+            if (entryName === 'app') {
+              return {
+                ...config,
+                title: 'App Default',
+                filename: 'app-default.html',
+                publicPath: '/',
+                flavors: [
+                  {
+                    title: 'App - IBM',
+                    filename: 'app-ibm-oem.html',
+                    chunks: ['ibmPreOnly', ...(config.chunks as string[])],
+                    publicPath: 'https://ibm-cdn.example.com/',
+                    meta: { 'api:prefix': 'https://ibm.example.com' },
+                  },
+                  {
+                    title: 'App - AOC',
+                    filename: 'app-aoc-oem.html',
+                    publicPath: 'https://aoc-cdn.example.com/',
+                    meta: { 'api:prefix': 'https://aoc.example.com' },
+                  },
+                ],
+              };
+            }
+            return { ...config, title: entryName };
+          },
+        },
+      },
+    });
+    rsbuild = _rsbuild;
+    htmls = Object.fromEntries(
+      Object.entries(await _rsbuild.unwrapOutputJSON())
+        .filter(([filepath]) => /\.html$/.test(filepath))
+        .map(([filepath, content]) => {
+          const name = basename(relative(_rsbuild.distPath, filepath), '.html');
+          return [name, content] as const;
+        }),
+    );
+  });
+
+  test.afterAll(async () => {
+    htmls = {};
+    await rsbuild?.close();
+    rsbuild = void 0;
+  });
+
+  test('should skip disabled entry', () => {
+    expect(htmls).not.toHaveProperty('ibmPreOnly');
+  });
+  test('should create html as usual', () => {
+    expect(Object.keys(htmls)).toMatchObject(
+      expect.arrayContaining([
+        'app-default',
+        'app-ibm-oem',
+        'app-aoc-oem',
+        'landing',
+      ]),
+    );
+  });
+
+  test("flavors has it's own title", () => {
+    expect(htmls['app-aoc-oem']).toMatch('<title>App - AOC</title>');
+    expect(htmls['app-ibm-oem']).toMatch('<title>App - IBM</title>');
+    expect(htmls['app-default']).toMatch('<title>App Default</title>');
+  });
+  test("flavors has it's own publicPath", () => {
+    expect(htmls['app-aoc-oem']).toMatch(
+      'https://aoc-cdn.example.com/static/js/app',
+    );
+    expect(htmls['app-ibm-oem']).toMatch(
+      'https://ibm-cdn.example.com/static/js/app',
+    );
+  });
+
+  test("flavors has it's own chunk list", () => {
+    expect(htmls['app-ibm-oem']).toMatch(
+      'https://ibm-cdn.example.com/static/js/ibmPreOnly',
+    );
+
+    expect(htmls['app-aoc-oem']).not.toMatch(
+      'https://ibm-cdn.example.com/static/js/ibmPreOnly',
+    );
+  });
+
+  test("flavors has it's own meta", () => {
+    expect(htmls['app-ibm-oem']).toMatch(
+      /<meta.+name="api:prefix".+content="https:\/\/ibm.example.com"/,
+    );
+
+    expect(htmls['app-aoc-oem']).toMatch(
+      /<meta.+name="api:prefix".+content="https:\/\/aoc.example.com"/,
+    );
+
+    expect(htmls['app-default']).not.toMatch(/<meta.+name="api:prefix"/);
+  });
+});

--- a/e2e/cases/html/multiple-output/src/app.js
+++ b/e2e/cases/html/multiple-output/src/app.js
@@ -1,0 +1,1 @@
+console.log(document.querySelector('meta[name="api:prefix"]')?.content);

--- a/e2e/cases/html/multiple-output/src/ibm-only.js
+++ b/e2e/cases/html/multiple-output/src/ibm-only.js
@@ -1,0 +1,1 @@
+console.log('ibm only');

--- a/e2e/cases/html/multiple-output/src/landing.js
+++ b/e2e/cases/html/multiple-output/src/landing.js
@@ -1,0 +1,1 @@
+console.log('landing');

--- a/packages/document/docs/en/config/tools/html-plugin.mdx
+++ b/packages/document/docs/en/config/tools/html-plugin.mdx
@@ -76,6 +76,60 @@ export default {
 };
 ```
 
+### Additional Properties
+
+#### `disabled`
+
+- **Type:** `boolean | undefined`
+- **Default:** `undefined`
+
+This property allows you skip the html generation for a specific entry.
+
+```js
+export default {
+  tools: {
+    htmlPlugin: (config, { entryName }) => {
+      if (entryName === 'vendor') {
+        config.disabled = true;
+      }
+    },
+  },
+};
+```
+
+#### `flavors`
+
+- **Type:** `Partial<HTMLPluginOptions>[] | undefined`
+- **Default:** `undefined`
+
+This property allows you generating extra html files for a specific entry.
+
+```js
+export default {
+  tools: {
+    htmlPlugin: (config, { entryName }) => {
+      if (entryName === 'app') {
+        config.flavors = [
+          ...(config.flavors || []),
+          // emit extra html file `a.html` for tenant A with endpoint variable `https://a.corp.com/`
+          {
+            title: 'App - Tenant A',
+            filename: 'a.html',
+            templateParameters: { endpoint: 'https://a.corp.com/' },
+          },
+          // emit extra html file `b.html` for tenant B with endpoint variable `https://b.corp.com/`
+          {
+            title: 'App - Tenant B',
+            filename: 'b.html',
+            templateParameters: { endpoint: 'https://b.corp.com/' },
+          },
+        ];
+      }
+    },
+  },
+};
+```
+
 ## Example
 
 ### Modify HTML File Name

--- a/packages/document/docs/zh/config/tools/html-plugin.mdx
+++ b/packages/document/docs/zh/config/tools/html-plugin.mdx
@@ -76,6 +76,62 @@ export default {
 };
 ```
 
+### 额外属性
+
+除去 html-webpack-plugin 的配置项外，你还可以设置以下属性。
+
+#### `disabled`
+
+- **类型：** `boolean | undefined`
+- **默认值：** `undefined`
+
+该属性允许你为某一 entry 跳过 html 生成。
+
+```js
+export default {
+  tools: {
+    htmlPlugin: (config, { entryName }) => {
+      if (entryName === 'vendor') {
+        config.disabled = true;
+      }
+    },
+  },
+};
+```
+
+#### `flavors`
+
+- **类型：** `Partial<HTMLPluginOptions>[] | undefined`
+- **默认值：** `undefined`
+
+该属性允许你为某一 entry 生成额外的 html 文件。
+
+```js
+export default {
+  tools: {
+    htmlPlugin: (config, { entryName }) => {
+      if (entryName === 'app') {
+        config.flavors = [
+          ...(config.flavors || []),
+          // 为租户 A 生成一个额外的 html 文件 `a.html`，包含一个 `endpoint` 变量 `https://a.corp.com/`
+          {
+            title: 'App - 租户 A',
+            filename: 'a.html',
+            templateParameters: { endpoint: 'https://a.corp.com/' },
+          },
+          // 为租户 B 生成一个额外的 html 文件 `b.html`，包含一个 `endpoint` 变量 `https://b.corp.com/`
+          {
+            title: 'App - 租户 B',
+            filename: 'b.html',
+            templateParameters: { endpoint: 'https://b.corp.com/' },
+          },
+        ];
+      }
+    },
+  },
+};
+```
+
 ## 示例
 
 ### 修改 HTML 文件名

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -20,14 +20,39 @@ import type {
 import type { BundlerChain } from '../bundlerConfig';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
 import type { RspackConfig, RspackRule } from '../rspack';
-import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
+import type { Options as RawHTMLPluginOptions } from 'html-webpack-plugin';
 import type { BundlerPluginInstance } from '../bundlerConfig';
 import type {
   ModifyWebpackChainUtils,
   ModifyWebpackConfigUtils,
 } from '../plugin';
 
-export type { HTMLPluginOptions };
+export interface HTMLPluginOptions extends RawHTMLPluginOptions {
+  /**
+   * skip html output for an entry
+   * @example skip html output for entry named `vendor`
+   * ```
+   * { tools: {
+   *   html(config, { entryName }) {
+   *     if (entryName === "vendor") return { disabled: true }
+   *   }
+   * }}
+   * ```
+   */
+  disabled?: boolean;
+  /**
+   * generate extra html files for specific entry
+   * @example generate an extra html with title "Xmas Version" and filename `x-mas.html`
+   * ```
+   * { tools: {
+   *   html(config) {
+   *     return { ...config, flavors: [{ title: "Xmas Version", filename: "x-mas.html" }] }
+   *   }
+   * }}
+   * ```
+   */
+  flavors?: Partial<RawHTMLPluginOptions>[];
+}
 
 export type ToolsAutoprefixerConfig = ChainedConfig<AutoprefixerOptions>;
 


### PR DESCRIPTION
## Summary

As it's hard to change `ChainedConfigWithUtils<HTMLPluginOptions>` to `ChainedConfigWithUtils<false | HTMLPluginOptions | HTMLPluginOptions[]>` without breaking developers' config, I added two new properties into`HTMLPluginOptions` instead:

- `disabled` for bypass html generation for specific entry
- `flavors` for extra html generation for specific entry

API Detail: https://deploy-preview-1113--rsbuild.netlify.app/config/tools/html-plugin#additional-properties

## Related Links

<!--- Provide links of related issues or pages -->

Closes #1035

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
