### PR TITLE
fix: should not exclude initial js when preload resource

### DIFF
--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -147,7 +147,7 @@ test('should generate prefetch link by config (distinguish html)', async () => {
   )!;
 
   // icon.png、test.js、test.css、test.png
-  expect(content.match(/rel="prefetch"/g)?.length).toBe(4);
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(6);
 
   const assetFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/'),
@@ -165,8 +165,8 @@ test('should generate prefetch link by config (distinguish html)', async () => {
     name.endsWith('page2.html'),
   )!;
 
-  // test.js、test.css、test.png
-  expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
+  // lib-react、main.js、test.js、test.css、test.png
+  expect(content2.match(/rel="prefetch"/g)?.length).toBe(5);
 });
 
 test('should generate preload link when preload is defined', async () => {

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -46,18 +46,6 @@ interface Attributes {
   crossorigin?: string;
 }
 
-function filterResourceHints(
-  resourceHints: HtmlWebpackPlugin.HtmlTagObject[],
-  scripts: HtmlWebpackPlugin.HtmlTagObject[],
-): HtmlWebpackPlugin.HtmlTagObject[] {
-  return resourceHints.filter(
-    (resourceHint) =>
-      !scripts.find(
-        (script) => script.attributes.src === resourceHint.attributes.href,
-      ),
-  );
-}
-
 function generateLinks(
   options: PreloadOrPreFetchOption,
   type: LinkType,
@@ -215,10 +203,7 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
           (htmlPluginData) => {
             if (this.resourceHints) {
               htmlPluginData.assetTags.styles = [
-                ...filterResourceHints(
-                  this.resourceHints,
-                  htmlPluginData.assetTags.scripts,
-                ),
+                ...this.resourceHints,
                 ...htmlPluginData.assetTags.styles,
               ];
             }


### PR DESCRIPTION
## Summary

initial js should not exclude when preload resource, actual demo shows that preload initial js performance is better than filter.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
