### PR TITLE
docs: update extend asset types example

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -47,6 +47,7 @@
     "transpiling",
     "tsbuildinfo",
     "unocss",
-    "vitest"
+    "vitest",
+    "webm"
   ]
 }

--- a/packages/document/docs/en/guide/basic/static-assets.md
+++ b/packages/document/docs/en/guide/basic/static-assets.md
@@ -128,18 +128,21 @@ After adding the type declaration, if the type error still exists, you can try t
 
 ## Extend Asset Types
 
-If the built-in asset types in Rsbuild cannot meet your requirements, you can modify the built-in Rspack configuration and extend the asset types you need using [tools.bundlerChain](/config/tools/bundler-chain).
+If the built-in asset types in Rsbuild cannot meet your requirements, you can modify the built-in Rspack configuration and extend the asset types you need using [tools.rspack](/config/tools/rspack).
 
 For example, if you want to treat `*.pdf` files as assets and directly output them to the dist directory, you can add the following configuration:
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain(chain) {
-      chain.module
-        .rule('pdf')
-        .test(/\.pdf$/)
-        .type('asset/resource');
+    rspack(config, { addRules }) {
+      addRules([
+        {
+          test: /\.pdf$/,
+          // converts asset to a separate file and exports the URL address.
+          type: 'asset/resource',
+        },
+      ]);
     },
   },
 };
@@ -153,10 +156,7 @@ import myFile from './static/myFile.pdf';
 console.log(myFile); // "/static/myFile.6c12aba3.pdf"
 ```
 
-For more information about asset modules, please refer to:
-
-- [Rspack Documentation - Asset modules](https://rspack.dev/guide/asset-module#asset-modules)
-- [webpack Documentation - Asset modules](https://webpack.js.org/guides/asset-modules/)
+For more information about asset modules, please refer to [Rspack - Asset modules](https://rspack.dev/guide/asset-module#asset-modules).
 
 ## Image Format
 

--- a/packages/document/docs/zh/guide/basic/static-assets.md
+++ b/packages/document/docs/zh/guide/basic/static-assets.md
@@ -128,18 +128,21 @@ declare module '*.png' {
 
 ## 扩展静态资源类型
 
-如果 Rsbuild 内置的静态资源类型不能满足你的需求，那么你可以通过 [tools.bundlerChain](/config/tools/bundler-chain) 来修改内置的 Rspack 配置，并扩展你需要的静态资源类型。
+如果 Rsbuild 内置的静态资源类型不能满足你的需求，那么你可以通过 [tools.rspack](/config/tools/rspack) 来修改内置的 Rspack 配置，并扩展你需要的静态资源类型。
 
 比如，你需要把 `*.pdf` 文件当做静态资源直接输出到产物目录，可以添加以下配置：
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain(chain) {
-      chain.module
-        .rule('pdf')
-        .test(/\.pdf$/)
-        .type('asset/resource');
+    rspack(config, { addRules }) {
+      addRules([
+        {
+          test: /\.pdf$/,
+          // 将资源转换为单独的文件，并且导出产物地址
+          type: 'asset/resource',
+        },
+      ]);
     },
   },
 };
@@ -153,10 +156,7 @@ import myFile from './static/myFile.pdf';
 console.log(myFile); // "/static/myFile.6c12aba3.pdf"
 ```
 
-关于以上配置的更多介绍，请参考：
-
-- [Rspack 文档 - Asset modules](https://rspack.dev/guide/asset-module#asset-modules)
-- [webpack 文档 - Asset modules](https://webpack.js.org/guides/asset-modules/)
+关于 asset modules 的更多介绍，请参考 [Rspack - Asset modules](https://rspack.dev/guide/asset-module#asset-modules)。
 
 ## 图片格式
 


### PR DESCRIPTION
## Summary

Update extend asset types example, use `tools.rspack` instead of `tools.bundlerChain`, as it is easier to use.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
