### PR TITLE
docs: move fast refresh guide to react document

### DIFF
--- a/packages/document/docs/en/guide/faq/hmr.md
+++ b/packages/document/docs/en/guide/faq/hmr.md
@@ -97,40 +97,6 @@ export default {
 
 ---
 
-### HMR not working when updating React components?
-
-Rsbuild uses React's official [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) capability to perform component hot updates.
-
-If there is a problem that the hot update of the React component cannot take effect, or the state of the React component is lost after the hot update, it is usually because your React component uses an anonymous function. In the official practice of React Fast Refresh, it is required that the component cannot be an anonymous function, otherwise the state of the React component cannot be preserved after hot update.
-
-Here are some examples of wrong usage:
-
-```tsx
-// bad
-export default function () {
-  return <div>Hello World</div>;
-}
-
-// bad
-export default () => <div>Hello World</div>;
-```
-
-The correct usage is to declare a name for each component function:
-
-```tsx
-// good
-export default function MyComponent() {
-  return <div>Hello World</div>;
-}
-
-// good
-const MyComponent = () => <div>Hello World</div>;
-
-export default MyComponent;
-```
-
----
-
 ### HMR not working when use https?
 
 If https is enabled, the HMR connection may fail due to a certificate issue, and if you open the console, you will get an HMR connect failed error.

--- a/packages/document/docs/en/guide/framework/react.mdx
+++ b/packages/document/docs/en/guide/framework/react.mdx
@@ -49,7 +49,7 @@ import DeployApp from '@en/shared/deployApp.md';
 
 ## React Fast Refresh
 
-Rsbuild uses React's official [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) capability to perform component hot updates.
+Rsbuild uses React's official [Fast Refresh](https://www.npmjs.com/package/react-refresh) capability to perform component hot updates.
 
 Note that React Refresh requires components to be written according to the standards. Otherwise HMR may not work. You can use [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) for validation.
 

--- a/packages/document/docs/en/guide/framework/react.mdx
+++ b/packages/document/docs/en/guide/framework/react.mdx
@@ -46,3 +46,37 @@ If you need to use styled-components, We recommend register the [Styled Componen
 import DeployApp from '@en/shared/deployApp.md';
 
 <DeployApp />
+
+## React Fast Refresh
+
+Rsbuild uses React's official [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) capability to perform component hot updates.
+
+Note that React Refresh requires components to be written according to the standards. Otherwise HMR may not work. You can use [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) for validation.
+
+For example, if the hot update of the React component cannot take effect, or the state of the React component is lost after the hot update, it is usually because your React component uses an anonymous function. In the official practice of React Fast Refresh, it is required that the component cannot be an anonymous function, otherwise the state of the React component cannot be preserved after hot update.
+
+Here are some examples of wrong usage:
+
+```tsx
+// bad
+export default function () {
+  return <div>Hello World</div>;
+}
+
+// bad
+export default () => <div>Hello World</div>;
+```
+
+The correct usage is to declare a name for each component function:
+
+```tsx
+// good
+export default function MyComponent() {
+  return <div>Hello World</div>;
+}
+
+// good
+const MyComponent = () => <div>Hello World</div>;
+
+export default MyComponent;
+```

--- a/packages/document/docs/zh/guide/faq/hmr.md
+++ b/packages/document/docs/zh/guide/faq/hmr.md
@@ -97,40 +97,6 @@ export default {
 
 ---
 
-### React 组件的热更新无法生效？
-
-Rsbuild 使用 React 官方的 [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) 能力来进行组件热更新。
-
-如果出现 React 组件的热更新无法生效的问题，或者是热更新后 React 组件的 state 丢失，这通常是因为你的 React 组件使用了匿名函数。在 React Fast Refresh 的官方实践中，要求组件不能为匿名函数，否则热更新后无法保留 React 组件的 state。
-
-以下是一些错误用法的例子：
-
-```tsx
-// 错误写法 1
-export default function () {
-  return <div>Hello World</div>;
-}
-
-// 错误写法 2
-export default () => <div>Hello World</div>;
-```
-
-正确用法是给每个组件函数声明一个名称：
-
-```tsx
-// 正确写法 1
-export default function MyComponent() {
-  return <div>Hello World</div>;
-}
-
-// 正确写法 2
-const MyComponent = () => <div>Hello World</div>;
-
-export default MyComponent;
-```
-
----
-
 ### 开启 https 后，热更新不生效？
 
 当开启 https 时，由于证书的问题，可能会出现 HMR 连接失败的情况，此时打开控制台，会出现 HMR connect failed 的报错。

--- a/packages/document/docs/zh/guide/framework/react.mdx
+++ b/packages/document/docs/zh/guide/framework/react.mdx
@@ -49,7 +49,7 @@ import DeployApp from '@zh/shared/deployApp.md';
 
 ## React Fast Refresh
 
-Rsbuild 使用 React 官方的 [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) 能力来进行组件热更新。
+Rsbuild 使用 React 官方的 [Fast Refresh](https://www.npmjs.com/package/react-refresh) 能力来进行组件热更新。
 
 注意 React Refresh 要求组件按照规范的方式编写，否则热更新可能无效，你可以使用 [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) 进行校验。
 

--- a/packages/document/docs/zh/guide/framework/react.mdx
+++ b/packages/document/docs/zh/guide/framework/react.mdx
@@ -46,3 +46,37 @@ Rsbuild 提供对 styled-components 的编译时支持，优化调试体验并�
 import DeployApp from '@zh/shared/deployApp.md';
 
 <DeployApp />
+
+## React Fast Refresh
+
+Rsbuild 使用 React 官方的 [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin) 能力来进行组件热更新。
+
+注意 React Refresh 要求组件按照规范的方式编写，否则热更新可能无效，你可以使用 [eslint-plugin-react-refresh](https://github.com/ArnaudBarre/eslint-plugin-react-refresh) 进行校验。
+
+比如，如果 React 组件的热更新无法生效，或者是热更新后 React 组件的 state 丢失，这通常是因为你的 React 组件使用了匿名函数。在 React Fast Refresh 的官方实践中，要求组件不能为匿名函数，否则热更新后无法保留 React 组件的 state。
+
+以下是一些错误用法的例子：
+
+```tsx
+// 错误写法 1
+export default function () {
+  return <div>Hello World</div>;
+}
+
+// 错误写法 2
+export default () => <div>Hello World</div>;
+```
+
+正确用法是给每个组件函数声明一个名称：
+
+```tsx
+// 正确写法 1
+export default function MyComponent() {
+  return <div>Hello World</div>;
+}
+
+// 正确写法 2
+const MyComponent = () => <div>Hello World</div>;
+
+export default MyComponent;
+```


### PR DESCRIPTION
## Summary

Move fast refresh guide to react document, easier to find it.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
