### PR TITLE
docs: add Vue 2 version requirements

### DIFF
--- a/packages/document/docs/en/guide/framework/vue2.mdx
+++ b/packages/document/docs/en/guide/framework/vue2.mdx
@@ -28,7 +28,10 @@ export default defineConfig({
 ```
 
 :::tip
-For projects using Vue CLI, you can refer to the [Vue CLI Migration Guide](/guide/migration/vue-cli).
+
+- The Vue 2 plugin only supports Vue >= 2.7.0.
+- For projects using Vue CLI, you can refer to the [Vue CLI Migration Guide](/guide/migration/vue-cli).
+
 :::
 
 ## Use the JSX syntax of Vue

--- a/packages/document/docs/en/plugins/list/plugin-vue2.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-vue2.mdx
@@ -2,6 +2,10 @@
 
 The Vue 2 plugin provides support for Vue 2 SFC (Single File Components). The plugin internally integrates [vue-loader](https://vue-loader.vuejs.org/) v15.
 
+:::tip
+The Vue 2 plugin only supports Vue >= 2.7.0.
+:::
+
 ## Quick Start
 
 ### Install Plugin

--- a/packages/document/docs/zh/guide/framework/vue2.mdx
+++ b/packages/document/docs/zh/guide/framework/vue2.mdx
@@ -28,7 +28,10 @@ export default defineConfig({
 ```
 
 :::tip
-对于使用 Vue CLI 的项目，可以参考 [Vue CLI 迁移指南](/guide/migration/vue-cli)。
+
+- Vue 2 插件仅支持 Vue >= 2.7.0 版本。
+- 对于使用 Vue CLI 的项目，可以参考 [Vue CLI 迁移指南](/guide/migration/vue-cli)。
+
 :::
 
 ## 使用 Vue JSX 语法

--- a/packages/document/docs/zh/plugins/list/plugin-vue2.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-vue2.mdx
@@ -2,6 +2,10 @@
 
 Vue 2 插件提供了对 Vue 2 SFC（单文件组件）的支持，插件内部集成了 [vue-loader](https://vue-loader.vuejs.org/) v15 版本。
 
+:::tip
+Vue 2 插件仅支持 Vue >= 2.7.0 版本。
+:::
+
 ## 快速开始
 
 ### 安装插件


### PR DESCRIPTION
## Summary

Add Vue 2 version requirements.

Rspack + vue-loader@15.11.1 only works with Vue >= 2.7.0.

## Related Links

- https://github.com/vuejs/vue-loader/blob/v15.11.1/lib/plugin-webpack5.js#L203
- https://github.com/vuejs/vue-loader/blob/v15.11.1/lib/loaders/pitcher.js#L204

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
