### PR TITLE
fix(server): treat assetPrefix auto as ""

### DIFF
--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -124,7 +124,7 @@ export class CompilerDevMiddleware {
         url && publicPaths.find((prefix) => url.startsWith(prefix));
 
       // slice publicPath, static asset have publicPath but html does not.
-      if (assetPrefix && assetPrefix !== '/') {
+      if (assetPrefix && assetPrefix !== '/' && assetPrefix !== 'auto') {
         req.url = url.slice(assetPrefix.length - 1);
 
         middleware(req, res, (...args) => {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -124,7 +124,11 @@ export class RsbuildProdServer {
       const url = req.url;
 
       // handler assetPrefix
-      if (assetPrefix && url?.startsWith(assetPrefix)) {
+      if (
+        assetPrefix &&
+        url?.startsWith(assetPrefix) &&
+        assetPrefix !== 'auto'
+      ) {
         req.url = url.slice(assetPrefix.length);
         assetMiddleware(req, res, (...args) => {
           req.url = url;


### PR DESCRIPTION
## Summary

server will slice assetPrefix when match static resource, but assetPrefix 'auto' is special.
## Related Links

https://webpack.js.org/guides/public-path/#automatic-publicpath
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
