### PR TITLE
fix(plugin-source-build): skip references for JS project

### DIFF
--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { setConfig, TS_CONFIG_FILE } from '@rsbuild/shared';
+import { TS_CONFIG_FILE } from '@rsbuild/shared';
 import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
 import {
   filterByField,
@@ -107,7 +107,16 @@ export function pluginSourceBuild(
 
       if (api.context.bundlerType === 'rspack') {
         api.modifyRspackConfig((config) => {
-          setConfig(config, 'resolve.tsConfig.references', getReferences());
+          if (!api.context.tsconfigPath) {
+            return;
+          }
+
+          config.resolve ||= {};
+          config.resolve.tsConfig = {
+            ...config.resolve.tsConfig,
+            configFile: api.context.tsconfigPath,
+            references: getReferences(),
+          };
         });
       } else {
         api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
@@ -44,6 +44,7 @@ exports[`plugin-source-build > should allow to set resolve priority 1`] = `
   },
   "resolve": {
     "tsConfig": {
+      "configFile": "<ROOT>/packages/plugin-source-build/tests/tsconfig.json",
       "references": [],
     },
   },


### PR DESCRIPTION
## Summary

Skip TypeScript references config for JS project.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
