### PR TITLE
fix: html plugin chain_id conflict

### DIFF
--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -191,13 +191,13 @@ export const CHAIN_ID = {
     /** WebpackBundleAnalyzer */
     BUNDLE_ANALYZER: 'bundle-analyze',
     /** HtmlTagsPlugin */
-    HTML_TAGS: 'html-tags',
+    HTML_TAGS: 'html-tags-plugin',
     /** HtmlBasicPlugin */
-    HTML_BASIC: 'html-basic',
+    HTML_BASIC: 'html-basic-plugin',
     /** HtmlNoncePlugin */
-    HTML_NONCE: 'html-nonce',
+    HTML_NONCE: 'html-nonce-plugin',
     /** HtmlCrossOriginPlugin */
-    HTML_CROSS_ORIGIN: 'html-cross-origin',
+    HTML_CROSS_ORIGIN: 'html-cross-origin-plugin',
     /** htmlPreconnectPlugin */
     HTML_PRECONNECT: 'html-preconnect-plugin',
     /** htmlDnsPrefetchPlugin */


### PR DESCRIPTION
## Summary

inner html plugin chain_id  conflict with user's, when user's entryName is basic/tag/...

<img width="636" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/35fec79e-3ca2-4180-bc98-2423577a8b40">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
