### PR TITLE
perf: set default WATCHPACK_WATCHER_LIMIT to 20

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -56,6 +56,7 @@
     "tsbuildinfo",
     "unocss",
     "vitest",
+    "watchpack",
     "webm"
   ]
 }

--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -8,5 +8,9 @@ export const pluginTransition = (): RsbuildPlugin => ({
 
   setup() {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+
+    // improve kill process performance
+    // https://github.com/web-infra-dev/rspack/pull/5486
+    process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
   },
 });


### PR DESCRIPTION
## Summary

Set default WATCHPACK_WATCHER_LIMIT to 20 to improve kill process performance.

see https://github.com/web-infra-dev/rspack/pull/5486 for details.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
