### PR TITLE
breaking change: default value of distPath.server is changed to 'server'

### DIFF
--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -13,5 +13,5 @@ test('should compile Node addons correctly', async () => {
   const files = await rsbuild.unwrapOutputJSON();
   const addonFile = Object.keys(files).find((file) => file.endsWith('a.node'));
 
-  expect(addonFile?.includes('bundles/a.node')).toBeTruthy();
+  expect(addonFile?.includes('server/a.node')).toBeTruthy();
 });

--- a/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/plugins/__snapshots__/default.test.ts.snap
@@ -1342,8 +1342,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "splitChunks": false,
   },
   "output": {
-    "chunkFilename": "bundles/[name].js",
-    "filename": "bundles/[name].js",
+    "chunkFilename": "server/[name].js",
+    "filename": "server/[name].js",
     "hashFunction": "xxhash64",
     "libraryTarget": "commonjs2",
     "path": "<ROOT>/dist",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -1812,10 +1812,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "splitChunks": false,
   },
   "output": {
-    "chunkFilename": "bundles/[name].js",
+    "chunkFilename": "server/[name].js",
     "cssChunkFilename": "static/css/async/[name].css",
     "cssFilename": "static/css/[name].css",
-    "filename": "bundles/[name].js",
+    "filename": "server/[name].js",
     "hashFunction": "xxhash64",
     "libraryTarget": "commonjs2",
     "path": "<ROOT>/dist",

--- a/packages/document/docs/en/config/output/dist-path.mdx
+++ b/packages/document/docs/en/config/output/dist-path.mdx
@@ -31,7 +31,7 @@ const defaultDistPath = {
   wasm: 'static/wasm',
   image: 'static/image',
   media: 'static/media',
-  server: 'bundles',
+  server: 'server',
   worker: 'worker',
 };
 ```
@@ -50,7 +50,7 @@ Detail:
 - `image`: The output directory of non-SVG images.
 - `media`: The output directory of media assets, such as videos.
 - `server`: The output directory of server bundles when target is `node`.
-- `worker`: The output directory of worker bundles when target is `service-worker`.
+- `worker`: The output directory of service worker bundles when target is `service-worker`.
 
 ### Root Directory
 

--- a/packages/document/docs/en/guide/basic/config.mdx
+++ b/packages/document/docs/en/guide/basic/config.mdx
@@ -63,7 +63,7 @@ export default defineConfig({
 Rsbuild uses [jiti](https://github.com/unjs/jiti) to load configuration files, providing interoperability between ESM and CommonJS. The behavior of module resolution differs slightly from the native behavior of Node.js.
 :::
 
-### Specify Config File
+## Specify Config File
 
 Rsbuild CLI uses the `--config` option to specify the config file, which can be set to a relative path or an absolute path.
 

--- a/packages/document/docs/en/guide/basic/output-files.md
+++ b/packages/document/docs/en/guide/basic/output-files.md
@@ -92,11 +92,11 @@ dist
 
 ## Node.js Output Directory
 
-When the [output.targets](/config/output/targets) of Rsbuild contains `'node'`, or you have enabled server-side features such as SSR in the higher level solutions, Rsbuild will generate some output files for Node.js and output them to the `bundles` directory:
+When the [output.targets](/config/output/targets) of Rsbuild contains `'node'`, or you have enabled server-side features such as SSR in the higher level solutions, Rsbuild will generate some output files for Node.js and output them to the `server` directory:
 
 ```bash
 dist
-├── bundles
+├── server
 │   └── [name].js
 ├── static
 └── [name].html

--- a/packages/document/docs/zh/config/output/dist-path.mdx
+++ b/packages/document/docs/zh/config/output/dist-path.mdx
@@ -31,7 +31,7 @@ const defaultDistPath = {
   wasm: 'static/wasm',
   image: 'static/image',
   media: 'static/media',
-  server: 'bundles',
+  server: 'server',
   worker: 'worker',
 };
 ```

--- a/packages/document/docs/zh/guide/basic/config.mdx
+++ b/packages/document/docs/zh/guide/basic/config.mdx
@@ -63,7 +63,7 @@ export default defineConfig({
 Rsbuild 使用 [jiti](https://github.com/unjs/jiti) 来加载配置文件，提供 ESM 与 CommonJS 的互操作性，模块解析的行为与 Node.js 原生行为存在一定差异。
 :::
 
-### 指定配置文件
+## 指定配置文件
 
 Rsbuild CLI 通过 `--config` 选项来指定配置文件，可以设置为相对路径或绝对路径。
 

--- a/packages/document/docs/zh/guide/basic/output-files.md
+++ b/packages/document/docs/zh/guide/basic/output-files.md
@@ -92,11 +92,11 @@ dist
 
 ## Node.js 产物目录
 
-当 Rsbuild 的 [output.targets](/config/output/targets) 中包含 `'node'`，或者你在上层框架中开启了 SSR 等服务端功能时，Rsbuild 会在构建后生成一份 Node.js 产物，并输出到 `bundles` 目录下：
+当 Rsbuild 的 [output.targets](/config/output/targets) 中包含 `'node'`，或者你在上层框架中开启了 SSR 等服务端功能时，Rsbuild 会在构建后生成一份 Node.js 产物，并输出到 `server` 目录下：
 
 ```bash
 dist
-├── bundles
+├── server
 │   └── [name].js
 ├── static
 └── [name].html

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -23,7 +23,7 @@ export const DEFAULT_BROWSERSLIST = {
 // Paths
 export const ROOT_DIST_DIR = 'dist';
 export const HTML_DIST_DIR = '/';
-export const SERVER_DIST_DIR = 'bundles';
+export const SERVER_DIST_DIR = 'server';
 export const SERVER_WORKER_DIST_DIR = 'worker';
 export const JS_DIST_DIR = 'static/js';
 export const CSS_DIST_DIR = 'static/css';

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -23,7 +23,7 @@ export type DistPathConfig = {
   media?: string;
   /** The output directory of server bundles when target is `node`. */
   server?: string;
-  /** The output directory of server bundles when target is `service-worker`. */
+  /** The output directory of service worker bundles when target is `service-worker`. */
   worker?: string;
 };
 


### PR DESCRIPTION
## Summary

The default value of `output.distPath.server` is changed to from 'bundles' to  'server'.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1101

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
