### PR TITLE
fix: should ignore node addons when targeting service worker

### DIFF
--- a/e2e/cases/mjs-artifact/test.mjs
+++ b/e2e/cases/mjs-artifact/test.mjs
@@ -6,6 +6,7 @@ import { pluginImageCompress } from '@rsbuild/plugin-image-compress';
 import { pluginNodePolyfill } from '@rsbuild/plugin-node-polyfill';
 import { pluginPug } from '@rsbuild/plugin-pug';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginPreact } from '@rsbuild/plugin-preact';
 import { pluginRem } from '@rsbuild/plugin-rem';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 import { pluginSolid } from '@rsbuild/plugin-solid';
@@ -18,6 +19,8 @@ import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
 import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
+import { pluginToml } from '@rsbuild/plugin-toml';
+import { pluginYaml } from '@rsbuild/plugin-yaml';
 
 export default {
   pluginAssetsRetry,
@@ -28,6 +31,7 @@ export default {
   pluginNodePolyfill,
   pluginPug,
   pluginReact,
+  pluginPreact,
   pluginRem,
   pluginSvgr,
   pluginSolid,
@@ -40,4 +44,6 @@ export default {
   pluginVue2,
   pluginVueJsx,
   pluginVue2Jsx,
+  pluginToml,
+  pluginYaml,
 };

--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -11,51 +11,49 @@ export const pluginNodeAddons = (): RsbuildPlugin => ({
   name: 'rsbuild:node-addons',
 
   setup(api) {
-    api.modifyBundlerChain(
-      async (chain, { isServer, isServiceWorker, CHAIN_ID }) => {
-        if (!isServer && !isServiceWorker) {
-          return;
+    api.modifyBundlerChain(async (chain, { isServer, CHAIN_ID }) => {
+      if (!isServer) {
+        return;
+      }
+
+      const getDistName = (resourcePath: string) => {
+        const pkgJSON = findUpSync({
+          filename: 'package.json',
+          cwd: dirname(resourcePath),
+        });
+
+        if (!pkgJSON) {
+          throw new Error(
+            `Failed to compile Node.js addons, couldn't find the package.json of ${color.yellow(
+              resourcePath,
+            )}.`,
+          );
         }
 
-        const getDistName = (resourcePath: string) => {
-          const pkgJSON = findUpSync({
-            filename: 'package.json',
-            cwd: dirname(resourcePath),
-          });
-
-          if (!pkgJSON) {
-            throw new Error(
-              `Failed to compile Node.js addons, couldn't find the package.json of ${color.yellow(
-                resourcePath,
-              )}.`,
-            );
+        const getFilename = (resource: string, pkgName: string) => {
+          const reg = new RegExp(`node_modules/${pkgName}/(.+)`);
+          const match = resource.match(reg);
+          const filename = match?.[1];
+          if (!filename) {
+            return '[name].[ext]';
           }
-
-          const getFilename = (resource: string, pkgName: string) => {
-            const reg = new RegExp(`node_modules/${pkgName}/(.+)`);
-            const match = resource.match(reg);
-            const filename = match?.[1];
-            if (!filename) {
-              return '[name].[ext]';
-            }
-            return `${filename}`;
-          };
-
-          const { name: pkgName } = require(pkgJSON);
-          const config = api.getNormalizedConfig();
-          const serverPath = getDistPath(config, 'server');
-          return `${serverPath}/${getFilename(resourcePath, pkgName)}`;
+          return `${filename}`;
         };
 
-        chain.module
-          .rule(CHAIN_ID.RULE.NODE)
-          .test(/\.node$/)
-          .use(CHAIN_ID.USE.NODE)
-          .loader(getSharedPkgCompiledPath('node-loader'))
-          .options({
-            name: getDistName,
-          });
-      },
-    );
+        const { name: pkgName } = require(pkgJSON);
+        const config = api.getNormalizedConfig();
+        const serverPath = getDistPath(config, 'server');
+        return `${serverPath}/${getFilename(resourcePath, pkgName)}`;
+      };
+
+      chain.module
+        .rule(CHAIN_ID.RULE.NODE)
+        .test(/\.node$/)
+        .use(CHAIN_ID.USE.NODE)
+        .loader(getSharedPkgCompiledPath('node-loader'))
+        .options({
+          name: getDistName,
+        });
+    });
   },
 });

--- a/packages/core/tests/plugins/nodeAddons.test.ts
+++ b/packages/core/tests/plugins/nodeAddons.test.ts
@@ -16,4 +16,49 @@ describe('plugin-node-addons', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should not add node addons rule when target is web', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginNodeAddons()],
+      rsbuildConfig: {
+        output: {
+          targets: ['web'],
+        },
+      },
+    });
+
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.module).toBeUndefined();
+  });
+
+  it('should not add node addons rule when target is web-worker', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginNodeAddons()],
+      rsbuildConfig: {
+        output: {
+          targets: ['web-worker'],
+        },
+      },
+    });
+
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.module).toBeUndefined();
+  });
+
+  it('should not add node addons rule when target is service-worker', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginNodeAddons()],
+      rsbuildConfig: {
+        output: {
+          targets: ['service-worker'],
+        },
+      },
+    });
+
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config.module).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Should ignore node addons when targeting service worker, the node addons is only supported when targeting node environment.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
