### PR TITLE
types: allow less.additionalData to be async function

### DIFF
--- a/.changeset/tender-planes-add.md
+++ b/.changeset/tender-planes-add.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+release: 0.3.6

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -43,7 +43,7 @@ export type LessLoaderOptions = {
     | ((
         content: string,
         loaderContext: LoaderContext<LessLoaderOptions>,
-      ) => string);
+      ) => string | Promise<string>);
   sourceMap?: boolean;
   webpackImporter?: boolean;
   implementation?: unknown;


### PR DESCRIPTION
## Summary

allow less.additionalData to be async function

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/1375

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
