### PR TITLE
fix: failed to prepend entry via chain API

### DIFF
--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -2,9 +2,11 @@ import {
   debug,
   CHAIN_ID,
   castArray,
+  chainToConfig,
   modifyBundlerChain,
   mergeChainedOptions,
   type NodeEnv,
+  type BundlerChain,
   type RsbuildTarget,
   type ModifyWebpackChainUtils,
   type ModifyWebpackConfigUtils,
@@ -177,7 +179,9 @@ export async function generateWebpackConfig({
     bundlerChain as unknown as WebpackChain,
   );
 
-  let webpackConfig = chain.toConfig();
+  let webpackConfig = chainToConfig(
+    chain as unknown as BundlerChain,
+  ) as WebpackConfig;
 
   webpackConfig = await modifyWebpackConfig(
     context,

--- a/packages/core/src/provider/core/rspackConfig.ts
+++ b/packages/core/src/provider/core/rspackConfig.ts
@@ -2,6 +2,7 @@ import {
   debug,
   CHAIN_ID,
   castArray,
+  chainToConfig,
   modifyBundlerChain,
   mergeChainedOptions,
   type NodeEnv,
@@ -130,7 +131,7 @@ export async function generateRspackConfig({
     },
   });
 
-  let rspackConfig = chain.toConfig() as RspackConfig;
+  let rspackConfig = chainToConfig(chain);
 
   rspackConfig = await modifyRspackConfig(
     context,


### PR DESCRIPTION
## Summary

Fix failed to prepend entry via chain API.

webpack-chain can not handle entry description object correctly, so we need to format the entry object and correct the entry description object.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
