### PR TITLE
fix: merge dev.startUrl with overrides strategy

### DIFF
--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -18,6 +18,8 @@ export const isOverriddenConfigKey = (key: string) =>
     'targets',
     // server.printUrls
     'printUrls',
+    // dev.startUrl
+    'startUrl',
   ].includes(key);
 
 export const mergeRsbuildConfig = <T>(...configs: T[]): T =>

--- a/packages/shared/tests/mergeConfig.test.ts
+++ b/packages/shared/tests/mergeConfig.test.ts
@@ -158,4 +158,25 @@ describe('mergeRsbuildConfig', () => {
       d: { test: [2] },
     });
   });
+
+  test('should merge dev.startUrl correctly', async () => {
+    expect(
+      mergeRsbuildConfig(
+        {
+          dev: {
+            startUrl: ['http://localhost:8080'],
+          },
+        },
+        {
+          dev: {
+            startUrl: false,
+          },
+        },
+      ),
+    ).toEqual({
+      dev: {
+        startUrl: false,
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Merge dev.startUrl with overrides strategy. If `[string]` and `[false]` are merged into `[string, false]`, the startUrl plugin can not handle it.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
