### PR TITLE
fix: infinitely reload when disabling HMR

### DIFF
--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -111,10 +111,9 @@ function handleAvailableHash(hash: string) {
   mostRecentCompilationHash = hash;
 }
 
-// Is there a newer version of this code available?
 function isUpdateAvailable() {
   // __webpack_hash__ is the hash of the current compilation.
-  // It's a global variable injected by webpack.
+  // It's a global variable injected by webpack / Rspack.
   return mostRecentCompilationHash !== __webpack_hash__;
 }
 
@@ -125,13 +124,18 @@ function canApplyUpdates() {
 
 // Attempt to update code on the fly, fall back to a hard reload.
 function tryApplyUpdates() {
+  // detect is there a newer version of this code available
+  if (!isUpdateAvailable()) {
+    return;
+  }
+
   if (!module.hot) {
-    // HotModuleReplacementPlugin is not in webpack configuration.
+    // HotModuleReplacementPlugin is not in Rspack configuration.
     window.location.reload();
     return;
   }
 
-  if (!isUpdateAvailable() || !canApplyUpdates()) {
+  if (!canApplyUpdates()) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Fix infinitely reload when disabling HMR, we should detect is there a newer version of this code before reloading the page.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/1231

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
