### PR TITLE
chore(workflow): enable biome useNodejsImportProtocol rule

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -11,6 +11,7 @@
       "coverage/**/*",
       "cspell.json",
       "compiled/**/*",
+      "node_modules/**/*",
       "plugin-swc/tests/fixtures/**/*",
       "*.css.d.ts"
     ],
@@ -35,7 +36,8 @@
       },
       "nursery": {
         "useImportType": "error",
-        "useExportType": "error"
+        "useExportType": "error",
+        "useNodejsImportProtocol": "error"
       }
     }
   }

--- a/e2e/cases/bundler-chain/index.test.ts
+++ b/e2e/cases/bundler-chain/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/cache/index.test.ts
+++ b/e2e/cases/cache/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect } from '@playwright/test';
 import { build, webpackOnlyTest } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';

--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';

--- a/e2e/cases/cli/basic-rspack/index.rspack.test.ts
+++ b/e2e/cases/cli/basic-rspack/index.rspack.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/basic-webpack/index.webpack.test.ts
+++ b/e2e/cases/cli/basic-webpack/index.webpack.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { exec } from 'child_process';
+import path from 'node:path';
+import { exec } from 'node:child_process';
 import { test, expect } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { awaitFileExists } from '@e2e/helper';

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -1,7 +1,7 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 test('should allow to custom env prefix via loadEnv method', async () => {
   execSync('npx rsbuild build', {

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,6 +1,6 @@
 import { fse } from '@rsbuild/shared';
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '@e2e/helper';
 

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/load-env/index.test.ts
+++ b/e2e/cases/cli/load-env/index.test.ts
@@ -1,7 +1,7 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 const localFile = path.join(__dirname, '.env.local');
 const prodLocalFile = path.join(__dirname, '.env.production.local');

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect, test } from '@playwright/test';
 import { globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -1,7 +1,7 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
-import { execSync } from 'child_process';
+import { execSync } from 'node:child_process';
 
 test('should inject public env vars to client', async () => {
   execSync('npx rsbuild build', {

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { exec } from 'child_process';
+import path from 'node:path';
+import { exec } from 'node:child_process';
 import { test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { getRandomPort, awaitFileExists } from '@e2e/helper';

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { exec } from 'child_process';
+import path from 'node:path';
+import { exec } from 'node:child_process';
 import { test, expect } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { getRandomPort, awaitFileExists } from '@e2e/helper';

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { execSync } from 'child_process';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
 import { expect } from '@playwright/test';
 import { rspackOnlyTest, globContentJSON } from '../../../scripts/helper';
 

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';

--- a/e2e/cases/css/css-modules-ts-declaration/index.test.ts
+++ b/e2e/cases/css/css-modules-ts-declaration/index.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';

--- a/e2e/cases/css/less-npm-import/index.test.ts
+++ b/e2e/cases/css/less-npm-import/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';

--- a/e2e/cases/css/resolve-alias/rsbuild.config.ts
+++ b/e2e/cases/css/resolve-alias/rsbuild.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/e2e/cases/css/tailwindcss-mjs/postcss.config.mjs
+++ b/e2e/cases/css/tailwindcss-mjs/postcss.config.mjs
@@ -1,5 +1,5 @@
-import { fileURLToPath } from 'url';
-import { join, dirname } from 'path';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 

--- a/e2e/cases/css/tailwindcss-mjs/tailwind.config.mjs
+++ b/e2e/cases/css/tailwindcss-mjs/tailwind.config.mjs
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 
 /** @type {import('tailwindcss').Config} */
 export default {

--- a/e2e/cases/css/tailwindcss/postcss.config.cjs
+++ b/e2e/cases/css/tailwindcss/postcss.config.cjs
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 module.exports = {
   plugins: {

--- a/e2e/cases/css/tailwindcss/tailwind.config.cjs
+++ b/e2e/cases/css/tailwindcss/tailwind.config.cjs
@@ -1,4 +1,4 @@
-const path = require('path');
+const path = require('node:path');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {

--- a/e2e/cases/external-helpers/index.test.ts
+++ b/e2e/cases/external-helpers/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { build, providerType } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginSwc } from '@rsbuild/plugin-swc';

--- a/e2e/cases/html-tags/index.test.ts
+++ b/e2e/cases/html-tags/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/html/combined/html.test.ts
+++ b/e2e/cases/html/combined/html.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { build } from '@e2e/helper';

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, globContentJSON } from '@e2e/helper';
 

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -1,5 +1,5 @@
 import { fse } from '@rsbuild/shared';
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { pluginRem } from '@rsbuild/plugin-rem';

--- a/e2e/cases/html/mount-id/index.test.ts
+++ b/e2e/cases/html/mount-id/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { build, gotoPage } from '@e2e/helper';

--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { join } from 'path';
+import fs from 'node:fs';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/image-compress/index.test.ts
+++ b/e2e/cases/image-compress/index.test.ts
@@ -1,7 +1,7 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, globContentJSON } from '@e2e/helper';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 
 test('should compress image with use plugin-image-compress', async () => {
   await expect(

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 import type { BundlerChain } from '@rsbuild/shared';

--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
 import { createRsbuild } from '@e2e/helper';

--- a/e2e/cases/javascript-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/javascript-api/plugin-hooks/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { test, expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
 import { fse } from '@rsbuild/shared';

--- a/e2e/cases/javascript-api/plugin/index.test.ts
+++ b/e2e/cases/javascript-api/plugin/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect } from '@playwright/test';
 import { rspackOnlyTest, globContentJSON } from '../../../scripts/helper';
 import { createRsbuild } from '@rsbuild/core';

--- a/e2e/cases/live-reload/index.test.ts
+++ b/e2e/cases/live-reload/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 import { test, expect } from '@playwright/test';
 import { dev, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/mjs-artifact/index.test.ts
+++ b/e2e/cases/mjs-artifact/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { execSync } from 'child_process';
-import path from 'path';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
 
 // check for https://github.com/web-infra-dev/rsbuild/pull/809
 test('should import mjs artifact correctly', () => {

--- a/e2e/cases/node-polyfill/src/App.jsx
+++ b/e2e/cases/node-polyfill/src/App.jsx
@@ -1,6 +1,6 @@
+// biome-ignore lint: node polyfill only supports non-prefix usage
 import querystring from 'querystring';
 
-// eslint-disable-next-line node/prefer-global/buffer
 const bufferData = Buffer.from('xxxx');
 
 const qsRes = querystring.stringify({

--- a/e2e/cases/output/assets.test.ts
+++ b/e2e/cases/output/assets.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/output/output.test.ts
+++ b/e2e/cases/output/output.test.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from 'path';
+import { join, dirname } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { build } from '@e2e/helper';

--- a/e2e/cases/output/rem/tests/index.test.ts
+++ b/e2e/cases/output/rem/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev, build, globContentJSON } from '@e2e/helper';
 

--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/performance/performance.test.ts
+++ b/e2e/cases/performance/performance.test.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { join, resolve } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/performance/single-vendor/index.test.ts
+++ b/e2e/cases/performance/single-vendor/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { basename } from 'path';
+import { basename } from 'node:path';
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async () => {
   const rsbuild = await build({

--- a/e2e/cases/performance/split-by-module/index.test.ts
+++ b/e2e/cases/performance/split-by-module/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { basename } from 'path';
+import { basename } from 'node:path';
 
 test('should generate module chunks when chunkSplit is "split-by-module"', async () => {
   const rsbuild = await build({

--- a/e2e/cases/polyfill/browserslist/index.test.ts
+++ b/e2e/cases/polyfill/browserslist/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev, build, globContentJSON, gotoPage } from '@e2e/helper';
 import { getPolyfillContent } from '../helper';

--- a/e2e/cases/preview/index.test.ts
+++ b/e2e/cases/preview/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, getRandomPort, gotoPage } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/server/custom-server/scripts/pure-server.mjs
+++ b/e2e/cases/server/custom-server/scripts/pure-server.mjs
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { createRsbuild } from '@rsbuild/core';
 import polka from 'polka';

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { createRsbuild } from '@rsbuild/core';
 import polka from 'polka';

--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { expect, test } from '@playwright/test';
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev, build, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/server/htmlFallback.test.ts
+++ b/e2e/cases/server/htmlFallback.test.ts
@@ -1,7 +1,7 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev } from '@e2e/helper';
-import fs from 'fs';
+import fs from 'node:fs';
 
 const fixtures = __dirname;
 

--- a/e2e/cases/server/ipv6-host/index.test.ts
+++ b/e2e/cases/server/ipv6-host/index.test.ts
@@ -1,4 +1,4 @@
-import { URL } from 'url';
+import { URL } from 'node:url';
 import { expect, test } from '@playwright/test';
 import { dev } from '@e2e/helper';
 

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev } from '@e2e/helper';
 

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev, build } from '@e2e/helper';
 

--- a/e2e/cases/server/writeToDisk.test.ts
+++ b/e2e/cases/server/writeToDisk.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { dev, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/solid/hmr/index.test.ts
+++ b/e2e/cases/solid/hmr/index.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { test, expect } from '@playwright/test';
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 

--- a/e2e/cases/solid/index.test.ts
+++ b/e2e/cases/solid/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect } from '@playwright/test';
 import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 

--- a/e2e/cases/source/entry-description-object/index.test.ts
+++ b/e2e/cases/source/entry-description-object/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, globContentJSON } from '@e2e/helper';
 

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';

--- a/e2e/cases/source/source-exclude/index.test.ts
+++ b/e2e/cases/source/source-exclude/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';

--- a/e2e/cases/source/source-include/index.test.ts
+++ b/e2e/cases/source/source-include/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, proxyConsole } from '@e2e/helper';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import fs from 'fs';
+import path from 'node:path';
+import fs from 'node:fs';
 import { test, expect } from '@playwright/test';
 import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';

--- a/e2e/cases/svg/svg.test.ts
+++ b/e2e/cases/svg/svg.test.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { join } from 'path';
+import fs from 'node:fs';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';

--- a/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/svg/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-view-box/index.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build, gotoPage } from '@e2e/helper';
 

--- a/e2e/cases/web-worker/index.test.ts
+++ b/e2e/cases/web-worker/index.test.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,5 +1,5 @@
-import { platform } from 'os';
-import { join } from 'path';
+import { platform } from 'node:os';
+import { join } from 'node:path';
 import { test } from '@playwright/test';
 import { fse, type ConsoleType, castArray } from '@rsbuild/shared';
 import glob, {

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,7 +1,7 @@
-import net from 'net';
-import { URL } from 'url';
-import assert from 'assert';
-import { join } from 'path';
+import net from 'node:net';
+import { URL } from 'node:url';
+import assert from 'node:assert';
+import { join } from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { globContentJSON } from './helper';
 import { pluginSwc } from '@rsbuild/plugin-swc';

--- a/packages/babel-preset/src/pluginLockCorejsVersion.ts
+++ b/packages/babel-preset/src/pluginLockCorejsVersion.ts
@@ -1,4 +1,4 @@
-import nodePath from 'path';
+import nodePath from 'node:path';
 import * as t from '@babel/types';
 
 const REWRITE_TARGETS: Record<string, string> = {

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { deepmerge, getCoreJsVersion } from '@rsbuild/shared';
 import { generateBaseConfig } from './base';
 import type { BabelConfig, WebPresetOptions } from './types';

--- a/packages/compat/plugin-swc/src/constants.ts
+++ b/packages/compat/plugin-swc/src/constants.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 export const CORE_JS_PATH = require.resolve('core-js/package.json');
 export const SWC_HELPERS_PATH = require.resolve('@swc/helpers/package.json');

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { PLUGIN_SWC_NAME, PLUGIN_BABEL_NAME } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,

--- a/packages/compat/webpack/src/core/devMiddleware.ts
+++ b/packages/compat/webpack/src/core/devMiddleware.ts
@@ -5,7 +5,7 @@ import {
   isClientCompiler,
   type DevMiddleware,
 } from '@rsbuild/shared';
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 const applyHMREntry = (
   compiler: Compiler | MultiCompiler,

--- a/packages/compat/webpack/src/core/inspectConfig.ts
+++ b/packages/compat/webpack/src/core/inspectConfig.ts
@@ -1,4 +1,4 @@
-import { join, isAbsolute } from 'path';
+import { join, isAbsolute } from 'node:path';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import {
   setNodeEnv,

--- a/packages/compat/webpack/src/plugins/copy.ts
+++ b/packages/compat/webpack/src/plugins/copy.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import type { RsbuildPlugin, CopyPluginOptions } from '@rsbuild/shared';
 
 export const pluginCopy = (): RsbuildPlugin => ({

--- a/packages/compat/webpack/src/plugins/output.ts
+++ b/packages/compat/webpack/src/plugins/output.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path';
+import { posix } from 'node:path';
 import {
   getDistPath,
   getFilename,

--- a/packages/compat/webpack/src/plugins/server.ts
+++ b/packages/compat/webpack/src/plugins/server.ts
@@ -1,6 +1,6 @@
 import type { RsbuildPlugin } from '@rsbuild/shared';
-import fs from 'fs';
-import { join, isAbsolute } from 'path';
+import fs from 'node:fs';
+import { join, isAbsolute } from 'node:path';
 
 // For Rsbuild Server Config
 export const pluginServer = (): RsbuildPlugin => ({

--- a/packages/compat/webpack/src/progress/helpers/bus.ts
+++ b/packages/compat/webpack/src/progress/helpers/bus.ts
@@ -1,4 +1,4 @@
-import { Console } from 'console';
+import { Console } from 'node:console';
 import patchConsole from '../../../compiled/patch-console';
 import cliTruncate from '../../../compiled/cli-truncate';
 import type { Props } from './type';

--- a/packages/compat/webpack/src/progress/helpers/log.ts
+++ b/packages/compat/webpack/src/progress/helpers/log.ts
@@ -1,4 +1,4 @@
-import type { Writable } from 'stream';
+import type { Writable } from 'node:stream';
 import ansiEscapes from '../../../compiled/ansi-escapes';
 
 export interface LogUpdate {

--- a/packages/compat/webpack/src/shared.ts
+++ b/packages/compat/webpack/src/shared.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { join } from 'path';
+import fs from 'node:fs';
+import { join } from 'node:path';
 import {
   getSharedPkgCompiledPath,
   type SharedCompiledPkgNames,

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,5 +1,5 @@
-import { join } from 'path';
-import { existsSync } from 'fs';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
 import { color, isDev, logger } from '@rsbuild/shared';
 import { program, type Command } from '@rsbuild/shared/commander';
 import { loadEnv } from '../loadEnv';

--- a/packages/core/src/cli/config.ts
+++ b/packages/core/src/cli/config.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { isAbsolute, join } from 'path';
+import fs from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 import {
   color,
   logger,

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { join } from 'path';
+import fs from 'node:fs';
+import { join } from 'node:path';
 import { getNodeEnv, isFileSync } from '@rsbuild/shared';
 import { parse } from '../compiled/dotenv';
 import { expand } from '../compiled/dotenv-expand';

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import {
   getDistPath,
   getFilename,

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { TARGET_ID_MAP, getJsSourceMap, isUsingHMR } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-import { isAbsolute, join } from 'path';
+import crypto from 'node:crypto';
+import { isAbsolute, join } from 'node:path';
 import { fse } from '@rsbuild/shared';
 import {
   findExists,

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -2,7 +2,7 @@
  * modified from https://github.com/facebook/create-react-app
  * license at https://github.com/facebook/create-react-app/blob/master/LICENSE
  */
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { color, logger } from '@rsbuild/shared';
 import type {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,4 +1,4 @@
-import path, { isAbsolute } from 'path';
+import path, { isAbsolute } from 'node:path';
 import {
   fse,
   color,

--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -1,4 +1,4 @@
-import { join, dirname } from 'path';
+import { join, dirname } from 'node:path';
 import { fse, color, findUpSync, getDistPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -1,5 +1,5 @@
 import { fse } from '@rsbuild/shared';
-import { join, isAbsolute } from 'path';
+import { join, isAbsolute } from 'node:path';
 import type { RsbuildPlugin } from '../types';
 
 // For Rsbuild Server Config

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import {
   NODE_MODULES_REGEX,
   createDependenciesRegExp,

--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -1,7 +1,7 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import { debug, logger, castArray, type Routes } from '@rsbuild/shared';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
 import type { RsbuildPlugin } from '../types';
 
 const execAsync = promisify(exec);

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path';
+import { posix } from 'node:path';
 import { getDistPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/provider/config.ts
+++ b/packages/core/src/provider/config.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 
 import {
   findExists,

--- a/packages/core/src/provider/core/createContext.ts
+++ b/packages/core/src/provider/core/createContext.ts
@@ -1,4 +1,4 @@
-import { join, isAbsolute } from 'path';
+import { join, isAbsolute } from 'node:path';
 import {
   logger,
   getDistPath,

--- a/packages/core/src/provider/core/inspectConfig.ts
+++ b/packages/core/src/provider/core/inspectConfig.ts
@@ -1,4 +1,4 @@
-import { join, isAbsolute } from 'path';
+import { join, isAbsolute } from 'node:path';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import {
   setNodeEnv,

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import {
   logger,
   getBrowserslistWithDefault,

--- a/packages/core/src/provider/plugins/output.ts
+++ b/packages/core/src/provider/plugins/output.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path';
+import { posix } from 'node:path';
 import { getDistPath, getFilename, applyOutputPlugin } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../../types';
 

--- a/packages/core/src/provider/plugins/rspackProfile.ts
+++ b/packages/core/src/provider/plugins/rspackProfile.ts
@@ -1,6 +1,6 @@
 import type { RsbuildPlugin } from '../../types';
-import path from 'path';
-import inspector from 'inspector';
+import path from 'node:path';
+import inspector from 'node:inspector';
 import { fse } from '@rsbuild/shared';
 import { logger } from '@rsbuild/shared';
 

--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -12,7 +12,7 @@ import {
   type RsbuildTarget,
   type BuiltinSwcLoaderOptions,
 } from '@rsbuild/shared';
-import path from 'path';
+import path from 'node:path';
 import type {
   RsbuildPlugin,
   NormalizedConfig,

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import {
   color,
   getSharedPkgCompiledPath,

--- a/packages/core/src/rspack/HtmlAppIconPlugin.ts
+++ b/packages/core/src/rspack/HtmlAppIconPlugin.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import { posix, basename } from 'path';
+import fs from 'node:fs';
+import { posix, basename } from 'node:path';
 import type { Compiler, Compilation } from '@rspack/core';
 import WebpackSources from '@rsbuild/shared/webpack-sources';
 import { withPublicPath, getPublicPathFromCompiler } from '@rsbuild/shared';

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/InlineChunkHtmlPlugin.js
  */
-import { join } from 'path';
+import { join } from 'node:path';
 import {
   isFunction,
   addTrailingSlash,

--- a/packages/core/src/rspack/preload/helpers/determineAsValue.ts
+++ b/packages/core/src/rspack/preload/helpers/determineAsValue.ts
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-import path from 'path';
-import { URL } from 'url';
+import path from 'node:path';
+import { URL } from 'node:url';
 import type { As } from './type';
 
 export function determineAsValue({

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import type { Socket } from 'net';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
 import type {
   DevMiddlewaresConfig,
   DevMiddlewareAPI,

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,4 +1,4 @@
-import url from 'url';
+import url from 'node:url';
 import type {
   ServerAPIs,
   Middlewares,
@@ -11,7 +11,7 @@ import {
   faviconFallbackMiddleware,
   getHtmlFallbackMiddleware,
 } from './middlewares';
-import { join, isAbsolute } from 'path';
+import { join, isAbsolute } from 'node:path';
 
 export type RsbuildDevMiddlewareOptions = {
   pwd: string;

--- a/packages/core/src/server/httpServer.ts
+++ b/packages/core/src/server/httpServer.ts
@@ -6,10 +6,10 @@ export const createHttpServer = async (options: {
   middlewares: connect.Server;
 }) => {
   if (options.https) {
-    const { createServer } = await import('https');
+    const { createServer } = await import('node:https');
     return createServer(options.https, options.middlewares);
   }
 
-  const { createServer } = await import('http');
+  const { createServer } = await import('node:http');
   return createServer(options.middlewares);
 };

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -5,9 +5,9 @@ import {
   type HtmlFallback,
   type RequestHandler as Middleware,
 } from '@rsbuild/shared';
-import { parse } from 'url';
-import path from 'path';
-import fs from 'fs';
+import { parse } from 'node:url';
+import path from 'node:path';
+import fs from 'node:fs';
 
 export const faviconFallbackMiddleware: Middleware = (req, res, next) => {
   if (req.url === '/favicon.ico') {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,6 +1,6 @@
-import type { Server } from 'http';
+import type { Server } from 'node:http';
 import connect from '@rsbuild/shared/connect';
-import { join } from 'path';
+import { join } from 'node:path';
 import sirv from '../../compiled/sirv';
 import {
   getNodeEnv,

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { color, logger } from '@rsbuild/shared';
 import { init } from '../cli/commands';
 

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage } from 'http';
-import type { Socket } from 'net';
+import type { IncomingMessage } from 'node:http';
+import type { Socket } from 'node:net';
 import ws from '../../compiled/ws';
 import { logger, type Stats, type DevMiddlewaresConfig } from '@rsbuild/shared';
 

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { logger } from 'rslog';
 import { text, select, isCancel, cancel, note, outro } from '@clack/prompts';
 

--- a/packages/document/docs/en/config/html/app-icon.mdx
+++ b/packages/document/docs/en/config/html/app-icon.mdx
@@ -22,7 +22,7 @@ export default {
 Set to an absolute path:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {

--- a/packages/document/docs/en/config/html/favicon.mdx
+++ b/packages/document/docs/en/config/html/favicon.mdx
@@ -26,7 +26,7 @@ export default {
 Set to an absolute path:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {
@@ -38,7 +38,7 @@ export default {
 Set to a URL:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {

--- a/packages/document/docs/en/config/server/https.mdx
+++ b/packages/document/docs/en/config/server/https.mdx
@@ -26,7 +26,7 @@ You can manually pass in the certificate and the private key required in the `se
 For details, please refer to [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener).
 
 ```ts
-import fs from 'fs';
+import fs from 'node:fs';
 
 export default {
   server: {

--- a/packages/document/docs/en/config/source/alias.mdx
+++ b/packages/document/docs/en/config/source/alias.mdx
@@ -63,7 +63,7 @@ export default {
 By default, `source.alias` will automatically match sub-paths, for example, with the following configuration:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -84,7 +84,7 @@ import b from '@common/util'; // resolved to `./src/common/util`
 You can add the `$` symbol to enable exact matching, which will not automatically match sub-paths.
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -109,7 +109,7 @@ You can use `alias` to resolve an npm package to a specific directory.
 For example, if multiple versions of the `react` are installed in the project, you can alias `react` to the version installed in the root `node_modules` directory to avoid bundling multiple copies of the React code.
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/en/config/source/exclude.mdx
+++ b/packages/document/docs/en/config/source/exclude.mdx
@@ -8,7 +8,7 @@ Specifies JavaScript/TypeScript files that do not need to be compiled. The usage
 For example:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/en/config/source/include.mdx
+++ b/packages/document/docs/en/config/source/include.mdx
@@ -21,7 +21,7 @@ Through the `source.include` config, you can specify directories or modules that
 For example:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -37,7 +37,7 @@ A typical usage scenario is to compile npm packages under node_modules, because 
 Take `query-string` as an example, you can add the following config:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -83,7 +83,7 @@ export default {
 When developing in Monorepo, if you need to refer to the source code of other libraries in Monorepo, you can add the corresponding library to `source.include`:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/en/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/en/guide/advanced/browser-compatibility.md
@@ -141,7 +141,7 @@ When you find that a third-party dependencies causes compatibility issues, you c
 Taking the npm package `query-string` as an example, you can add the following config:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -159,7 +159,7 @@ When you import the code out of the current project, if the code has not been co
 For example, if you need to reference a module under the `packages` directory in the monorepo, you can add the following config:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/zh/config/html/app-icon.mdx
+++ b/packages/document/docs/zh/config/html/app-icon.mdx
@@ -22,7 +22,7 @@ export default {
 设置为绝对路径：
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {

--- a/packages/document/docs/zh/config/html/favicon.mdx
+++ b/packages/document/docs/zh/config/html/favicon.mdx
@@ -26,7 +26,7 @@ export default {
 设置为绝对路径：
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {
@@ -38,7 +38,7 @@ export default {
 设置为 URL：
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   html: {

--- a/packages/document/docs/zh/config/server/https.mdx
+++ b/packages/document/docs/zh/config/server/https.mdx
@@ -26,7 +26,7 @@
 具体可以参考 [https.createServer](https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener)。
 
 ```ts
-import fs from 'fs';
+import fs from 'node:fs';
 
 export default {
   server: {

--- a/packages/document/docs/zh/config/source/alias.mdx
+++ b/packages/document/docs/zh/config/source/alias.mdx
@@ -63,7 +63,7 @@ export default {
 默认情况，`source.alias` 会自动匹配子路径，比如以下配置：
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -84,7 +84,7 @@ import b from '@common/util'; // 解析为 `./src/common/util`
 你可以添加 `$` 符号来开启精确匹配，开启后将不会自动匹配子路径。
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -109,7 +109,7 @@ import b from '@common/util'; // 保持 `@common/util` 不变
 比如项目中安装了多份 `react`，你可以将 `react` 统一指向根目录的 `node_modules` 中安装的版本，避免出现打包多份 React 代码的问题。
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/zh/config/source/exclude.mdx
+++ b/packages/document/docs/zh/config/source/exclude.mdx
@@ -8,7 +8,7 @@
 比如:
 
 ```js
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/zh/config/source/include.mdx
+++ b/packages/document/docs/zh/config/source/include.mdx
@@ -21,7 +21,7 @@ const defaultInclude = [
 比如:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -37,7 +37,7 @@ export default {
 以 `query-string` 为例，你可以做如下的配置：
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -83,7 +83,7 @@ export default {
 在 Monorepo 中进行开发时，如果需要引用 Monorepo 中其他库的 JavaScript 代码，也可以直接在 `source.include` 进行配置:
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/docs/zh/guide/advanced/browser-compatibility.md
+++ b/packages/document/docs/zh/guide/advanced/browser-compatibility.md
@@ -141,7 +141,7 @@ if (!String.prototype.replaceAll) {
 以 `query-string` 这个 npm 包为例，你可以做如下的配置：
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {
@@ -159,7 +159,7 @@ export default {
 比如，你需要引用 monorepo 中 `packages` 目录下的某个模块，可以添加如下的配置：
 
 ```ts
-import path from 'path';
+import path from 'node:path';
 
 export default {
   source: {

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'rspress/config';
 import { rsbuildPluginOverview } from './src/rsbuildPluginOverview';
 

--- a/packages/document/src/rsbuildPluginOverview.ts
+++ b/packages/document/src/rsbuildPluginOverview.ts
@@ -1,6 +1,6 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import glob from 'fast-glob';
-import path from 'path';
+import path from 'node:path';
 import type { Group } from './components/Overview';
 
 const camelCase = (input: string): string =>

--- a/packages/monorepo-utils/src/common/getBaseData.ts
+++ b/packages/monorepo-utils/src/common/getBaseData.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { MonorepoAnalyzer } from '../types';
 import { isMonorepo, type IsMonorepoFn } from './isMonorepo';
 import type { GetProjectsFunc } from './getProjects';

--- a/packages/monorepo-utils/src/common/isMonorepo.ts
+++ b/packages/monorepo-utils/src/common/isMonorepo.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { PNPM_WORKSPACE_FILE, RUSH_JSON_FILE } from '../constants';
 

--- a/packages/monorepo-utils/src/common/pnpm.ts
+++ b/packages/monorepo-utils/src/common/pnpm.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { parse } from '@rsbuild/shared/yaml';
 import glob, { type Options as GlobOptions } from 'fast-glob';

--- a/packages/monorepo-utils/src/common/rush.ts
+++ b/packages/monorepo-utils/src/common/rush.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { Project } from '../project/project';
 import { readRushJson } from '../utils';
 
@@ -6,7 +6,7 @@ export const getProjects = async (monorepoRoot: string): Promise<Project[]> => {
   const rushConfiguration = await readRushJson(monorepoRoot);
   const { projects = [] } = rushConfiguration;
   return Promise.all(
-    projects.map(async p => {
+    projects.map(async (p) => {
       const project = new Project(
         p.packageName,
         path.join(monorepoRoot, p.projectFolder),

--- a/packages/monorepo-utils/src/project-utils/getDependentProjects.ts
+++ b/packages/monorepo-utils/src/project-utils/getDependentProjects.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import { getMonorepoBaseData, getMonorepoSubProjects } from '../common';
 import type { Project } from '../project/project';

--- a/packages/monorepo-utils/src/project/project.ts
+++ b/packages/monorepo-utils/src/project/project.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { INodePackageJson, ExportsConfig } from '../types/packageJson';
 import { readPackageJson } from '../utils';
 import { PACKAGE_JSON } from '../constants';
@@ -48,7 +48,7 @@ export class Project {
     computedSet.add(this.name);
 
     const queue = this.getDirectDependentProjects(allProjectMap).filter(
-      p => !computedSet.has(p.name),
+      (p) => !computedSet.has(p.name),
     );
     const result = [];
 
@@ -159,7 +159,7 @@ export class Project {
       }
     }
 
-    return Array.from(commonRootPathsSet).map(p => path.join(this.dir, p));
+    return Array.from(commonRootPathsSet).map((p) => path.join(this.dir, p));
   }
 
   #getRootPath(p: string) {

--- a/packages/monorepo-utils/src/utils.ts
+++ b/packages/monorepo-utils/src/utils.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import json5 from '@rsbuild/shared/json5';
 import { RUSH_JSON_FILE } from './constants';

--- a/packages/plugin-assets-retry/scripts/postCompile.js
+++ b/packages/plugin-assets-retry/scripts/postCompile.js
@@ -1,7 +1,7 @@
-const path = require('path');
-const { readFile, writeFile } = require('fs/promises');
+const path = require('node:path');
+const { readFile, writeFile } = require('node:fs/promises');
 const { transformAsync } = require('@babel/core');
-const { performance } = require('perf_hooks');
+const { performance } = require('node:perf_hooks');
 
 async function compileRetryRuntime() {
   const { minify } = await import('terser');

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import WebpackSources from '@rsbuild/shared/webpack-sources';
 import {
   fse,

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -1,4 +1,4 @@
-import { isAbsolute, normalize, sep } from 'path';
+import { isAbsolute, normalize, sep } from 'node:path';
 import {
   castArray,
   mergeChainedOptions,

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import { castArray, cloneDeep, SCRIPT_REGEX, isProd } from '@rsbuild/shared';
 import { applyUserBabelConfig, BABEL_JS_RULE } from './helper';

--- a/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
+++ b/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { parse } from 'acorn';
 import {
   printErrors,

--- a/packages/plugin-image-compress/src/index.ts
+++ b/packages/plugin-image-compress/src/index.ts
@@ -1,5 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import assert from 'assert';
+import assert from 'node:assert';
 import { ImageMinimizerPlugin } from './minimizer';
 import { withDefaultOptions } from './shared/utils';
 import type { Codecs, Options } from './types';

--- a/packages/plugin-image-compress/src/minimizer.ts
+++ b/packages/plugin-image-compress/src/minimizer.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 import type { webpack } from '@rsbuild/webpack';
 import Codecs from './shared/codecs';
 import type { FinalOptions } from './types';

--- a/packages/plugin-image-compress/src/shared/codecs.ts
+++ b/packages/plugin-image-compress/src/shared/codecs.ts
@@ -1,4 +1,4 @@
-import { Buffer } from 'buffer';
+import { Buffer } from 'node:buffer';
 import {
   compressJpeg,
   losslessCompressPng,

--- a/packages/plugin-image-compress/src/shared/utils.ts
+++ b/packages/plugin-image-compress/src/shared/utils.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 import type { FinalOptions, Options } from '../types';
 import codecs from './codecs';
 

--- a/packages/plugin-image-compress/src/types/index.ts
+++ b/packages/plugin-image-compress/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { Buffer } from 'buffer';
+import type { Buffer } from 'node:buffer';
 import type {
   JpegCompressOptions,
   PNGLosslessOptions,

--- a/packages/plugin-image-compress/tests/shared/codecs.test.ts
+++ b/packages/plugin-image-compress/tests/shared/codecs.test.ts
@@ -1,5 +1,5 @@
-import assert from 'assert';
-import path from 'path';
+import assert from 'node:assert';
+import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import codecs from '../../src/shared/codecs';
 

--- a/packages/plugin-image-compress/vitest.config.ts
+++ b/packages/plugin-image-compress/vitest.config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 const config = defineConfig({

--- a/packages/plugin-pug/src/index.ts
+++ b/packages/plugin-pug/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { mergeChainedOptions } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { Options as PugOptions } from 'pug';

--- a/packages/plugin-react/src/utils.ts
+++ b/packages/plugin-react/src/utils.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'node:fs';
 import semver from '@rsbuild/shared/semver';
 import { findUp } from '@rsbuild/shared';
 

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { logger } from '@rsbuild/core';
 import {
   isProd,

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { setConfig, TS_CONFIG_FILE } from '@rsbuild/shared';
 import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import {

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { logger } from '@rsbuild/core';
 import { deepmerge } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '@rsbuild/core';

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import {
   JS_REGEX,
   TS_REGEX,

--- a/packages/plugin-svgr/src/loader.ts
+++ b/packages/plugin-svgr/src/loader.ts
@@ -6,9 +6,9 @@
  * modified from https://github.com/gregberge/svgr/blob/7595d378b73d4826a4cead165b3f32386b07315b/packages/webpack/src/index.ts
  */
 
-import { callbackify } from 'util';
+import { callbackify } from 'node:util';
 import { transform, type Config, type State } from '@svgr/core';
-import { normalize } from 'path';
+import { normalize } from 'node:path';
 import svgo from '@svgr/plugin-svgo';
 import jsx from '@svgr/plugin-jsx';
 import type { Rspack } from '@rsbuild/core';

--- a/packages/plugin-toml/src/index.ts
+++ b/packages/plugin-toml/src/index.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginToml = (): RsbuildPlugin => ({

--- a/packages/plugin-yaml/src/index.ts
+++ b/packages/plugin-yaml/src/index.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginYaml = (): RsbuildPlugin => ({

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -1,4 +1,4 @@
-import { posix } from 'path';
+import { posix } from 'node:path';
 import { getDistPath, getFilename } from './fs';
 import { addTrailingSlash, isPlainObject } from './utils';
 import { castArray, ensureAbsolutePath } from './utils';

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -30,7 +30,7 @@ import type {
   NormalizedConfig,
 } from './types';
 import { logger } from './logger';
-import { join } from 'path';
+import { join } from 'node:path';
 import type { minify } from 'terser';
 import fse from '../compiled/fs-extra';
 import { pick, color, upperFirst } from './utils';

--- a/packages/shared/src/fs.ts
+++ b/packages/shared/src/fs.ts
@@ -1,6 +1,6 @@
-import path from 'path';
+import path from 'node:path';
 import fse from '../compiled/fs-extra';
-import { promises, constants, statSync } from 'fs';
+import { promises, constants, statSync } from 'node:fs';
 import type {
   RsbuildConfig,
   DistPathConfig,

--- a/packages/shared/src/loaders/cssModulesTypescriptLoader.ts
+++ b/packages/shared/src/loaders/cssModulesTypescriptLoader.ts
@@ -10,8 +10,8 @@
  * https://github.com/seek-oss/css-modules-typescript-loader/blob/master/LICENSE
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import LineDiff from '../../compiled/line-diff';
 import type { LoaderContext } from '@rspack/core';
 import { isCssModules, type CssLoaderModules, isInNodeModules } from '../css';

--- a/packages/shared/src/patch.ts
+++ b/packages/shared/src/patch.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { pathToFileURL } from 'url';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { CompilerTapFn } from './types';
 
 const GLOBAL_PATCHED_SYMBOL: unique symbol = Symbol('GLOBAL_PATCHED_SYMBOL');

--- a/packages/shared/src/port.ts
+++ b/packages/shared/src/port.ts
@@ -1,4 +1,4 @@
-import net from 'net';
+import net from 'node:net';
 import { color } from './utils';
 import { logger } from './logger';
 

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -1,5 +1,5 @@
 import type { ArrayOrNot } from '../utils';
-import type { IncomingMessage, ServerResponse } from 'http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 export type ProgressBarConfig = {
   id?: string;

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import type { ServerOptions as HttpsServerOptions } from 'https';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ServerOptions as HttpsServerOptions } from 'node:https';
 import type {
   Options as BaseProxyOptions,
   Filter as ProxyFilter,

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,5 +1,5 @@
-import type { IncomingMessage, ServerResponse } from 'http';
-import type { Socket } from 'net';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
 import type {
   DevConfig,
   NextFunction,

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,7 +1,7 @@
-import os from 'os';
-import { URL } from 'url';
-import { posix } from 'path';
-import { isIPv6 } from 'net';
+import os from 'node:os';
+import { URL } from 'node:url';
+import { posix } from 'node:path';
+import { isIPv6 } from 'node:net';
 import { DEFAULT_DEV_HOST } from './constants';
 
 // remove repeat '/'

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import type { Compiler } from '@rspack/core';
 import type {
   NodeEnv,

--- a/scripts/check-changeset/src/index.ts
+++ b/scripts/check-changeset/src/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import readChangesets from '@changesets/read';
 import { getPackages, type Package } from '@manypkg/get-packages';
 

--- a/scripts/prebundle/src/constant.ts
+++ b/scripts/prebundle/src/constant.ts
@@ -1,4 +1,4 @@
-import path, { join } from 'path';
+import path, { join } from 'node:path';
 import type { ParsedTask, TaskConfig } from './types';
 import fs, { copySync } from 'fs-extra';
 import { replaceFileContent } from './helper';

--- a/scripts/prebundle/src/helper.ts
+++ b/scripts/prebundle/src/helper.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'path';
+import { dirname, join } from 'node:path';
 import fs from 'fs-extra';
 import { TASKS, DIST_DIR, PACKAGES_DIR } from './constant';
 import type { ParsedTask } from './types';

--- a/scripts/prebundle/src/prebundle.ts
+++ b/scripts/prebundle/src/prebundle.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join } from 'node:path';
 import ncc from '@vercel/ncc';
 import { Package as DtsPacker } from 'dts-packer';
 import fs from 'fs-extra';

--- a/scripts/skipCI.js
+++ b/scripts/skipCI.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process');
+const { execSync } = require('node:child_process');
 
 const SKIP_FOLDERS = [
   'cspell.json',

--- a/scripts/test-helper/src/path.ts
+++ b/scripts/test-helper/src/path.ts
@@ -1,6 +1,6 @@
-import path from 'path';
-import os from 'os';
-import fs from 'fs';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs';
 import _ from 'lodash';
 import upath from 'upath';
 

--- a/scripts/test-helper/src/pathSerializer.ts
+++ b/scripts/test-helper/src/pathSerializer.ts
@@ -1,4 +1,4 @@
-import os from 'os';
+import os from 'node:os';
 import _ from 'lodash';
 import {
   splitPathString,

--- a/scripts/test-helper/vitest.setup.ts
+++ b/scripts/test-helper/vitest.setup.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 import { expect, beforeAll } from 'vitest';
 import { createSnapshotSerializer } from './dist';
 

--- a/scripts/update-packages/src/modern.ts
+++ b/scripts/update-packages/src/modern.ts
@@ -1,7 +1,7 @@
 /**
  * In this script, we will find all the Modern.js dependencies and update the version.
  */
-import path from 'path';
+import path from 'node:path';
 import fs from 'fs-extra';
 import { getPackages } from '@manypkg/get-packages';
 import { getPackageVersion } from './utils';

--- a/scripts/update-packages/src/rspack.ts
+++ b/scripts/update-packages/src/rspack.ts
@@ -1,7 +1,7 @@
 /**
  * In this script, we will find all the Rspack dependencies and update the version.
  */
-import path from 'path';
+import path from 'node:path';
 import fs from 'fs-extra';
 import { getPackages } from '@manypkg/get-packages';
 import { getPackageVersion } from './utils';

--- a/scripts/update-packages/src/rspress.ts
+++ b/scripts/update-packages/src/rspress.ts
@@ -1,7 +1,7 @@
 /**
  * In this script, we will find all the rspress dependencies and update the version.
  */
-import path from 'path';
+import path from 'node:path';
 import fs from 'fs-extra';
 import { getPackageVersion } from './utils';
 

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,5 +1,5 @@
 import { defineWorkspace } from 'vitest/config';
-import { Console } from 'console';
+import { Console } from 'node:console';
 
 // Disable color in test
 process.env.NO_COLOR = '1';


### PR DESCRIPTION
## Summary

Enable biome useNodejsImportProtocol rule, we prefer using `node:path` instead of `path`.

## Related Links

https://biomejs.dev/linter/rules/use-nodejs-import-protocol/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
