### PR TITLE
feat(plugin-react): add jsxRuntime option to support React 16

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+registry = 'https://registry.npmjs.org/'
 strict-peer-dependencies=false

--- a/e2e/cases/react/legacy-jsx/index.test.ts
+++ b/e2e/cases/react/legacy-jsx/index.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { build, getHrefByEntryName } from '@scripts/shared';
+
+const fixtures = __dirname;
+
+test('should render element with legacy JSX runtime correctly', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    runServer: true,
+  });
+
+  await page.goto(getHrefByEntryName('index', rsbuild.port));
+
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/react/legacy-jsx/rsbuild.config.ts
+++ b/e2e/cases/react/legacy-jsx/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default {
+  plugins: [pluginReact({ jsxRuntime: 'classic' })],
+};

--- a/e2e/cases/react/legacy-jsx/src/App.jsx
+++ b/e2e/cases/react/legacy-jsx/src/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const App = () => <div id="test">Hello Rsbuild!</div>;
+
+export default App;

--- a/e2e/cases/react/legacy-jsx/src/index.js
+++ b/e2e/cases/react/legacy-jsx/src/index.js
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(React.createElement(App), document.getElementById('root'));

--- a/packages/document/docs/en/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-react.mdx
@@ -66,6 +66,33 @@ At the same time, the above default behavior can be turned off by manually setti
 
 ## Options
 
+### jsxRuntime
+
+- **Type:** `'automatic' | 'classic'`
+- **Default:** `'automatic'`
+
+By default, Rsbuild uses the [new JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html) introduced in React 17, which is `jsxRuntime: 'automatic'`.
+
+If your current React version is lower than 16.14.0, you can set `jsxRuntime` to `'classic'`:
+
+```ts
+pluginReact({
+  jsxRuntime: 'classic',
+});
+```
+
+> React 16.14.0 can use the new JSX runtime.
+
+When using the classic JSX runtime, you need to manually import React in your code:
+
+```jsx
+import React from 'react';
+
+function App() {
+  return <h1>Hello World</h1>;
+}
+```
+
 ### splitChunks
 
 When [chunkSplit.strategy](/config/performance/chunk-split) set to `split-by-experience`, Rsbuild will automatically split `react` and `router` related packages into separate chunks by default:

--- a/packages/document/docs/zh/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-react.mdx
@@ -66,6 +66,33 @@ const defaultArcoConfig = [
 
 ## 选项
 
+### jsxRuntime
+
+- **类型：** `'automatic' | 'classic'`
+- **默认值：** `'automatic'`
+
+默认情况下，Rsbuild 使用 React 17 引入的[新版本 JSX runtime](https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html)，即 `jsxRuntime: 'automatic'`。
+
+如果你当前的 React 版本低于 16.14.0，可以将 `jsxRuntime` 设置为 `'classic'`：
+
+```ts
+pluginReact({
+  jsxRuntime: 'classic',
+});
+```
+
+> React 16.14.0 可以使用新版本 JSX runtime。
+
+在使用 classic JSX runtime 时，你需要手动在代码中引入 React：
+
+```jsx
+import React from 'react';
+
+function App() {
+  return <h1>Hello World</h1>;
+}
+```
+
 ### splitChunks
 
 在 [chunkSplit.strategy](/config/performance/chunk-split) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `react` 和 `router` 相关的包拆分为单独的 chunk:

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -23,6 +23,12 @@ export type SplitReactChunkOptions = {
 
 export type PluginReactOptions = {
   /**
+   * Decides which React JSX runtime to use.
+   * `automatic` auto imports the functions for transpiled JSX. `classic` does not automatic import anything.
+   * @default 'automatic'
+   */
+  jsxRuntime?: 'classic' | 'automatic';
+  /**
    * Configuration for chunk splitting of React-related dependencies.
    */
   splitChunks?: SplitReactChunkOptions;
@@ -37,7 +43,7 @@ export const pluginReact = (
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {
-      applyBasicReactSupport(api);
+      applyBasicReactSupport(api, options);
     }
     applyAntdSupport(api);
     applyArcoSupport(api);

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,5 +1,6 @@
 import { isUsingHMR, isClientCompiler, isProd } from '@rsbuild/shared';
 import type { Rspack, RsbuildPluginAPI } from '@rsbuild/core';
+import type { PluginReactOptions } from '.';
 
 function getReactRefreshEntry(compiler: Rspack.Compiler) {
   const hot = compiler.options.devServer?.hot ?? true;
@@ -30,7 +31,10 @@ const setupCompiler = (compiler: Rspack.Compiler) => {
   }).apply(compiler);
 };
 
-export const applyBasicReactSupport = (api: RsbuildPluginAPI) => {
+export const applyBasicReactSupport = (
+  api: RsbuildPluginAPI,
+  options: PluginReactOptions,
+) => {
   api.onAfterCreateCompiler(({ compiler: multiCompiler }) => {
     if (isProd()) {
       return;
@@ -51,7 +55,7 @@ export const applyBasicReactSupport = (api: RsbuildPluginAPI) => {
     const reactOptions = {
       development: !isProd,
       refresh: usingHMR,
-      runtime: 'automatic',
+      runtime: options.jsxRuntime ?? 'automatic',
     };
 
     rule.use(CHAIN_ID.USE.SWC).tap((options) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6011,7 +6011,6 @@ packages:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
     dependencies:
       dequal: 2.0.3
-    dev: false
 
   /array-buffer-byte-length@1.0.0:
     resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
@@ -6141,7 +6140,6 @@ packages:
     resolution: {integrity: sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==}
     dependencies:
       dequal: 2.0.3
-    dev: false
 
   /babel-loader@9.1.3(@babel/core@7.23.2)(webpack@5.89.0):
     resolution: {integrity: sha512-xG3ST4DglodGf8qSwv0MdeWLhrDsw/32QMdTO5T1ZIp9gQur0HkCyFs7Awskr10JKXFXwpAhiCuYX5oGXnRGbw==}
@@ -6706,7 +6704,6 @@ packages:
       acorn: 8.10.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
-    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -9596,7 +9593,6 @@ packages:
 
   /locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
-    dev: false
 
   /locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -13127,7 +13123,6 @@ packages:
       locate-character: 3.0.0
       magic-string: 0.30.5
       periscopic: 3.1.0
-    dev: false
 
   /svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}


### PR DESCRIPTION
## Summary

Add new `jsxRuntime` option to support React 16.

## Related Links

- https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
- https://babeljs.io/docs/babel-preset-react#react-classic-runtime

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
