### PR TITLE
feat: enable Rspack new tree shaking by default

### DIFF
--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -1,3 +1,4 @@
+import { setConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 
 /**
@@ -6,7 +7,11 @@ import type { RsbuildPlugin } from '../../types';
 export const pluginTransition = (): RsbuildPlugin => ({
   name: 'rsbuild:transition',
 
-  setup() {
+  setup(api) {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+
+    api.modifyRspackConfig((config) => {
+      setConfig(config, 'experiments.rspackFuture.newTreeshaking', true);
+    });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -20,6 +20,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/rspack-provider/plugins/__snapshots__/default.test.ts.snap
@@ -20,6 +20,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -687,6 +690,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1400,6 +1406,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1811,6 +1820,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -37,6 +37,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary

Enable Rspack new tree shaking by default, which can greatly reduce the bundle size for some cases, see: 
 https://github.com/web-infra-dev/rspack/issues/5317.

Also we want to get more feedbacks for it.

https://github.com/web-infra-dev/rsbuild/pull/1212

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
