### PR TITLE
chore: turn `loadEnv` into a pure function

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,10 +1,11 @@
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { color, logger } from '@rsbuild/shared';
+import { color, isDev, logger } from '@rsbuild/shared';
 import { program } from '@rsbuild/shared/commander';
 import { loadEnv } from '../loadEnv';
 import { loadConfig } from './config';
 import type { RsbuildMode } from '..';
+import { onBeforeRestartServer } from 'src/server/restart';
 
 export type CommonOptions = {
   config?: string;
@@ -42,7 +43,9 @@ export async function init({
 
   try {
     const root = process.cwd();
-    const { publicVars } = loadEnv({ cwd: root });
+    const envs = loadEnv({ cwd: root });
+    isDev() && onBeforeRestartServer(envs.cleanup);
+
     const config = await loadConfig({
       cwd: root,
       path: commonOpts.config,
@@ -51,7 +54,7 @@ export async function init({
 
     config.source ||= {};
     config.source.define = {
-      ...publicVars,
+      ...envs.publicVars,
       ...config.source.define,
     };
 

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import { join } from 'path';
-import { isDev, isFileSync } from '@rsbuild/shared';
-import { onBeforeRestartServer } from './server/restart';
+import { isFileSync } from '@rsbuild/shared';
 import { parse } from '../compiled/dotenv';
 import { expand } from '../compiled/dotenv-expand';
 
@@ -34,19 +33,20 @@ export function loadEnv({
     }
   });
 
-  // clear the assigned env vars before restarting dev server
-  if (isDev()) {
-    onBeforeRestartServer(() => {
-      Object.keys(parsed).forEach((key) => {
-        if (process.env[key] === parsed[key]) {
-          delete process.env[key];
-        }
-      });
+  let _cleaned = false;
+  const cleanup = () => {
+    if (_cleaned) return;
+    Object.keys(parsed).forEach((key) => {
+      if (process.env[key] === parsed[key]) {
+        delete process.env[key];
+      }
     });
-  }
+    _cleaned = true;
+  };
 
   return {
     parsed,
     publicVars,
+    cleanup,
   };
 }


### PR DESCRIPTION
## Summary

Turn `loadEnv` into a pure function so that we can register hook in some other places.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
