### PR TITLE
chore(shared): remove setConfig helper

### DIFF
--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -6,7 +6,6 @@ import {
   CSS_REGEX,
   CSS_MODULES_REGEX,
   getCssLoaderOptions,
-  setConfig,
   getPostcssLoaderOptions,
   getCssModuleLocalIdentName,
   resolvePackage,
@@ -227,7 +226,8 @@ export const pluginCss = (): RsbuildPlugin => {
           const config = api.getNormalizedConfig();
 
           if (!enableNativeCss(config)) {
-            setConfig(rspackConfig, 'experiments.css', false);
+            rspackConfig.experiments ||= {};
+            rspackConfig.experiments.css = false;
             return;
           }
 
@@ -244,11 +244,13 @@ export const pluginCss = (): RsbuildPlugin => {
           }
 
           // need use type: "css/module" rule instead of modules.auto config
-          setConfig(rspackConfig, 'builtins.css.modules', {
+          rspackConfig.builtins ||= {};
+          rspackConfig.builtins.css ||= {};
+          rspackConfig.builtins.css.modules = {
             localsConvention: config.output.cssModules.exportLocalsConvention,
             localIdentName,
             exportsOnly: isServer || isWebWorker,
-          });
+          };
 
           const rules = rspackConfig.module?.rules;
 

--- a/packages/core/src/provider/plugins/resolve.ts
+++ b/packages/core/src/provider/plugins/resolve.ts
@@ -1,5 +1,5 @@
 import type { RsbuildPlugin } from '../../types';
-import { setConfig, applyResolvePlugin } from '@rsbuild/shared';
+import { applyResolvePlugin } from '@rsbuild/shared';
 
 export const pluginResolve = (): RsbuildPlugin => ({
   name: 'rsbuild:resolve',
@@ -11,12 +11,10 @@ export const pluginResolve = (): RsbuildPlugin => ({
       const isTsProject = Boolean(api.context.tsconfigPath);
       const config = api.getNormalizedConfig();
 
+      rspackConfig.resolve ||= {};
+
       if (isTsProject && config.source.aliasStrategy === 'prefer-tsconfig') {
-        setConfig(
-          rspackConfig,
-          'resolve.tsConfigPath',
-          api.context.tsconfigPath,
-        );
+        rspackConfig.resolve.tsConfigPath = api.context.tsconfigPath;
       }
 
       if (isServer) {
@@ -24,8 +22,7 @@ export const pluginResolve = (): RsbuildPlugin => ({
         // When targe = node, we no need to specify conditionsNames.
         // We guess the webpack would auto specify reference to target.
         // Rspack has't the action, so we need manually specify.
-        const nodeConditionNames = ['require', 'node'];
-        setConfig(rspackConfig, 'resolve.conditionNames', nodeConditionNames);
+        rspackConfig.resolve.conditionNames = ['require', 'node'];
       }
     });
   },

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -35,7 +35,6 @@ import type { minify } from 'terser';
 import fse from '../compiled/fs-extra';
 import { pick, color, upperFirst } from './utils';
 
-import _ from 'lodash';
 import { DEFAULT_DEV_HOST } from './constants';
 import { getTerserMinifyOptions } from './minimize';
 
@@ -219,14 +218,6 @@ export type GetTypeByPath<
   : T extends `${infer K}.${infer P}`
   ? GetTypeByPath<P, K extends '' ? C : NonNullable<C[K]>>
   : C[T];
-
-export const setConfig = <T extends Record<string, any>, P extends string>(
-  config: T,
-  path: P,
-  value: GetTypeByPath<P, T>,
-) => {
-  _.set(config, path, value);
-};
 
 type MinifyOptions = NonNullable<Parameters<typeof minify>[1]>;
 


### PR DESCRIPTION
## Summary

Remove setConfig helper:

- To remove `lodash` dependency.
- To keep type friendly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
