### PR TITLE
feat: improve time info in debug logs

### DIFF
--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -1,5 +1,11 @@
 import { join } from 'path';
-import { logger, castArray, normalizeUrl, type Routes } from '@rsbuild/shared';
+import {
+  debug,
+  logger,
+  castArray,
+  normalizeUrl,
+  type Routes,
+} from '@rsbuild/shared';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import type { RsbuildPlugin } from '../types';
@@ -59,9 +65,9 @@ export async function openBrowser(url: string): Promise<boolean> {
 
         return true;
       }
-      logger.debug('Failed to find the target browser.');
+      debug('Failed to find the target browser.');
     } catch (err) {
-      logger.debug('Failed to open start URL with apple script.');
+      debug('Failed to open start URL with apple script.');
       logger.debug(err);
     }
   }

--- a/packages/core/src/provider/core/createCompiler.ts
+++ b/packages/core/src/provider/core/createCompiler.ts
@@ -53,7 +53,7 @@ export async function createCompiler({
 
   const logRspackVersion = () => {
     if (!isVersionLogged) {
-      logger.debug(`Use Rspack v${rspack.rspackVersion}`);
+      debug(`Use Rspack v${rspack.rspackVersion}`);
       isVersionLogged = true;
     }
   };

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -20,12 +20,20 @@ export const isDebug = () => {
   );
 };
 
+function getTime() {
+  const now = new Date();
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  const seconds = String(now.getSeconds()).padStart(2, '0');
+
+  return `${hours}:${minutes}:${seconds}`;
+}
+
 export const debug = (message: string | (() => string)) => {
   if (isDebug()) {
-    const { performance } = require('perf_hooks');
     const result = typeof message === 'string' ? message : message();
-    const time = color.gray(`[${performance.now().toFixed(2)} ms]`);
-    logger.debug(`${result} ${time}`);
+    const time = color.gray(`${getTime()}`);
+    logger.debug(`${time} ${result}`);
   }
 };
 


### PR DESCRIPTION
## Summary

Improve time info in debug logs, display current time is better than `performance.now` when dev server run a long time.

<img width="500" alt="Screenshot 2024-01-17 at 22 34 22" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/aeea25ad-d95e-45dd-a6e2-f22785601f46">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
