### PR TITLE
fix(plugin-babel): export getDefaultBabelOptions util from index

### DIFF
--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,4 +1,4 @@
-export { pluginBabel } from './plugin';
+export { pluginBabel, getDefaultBabelOptions } from './plugin';
 export {
   getBabelUtils,
   getUseBuiltIns,


### PR DESCRIPTION
## Summary

export getDefaultBabelOptions util from index for Modern.js.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
