### PR TITLE
docs(vue3): update outdated typescript support

### DIFF
--- a/packages/document/docs/en/guide/framework/vue3.mdx
+++ b/packages/document/docs/en/guide/framework/vue3.mdx
@@ -35,21 +35,8 @@ For projects using Vue CLI, you can refer to the [Vue CLI Migration Guide](/guid
 
 If you need to use the JSX syntax of Vue, you also need to register the [Vue 3 JSX plugin](/plugins/list/plugin-vue-jsx).
 
-## Type Declarations
+## TypeScript Support
 
-In a TypeScript project, you need to add type definitions for `*.vue` files so that TypeScript can recognize them correctly.
+Rsbuild supports compiling TypeScript by default.
 
-Create `env.d.ts` in the `src` directory and add the following content:
-
-```ts title="src/env.d.ts"
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue';
-
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
-}
-```
-
-import DeployApp from '@en/shared/deployApp.md';
-
-<DeployApp />
+Please refer to the [TypeScript - IDE Support](https://vuejs.org/guide/typescript/overview.html#ide-support) section of the Vue documentation to learn how to set up Vue TypeScript support in your IDE.

--- a/packages/document/docs/zh/guide/framework/vue3.mdx
+++ b/packages/document/docs/zh/guide/framework/vue3.mdx
@@ -35,21 +35,8 @@ export default defineConfig({
 
 如果你需要使用 Vue 的 JSX 语法，还需要注册 Rsbuild 的 [Vue 3 JSX 插件](/plugins/list/plugin-vue-jsx)。
 
-## 类型声明
+## TypeScript 支持
 
-在 TypeScript 项目中，你需要为 `*.vue` 文件添加类型定义，使 TypeScript 能够正确识别它。
+Rsbuild 默认支持编译 TypeScript。
 
-请在 `src` 目录下创建 `env.d.ts`，并添加以下内容：
-
-```ts title="src/env.d.ts"
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue';
-
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
-}
-```
-
-import DeployApp from '@zh/shared/deployApp.md';
-
-<DeployApp />
+请参考 Vue 官方文档的 [TypeScript - IDE 支持](https://cn.vuejs.org/guide/typescript/overview.html#ide-support) 小节，了解如何在 IDE 中设置 Vue TypeScript 支持。


### PR DESCRIPTION
## Summary

Update outdated typescript support, the `declare module '*.vue'` is no longer needed. It is recommended to use the VS Code extension instead.

## Related Links

https://vuejs.org/guide/typescript/overview.html#ide-support

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
