### PR TITLE
chore(workflow): allow pnpmfile in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,6 +2,8 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
 	"ignorePaths": ["**/tests/**", "**/compiled/**", "**/node_modules/**"],
+	// ensure pnpmfile can be run
+	"allowScripts": true,
 	"packageRules": [
 		// Use chore as semantic commit type for commit messages
 		{


### PR DESCRIPTION
## Summary

Allow pnpmfile in renovate config.

## Related Links

https://github.com/renovatebot/renovate/discussions/16063

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
