### PR TITLE
chore: fix type issues in server test, update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,11 +14,6 @@
 			"groupSlug": "babel"
 		},
 		{
-			"groupName": "rspack",
-			"packagePatterns": ["rspack"],
-			"groupSlug": "rspack"
-		},
-		{
 			"groupName": "types",
 			"packagePatterns": ["^@types/"],
 			"groupSlug": "types"
@@ -31,6 +26,11 @@
 		// manually update peer dependencies
 		{
 			"depTypeList": ["peerDependencies"],
+			"enabled": false
+		},
+		// use GitHub actions to update rspress and modern, manually update rspack
+		{
+			"packagePatterns": ["rspack", "rspress", "modern"],
 			"enabled": false
 		}
 	],

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,4 +1,4 @@
-import webpack from 'webpack';
+import { rspack } from '@rspack/core';
 import {
   mergeDevOptions,
   formatRoutes,
@@ -228,7 +228,7 @@ test('printServerURLs', () => {
 
 describe('test dev server', () => {
   test('should setupServerHooks correctly', () => {
-    const compiler = webpack({});
+    const compiler = rspack({});
     const onDoneFn = vi.fn();
     const onInvalidFn = vi.fn();
 
@@ -256,7 +256,7 @@ describe('test dev server', () => {
     expect(isInvalidHookRegistered).toBeTruthy();
   });
   test('should not setupServerHooks when compiler is server', () => {
-    const compiler = webpack({
+    const compiler = rspack({
       name: 'server',
     });
     const onDoneFn = vi.fn();
@@ -275,11 +275,11 @@ describe('test dev server', () => {
   });
 
   test('check isClientCompiler', () => {
-    expect(isClientCompiler(webpack({}))).toBeTruthy();
+    expect(isClientCompiler(rspack({}))).toBeTruthy();
 
     expect(
       isClientCompiler(
-        webpack({
+        rspack({
           target: ['web', 'es5'],
         }),
       ),
@@ -287,7 +287,7 @@ describe('test dev server', () => {
 
     expect(
       isClientCompiler(
-        webpack({
+        rspack({
           target: 'node',
         }),
       ),
@@ -295,7 +295,7 @@ describe('test dev server', () => {
 
     expect(
       isClientCompiler(
-        webpack({
+        rspack({
           target: ['node'],
         }),
       ),


### PR DESCRIPTION
## Summary

- fix type issues in server test, use rspack instead of webpack.
- update renovate config, use GitHub actions to update rspress and modern, manually update rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
