### PR TITLE
Revert "feat: enable Rspack new tree shaking by default (#1077)"

### DIFF
--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -22,8 +22,6 @@ export const pluginTransition = (): RsbuildPlugin => ({
         'experiments.rspackFuture.disableApplyEntryLazily',
         true,
       );
-
-      setConfig(config, 'experiments.rspackFuture.newTreeshaking', true);
     });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -22,7 +22,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -22,7 +22,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {
@@ -693,7 +692,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {
@@ -1411,7 +1409,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {
@@ -1826,7 +1823,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -39,7 +39,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "asyncWebAssembly": true,
     "rspackFuture": {
       "disableApplyEntryLazily": true,
-      "newTreeshaking": true,
     },
   },
   "infrastructureLogging": {


### PR DESCRIPTION
This reverts commit f4fd4f8c4eb6f551f004d6dc6edcdc81b05a3f95.

## Related Links

https://github.com/web-infra-dev/rspack/issues/5270

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
