### PR TITLE
chore(plugin-image-compress): rename some internal vars

### DIFF
--- a/packages/plugin-image-compress/src/index.ts
+++ b/packages/plugin-image-compress/src/index.ts
@@ -1,6 +1,6 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import assert from 'assert';
-import { ModernJsImageMinimizerPlugin } from './minimizer';
+import { ImageMinimizerPlugin } from './minimizer';
 import { withDefaultOptions } from './shared/utils';
 import { Codecs, Options } from './types';
 
@@ -38,18 +38,21 @@ export const pluginImageCompress: IPluginImageCompress = (
   ...args
 ): RsbuildPlugin => ({
   name: 'rsbuild:image-compress',
+
   setup(api) {
     const opts = normalizeOptions(castOptions(args));
 
-    api.modifyBundlerChain((chain, { env }) => {
-      if (env !== 'production') {
+    api.modifyBundlerChain((chain, { isProd }) => {
+      if (!isProd) {
         return;
       }
+
       chain.optimization.minimize(true);
+
       for (const opt of opts) {
         chain.optimization
           .minimizer(`image-compress-${opt.use}`)
-          .use(ModernJsImageMinimizerPlugin, [opt]);
+          .use(ImageMinimizerPlugin, [opt]);
       }
     });
   },

--- a/packages/plugin-image-compress/src/minimizer.ts
+++ b/packages/plugin-image-compress/src/minimizer.ts
@@ -3,15 +3,15 @@ import type { webpack } from '@rsbuild/webpack';
 import Codecs from './shared/codecs';
 import type { FinalOptions } from './types';
 
-export const MODERN_JS_IMAGE_MINIMIZER_PLUGIN_NAME =
+export const IMAGE_MINIMIZER_PLUGIN_NAME =
   '@rsbuild/plugin-image-compress/minimizer' as const;
 
 export interface MinimizedResult {
   source: webpack.sources.RawSource;
 }
 
-export class ModernJsImageMinimizerPlugin {
-  name = MODERN_JS_IMAGE_MINIMIZER_PLUGIN_NAME;
+export class ImageMinimizerPlugin {
+  name = IMAGE_MINIMIZER_PLUGIN_NAME;
 
   options: FinalOptions;
 
@@ -24,14 +24,15 @@ export class ModernJsImageMinimizerPlugin {
     compilation: webpack.Compilation,
     assets: Record<string, webpack.sources.Source>,
   ): Promise<void> {
-    const cache = compilation.getCache(MODERN_JS_IMAGE_MINIMIZER_PLUGIN_NAME);
+    const cache = compilation.getCache(IMAGE_MINIMIZER_PLUGIN_NAME);
     const { RawSource } = compiler.webpack.sources;
     const { matchObject } = compiler.webpack.ModuleFilenameHelpers;
+
     const buildError = (error: unknown, file?: string, context?: string) => {
       const cause = error instanceof Error ? error : new Error();
       const message =
         file && context
-          ? `"${file}" in "${context}" from Modern.js Image Minimizer:\n${cause.message}`
+          ? `"${file}" in "${context}" from Image Minimizer:\n${cause.message}`
           : cause.message;
       const ret = new compiler.webpack.WebpackError(message);
       error instanceof Error && ((ret as any).error = error);

--- a/packages/plugin-image-compress/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-image-compress/tests/__snapshots__/index.test.ts.snap
@@ -117,21 +117,21 @@ exports[`plugin-image-compress > should generate correct options 1`] = `
   "optimization": {
     "minimize": true,
     "minimizer": [
-      ModernJsImageMinimizerPlugin {
+      ImageMinimizerPlugin {
         "name": "@rsbuild/plugin-image-compress/minimizer",
         "options": {
           "test": /\\\\\\.\\(jpg\\|jpeg\\)\\$/,
           "use": "jpeg",
         },
       },
-      ModernJsImageMinimizerPlugin {
+      ImageMinimizerPlugin {
         "name": "@rsbuild/plugin-image-compress/minimizer",
         "options": {
           "test": /\\\\\\.png\\$/,
           "use": "png",
         },
       },
-      ModernJsImageMinimizerPlugin {
+      ImageMinimizerPlugin {
         "name": "@rsbuild/plugin-image-compress/minimizer",
         "options": {
           "test": /\\\\\\.\\(ico\\|icon\\)\\$/,

--- a/packages/plugin-image-compress/tests/index.test.ts
+++ b/packages/plugin-image-compress/tests/index.test.ts
@@ -21,14 +21,14 @@ describe('plugin-image-compress', () => {
     const config = await rsbuild.unwrapConfig();
     expect(config.optimization?.minimizer).toMatchInlineSnapshot(`
       [
-        ModernJsImageMinimizerPlugin {
+        ImageMinimizerPlugin {
           "name": "@rsbuild/plugin-image-compress/minimizer",
           "options": {
             "test": /\\\\\\.\\(jpg\\|jpeg\\)\\$/,
             "use": "jpeg",
           },
         },
-        ModernJsImageMinimizerPlugin {
+        ImageMinimizerPlugin {
           "name": "@rsbuild/plugin-image-compress/minimizer",
           "options": {
             "test": /\\\\\\.png\\$/,
@@ -47,14 +47,14 @@ describe('plugin-image-compress', () => {
     const config = await rsbuild.unwrapConfig();
     expect(config.optimization?.minimizer).toMatchInlineSnapshot(`
       [
-        ModernJsImageMinimizerPlugin {
+        ImageMinimizerPlugin {
           "name": "@rsbuild/plugin-image-compress/minimizer",
           "options": {
             "test": /\\\\\\.\\(jpg\\|jpeg\\)\\$/,
             "use": "jpeg",
           },
         },
-        ModernJsImageMinimizerPlugin {
+        ImageMinimizerPlugin {
           "name": "@rsbuild/plugin-image-compress/minimizer",
           "options": {
             "test": /\\\\\\.png\\$/,


### PR DESCRIPTION
## Summary

Rename some internal vars of `plugin-image-compress`, remove the Modern.js related prefixes, as Rsbuild now is not part of Modern.js.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
