### PR TITLE
fix: format assetPrefix for define and template

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -49,3 +49,25 @@ test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();
 });
+
+test('should inject assetPrefix to env var and template correctly', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+    rsbuildConfig: {
+      html: {
+        template: './src/template.html',
+      },
+      output: {
+        assetPrefix: 'http://example.com',
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  await expect(page.locator('#prefix1')).toHaveText('http://example.com');
+  await expect(page.locator('#prefix2')).toHaveText('http://example.com');
+  await rsbuild.close();
+});

--- a/e2e/cases/asset-prefix/src/template.html
+++ b/e2e/cases/asset-prefix/src/template.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <div id="prefix1"><%= assetPrefix %></div>
+    <div id="prefix2"><%= process.env.ASSET_PREFIX %></div>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -1,4 +1,8 @@
-import { getNodeEnv, removeTailSlash, type Define } from '@rsbuild/shared';
+import {
+  getNodeEnv,
+  getPublicPathFromChain,
+  type Define,
+} from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginDefine = (): RsbuildPlugin => ({
@@ -7,16 +11,10 @@ export const pluginDefine = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID, bundler }) => {
       const config = api.getNormalizedConfig();
-      const publicPath = chain.output.get('publicPath');
-      const assetPrefix =
-        publicPath && typeof publicPath === 'string'
-          ? publicPath
-          : config.output.assetPrefix;
-
       const builtinVars: Define = {
         'process.env.NODE_ENV': JSON.stringify(getNodeEnv()),
         'process.env.ASSET_PREFIX': JSON.stringify(
-          removeTailSlash(assetPrefix),
+          getPublicPathFromChain(chain, false),
         ),
       };
 

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -10,8 +10,8 @@ import {
   isFileExists,
   isPlainObject,
   isHtmlDisabled,
-  removeTailSlash,
   mergeChainedOptions,
+  getPublicPathFromChain,
 } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
 import type {
@@ -242,9 +242,7 @@ export const pluginHtml = (): RsbuildPlugin => ({
         }
 
         const minify = await getMinify(isProd, config);
-        const assetPrefix = removeTailSlash(
-          chain.output.get('publicPath') || '',
-        );
+        const assetPrefix = getPublicPathFromChain(chain, false);
         const entries = chain.entryPoints.entries() || {};
         const entryNames = Object.keys(entries);
         const htmlPaths = api.getHTMLPaths();

--- a/packages/document/docs/en/config/dev/asset-prefix.mdx
+++ b/packages/document/docs/en/config/dev/asset-prefix.mdx
@@ -58,4 +58,4 @@ The differences from the native configuration are as follows:
 
 - `dev.assetPrefix` only takes effect during development.
 - `dev.assetPrefix` automatically appends a trailing `/` by default.
-- The value of `dev.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable (can only be accessed in client code).
+- The value of `dev.assetPrefix` is written to the [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) environment variable (can only be accessed in client code).

--- a/packages/document/docs/en/config/output/asset-prefix.mdx
+++ b/packages/document/docs/en/config/output/asset-prefix.mdx
@@ -41,4 +41,4 @@ The differences from the native configuration are as follows:
 
 - `output.assetPrefix` only takes effect in the production environment.
 - `output.assetPrefix` automatically appends a trailing `/` by default.
-- The value of `output.assetPrefix` is written to the `process.env.ASSET_PREFIX` environment variable (can only be accessed in client code).
+- The value of `output.assetPrefix` is written to the [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) environment variable (can only be accessed in client code).

--- a/packages/document/docs/zh/config/dev/asset-prefix.mdx
+++ b/packages/document/docs/zh/config/dev/asset-prefix.mdx
@@ -58,4 +58,4 @@ export default {
 
 - `dev.assetPrefix` 仅在开发环境下生效。
 - `dev.assetPrefix` 默认会自动补全尾部的 `/`。
-- `dev.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量（只能在 client 代码中访问）。
+- `dev.assetPrefix` 的值会写入 [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) 环境变量（只能在 client 代码中访问）。

--- a/packages/document/docs/zh/config/output/asset-prefix.mdx
+++ b/packages/document/docs/zh/config/output/asset-prefix.mdx
@@ -41,4 +41,4 @@ export default {
 
 - `output.assetPrefix` 仅在生产环境下生效。
 - `output.assetPrefix` 默认会自动补全尾部的 `/`。
-- `output.assetPrefix` 的值会写入 `process.env.ASSET_PREFIX` 环境变量（只能在 client 代码中访问）。
+- `output.assetPrefix` 的值会写入 [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) 环境变量（只能在 client 代码中访问），。

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -1,6 +1,6 @@
 import { posix } from 'node:path';
 import { getDistPath, getFilename } from './fs';
-import { addTrailingSlash, isPlainObject } from './utils';
+import { addTrailingSlash, isPlainObject, removeTailingSlash } from './utils';
 import { castArray, ensureAbsolutePath } from './utils';
 import { debug } from './logger';
 import {
@@ -282,6 +282,30 @@ export function applyScriptCondition({
   });
 }
 
+export const formatPublicPath = (publicPath: string, withSlash = true) => {
+  // 'auto' is a magic value in Rspack and we should not add trailing slash
+  if (publicPath === 'auto') {
+    return publicPath;
+  }
+
+  return withSlash
+    ? addTrailingSlash(publicPath)
+    : removeTailingSlash(publicPath);
+};
+
+export const getPublicPathFromChain = (
+  chain: BundlerChain,
+  withSlash = true,
+) => {
+  const publicPath = chain.output.get('publicPath');
+
+  if (typeof publicPath === 'string') {
+    return formatPublicPath(publicPath, withSlash);
+  }
+
+  return formatPublicPath(DEFAULT_ASSET_PREFIX, withSlash);
+};
+
 function getPublicPath({
   config,
   isProd,
@@ -317,12 +341,7 @@ function getPublicPath({
     }
   }
 
-  // 'auto' is a magic value in Rspack and we should not add trailing slash
-  if (publicPath === 'auto') {
-    return publicPath;
-  }
-
-  return addTrailingSlash(publicPath);
+  return formatPublicPath(publicPath);
 }
 
 export function applyOutputPlugin(api: RsbuildPluginAPI) {

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -58,8 +58,7 @@ export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
 
 export const removeLeadingSlash = (s: string): string => s.replace(/^\/+/, '');
-export const removeTailSlash = (s: string): string => s.replace(/\/+$/, '');
-
+export const removeTailingSlash = (s: string): string => s.replace(/\/+$/, '');
 export const addTrailingSlash = (s: string): string =>
   s.endsWith('/') ? s : `${s}/`;
 


### PR DESCRIPTION
## Summary

Format assetPrefix for define and template. If `output.assetPrefix` is `auto`, `process.env.ASSET_PREFIX`  will be format to empty string.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
