### PR TITLE
feat: allow chunkSplit.strategy to be optional

### DIFF
--- a/examples/module-federation/host/module-federation.config.ts
+++ b/examples/module-federation/host/module-federation.config.ts
@@ -1,6 +1,7 @@
-const { dependencies } = require('./package.json');
+import { dependencies } from './package.json';
+import type { Rspack } from '@rsbuild/core';
 
-module.exports = {
+export const mfConfig: Rspack.ModuleFederationPluginOptions = {
   name: 'host',
   remotes: {
     remote: 'remote@http://localhost:3002/remoteEntry.js',

--- a/examples/module-federation/host/rsbuild.config.ts
+++ b/examples/module-federation/host/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import mfConfig from './module-federation.config';
+import { mfConfig } from './module-federation.config';
 
 export default defineConfig({
   plugins: [pluginReact()],
@@ -12,10 +12,8 @@ export default defineConfig({
   },
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       override: {
         chunks: 'async',
-        minSize: 30000,
       },
     },
   },

--- a/examples/module-federation/remote/module-federation.config.ts
+++ b/examples/module-federation/remote/module-federation.config.ts
@@ -1,6 +1,7 @@
-const { dependencies } = require('./package.json');
+import { dependencies } from './package.json';
+import type { Rspack } from '@rsbuild/core';
 
-module.exports = {
+export const mfConfig: Rspack.ModuleFederationPluginOptions = {
   name: 'remote',
   exposes: {
     './Button': './src/Button',

--- a/examples/module-federation/remote/rsbuild.config.ts
+++ b/examples/module-federation/remote/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import mfConfig from './module-federation.config';
+import { mfConfig } from './module-federation.config';
 
 export default defineConfig({
   plugins: [pluginReact()],
@@ -12,10 +12,8 @@ export default defineConfig({
   },
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       override: {
         chunks: 'async',
-        minSize: 30000,
       },
     },
   },

--- a/packages/document/docs/en/config/performance/chunk-split.mdx
+++ b/packages/document/docs/en/config/performance/chunk-split.mdx
@@ -19,7 +19,7 @@ interface BaseChunkSplit {
 }
 
 interface SplitBySize {
-  strategy?: 'split-by-size';
+  strategy: 'split-by-size';
   minSize?: number;
   maxSize?: number;
   override?: SplitChunks;
@@ -27,7 +27,7 @@ interface SplitBySize {
 }
 
 interface SplitCustom {
-  strategy?: 'custom';
+  strategy: 'custom';
   splitChunks?: SplitChunks;
   forceSplitting?: ForceSplitting;
 }

--- a/packages/document/docs/en/config/performance/chunk-split.mdx
+++ b/packages/document/docs/en/config/performance/chunk-split.mdx
@@ -111,7 +111,6 @@ For example, split the `axios` library under node_modules into `axios.js`:
 export default {
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       forceSplitting: {
         axios: /node_modules[\\/]axios/,
       },
@@ -157,7 +156,6 @@ When `performance.chunkSplit.strategy` is `split-by-experience`, `split-by-modul
 export default {
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       override: {
         cacheGroups: {
           react: {

--- a/packages/document/docs/zh/config/performance/chunk-split.mdx
+++ b/packages/document/docs/zh/config/performance/chunk-split.mdx
@@ -111,7 +111,6 @@ export default {
 export default {
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       forceSplitting: {
         axios: /node_modules[\\/]axios/,
       },
@@ -157,7 +156,6 @@ export default {
 export default {
   performance: {
     chunkSplit: {
-      strategy: 'split-by-experience',
       override: {
         cacheGroups: {
           react: {

--- a/packages/document/docs/zh/config/performance/chunk-split.mdx
+++ b/packages/document/docs/zh/config/performance/chunk-split.mdx
@@ -19,7 +19,7 @@ interface BaseChunkSplit {
 }
 
 interface SplitBySize {
-  strategy?: 'split-by-size';
+  strategy: 'split-by-size';
   minSize?: number;
   maxSize?: number;
   override?: SplitChunks;
@@ -27,7 +27,7 @@ interface SplitBySize {
 }
 
 interface SplitCustom {
-  strategy?: 'custom';
+  strategy: 'custom';
   splitChunks?: SplitChunks;
   forceSplitting?: ForceSplitting;
 }

--- a/packages/shared/src/types/config/performance.ts
+++ b/packages/shared/src/types/config/performance.ts
@@ -138,13 +138,13 @@ export type CacheGroup = Configuration extends {
 export type ForceSplitting = RegExp[] | Record<string, RegExp>;
 
 export interface BaseSplitRules {
-  strategy: string;
+  strategy?: string;
   forceSplitting?: ForceSplitting;
   override?: SplitChunks;
 }
 
 export interface BaseChunkSplit extends BaseSplitRules {
-  strategy:
+  strategy?:
     | 'split-by-module'
     | 'split-by-experience'
     | 'all-in-one'


### PR DESCRIPTION
## Summary

Allow `chunkSplit.strategy` to be optional, making it easier to override some chunkSplit rules.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
