### PR TITLE
docs: add guide for plugin hooks execution order

### DIFF
--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -4,8 +4,6 @@ This chapter introduces the plugin hooks available for Rsbuild plugins.
 
 ## Overview
 
-## Table of Contents
-
 ### Common Hooks
 
 - [modifyRsbuildConfig](#modifyrsbuildconfig): Modify the configuration object passed to Rsbuild.
@@ -15,14 +13,7 @@ This chapter introduces the plugin hooks available for Rsbuild plugins.
 - [onAfterCreateCompiler](#onaftercreatecompiler): Called after creating a compiler instance and before building.
 - [onExit](#onexit): Called when the process is about to exit.
 
-### Build Hooks
-
-Called only when running the `rsbuild build` command or the `rsbuild.build()` method.
-
-- [onBeforeBuild](#onbeforebuild): Called before running the production build.
-- [onAfterBuild](#onafterbuild): Called after running the production build. You can get the build result information.
-
-### Dev Server Hooks
+### Dev Hooks
 
 Called only when running the `rsbuild dev` command or the `rsbuild.startDevServer()` method.
 
@@ -30,12 +21,59 @@ Called only when running the `rsbuild dev` command or the `rsbuild.startDevServe
 - [onAfterStartDevServer](#onafterstartdevserver): Called after starting the dev server.
 - [onDevCompileDone](#ondevcompiledone): Called after each build during development.
 
-### Prod Server Hooks
+### Build Hooks
+
+Called only when running the `rsbuild build` command or the `rsbuild.build()` method.
+
+- [onBeforeBuild](#onbeforebuild): Called before running the production build.
+- [onAfterBuild](#onafterbuild): Called after running the production build. You can get the build result information.
+
+### Preview Hooks
 
 Called only when running the `rsbuild preview` command or the `rsbuild.preview()` method.
 
 - [onBeforeStartProdServer](#onbeforestartprodserver): Called before starting the production server.
 - [onAfterStartProdServer](#onafterstartprodserver): Called after starting the production server.
+
+---
+
+## Execution Order
+
+### Dev Hooks
+
+When the `rsbuild dev` command or `rsbuild.startDevServer()` method is executed, Rsbuild will execute the following hooks in order:
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [onBeforeStartDevServer](#onbeforestartdevserver)
+- [modifyBundlerChain](#modifybundlerchain)
+- [modifyRspackConfig](#modifyrspackconfig)
+- [onBeforeCreateCompiler](#onbeforecreatecompiler)
+- [onAfterCreateCompiler](#onaftercreatecompiler)
+- [onAfterStartDevServer](#onafterstartdevserver)
+- [onDevCompileDone](#ondevcompiledone)
+- [onExit](#onexit)
+
+### Build Hooks
+
+When the `rsbuild build` command or `rsbuild.build()` method is executed, Rsbuild will execute the following hooks in order:
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [modifyBundlerChain](#modifybundlerchain)
+- [modifyRspackConfig](#modifyrspackconfig)
+- [onBeforeCreateCompiler](#onbeforecreatecompiler)
+- [onAfterCreateCompiler](#onaftercreatecompiler)
+- [onBeforeBuild](#onbeforebuild)
+- [onAfterBuild](#onafterbuild)
+- [onExit](#onexit)
+
+### Preview Hooks
+
+When executing the `rsbuild preview` command or `rsbuild.preview()` method, Rsbuild will execute the following hooks in order:
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [onBeforeStartProdServer](#onbeforestartprodserver)
+- [onAfterStartProdServer](#onafterstartprodserver)
+- [onExit](#onexit)
 
 ---
 
@@ -243,7 +281,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Dev Server Hooks
+## Dev Hooks
 
 ### onBeforeStartDevServer
 
@@ -304,7 +342,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Prod Server Hooks
+## Preview Hooks
 
 ### onBeforeStartProdServer
 

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -13,14 +13,7 @@
 - [onAfterCreateCompiler](#onaftercreatecompiler)：在创建 compiler 实例后、执行构建前调用。
 - [onExit](#onexit)：在进程即将退出时调用。
 
-### Build Hooks
-
-仅在执行 `rsbuild build` 命令或 `rsbuild.build()` 方法时调用。
-
-- [onBeforeBuild](#onbeforebuild)：在执行生产环境构建前调用。
-- [onAfterBuild](#onafterbuild)：在执行生产环境构建后调用，可以获取到构建结果信息。
-
-### Dev Server Hooks
+### Dev Hooks
 
 仅在执行 `rsbuild dev` 命令或 `rsbuild.startDevServer()` 方法时调用。
 
@@ -28,12 +21,59 @@
 - [onAfterStartDevServer](#onafterstartdevserver)：在启动开发服务器后调用。
 - [onDevCompileDone](#ondevcompiledone)：在每次开发环境构建结束后调用。
 
-### Prod Server Hooks
+### Build Hooks
+
+仅在执行 `rsbuild build` 命令或 `rsbuild.build()` 方法时调用。
+
+- [onBeforeBuild](#onbeforebuild)：在执行生产环境构建前调用。
+- [onAfterBuild](#onafterbuild)：在执行生产环境构建后调用，可以获取到构建结果信息。
+
+### Preview Hooks
 
 仅在执行 `rsbuild preview` 命令或 `rsbuild.preview()` 方法时调用。
 
 - [onBeforeStartProdServer](#onbeforestartprodserver)：在启动生产服务器前调用。
 - [onAfterStartProdServer](#onafterstartprodserver)：在启动生产服务器后调用。
+
+---
+
+## 执行顺序
+
+### Dev Hooks
+
+执行 `rsbuild dev` 命令或 `rsbuild.startDevServer()` 方法时，Rsbuild 会依次执行以下 hooks：
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [onBeforeStartDevServer](#onbeforestartdevserver)
+- [modifyBundlerChain](#modifybundlerchain)
+- [modifyRspackConfig](#modifyrspackconfig)
+- [onBeforeCreateCompiler](#onbeforecreatecompiler)
+- [onAfterCreateCompiler](#onaftercreatecompiler)
+- [onAfterStartDevServer](#onafterstartdevserver)
+- [onDevCompileDone](#ondevcompiledone)
+- [onExit](#onexit)
+
+### Build Hooks
+
+执行 `rsbuild build` 命令或 `rsbuild.build()` 方法时，Rsbuild 会依次执行以下 hooks：
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [modifyBundlerChain](#modifybundlerchain)
+- [modifyRspackConfig](#modifyrspackconfig)
+- [onBeforeCreateCompiler](#onbeforecreatecompiler)
+- [onAfterCreateCompiler](#onaftercreatecompiler)
+- [onBeforeBuild](#onbeforebuild)
+- [onAfterBuild](#onafterbuild)
+- [onExit](#onexit)
+
+### Preview Hooks
+
+执行 `rsbuild preview` 命令或 `rsbuild.preview()` 方法时，Rsbuild 会依次执行以下 hooks：
+
+- [modifyRsbuildConfig](#modifyrsbuildconfig)
+- [onBeforeStartProdServer](#onbeforestartprodserver)
+- [onAfterStartProdServer](#onafterstartprodserver)
+- [onExit](#onexit)
 
 ---
 
@@ -244,7 +284,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Dev Server Hooks
+## Dev Hooks
 
 ### onBeforeStartDevServer
 
@@ -305,7 +345,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Prod Server Hooks
+## Preview Hooks
 
 ### onBeforeStartProdServer
 


### PR DESCRIPTION
## Summary

Add guide for plugin hooks execution order.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
