### PR TITLE
perf(create-rsbuild): bundle dependencies for speed up

### DIFF
--- a/packages/create-rsbuild/.npmignore
+++ b/packages/create-rsbuild/.npmignore
@@ -1,6 +1,0 @@
-template-*/dist/
-template-*/node_modules/
-src/
-./tsconfig.json
-./modern.config.ts
-./CHANGELOG.md

--- a/packages/create-rsbuild/modern.config.ts
+++ b/packages/create-rsbuild/modern.config.ts
@@ -1,3 +1,3 @@
-import baseConfig from '../../scripts/modern.base.config';
+import { bundleMjsOnlyConfig } from '../../scripts/modern.base.config';
 
-export default baseConfig;
+export default bundleMjsOnlyConfig;

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -16,6 +16,9 @@
       "default": "./dist/index.js"
     }
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -9,7 +9,7 @@
     "directory": "packages/create-rsbuild"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -21,17 +21,19 @@
   "bin": {
     "create-rsbuild": "./dist/index.js"
   },
+  "files": [
+    "template-*",
+    "dist"
+  ],
   "scripts": {
     "build": "modern build",
     "dev": "modern build --watch",
     "start": "node ./dist/index.js"
   },
-  "dependencies": {
-    "@clack/prompts": "^0.7.0",
-    "rslog": "^1.2.0"
-  },
   "devDependencies": {
+    "@clack/prompts": "^0.7.0",
     "@types/node": "16.x",
+    "rslog": "^1.2.0",
     "typescript": "^5.3.0"
   },
   "publishConfig": {

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -26,7 +26,7 @@ function pkgFromUserAgent(userAgent: string | undefined) {
   };
 }
 
-async function main() {
+export async function main() {
   console.log('');
   logger.greet('◆  Create Rsbuild Project');
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,245 +639,16 @@ importers:
         version: 5.89.0
 
   packages/create-rsbuild:
-    dependencies:
+    devDependencies:
       '@clack/prompts':
         specifier: ^0.7.0
         version: 0.7.0
-      rslog:
-        specifier: ^1.2.0
-        version: 1.2.0
-    devDependencies:
       '@types/node':
         specifier: 16.x
         version: 16.18.59
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-lit-js:
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      lit:
-        specifier: ^3.0.2
-        version: 3.0.2
-
-  packages/create-rsbuild/template-lit-ts:
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      lit:
-        specifier: ^3.0.2
-        version: 3.0.2
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-preact-js:
-    dependencies:
-      preact:
-        specifier: ^10.19.3
-        version: 10.19.3
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-preact':
-        specifier: workspace:*
-        version: link:../../plugin-preact
-
-  packages/create-rsbuild/template-preact-ts:
-    dependencies:
-      preact:
-        specifier: ^10.19.3
-        version: 10.19.3
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-preact':
-        specifier: workspace:*
-        version: link:../../plugin-preact
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-react-js:
-    dependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-react':
-        specifier: link:../../plugin-react
-        version: link:../../plugin-react
-
-  packages/create-rsbuild/template-react-ts:
-    dependencies:
-      react:
-        specifier: ^18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.2.0(react@18.2.0)
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-react':
-        specifier: link:../../plugin-react
-        version: link:../../plugin-react
-      '@types/react':
-        specifier: ^18.2.47
-        version: 18.2.47
-      '@types/react-dom':
-        specifier: ^18.2.18
-        version: 18.2.18
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-solid-js:
-    dependencies:
-      solid-js:
-        specifier: ^1.8.5
-        version: 1.8.5
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-babel':
-        specifier: workspace:*
-        version: link:../../plugin-babel
-      '@rsbuild/plugin-solid':
-        specifier: workspace:*
-        version: link:../../plugin-solid
-
-  packages/create-rsbuild/template-solid-ts:
-    dependencies:
-      solid-js:
-        specifier: ^1.8.5
-        version: 1.8.5
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-babel':
-        specifier: workspace:*
-        version: link:../../plugin-babel
-      '@rsbuild/plugin-solid':
-        specifier: workspace:*
-        version: link:../../plugin-solid
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-svelte-js:
-    dependencies:
-      svelte:
-        specifier: ^4.2.2
-        version: 4.2.2
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-svelte':
-        specifier: workspace:*
-        version: link:../../plugin-svelte
-
-  packages/create-rsbuild/template-svelte-ts:
-    dependencies:
-      svelte:
-        specifier: ^4.2.2
-        version: 4.2.2
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-svelte':
-        specifier: workspace:*
-        version: link:../../plugin-svelte
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-vanilla-js:
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-
-  packages/create-rsbuild/template-vanilla-ts:
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-vue2-js:
-    dependencies:
-      vue:
-        specifier: ^2.7.14
-        version: 2.7.14
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-vue2':
-        specifier: workspace:*
-        version: link:../../plugin-vue2
-
-  packages/create-rsbuild/template-vue2-ts:
-    dependencies:
-      vue:
-        specifier: ^2.7.14
-        version: 2.7.14
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-vue2':
-        specifier: workspace:*
-        version: link:../../plugin-vue2
-      typescript:
-        specifier: ^5.3.0
-        version: 5.3.2
-
-  packages/create-rsbuild/template-vue3-js:
-    dependencies:
-      vue:
-        specifier: ^3.3.4
-        version: 3.3.4
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-vue':
-        specifier: workspace:*
-        version: link:../../plugin-vue
-
-  packages/create-rsbuild/template-vue3-ts:
-    dependencies:
-      vue:
-        specifier: ^3.3.4
-        version: 3.3.4
-    devDependencies:
-      '@rsbuild/core':
-        specifier: link:../../core
-        version: link:../../core
-      '@rsbuild/plugin-vue':
-        specifier: workspace:*
-        version: link:../../plugin-vue
+      rslog:
+        specifier: ^1.2.0
+        version: 1.2.0
       typescript:
         specifier: ^5.3.0
         version: 5.3.2
@@ -3476,7 +3247,7 @@ packages:
     dependencies:
       picocolors: 1.0.0
       sisteransi: 1.0.5
-    dev: false
+    dev: true
 
   /@clack/prompts@0.7.0:
     resolution: {integrity: sha512-0MhX9/B4iL6Re04jPrttDm+BsP8y6mS7byuv0BvXgdXhbV5PdlsHt55dvNsuBCPZ7xq1oTAOOuotR9NFbQyMSA==}
@@ -3484,7 +3255,7 @@ packages:
       '@clack/core': 0.3.3
       picocolors: 1.0.0
       sisteransi: 1.0.5
-    dev: false
+    dev: true
     bundledDependencies:
       - is-unicode-supported
 
@@ -11848,6 +11619,7 @@ packages:
   /rslog@1.2.0:
     resolution: {integrity: sha512-2ZFW7Jtkzt4VkwCFRTE+0lKbzSLSH7U5OM9qZ5YuKk4xVrlIJJZx9Qh/fCyfsk8H+qXbermMc7+18qKJxLQ/bw==}
     engines: {node: '>=14.17.6'}
+    dev: true
 
   /rspack-plugin-virtual-module@0.1.12:
     resolution: {integrity: sha512-qyBM9XsP7oxBQSms2cr715XOeoDi6p5hUYXtlNDfst0jha8vfWVPNeC7j5+j5dG+yt//1OCmLaOY2rWqPSVXDg==}
@@ -12134,7 +11906,7 @@ packages:
 
   /sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
-    dev: false
+    dev: true
 
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'packages/**'
   - 'examples/**'
   - '!**/compiled/**'
+  - '!**/create-rsbuild/template-*'

--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -10,17 +10,36 @@ const define = {
 
 const BUILD_TARGET = 'es2020' as const;
 
-export const baseBuildConfig = {
+const requireShim = {
+  // use import.meta['url'] to bypass bundle-require replacement of import.meta.url
+  js: `import { createRequire } from 'module';
+var require = createRequire(import.meta['url']);\n`,
+};
+
+export const baseBuildConfig = defineConfig({
   plugins: [moduleTools()],
   buildConfig: {
-    buildType: 'bundleless' as const,
-    format: 'cjs' as const,
+    buildType: 'bundleless',
+    format: 'cjs',
     target: BUILD_TARGET,
     define,
   },
-};
+});
 
-export default defineConfig(baseBuildConfig);
+export const bundleMjsOnlyConfig = defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: {
+    buildType: 'bundle',
+    format: 'esm',
+    target: BUILD_TARGET,
+    define,
+    autoExtension: true,
+    shims: true,
+    banner: requireShim,
+  },
+});
+
+export default baseBuildConfig;
 
 const externals = ['@rsbuild/core', /[\\/]compiled[\\/]/];
 
@@ -43,11 +62,7 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     autoExtension: true,
     shims: true,
     externals,
-    // use import.meta['url'] to bypass bundle-require replacement of import.meta.url
-    banner: {
-      js: `import { createRequire } from 'module';
-var require = createRequire(import.meta['url']);\n`,
-    },
+    banner: requireShim,
   },
 ];
 


### PR DESCRIPTION
## Summary

- bundle dependencies for speed up
- this package is now ESM-only, as user only use it via `npm create`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
