### PR TITLE
fix: enable relase-nightly schedule for edenx nightly test

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,9 +2,9 @@ name: Release Nightly
 
 on:
   workflow_dispatch:
-  # schedule:
+  schedule:
     # 00:00 AM Beijing Time.
-    # - cron: "0 16 * * *"
+    - cron: "0 16 * * *"
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

It's a problem about edenx nightly test, edenx needs use rsbuild nightly version to run nightly test, but only find v20231112.


<img width="667" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/40d31f6f-72cc-4c8e-88f4-d300cfdcd964">

<img width="985" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/2b0150fd-be2a-4d00-8b05-c938eefa98e9">





## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
