### PR TITLE
chore: use helper to get and set NODE_ENV

### DIFF
--- a/packages/babel-preset/src/base.ts
+++ b/packages/babel-preset/src/base.ts
@@ -1,3 +1,4 @@
+import { isTest } from '@rsbuild/shared';
 import type { BabelConfig, BasePresetOptions } from './types';
 
 export const generateBaseConfig = (
@@ -15,13 +16,11 @@ export const generateBaseConfig = (
   } = options;
 
   if (presetEnv) {
-    const isTest = process.env.NODE_ENV === 'test';
-
     config.presets?.push([
       require.resolve('@babel/preset-env'),
       {
         // Jest only supports commonjs
-        modules: isTest ? 'commonjs' : false,
+        modules: isTest() ? 'commonjs' : false,
         exclude: ['transform-typeof-symbol'],
         ...presetEnv,
       },

--- a/packages/compat/webpack/src/core/build.ts
+++ b/packages/compat/webpack/src/core/build.ts
@@ -2,6 +2,8 @@ import { createCompiler } from './createCompiler';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import {
   logger,
+  getNodeEnv,
+  setNodeEnv,
   type Stats,
   type Rspack,
   type MultiStats,
@@ -14,8 +16,8 @@ export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
 ) => {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = mode;
+  if (!getNodeEnv()) {
+    setNodeEnv(mode);
   }
 
   const { context } = initOptions;

--- a/packages/compat/webpack/src/core/inspectConfig.ts
+++ b/packages/compat/webpack/src/core/inspectConfig.ts
@@ -1,8 +1,10 @@
 import { join, isAbsolute } from 'path';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import {
-  outputInspectConfigFiles,
+  setNodeEnv,
+  getNodeEnv,
   stringifyConfig,
+  outputInspectConfigFiles,
   type NormalizedConfig,
   type InspectConfigResult,
   type InspectConfigOptions,
@@ -20,9 +22,9 @@ export async function inspectConfig({
   bundlerConfigs?: WebpackConfig[];
 }): Promise<InspectConfigResult<'webpack'>> {
   if (inspectOptions.env) {
-    process.env.NODE_ENV = inspectOptions.env;
-  } else if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
+    setNodeEnv(inspectOptions.env);
+  } else if (!getNodeEnv()) {
+    setNodeEnv('development');
   }
 
   const webpackConfigs =

--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -2,10 +2,10 @@ import {
   debug,
   CHAIN_ID,
   castArray,
+  getNodeEnv,
   chainToConfig,
   modifyBundlerChain,
   mergeChainedOptions,
-  type NodeEnv,
   type BundlerChain,
   type RsbuildTarget,
   type WebpackChain,
@@ -70,8 +70,7 @@ async function getChainUtils(
   const { default: webpack } = await import('webpack');
   const { getHTMLPlugin } = await import('@rsbuild/core/provider');
   const HtmlPlugin = getHTMLPlugin();
-
-  const nodeEnv = process.env.NODE_ENV as NodeEnv;
+  const nodeEnv = getNodeEnv();
 
   const nameMap = {
     web: 'client',

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -1,6 +1,12 @@
 import fs from 'fs';
 import { isAbsolute, join } from 'path';
-import { color, logger, debounce, type RsbuildConfig } from '@rsbuild/shared';
+import {
+  color,
+  logger,
+  debounce,
+  getNodeEnv,
+  type RsbuildConfig,
+} from '@rsbuild/shared';
 import { getEnvFiles } from '../loadEnv';
 import { restartDevServer } from '../server/restart';
 
@@ -121,7 +127,7 @@ export async function loadConfig({
 
     if (typeof configExport === 'function') {
       const params: ConfigParams = {
-        env: process.env.NODE_ENV!,
+        env: getNodeEnv(),
         command,
       };
 

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import { join } from 'path';
-import { isFileSync } from '@rsbuild/shared';
+import { getNodeEnv, isFileSync } from '@rsbuild/shared';
 import { parse } from '../compiled/dotenv';
 import { expand } from '../compiled/dotenv-expand';
 
 export const getEnvFiles = () => {
-  const { NODE_ENV } = process.env;
-  return ['.env', '.env.local', `.env.${NODE_ENV}`, `.env.${NODE_ENV}.local`];
+  const nodeEnv = getNodeEnv();
+  return ['.env', '.env.local', `.env.${nodeEnv}`, `.env.${nodeEnv}.local`];
 };
 
 export function loadEnv({

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -1,4 +1,4 @@
-import { removeTailSlash, type Define } from '@rsbuild/shared';
+import { getNodeEnv, removeTailSlash, type Define } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginDefine = (): RsbuildPlugin => ({
@@ -14,7 +14,7 @@ export const pluginDefine = (): RsbuildPlugin => ({
           : config.output.assetPrefix;
 
       const builtinVars: Define = {
-        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+        'process.env.NODE_ENV': JSON.stringify(getNodeEnv()),
         'process.env.ASSET_PREFIX': JSON.stringify(
           removeTailSlash(assetPrefix),
         ),

--- a/packages/core/src/provider/core/build.ts
+++ b/packages/core/src/provider/core/build.ts
@@ -1,6 +1,6 @@
 import { createCompiler } from './createCompiler';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
-import { logger } from '@rsbuild/shared';
+import { getNodeEnv, logger, setNodeEnv } from '@rsbuild/shared';
 import type {
   Stats,
   MultiStats,
@@ -14,8 +14,8 @@ export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
 ) => {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = mode;
+  if (!getNodeEnv()) {
+    setNodeEnv(mode);
   }
 
   const { context } = initOptions;

--- a/packages/core/src/provider/core/inspectConfig.ts
+++ b/packages/core/src/provider/core/inspectConfig.ts
@@ -1,6 +1,8 @@
 import { join, isAbsolute } from 'path';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import {
+  setNodeEnv,
+  getNodeEnv,
   stringifyConfig,
   outputInspectConfigFiles,
   type RspackConfig,
@@ -20,9 +22,9 @@ export async function inspectConfig({
   bundlerConfigs?: RspackConfig[];
 }): Promise<InspectConfigResult<'rspack'>> {
   if (inspectOptions.env) {
-    process.env.NODE_ENV = inspectOptions.env;
-  } else if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
+    setNodeEnv(inspectOptions.env);
+  } else if (!getNodeEnv()) {
+    setNodeEnv('development');
   }
 
   const rspackConfigs =

--- a/packages/core/src/provider/core/rspackConfig.ts
+++ b/packages/core/src/provider/core/rspackConfig.ts
@@ -2,10 +2,10 @@ import {
   debug,
   CHAIN_ID,
   castArray,
+  getNodeEnv,
   chainToConfig,
   modifyBundlerChain,
   mergeChainedOptions,
-  type NodeEnv,
   type RspackConfig,
   type RsbuildTarget,
   type ModifyChainUtils,
@@ -91,7 +91,7 @@ async function getConfigUtils(
 }
 
 async function getChainUtils(target: RsbuildTarget): Promise<ModifyChainUtils> {
-  const nodeEnv = process.env.NODE_ENV as NodeEnv;
+  const nodeEnv = getNodeEnv();
 
   return {
     env: nodeEnv,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,5 +1,7 @@
 import {
   debug,
+  getNodeEnv,
+  setNodeEnv,
   ROOT_DIST_DIR,
   getAddressUrls,
   getPublicPathFromCompiler,
@@ -38,8 +40,8 @@ export async function getServerAPIs<
     defaultPort?: number;
   } = {},
 ): Promise<DevServerAPIs> {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'development';
+  if (!getNodeEnv()) {
+    setNodeEnv('development');
   }
 
   const rsbuildConfig = options.context.config;

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -3,6 +3,8 @@ import connect from '@rsbuild/shared/connect';
 import { join } from 'path';
 import sirv from '../../compiled/sirv';
 import {
+  getNodeEnv,
+  setNodeEnv,
   ROOT_DIST_DIR,
   getAddressUrls,
   type ServerConfig,
@@ -134,8 +136,8 @@ export async function startProdServer(
   rsbuildConfig: RsbuildConfig,
   { getPortSilently }: PreviewServerOptions = {},
 ) {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'production';
+  if (!getNodeEnv()) {
+    setNodeEnv('production');
   }
 
   const { serverConfig, port, host, https } = await getServerOptions({

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { logger } from '@rsbuild/core';
 import {
+  isProd,
   withPublicPath,
   generateScriptTag,
   getPublicPathFromCompiler,
@@ -94,7 +95,7 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
 
     const getRuntimeCode = async () => {
       if (!runtimeCode) {
-        const isCompress = process.env.NODE_ENV === 'production';
+        const isCompress = isProd();
         runtimeCode = await getRootPixelCode(this.options, isCompress);
       }
       return runtimeCode;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import type { Compiler } from '@rspack/core';
 import type {
+  NodeEnv,
   CacheGroup,
   CompilerTapFn,
   RsbuildTarget,
@@ -20,11 +21,17 @@ export type Colors = Omit<
   'createColor' | 'isColorSupported'
 >;
 
-export const isDev = (): boolean => process.env.NODE_ENV === 'development';
+export const getNodeEnv = () => process.env.NODE_ENV as NodeEnv;
 
-export const isProd = (): boolean => process.env.NODE_ENV === 'production';
+export const setNodeEnv = (env: NodeEnv) => {
+  process.env.NODE_ENV = env;
+};
 
-export const isTest = () => process.env.NODE_ENV === 'test';
+export const isDev = (): boolean => getNodeEnv() === 'development';
+
+export const isProd = (): boolean => getNodeEnv() === 'production';
+
+export const isTest = () => getNodeEnv() === 'test';
 
 export const isString = (str: unknown): str is string =>
   typeof str === 'string';


### PR DESCRIPTION
## Summary

Use helper to get and set NODE_ENV, we should then try to minimize code that can directly write NODE_ENV.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
