### PR TITLE
feat: improve publicDir copy error log

### DIFF
--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -1,4 +1,4 @@
-import { fse } from '@rsbuild/shared';
+import { fse, logger } from '@rsbuild/shared';
 import { join, isAbsolute } from 'path';
 import type { RsbuildPlugin } from '../types';
 
@@ -25,10 +25,16 @@ export const pluginServer = (): RsbuildPlugin => ({
           return;
         }
 
-        await fse.copy(publicDir, api.context.distPath, {
-          // dereference symlinks
-          dereference: true,
-        });
+        try {
+          // can not get useful error stack when copy error
+          // so we manually catch and throw again
+          await fse.copy(publicDir, api.context.distPath, {
+            // dereference symlinks
+            dereference: true,
+          });
+        } catch (err) {
+          logger.error(`Copy publicDir(${publicDir}) to dist error:`, err);
+        }
       }
     });
   },


### PR DESCRIPTION
## Summary

update publicDir copy error log, currently we can not get useful error stack when copy error

see: https://github.com/jprichardson/node-fs-extra/issues/769

<img width="765" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/b1572c12-3914-47e1-8f42-5c64bf88c171">

## Related Links

https://github.com/web-infra-dev/rspress/pull/559

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
