### PR TITLE
fix: incorrect peer dependency range

### DIFF
--- a/packages/compat/plugin-esbuild/package.json
+++ b/packages/compat/plugin-esbuild/package.json
@@ -37,6 +37,9 @@
     "@rsbuild/webpack": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -51,6 +51,9 @@
     "typescript": "^5.3.0",
     "webpack": "^5.89.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -41,6 +41,9 @@
     "terser": "5.19.2",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -39,6 +39,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -40,7 +40,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -36,6 +36,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -39,6 +39,9 @@
     "typescript": "^5.3.0",
     "webpack": "^5.89.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -34,6 +34,9 @@
     "@rsbuild/core": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -34,6 +34,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -36,6 +36,9 @@
     "@scripts/test-helper": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -36,6 +36,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,6 +37,9 @@
     "html-webpack-plugin": "npm:html-rspack-plugin@5.5.7",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -34,6 +34,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -39,7 +39,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "peerDependenciesMeta": {
     "@rsbuild/core": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -37,6 +37,9 @@
     "svelte": "^4.2.2",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -39,6 +39,9 @@
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -35,6 +35,9 @@
     "@scripts/test-helper": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -34,6 +34,9 @@
     "@scripts/test-helper": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.3.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "0.x"
+    "@rsbuild/core": "^0.3.3"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -35,6 +35,9 @@
     "@scripts/test-helper": "workspace:*",
     "typescript": "^5.3.0"
   },
+  "peerDependencies": {
+    "@rsbuild/core": "^0.3.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true,

--- a/scripts/check-changeset/src/index.ts
+++ b/scripts/check-changeset/src/index.ts
@@ -38,11 +38,10 @@ function validatePackagePeerDependencies(packages: Package[]) {
       const depPkg = packages.find((pkg) => pkg.packageJson.name === dep);
       if (depPkg) {
         const version = peerDependencies[dep];
-        const isValid =
-          version === `workspace:^${depPkg.packageJson.version}` ||
-          version === '0.x' ||
-          version === '1.x';
-        if (!isValid) {
+        const isInvalid =
+          version.startsWith('workspace') &&
+          version !== `workspace:^${depPkg.packageJson.version}`;
+        if (isInvalid) {
           throw Error(
             `${packageJson.name}'s peerDependencies ${dep} version is not right, expect "workspace:^${depPkg.packageJson.version}"`,
           );


### PR DESCRIPTION
## Summary

Fix incorrect peer dependency range. pnpm may resolve `@rsbuild/core: 0.x` to v0.1.0 and breaks some plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
