### PR TITLE
chore(workflow): fix pnpm publish failed to resolve

### DIFF
--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/check-changeset",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -1,4 +1,5 @@
 {
   "name": "@rsbuild/tsconfig",
+  "version": "1.0.0",
   "private": true
 }

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/update-packages",
-  "version": "0.0.7",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "start:modern": "tsx ./src/modern.ts",


### PR DESCRIPTION
## Summary

Fix pnpm publish failed to resolve `@scripts/test-helper`, the private package should also provides a version field.

see: https://github.com/pnpm/pnpm/issues/5094

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
