### PR TITLE
fix: prevent using 'local' as the env mode

### DIFF
--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -36,6 +36,12 @@ export function loadEnv({
   /** Clear the environment variables mounted on `process.env` */
   cleanup: () => void;
 } {
+  if (mode === 'local') {
+    throw new Error(
+      `'local' cannot be used as a value for env mode, because ".env.local" represents a temporary local file. Please use another value.`,
+    );
+  }
+
   const filenames = [
     '.env',
     '.env.local',


### PR DESCRIPTION
## Summary

Prevent using 'local' as the env mode.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/eca1ee0d-3771-4569-b0a9-a48a83fc4a1f)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
