### PR TITLE
refactor: optimize readability and robustness of pluginDagSort

### DIFF
--- a/packages/shared/tests/pluginDagSort.test.ts
+++ b/packages/shared/tests/pluginDagSort.test.ts
@@ -1,0 +1,61 @@
+import type { RsbuildPlugin } from '../src';
+import { pluginDagSort } from '../src/pluginStore';
+
+describe('sort plugins', () => {
+  it('should verify each plugin', () => {
+    const cases = [
+      { name: '1' },
+      { name: '2', pre: [], post: [] },
+      { name: '3', pre: ['1'], post: ['2'] },
+      { name: '4', pre: [], post: [] },
+      { name: '5', pre: ['6'], post: ['3'] },
+      { name: '6', pre: [], post: [] },
+    ] as RsbuildPlugin[];
+
+    const result = pluginDagSort(cases);
+    const p1Index = result.findIndex((item) => item.name === '1');
+    const p2Index = result.findIndex((item) => item.name === '2');
+    const p3Index = result.findIndex((item) => item.name === '3');
+    const p5Index = result.findIndex((item) => item.name === '5');
+    const p6Index = result.findIndex((item) => item.name === '6');
+
+    // is plugin 3 verified
+    expect(p2Index > p3Index).toBeTruthy();
+    expect(p1Index < p3Index).toBeTruthy();
+    // is plugin 5 verified
+    expect(p5Index < p3Index).toBeTruthy();
+    expect(p5Index > p6Index).toBeTruthy();
+  });
+
+  it('should allow some invalid plugins', () => {
+    const cases = [
+      { name: '1' },
+      { name: '2', pre: [undefined], post: [] },
+      { name: '3', pre: ['1'], post: ['2', undefined] },
+      { name: undefined },
+    ] as RsbuildPlugin[];
+
+    const result = pluginDagSort(cases);
+    const p1Index = result.findIndex((item) => item.name === '1');
+    const p2Index = result.findIndex((item) => item.name === '2');
+    const p3Index = result.findIndex((item) => item.name === '3');
+
+    expect(p2Index > p3Index).toBeTruthy();
+    expect(p1Index < p3Index).toBeTruthy();
+  });
+
+  it('should throw error when plugin has ring', () => {
+    const cases = [
+      { name: '1', pre: [], post: [] },
+      { name: '2', pre: [], post: ['5'] },
+      { name: '3', pre: ['1'], post: ['2'] },
+      { name: '4', pre: [], post: [] },
+      { name: '5', pre: ['6'], post: ['3'] },
+      { name: '6', pre: [], post: [] },
+    ] as RsbuildPlugin[];
+
+    expect(() => {
+      pluginDagSort(cases);
+    }).toThrow(/plugins dependencies has loop: 2,3,5/);
+  });
+});


### PR DESCRIPTION
## Summary

- optimize readability and robustness of pluginDagSort
- allow `pre` and `post` to contain `undefined` in some edge cases.

<img width="1130" alt="Screenshot 2024-01-18 at 20 22 53" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/11f93cea-8bc7-4d2d-bdd5-e776cd0237ae">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
