### PR TITLE
fix(babel-preset): allow disable presetEnv for web target

### DIFF
--- a/packages/babel-preset/src/types.ts
+++ b/packages/babel-preset/src/types.ts
@@ -1,8 +1,4 @@
-import type {
-  PresetEnvOptions,
-  PresetEnvTargets,
-  PresetEnvBuiltIns,
-} from '@rsbuild/plugin-babel';
+import type { PresetEnvOptions } from '@rsbuild/plugin-babel';
 
 export type { TransformOptions as BabelConfig } from '@babel/core';
 
@@ -26,10 +22,6 @@ export type BasePresetOptions = {
 };
 
 export type WebPresetOptions = BasePresetOptions & {
-  presetEnv: PresetEnvOptions & {
-    targets: PresetEnvTargets;
-    useBuiltIns: PresetEnvBuiltIns;
-  };
   pluginTransformRuntime?: Record<string, unknown> | false;
 };
 

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -3,20 +3,27 @@ import { deepmerge, getCoreJsVersion } from '@rsbuild/shared';
 import { generateBaseConfig } from './base';
 import type { BabelConfig, WebPresetOptions } from './types';
 
+const getDefaultPresetEnvOption = (options: WebPresetOptions) => {
+  if (options.presetEnv === false) {
+    return false;
+  }
+
+  return {
+    bugfixes: true,
+    // core-js is required for web target
+    corejs: options.presetEnv?.useBuiltIns
+      ? {
+          version: getCoreJsVersion(require.resolve('core-js/package.json')),
+          proposals: true,
+        }
+      : undefined,
+  };
+};
+
 export const getBabelConfigForWeb = (options: WebPresetOptions) => {
   const mergedOptions = deepmerge(
     {
-      presetEnv: {
-        bugfixes: true,
-        corejs: options.presetEnv?.useBuiltIns
-          ? {
-              version: getCoreJsVersion(
-                require.resolve('core-js/package.json'),
-              ),
-              proposals: true,
-            }
-          : undefined,
-      },
+      presetEnv: getDefaultPresetEnvOption(options),
     },
     options,
   );

--- a/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -163,6 +163,47 @@ exports[`should provide web preset as expected 1`] = `
 }
 `;
 
+exports[`should provide web preset as expected when presetEnv is empty object 1`] = `
+[
+  [
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+    {
+      "bugfixes": true,
+      "corejs": undefined,
+      "exclude": [
+        "transform-typeof-symbol",
+      ],
+      "modules": "commonjs",
+    },
+  ],
+  [
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+    {
+      "allExtensions": true,
+      "allowDeclareFields": true,
+      "allowNamespaces": true,
+      "isTSX": true,
+      "optimizeConstEnums": true,
+    },
+  ],
+]
+`;
+
+exports[`should provide web preset as expected when presetEnv is false 1`] = `
+[
+  [
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+    {
+      "allExtensions": true,
+      "allowDeclareFields": true,
+      "allowNamespaces": true,
+      "isTSX": true,
+      "optimizeConstEnums": true,
+    },
+  ],
+]
+`;
+
 exports[`should support inject core-js polyfills by entry 1`] = `
 {
   "plugins": [

--- a/packages/babel-preset/tests/web.test.ts
+++ b/packages/babel-preset/tests/web.test.ts
@@ -11,6 +11,22 @@ test('should provide web preset as expected', () => {
   ).toMatchSnapshot();
 });
 
+test('should provide web preset as expected when presetEnv is false', () => {
+  expect(
+    getBabelConfigForWeb({
+      presetEnv: false,
+    }).presets,
+  ).toMatchSnapshot();
+});
+
+test('should provide web preset as expected when presetEnv is empty object', () => {
+  expect(
+    getBabelConfigForWeb({
+      presetEnv: {},
+    }).presets,
+  ).toMatchSnapshot();
+});
+
 test('should support inject core-js polyfills by entry', () => {
   expect(
     getBabelConfigForWeb({


### PR DESCRIPTION
## Summary

Allow disable presetEnv for web target.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
