### PR TITLE
fix(babel): presetEnv need allow null value

### DIFF
--- a/.changeset/famous-penguins-tan.md
+++ b/.changeset/famous-penguins-tan.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/babel-preset': patch
+---
+
+fix: presetEnv need allow null value
+fix: presetEnv 需要允许传入空值

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -8,7 +8,7 @@ export const getBabelConfigForWeb = (options: WebPresetOptions) => {
     {
       presetEnv: {
         bugfixes: true,
-        corejs: options.presetEnv.useBuiltIns
+        corejs: options.presetEnv?.useBuiltIns
           ? {
               version: getCoreJsVersion(
                 require.resolve('core-js/package.json'),


### PR DESCRIPTION
## Summary

in [@rsbuild/babel-preset base](https://github.com/web-infra-dev/rsbuild/blob/7a5eb25fff1bfdc449f2e27487882f1ae6f66b72/packages/babel-preset/src/base.ts#L17), it seems we can pass in null value.

```typescript
if (presetEnv) {
   // some code
}
```

but actually not, if we use the web preset.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
