### PR TITLE
perf(source-build): remove p-map dependency

### DIFF
--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -30,8 +30,7 @@
     "@types/js-yaml": "^4.0.6",
     "fast-glob": "^3.3.1",
     "js-yaml": "^4.1.0",
-    "json5": "^2.2.3",
-    "p-map": "^4.0.0"
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@types/node": "16.x",

--- a/packages/monorepo-utils/src/utils.ts
+++ b/packages/monorepo-utils/src/utils.ts
@@ -1,16 +1,11 @@
 import path from 'path';
 import { fse } from '@rsbuild/shared';
 import json5 from 'json5';
-import { PACKAGE_JSON, RUSH_JSON_FILE } from './constants';
+import { RUSH_JSON_FILE } from './constants';
 import type { INodePackageJson, IRushConfig } from './types';
 
 export const readPackageJson = async (pkgJsonFilePath: string) => {
-  const packageJson = readJson<INodePackageJson>(
-    pkgJsonFilePath.includes(PACKAGE_JSON)
-      ? pkgJsonFilePath
-      : path.join(pkgJsonFilePath, PACKAGE_JSON),
-  );
-  return packageJson;
+  return readJson<INodePackageJson>(pkgJsonFilePath);
 };
 
 export const readRushJson = async (rushJsonFilePath: string) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -949,9 +949,6 @@ importers:
       json5:
         specifier: ^2.2.3
         version: 2.2.3
-      p-map:
-        specifier: ^4.0.0
-        version: 4.0.0
     devDependencies:
       '@types/node':
         specifier: 16.x
@@ -6077,14 +6074,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  /aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-    dev: false
-
   /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -6802,11 +6791,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       safe-buffer: 5.2.1
-    dev: false
-
-  /clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
     dev: false
 
   /cli-cursor@3.1.0:
@@ -9107,6 +9091,7 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+    dev: true
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -11038,13 +11023,6 @@ packages:
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
-
-  /p-map@4.0.0:
-    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
-    engines: {node: '>=10'}
-    dependencies:
-      aggregate-error: 3.1.0
-    dev: false
 
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}


### PR DESCRIPTION
## Summary

Remove p-map dependency from plugin-source-build, as we do not need to limit concurrency in this case.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
