### PR TITLE
feat(plugin-react): add jsxImportSource option

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-react.mdx
@@ -93,6 +93,21 @@ function App() {
 }
 ```
 
+### jsxImportSource
+
+- **Type:** `string`
+- **Default:** `'react'`
+
+When `jsxRuntime` is `'automatic'`, you can specify the import path of the JSX runtime through `jsxImportSource`.
+
+For example, when using [Emotion](https://emotion.sh/), you can set `jsxImportSource` to `'@emotion/react'`:
+
+```ts
+pluginReact({
+  jsxImportSource: '@emotion/react',
+});
+```
+
 ### splitChunks
 
 When [chunkSplit.strategy](/config/performance/chunk-split) set to `split-by-experience`, Rsbuild will automatically split `react` and `router` related packages into separate chunks by default:

--- a/packages/document/docs/zh/plugins/list/plugin-react.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-react.mdx
@@ -93,6 +93,21 @@ function App() {
 }
 ```
 
+### jsxImportSource
+
+- **类型：** `string`
+- **默认值：** `'react'`
+
+当 `jsxRuntime` 为 `'automatic'` 时，你可以通过 `jsxImportSource` 来指定 JSX runtime 的引入路径。
+
+比如，在使用 [Emotion](https://emotion.sh/) 时，你可以将 `jsxImportSource` 设置为 `'@emotion/react'`：
+
+```ts
+pluginReact({
+  jsxImportSource: '@emotion/react',
+});
+```
+
 ### splitChunks
 
 在 [chunkSplit.strategy](/config/performance/chunk-split) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `react` 和 `router` 相关的包拆分为单独的 chunk:

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -29,6 +29,11 @@ export type PluginReactOptions = {
    */
   jsxRuntime?: 'classic' | 'automatic';
   /**
+   * Specify the import path of the JSX runtime when `jsxRuntime` is `'automatic'`.
+   * @default 'react'
+   */
+  jsxImportSource?: string;
+  /**
    * Configuration for chunk splitting of React-related dependencies.
    */
   splitChunks?: SplitReactChunkOptions;

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,4 +1,9 @@
-import { isUsingHMR, isClientCompiler, isProd } from '@rsbuild/shared';
+import {
+  isProd,
+  isUsingHMR,
+  isClientCompiler,
+  type ReactConfig,
+} from '@rsbuild/shared';
 import type { Rspack, RsbuildPluginAPI } from '@rsbuild/core';
 import type { PluginReactOptions } from '.';
 
@@ -52,11 +57,15 @@ export const applyBasicReactSupport = (
     const usingHMR = isUsingHMR(config, { isProd, target });
     const rule = chain.module.rule(CHAIN_ID.RULE.JS);
 
-    const reactOptions = {
+    const reactOptions: ReactConfig = {
       development: !isProd,
       refresh: usingHMR,
       runtime: options.jsxRuntime ?? 'automatic',
     };
+
+    if (options.jsxImportSource) {
+      reactOptions.importSource = options.jsxImportSource;
+    }
 
     rule.use(CHAIN_ID.USE.SWC).tap((options) => {
       options.jsc.transform.react = {

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -73,4 +73,19 @@ describe('plugins/react', () => {
 
     expect(config.optimization.splitChunks).toMatchSnapshot();
   });
+
+  it('should allow to custom jsxImportSource', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([
+      pluginReact({
+        jsxImportSource: '@emotion/react',
+      }),
+    ]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(JSON.stringify(config)).toContain(`"importSource":"@emotion/react"`);
+  });
 });


### PR DESCRIPTION
## Summary

Add new jsxImportSource option for Emotion.

## Related Links

- https://emotion.sh/docs/css-prop
- https://swc.rs/docs/configuration/compilation#jsctransformreactimportsource

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
