### PR TITLE
feat: support return modified urls with printUrls

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -95,3 +95,36 @@ test('should allow to custom urls', async ({ page }) => {
   await rsbuild.server.close();
   restore();
 });
+
+test('should allow to modify and return new urls', async ({ page }) => {
+  const { logs, restore } = proxyConsole('log');
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: ({ urls }) => urls.map((url) => `${url}/test`),
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const localLog = logs.find(
+    (log) =>
+      log.includes('Local:') &&
+      log.includes(`http://localhost:${rsbuild.port}/test/`),
+  );
+  const networkLog = logs.find(
+    (log) =>
+      log.includes('Network:') &&
+      log.includes('http://') &&
+      log.endsWith('/test/'),
+  );
+
+  expect(localLog).toBeFalsy();
+  expect(networkLog).toBeFalsy();
+
+  await rsbuild.server.close();
+  restore();
+});

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -68,6 +68,8 @@ function getURLMessages(
       )}${color.cyan(normalizeUrl(`${url}/${r.route}`))}\n`;
     });
   });
+
+  return message;
 }
 
 export function printServerURLs({

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -4,6 +4,7 @@ import {
   getPort,
   deepmerge,
   isFunction,
+  getUrlLabel,
   normalizeUrl,
   DEFAULT_PORT,
   DEFAULT_DEV_HOST,
@@ -39,8 +40,38 @@ export const formatRoutes = (
   );
 };
 
+function getURLMessages(
+  urls: Array<{ url: string; label: string }>,
+  routes: Routes,
+) {
+  if (routes.length === 1) {
+    return urls
+      .map(
+        ({ label, url }) =>
+          `  ${`> ${label.padEnd(10)}`}${color.cyan(
+            normalizeUrl(`${url}/${routes[0].route}`),
+          )}\n`,
+      )
+      .join('');
+  }
+
+  let message = '';
+  const maxNameLength = Math.max(...routes.map((r) => r.name.length));
+  urls.forEach(({ label, url }, index) => {
+    if (index > 0) {
+      message += '\n';
+    }
+    message += `  ${`> ${label}`}\n`;
+    routes.forEach((r) => {
+      message += `  ${color.dim('-')} ${color.dim(
+        r.name.padEnd(maxNameLength + 4),
+      )}${color.cyan(normalizeUrl(`${url}/${r.route}`))}\n`;
+    });
+  });
+}
+
 export function printServerURLs({
-  urls,
+  urls: originalUrls,
   port,
   routes,
   protocol,
@@ -56,41 +87,36 @@ export function printServerURLs({
     return;
   }
 
+  let urls = originalUrls;
+
   if (isFunction(printUrls)) {
-    printUrls({
+    const newUrls = printUrls({
       urls: urls.map((item) => item.url),
       port,
       protocol,
     });
+
+    if (!newUrls) {
+      return;
+    }
+
+    if (!Array.isArray(newUrls)) {
+      throw new Error(
+        `"server.printUrls" must return an array, but got ${typeof newUrls}.`,
+      );
+    }
+
+    urls = newUrls.map((url) => ({
+      url,
+      label: getUrlLabel(url),
+    }));
+  }
+
+  if (urls.length === 0) {
     return;
   }
 
-  let message = '';
-
-  if (routes.length === 1) {
-    message = urls
-      .map(
-        ({ label, url }) =>
-          `  ${`> ${label.padEnd(10)}`}${color.cyan(
-            normalizeUrl(`${url}/${routes[0].route}`),
-          )}\n`,
-      )
-      .join('');
-  } else {
-    const maxNameLength = Math.max(...routes.map((r) => r.name.length));
-    urls.forEach(({ label, url }, index) => {
-      if (index > 0) {
-        message += '\n';
-      }
-      message += `  ${`> ${label}`}\n`;
-      routes.forEach((r) => {
-        message += `  ${color.dim('-')} ${color.dim(
-          r.name.padEnd(maxNameLength + 4),
-        )}${color.cyan(normalizeUrl(`${url}/${r.route}`))}\n`;
-      });
-    });
-  }
-
+  const message = getURLMessages(urls, routes);
   logger.log(message);
 
   return message;

--- a/packages/document/docs/en/config/server/print-urls.mdx
+++ b/packages/document/docs/en/config/server/print-urls.mdx
@@ -16,7 +16,30 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 
 `server.printUrls` can be set to a function, with parameters including port, protocol, and urls.
 
-When `server.printUrls` is set to a function, Rsbuild will not print the server's URL addresses. You can customize the log content based on the parameters and output it to the terminal yourself.
+### Modify URL
+
+If the `printUrls` function returns a set of new URLs, Rsbuild will output these URLs in the default format to the terminal:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ urls }) {
+      return urls.map((url) => `${url}/base`);
+    },
+  },
+};
+```
+
+Output:
+
+```text
+> Local:    http://localhost:8080/base/
+> Network:  http://192.168.0.1:8080/base/
+```
+
+### Fully Customizable
+
+If the `printUrls` function does not return a value, Rsbuild will not print the server's URL addresses. You can customize the log content based on the parameters and output it to the terminal yourself.
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/packages/document/docs/en/config/server/print-urls.mdx
+++ b/packages/document/docs/en/config/server/print-urls.mdx
@@ -14,11 +14,11 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 
 ## Custom Logging
 
-`server.printUrls` can be set to a function, with parameters including port, protocol, and urls.
+`server.printUrls` can be set to a function, with parameters including `port`, `protocol`, and `urls`.
 
 ### Modify URL
 
-If the `printUrls` function returns a set of new URLs, Rsbuild prints these URLs to the terminal in the default format:
+If the `printUrls` function returns an URLs array, Rsbuild prints these URLs to the terminal in the default format:
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/packages/document/docs/en/config/server/print-urls.mdx
+++ b/packages/document/docs/en/config/server/print-urls.mdx
@@ -18,7 +18,7 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 
 ### Modify URL
 
-If the `printUrls` function returns a set of new URLs, Rsbuild will output these URLs in the default format to the terminal:
+If the `printUrls` function returns a set of new URLs, Rsbuild prints these URLs to the terminal in the default format:
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/packages/document/docs/zh/config/server/print-urls.mdx
+++ b/packages/document/docs/zh/config/server/print-urls.mdx
@@ -16,7 +16,30 @@
 
 `server.printUrls` 可以设置为一个函数，函数的入参包括 port，protocol 和 urls。
 
-当 `server.printUrls` 设置为函数时，Rsbuild 将不会输出 server 的 URL 地址，你可以基于入参来自定义日志内容，并自行输出到 terminal。
+### 修改 URL
+
+如果 `printUrls` 函数返回了一组新的 urls，那么 Rsbuild 将会把这组 urls 按照默认格式输出到 terminal：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ urls }) {
+      return urls.map((url) => `${url}/base`);
+    },
+  },
+};
+```
+
+输出为：
+
+```text
+> Local:    http://localhost:8080/base/
+> Network:  http://192.168.0.1:8080/base/
+```
+
+### 完全自定义
+
+如果 `printUrls` 函数没有返回值，Rsbuild 将不会输出 server 的 URL 地址，你可以基于入参来自定义日志内容，并自行输出到 terminal。
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/packages/document/docs/zh/config/server/print-urls.mdx
+++ b/packages/document/docs/zh/config/server/print-urls.mdx
@@ -14,11 +14,11 @@
 
 ## 自定义日志
 
-`server.printUrls` 可以设置为一个函数，函数的入参包括 port，protocol 和 urls。
+`server.printUrls` 可以设置为一个函数，函数的入参包括 `port`，`protocol` 和 `urls`。
 
 ### 修改 URL
 
-如果 `printUrls` 函数返回了一组新的 urls，那么 Rsbuild 将会把这组 urls 按照默认格式输出到 terminal：
+如果 `printUrls` 函数返回了一组新的 URLs，那么 Rsbuild 将会把这组 URLs 按照默认格式输出到 terminal：
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -42,7 +42,11 @@ export type HistoryApiFallbackOptions = {
 
 export type PrintUrls =
   | boolean
-  | ((params: { urls: string[]; port: number; protocol: string }) => void);
+  | ((params: {
+      urls: string[];
+      port: number;
+      protocol: string;
+    }) => string[] | void);
 
 export type PublicDir =
   | false

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -83,6 +83,18 @@ const concatUrl = ({
   protocol: string;
 }) => `${protocol}://${host}:${port}`;
 
+const LOCAL_LABEL = 'Local:  ';
+const NETWORK_LABEL = 'Network:  ';
+
+export const getUrlLabel = (url: string) => {
+  try {
+    const { host } = new URL(url);
+    return isLoopbackHost(host) ? LOCAL_LABEL : NETWORK_LABEL;
+  } catch (err) {
+    return NETWORK_LABEL;
+  }
+};
+
 export const getAddressUrls = ({
   protocol = 'http',
   port,
@@ -92,9 +104,6 @@ export const getAddressUrls = ({
   port: number;
   host?: string;
 }) => {
-  const LOCAL_LABEL = 'Local:  ';
-  const NETWORK_LABEL = 'Network:  ';
-
   if (host && host !== DEFAULT_DEV_HOST) {
     return [
       {


### PR DESCRIPTION
## Summary

If the `printUrls` function returns a set of new URLs, Rsbuild will output these URLs in the default format to the terminal:

```ts title="rsbuild.config.ts"
export default {
  server: {
    printUrls({ urls }) {
      return urls.map((url) => `${url}/base`);
    },
  },
};
```

Output:

```text
> Local:    http://localhost:8080/base/
> Network:  http://192.168.0.1:8080/base/
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
