### PR TITLE
fix(server): access page error when url with query or hash

### DIFF
--- a/e2e/cases/server/htmlFallback.test.ts
+++ b/e2e/cases/server/htmlFallback.test.ts
@@ -66,6 +66,30 @@ test('should return 404 when htmlFallback false', async ({ page }) => {
   await rsbuild.server.close();
 });
 
+test('should access /main with query success', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: join(fixtures, 'basic'),
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'basic', 'src/index.ts'),
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/main?aa=1`);
+
+  const res = await page.goto(url.href);
+
+  expect(res?.status()).toBe(200);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.server.close();
+});
+
 test('should access /main.html success when entry is main', async ({
   page,
 }) => {

--- a/e2e/cases/server/htmlFallback.test.ts
+++ b/e2e/cases/server/htmlFallback.test.ts
@@ -66,7 +66,7 @@ test('should return 404 when htmlFallback false', async ({ page }) => {
   await rsbuild.server.close();
 });
 
-test('should access /main with query success', async ({ page }) => {
+test('should access /main with query or hash success', async ({ page }) => {
   const rsbuild = await dev({
     cwd: join(fixtures, 'basic'),
     rsbuildConfig: {
@@ -86,6 +86,12 @@ test('should access /main with query success', async ({ page }) => {
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
+
+  const url1 = new URL(`http://localhost:${rsbuild.port}/main#aa=1`);
+
+  const res1 = await page.goto(url1.href);
+
+  expect(res1?.status()).toBe(200);
 
   await rsbuild.server.close();
 });

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -5,6 +5,7 @@ import {
   type HtmlFallback,
   type RequestHandler as Middleware,
 } from '@rsbuild/shared';
+import { parse } from 'url';
 import path from 'path';
 import fs from 'fs';
 
@@ -55,7 +56,7 @@ export const getHtmlFallbackMiddleware: (params: {
 
     // Handle invalid URLs
     try {
-      pathname = decodeURIComponent(url);
+      pathname = parse(url, false, true).pathname!;
     } catch (err) {
       logger.error(
         new Error(`Invalid URL: ${color.yellow(url)}`, { cause: err }),
@@ -89,7 +90,7 @@ export const getHtmlFallbackMiddleware: (params: {
 
     // '/' => '/index.html'
     if (pathname.endsWith('/')) {
-      const newUrl = `${url}index.html`;
+      const newUrl = `${pathname}index.html`;
       const filePath = path.join(distPath, pathname, 'index.html');
 
       if (outputFileSystem.existsSync(filePath)) {
@@ -99,7 +100,7 @@ export const getHtmlFallbackMiddleware: (params: {
       // '/main' => '/main.html'
       !pathname.endsWith('.html')
     ) {
-      const newUrl = `${url}.html`;
+      const newUrl = `${pathname}.html`;
       const filePath = path.join(distPath, `${pathname}.html`);
 
       if (outputFileSystem.existsSync(filePath)) {


### PR DESCRIPTION
## Summary

This is a bug about accessing page get 404 error when the request url with query or hash.

For example:  visit `http://localhost:8082/index?aa=1` should be succeed as expected, but now got error in Rsbuild.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
