### PR TITLE
chore: extract some plugin names as constants

### DIFF
--- a/packages/compat/plugin-esbuild/src/index.ts
+++ b/packages/compat/plugin-esbuild/src/index.ts
@@ -1,5 +1,5 @@
 import { JS_REGEX, TS_REGEX, applyScriptCondition } from '@rsbuild/shared';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import type {
   LoaderOptions,
   MinifyPluginOptions,
@@ -16,7 +16,7 @@ export function pluginEsbuild(
   return {
     name: 'rsbuild-webpack:esbuild',
 
-    pre: ['rsbuild:babel', 'uni-builder:babel'],
+    pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel'],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {

--- a/packages/compat/plugin-esbuild/tsconfig.json
+++ b/packages/compat/plugin-esbuild/tsconfig.json
@@ -2,7 +2,17 @@
   "extends": "@rsbuild/tsconfig/base",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "rootDir": "src",
+    "composite": true
   },
+  "references": [
+    {
+      "path": "../../shared"
+    },
+    {
+      "path": "../../core"
+    }
+  ],
   "include": ["src"]
 }

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { PLUGIN_BABEL_NAME } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,
   DEFAULT_BROWSERSLIST,
@@ -13,7 +14,7 @@ import {
 } from './utils';
 import { SwcMinimizerPlugin } from './minimizer';
 
-const PLUGIN_NAME = 'rsbuild-webpack:swc';
+const PLUGIN_WEBPACK_SWC_NAME = 'rsbuild-webpack:swc';
 
 /**
  * In this plugin, we do:
@@ -23,9 +24,9 @@ const PLUGIN_NAME = 'rsbuild-webpack:swc';
  * - Add swc minifier plugin
  */
 export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
-  name: PLUGIN_NAME,
+  name: PLUGIN_WEBPACK_SWC_NAME,
 
-  pre: ['rsbuild:babel', 'uni-builder:babel'],
+  pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel'],
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { PLUGIN_BABEL_NAME } from '@rsbuild/core';
+import { PLUGIN_SWC_NAME, PLUGIN_BABEL_NAME } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,
   DEFAULT_BROWSERSLIST,
@@ -14,8 +14,6 @@ import {
 } from './utils';
 import { SwcMinimizerPlugin } from './minimizer';
 
-const PLUGIN_WEBPACK_SWC_NAME = 'rsbuild-webpack:swc';
-
 /**
  * In this plugin, we do:
  * - Remove Babel loader if exists
@@ -24,7 +22,7 @@ const PLUGIN_WEBPACK_SWC_NAME = 'rsbuild-webpack:swc';
  * - Add swc minifier plugin
  */
 export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
-  name: PLUGIN_WEBPACK_SWC_NAME,
+  name: PLUGIN_SWC_NAME,
 
   pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel'],
 

--- a/packages/compat/plugin-swc/tsconfig.json
+++ b/packages/compat/plugin-swc/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../../shared"
+    },
+    {
+      "path": "../../core"
     }
   ],
   "include": ["src"],

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,0 +1,6 @@
+export const PLUGIN_SWC_NAME = 'rsbuild:swc';
+export const PLUGIN_CSS_NAME = 'rsbuild:css';
+export const PLUGIN_LESS_NAME = 'rsbuild:less';
+export const PLUGIN_SASS_NAME = 'rsbuild:sass';
+export const PLUGIN_BABEL_NAME = 'rsbuild:babel';
+export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,16 @@ export const version = RSBUILD_VERSION;
 // Helpers
 export { logger, mergeRsbuildConfig } from '@rsbuild/shared';
 
+// Constants
+export {
+  PLUGIN_SWC_NAME,
+  PLUGIN_CSS_NAME,
+  PLUGIN_SASS_NAME,
+  PLUGIN_LESS_NAME,
+  PLUGIN_BABEL_NAME,
+  PLUGIN_STYLUS_NAME,
+} from './constants';
+
 // Types
 export type { Rspack } from './provider';
 export type {

--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -18,6 +18,7 @@ import type {
   NormalizedConfig,
   NormalizedSourceConfig,
 } from '../../types';
+import { PLUGIN_SWC_NAME } from '../../constants';
 
 const builtinSwcLoaderName = 'builtin:swc-loader';
 
@@ -50,7 +51,7 @@ export async function getDefaultSwcConfig(
  * Provide some swc configs of rspack
  */
 export const pluginSwc = (): RsbuildPlugin => ({
-  name: 'rsbuild:swc',
+  name: PLUGIN_SWC_NAME,
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import { castArray, cloneDeep, SCRIPT_REGEX, isProd } from '@rsbuild/shared';
 import { applyUserBabelConfig, BABEL_JS_RULE } from './helper';
 import type { PluginBabelOptions } from './types';
@@ -33,10 +33,12 @@ export const getDefaultBabelOptions = () => {
   };
 };
 
+export { PLUGIN_BABEL_NAME };
+
 export const pluginBabel = (
   options: PluginBabelOptions = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:babel',
+  name: PLUGIN_BABEL_NAME,
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_SWC_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import {
   deepmerge,
   modifySwcLoaderOptions,
@@ -18,7 +18,7 @@ export const pluginPreact = (
 ): RsbuildPlugin => ({
   name: 'rsbuild:preact',
 
-  pre: ['rsbuild:swc'],
+  pre: [PLUGIN_SWC_NAME],
 
   setup(api) {
     const { reactAliasesEnabled = true } = options;

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_SWC_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import { applyAntdSupport } from './antd';
 import { applyArcoSupport } from './arco';
 import { applySplitChunksRule } from './splitChunks';
@@ -34,12 +34,14 @@ export type PluginReactOptions = {
   splitChunks?: SplitReactChunkOptions;
 };
 
+export const PLUGIN_REACT_NAME = 'rsbuild:react';
+
 export const pluginReact = (
   options: PluginReactOptions = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:react',
+  name: PLUGIN_REACT_NAME,
 
-  pre: ['rsbuild:swc'],
+  pre: [PLUGIN_SWC_NAME],
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -1,4 +1,10 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import {
+  PLUGIN_CSS_NAME,
+  PLUGIN_SASS_NAME,
+  PLUGIN_LESS_NAME,
+  PLUGIN_STYLUS_NAME,
+  type RsbuildPlugin,
+} from '@rsbuild/core';
 import { getDistPath } from '@rsbuild/shared';
 import { cloneDeep } from '@rsbuild/shared';
 import type { PluginRemOptions, PxToRemOptions } from './types';
@@ -13,7 +19,12 @@ export type { PluginRemOptions };
 export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
   name: 'rsbuild:rem',
 
-  pre: ['rsbuild:css', 'rsbuild:less', 'rsbuild:sass', 'rsbuild:stylus'],
+  pre: [
+    PLUGIN_CSS_NAME,
+    PLUGIN_SASS_NAME,
+    PLUGIN_LESS_NAME,
+    PLUGIN_STYLUS_NAME,
+  ],
 
   setup(api) {
     api.modifyBundlerChain(

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import type { SolidPresetOptions } from './types';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
@@ -6,13 +6,15 @@ export type PluginSolidPresetOptions = {
   solidPresetOptions?: SolidPresetOptions;
 };
 
+export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
+
 export function pluginSolid(
   options: PluginSolidPresetOptions = {},
 ): RsbuildPlugin {
   return {
-    name: 'rsbuild:solid',
+    name: PLUGIN_SOLID_NAME,
 
-    pre: ['rsbuild:babel'],
+    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { setConfig, TS_CONFIG_FILE } from '@rsbuild/shared';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import {
   filterByField,
   getDependentProjects,
@@ -9,7 +9,7 @@ import {
   type ExtraMonorepoStrategies,
 } from '@rsbuild/monorepo-utils';
 
-export const pluginName = 'rsbuild:source-build';
+export const PLUGIN_SOURCE_BUILD_NAME = 'rsbuild:source-build';
 
 export const getSourceInclude = async (options: {
   projects: Project[];
@@ -51,10 +51,10 @@ export function pluginSourceBuild(
   } = options ?? {};
 
   return {
-    name: pluginName,
+    name: PLUGIN_SOURCE_BUILD_NAME,
 
     pre: [
-      'rsbuild:babel',
+      PLUGIN_BABEL_NAME,
       'uni-builder:babel',
       'uni-builder:ts-loader',
       'rsbuild-webpack:swc',

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -53,12 +53,7 @@ export function pluginSourceBuild(
   return {
     name: PLUGIN_SOURCE_BUILD_NAME,
 
-    pre: [
-      PLUGIN_BABEL_NAME,
-      'uni-builder:babel',
-      'uni-builder:ts-loader',
-      'rsbuild-webpack:swc',
-    ],
+    pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel', 'uni-builder:ts-loader'],
 
     setup(api) {
       const projectRootPath = api.context.rootPath;

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_STYLUS_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import { deepmerge, mergeChainedOptions } from '@rsbuild/shared';
 
 type StylusOptions = {
@@ -19,7 +19,7 @@ export type PluginStylusOptions = StylusLoaderOptions;
 
 export function pluginStylus(options?: PluginStylusOptions): RsbuildPlugin {
   return {
-    name: 'rsbuild:stylus',
+    name: PLUGIN_STYLUS_NAME,
 
     setup(api) {
       const STYLUS_REGEX = /\.styl(us)?$/;

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -28,13 +28,13 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "@rsbuild/plugin-react": "workspace:*",
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-react": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "16.x",
     "typescript": "^5.3.0"

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -8,7 +8,8 @@ import {
   getFilename,
   chainStaticAssetRule,
 } from '@rsbuild/shared';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import type { Config } from '@svgr/core';
 
 export type SvgDefaultExport = 'component' | 'url';
@@ -49,8 +50,8 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
 
   pre: [
     // SVGR needs to reuse the SWC loader options with react config
-    'rsbuild:react',
-    'rsbuild:babel',
+    PLUGIN_REACT_NAME,
+    PLUGIN_BABEL_NAME,
     'uni-builder:babel',
     'rsbuild-webpack:swc',
   ],

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -53,7 +53,6 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
     PLUGIN_REACT_NAME,
     PLUGIN_BABEL_NAME,
     'uni-builder:babel',
-    'rsbuild-webpack:swc',
   ],
 
   setup(api) {

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -12,6 +12,9 @@
     },
     {
       "path": "../shared"
+    },
+    {
+      "path": "../plugin-react"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import type { VueJSXPluginOptions } from '@vue/babel-plugin-jsx';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
@@ -10,7 +10,7 @@ export function pluginVueJsx(options: PluginVueJsxOptions = {}): RsbuildPlugin {
   return {
     name: 'rsbuild:vue-jsx',
 
-    pre: ['rsbuild:babel'],
+    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/core';
+import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
 type VueJSXPresetOptions = {
@@ -32,7 +32,7 @@ export function pluginVue2Jsx(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: 'rsbuild:vue2-jsx',
 
-    pre: ['rsbuild:babel'],
+    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,6 +1349,9 @@ importers:
 
   packages/plugin-svgr:
     dependencies:
+      '@rsbuild/plugin-react':
+        specifier: workspace:*
+        version: link:../plugin-react
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
@@ -1365,9 +1368,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
-      '@rsbuild/plugin-react':
-        specifier: workspace:*
-        version: link:../plugin-react
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper


### PR DESCRIPTION
## Summary

Extract some plugin names as constants, which allows other plugins to directly import the constant when defining plugin orders instead of using a string name.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
