### PR TITLE
test(e2e): add gotoPage helper to simplify code

### DIFF
--- a/e2e/cases/babel/build.test.ts
+++ b/e2e/cases/babel/build.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
@@ -16,7 +16,7 @@ rspackOnlyTest('babel', async ({ page }) => {
     ],
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.b')).toBe(10);
 
   await rsbuild.close();
@@ -40,7 +40,7 @@ rspackOnlyTest('babel exclude', async ({ page }) => {
     ],
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.b')).toBe(10);
   expect(await page.evaluate('window.bb')).toBeUndefined();
 

--- a/e2e/cases/bundler-chain/index.test.ts
+++ b/e2e/cases/bundler-chain/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
   page,
@@ -19,7 +19,7 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 
   await rsbuild.close();

--- a/e2e/cases/configure-rspack/index.test.ts
+++ b/e2e/cases/configure-rspack/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest(
   'should allow to use tools.rspack to configure Rspack',
@@ -21,7 +21,7 @@ rspackOnlyTest(
       },
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/configure-webpack/index.test.ts
+++ b/e2e/cases/configure-webpack/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { webpackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 webpackOnlyTest(
   'should allow to use tools.webpackChain to configure Webpack',
@@ -21,7 +21,7 @@ webpackOnlyTest(
       },
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { fse } from '@rsbuild/shared';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -57,7 +57,7 @@ test('injectStyles', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // injectStyles worked
   const files = await rsbuild.unwrapOutputJSON();

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,4 +1,4 @@
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -16,7 +16,7 @@ test('should inline style when injectStyles is true', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // injectStyles worked
   const files = await rsbuild.unwrapOutputJSON();

--- a/e2e/cases/decorator/common/index.test.ts
+++ b/e2e/cases/decorator/common/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('decorator legacy(default)', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ test('decorator legacy(default)', async ({ page }) => {
     rsbuildConfig: {},
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello!');
   expect(await page.evaluate('window.bbb')).toBe('world');
 
@@ -26,7 +26,7 @@ test('decorator latest', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello!');
   expect(await page.evaluate('window.bbb')).toBe('world');
 

--- a/e2e/cases/decorator/latest/index.test.ts
+++ b/e2e/cases/decorator/latest/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test.skip('decorator latest', async ({ page }) => {
   const rsbuild = await build({
@@ -12,7 +12,7 @@ test.skip('decorator latest', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello world');
 
   // swc...

--- a/e2e/cases/decorator/legacy/index.test.ts
+++ b/e2e/cases/decorator/legacy/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest('decorator legacy(default)', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ rspackOnlyTest('decorator legacy(default)', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello world');
 
   if (rsbuild.providerType !== 'rspack') {

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -1,7 +1,7 @@
 import { fse } from '@rsbuild/shared';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('tools.htmlPlugin', async ({ page }) => {
   const rsbuild = await build({
@@ -18,7 +18,7 @@ test('tools.htmlPlugin', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const pagePath = join(rsbuild.distPath, 'index.html');
   const content = await fse.readFile(pagePath, 'utf-8');

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 const fixtures = __dirname;
 
@@ -17,7 +17,7 @@ test('should minify template js & css', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
 
@@ -66,7 +66,7 @@ test('should minify template success when inlineScripts & inlineStyles', async (
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
 

--- a/e2e/cases/html/mount-id/index.test.ts
+++ b/e2e/cases/html/mount-id/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test.describe('should render mountId correctly', () => {
   let rsbuild: Awaited<ReturnType<typeof build>>;
@@ -26,7 +26,7 @@ test.describe('should render mountId correctly', () => {
     const errors: string[] = [];
     page.on('pageerror', (err) => errors.push(err.message));
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const test = page.locator('#test');
     await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('html.outputStructure', async ({ page }) => {
   const rsbuild = await build({
@@ -14,7 +14,7 @@ test('html.outputStructure', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const pagePath = join(rsbuild.distPath, 'index/index.html');
 

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should set template via function correctly', async () => {
   const rsbuild = await build({
@@ -50,7 +50,7 @@ test('should allow to access templateParameters', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testTemplate = page.locator('#test-template');
   await expect(testTemplate).toHaveText('xxx');

--- a/e2e/cases/import-json/index.test.ts
+++ b/e2e/cases/import-json/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest('should import JSON correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ rspackOnlyTest('should import JSON correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.age')).toBe(1);
   expect(await page.evaluate('window.b')).toBe('{"list":[1,2]}');
 

--- a/e2e/cases/import-toml/index.test.ts
+++ b/e2e/cases/import-toml/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest('should import TOML correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ rspackOnlyTest('should import TOML correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.age')).toBe(1);
   expect(await page.evaluate('window.b')).toBe('{"list":[1,2]}');
 

--- a/e2e/cases/import-yaml/index.test.ts
+++ b/e2e/cases/import-yaml/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest('should import YAML correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ rspackOnlyTest('should import YAML correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.age')).toBe(1);
   expect(await page.evaluate('window.b')).toBe('{"list":[1,2]}');
 

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import type { BundlerChain } from '@rsbuild/shared';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map
@@ -37,7 +37,7 @@ test('inline all scripts should work and emit all source maps', async ({
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // test runtime
   expect(await page.evaluate('window.test')).toBe('aaaa');

--- a/e2e/cases/legal-comments/index.test.ts
+++ b/e2e/cases/legal-comments/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -19,7 +19,7 @@ rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
@@ -66,7 +66,7 @@ test('legalComments none', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
@@ -107,7 +107,7 @@ test('legalComments inline', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 

--- a/e2e/cases/live-reload/index.test.ts
+++ b/e2e/cases/live-reload/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { dev, getHrefByEntryName } from '@scripts/shared';
+import { dev, gotoPage } from '@scripts/shared';
 
 const appFile = path.join(__dirname, 'src/App.jsx');
 let appCode: string;
@@ -27,7 +27,7 @@ test('should fallback to live-reload when dev.hmr is false', async ({
     cwd: __dirname,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
@@ -50,7 +50,7 @@ test('should not reload page when live-reload is disabled', async ({
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/multi-compiler/index.test.ts
+++ b/e2e/cases/multi-compiler/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, dev, getHrefByEntryName } from '@scripts/shared';
+import { build, dev, gotoPage } from '@scripts/shared';
 
 test('multi compiler build', async ({ page }) => {
   const rsbuild = await build({
@@ -12,7 +12,7 @@ test('multi compiler build', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
@@ -33,7 +33,7 @@ test('multi compiler dev', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/node-polyfill/index.test.ts
+++ b/e2e/cases/node-polyfill/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should add node-polyfill when add node-polyfill plugin', async ({
   page,
@@ -8,7 +8,7 @@ test('should add node-polyfill when add node-polyfill plugin', async ({
     cwd: __dirname,
     runServer: true,
   });
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/output/ascii/index.test.ts
+++ b/e2e/cases/output/ascii/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('output.charset default (ascii)', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('output.charset default (ascii)', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
   const files = await rsbuild.unwrapOutputJSON();
@@ -35,7 +35,7 @@ test('output.charset (utf8)', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
   const files = await rsbuild.unwrapOutputJSON();

--- a/e2e/cases/output/assets.test.ts
+++ b/e2e/cases/output/assets.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
@@ -67,7 +67,7 @@ cases.forEach((_case) => {
       rsbuildConfig: _case.config || {},
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     if (_case.expected === 'url') {
       await expect(

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = resolve(__dirname, '../');
@@ -22,7 +22,7 @@ test('externals', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/output/rem/tests/index.test.ts
+++ b/e2e/cases/output/rem/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
@@ -12,7 +12,7 @@ test('rem default (disable)', async ({ page }) => {
     plugins: [pluginReact()],
     runServer: true,
   });
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const title = page.locator('#title');
   await expect(title).toHaveCSS('font-size', '20px');
@@ -31,7 +31,7 @@ test('rem enable', async ({ page }) => {
     plugins: [pluginReact(), pluginRem()],
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const root = page.locator('html');
   await expect(root).toHaveCSS('font-size', '64px');

--- a/e2e/cases/polyfill/index.test.ts
+++ b/e2e/cases/polyfill/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 const POLYFILL_RE = /\/lib-polyfill/;
 
@@ -43,7 +43,7 @@ test('should add polyfill when set polyfill entry (default)', async ({
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 
@@ -79,7 +79,7 @@ rspackOnlyTest(
       console.log('page err', err);
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 

--- a/e2e/cases/preact/basic/index.test.ts
+++ b/e2e/cases/preact/basic/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { dev, build, getHrefByEntryName } from '@scripts/shared';
+import { dev, build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest(
   'should render basic Preact component in development correctly',
@@ -9,7 +9,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
@@ -28,7 +28,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');

--- a/e2e/cases/preview/index.test.ts
+++ b/e2e/cases/preview/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getRandomPort, getHrefByEntryName } from '@scripts/shared';
+import { build, getRandomPort, gotoPage } from '@scripts/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should preview dist files correctly', async ({ page }) => {
@@ -12,7 +12,7 @@ test('should preview dist files correctly', async ({ page }) => {
 
   const { port, server } = await instance.preview();
 
-  await page.goto(getHrefByEntryName('index', port));
+  await gotoPage(page, { port });
 
   const rootEl = page.locator('#root');
   await expect(rootEl).toHaveText('Hello Rsbuild!');
@@ -46,7 +46,7 @@ test('should allow plugin to modify preview server config', async ({
 
   expect(port).toEqual(PORT);
 
-  await page.goto(getHrefByEntryName('index', port));
+  await gotoPage(page, { port });
   const rootEl = page.locator('#root');
   await expect(rootEl).toHaveText('Hello Rsbuild!');
   await server.close();

--- a/e2e/cases/pug/basic/index.test.ts
+++ b/e2e/cases/pug/basic/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('should allow to use .pug template file', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testPug = page.locator('#test-pug');
   await expect(testPug).toHaveText('Pug source code!');

--- a/e2e/cases/pug/vue2-template/index.test.ts
+++ b/e2e/cases/pug/vue2-template/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('should allow to use .pug template file', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testPug = page.locator('#test-pug');
   await expect(testPug).toHaveText('Pug source code!');

--- a/e2e/cases/pug/vue3-template/index.test.ts
+++ b/e2e/cases/pug/vue3-template/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('should allow to use .pug template file', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testPug = page.locator('#test-pug');
   await expect(testPug).toHaveText('Pug source code!');

--- a/e2e/cases/react/basic/index.test.ts
+++ b/e2e/cases/react/basic/index.test.ts
@@ -1,6 +1,6 @@
 import { expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { dev, build, getHrefByEntryName } from '@scripts/shared';
+import { dev, build, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest(
   'should render basic React component in development correctly',
@@ -9,7 +9,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
@@ -28,7 +28,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');

--- a/e2e/cases/react/legacy-jsx/index.test.ts
+++ b/e2e/cases/react/legacy-jsx/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 const fixtures = __dirname;
 
@@ -11,7 +11,7 @@ test('should render element with legacy JSX runtime correctly', async ({
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/react/remove-prop-types/index.test.ts
+++ b/e2e/cases/react/remove-prop-types/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
@@ -11,7 +11,7 @@ test.skip('should remove prop-types by default', async ({ page }) => {
     runServer: true,
     plugins: [pluginReact()],
   });
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   expect(await page.evaluate('window.testAppPropTypes')).toBeUndefined();
   await rsbuild.close();

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from '@playwright/test';
-import { getHrefByEntryName } from '@scripts/shared';
+import { gotoPage } from '@scripts/shared';
 import { startDevServer } from './scripts/server.mjs';
 import { startDevServerPure } from './scripts/pure-server.mjs';
 
 test('custom server', async ({ page }) => {
   const { config, close } = await startDevServer(__dirname);
 
-  await page.goto(getHrefByEntryName('index', config.port));
+  await gotoPage(page, config);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -22,8 +22,7 @@ test('custom server', async ({ page }) => {
 
 test('custom server without compile', async ({ page }) => {
   const { config, close } = await startDevServerPure(__dirname);
-
-  const indexRes = await page.goto(getHrefByEntryName('index', config.port));
+  const indexRes = await gotoPage(page, config);
 
   expect(indexRes?.status()).toBe(404);
 

--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { dev, getHrefByEntryName } from '@scripts/shared';
+import { dev, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
@@ -38,7 +38,7 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -109,7 +109,7 @@ test('dev.port & output.distPath', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   expect(rsbuild.port).toBe(3000);
 
@@ -164,7 +164,7 @@ rspackOnlyTest(
       },
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
     expect(rsbuild.port).toBe(3001);
 
     const appPath = join(fixtures, 'hmr', 'test-src-1/App.tsx');
@@ -222,7 +222,7 @@ test('devServer', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/server/writeToDisk.test.ts
+++ b/e2e/cases/server/writeToDisk.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev, getHrefByEntryName } from '@scripts/shared';
+import { dev, gotoPage } from '@scripts/shared';
 
 const fixtures = __dirname;
 
@@ -16,7 +16,7 @@ test('writeToDisk default', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -39,7 +39,7 @@ test('writeToDisk false', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -62,7 +62,7 @@ test('writeToDisk true', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/solid/hmr/index.test.ts
+++ b/e2e/cases/solid/hmr/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { rspackOnlyTest } from '@scripts/helper';
-import { dev, getHrefByEntryName } from '@scripts/shared';
+import { dev, gotoPage } from '@scripts/shared';
 
 rspackOnlyTest('hmr should work properly', async ({ page }) => {
   // HMR cases will fail in Windows
@@ -12,11 +12,11 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   const root = __dirname;
 
-  const handle = await dev({
+  const rsbuild = await dev({
     cwd: root,
   });
 
-  await page.goto(getHrefByEntryName('index', handle.port));
+  await gotoPage(page, rsbuild);
 
   const a = page.locator('#A');
   const b = page.locator('#B');
@@ -47,5 +47,5 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   // recover the source code
   fs.writeFileSync(filePath, sourceCodeB, 'utf-8');
-  handle.server.close();
+  rsbuild.server.close();
 });

--- a/e2e/cases/solid/index.test.ts
+++ b/e2e/cases/solid/index.test.ts
@@ -4,7 +4,7 @@ import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
 import { rspackOnlyTest } from '@scripts/helper';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 const buildFixture = (rootDir: string): ReturnType<typeof build> => {
   const root = path.join(__dirname, rootDir);
@@ -28,38 +28,32 @@ const buildFixture = (rootDir: string): ReturnType<typeof build> => {
 rspackOnlyTest(
   'should build basic solid component properly',
   async ({ page }) => {
-    const handle = await buildFixture('basic');
+    const rsbuild = await buildFixture('basic');
 
-    await page.goto(getHrefByEntryName('index', handle.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
-
     await expect(button).toHaveText('count: 0');
 
     button.click();
-
     await expect(button).toHaveText('count: 1');
-
-    handle.close();
+    rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should build solid component with typescript',
   async ({ page }) => {
-    const handle = await buildFixture('ts');
+    const rsbuild = await buildFixture('ts');
 
-    await page.goto(getHrefByEntryName('index', handle.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
-
     await expect(button).toHaveText('count: 0');
 
     button.click();
-
     await expect(button).toHaveText('count: 1');
-
-    handle.close();
+    rsbuild.close();
   },
 );
 
@@ -68,9 +62,9 @@ rspackOnlyTest(
   rspackOnlyTest(
     `should build solid component with ${name}`,
     async ({ page }) => {
-      const handle = await buildFixture(name);
+      const rsbuild = await buildFixture(name);
 
-      await page.goto(getHrefByEntryName('index', handle.port));
+      await gotoPage(page, rsbuild);
 
       const title = page.locator('#title');
 
@@ -78,7 +72,7 @@ rspackOnlyTest(
       // use the text color to assert the compilation result
       await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
 
-      handle.close();
+      rsbuild.close();
     },
   );
 });

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 const fixture = join(__dirname, 'app');
@@ -13,7 +13,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const locator = page.locator('#root');
     await expect(locator).toHaveText(

--- a/e2e/cases/source/custom-tsconfig/index.test.ts
+++ b/e2e/cases/source/custom-tsconfig/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '../../../scripts/shared';
+import { build, gotoPage } from '../../../scripts/shared';
 
 test('tsconfig paths should work and override the alias config', async ({
   page,
@@ -9,7 +9,7 @@ test('tsconfig paths should work and override the alias config', async ({
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('tsconfig paths worked');

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 const fixtures = __dirname;
 
@@ -30,12 +30,12 @@ test.describe('source configure multi', () => {
   });
 
   test('alias', async ({ page }) => {
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
     await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
   });
 
   test('pre-entry', async ({ page }) => {
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
     await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
 
     // test order
@@ -56,7 +56,7 @@ test('define', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test-el');
   await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/source/tsconfig-paths/index.test.ts
+++ b/e2e/cases/source/tsconfig-paths/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '../../../scripts/shared';
+import { build, gotoPage } from '../../../scripts/shared';
 
 test('tsconfig paths should work and override the alias config', async ({
   page,
@@ -16,7 +16,7 @@ test('tsconfig paths should work and override the alias config', async ({
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('tsconfig paths worked');
@@ -40,7 +40,7 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('source.alias worked');

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { build, dev, getHrefByEntryName } from '@scripts/shared';
+import { build, dev, gotoPage } from '@scripts/shared';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 import { rspackOnlyTest } from '@scripts/helper';
 
@@ -28,15 +28,15 @@ const buildFixture = (
 rspackOnlyTest(
   'should build basic svelte component properly',
   async ({ page }) => {
-    const handle = await buildFixture('basic', 'src/index.js');
+    const rsbuild = await buildFixture('basic', 'src/index.js');
 
-    await page.goto(getHrefByEntryName('index', handle.port));
+    await gotoPage(page, rsbuild);
 
     const title = page.locator('#title');
 
     await expect(title).toHaveText('Hello world!');
 
-    handle.close();
+    rsbuild.close();
   },
 );
 
@@ -48,7 +48,7 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   const root = path.join(__dirname, 'hmr');
 
-  const handle = await dev({
+  const rsbuild = await dev({
     cwd: root,
     plugins: [pluginSvelte()],
     rsbuildConfig: {
@@ -60,7 +60,7 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', handle.port));
+  await gotoPage(page, rsbuild);
 
   const a = page.locator('#A');
   const b = page.locator('#B');
@@ -83,21 +83,21 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
   await expect(a).toHaveText('A: 5');
 
   fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
-  handle.server.close();
+  rsbuild.server.close();
 });
 
 rspackOnlyTest(
   'should build svelte component with typescript',
   async ({ page }) => {
-    const handle = await buildFixture('ts', 'src/index.ts');
+    const rsbuild = await buildFixture('ts', 'src/index.ts');
 
-    await page.goto(getHrefByEntryName('index', handle.port));
+    await gotoPage(page, rsbuild);
 
     const title = page.locator('#title');
 
     await expect(title).toHaveText('Hello world!');
 
-    handle.close();
+    rsbuild.close();
   },
 );
 
@@ -106,9 +106,9 @@ rspackOnlyTest(
   rspackOnlyTest(
     `should build svelte component with ${name}`,
     async ({ page }) => {
-      const handle = await buildFixture(name, 'src/index.js');
+      const rsbuild = await buildFixture(name, 'src/index.js');
 
-      await page.goto(getHrefByEntryName('index', handle.port));
+      await gotoPage(page, rsbuild);
 
       const title = page.locator('#title');
 
@@ -116,7 +116,7 @@ rspackOnlyTest(
       // use the text color to assert the compilation result
       await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
 
-      handle.close();
+      rsbuild.close();
     },
   );
 });

--- a/e2e/cases/svg/svg.test.ts
+++ b/e2e/cases/svg/svg.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
@@ -20,7 +20,7 @@ test('svg (assets)', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // test svg asset
   await expect(
@@ -52,7 +52,7 @@ test('svgr (defaultExport component)', async ({ page }) => {
     ],
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('test-svg').tagName === 'svg'`),
@@ -109,7 +109,7 @@ test('svgr (external react)', async ({ page }) => {
     },
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // test svgr（namedExport）
   await expect(

--- a/e2e/cases/svg/svgr-default-export-url/index.test.ts
+++ b/e2e/cases/svg/svgr-default-export-url/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should import default from SVG with SVGR correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('should import default from SVG with SVGR correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // test svgr（namedExport）
   await expect(

--- a/e2e/cases/svg/svgr-query-url/index.test.ts
+++ b/e2e/cases/svg/svgr-query-url/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should import svg with SVGR plugin and query URL correctly', async ({
   page,
@@ -9,7 +9,7 @@ test('should import svg with SVGR plugin and query URL correctly', async ({
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   // test svg asset
   await expect(

--- a/e2e/cases/top-level-await/index.test.ts
+++ b/e2e/cases/top-level-await/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should run top level await correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -7,7 +7,7 @@ test('should run top level await correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   expect(await page.evaluate('window.foo')).toEqual('hello');
 

--- a/e2e/cases/type-checker/index.test.ts
+++ b/e2e/cases/type-checker/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '../../scripts/shared';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
-import { proxyConsole } from '@scripts/helper';
+import { proxyConsole } from '../../scripts/helper';
 
 test('should throw error when exist type errors', async () => {
   const { logs, restore } = proxyConsole();

--- a/e2e/cases/type-checker/tsconfig.json
+++ b/e2e/cases/type-checker/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/e2e/cases/umd/basic/index.test.ts
+++ b/e2e/cases/umd/basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should generate UMD bundle correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -8,7 +8,7 @@ test('should generate UMD bundle correctly', async ({ page }) => {
   });
 
   // Browser env
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   const test = page.locator('#test');
   await expect(test).toHaveText('2');
 

--- a/e2e/cases/umd/export-array/index.test.ts
+++ b/e2e/cases/umd/export-array/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should generate UMD bundle with default export correctly', async ({
   page,
@@ -10,7 +10,7 @@ test('should generate UMD bundle with default export correctly', async ({
   });
 
   // Browser env
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   const test = page.locator('#test');
   await expect(test).toHaveText('2');
 

--- a/e2e/cases/umd/export/index.test.ts
+++ b/e2e/cases/umd/export/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should generate UMD bundle with default export correctly', async ({
   page,
@@ -10,7 +10,7 @@ test('should generate UMD bundle with default export correctly', async ({
   });
 
   // Browser env
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
   const test = page.locator('#test');
   await expect(test).toHaveText('2');
 

--- a/e2e/cases/vue/jsx-basic/index.test.ts
+++ b/e2e/cases/vue/jsx-basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   await expect(button1).toHaveText('A: 0');

--- a/e2e/cases/vue/sfc-basic/index.test.ts
+++ b/e2e/cases/vue/sfc-basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   const button2 = page.locator('#button2');

--- a/e2e/cases/vue/sfc-lang-jsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-jsx/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-ts/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');

--- a/e2e/cases/vue/sfc-lang-tsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-tsx/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue/sfc-style/index.test.ts
+++ b/e2e/cases/vue/sfc-style/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button = page.locator('#button');
   await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue2/jsx-basic/index.test.ts
+++ b/e2e/cases/vue2/jsx-basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   await expect(button1).toHaveText('A: 0');

--- a/e2e/cases/vue2/sfc-basic/index.test.ts
+++ b/e2e/cases/vue2/sfc-basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   const button2 = page.locator('#button2');

--- a/e2e/cases/vue2/sfc-lang-jsx/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-jsx/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue2/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-ts/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');

--- a/e2e/cases/vue2/sfc-lang-tsx/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-tsx/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       runServer: true,
     });
 
-    await page.goto(getHrefByEntryName('index', rsbuild.port));
+    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue2/sfc-style/index.test.ts
+++ b/e2e/cases/vue2/sfc-style/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 import { rspackOnlyTest } from '@scripts/helper';
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
     runServer: true,
   });
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   const button = page.locator('#button');
   await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getHrefByEntryName } from '@scripts/shared';
+import { build, gotoPage } from '@scripts/shared';
 
 test('should allow to import wasm file', async ({ page }) => {
   const root = join(__dirname, 'wasm-basic');
@@ -17,7 +17,7 @@ test('should allow to import wasm file', async ({ page }) => {
   expect(wasmFile).toBeTruthy();
   expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);
@@ -61,7 +61,7 @@ test('should allow to use new URL to get path of wasm file', async ({
   expect(wasmFile).toBeTruthy();
   expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
 
-  await page.goto(getHrefByEntryName('index', rsbuild.port));
+  await gotoPage(page, rsbuild);
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -3,13 +3,14 @@ import { URL } from 'url';
 import assert from 'assert';
 import { join } from 'path';
 import { fse } from '@rsbuild/shared';
-import { globContentJSON } from '@scripts/helper';
+import { globContentJSON } from './helper';
 import { pluginSwc } from '@rsbuild/plugin-swc';
 import type {
   RsbuildConfig,
   RsbuildPlugin,
   CreateRsbuildOptions,
 } from '@rsbuild/core';
+import type { Page } from 'playwright';
 
 export const getHrefByEntryName = (entryName: string, port: number) => {
   const htmlRoot = new URL(`http://localhost:${port}`);
@@ -17,6 +18,12 @@ export const getHrefByEntryName = (entryName: string, port: number) => {
 
   return homeUrl.href;
 };
+
+export const gotoPage = async (
+  page: Page,
+  rsbuild: { port: number },
+  path = 'index',
+) => page.goto(getHrefByEntryName(path, rsbuild.port));
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = async () => {};


### PR DESCRIPTION
## Summary

Add gotoPage helper to simplify code.

- before

```js
await page.goto(getHrefByEntryName('index', rsbuild.port));
```

- after:

```js
await gotoPage(page, rsbuild);
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
