### PR TITLE
chore: remove unused config for Rspack 0.5

### DIFF
--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -1,4 +1,3 @@
-import { setConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
 /**
@@ -7,21 +6,7 @@ import type { RsbuildPlugin } from '../../types';
 export const pluginTransition = (): RsbuildPlugin => ({
   name: 'rsbuild:transition',
 
-  setup(api) {
+  setup() {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
-
-    api.modifyBundlerChain(async (chain, { isProd }) => {
-      if (isProd) {
-        chain.optimization.chunkIds('deterministic');
-      }
-    });
-
-    api.modifyRspackConfig((config) => {
-      setConfig(
-        config,
-        'experiments.rspackFuture.disableApplyEntryLazily',
-        true,
-      );
-    });
   },
 });

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -44,7 +44,7 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
   ]);
 
 // apply builtin:swc-loader
-export const rspackMinVersion = '0.4.0';
+export const rspackMinVersion = '0.4.5';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -20,9 +20,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -20,9 +20,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -690,9 +687,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1232,7 +1226,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "name": "Client",
   "optimization": {
-    "chunkIds": "deterministic",
     "minimize": true,
     "minimizer": [
       SwcJsMinimizerRspackPlugin {
@@ -1407,9 +1400,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1821,9 +1811,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -37,9 +37,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "disableApplyEntryLazily": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary

Remove some unused configs for Rspack 0.5:

- disableApplyEntryLazily is enabled by default, see https://github.com/web-infra-dev/rspack/pull/5179
- chunkIds defaults to `deterministic` in production, see https://github.com/web-infra-dev/rspack/pull/4822

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
