### PR TITLE
feat(create-rsbuild): enable useDefineForClassFields by default

### DIFF
--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-preact-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-preact-ts/tsconfig.json
@@ -10,6 +10,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
+    "useDefineForClassFields": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],
       "react-dom": ["./node_modules/preact/compat/"]

--- a/packages/create-rsbuild/template-react-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react-ts/tsconfig.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -7,7 +7,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vue2-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue2-ts/tsconfig.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vue3-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue3-ts/tsconfig.json
@@ -9,7 +9,8 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "useDefineForClassFields": true
   },
   "include": ["src"]
 }

--- a/scripts/tsconfig/base.json
+++ b/scripts/tsconfig/base.json
@@ -12,7 +12,8 @@
     "noUnusedParameters": true,
     "jsx": "preserve",
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "useDefineForClassFields": true
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Base"


### PR DESCRIPTION
## Summary

Enable useDefineForClassFields by default in the template's tsconfig.json.

Rsbuild uses SWC to transform the code, and SWC enables `useDefineForClassFields` by default, see https://github.com/swc-project/swc/pull/7055

So it is best for Rsbuild to set it in tsconfig.json by default to keep it consistent with the compilation behavior.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
