### PR TITLE
fix(plugin-vue2): alias Vue to support element-ui

### DIFF
--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -22,6 +22,11 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {
         chain.resolve.extensions.add('.vue');
 
+        // https://github.com/web-infra-dev/rsbuild/issues/1132
+        if (!chain.resolve.alias.get('vue$')) {
+          chain.resolve.alias.set('vue$', 'vue/dist/vue.runtime.esm.js');
+        }
+
         const vueLoaderOptions = deepmerge(
           {
             compilerOptions: {

--- a/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -24,6 +24,9 @@ exports[`plugin-vue2 > should add vue-loader and VueLoaderPlugin correctly 1`] =
     VueLoaderPlugin {},
   ],
   "resolve": {
+    "alias": {
+      "vue$": "vue/dist/vue.runtime.esm.js",
+    },
     "extensions": [
       ".vue",
     ],
@@ -56,6 +59,9 @@ exports[`plugin-vue2 > should allow to configure vueLoader options 1`] = `
     VueLoaderPlugin {},
   ],
   "resolve": {
+    "alias": {
+      "vue$": "vue/dist/vue.runtime.esm.js",
+    },
     "extensions": [
       ".vue",
     ],


### PR DESCRIPTION
## Summary

Alias Vue to support element-ui, resolve https://github.com/web-infra-dev/rsbuild/issues/1132

## Related Links

- https://github.com/ElemeFE/element/issues/21968
- https://github.com/vitejs/vite-plugin-vue2/blob/main/src/index.ts#L103-L109

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
