### PR TITLE
build: remove require shims

### DIFF
--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -3,7 +3,6 @@ import {
   moduleTools,
   type PartialBaseBuildConfig,
 } from '@modern-js/module-tools';
-import path from 'path';
 
 const define = {
   RSBUILD_VERSION: require('../packages/core/package.json').version,
@@ -44,18 +43,10 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     autoExtension: true,
     shims: true,
     externals,
-    esbuildOptions: (option) => {
-      let { inject } = option;
-      const filepath = path.join(__dirname, 'requireShims.js');
-      if (inject) {
-        inject.push(filepath);
-      } else {
-        inject = [filepath];
-      }
-      return {
-        ...option,
-        inject,
-      };
+    // use import.meta['url'] to bypass bundle-require replacement of import.meta.url
+    banner: {
+      js: `import { createRequire } from 'module';
+var require = createRequire(import.meta['url']);\n`,
     },
   },
 ];

--- a/scripts/requireShims.js
+++ b/scripts/requireShims.js
@@ -1,6 +1,0 @@
-// If you declare a variable named 'require', esbuild will change it to 'require2'
-// Otherwise you use banner to add this code, import.meta.url will be replaced with source file's value by bundle-require
-// So we can only add it to global scope, and not pure
-import { createRequire } from 'module';
-
-global.require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary

## Related Links

Part of https://github.com/web-infra-dev/rsbuild/pull/1286.

remove the non-pure shims for ESM. Since the phantom dependencies are no longer available, the test case `e2e/cases/mjs-artifact/test.mjs` would fail because `global.require` will be set concurrently and fail due to the non-availability of the phantom dependency.


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
