### PR TITLE
fix(server): print local label for more hosts

### DIFF
--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -61,6 +61,11 @@ const getIpv4Interfaces = () => {
   return Array.from(ipv4Interfaces.values());
 };
 
+const isLocalHost = (host: string) => {
+  const loopbackHosts = ['localhost', '127.0.0.1', '::1'];
+  return loopbackHosts.includes(host);
+};
+
 export const getAddressUrls = (
   protocol = 'http',
   port: number,
@@ -68,12 +73,11 @@ export const getAddressUrls = (
 ) => {
   const LOCAL_LABEL = 'Local:  ';
   const NETWORK_LABEL = 'Network:  ';
-  const isLocalhost = (url: string) => url?.includes('localhost');
 
   if (host && host !== DEFAULT_DEV_HOST) {
     return [
       {
-        label: isLocalhost(host) ? LOCAL_LABEL : NETWORK_LABEL,
+        label: isLocalHost(host) ? LOCAL_LABEL : NETWORK_LABEL,
         url: `${protocol}://${host}:${port}`,
       },
     ];
@@ -82,7 +86,7 @@ export const getAddressUrls = (
   const ipv4Interfaces = getIpv4Interfaces();
 
   return ipv4Interfaces.reduce((memo: AddressUrl[], detail) => {
-    if (isLocalhost(detail.address) || detail.internal) {
+    if (isLocalHost(detail.address) || detail.internal) {
       memo.push({
         label: LOCAL_LABEL,
         url: `${protocol}://localhost:${port}`,

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -61,7 +61,7 @@ const getIpv4Interfaces = () => {
   return Array.from(ipv4Interfaces.values());
 };
 
-const isLocalHost = (host: string) => {
+const isLoopbackHost = (host: string) => {
   const loopbackHosts = ['localhost', '127.0.0.1', '::1'];
   return loopbackHosts.includes(host);
 };
@@ -77,7 +77,7 @@ export const getAddressUrls = (
   if (host && host !== DEFAULT_DEV_HOST) {
     return [
       {
-        label: isLocalHost(host) ? LOCAL_LABEL : NETWORK_LABEL,
+        label: isLoopbackHost(host) ? LOCAL_LABEL : NETWORK_LABEL,
         url: `${protocol}://${host}:${port}`,
       },
     ];
@@ -86,7 +86,7 @@ export const getAddressUrls = (
   const ipv4Interfaces = getIpv4Interfaces();
 
   return ipv4Interfaces.reduce((memo: AddressUrl[], detail) => {
-    if (isLocalHost(detail.address) || detail.internal) {
+    if (isLoopbackHost(detail.address) || detail.internal) {
       memo.push({
         label: LOCAL_LABEL,
         url: `${protocol}://localhost:${port}`,


### PR DESCRIPTION
## Summary

Print local label for more hosts.

before:

<img width="396" alt="Screenshot 2024-01-02 at 20 43 19" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/b9a2f3d7-8b0b-4cae-8810-d7d78a403d08">

after:

<img width="404" alt="Screenshot 2024-01-02 at 20 51 20" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/92a15ecb-c768-444b-aa5f-015cb8a4acf7">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
