### PR TITLE
perf(source-build): reuse shared dependencies

### DIFF
--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -27,10 +27,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@types/js-yaml": "^4.0.6",
-    "fast-glob": "^3.3.1",
-    "js-yaml": "^4.1.0",
-    "json5": "^2.2.3"
+    "fast-glob": "^3.3.1"
   },
   "devDependencies": {
     "@types/node": "16.x",

--- a/packages/monorepo-utils/src/common/pnpm.ts
+++ b/packages/monorepo-utils/src/common/pnpm.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fse } from '@rsbuild/shared';
-import { load } from 'js-yaml';
+import { parse } from '@rsbuild/shared/yaml';
 import glob, { type Options as GlobOptions } from 'fast-glob';
 import { Project } from '../project/project';
 import { PNPM_WORKSPACE_FILE, PACKAGE_JSON } from '../constants';
@@ -10,7 +10,7 @@ import type { IPnpmWorkSpace } from '../types';
 export const getPatternsFromYaml = async (monorepoRoot: string) => {
   const workspaceYamlFilePath = path.join(monorepoRoot, PNPM_WORKSPACE_FILE);
   const yamlContent = await fse.readFile(workspaceYamlFilePath, 'utf8');
-  const pnpmWorkspace = load(yamlContent) as IPnpmWorkSpace;
+  const pnpmWorkspace = parse(yamlContent) as IPnpmWorkSpace;
   return pnpmWorkspace.packages || [];
 };
 

--- a/packages/monorepo-utils/src/utils.ts
+++ b/packages/monorepo-utils/src/utils.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { fse } from '@rsbuild/shared';
-import json5 from 'json5';
+import json5 from '@rsbuild/shared/json5';
 import { RUSH_JSON_FILE } from './constants';
 import type { INodePackageJson, IRushConfig } from './types';
 

--- a/packages/shared/compiled/yaml/index.d.ts
+++ b/packages/shared/compiled/yaml/index.d.ts
@@ -1,1 +1,1 @@
-export = any;
+export declare function parse(src: string, options?: any): any;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,10 @@
       "types": "./compiled/rslog/dist/index.d.ts",
       "default": "./compiled/rslog/index.js"
     },
+    "./yaml": {
+      "types": "./compiled/yaml/index.d.ts",
+      "default": "./compiled/yaml/index.js"
+    },
     "./json5": {
       "types": "./compiled/json5/lib/index.d.ts",
       "default": "./compiled/json5/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -937,18 +937,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
-      '@types/js-yaml':
-        specifier: ^4.0.6
-        version: 4.0.8
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.2
-      js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.0
-      json5:
-        specifier: ^2.2.3
-        version: 2.2.3
     devDependencies:
       '@types/node':
         specifier: 16.x
@@ -5360,6 +5351,7 @@ packages:
 
   /@types/js-yaml@4.0.8:
     resolution: {integrity: sha512-m6jnPk1VhlYRiLFm3f8X9Uep761f+CK8mHyS65LutH2OhmBF0BeMEjHgg05usH8PLZMWWc/BUR9RPmkvpWnyRA==}
+    dev: true
 
   /@types/json-schema@7.0.14:
     resolution: {integrity: sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==}

--- a/scripts/prebundle/src/constant.ts
+++ b/scripts/prebundle/src/constant.ts
@@ -86,6 +86,12 @@ export const TASKS: TaskConfig[] = [
       {
         name: 'yaml',
         ignoreDts: true,
+        afterBundle(task) {
+          fs.writeFileSync(
+            join(task.distPath, 'index.d.ts'),
+            'export declare function parse(src: string, options?: any): any;',
+          );
+        },
       },
       {
         name: 'line-diff',


### PR DESCRIPTION
## Summary

Reuse shared dependencies from `@rsbuild/shared`, use `yaml` instead of `js-yaml`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
