### PR TITLE
types(core): export the type of config sub key

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,12 +28,28 @@ export type { Rspack } from './provider';
 export type {
   // Config Types
   RsbuildConfig,
+  DevConfig,
+  HtmlConfig,
+  ToolsConfig,
+  SourceConfig,
+  OutputConfig,
+  SecurityConfig,
+  PerformanceConfig,
+  // Normalized Config Types
   NormalizedConfig,
+  NormalizedDevConfig,
+  NormalizedHtmlConfig,
+  NormalizedToolsConfig,
+  NormalizedSourceConfig,
+  NormalizedOutputConfig,
+  NormalizedSecurityConfig,
+  NormalizedPerformanceConfig,
   // Plugin Types
   RsbuildPlugin,
   RsbuildPlugins,
   RsbuildPluginAPI,
 } from './types';
+
 export type {
   RsbuildMode,
   RsbuildEntry,

--- a/packages/document/docs/en/api/javascript-api/types.mdx
+++ b/packages/document/docs/en/api/javascript-api/types.mdx
@@ -24,6 +24,20 @@ const config: RsbuildConfig = {
 };
 ```
 
+You can also import the type definitions of each field in the Rsbuild config:
+
+```ts
+import type {
+  DevConfig,
+  HtmlConfig,
+  ToolsConfig,
+  SourceConfig,
+  OutputConfig,
+  SecurityConfig,
+  PerformanceConfig,
+} from '@rsbuild/core';
+```
+
 ## NormalizedConfig
 
 The type of Rsbuild configuration after normalization, corresponding to the return value of the [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method.
@@ -32,6 +46,20 @@ The type of Rsbuild configuration after normalization, corresponding to the retu
 import type { NormalizedConfig } from '@rsbuild/core';
 
 const config: NormalizedConfig = api.getNormalizedConfig();
+```
+
+You can also import the type definitions of each field in the normalized config:
+
+```ts
+import type {
+  NormalizedDevConfig,
+  NormalizedHtmlConfig,
+  NormalizedToolsConfig,
+  NormalizedSourceConfig,
+  NormalizedOutputConfig,
+  NormalizedSecurityConfig,
+  NormalizedPerformanceConfig,
+} from '@rsbuild/core';
 ```
 
 ## RsbuildContext

--- a/packages/document/docs/zh/api/javascript-api/types.mdx
+++ b/packages/document/docs/zh/api/javascript-api/types.mdx
@@ -24,6 +24,20 @@ const config: RsbuildConfig = {
 };
 ```
 
+你也可以引用 Rsbuild 配置中各个字段的类型定义：
+
+```ts
+import type {
+  DevConfig,
+  HtmlConfig,
+  ToolsConfig,
+  SourceConfig,
+  OutputConfig,
+  SecurityConfig,
+  PerformanceConfig,
+} from '@rsbuild/core';
+```
+
 ## NormalizedConfig
 
 Rsbuild 配置归一化后的类型，对应 [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
@@ -32,6 +46,20 @@ Rsbuild 配置归一化后的类型，对应 [getNormalizedConfig](/plugins/dev/
 import type { NormalizedConfig } from '@rsbuild/core';
 
 const config: NormalizedConfig = api.getNormalizedConfig();
+```
+
+你也可以引用归一化后的 Rsbuild 配置中各个字段的类型定义：
+
+```ts
+import type {
+  NormalizedDevConfig,
+  NormalizedHtmlConfig,
+  NormalizedToolsConfig,
+  NormalizedSourceConfig,
+  NormalizedOutputConfig,
+  NormalizedSecurityConfig,
+  NormalizedPerformanceConfig,
+} from '@rsbuild/core';
 ```
 
 ## RsbuildContext


### PR DESCRIPTION
## Summary

Export the types of config sub key from `@rsbuild/core`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
