### PR TITLE
chore: remove cli exports from core

### DIFF
--- a/.changeset/shiny-mayflies-float.md
+++ b/.changeset/shiny-mayflies-float.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.3.3

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,10 +26,6 @@
       "types": "./dist/client/*.d.ts",
       "default": "./dist/client/*.js"
     },
-    "./cli": {
-      "types": "./dist/cli/commands.d.ts",
-      "default": "./dist/cli/commands.js"
-    },
     "./plugins/*": {
       "types": "./dist/plugins/*.d.ts",
       "default": "./dist/plugins/*.js"


### PR DESCRIPTION
## Summary

Remove cli exports from `@rsbuild/core`, it was previously added to Modern.js Builder, and never used by Rsbuild or users.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
