### PR TITLE
test(e2e): fix helper typing issue

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -41,7 +41,7 @@ If the capability corresponding to the test case is not yet supported in other b
 you can use the `webpackOnlyTest` or `rspackOnlyTest` methods for testing. Once other bundlers also support it, you can replace it with the `test` method.
 
 ```ts
-import { webpackOnlyTest } from '@scripts/helper';
+import { webpackOnlyTest } from '@e2e/helper';
 // will passed in webpack, and skipped in rspack
 webpackOnlyTest('test 1 + 1', () => {
   expect(1 + 1).toBe(2);

--- a/e2e/cases/babel/build.test.ts
+++ b/e2e/cases/babel/build.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
 rspackOnlyTest('babel', async ({ page }) => {

--- a/e2e/cases/bundler-chain/index.test.ts
+++ b/e2e/cases/bundler-chain/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
   page,

--- a/e2e/cases/cache/index.test.ts
+++ b/e2e/cases/cache/index.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { expect } from '@playwright/test';
-import { webpackOnlyTest } from '@scripts/helper';
-import { build } from '@scripts/shared';
+import { build, webpackOnlyTest } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';
 
 webpackOnlyTest(

--- a/e2e/cases/cache/tsconfig.json
+++ b/e2e/cases/cache/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -1,9 +1,8 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 import type { RsbuildConfig } from '@rsbuild/shared';
-import { proxyConsole } from '@scripts/helper';
 import { normalizeToPosixPath } from '@scripts/test-helper';
 
 function getCommonBuildConfig(cwd: string): RsbuildConfig {

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { test, expect } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { awaitFileExists } from '@scripts/helper';
+import { awaitFileExists } from '@e2e/helper';
 
 test('should support watch mode for build command', async () => {
   const indexFile = path.join(__dirname, 'src/index.js');

--- a/e2e/cases/cli/build-watch/tsconfig.json
+++ b/e2e/cases/cli/build-watch/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -2,7 +2,7 @@ import { fse } from '@rsbuild/shared';
 import path from 'path';
 import { execSync } from 'child_process';
 import { expect, test } from '@playwright/test';
-import { globContentJSON } from '@scripts/helper';
+import { globContentJSON } from '@e2e/helper';
 
 test('should allow to export function in config file', async () => {
   const targetDir = path.join(__dirname, 'dist-production-build');

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -2,8 +2,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { awaitFileExists } from '@scripts/helper';
-import { getRandomPort } from '@scripts/shared';
+import { getRandomPort, awaitFileExists } from '@e2e/helper';
 
 test('should restart dev server and reload config when config file changed', async () => {
   const dist1 = path.join(__dirname, 'dist');

--- a/e2e/cases/cli/reload-config/tsconfig.json
+++ b/e2e/cases/cli/reload-config/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -2,8 +2,7 @@ import path from 'path';
 import { exec } from 'child_process';
 import { test, expect } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { awaitFileExists } from '@scripts/helper';
-import { getRandomPort } from '@scripts/shared';
+import { getRandomPort, awaitFileExists } from '@e2e/helper';
 
 // Skipped as it occasionally failed in CI
 test.skip('should restart dev server when .env file is changed', async () => {

--- a/e2e/cases/cli/reload-env/tsconfig.json
+++ b/e2e/cases/cli/reload-env/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/configure-rspack/index.test.ts
+++ b/e2e/cases/configure-rspack/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to use tools.rspack to configure Rspack',

--- a/e2e/cases/configure-webpack/index.test.ts
+++ b/e2e/cases/configure-webpack/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { webpackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, webpackOnlyTest } from '@e2e/helper';
 
 webpackOnlyTest(
   'should allow to use tools.webpackChain to configure Webpack',

--- a/e2e/cases/css/css-minimize/index.test.ts
+++ b/e2e/cases/css/css-minimize/index.test.ts
@@ -1,6 +1,5 @@
-import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { expect } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 rspackOnlyTest('should minimize CSS correctly by default', async () => {

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile CSS modules composes correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { fse } from '@rsbuild/shared';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 

--- a/e2e/cases/css/css-modules-dom/tsconfig.json
+++ b/e2e/cases/css/css-modules-dom/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "tests", "index.test.ts"]
 }

--- a/e2e/cases/css/css-modules-global/index.test.ts
+++ b/e2e/cases/css/css-modules-global/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile CSS modules with :global() correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/e2e/cases/css/css-modules-ts-declaration/index.test.ts
@@ -1,7 +1,7 @@
 import { join, resolve } from 'path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile CSS modules correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile common css import correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/import-loaders/index.test.ts
+++ b/e2e/cases/css/import-loaders/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { webpackOnlyTest } from '../../../scripts/helper';
 
 webpackOnlyTest(

--- a/e2e/cases/css/less-exclude/index.test.ts
+++ b/e2e/cases/css/less-exclude/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should exclude specified less file', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/less-import/index.test.ts
+++ b/e2e/cases/css/less-import/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile less import correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/less-inline-js/index.test.ts
+++ b/e2e/cases/css/less-inline-js/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile less inline js correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/less-npm-import/index.test.ts
+++ b/e2e/cases/css/less-npm-import/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';
 
 test('should compile less npm import correctly', async () => {

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should emit multiple css files correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';
 
 test('should compile nested npm import correctly', async () => {

--- a/e2e/cases/css/relative-import/index.test.ts
+++ b/e2e/cases/css/relative-import/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile CSS relative imports correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/resolve-alias/index.test.ts
+++ b/e2e/cases/css/resolve-alias/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile CSS with alias correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/resolve-url-loader/index.test.ts
+++ b/e2e/cases/css/resolve-url-loader/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should resolve relative asset correctly in SCSS file', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/sass-exclude/index.test.ts
+++ b/e2e/cases/css/sass-exclude/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should exclude specified scss file', async () => {
   const rsbuild = await build({

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 

--- a/e2e/cases/css/style-loader/tsconfig.json
+++ b/e2e/cases/css/style-loader/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "tests"]
 }

--- a/e2e/cases/css/tailwindcss-mjs/index.test.ts
+++ b/e2e/cases/css/tailwindcss-mjs/index.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should generate tailwindcss utilities with mjs config correctly', async () => {

--- a/e2e/cases/css/tailwindcss/index.test.ts
+++ b/e2e/cases/css/tailwindcss/index.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should generate tailwindcss utilities correctly', async () => {

--- a/e2e/cases/decorator/common/index.test.ts
+++ b/e2e/cases/decorator/common/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('decorator legacy(default)', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/decorator/latest/index.test.ts
+++ b/e2e/cases/decorator/latest/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test.skip('decorator latest', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/decorator/legacy/index.test.ts
+++ b/e2e/cases/decorator/legacy/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('decorator legacy(default)', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/exports-presence/index.test.ts
+++ b/e2e/cases/exports-presence/index.test.ts
@@ -1,7 +1,5 @@
 import { expect } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
-import { proxyConsole } from '@scripts/helper';
+import { build, proxyConsole, webpackOnlyTest } from '@e2e/helper';
 
 // TODO: needs rspack exportsPresence error
 // https://github.com/web-infra-dev/rspack/issues/4323

--- a/e2e/cases/external-helpers/index.test.ts
+++ b/e2e/cases/external-helpers/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { build } from '@scripts/shared';
-import { providerType } from '@scripts/helper';
+import { build, providerType } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginSwc } from '@rsbuild/plugin-swc';
 

--- a/e2e/cases/html-tags/index.test.ts
+++ b/e2e/cases/html-tags/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 const isHtmlMatch = (html: string, pattern: RegExp): boolean =>
   Boolean(html.match(pattern));

--- a/e2e/cases/html-tags/tsconfig.json
+++ b/e2e/cases/html-tags/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should emit app icon to dist path', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/combined/html.test.ts
+++ b/e2e/cases/html/combined/html.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test.describe('should combine multiple html config correctly', () => {
   let rsbuild: Awaited<ReturnType<typeof build>>;

--- a/e2e/cases/html/combined/tsconfig.json
+++ b/e2e/cases/html/combined/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]
 }

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should not apply crossOrigin by default', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should emit local favicon to dist path', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { globContentJSON } from '@scripts/helper';
+import { build, globContentJSON } from '@e2e/helper';
 
 test('should allow to generate HTML with filename hash', async () => {
   await build({

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -1,7 +1,7 @@
 import { fse } from '@rsbuild/shared';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('tools.htmlPlugin', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
 test('injection script order should be as expected', async () => {

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should not inject charset meta if template already contains it', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/html/minify/tsconfig.json
+++ b/e2e/cases/html/minify/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src"]
 }

--- a/e2e/cases/html/mount-id/index.test.ts
+++ b/e2e/cases/html/mount-id/index.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test.describe('should render mountId correctly', () => {
   let rsbuild: Awaited<ReturnType<typeof build>>;

--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('html.outputStructure', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should apply defer by default', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should set template via function correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should generate default title correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/ignore-css/removeCss.test.ts
+++ b/e2e/cases/ignore-css/removeCss.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should ignore css content when build node target', async () => {
   const rsbuild = await build({

--- a/e2e/cases/ignore-css/tsconfig.json
+++ b/e2e/cases/ignore-css/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "*.test.ts", "removeCss.test.ts"]

--- a/e2e/cases/image-compress/index.test.ts
+++ b/e2e/cases/image-compress/index.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { globContentJSON } from '@scripts/helper';
-import { build } from '@scripts/shared';
+import { build, globContentJSON } from '@e2e/helper';
 import { readFileSync } from 'fs';
 
 test('should compress image with use plugin-image-compress', async () => {

--- a/e2e/cases/import-json/index.test.ts
+++ b/e2e/cases/import-json/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should import JSON correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/import-toml/index.test.ts
+++ b/e2e/cases/import-toml/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should import TOML correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/import-yaml/index.test.ts
+++ b/e2e/cases/import-yaml/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should import YAML correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import type { BundlerChain } from '@rsbuild/shared';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map

--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
-import { createRsbuild } from '@scripts/shared';
+import { createRsbuild } from '@e2e/helper';
 
 const rsbuildConfig = path.resolve(__dirname, './dist/rsbuild.config.mjs');
 const bundlerConfig = path.resolve(

--- a/e2e/cases/javascript-api/custom-logger/index.test.ts
+++ b/e2e/cases/javascript-api/custom-logger/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { rspackOnlyTest, proxyConsole } from '@scripts/helper';
+import { build, rspackOnlyTest, proxyConsole } from '@e2e/helper';
 
 rspackOnlyTest('should allow to customize logger', async () => {
   const { logs, restore } = proxyConsole('log');

--- a/e2e/cases/legal-comments/index.test.ts
+++ b/e2e/cases/legal-comments/index.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/live-reload/index.test.ts
+++ b/e2e/cases/live-reload/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { dev, gotoPage } from '@scripts/shared';
+import { dev, gotoPage } from '@e2e/helper';
 
 const appFile = path.join(__dirname, 'src/App.jsx');
 let appCode: string;

--- a/e2e/cases/lodash/index.test.ts
+++ b/e2e/cases/lodash/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 // TODO: needs builtin:swc-loader wasm plugin
 // Not supported yet

--- a/e2e/cases/moment/index.test.ts
+++ b/e2e/cases/moment/index.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { webpackOnlyTest } from '@scripts/helper';
+import { build, webpackOnlyTest } from '@e2e/helper';
 
 // todo: https://github.com/web-infra-dev/rspack/issues/3346
 webpackOnlyTest('removeMomentLocale false (default)', async () => {

--- a/e2e/cases/multi-compiler/index.test.ts
+++ b/e2e/cases/multi-compiler/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, dev, gotoPage } from '@scripts/shared';
+import { build, dev, gotoPage } from '@e2e/helper';
 
 test('multi compiler build', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should compile Node addons correctly', async () => {
   const rsbuild = await build({

--- a/e2e/cases/node-polyfill/index.test.ts
+++ b/e2e/cases/node-polyfill/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should add node-polyfill when add node-polyfill plugin', async ({
   page,

--- a/e2e/cases/output/ascii/index.test.ts
+++ b/e2e/cases/output/ascii/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('output.charset default (ascii)', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/output/assets-retry/index.test.ts
+++ b/e2e/cases/output/assets-retry/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 
 test('should inline assets retry runtime code to html by default', async () => {

--- a/e2e/cases/output/assets.test.ts
+++ b/e2e/cases/output/assets.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = resolve(__dirname, '../');

--- a/e2e/cases/output/output.test.ts
+++ b/e2e/cases/output/output.test.ts
@@ -1,7 +1,7 @@
 import { join, dirname } from 'path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/output/rem/tests/index.test.ts
+++ b/e2e/cases/output/rem/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginRem } from '@rsbuild/plugin-rem';
 

--- a/e2e/cases/output/rem/tsconfig.json
+++ b/e2e/cases/output/rem/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "tests"]
 }

--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev, build } from '@scripts/shared';
-import { globContentJSON } from '@scripts/helper';
+import { dev, build, globContentJSON } from '@e2e/helper';
 
 test('should emit bundle analyze report correctly when dev', async ({
   page,

--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/performance/load-resource/tsconfig.json
+++ b/e2e/cases/performance/load-resource/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",
-    "outDir": "./dist",
-    "paths": {
-      "@scripts/*": ["../../../scripts/*"]
-    }
+    "outDir": "./dist"
   },
   "include": ["src", "index.test.ts"]
 }

--- a/e2e/cases/performance/performance.test.ts
+++ b/e2e/cases/performance/performance.test.ts
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/performance/print-file-size/index.test.ts
+++ b/e2e/cases/performance/print-file-size/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 const cwd = __dirname;
 

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 const cwd = __dirname;
 

--- a/e2e/cases/performance/single-vendor/index.test.ts
+++ b/e2e/cases/performance/single-vendor/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { basename } from 'path';
 

--- a/e2e/cases/performance/split-by-module/index.test.ts
+++ b/e2e/cases/performance/split-by-module/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { basename } from 'path';
 

--- a/e2e/cases/polyfill/index.test.ts
+++ b/e2e/cases/polyfill/index.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 const POLYFILL_RE = /\/lib-polyfill/;
 

--- a/e2e/cases/preact/basic/index.test.ts
+++ b/e2e/cases/preact/basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { dev, build, gotoPage } from '@scripts/shared';
+import { dev, build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should render basic Preact component in development correctly',

--- a/e2e/cases/preview/index.test.ts
+++ b/e2e/cases/preview/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, getRandomPort, gotoPage } from '@scripts/shared';
+import { build, getRandomPort, gotoPage } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should preview dist files correctly', async ({ page }) => {

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/progress/index.test.ts
+++ b/e2e/cases/progress/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { webpackOnlyTest } from '@scripts/helper';
-import { build } from '@scripts/shared';
+import { build, webpackOnlyTest } from '@e2e/helper';
 import { logger } from '@rsbuild/shared';
 
 webpackOnlyTest('should emit progress log in non-TTY environment', async () => {

--- a/e2e/cases/pug/basic/index.test.ts
+++ b/e2e/cases/pug/basic/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/pug/vue2-template/index.test.ts
+++ b/e2e/cases/pug/vue2-template/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/pug/vue3-template/index.test.ts
+++ b/e2e/cases/pug/vue3-template/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should allow to use .pug template file', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/react/basic/index.test.ts
+++ b/e2e/cases/react/basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { dev, build, gotoPage } from '@scripts/shared';
+import { dev, build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should render basic React component in development correctly',

--- a/e2e/cases/react/legacy-jsx/index.test.ts
+++ b/e2e/cases/react/legacy-jsx/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/react/remove-prop-types/index.test.ts
+++ b/e2e/cases/react/remove-prop-types/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/react/split-chunk/index.test.ts
+++ b/e2e/cases/react/split-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { gotoPage } from '@scripts/shared';
+import { gotoPage } from '@e2e/helper';
 import { startDevServer } from './scripts/server.mjs';
 import { startDevServerPure } from './scripts/pure-server.mjs';
 

--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -1,8 +1,7 @@
 import { join } from 'path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { dev, gotoPage } from '@scripts/shared';
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev, build } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { dev, build, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const cwd = __dirname;

--- a/e2e/cases/server/htmlFallback.test.ts
+++ b/e2e/cases/server/htmlFallback.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev } from '@scripts/shared';
+import { dev } from '@e2e/helper';
 import fs from 'fs';
 
 const fixtures = __dirname;

--- a/e2e/cases/server/ipv6-host/index.test.ts
+++ b/e2e/cases/server/ipv6-host/index.test.ts
@@ -1,6 +1,6 @@
 import { URL } from 'url';
 import { expect, test } from '@playwright/test';
-import { dev } from '@scripts/shared';
+import { dev } from '@e2e/helper';
 
 test('should allow to listen ipv6 host', async ({ page }) => {
   const rsbuild = await dev({

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { dev } from '@scripts/shared';
-import { proxyConsole } from '@scripts/helper';
+import { dev, proxyConsole } from '@e2e/helper';
 
 const cwd = __dirname;
 

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev } from '@scripts/shared';
+import { dev } from '@e2e/helper';
 
 const prj1 = join(__dirname, 'project1');
 const prj2 = join(__dirname, 'project2');

--- a/e2e/cases/server/public-dir-with-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-template/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { dev, build } from '@scripts/shared';
+import { dev, build } from '@e2e/helper';
 
 const cwd = __dirname;
 

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev, build } from '@scripts/shared';
+import { dev, build } from '@e2e/helper';
 
 const cwd = __dirname;
 

--- a/e2e/cases/server/writeToDisk.test.ts
+++ b/e2e/cases/server/writeToDisk.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { dev, gotoPage } from '@scripts/shared';
+import { dev, gotoPage } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/solid/hmr/index.test.ts
+++ b/e2e/cases/solid/hmr/index.test.ts
@@ -1,8 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import { rspackOnlyTest } from '@scripts/helper';
-import { dev, gotoPage } from '@scripts/shared';
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('hmr should work properly', async ({ page }) => {
   // HMR cases will fail in Windows

--- a/e2e/cases/solid/index.test.ts
+++ b/e2e/cases/solid/index.test.ts
@@ -3,8 +3,7 @@ import { expect } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
-import { rspackOnlyTest } from '@scripts/helper';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 const buildFixture = (rootDir: string): ReturnType<typeof build> => {
   const root = path.join(__dirname, rootDir);

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 const fixture = join(__dirname, 'app');
 

--- a/e2e/cases/source-map/source.test.ts
+++ b/e2e/cases/source-map/source.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 import sourceMap from 'source-map';

--- a/e2e/cases/source/entry-description-object/index.test.ts
+++ b/e2e/cases/source/entry-description-object/index.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
-import { globContentJSON } from '@scripts/helper';
+import { build, globContentJSON } from '@e2e/helper';
 
 test('should allow to set entry description object', async () => {
   await build({

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import type { RsbuildConfig } from '@rsbuild/core';

--- a/e2e/cases/source/plugin-import/index.rspack.test.ts
+++ b/e2e/cases/source/plugin-import/index.rspack.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { cases, shareTest, copyPkgToNodeModules, findEntry } from './helper';
 

--- a/e2e/cases/source/plugin-import/index.webpack.test.ts
+++ b/e2e/cases/source/plugin-import/index.webpack.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginSwc } from '@rsbuild/plugin-swc';
 import { findEntry, copyPkgToNodeModules, cases, shareTest } from './helper';

--- a/e2e/cases/source/source-exclude/index.test.ts
+++ b/e2e/cases/source/source-exclude/index.test.ts
@@ -1,8 +1,7 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
-import { proxyConsole } from '@scripts/helper';
 import { normalizeToPosixPath } from '@scripts/test-helper';
 
 test('should not compile specified file when source.exclude', async () => {

--- a/e2e/cases/source/source-include/index.test.ts
+++ b/e2e/cases/source/source-include/index.test.ts
@@ -1,8 +1,7 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
-import { proxyConsole } from '@scripts/helper';
 import { normalizeToPosixPath } from '@scripts/test-helper';
 
 test('should not compile file which outside of project by default', async () => {

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/styled-component/index.rspack.test.ts
+++ b/e2e/cases/styled-component/index.rspack.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginStyledComponents } from '@rsbuild/plugin-styled-components';
 

--- a/e2e/cases/stylus-rem/index.test.ts
+++ b/e2e/cases/stylus-rem/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
 import { pluginRem } from '@rsbuild/plugin-rem';
 

--- a/e2e/cases/stylus/index.test.ts
+++ b/e2e/cases/stylus/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
 
 test('should compile stylus correctly', async () => {

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -1,9 +1,8 @@
 import path from 'path';
 import fs from 'fs';
 import { test, expect } from '@playwright/test';
-import { build, dev, gotoPage } from '@scripts/shared';
+import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
-import { rspackOnlyTest } from '@scripts/helper';
 
 const buildFixture = (
   rootDir: string,

--- a/e2e/cases/svg/svg.test.ts
+++ b/e2e/cases/svg/svg.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 

--- a/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should add id prefix after svgo minification', async () => {
   const rsbuild = await build({

--- a/e2e/cases/svg/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-view-box/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should preserve viewBox after svgo minification', async () => {
   const buildOpts = {

--- a/e2e/cases/svg/svgr-default-export-url/index.test.ts
+++ b/e2e/cases/svg/svgr-default-export-url/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should import default from SVG with SVGR correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/svg/svgr-query-url/index.test.ts
+++ b/e2e/cases/svg/svgr-query-url/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should import svg with SVGR plugin and query URL correctly', async ({
   page,

--- a/e2e/cases/top-level-await/index.test.ts
+++ b/e2e/cases/top-level-await/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should run top level await correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/top-level-await/tsconfig.json
+++ b/e2e/cases/top-level-await/tsconfig.json
@@ -7,8 +7,7 @@
     "module": "ES2022",
     "target": "ES2017",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/typescript/index.test.ts
+++ b/e2e/cases/typescript/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 // TODO not supported yet
 test.skip('should compile const enum correctly', async () => {

--- a/e2e/cases/typescript/tsconfig.json
+++ b/e2e/cases/typescript/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/umd/basic/index.test.ts
+++ b/e2e/cases/umd/basic/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should generate UMD bundle correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/umd/export-array/index.test.ts
+++ b/e2e/cases/umd/export-array/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should generate UMD bundle with default export correctly', async ({
   page,

--- a/e2e/cases/umd/export/index.test.ts
+++ b/e2e/cases/umd/export/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should generate UMD bundle with default export correctly', async ({
   page,

--- a/e2e/cases/vue/jsx-basic/index.test.ts
+++ b/e2e/cases/vue/jsx-basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue/sfc-basic/index.test.ts
+++ b/e2e/cases/vue/sfc-basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue/sfc-lang-jsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-jsx/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="jsx" correctly',

--- a/e2e/cases/vue/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-ts/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="ts" correctly',

--- a/e2e/cases/vue/sfc-lang-tsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-tsx/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="tsx" correctly',

--- a/e2e/cases/vue/sfc-style/index.test.ts
+++ b/e2e/cases/vue/sfc-style/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue/split-chunk/index.test.ts
+++ b/e2e/cases/vue/split-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
 const fixtures = __dirname;

--- a/e2e/cases/vue2/jsx-basic/index.test.ts
+++ b/e2e/cases/vue2/jsx-basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue2/sfc-basic/index.test.ts
+++ b/e2e/cases/vue2/sfc-basic/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue2/sfc-lang-jsx/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-jsx/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="jsx" correctly',

--- a/e2e/cases/vue2/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-ts/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="ts" correctly',

--- a/e2e/cases/vue2/sfc-lang-tsx/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-tsx/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should build Vue sfc with lang="tsx" correctly',

--- a/e2e/cases/vue2/sfc-style/index.test.ts
+++ b/e2e/cases/vue2/sfc-style/index.test.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
-import { rspackOnlyTest } from '@scripts/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const rsbuild = await build({

--- a/e2e/cases/vue2/split-chunk/index.test.ts
+++ b/e2e/cases/vue2/split-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 
 const fixtures = __dirname;

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@scripts/shared';
+import { build, gotoPage } from '@e2e/helper';
 
 test('should allow to import wasm file', async ({ page }) => {
   const root = join(__dirname, 'wasm-basic');

--- a/e2e/cases/wasm/tsconfig.json
+++ b/e2e/cases/wasm/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["wasm-basic/src/*"],
-      "@scripts/*": ["../../scripts/*"]
+      "@/*": ["wasm-basic/src/*"]
     }
   },
   "include": ["wasm-basic/src", "*.test.ts", "index.test.ts"]

--- a/e2e/cases/web-worker/index.test.ts
+++ b/e2e/cases/web-worker/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { expect, test } from '@playwright/test';
-import { build } from '@scripts/shared';
+import { build } from '@e2e/helper';
 
 test('should build web-worker target correctly', async () => {
   const rsbuild = await build({

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,6 +19,7 @@
     "vue-router": "^4.2.5"
   },
   "devDependencies": {
+    "@e2e/helper": "workspace:*",
     "@playwright/test": "1.33.0",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-assets-retry": "workspace:*",

--- a/e2e/scripts/index.ts
+++ b/e2e/scripts/index.ts
@@ -1,0 +1,2 @@
+export * from './helper';
+export * from './shared';

--- a/e2e/scripts/package.json
+++ b/e2e/scripts/package.json
@@ -1,5 +1,7 @@
 {
   "name": "@e2e/helper",
+  "private": true,
+  "version": "1.0.0",
   "main": "index.ts",
   "types": "index.ts"
 }

--- a/e2e/scripts/package.json
+++ b/e2e/scripts/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@e2e/helper",
+  "main": "index.ts",
+  "types": "index.ts"
+}

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -5,8 +5,7 @@
     "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
-      "@/*": ["./src/*"],
-      "@scripts/*": ["./scripts/*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
         specifier: ^4.2.5
         version: 4.2.5(vue@3.3.4)
     devDependencies:
+      '@e2e/helper':
+        specifier: workspace:*
+        version: link:scripts
       '@playwright/test':
         specifier: 1.33.0
         version: 1.33.0
@@ -293,6 +296,8 @@ importers:
       vue:
         specifier: ^2.7.14
         version: 2.7.14
+
+  e2e/scripts: {}
 
   examples/lit:
     devDependencies:


### PR DESCRIPTION
## Summary

Fix helper typing issue, use `@e2e/helper` package instead of `tsconfig.paths`, the paths rely on the closest tsconfig.json configuration and often fails.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
