### PR TITLE
types: allow to narrow Compiler type for createCompiler

### DIFF
--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -1,5 +1,6 @@
 import {
   pickRsbuildConfig,
+  type CreateCompiler,
   type RsbuildProvider,
   type PreviewServerOptions,
 } from '@rsbuild/shared';
@@ -23,10 +24,22 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
 
   context.pluginAPI = pluginAPI;
 
+  const createCompiler = (async () => {
+    const { createCompiler } = await import('./core/createCompiler');
+    const { webpackConfigs } = await initConfigs({
+      context,
+      pluginStore,
+      rsbuildOptions,
+    });
+    return createCompiler({ context, webpackConfigs });
+  }) as CreateCompiler;
+
   return {
     bundler: 'webpack',
 
     pluginAPI,
+
+    createCompiler,
 
     publicContext: createPublicContext(context),
 
@@ -41,16 +54,6 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
         rsbuildOptions,
       });
       return webpackConfigs;
-    },
-
-    async createCompiler() {
-      const { createCompiler } = await import('./core/createCompiler');
-      const { webpackConfigs } = await initConfigs({
-        context,
-        pluginStore,
-        rsbuildOptions,
-      });
-      return createCompiler({ context, webpackConfigs });
     },
 
     async getServerAPIs(options) {

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -1,5 +1,6 @@
 import {
   pickRsbuildConfig,
+  type CreateCompiler,
   type RsbuildProvider,
   type PreviewServerOptions,
 } from '@rsbuild/shared';
@@ -20,29 +21,31 @@ export const rspackProvider: RsbuildProvider = async ({
 
   context.pluginAPI = pluginAPI;
 
+  const createCompiler = (async () => {
+    const { createCompiler } = await import('./core/createCompiler');
+    const { rspackConfigs } = await initConfigs({
+      context,
+      pluginStore,
+      rsbuildOptions,
+    });
+
+    return createCompiler({
+      context,
+      rspackConfigs,
+    });
+  }) as CreateCompiler;
+
   return {
     bundler: 'rspack',
 
     pluginAPI,
 
+    createCompiler,
+
     publicContext: createPublicContext(context),
 
     async applyDefaultPlugins() {
       pluginStore.addPlugins(await applyDefaultPlugins(plugins));
-    },
-
-    async createCompiler() {
-      const { createCompiler } = await import('./core/createCompiler');
-      const { rspackConfigs } = await initConfigs({
-        context,
-        pluginStore,
-        rsbuildOptions,
-      });
-
-      return createCompiler({
-        context,
-        rspackConfigs,
-      });
     },
 
     async getServerAPIs(options) {

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -51,6 +51,10 @@ export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
     rsbuildOptions: Required<CreateRsbuildOptions>;
   }) => Promise<ProviderInstance<B>>;
 
+export type CreateCompiler =
+  // Allow user to manually narrow Compiler type
+  <C = Compiler | MultiCompiler>(options?: CreateCompilerOptions) => Promise<C>;
+
 export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   readonly bundler: Bundler;
 
@@ -60,9 +64,7 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
 
   applyDefaultPlugins: (pluginStore: PluginStore) => Promise<void>;
 
-  createCompiler: (
-    options?: CreateCompilerOptions,
-  ) => Promise<Compiler | MultiCompiler>;
+  createCompiler: CreateCompiler;
 
   /**
    * This API is not stable


### PR DESCRIPTION
## Summary

Allow to narrow Compiler type for createCompiler.

```ts
import type { Compiler } from '@rspack/core';

const compiler = rsbuild.createCompiler<Compiler>();
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
