### PR TITLE
breaking change: remove deprecated printURLs option

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,7 +1,6 @@
 import {
   debug,
   logger as defaultLogger,
-  isFunction,
   ROOT_DIST_DIR,
   getAddressUrls,
   StartServerResult,
@@ -143,7 +142,6 @@ export async function startDevServer<
   ) => Promise<CreateDevMiddlewareReturns>,
   {
     compiler,
-    printURLs = true,
     logger: customLogger,
     getPortSilently,
   }: StartDevServerOptions & {
@@ -154,7 +152,6 @@ export async function startDevServer<
 
   const serverAPIs = await getServerAPIs(options, createDevMiddleware, {
     compiler,
-    printURLs,
     logger: customLogger,
     getPortSilently,
   });
@@ -178,24 +175,14 @@ export async function startDevServer<
   let urls = getAddressUrls(protocol, port, host);
 
   // print url after http server created and before dev compile (just a short time interval)
-  if (printURLs) {
-    if (isFunction(printURLs)) {
-      urls = printURLs(urls);
-
-      if (!Array.isArray(urls)) {
-        throw new Error('Please return an array in the `printURLs` function.');
-      }
-    }
-
-    printServerURLs({
-      urls,
-      port,
-      routes: defaultRoutes,
-      logger,
-      protocol,
-      printUrls: devServerConfig.printUrls,
-    });
-  }
+  printServerURLs({
+    urls,
+    port,
+    routes: defaultRoutes,
+    logger,
+    protocol,
+    printUrls: devServerConfig.printUrls,
+  });
 
   const compileMiddlewareAPI = await serverAPIs.startCompile();
 

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -3,7 +3,6 @@ import connect from '@rsbuild/shared/connect';
 import { join } from 'path';
 import sirv from '../../compiled/sirv';
 import {
-  isFunction,
   ROOT_DIST_DIR,
   getAddressUrls,
   type ServerConfig,
@@ -133,7 +132,7 @@ export class RsbuildProdServer {
 export async function startProdServer(
   context: InternalContext,
   rsbuildConfig: RsbuildConfig,
-  { printURLs = true, getPortSilently }: PreviewServerOptions = {},
+  { getPortSilently }: PreviewServerOptions = {},
 ) {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'production';
@@ -183,7 +182,7 @@ export async function startProdServer(
         const urls = getAddressUrls(protocol, port);
 
         printServerURLs({
-          urls: isFunction(printURLs) ? printURLs(urls) : urls,
+          urls,
           port,
           routes,
           protocol,

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -3,7 +3,6 @@ import type { RsbuildContext } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { StartServerResult, DevServerAPIs } from './server';
-import type { AddressUrl } from '../url';
 import type { Logger } from '../logger';
 import type { NormalizedConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
@@ -20,18 +19,10 @@ export type StartDevServerOptions = {
    * @deprecated use `logger.override()` instead
    */
   logger?: Logger;
-  /**
-   * @deprecated use `server.printUrls` instead
-   */
-  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
 };
 
 export type PreviewServerOptions = {
   getPortSilently?: boolean;
-  /**
-   * @deprecated use `server.printUrls` instead
-   */
-  printURLs?: boolean | ((urls: AddressUrl[]) => AddressUrl[]);
 };
 
 export type BuildOptions = {
@@ -83,9 +74,7 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
    *
    * It is designed for high-level frameworks that require a custom server
    */
-  getServerAPIs: (
-    options?: Omit<StartDevServerOptions, 'printURLs'>,
-  ) => Promise<DevServerAPIs>;
+  getServerAPIs: (options?: StartDevServerOptions) => Promise<DevServerAPIs>;
 
   startDevServer: (
     options?: StartDevServerOptions,


### PR DESCRIPTION
## Summary

Remove deprecated printURLs option of `rsbuild.startDevServer`.

The `printURLs` option of `rsbuild.startDevServer` is deprecated, use [server.printUrls](https://rsbuild.dev/config/server/print-urls) instead.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1101

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
