### PR TITLE
test(e2e): add case for assetPrefix auto

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -1,0 +1,51 @@
+import { expect, test } from '@playwright/test';
+import { dev, build, gotoPage } from '@e2e/helper';
+
+test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        assetPrefix: 'auto',
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await rsbuild.server.close();
+});
+
+test('should allow dev.assetPrefix to be true', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        assetPrefix: true,
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await rsbuild.server.close();
+});
+
+test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+    rsbuildConfig: {
+      output: {
+        assetPrefix: 'auto',
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await rsbuild.close();
+});

--- a/e2e/cases/asset-prefix/src/index.js
+++ b/e2e/cases/asset-prefix/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);


### PR DESCRIPTION
## Summary

Add E2E case for assetPrefix: 'auto'.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1447

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
