### PR TITLE
feat: check output dir when running the preview command

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
-import { logger } from '@rsbuild/shared';
+import { existsSync } from 'fs';
+import { color, logger } from '@rsbuild/shared';
 import { program } from '@rsbuild/shared/commander';
 import { loadEnv } from '../loadEnv';
 import { loadConfig } from './config';
@@ -152,6 +153,15 @@ export function runCli() {
     .action(async (options: PreviewOptions) => {
       try {
         const rsbuild = await init({ cliOptions: options });
+
+        if (rsbuild && !existsSync(rsbuild.context.distPath)) {
+          throw new Error(
+            `The output directory ${color.yellow(
+              rsbuild.context.distPath,
+            )} does not exist, please build the project before previewing.`,
+          );
+        }
+
         await rsbuild?.preview();
       } catch (err) {
         logger.error('Failed to start preview server.');


### PR DESCRIPTION
## Summary

Check output dir when running the preview command:

<img width="1183" alt="Screenshot 2024-01-04 at 11 51 02" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/00b3a68e-3011-48fa-9186-c0fd97e48582">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
