### PR TITLE
perf: improve mergeRsbuildConfig performance

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -2,6 +2,7 @@ import path, { isAbsolute } from 'node:path';
 import {
   fse,
   color,
+  isNil,
   isURL,
   castArray,
   getMinify,
@@ -11,7 +12,6 @@ import {
   isHtmlDisabled,
   removeTailSlash,
   mergeChainedOptions,
-  isNil,
 } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
 import type {

--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -1,62 +1,52 @@
-import { castArray, isFunction, isObject, cloneDeep } from './utils';
+import { castArray, isFunction, isPlainObject } from './utils';
 import type { RsbuildConfig } from './types/config';
+
+const OVERRIDE_PATH = [
+  'performance.removeConsole',
+  'output.inlineScripts',
+  'output.inlineStyles',
+  'output.cssModules.auto',
+  'output.targets',
+  'server.printUrls',
+  'dev.startUrl',
+];
 
 /**
  * When merging configs, some properties prefer `override` over `merge to array`
  */
-const isOverriddenConfigKey = (key: string) =>
-  [
-    'performance.removeConsole',
-    'output.inlineScripts',
-    'output.inlineStyles',
-    'output.cssModules.auto',
-    'output.targets',
-    'server.printUrls',
-    'dev.startUrl',
-  ].includes(key);
-
-function isMergeableObject(value: unknown): value is Record<string, unknown> {
-  if (!isObject(value)) {
-    return false;
-  }
-  const type = Object.prototype.toString.call(value);
-  return type !== '[object RegExp]' && type !== '[object Date]';
-}
-
-const clone = (value: unknown) =>
-  isMergeableObject(value) ? cloneDeep(value) : value;
+const isOverridePath = (key: string) => OVERRIDE_PATH.includes(key);
 
 const merge = (x: unknown, y: unknown, path = '') => {
   // force some keys to override
-  if (isOverriddenConfigKey(path)) {
-    return clone(y ?? x);
+  if (isOverridePath(path)) {
+    return y ?? x;
   }
 
   // ignore undefined property
   if (x === undefined) {
-    return clone(y);
+    return y;
   }
   if (y === undefined) {
-    return clone(x);
+    return x;
   }
 
   const pair = [x, y];
 
   // combine array
   if (pair.some(Array.isArray)) {
-    return [...castArray(clone(x)), ...castArray(clone(y))];
+    return [...castArray(x), ...castArray(y)];
   }
 
   // convert function to chained function
   if (pair.some(isFunction)) {
-    return [clone(x), clone(y)];
+    return pair;
   }
 
-  if (!isMergeableObject(x) || !isMergeableObject(y)) {
+  if (!isPlainObject(x) || !isPlainObject(y)) {
     return y;
   }
 
-  const merged: Record<string, any> = {};
+  const merged: Record<string, unknown> = {};
   const keys = new Set([...Object.keys(x), ...Object.keys(y)]);
 
   keys.forEach((key) => {
@@ -70,12 +60,12 @@ const merge = (x: unknown, y: unknown, path = '') => {
 export const mergeRsbuildConfig = (
   ...configs: RsbuildConfig[]
 ): RsbuildConfig => {
-  if (configs.length < 2) {
-    return configs[0];
-  }
-
   if (configs.length === 2) {
     return merge(configs[0], configs[1]) as RsbuildConfig;
+  }
+
+  if (configs.length < 2) {
+    return configs[0];
   }
 
   return configs.reduce(

--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -1,54 +1,85 @@
-import _ from 'lodash';
-import { castArray, isFunction, isUndefined } from './utils';
+import { castArray, isFunction, isObject, cloneDeep } from './utils';
 import type { RsbuildConfig } from './types/config';
 
 /**
- * When merging config, some properties prefer `override` rather than `merge to array`
+ * When merging configs, some properties prefer `override` over `merge to array`
  */
-export const isOverriddenConfigKey = (key: string) =>
+const isOverriddenConfigKey = (key: string) =>
   [
-    // performance.removeConsole
-    'removeConsole',
-    // output.inlineScripts
-    'inlineScripts',
-    // output.inlineStyles
-    'inlineStyles',
-    // cssModules.auto
-    'auto',
-    // output.targets
-    'targets',
-    // server.printUrls
-    'printUrls',
-    // dev.startUrl
-    'startUrl',
+    'performance.removeConsole',
+    'output.inlineScripts',
+    'output.inlineStyles',
+    'output.cssModules.auto',
+    'output.targets',
+    'server.printUrls',
+    'dev.startUrl',
   ].includes(key);
+
+function isMergeableObject(value: unknown): value is Record<string, unknown> {
+  if (!isObject(value)) {
+    return false;
+  }
+  const type = Object.prototype.toString.call(value);
+  return type !== '[object RegExp]' && type !== '[object Date]';
+}
+
+const clone = (value: unknown) =>
+  isMergeableObject(value) ? cloneDeep(value) : value;
+
+const merge = (x: unknown, y: unknown, path = '') => {
+  // force some keys to override
+  if (isOverriddenConfigKey(path)) {
+    return clone(y ?? x);
+  }
+
+  // ignore undefined property
+  if (x === undefined) {
+    return clone(y);
+  }
+  if (y === undefined) {
+    return clone(x);
+  }
+
+  const pair = [x, y];
+
+  // combine array
+  if (pair.some(Array.isArray)) {
+    return [...castArray(clone(x)), ...castArray(clone(y))];
+  }
+
+  // convert function to chained function
+  if (pair.some(isFunction)) {
+    return [clone(x), clone(y)];
+  }
+
+  if (!isMergeableObject(x) || !isMergeableObject(y)) {
+    return y;
+  }
+
+  const merged: Record<string, any> = {};
+  const keys = new Set([...Object.keys(x), ...Object.keys(y)]);
+
+  keys.forEach((key) => {
+    const childPath = path ? `${path}.${key}` : key;
+    merged[key] = merge(x[key], y[key], childPath);
+  });
+
+  return merged;
+};
 
 export const mergeRsbuildConfig = (
   ...configs: RsbuildConfig[]
-): RsbuildConfig =>
-  _.mergeWith(
+): RsbuildConfig => {
+  if (configs.length < 2) {
+    return configs[0];
+  }
+
+  if (configs.length === 2) {
+    return merge(configs[0], configs[1]) as RsbuildConfig;
+  }
+
+  return configs.reduce(
+    (result, config) => merge(result, config) as RsbuildConfig,
     {},
-    ...configs,
-    (target: unknown, source: unknown, key: string) => {
-      const pair = [target, source];
-      if (pair.some(isUndefined)) {
-        // fallback to lodash default merge behavior
-        return undefined;
-      }
-
-      // Some keys should use source to override target
-      if (isOverriddenConfigKey(key)) {
-        return source ?? target;
-      }
-
-      if (pair.some(Array.isArray)) {
-        return [...castArray(target), ...castArray(source)];
-      }
-      // convert function to chained function
-      if (pair.some(isFunction)) {
-        return [target, source];
-      }
-      // fallback to lodash default merge behavior
-      return undefined;
-    },
   );
+};


### PR DESCRIPTION
## Summary

Rewrite `mergeRsbuildConfig` function:

- improved performance.
- no longer depend on `lodash`.
- stricter path matching

## Performance

- before:

<img width="458" alt="Screenshot 2024-01-23 at 13 43 34" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/60f79c3a-62cf-469a-9868-6a34d9f942c7">

- after:

<img width="596" alt="Screenshot 2024-01-23 at 13 48 57" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/9ee7c9f9-bc19-4df1-87ce-e2f1b192a3a3">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
