### PR TITLE
fix(server): print server url should between listen and beforeCompile

### DIFF
--- a/e2e/cases/javascript-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/javascript-api/plugin-hooks/index.test.ts
@@ -67,9 +67,9 @@ test('should run plugin hooks correctly when running startDevServer', async () =
   const result = await rsbuild.startDevServer();
 
   expect(fse.readFileSync(distFile, 'utf-8').split(',')).toEqual([
+    'BeforeStartDevServer',
     'BeforeCreateCompiler',
     'AfterCreateCompiler',
-    'BeforeStartDevServer',
     'AfterStartDevServer',
   ]);
 

--- a/packages/core/src/provider/core/initConfigs.ts
+++ b/packages/core/src/provider/core/initConfigs.ts
@@ -87,7 +87,7 @@ export async function initConfigs({
 
     // run inspect later to avoid cleaned by cleanOutput plugin
     context.hooks.onBeforeBuild.tap(inspect);
-    context.hooks.onBeforeStartDevServer.tap(inspect);
+    context.hooks.onAfterStartDevServer.tap(inspect);
   }
 
   return {


### PR DESCRIPTION
## Summary

print server url should between listen and beforeCompile
- after listen: server can response url request when user visit page
- beforeCompile: the compile message can be printed at the bottom of terminal

<img width="658" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/ca362770-7cad-4599-b381-38ececdc6f88">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
