### PR TITLE
feat(create-rsbuild): add extensions config for Vue projects

### DIFF
--- a/.changeset/big-bugs-think.md
+++ b/.changeset/big-bugs-think.md
@@ -1,0 +1,5 @@
+---
+'create-rsbuild': patch
+---
+
+feat(create-rsbuild): add extensions config for Vue projects

--- a/packages/create-rsbuild/template-vue3-js/.vscode/extensions.json
+++ b/packages/create-rsbuild/template-vue3-js/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+}

--- a/packages/create-rsbuild/template-vue3-ts/.vscode/extensions.json
+++ b/packages/create-rsbuild/template-vue3-ts/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+}

--- a/packages/create-rsbuild/template-vue3-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-vue3-ts/src/env.d.ts
@@ -1,8 +1,1 @@
 /// <reference types="@rsbuild/core/types" />
-
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue';
-
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
-}


### PR DESCRIPTION
## Summary

Add extensions config for Vue projects, be consistent with the official Vue template.

## Related Links

- https://vuejs.org/guide/typescript/overview.html#using-vue-with-typescript
- https://github.com/vuejs/create-vue/blob/333ec677088bfacd33bb10a85059ccba45dea37a/template/base/.vscode/extensions.json#L2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
