### PR TITLE
chore(workflow): should build script packages for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     ]
   },
   "scripts": {
-    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @scripts/* @e2e/* rsbuild-* --parallel=10",
+    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @e2e/* rsbuild-* --parallel=10",
     "bump": "modern bump",
     "change": "modern change",
     "check-changeset": "cd ./scripts/check-changeset && pnpm start",

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -3,7 +3,6 @@
   "version": "0.0.7",
   "private": true,
   "scripts": {
-    "build": "tsc",
     "dev": "tsc --watch",
     "start": "tsx ./src/index.ts"
   },

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -3,8 +3,6 @@
   "version": "0.0.7",
   "private": true,
   "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch",
     "start:modern": "tsx ./src/modern.ts",
     "start:rspack": "tsx ./src/rspack.ts",
     "start:rspress": "tsx ./src/rspress.ts"


### PR DESCRIPTION
## Summary

The `@scripts/test-helper` package should be built by default, otherwise the release CI will be broken.

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/7490120274/job/20388235225

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
