### PR TITLE
feat(plugin-preact): add reactAliasesEnabled option

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-preact.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-preact.mdx
@@ -25,3 +25,20 @@ export default {
 ```
 
 After registering the plugin, you can directly develop Preact.
+
+## Options
+
+### reactAliasesEnabled
+
+- **Type:** `boolean`
+- **Default:** `true`
+
+Whether to aliases `react`, `react-dom` to `preact/compat`.
+
+- **Example:** Disable aliases.
+
+```ts
+pluginPreact({
+  reactAliasesEnabled: false,
+});
+```

--- a/packages/document/docs/en/plugins/list/plugin-preact.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-preact.mdx
@@ -30,11 +30,10 @@ After registering the plugin, you can directly develop Preact.
 
 ### reactAliasesEnabled
 
-- **Type:** `boolean`
-- **Default:** `true`
-
 Whether to aliases `react`, `react-dom` to `preact/compat`.
 
+- **Type:** `boolean`
+- **Default:** `true`
 - **Example:** Disable aliases.
 
 ```ts

--- a/packages/document/docs/zh/plugins/list/plugin-preact.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-preact.mdx
@@ -30,11 +30,10 @@ export default {
 
 ### reactAliasesEnabled
 
-- **类型：** `boolean`
-- **默认值：** `true`
-
 是否将 `react`、`react-dom` 通过 alias 指向 `preact/compat`。
 
+- **类型：** `boolean`
+- **默认值：** `true`
 - **示例：** 禁用别名。
 
 ```ts

--- a/packages/document/docs/zh/plugins/list/plugin-preact.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-preact.mdx
@@ -25,3 +25,20 @@ export default {
 ```
 
 注册完插件后，你可以直接进行 Preact 开发。
+
+## 选项
+
+### reactAliasesEnabled
+
+- **类型：** `boolean`
+- **默认值：** `true`
+
+是否将 `react`、`react-dom` 通过 alias 指向 `preact/compat`。
+
+- **示例：** 禁用别名。
+
+```ts
+pluginPreact({
+  reactAliasesEnabled: false,
+});
+```

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -1,23 +1,33 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { SwcReactConfig } from '@rsbuild/shared';
 
-export type PluginPreactOptions = Record<string, never>;
+export type PluginPreactOptions = {
+  /**
+   * Whether to aliases `react`, `react-dom` to `preact/compat`
+   * @default true
+   */
+  reactAliasesEnabled?: boolean;
+};
 
 export const pluginPreact = (
-  _options: PluginPreactOptions = {},
+  options: PluginPreactOptions = {},
 ): RsbuildPlugin => ({
   name: 'rsbuild:preact',
 
   pre: ['rsbuild:swc'],
 
   setup(api) {
+    const { reactAliasesEnabled = true } = options;
+
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {
-      chain.resolve.alias.merge({
-        react: 'preact/compat',
-        'react-dom/test-utils': 'preact/test-utils',
-        'react-dom': 'preact/compat',
-        'react/jsx-runtime': 'preact/jsx-runtime',
-      });
+      if (reactAliasesEnabled) {
+        chain.resolve.alias.merge({
+          react: 'preact/compat',
+          'react-dom/test-utils': 'preact/test-utils',
+          'react-dom': 'preact/compat',
+          'react/jsx-runtime': 'preact/jsx-runtime',
+        });
+      }
 
       const reactOptions: SwcReactConfig = {
         development: !isProd,
@@ -25,27 +35,19 @@ export const pluginPreact = (
         importSource: 'preact',
       };
 
-      chain.module
-        .rule(CHAIN_ID.RULE.JS)
-        .use(CHAIN_ID.USE.SWC)
-        .tap((options) => {
-          options.jsc.transform.react = {
-            ...reactOptions,
-          };
-          return options;
-        });
-
-      if (chain.module.rules.has(CHAIN_ID.RULE.JS_DATA_URI)) {
-        chain.module
-          .rule(CHAIN_ID.RULE.JS_DATA_URI)
-          .use(CHAIN_ID.USE.SWC)
-          .tap((options) => {
-            options.jsc.transform.react = {
-              ...reactOptions,
-            };
-            return options;
-          });
-      }
+      [CHAIN_ID.RULE.JS, CHAIN_ID.RULE.JS_DATA_URI].forEach((ruleId) => {
+        if (chain.module.rules.has(ruleId)) {
+          const rule = chain.module.rule(ruleId);
+          if (rule.uses.has(CHAIN_ID.USE.SWC)) {
+            rule.use(CHAIN_ID.USE.SWC).tap((options) => {
+              options.jsc.transform.react = {
+                ...reactOptions,
+              };
+              return options;
+            });
+          }
+        }
+      });
     });
   },
 });

--- a/packages/plugin-preact/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-preact/tests/__snapshots__/features.test.ts.snap
@@ -1,0 +1,211 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is installed 1`] = `
+{
+  "cacheGroups": {
+    "lib-axios": {
+      "name": "lib-axios",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(axios\\|axios-\\.\\+\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-lodash": {
+      "name": "lib-lodash",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(lodash\\|lodash-es\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-polyfill": {
+      "name": "lib-polyfill",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(tslib\\|core-js\\|@babel\\\\/runtime\\|@swc\\\\/helpers\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-react": {
+      "name": "lib-react",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react\\|react-dom\\|scheduler\\|react-refresh\\|@rspack\\[\\\\\\\\/\\]plugin-react-refresh\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-router": {
+      "name": "lib-router",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(react-router\\|react-router-dom\\|history\\|@remix-run\\[\\\\\\\\/\\]router\\)\\[\\\\\\\\/\\]/,
+    },
+  },
+  "chunks": "all",
+  "enforceSizeThreshold": 50000,
+}
+`;
+
+exports[`splitChunks > should apply splitChunks.react/router plugin option when strategy is split-by-experience 1`] = `
+{
+  "cacheGroups": {
+    "lib-axios": {
+      "name": "lib-axios",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(axios\\|axios-\\.\\+\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-lodash": {
+      "name": "lib-lodash",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(lodash\\|lodash-es\\)\\[\\\\\\\\/\\]/,
+    },
+    "lib-polyfill": {
+      "name": "lib-polyfill",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(tslib\\|core-js\\|@babel\\\\/runtime\\|@swc\\\\/helpers\\)\\[\\\\\\\\/\\]/,
+    },
+  },
+  "chunks": "all",
+  "enforceSizeThreshold": 50000,
+}
+`;
+
+exports[`splitChunks > should not apply splitChunks rule when strategy is not split-by-experience 1`] = `
+{
+  "cacheGroups": {
+    "singleVendor": {
+      "chunks": "all",
+      "enforce": true,
+      "name": "vendor",
+      "priority": 0,
+      "reuseExistingChunk": true,
+      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+    },
+  },
+  "chunks": "all",
+  "enforceSizeThreshold": 50000,
+}
+`;
+
+exports[`transformImport > should apply antd & arco transformImport 1`] = `
+{
+  "include": [
+    {
+      "and": [
+        "<ROOT>",
+        {
+          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+        },
+      ],
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  "type": "javascript/auto",
+  "use": [
+    {
+      "loader": "builtin:swc-loader",
+      "options": {
+        "env": {
+          "coreJs": "3.32",
+          "mode": "usage",
+          "shippedProposals": true,
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+        "isModule": "unknown",
+        "jsc": {
+          "externalHelpers": true,
+          "parser": {
+            "decorators": true,
+            "syntax": "typescript",
+            "tsx": true,
+          },
+          "preserveAllComments": true,
+          "transform": {
+            "decoratorMetadata": true,
+            "legacyDecorator": true,
+            "react": {
+              "development": true,
+              "refresh": true,
+              "runtime": "automatic",
+            },
+          },
+        },
+        "rspackExperiments": {
+          "import": [
+            {
+              "camelToDashComponentName": false,
+              "libraryDirectory": "es",
+              "libraryName": "@arco-design/web-react",
+              "style": true,
+            },
+            {
+              "camelToDashComponentName": false,
+              "libraryDirectory": "react-icon",
+              "libraryName": "@arco-design/web-react/icon",
+            },
+          ],
+        },
+        "sourceMaps": true,
+      },
+    },
+  ],
+}
+`;
+
+exports[`transformImport > should not apply antd & arco when transformImport is false 1`] = `
+{
+  "include": [
+    {
+      "and": [
+        "<ROOT>",
+        {
+          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+        },
+      ],
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  "type": "javascript/auto",
+  "use": [
+    {
+      "loader": "builtin:swc-loader",
+      "options": {
+        "env": {
+          "coreJs": "3.32",
+          "mode": "usage",
+          "shippedProposals": true,
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+        "isModule": "unknown",
+        "jsc": {
+          "externalHelpers": true,
+          "parser": {
+            "decorators": true,
+            "syntax": "typescript",
+            "tsx": true,
+          },
+          "preserveAllComments": true,
+          "transform": {
+            "decoratorMetadata": true,
+            "legacyDecorator": true,
+            "react": {
+              "development": true,
+              "refresh": true,
+              "runtime": "automatic",
+            },
+          },
+        },
+        "sourceMaps": true,
+      },
+    },
+  ],
+}
+`;

--- a/packages/plugin-preact/tests/index.test.ts
+++ b/packages/plugin-preact/tests/index.test.ts
@@ -1,0 +1,34 @@
+import { expect, describe, it, vi } from 'vitest';
+import { pluginPreact } from '../src';
+import { createStubRsbuild } from '@scripts/test-helper';
+
+describe('plugins/preact', () => {
+  it('should apply react aliases by default', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginPreact()],
+    });
+
+    const config = await rsbuild.unwrapConfig();
+    expect(config.resolve.alias).toMatchInlineSnapshot(`
+      {
+        "react": "preact/compat",
+        "react-dom": "preact/compat",
+        "react-dom/test-utils": "preact/test-utils",
+        "react/jsx-runtime": "preact/jsx-runtime",
+      }
+    `);
+  });
+
+  it('should not apply react aliases if reactAliasesEnabled is false', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        pluginPreact({
+          reactAliasesEnabled: false,
+        }),
+      ],
+    });
+
+    const config = await rsbuild.unwrapConfig();
+    expect(config.resolve?.alias).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

Add reactAliasesEnabled option, use the same API as the official preset.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f66644d4-e02d-4b18-bc88-ec0ceff23db3)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
