### PR TITLE
fix: double slash in formatted routes

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -109,7 +109,6 @@ export function printServerURLs({
     const newUrls = printUrls({
       urls: urls.map((item) => item.url),
       port,
-      routes,
       protocol,
     });
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -20,7 +20,7 @@ import type {
 
 const formatPrefix = (prefix: string | undefined) => {
   if (!prefix) {
-    return '/';
+    return '';
   }
   if (prefix.endsWith('/')) {
     return prefix;
@@ -42,7 +42,7 @@ export const formatRoutes = (
     Object.keys(entry)
       .map((name) => {
         // fix case: /html/index/index.html
-        const isIndex = name === 'index' && outputStructure === 'flat';
+        const isIndex = name === 'index' && outputStructure !== 'nested';
         const displayName = isIndex ? '' : name;
         return {
           name,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -18,6 +18,16 @@ import type {
   OutputStructure,
 } from '@rsbuild/shared';
 
+const formatPrefix = (prefix: string | undefined) => {
+  if (!prefix) {
+    return '/';
+  }
+  if (prefix.endsWith('/')) {
+    return prefix;
+  }
+  return `${prefix}/`;
+};
+
 /*
  * format route by entry and adjust the index route to be the first
  */
@@ -26,15 +36,19 @@ export const formatRoutes = (
   prefix: string | undefined,
   outputStructure: OutputStructure | undefined,
 ): Routes => {
+  const formattedPrefix = formatPrefix(prefix);
+
   return (
     Object.keys(entry)
-      .map((name) => ({
-        name,
-        route:
-          (prefix ? `${prefix}/` : '') +
-          // fix case: /html/index/index.html
-          (name === 'index' && outputStructure !== 'nested' ? '' : name),
-      }))
+      .map((name) => {
+        // fix case: /html/index/index.html
+        const isIndex = name === 'index' && outputStructure === 'flat';
+        const displayName = isIndex ? '' : name;
+        return {
+          name,
+          route: formattedPrefix + displayName,
+        };
+      })
       // adjust the index route to be the first
       .sort((a) => (a.name === 'index' ? -1 : 1))
   );
@@ -95,6 +109,7 @@ export function printServerURLs({
     const newUrls = printUrls({
       urls: urls.map((item) => item.url),
       port,
+      routes,
       protocol,
     });
 

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -35,6 +35,26 @@ test('formatRoutes', () => {
   expect(
     formatRoutes(
       {
+        index: 'src/index.ts',
+        foo: 'src/index.ts',
+      },
+      '/',
+      undefined,
+    ),
+  ).toEqual([
+    {
+      name: 'index',
+      route: '/',
+    },
+    {
+      name: 'foo',
+      route: '/foo',
+    },
+  ]);
+
+  expect(
+    formatRoutes(
+      {
         foo: 'src/index.ts',
         bar: 'src/index.ts',
         index: 'src/index.ts',


### PR DESCRIPTION
## Summary

Fix double slash in formatted routes:

<img width="739" alt="Screenshot 2024-01-17 at 17 36 50" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/ef0d7031-ad2d-40bc-b3b6-58752f3e91d5">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
