### PR TITLE
chore: simplify rsbuild.build implementation

### DIFF
--- a/packages/compat/webpack/src/core/build.ts
+++ b/packages/compat/webpack/src/core/build.ts
@@ -4,49 +4,15 @@ import {
   logger,
   type Stats,
   type Rspack,
+  type MultiStats,
   type BuildOptions,
   type RspackConfig,
 } from '@rsbuild/shared';
-import type {
-  Compiler,
-  MultiStats,
-  MultiCompiler,
-  Configuration as WebpackConfig,
-} from 'webpack';
-
-export interface BuildExecuter {
-  (compiler: Compiler): Promise<{ stats: Stats }>;
-  (compiler: MultiCompiler): Promise<{ stats: MultiStats }>;
-  (compiler: Compiler | MultiCompiler): Promise<{ stats: Stats | MultiStats }>;
-}
-
-export const webpackBuild: BuildExecuter = async (compiler) => {
-  return new Promise((resolve, reject) => {
-    compiler.run((err, stats) => {
-      if (err || stats?.hasErrors()) {
-        const buildError = err || new Error('Webpack build failed!');
-        reject(buildError);
-      }
-      // If there is a compilation error, the close method should not be called.
-      // Otherwise bundler may generate an invalid cache.
-      else {
-        // When using run or watch, call close and wait for it to finish before calling run or watch again.
-        // Concurrent compilations will corrupt the output files.
-        compiler.close((closeErr) => {
-          closeErr && logger.error(closeErr);
-
-          // Assert type of stats must align to compiler.
-          resolve({ stats: stats as any });
-        });
-      }
-    });
-  });
-};
+import type { Configuration as WebpackConfig } from 'webpack';
 
 export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
-  executer?: BuildExecuter,
 ) => {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = mode;
@@ -80,10 +46,31 @@ export const build = async (
         logger.error(err);
       }
     });
-  } else {
-    const executeResult = await executer?.(compiler as unknown as Compiler);
-    await context.hooks.onAfterBuildHook.call({
-      stats: executeResult?.stats as Stats,
-    });
+    return;
   }
+
+  const { stats } = await new Promise<{ stats: Stats | MultiStats }>(
+    (resolve, reject) => {
+      compiler.run((err, stats) => {
+        if (err || stats?.hasErrors()) {
+          const buildError = err || new Error('Webpack build failed!');
+          reject(buildError);
+        }
+        // If there is a compilation error, the close method should not be called.
+        // Otherwise bundler may generate an invalid cache.
+        else {
+          // When using run or watch, call close and wait for it to finish before calling run or watch again.
+          // Concurrent compilations will corrupt the output files.
+          compiler.close((closeErr) => {
+            closeErr && logger.error(closeErr);
+
+            // Assert type of stats must align to compiler.
+            resolve({ stats: stats as any });
+          });
+        }
+      });
+    },
+  );
+
+  await context.hooks.onAfterBuildHook.call({ stats });
 };

--- a/packages/compat/webpack/src/index.ts
+++ b/packages/compat/webpack/src/index.ts
@@ -1,5 +1,4 @@
 export { webpackProvider } from './provider';
-export { webpackBuild } from './core/build';
 export type {
   // Third Party Types
   webpack,

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -92,12 +92,8 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
     },
 
     async build(options) {
-      const { build: buildImpl, webpackBuild } = await import('./core/build');
-      return buildImpl(
-        { context, pluginStore, rsbuildOptions },
-        options,
-        webpackBuild,
-      );
+      const { build } = await import('./core/build');
+      return build({ context, pluginStore, rsbuildOptions }, options);
     },
 
     async inspectConfig(inspectOptions) {

--- a/packages/core/src/provider/core/build.ts
+++ b/packages/core/src/provider/core/build.ts
@@ -10,39 +10,9 @@ import type {
   RspackMultiCompiler,
 } from '@rsbuild/shared';
 
-export type BuildExecuter = {
-  (compiler: RspackCompiler): Promise<{ stats?: Stats }>;
-  (compiler: RspackMultiCompiler): Promise<{ stats?: MultiStats }>;
-  (
-    compiler: RspackCompiler | RspackMultiCompiler,
-  ): Promise<{ stats?: Stats | MultiStats }>;
-};
-
-export const rspackBuild: BuildExecuter = async (compiler) => {
-  return new Promise((resolve, reject) => {
-    compiler.run((err: any, stats?: Stats) => {
-      if (err || stats?.hasErrors()) {
-        const buildError = err || new Error('Rspack build failed!');
-        reject(buildError);
-      }
-      // If there is a compilation error, the close method should not be called.
-      // Otherwise the bundler may generate an invalid cache.
-      else {
-        // When using run or watch, call close and wait for it to finish before calling run or watch again.
-        // Concurrent compilations will corrupt the output files.
-        compiler.close(() => {
-          // Assert type of stats must align to compiler.
-          resolve({ stats: stats as any });
-        });
-      }
-    });
-  });
-};
-
 export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
-  executer?: BuildExecuter,
 ) => {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = mode;
@@ -74,10 +44,29 @@ export const build = async (
         logger.error(err);
       }
     });
-  } else {
-    const executeResult = await executer?.(compiler);
-    await context.hooks.onAfterBuildHook.call({
-      stats: executeResult?.stats,
-    });
+    return;
   }
+
+  const { stats } = await new Promise<{ stats?: Stats | MultiStats }>(
+    (resolve, reject) => {
+      compiler.run((err: any, stats?: Stats) => {
+        if (err || stats?.hasErrors()) {
+          const buildError = err || new Error('Rspack build failed!');
+          reject(buildError);
+        }
+        // If there is a compilation error, the close method should not be called.
+        // Otherwise the bundler may generate an invalid cache.
+        else {
+          // When using run or watch, call close and wait for it to finish before calling run or watch again.
+          // Concurrent compilations will corrupt the output files.
+          compiler.close(() => {
+            // Assert type of stats must align to compiler.
+            resolve({ stats });
+          });
+        }
+      });
+    },
+  );
+
+  await context.hooks.onAfterBuildHook.call({ stats });
 };

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -74,12 +74,8 @@ export const rspackProvider: RsbuildProvider = async ({
     },
 
     async build(options) {
-      const { build: buildImpl, rspackBuild } = await import('./core/build');
-      return buildImpl(
-        { context, pluginStore, rsbuildOptions },
-        options,
-        rspackBuild,
-      );
+      const { build } = await import('./core/build');
+      return build({ context, pluginStore, rsbuildOptions }, options);
     },
 
     async initConfigs() {


### PR DESCRIPTION
## Summary

Simplify `rsbuild.build` implementation, no need to call standalone BuildExecuter function.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
