### PR TITLE
feat(plugin-source-build): add resolvePriority option

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-source-build.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-source-build.mdx
@@ -151,6 +151,8 @@ Note that the above example is a simplified one. In real monorepo projects, ther
 If you want to learn more about project reference, please refer to the official documentation on [TypeScript - Project References](https://typescriptlang.org/docs/handbook/project-references).
 :::
 
+## Options
+
 ### sourceField
 
 - **Type:** `string`

--- a/packages/document/docs/en/plugins/list/plugin-source-build.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-source-build.mdx
@@ -184,6 +184,38 @@ In `package.json`, the source code file path can be specified using `my-source`:
 }
 ```
 
+### resolvePriority
+
+- **Type:** `'source' | 'output'`
+- **Default:** `'source'`
+
+Used to control the priority of reading the source code or the output code.
+
+By default, Source Build plugin will reading the source code first, for example, in the following example, it will read the `source` field.
+
+```json title="package.json"
+{
+  "name": "lib",
+  "main": "./dist/index.js",
+  "source": "./src/index.ts"
+}
+```
+
+When `resolvePriority` is set to `'output'`, Source Build plugin will read the output code first, i.e., the code from the `main` or `module` field.
+
+```ts
+pluginSourceBuild({
+  resolvePriority: 'output',
+});
+```
+
+:::tip
+The `exports` field in package.json is not affected by `resolvePriority`.
+
+The keys order in `exports` determines the resolving order, earlier declared keys having higher priority.
+
+:::
+
 ## Caveat
 
 When using Source Build plugin, there are a few things to keep in mind:

--- a/packages/document/docs/zh/plugins/list/plugin-source-build.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-source-build.mdx
@@ -184,6 +184,38 @@ pluginSourceBuild({
 }
 ```
 
+### resolvePriority
+
+- **类型：** `'source' | 'output'`
+- **默认值：** `'source'`
+
+用于控制优先读取源代码还是产物代码。
+
+默认情况下，Source Build 插件会优先读取源代码，比如在下面的例子中，会优先读取 `source` 字段。
+
+```json title="package.json"
+{
+  "name": "lib",
+  "main": "./dist/index.js",
+  "source": "./src/index.ts"
+}
+```
+
+当 `resolvePriority` 设置为 `'output'` 时，Source Build 插件会优先读取产物代码，即 `main` 或 `module` 字段对应的代码。
+
+```ts
+pluginSourceBuild({
+  resolvePriority: 'output',
+});
+```
+
+:::tip
+package.json 中的 `exports` 字段不受 `resolvePriority` 的影响。
+
+`exports` 中 key 的声明顺序决定了读取顺序，较早声明的 key 具有更高的优先级。
+
+:::
+
 ## 注意事项
 
 在使用 Source Build 插件的时候，需要注意几点：

--- a/packages/document/docs/zh/plugins/list/plugin-source-build.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-source-build.mdx
@@ -191,7 +191,7 @@ pluginSourceBuild({
 
 用于控制优先读取源代码还是产物代码。
 
-默认情况下，Source Build 插件会优先读取源代码，比如在下面的例子中，会优先读取 `source` 字段。
+默认情况下，Source Build 插件会优先读取源代码，比如在下面的例子中，它会读取 `source` 字段。
 
 ```json title="package.json"
 {
@@ -201,7 +201,7 @@ pluginSourceBuild({
 }
 ```
 
-当 `resolvePriority` 设置为 `'output'` 时，Source Build 插件会优先读取产物代码，即 `main` 或 `module` 字段对应的代码。
+当 `resolvePriority` 设置为 `'output'` 时，Source Build 插件会优先读取产物代码，即 `main` 或 `module` 字段指向的代码。
 
 ```ts
 pluginSourceBuild({

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@rsbuild/core": "workspace:*",
+    "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/test-helper": "workspace:*",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`plugin-source-build > should allow to set resolve priority 1`] = `
+{
+  "module": {
+    "rules": [
+      {
+        "resolve": {
+          "conditionNames": [
+            "...",
+            "source",
+          ],
+          "mainFields": [
+            "...",
+            "source",
+          ],
+        },
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "use": [
+          {
+            "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+            "options": {
+              "babelrc": false,
+              "compact": false,
+              "configFile": false,
+              "plugins": [],
+              "presets": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+                  {
+                    "allExtensions": true,
+                    "allowDeclareFields": true,
+                    "allowNamespaces": true,
+                    "isTSX": true,
+                    "optimizeConstEnums": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  "resolve": {
+    "tsConfig": {
+      "references": [],
+    },
+  },
+}
+`;

--- a/packages/plugin-source-build/tests/index.test.ts
+++ b/packages/plugin-source-build/tests/index.test.ts
@@ -1,0 +1,19 @@
+import { createStubRsbuild } from '@rsbuild/test-helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginSourceBuild } from '../src';
+
+describe('plugin-source-build', () => {
+  it('should allow to set resolve priority', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        pluginBabel(),
+        pluginSourceBuild({
+          resolvePriority: 'output',
+        }),
+      ],
+    });
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config).toMatchSnapshot();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1192,6 +1192,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
+      '@rsbuild/plugin-babel':
+        specifier: workspace:*
+        version: link:../plugin-babel
       '@rsbuild/test-helper':
         specifier: workspace:*
         version: link:../test-helper


### PR DESCRIPTION
## Summary

Add resolvePriority option, it is used to control the priority of reading the source code or the output code.

By default, Source Build plugin will reading the source code first, for example, in the following example, it will read the `source` field.

```json title="package.json"
{
  "name": "lib",
  "main": "./dist/index.js",
  "source": "./src/index.ts"
}
```

When `resolvePriority` is set to `'output'`, Source Build plugin will read the output code first, i.e., the code from the `main` or `module` field.

```ts
pluginSourceBuild({
  resolvePriority: 'output',
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
