### PR TITLE
docs(plugin-stylus): fix sourceMap default value

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-stylus.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-stylus.mdx
@@ -86,9 +86,9 @@ pluginStylus({
 ### sourceMap
 
 - **Type:** `boolean`
-- **Default:** `isDev`
+- **Default:** the same as [output.sourceMap.css](/config/output/source-map)
 
-Whether to generate Source Map, enabled by default in the development environment.
+Whether to generate source map.
 
 ```ts
 pluginStylus({

--- a/packages/document/docs/zh/plugins/list/plugin-stylus.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-stylus.mdx
@@ -86,9 +86,9 @@ pluginStylus({
 ### sourceMap
 
 - **类型：** `boolean`
-- **默认值：** `isDev`
+- **默认值：** 与 [output.sourceMap.css](/config/output/source-map) 一致
 
-是否生成 Source Map，默认在开发环境下启用。
+是否生成 source map 文件。
 
 ```ts
 pluginStylus({

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -11,7 +11,13 @@ type StylusOptions = {
 };
 
 type StylusLoaderOptions = {
+  /**
+   * Options passed to Stylus.
+   */
   stylusOptions?: StylusOptions;
+  /**
+   * Whether to generate Source Map.
+   */
   sourceMap?: boolean;
 };
 


### PR DESCRIPTION
## Summary

Fix sourceMap default value of `plugin-stylus` in document, should be the same as [output.sourceMap.css](/config/output/source-map).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
