### PR TITLE
types: mergeRsbuildConfig no longer needs generics

### DIFF
--- a/.changeset/curly-cats-itch.md
+++ b/.changeset/curly-cats-itch.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.3.7

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -104,7 +104,7 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
 
 exports[`webpackConfig > should allow tools.webpack to modify config object 1`] = `
 {
-  "devtool": "eval",
+  "devtool": "eval-cheap-source-map",
 }
 `;
 

--- a/packages/compat/webpack/tests/webpackConfig.test.ts
+++ b/packages/compat/webpack/tests/webpackConfig.test.ts
@@ -26,7 +26,7 @@ describe('webpackConfig', () => {
       rsbuildConfig: {
         tools: {
           webpack(config) {
-            config.devtool = 'eval';
+            config.devtool = 'eval-cheap-source-map';
           },
         },
       },

--- a/packages/core/src/provider/config.ts
+++ b/packages/core/src/provider/config.ts
@@ -56,10 +56,7 @@ export const withDefaultConfig = async (
   rootPath: string,
   config: RsbuildConfig,
 ) => {
-  const merged = mergeRsbuildConfig<RsbuildConfig>(
-    createDefaultConfig(),
-    config,
-  );
+  const merged = mergeRsbuildConfig(createDefaultConfig(), config);
 
   merged.source ||= {};
 
@@ -84,7 +81,4 @@ export const withDefaultConfig = async (
  * 3. Meaningful and can be filled by constant value.
  */
 export const normalizeConfig = (config: RsbuildConfig): NormalizedConfig =>
-  mergeRsbuildConfig<NormalizedConfig>(
-    createDefaultConfig() as NormalizedConfig,
-    config as NormalizedConfig,
-  );
+  mergeRsbuildConfig(createDefaultConfig(), config) as NormalizedConfig;

--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -100,7 +100,7 @@ export default () => ({
   setup: (api) => {
     api.modifyRspackConfig((config, utils) => {
       if (utils.env === 'development') {
-        config.devtool = 'eval';
+        config.devtool = 'eval-cheap-source-map';
       }
     });
   },

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -100,7 +100,7 @@ export default () => ({
   setup: (api) => {
     api.modifyRspackConfig((config, utils) => {
       if (utils.env === 'development') {
-        config.devtool = 'eval';
+        config.devtool = 'eval-cheap-source-map';
       }
     });
   },

--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { castArray, isFunction, isUndefined } from './utils';
+import type { RsbuildConfig } from './types/config';
 
 /**
  * When merging config, some properties prefer `override` rather than `merge to array`
@@ -22,7 +23,9 @@ export const isOverriddenConfigKey = (key: string) =>
     'startUrl',
   ].includes(key);
 
-export const mergeRsbuildConfig = <T>(...configs: T[]): T =>
+export const mergeRsbuildConfig = (
+  ...configs: RsbuildConfig[]
+): RsbuildConfig =>
   _.mergeWith(
     {},
     ...configs,


### PR DESCRIPTION
## Summary

mergeRsbuildConfig no longer needs generics, declare the input and return type as `RsbuildConfig`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
