### PR TITLE
breaking change: remove deprecated logger option

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,6 +1,5 @@
 import {
   debug,
-  logger as defaultLogger,
   ROOT_DIST_DIR,
   getAddressUrls,
   StartServerResult,
@@ -142,7 +141,6 @@ export async function startDevServer<
   ) => Promise<CreateDevMiddlewareReturns>,
   {
     compiler,
-    logger: customLogger,
     getPortSilently,
   }: StartDevServerOptions & {
     defaultPort?: number;
@@ -152,15 +150,12 @@ export async function startDevServer<
 
   const serverAPIs = await getServerAPIs(options, createDevMiddleware, {
     compiler,
-    logger: customLogger,
     getPortSilently,
   });
 
   const {
     config: { devServerConfig, port, host, https, defaultRoutes },
   } = serverAPIs;
-
-  const logger = customLogger ?? defaultLogger;
 
   const middlewares = connect();
 
@@ -179,7 +174,6 @@ export async function startDevServer<
     urls,
     port,
     routes: defaultRoutes,
-    logger,
     protocol,
     printUrls: devServerConfig.printUrls,
   });

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -1,6 +1,6 @@
 import {
   color,
-  logger as defaultLogger,
+  logger,
   getPort,
   deepmerge,
   isFunction,
@@ -9,7 +9,6 @@ import {
   DEFAULT_DEV_HOST,
 } from '@rsbuild/shared';
 import type {
-  Logger,
   Routes,
   DevConfig,
   PrintUrls,
@@ -46,12 +45,10 @@ export function printServerURLs({
   routes,
   protocol,
   printUrls,
-  logger = defaultLogger,
 }: {
   urls: Array<{ url: string; label: string }>;
   port: number;
   routes: Routes;
-  logger?: Logger;
   protocol: string;
   printUrls?: PrintUrls;
 }) {
@@ -95,6 +92,8 @@ export function printServerURLs({
   }
 
   logger.log(message);
+
+  return message;
 }
 
 /**

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -114,14 +114,11 @@ test('formatRoutes', () => {
 });
 
 test('printServerURLs', () => {
-  let message: string;
-  const logger = {
-    log: (msg: string) => {
-      message = msg;
-    },
-  };
+  let message: string | undefined;
 
-  printServerURLs({
+  message = printServerURLs({
+    port: 8080,
+    protocol: 'http',
     urls: [
       {
         url: 'http://localhost:8080',
@@ -138,8 +135,6 @@ test('printServerURLs', () => {
         route: '',
       },
     ],
-    // @ts-expect-error
-    logger,
   });
 
   expect(message!).toMatchInlineSnapshot(`
@@ -148,7 +143,9 @@ test('printServerURLs', () => {
     "
   `);
 
-  printServerURLs({
+  message = printServerURLs({
+    port: 8080,
+    protocol: 'http',
     urls: [
       {
         url: 'http://localhost:8080',
@@ -173,8 +170,6 @@ test('printServerURLs', () => {
         route: 'bar',
       },
     ],
-    // @ts-expect-error
-    logger,
   });
 
   expect(message!).toMatchInlineSnapshot(`

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -3,7 +3,6 @@ import type { RsbuildContext } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
 import type { StartServerResult, DevServerAPIs } from './server';
-import type { Logger } from '../logger';
 import type { NormalizedConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
 import type { RspackConfig } from './rspack';
@@ -15,10 +14,6 @@ export type CreateCompilerOptions = { watch?: boolean };
 export type StartDevServerOptions = {
   compiler?: Compiler | MultiCompiler;
   getPortSilently?: boolean;
-  /**
-   * @deprecated use `logger.override()` instead
-   */
-  logger?: Logger;
 };
 
 export type PreviewServerOptions = {


### PR DESCRIPTION
## Summary

Remove deprecated logger option of `rsbuild.createServer`.

The `logger` option of `rsbuild.startDevServer` is deprecated, use [logger.override()](https://rsbuild.dev/api/javascript-api/core#logger) instead.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1101

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
