### PR TITLE
feat: support custom print urls

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -63,3 +63,35 @@ test('should not print server urls when printUrls is false', async ({
   await rsbuild.server.close();
   restore();
 });
+
+test('should allow to custom urls', async ({ page }) => {
+  const { logs, restore } = proxyConsole('log');
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: ({ urls, protocol, port }) => {
+          expect(typeof port).toEqual('number');
+          expect(protocol).toEqual('http');
+          expect(urls.includes(`http://localhost:${port}`)).toBeTruthy();
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const localLog = logs.find(
+    (log) => log.includes('Local:') && log.includes('http://localhost'),
+  );
+  const networkLog = logs.find(
+    (log) => log.includes('Network:') && log.includes('http://'),
+  );
+
+  expect(localLog).toBeFalsy();
+  expect(networkLog).toBeFalsy();
+
+  await rsbuild.server.close();
+  restore();
+});

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -178,7 +178,7 @@ export async function startDevServer<
   let urls = getAddressUrls(protocol, port, host);
 
   // print url after http server created and before dev compile (just a short time interval)
-  if (printURLs && devServerConfig.printUrls !== false) {
+  if (printURLs) {
     if (isFunction(printURLs)) {
       urls = printURLs(urls);
 
@@ -187,7 +187,14 @@ export async function startDevServer<
       }
     }
 
-    printServerURLs(urls, defaultRoutes, logger);
+    printServerURLs({
+      urls,
+      port,
+      routes: defaultRoutes,
+      logger,
+      protocol,
+      printUrls: devServerConfig.printUrls,
+    });
   }
 
   const compileMiddlewareAPI = await serverAPIs.startCompile();

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -3,6 +3,7 @@ import {
   logger as defaultLogger,
   getPort,
   deepmerge,
+  isFunction,
   normalizeUrl,
   DEFAULT_PORT,
   DEFAULT_DEV_HOST,
@@ -11,6 +12,7 @@ import type {
   Logger,
   Routes,
   DevConfig,
+  PrintUrls,
   RsbuildEntry,
   RsbuildConfig,
   OutputStructure,
@@ -38,11 +40,34 @@ export const formatRoutes = (
   );
 };
 
-export function printServerURLs(
-  urls: Array<{ url: string; label: string }>,
-  routes: Routes,
-  logger: Logger = defaultLogger,
-) {
+export function printServerURLs({
+  urls,
+  port,
+  routes,
+  protocol,
+  printUrls,
+  logger = defaultLogger,
+}: {
+  urls: Array<{ url: string; label: string }>;
+  port: number;
+  routes: Routes;
+  logger?: Logger;
+  protocol: string;
+  printUrls?: PrintUrls;
+}) {
+  if (printUrls === false) {
+    return;
+  }
+
+  if (isFunction(printUrls)) {
+    printUrls({
+      urls: urls.map((item) => item.url),
+      port,
+      protocol,
+    });
+    return;
+  }
+
   let message = '';
 
   if (routes.length === 1) {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -179,14 +179,16 @@ export async function startProdServer(
           routes,
         });
 
-        const urls = getAddressUrls(https ? 'https' : 'http', port);
+        const protocol = https ? 'https' : 'http';
+        const urls = getAddressUrls(protocol, port);
 
-        if (printURLs && serverConfig.printUrls !== false) {
-          printServerURLs(
-            isFunction(printURLs) ? printURLs(urls) : urls,
-            routes,
-          );
-        }
+        printServerURLs({
+          urls: isFunction(printURLs) ? printURLs(urls) : urls,
+          port,
+          routes,
+          protocol,
+          printUrls: serverConfig.printUrls,
+        });
 
         const onClose = () => {
           server.close();

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -121,8 +121,8 @@ test('printServerURLs', () => {
     },
   };
 
-  printServerURLs(
-    [
+  printServerURLs({
+    urls: [
       {
         url: 'http://localhost:8080',
         label: 'local',
@@ -132,7 +132,7 @@ test('printServerURLs', () => {
         label: 'network',
       },
     ],
-    [
+    routes: [
       {
         name: 'index',
         route: '',
@@ -140,7 +140,7 @@ test('printServerURLs', () => {
     ],
     // @ts-expect-error
     logger,
-  );
+  });
 
   expect(message!).toMatchInlineSnapshot(`
     "  > local     http:/localhost:8080/
@@ -148,8 +148,8 @@ test('printServerURLs', () => {
     "
   `);
 
-  printServerURLs(
-    [
+  printServerURLs({
+    urls: [
       {
         url: 'http://localhost:8080',
         label: 'local',
@@ -159,7 +159,7 @@ test('printServerURLs', () => {
         label: 'network',
       },
     ],
-    [
+    routes: [
       {
         name: 'index',
         route: '',
@@ -175,7 +175,7 @@ test('printServerURLs', () => {
     ],
     // @ts-expect-error
     logger,
-  );
+  });
 
   expect(message!).toMatchInlineSnapshot(`
     "  > local

--- a/packages/document/docs/en/config/server/print-urls.mdx
+++ b/packages/document/docs/en/config/server/print-urls.mdx
@@ -1,6 +1,6 @@
 # printUrls
 
-- **Type:** `boolean`
+- **Type:** `boolean | Function`
 - **Default:** `true`
 
 Whether to print the server's urls.
@@ -12,7 +12,25 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 > Network:  http://192.168.0.1:8080
 ```
 
-## Disabling Output
+## Custom Logging
+
+`server.printUrls` can be set to a function, with parameters including port, protocol, and urls.
+
+When `server.printUrls` is set to a function, Rsbuild will not print the server's URL addresses. You can customize the log content based on the parameters and output it to the terminal yourself.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ urls, port, protocol }) {
+      console.log(urls); // ['http://localhost:8080', 'http://192.168.0.1:8080']
+      console.log(port); // 8080
+      console.log(protocol); // 'http' or 'https'
+    },
+  },
+};
+```
+
+## Disable Output
 
 Setting `server.printUrls` to `false` will prevent Rsbuild from printing the server urls.
 

--- a/packages/document/docs/zh/config/server/print-urls.mdx
+++ b/packages/document/docs/zh/config/server/print-urls.mdx
@@ -1,6 +1,6 @@
 # printUrls
 
-- **类型：** `boolean`
+- **类型：** `boolean | Function`
 - **默认值：** `true`
 
 是否输出 server 的 URL 地址。
@@ -10,6 +10,24 @@
 ```text
 > Local:    http://localhost:8080
 > Network:  http://192.168.0.1:8080
+```
+
+## 自定义日志
+
+`server.printUrls` 可以设置为一个函数，函数的入参包括 port，protocol 和 urls。
+
+当 `server.printUrls` 设置为函数时，Rsbuild 将不会输出 server 的 URL 地址，你可以基于入参来自定义日志内容，并自行输出到 terminal。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ urls, port, protocol }) {
+      console.log(urls); // ['http://localhost:8080', 'http://192.168.0.1:8080']
+      console.log(port); // 8080
+      console.log(protocol); // 'http' or 'https'
+    },
+  },
+};
 ```
 
 ## 禁用输出

--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -16,6 +16,8 @@ export const isOverriddenConfigKey = (key: string) =>
     'auto',
     // output.targets
     'targets',
+    // server.printUrls
+    'printUrls',
   ].includes(key);
 
 export const mergeRsbuildConfig = <T>(...configs: T[]): T =>

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -34,6 +34,10 @@ export type HistoryApiFallbackOptions = {
   }>;
 };
 
+export type PrintUrls =
+  | boolean
+  | ((params: { urls: string[]; port: number; protocol: string }) => void);
+
 export type PublicDir =
   | false
   | {
@@ -94,7 +98,7 @@ export interface ServerConfig {
   /**
    * Whether to print the server urls when the server is started.
    */
-  printUrls?: boolean;
+  printUrls?: PrintUrls;
 }
 
 export type NormalizedServerConfig = ServerConfig &


### PR DESCRIPTION
## Summary

Support custom print urls via `server.printUrls`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/1121

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
