### PR TITLE
chore: deprecate legacy printURLs option

### DIFF
--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -181,8 +181,6 @@ Start the local dev server.
 
 ```ts
 type StartDevServerOptions = {
-  // Whether to output URL infos, the default is true
-  printURLs?: boolean | Function;
   // custom Compiler object
   compiler?: Compiler | MultiCompiler;
   // Whether to get the port silently, the default is false
@@ -242,29 +240,6 @@ console.log(port); // 8080
 
 // Close the dev server
 await server.close();
-```
-
-### Disable Print URLs
-
-Setting `printURLs` to `false` to disable the default URL output, so you can custom the logs.
-
-```ts
-await rsbuild.startDevServer({
-  printURLs: false,
-});
-```
-
-You can also directly configure `printURLs` as a function to modify URLs, such as adding a subpath to each URL:
-
-```ts
-await rsbuild.startDevServer({
-  printURLs: (urls) => {
-    return urls.map(({ label, url }) => ({
-      label,
-      url: `${url}/path`,
-    }));
-  },
-});
 ```
 
 ### Custom Compiler

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -181,8 +181,6 @@ await rsbuild.build({
 
 ```ts
 type StartDevServerOptions = {
-  // 是否输出 URL 信息，默认为 true
-  printURLs?: boolean | Function;
   // 自定义 Compiler 对象
   compiler?: Compiler | MultiCompiler;
   // 是否在启动时静默获取端口号，默认为 false
@@ -242,29 +240,6 @@ console.log(port); // 8080
 
 // 关闭 Dev Server
 await server.close();
-```
-
-### 自定义 URL 输出
-
-将 `printURLs` 设置为 `false` 可以禁用默认的 URL 输出，此时你可以输出自定义的日志内容。
-
-```ts
-await rsbuild.startDevServer({
-  printURLs: false,
-});
-```
-
-你也可以直接将 `printURLs` 配置为一个函数来修改 URL，比如给每个 URL 增加一个子路径：
-
-```ts
-await rsbuild.startDevServer({
-  printURLs: (urls) => {
-    return urls.map(({ label, url }) => ({
-      label,
-      url: `${url}/path`,
-    }));
-  },
-});
 ```
 
 ### 自定义 Compiler

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -15,14 +15,20 @@ export type CreateCompilerOptions = { watch?: boolean };
 
 export type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
-  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
   logger?: Logger;
   getPortSilently?: boolean;
+  /**
+   * @deprecated use `server.printUrls` instead
+   */
+  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
 };
 
 export type PreviewServerOptions = {
-  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
   getPortSilently?: boolean;
+  /**
+   * @deprecated use `server.printUrls` instead
+   */
+  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
 };
 
 export type BuildOptions = {


### PR DESCRIPTION
## Summary

Deprecate legacy printURLs option.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/1121

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
