### PR TITLE
feat: do not clean dist path if it is outside root

### DIFF
--- a/.changeset/unlucky-jars-drop.md
+++ b/.changeset/unlucky-jars-drop.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.3.9

--- a/cspell.json
+++ b/cspell.json
@@ -48,6 +48,7 @@
     "selfsign",
     "sirv",
     "stacktracey",
+    "Subdir",
     "subpage",
     "svgr",
     "systemjs",

--- a/cspell.json
+++ b/cspell.json
@@ -48,7 +48,7 @@
     "selfsign",
     "sirv",
     "stacktracey",
-    "Subdir",
+    "subdir",
     "subpage",
     "svgr",
     "systemjs",

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -1,0 +1,61 @@
+import { join } from 'node:path';
+import { expect, test } from '@playwright/test';
+import { fse } from '@rsbuild/shared';
+import { build, proxyConsole } from '@e2e/helper';
+
+const cwd = __dirname;
+const testDistFile = join(cwd, 'dist/test.json');
+
+test('should clean dist path by default', async () => {
+  await fse.outputFile(testDistFile, `{ "test": 1 }`);
+
+  await build({
+    cwd,
+  });
+
+  expect(fse.existsSync(testDistFile)).toBeFalsy();
+  fse.removeSync(testDistFile);
+});
+
+test('should not clean dist path if it is outside root', async () => {
+  const { logs, restore } = proxyConsole();
+  const testOutsideFile = join(cwd, '../node_modules/test.json');
+  await fse.outputFile(testOutsideFile, `{ "test": 1 }`);
+
+  await build({
+    cwd,
+    rsbuildConfig: {
+      output: {
+        distPath: {
+          root: '../node_modules',
+        },
+      },
+    },
+  });
+
+  expect(
+    logs.find((log) => log.includes('dist path is not a subdir of root path')),
+  ).toBeTruthy();
+
+  expect(fse.existsSync(testOutsideFile)).toBeTruthy();
+
+  fse.removeSync(testOutsideFile);
+  restore();
+});
+
+test('should allow to disable cleanDistPath', async () => {
+  await fse.outputFile(testDistFile, `{ "test": 1 }`);
+
+  await build({
+    cwd,
+    rsbuildConfig: {
+      output: {
+        cleanDistPath: false,
+      },
+    },
+  });
+
+  expect(fse.existsSync(testDistFile)).toBeTruthy();
+
+  fse.removeSync(testDistFile);
+});

--- a/e2e/cases/output/clean-dist-path/src/index.js
+++ b/e2e/cases/output/clean-dist-path/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/e2e/cases/output/output.test.ts
+++ b/e2e/cases/output/output.test.ts
@@ -40,10 +40,6 @@ test.describe('output configure multi', () => {
     await rsbuild.clean();
   });
 
-  test('cleanDistPath default (enable)', async () => {
-    expect(fse.existsSync(distFilePath)).toBeFalsy();
-  });
-
   test('copy', async () => {
     expect(fse.existsSync(join(fixtures, 'rem/dist-1/icon.png'))).toBeTruthy();
   });
@@ -55,34 +51,4 @@ test.describe('output configure multi', () => {
 
     expect(fse.existsSync(join(fixtures, 'rem/dist-1/aa/js'))).toBeTruthy();
   });
-});
-
-test('cleanDistPath disable', async () => {
-  const distFilePath = join(fixtures, 'rem/dist-2/test.json');
-
-  await fse.mkdir(dirname(distFilePath), { recursive: true });
-  await fse.writeFile(
-    distFilePath,
-    `{
-    "test": 1
-  }`,
-  );
-
-  const rsbuild = await build({
-    cwd: join(fixtures, 'rem'),
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      output: {
-        distPath: {
-          root: 'dist-2',
-        },
-        cleanDistPath: false,
-      },
-    },
-  });
-
-  expect(fse.existsSync(distFilePath)).toBeTruthy();
-
-  await rsbuild.close();
-  rsbuild.clean();
 });

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -1,4 +1,5 @@
-import { fse } from '@rsbuild/shared';
+import { sep } from 'path';
+import { fse, color, logger } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 const emptyDir = async (dir: string) => {
@@ -7,15 +8,41 @@ const emptyDir = async (dir: string) => {
   }
 };
 
+const addTrailingSep = (dir: string) => (dir.endsWith(sep) ? dir : dir + sep);
+
+const isStrictSubdir = (parent: string, child: string) => {
+  const parentDir = addTrailingSep(parent);
+  const childDir = addTrailingSep(child);
+  return parentDir !== childDir && childDir.startsWith(parentDir);
+};
+
 export const pluginCleanOutput = (): RsbuildPlugin => ({
   name: 'rsbuild:clean-output',
 
   setup(api) {
     const clean = async () => {
+      const { distPath, rootPath } = api.context;
       const config = api.getNormalizedConfig();
 
-      if (config.output.cleanDistPath) {
-        const { distPath } = api.context;
+      let { cleanDistPath } = config.output;
+
+      // only enable cleanDistPath when the dist path is a subdir of root path
+      if (cleanDistPath === undefined) {
+        cleanDistPath = isStrictSubdir(rootPath, distPath);
+
+        if (!cleanDistPath) {
+          logger.warn(
+            'The dist path is not a subdir of root path, Rsbuild will not empty it.',
+          );
+          logger.warn(
+            `Please set ${color.yellow('`output.cleanDistPath`')} config manually.`,
+          );
+          logger.warn(`Current root path: ${color.dim(rootPath)}`);
+          logger.warn(`Current dist path: ${color.dim(distPath)}`);
+        }
+      }
+
+      if (cleanDistPath) {
         await emptyDir(distPath);
       }
     };

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -1,4 +1,4 @@
-import { sep } from 'path';
+import { sep } from 'node:path';
 import { fse, color, logger } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/document/docs/en/config/output/clean-dist-path.mdx
+++ b/packages/document/docs/en/config/output/clean-dist-path.mdx
@@ -1,7 +1,7 @@
 # cleanDistPath
 
 - **Type:** `boolean`
-- **Default:** `auto`
+- **Default:** `undefined`
 
 Whether to clean up all files under the output directory before the build starts (the output directory defaults to `dist`).
 
@@ -9,7 +9,7 @@ Whether to clean up all files under the output directory before the build starts
 
 By default, if the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.
 
-When `output.distPath.root` is an external directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
+When `output.distPath.root` is an external directory, or equals to the project root directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
 
 ```js
 export default {

--- a/packages/document/docs/en/config/output/clean-dist-path.mdx
+++ b/packages/document/docs/en/config/output/clean-dist-path.mdx
@@ -1,21 +1,41 @@
 # cleanDistPath
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `auto`
 
-Whether to clean up all files under the output directory (default is `dist`) before the build starts.
+Whether to clean up all files under the output directory before the build starts (the output directory defaults to `dist`).
 
-By default, Rsbuild automatically cleans the files under the output directory. You can set `cleanDistPath` to `false` to disable this behavior.
+## Default Behavior
+
+By default, if the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.
+
+When `output.distPath.root` is an external directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
 
 ```js
 export default {
   output: {
-    cleanDistPath: false,
+    distPath: {
+      root: '../../some-dir',
+    },
   },
 };
 ```
 
-If you only need to clean files before the production build, and not in the development build, you can configure it as follows:
+## Forced Switch
+
+You can set `cleanDistPath` to `true` to force it to be enabled, or set it to `false` to force it to be disabled.
+
+```js
+export default {
+  output: {
+    cleanDistPath: true,
+  },
+};
+```
+
+## Conditional
+
+If you only need to clean files before the production build, but not before the development build, you can configure it as:
 
 ```js
 export default {

--- a/packages/document/docs/zh/config/output/clean-dist-path.mdx
+++ b/packages/document/docs/zh/config/output/clean-dist-path.mdx
@@ -1,19 +1,39 @@
 # cleanDistPath
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** `auto`
 
-是否在构建开始前清理产物目录（默认为 `dist`）下的所有文件。
+是否在构建开始前清理产物目录下的所有文件（产物目录默认为 `dist`）。
 
-默认情况下，Rsbuild 会自动清理产物目录下的文件，你可以把 `cleanDistPath` 设置为 `false` 来禁用该行为。
+## 默认行为
+
+默认情况下，如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
+
+当 `output.distPath.root` 为外部目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
 
 ```js
 export default {
   output: {
-    cleanDistPath: false,
+    distPath: {
+      root: '../../some-dir',
+    },
   },
 };
 ```
+
+## 强制开关
+
+你可以把 `cleanDistPath` 设置为 `true` 来强制开启，也可以设置为 `false` 来强制关闭该行为。
+
+```js
+export default {
+  output: {
+    cleanDistPath: true,
+  },
+};
+```
+
+## 条件判断
 
 如果你只需要在生产环境构建前清理文件，而在开发环境构建前不需要，那么可以配置为：
 

--- a/packages/document/docs/zh/config/output/clean-dist-path.mdx
+++ b/packages/document/docs/zh/config/output/clean-dist-path.mdx
@@ -1,7 +1,7 @@
 # cleanDistPath
 
 - **类型：** `boolean`
-- **默认值：** `auto`
+- **默认值：** `undefined`
 
 是否在构建开始前清理产物目录下的所有文件（产物目录默认为 `dist`）。
 
@@ -9,7 +9,7 @@
 
 默认情况下，如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
 
-当 `output.distPath.root` 为外部目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
+当 `output.distPath.root` 为外部目录，或等于项目根目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
 
 ```js
 export default {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -127,7 +127,6 @@ export const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
     media: DEFAULT_DATA_URL_SIZE,
   },
   legalComments: 'linked',
-  cleanDistPath: true,
   injectStyles: false,
   disableMinimize: false,
   sourceMap: {
@@ -216,8 +215,8 @@ export type GetTypeByPath<
 > = T extends `${infer K}[${infer P}]${infer S}`
   ? GetTypeByPath<`${K}.${P}${S}`, C>
   : T extends `${infer K}.${infer P}`
-  ? GetTypeByPath<P, K extends '' ? C : NonNullable<C[K]>>
-  : C[T];
+    ? GetTypeByPath<P, K extends '' ? C : NonNullable<C[K]>>
+    : C[T];
 
 type MinifyOptions = NonNullable<Parameters<typeof minify>[1]>;
 

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -207,7 +207,6 @@ export interface NormalizedOutputConfig extends OutputConfig {
   };
   assetPrefix: string;
   dataUriLimit: NormalizedDataUriLimit;
-  cleanDistPath: boolean;
   disableMinimize: boolean;
   disableFilenameHash: boolean;
   enableLatestDecorators: boolean;


### PR DESCRIPTION
## Summary

When `output.distPath.root` is an external directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
