### PR TITLE
feat: support log debug logger when debug=*

### DIFF
--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -15,7 +15,8 @@ export const isDebug = () => {
   return (
     flag === 'rsbuild' ||
     // compat the legacy usage from Modern.js Builder
-    flag === 'builder'
+    flag === 'builder' ||
+    flag === '*'
   );
 };
 


### PR DESCRIPTION
## Summary

`DEBUG=*` is a common usage to print all debug logs

<img width="748" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/806e69a6-ba61-46b3-869d-5663d3d8a15d">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
