### PR TITLE
fix(babel-preset): should merge targets array correctly

### DIFF
--- a/.changeset/old-bags-visit.md
+++ b/.changeset/old-bags-visit.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/babel-preset': patch
+---
+
+fix(babel-preset): should merge targets array correctly

--- a/packages/babel-preset/src/node.ts
+++ b/packages/babel-preset/src/node.ts
@@ -3,14 +3,18 @@ import { generateBaseConfig } from './base';
 import type { BabelConfig, NodePresetOptions } from './types';
 
 export const getBabelConfigForNode = (options: NodePresetOptions = {}) => {
-  const mergedOptions = deepmerge(
-    {
-      presetEnv: {
-        targets: ['node >= 14'],
+  let mergedOptions = options;
+
+  if (!options.presetEnv || !options.presetEnv.targets) {
+    mergedOptions = deepmerge(
+      {
+        presetEnv: {
+          targets: ['node >= 14'],
+        },
       },
-    },
-    options,
-  );
+      options,
+    );
+  }
 
   const config = generateBaseConfig(mergedOptions);
 

--- a/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
@@ -1,5 +1,45 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`should allow to override target node version 1`] = `
+{
+  "plugins": [
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-export-default-from/lib/index.js",
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-partial-application/lib/index.js",
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-pipeline-operator/lib/index.js",
+      {
+        "proposal": "minimal",
+      },
+    ],
+    "<ROOT>/node_modules/<PNPM_INNER>/babel-plugin-dynamic-import-node/lib/index.js",
+  ],
+  "presets": [
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-env/lib/index.js",
+      {
+        "exclude": [
+          "transform-typeof-symbol",
+        ],
+        "modules": "commonjs",
+        "targets": [
+          "node >= 20",
+        ],
+      },
+    ],
+    [
+      "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+      {
+        "allExtensions": true,
+        "allowDeclareFields": true,
+        "allowNamespaces": true,
+        "isTSX": true,
+        "optimizeConstEnums": true,
+      },
+    ],
+  ],
+}
+`;
+
 exports[`should provide node preset as expected 1`] = `
 {
   "plugins": [

--- a/packages/babel-preset/tests/node.test.ts
+++ b/packages/babel-preset/tests/node.test.ts
@@ -3,3 +3,13 @@ import { getBabelConfigForNode } from '../src/node';
 test('should provide node preset as expected', () => {
   expect(getBabelConfigForNode()).toMatchSnapshot();
 });
+
+test('should allow to override target node version', () => {
+  expect(
+    getBabelConfigForNode({
+      presetEnv: {
+        targets: ['node >= 20'],
+      },
+    }),
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
## Summary

Should merge targets array correctly.

`deepmerge` will merge `['node >= 14']` and `['node >= 16']` into `['node >= 14', 'node >= 16']`, which is not as expected. So we need to add some conditions.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
