### PR TITLE
feat: add new server.printUrls config

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { dev } from '@scripts/shared';
+import { proxyConsole } from '@scripts/helper';
+
+const cwd = __dirname;
+
+test('should print server urls correctly when printUrls is true', async ({
+  page,
+}) => {
+  const { logs, restore } = proxyConsole();
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: true,
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const localLog = logs.find(
+    (log) => log.includes('Local:') && log.includes('http://localhost'),
+  );
+  const networkLog = logs.find(
+    (log) => log.includes('Network:') && log.includes('http://'),
+  );
+
+  expect(localLog).toBeTruthy();
+  expect(networkLog).toBeTruthy();
+
+  await rsbuild.server.close();
+  restore();
+});
+
+test('should not print server urls when printUrls is false', async ({
+  page,
+}) => {
+  const { logs, restore } = proxyConsole();
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: false,
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const localLog = logs.find(
+    (log) => log.includes('Local:') && log.includes('http://localhost'),
+  );
+  const networkLog = logs.find(
+    (log) => log.includes('Network:') && log.includes('http://'),
+  );
+
+  expect(localLog).toBeFalsy();
+  expect(networkLog).toBeFalsy();
+
+  await rsbuild.server.close();
+  restore();
+});

--- a/e2e/cases/server/print-urls/src/index.js
+++ b/e2e/cases/server/print-urls/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -63,3 +63,19 @@ export const awaitFileExists = async (dir: string) => {
 
   throw new Error('awaitFileExists failed: ' + dir);
 };
+
+export const proxyConsole = (type: 'log' | 'warn' | 'error' = 'log') => {
+  const logs: string[] = [];
+
+  const original = console[type];
+  console[type] = (log) => {
+    logs.push(log);
+  };
+
+  return {
+    logs,
+    restore: () => {
+      console[type] = original;
+    },
+  };
+};

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -108,6 +108,7 @@ const updateConfigForTest = async (
   // make devPort random to avoid port conflict
   config.server = {
     ...(config.server || {}),
+    printUrls: config.server?.printUrls || false,
     port: await getRandomPort(config.server?.port),
   };
 
@@ -155,9 +156,7 @@ export async function dev({
 
   const rsbuild = await createRsbuild(options, plugins);
 
-  return rsbuild.startDevServer({
-    printURLs: false,
-  });
+  return rsbuild.startDevServer();
 }
 
 export async function build({
@@ -185,9 +184,7 @@ export async function build({
     port,
     server: { close },
   } = runServer
-    ? await rsbuild.preview({
-        printURLs: false,
-      })
+    ? await rsbuild.preview()
     : { port: 0, server: { close: noop } };
 
   const clean = async () => await fse.remove(distPath);

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -178,7 +178,7 @@ export async function startDevServer<
   let urls = getAddressUrls(protocol, port, host);
 
   // print url after http server created and before dev compile (just a short time interval)
-  if (printURLs) {
+  if (printURLs && devServerConfig.printUrls !== false) {
     if (isFunction(printURLs)) {
       urls = printURLs(urls);
 

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -181,7 +181,7 @@ export async function startProdServer(
 
         const urls = getAddressUrls(https ? 'https' : 'http', port);
 
-        if (printURLs) {
+        if (printURLs && serverConfig.printUrls !== false) {
           printServerURLs(
             isFunction(printURLs) ? printURLs(urls) : urls,
             routes,

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -51,6 +51,8 @@ export const getDefaultServerConfig = (): NormalizedServerConfig => ({
   host: DEFAULT_DEV_HOST,
   htmlFallback: 'index',
   compress: true,
+  printUrls: true,
+  strictPort: false,
   publicDir: {
     name: 'public',
     copyOnBuild: true,

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -74,6 +74,9 @@ export interface ServerConfig {
    * Adds headers to all responses.
    */
   headers?: Record<string, string | string[]>;
+  /**
+   * Whether to support html fallback.
+   */
   htmlFallback?: HtmlFallback;
   /**
    * Provide alternative pages for some 404 responses or other requests.
@@ -88,7 +91,22 @@ export interface ServerConfig {
    * Whether to throw an error when the port is occupied.
    */
   strictPort?: boolean;
+  /**
+   * Whether to print the server urls when the server is started.
+   */
+  printUrls?: boolean;
 }
 
 export type NormalizedServerConfig = ServerConfig &
-  Required<Pick<ServerConfig, 'htmlFallback' | 'port' | 'host' | 'publicDir'>>;
+  Required<
+    Pick<
+      ServerConfig,
+      | 'htmlFallback'
+      | 'port'
+      | 'host'
+      | 'compress'
+      | 'publicDir'
+      | 'strictPort'
+      | 'printUrls'
+    >
+  >;


### PR DESCRIPTION
## Summary

Add new `server.printUrls` config.

## TODO

- support function usage.
- deprecate `printURLs` option in Node API
- add document.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/1121

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
