### PR TITLE
chore(workflow): renovate ignore webpack-bundler-analyzer

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,8 @@
 		// manually update some packages
 		"core-js",
 		"esbuild",
-		"typescript"
+		"typescript",
+		// https://github.com/web-infra-dev/rsbuild/pull/1105
+		"webpack-bundle-analyzer"
 	]
 }


### PR DESCRIPTION
## Summary

Renovate ignore webpack-bundler-analyzer, see https://github.com/web-infra-dev/rsbuild/pull/1105

## Related Links

close https://github.com/web-infra-dev/rsbuild/pull/1356

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
