### PR TITLE
feat: add routes param to server.printUrls

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,15 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  source: {
-    entry: {
-      index: './src/index.jsx',
-      detail: './src/App.jsx',
-    },
-  },
-  server: {
-    printUrls({ routes }) {
-      console.log(routes);
-    },
-  },
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,4 +3,15 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  source: {
+    entry: {
+      index: './src/index.jsx',
+      detail: './src/App.jsx',
+    },
+  },
+  server: {
+    printUrls({ routes }) {
+      console.log(routes);
+    },
+  },
 });

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -1,11 +1,5 @@
 import { join } from 'path';
-import {
-  debug,
-  logger,
-  castArray,
-  normalizeUrl,
-  type Routes,
-} from '@rsbuild/shared';
+import { debug, logger, castArray, type Routes } from '@rsbuild/shared';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import type { RsbuildPlugin } from '../types';
@@ -114,11 +108,7 @@ export function pluginStartUrl(): RsbuildPlugin {
           const protocol = https ? 'https' : 'http';
           if (routes.length) {
             // auto open the first one
-            urls.push(
-              normalizeUrl(
-                `${protocol}://localhost:${port}/${routes[0].route}`,
-              ),
-            );
+            urls.push(`${protocol}://localhost:${port}${routes[0].pathname}`);
           }
         } else {
           urls.push(

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -19,16 +19,16 @@ test('formatRoutes', () => {
     ),
   ).toEqual([
     {
-      name: 'index',
-      route: '',
+      entryName: 'index',
+      pathname: '/',
     },
     {
-      name: 'foo',
-      route: 'foo',
+      entryName: 'foo',
+      pathname: '/foo',
     },
     {
-      name: 'bar',
-      route: 'bar',
+      entryName: 'bar',
+      pathname: '/bar',
     },
   ]);
 
@@ -38,17 +38,37 @@ test('formatRoutes', () => {
         index: 'src/index.ts',
         foo: 'src/index.ts',
       },
-      '/',
+      '/hello',
       undefined,
     ),
   ).toEqual([
     {
-      name: 'index',
-      route: '/',
+      entryName: 'index',
+      pathname: '/hello/',
     },
     {
-      name: 'foo',
-      route: '/foo',
+      entryName: 'foo',
+      pathname: '/hello/foo',
+    },
+  ]);
+
+  expect(
+    formatRoutes(
+      {
+        index: 'src/index.ts',
+        foo: 'src/index.ts',
+      },
+      '/hello/',
+      undefined,
+    ),
+  ).toEqual([
+    {
+      entryName: 'index',
+      pathname: '/hello/',
+    },
+    {
+      entryName: 'foo',
+      pathname: '/hello/foo',
     },
   ]);
 
@@ -64,16 +84,16 @@ test('formatRoutes', () => {
     ),
   ).toEqual([
     {
-      name: 'index',
-      route: '',
+      entryName: 'index',
+      pathname: '/',
     },
     {
-      name: 'foo',
-      route: 'foo',
+      entryName: 'foo',
+      pathname: '/foo',
     },
     {
-      name: 'bar',
-      route: 'bar',
+      entryName: 'bar',
+      pathname: '/bar',
     },
   ]);
 
@@ -87,8 +107,8 @@ test('formatRoutes', () => {
     ),
   ).toEqual([
     {
-      name: 'foo',
-      route: 'foo',
+      entryName: 'foo',
+      pathname: '/foo',
     },
   ]);
 
@@ -104,16 +124,16 @@ test('formatRoutes', () => {
     ),
   ).toEqual([
     {
-      name: 'index',
-      route: 'html/',
+      entryName: 'index',
+      pathname: '/html/',
     },
     {
-      name: 'foo',
-      route: 'html/foo',
+      entryName: 'foo',
+      pathname: '/html/foo',
     },
     {
-      name: 'bar',
-      route: 'html/bar',
+      entryName: 'bar',
+      pathname: '/html/bar',
     },
   ]);
 
@@ -127,8 +147,8 @@ test('formatRoutes', () => {
     ),
   ).toEqual([
     {
-      name: 'index',
-      route: 'html/index',
+      entryName: 'index',
+      pathname: '/html/index',
     },
   ]);
 });
@@ -151,8 +171,8 @@ test('printServerURLs', () => {
     ],
     routes: [
       {
-        name: 'index',
-        route: '',
+        entryName: 'index',
+        pathname: '/',
       },
     ],
   });
@@ -178,16 +198,16 @@ test('printServerURLs', () => {
     ],
     routes: [
       {
-        name: 'index',
-        route: '',
+        entryName: 'index',
+        pathname: '/',
       },
       {
-        name: 'foo',
-        route: 'html/foo',
+        entryName: 'foo',
+        pathname: '/html/foo',
       },
       {
-        name: 'bar',
-        route: 'bar',
+        entryName: 'bar',
+        pathname: '/bar',
       },
     ],
   });

--- a/packages/document/docs/en/config/server/print-urls.mdx
+++ b/packages/document/docs/en/config/server/print-urls.mdx
@@ -1,6 +1,23 @@
 # printUrls
 
-- **Type:** `boolean | Function`
+- **Type:**
+
+```ts
+type Routes = Array<{
+  entryName: string;
+  pathname: string;
+}>;
+
+type PrintUrls =
+  | boolean
+  | ((params: {
+      urls: string[];
+      port: number;
+      routes: Routes;
+      protocol: string;
+    }) => string[] | void);
+```
+
 - **Default:** `true`
 
 Whether to print the server's urls.
@@ -14,7 +31,7 @@ By default, when you start the dev server or preview server, Rsbuild will print 
 
 ## Custom Logging
 
-`server.printUrls` can be set to a function, with parameters including `port`, `protocol`, and `urls`.
+`server.printUrls` can be set to a function, with parameters including `port`, `protocol`, `urls` and `routes`.
 
 ### Modify URL
 
@@ -48,6 +65,28 @@ export default {
       console.log(urls); // ['http://localhost:8080', 'http://192.168.0.1:8080']
       console.log(port); // 8080
       console.log(protocol); // 'http' or 'https'
+    },
+  },
+};
+```
+
+### MPA Output
+
+If the current project contains multiple pages, you can generate a separate URL for each page based on the `routes` parameter.
+
+For example, when the project contains two pages, `index` and `detail`, the content of the `routes` would be:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ routes }) {
+      /**
+       * [
+       *   { entryName: 'index', pathname: '/' },
+       *   { entryName: 'detail', pathname: '/detail' }
+       * ]
+       */
+      console.log(routes);
     },
   },
 };

--- a/packages/document/docs/zh/config/server/print-urls.mdx
+++ b/packages/document/docs/zh/config/server/print-urls.mdx
@@ -1,6 +1,23 @@
 # printUrls
 
-- **类型：** `boolean | Function`
+- **类型：**
+
+```ts
+type Routes = Array<{
+  entryName: string;
+  pathname: string;
+}>;
+
+type PrintUrls =
+  | boolean
+  | ((params: {
+      urls: string[];
+      port: number;
+      routes: Routes;
+      protocol: string;
+    }) => string[] | void);
+```
+
 - **默认值：** `true`
 
 是否输出 server 的 URL 地址。
@@ -14,7 +31,7 @@
 
 ## 自定义日志
 
-`server.printUrls` 可以设置为一个函数，函数的入参包括 `port`，`protocol` 和 `urls`。
+`server.printUrls` 可以设置为一个函数，函数的入参包括 `port`，`protocol`、`urls` 和 `routes`。
 
 ### 修改 URL
 
@@ -48,6 +65,28 @@ export default {
       console.log(urls); // ['http://localhost:8080', 'http://192.168.0.1:8080']
       console.log(port); // 8080
       console.log(protocol); // 'http' or 'https'
+    },
+  },
+};
+```
+
+### 多页面输出
+
+如果当前项目包含多个页面，你可以基于 `routes` 参数，为每个页面单独输出一份 URL。
+
+比如项目包含 `index` 和 `detail` 两个页面时，routes 的内容如下：
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    printUrls({ routes }) {
+      /**
+       * [
+       *   { entryName: 'index', pathname: '/' },
+       *   { entryName: 'detail', pathname: '/detail' }
+       * ]
+       */
+      console.log(routes);
     },
   },
 };

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -4,6 +4,7 @@ import type {
   Options as BaseProxyOptions,
   Filter as ProxyFilter,
 } from '../../../compiled/http-proxy-middleware';
+import type { Routes } from '../hooks';
 
 export type HtmlFallback = false | 'index';
 
@@ -45,6 +46,7 @@ export type PrintUrls =
   | ((params: {
       urls: string[];
       port: number;
+      routes: Routes;
       protocol: string;
     }) => string[] | void);
 

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -26,8 +26,8 @@ export type OnBeforeStartDevServerFn = () => PromiseOrNot<void>;
 export type OnBeforeStartProdServerFn = () => PromiseOrNot<void>;
 
 export type Routes = Array<{
-  name: string;
-  route: string;
+  entryName: string;
+  pathname: string;
 }>;
 
 export type OnAfterStartDevServerFn = (params: {


### PR DESCRIPTION
## Summary

Add routes param to `server.printUrls`:


```ts title="rsbuild.config.ts"
export default {
  server: {
    printUrls({ routes }) {
      /**
       * [
       *   { entryName: 'index', pathname: '/' },
       *   { entryName: 'detail', pathname: '/detail' }
       * ]
       */
      console.log(routes);
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
