### PR TITLE
chore: deprecate logger option of startDevServer

### DIFF
--- a/.changeset/spicy-avocados-play.md
+++ b/.changeset/spicy-avocados-play.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+chore: deprecate logger option of startDevServer

--- a/packages/document/docs/en/api/javascript-api/instance.mdx
+++ b/packages/document/docs/en/api/javascript-api/instance.mdx
@@ -185,8 +185,6 @@ type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
   // Whether to get the port silently, the default is false
   getPortSilently?: boolean;
-  // custom logger
-  logger?: Logger;
 };
 
 type StartServerResult = {
@@ -266,42 +264,6 @@ await rsbuild.startDevServer({
   getPortSilently: true,
 });
 ```
-
-### Custom Logger
-
-By default, Rsbuild uses [rslog](https://github.com/rspack-contrib/rslog) to output logs. You can customize the log output object through the `logger` parameter.
-
-```ts
-const customLogger = {
-  // You need to define the following methods
-  info(msg: string) {
-    console.log(msg);
-  },
-  error(msg: string) {
-    console.error(msg);
-  },
-  warn(msg: string) {
-    console.warn(msg);
-  },
-  success(msg: string) {
-    console.log(`✅ msg`);
-  },
-  debug(msg: string) {
-    if (process.env.DEBUG) {
-      console.log(msg);
-    }
-  },
-  log(msg: string) {
-    console.log(msg);
-  };
-}
-
-await rsbuild.startDevServer({
-  logger: customLogger,
-});
-```
-
-Then Rsbuild will use the custom logger to output logs.
 
 ## rsbuild.preview
 

--- a/packages/document/docs/zh/api/javascript-api/instance.mdx
+++ b/packages/document/docs/zh/api/javascript-api/instance.mdx
@@ -185,8 +185,6 @@ type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
   // 是否在启动时静默获取端口号，默认为 false
   getPortSilently?: boolean;
-  // 自定义日志输出对象
-  logger?: Logger;
 };
 
 type StartServerResult = {
@@ -266,42 +264,6 @@ await rsbuild.startDevServer({
   getPortSilently: true,
 });
 ```
-
-### 自定义日志输出对象
-
-默认情况下，Rsbuild 会使用 [rslog](https://github.com/rspack-contrib/rslog) 来输出日志，你可以通过 `logger` 参数来自定义日志输出对象。
-
-```ts
-const customLogger = {
-  // 你需要定义以下的方法
-  info(msg: string) {
-    console.log(msg);
-  },
-  error(msg: string) {
-    console.error(msg);
-  },
-  warn(msg: string) {
-    console.warn(msg);
-  },
-  success(msg: string) {
-    console.log(`✅ msg`);
-  },
-  debug(msg: string) {
-    if (process.env.DEBUG) {
-      console.log(msg);
-    }
-  },
-  log(msg: string) {
-    console.log(msg);
-  };
-}
-
-await rsbuild.startDevServer({
-  logger: customLogger,
-});
-```
-
-这样，Rsbuild 会使用你自定义的日志输出对象来输出日志。
 
 ## rsbuild.preview
 

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -15,8 +15,11 @@ export type CreateCompilerOptions = { watch?: boolean };
 
 export type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
-  logger?: Logger;
   getPortSilently?: boolean;
+  /**
+   * @deprecated use `logger.override()` instead
+   */
+  logger?: Logger;
   /**
    * @deprecated use `server.printUrls` instead
    */


### PR DESCRIPTION
## Summary

Deprecate logger option of startDevServer, use `logger.override()` instead. 

## Related Links

see: https://github.com/web-infra-dev/rsbuild/pull/1146

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
