### PR TITLE
fix: treat publicPath auto as empty string

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -222,10 +222,13 @@ export const generateScriptTag = () => ({
 
 export const getPublicPathFromCompiler = (compiler: Compiler) => {
   const { publicPath } = compiler.options.output;
-  if (typeof publicPath === 'string' && publicPath !== 'auto') {
-    return addTrailingSlash(publicPath);
+
+  if (typeof publicPath === 'string') {
+    // 'auto' is a magic value in Rspack and behave like `publicPath: ""`
+    return publicPath === 'auto' ? '' : addTrailingSlash(publicPath);
   }
-  // publicPath function is not supported yet
+
+  // publicPath function is not supported yet, fallback to default value
   return DEFAULT_ASSET_PREFIX;
 };
 

--- a/packages/shared/tests/url.test.ts
+++ b/packages/shared/tests/url.test.ts
@@ -21,6 +21,7 @@ describe('withPublicPath', () => {
     expect(withPublicPath('foo/bar.js', PUBLIC_PATH)).toBe(
       'https://www.example.com/static/foo/bar.js',
     );
+    expect(withPublicPath('foo/bar.js', '')).toBe('foo/bar.js');
     expect(withPublicPath('foo/bar.js', '/')).toBe('/foo/bar.js');
     expect(withPublicPath('/foo/bar.js', PUBLIC_PATH)).toBe(
       'https://www.example.com/static/foo/bar.js',


### PR DESCRIPTION
## Summary

Treat publicPath auto as empty string, this will be more consistent with Rspack/webpack's behavior.

## Related Links

see https://github.com/jantimon/html-webpack-plugin/issues/1514

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
