### PR TITLE
docs: add react plugin introduce in the builder migration guide

### DIFF
--- a/packages/document/docs/en/guide/migration/modern-builder.mdx
+++ b/packages/document/docs/en/guide/migration/modern-builder.mdx
@@ -85,6 +85,30 @@ export default defineConfig({
 });
 ```
 
+## Add React-related Plugins
+
+Rsbuild is not coupled with any front-end UI framework. Therefore, if you are a React project, you need to manually add [React Plugin](/plugins/list/plugin-react):
+
+```ts title="rsbuild.config.ts"
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default {
+  plugins: [pluginReact()],
+};
+```
+
+If you are using SVGR in your current project, you also need to register [SVGR Plugin](/plugins/list/plugin-svgr):
+
+```ts title="rsbuild.config.ts"
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default {
+  plugins: [pluginSvgr()],
+};
+```
+
+If you are a user of other frameworks, you can refer to [Rsbuild Plugin List](/plugins/list/index) to select the corresponding framework plugin.
+
 ## Configuration Migration
 
 Most configs in Rsbuild and Builder are consistent, with only a few adjustments.

--- a/packages/document/docs/zh/guide/migration/modern-builder.mdx
+++ b/packages/document/docs/zh/guide/migration/modern-builder.mdx
@@ -85,6 +85,30 @@ export default defineConfig({
 });
 ```
 
+## 添加 React 相关插件
+
+Rsbuild 不与任何前端 UI 框架耦合。因此，如果你是一个 React 项目，需要手动添加 [React 插件](/plugins/list/plugin-react)：
+
+```ts title="rsbuild.config.ts"
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default {
+  plugins: [pluginReact()],
+};
+```
+
+如果你当前项目中有使用 SVGR，还需要注册 Rsbuild 的 [SVGR 插件](/plugins/list/plugin-svgr)：
+
+```ts title="rsbuild.config.ts"
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default {
+  plugins: [pluginSvgr()],
+};
+```
+
+如果你是其他框架的使用者，可参考 [插件列表](/plugins/list/index) 选择对应的框架插件。
+
 ## 配置迁移
 
 Rsbuild 和 Builder 的绝大多数配置项是一致的，仅有少许配置项进行了调整。


### PR DESCRIPTION
## Summary

Rsbuild is not coupled with any front-end UI framework. Therefore, if a React project wants to migrate from modern.js builder to rsbuild, add React Plugin is necessary.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
