### PR TITLE
test(e2e): align close server API

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -14,7 +14,7 @@ test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
   await gotoPage(page, rsbuild);
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should allow dev.assetPrefix to be true', async ({ page }) => {
@@ -30,7 +30,7 @@ test('should allow dev.assetPrefix to be true', async ({ page }) => {
   await gotoPage(page, rsbuild);
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should allow output.assetPrefix to be `auto`', async ({ page }) => {

--- a/e2e/cases/inspect-config/debug.test.ts
+++ b/e2e/cases/inspect-config/debug.test.ts
@@ -58,5 +58,5 @@ test('should generate config files when dev (with DEBUG)', async ({ page }) => {
 
   delete process.env.DEBUG;
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/live-reload/index.test.ts
+++ b/e2e/cases/live-reload/index.test.ts
@@ -35,7 +35,7 @@ test('should fallback to live-reload when dev.hmr is false', async ({
   fs.writeFileSync(appFile, appCode.replace('Rsbuild', 'Live Reload'), 'utf-8');
   await expect(testEl).toHaveText('Hello Live Reload!');
 
-  rsbuild.server.close();
+  rsbuild.close();
 });
 
 test('should not reload page when live-reload is disabled', async ({
@@ -58,5 +58,5 @@ test('should not reload page when live-reload is disabled', async ({
   fs.writeFileSync(appFile, appCode.replace('Rsbuild', 'Live Reload'), 'utf-8');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  rsbuild.server.close();
+  rsbuild.close();
 });

--- a/e2e/cases/module-federation/index.test.ts
+++ b/e2e/cases/module-federation/index.test.ts
@@ -27,7 +27,7 @@ rspackOnlyTest(
     await expect(page.locator('#title')).toHaveText('Host');
     await expect(page.locator('#button')).toHaveText('Button from remote');
 
-    await hostApp.server.close();
-    await remoteApp.server.close();
+    await hostApp.close();
+    await remoteApp.close();
   },
 );

--- a/e2e/cases/multi-compiler/index.test.ts
+++ b/e2e/cases/multi-compiler/index.test.ts
@@ -38,5 +38,5 @@ test('multi compiler dev', async ({ page }) => {
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -19,7 +19,7 @@ test('should emit bundle analyze report correctly when dev', async ({
   );
   expect(filePaths.length).toBe(1);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should emit bundle analyze report correctly when build', async () => {

--- a/e2e/cases/polyfill/browserslist/index.test.ts
+++ b/e2e/cases/polyfill/browserslist/index.test.ts
@@ -17,7 +17,7 @@ test('should read browserslist for development env correctly', async ({
 
   expect(content.includes('es.string.replace-all')).toBeFalsy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should read browserslist for production env correctly', async () => {

--- a/e2e/cases/preact/basic/index.test.ts
+++ b/e2e/cases/preact/basic/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest(
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.server.close();
+    rsbuild.close();
   },
 );
 

--- a/e2e/cases/react/basic/index.test.ts
+++ b/e2e/cases/react/basic/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest(
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.server.close();
+    rsbuild.close();
   },
 );
 

--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -82,7 +82,7 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
 }`,
   );
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('dev.port & output.distPath', async ({ page }) => {
@@ -121,7 +121,7 @@ test('dev.port & output.distPath', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 
   expect(errors).toEqual([]);
 
@@ -184,7 +184,7 @@ rspackOnlyTest(
       fse.readFileSync(appPath, 'utf-8').replace('Hello Test', 'Hello Rsbuild'),
     );
 
-    await rsbuild.server.close();
+    await rsbuild.close();
   },
 );
 
@@ -246,5 +246,5 @@ test('devServer', async ({ page }) => {
 
   expect(i).toBeGreaterThanOrEqual(1);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -39,7 +39,7 @@ rspackOnlyTest(
     await page.goto(`http://localhost:${rsbuild.port}/b`);
     expect(await page.innerHTML('body')).toContain('<div>B</div>');
 
-    await rsbuild.server.close();
+    await rsbuild.close();
   },
 );
 

--- a/e2e/cases/server/htmlFallback.test.ts
+++ b/e2e/cases/server/htmlFallback.test.ts
@@ -36,7 +36,7 @@ test('should access / success and htmlFallback success by default', async ({
 
   await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should return 404 when htmlFallback false', async ({ page }) => {
@@ -63,7 +63,7 @@ test('should return 404 when htmlFallback false', async ({ page }) => {
 
   expect(res?.status()).toBe(404);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main with query or hash success', async ({ page }) => {
@@ -93,7 +93,7 @@ test('should access /main with query or hash success', async ({ page }) => {
 
   expect(res1?.status()).toBe(200);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main.html success when entry is main', async ({
@@ -125,7 +125,7 @@ test('should access /main.html success when entry is main', async ({
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main', async ({ page }) => {
@@ -157,7 +157,7 @@ test('should access /main success when entry is main', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main and use memoryFs', async ({
@@ -189,7 +189,7 @@ test('should access /main success when entry is main and use memoryFs', async ({
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main and set assetPrefix', async ({
@@ -222,7 +222,7 @@ test('should access /main success when entry is main and set assetPrefix', async
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when entry is main and outputPath is /main/index.html', async ({
@@ -257,7 +257,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should return 404 when page is not found', async ({ page }) => {
@@ -286,7 +286,7 @@ test('should return 404 when page is not found', async ({ page }) => {
 
   expect(res?.status()).toBe(404);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /html/main success when entry is main and outputPath is /html/main.html', async ({
@@ -327,7 +327,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
 
   expect(res?.status()).toBe(404);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when modify publicPath in compiler', async ({
@@ -376,7 +376,7 @@ test('should access /main success when modify publicPath in compiler', async ({
 
   expect(content.includes('/aaaa/static/js/main.js')).toBeTruthy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should access /main success when distPath is absolute', async ({
@@ -406,5 +406,5 @@ test('should access /main success when distPath is absolute', async ({
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/server/ipv6-host/index.test.ts
+++ b/e2e/cases/server/ipv6-host/index.test.ts
@@ -12,5 +12,5 @@ test('should allow to listen ipv6 host', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -29,7 +29,7 @@ test('should print server urls correctly when printUrls is true', async ({
   expect(localLog).toBeTruthy();
   expect(networkLog).toBeTruthy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
   restore();
 });
 
@@ -59,7 +59,7 @@ test('should not print server urls when printUrls is false', async ({
   expect(localLog).toBeFalsy();
   expect(networkLog).toBeFalsy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
   restore();
 });
 
@@ -91,7 +91,7 @@ test('should allow to custom urls', async ({ page }) => {
   expect(localLog).toBeFalsy();
   expect(networkLog).toBeFalsy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
   restore();
 });
 
@@ -124,6 +124,6 @@ test('should allow to modify and return new urls', async ({ page }) => {
   expect(localLog).toBeFalsy();
   expect(networkLog).toBeFalsy();
 
-  await rsbuild.server.close();
+  await rsbuild.close();
   restore();
 });

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -37,6 +37,6 @@ test('should apply basic proxy rules correctly', async ({ page }) => {
   await page.goto(`http://localhost:${rsbuild2.port}/main`);
   expect(await page.innerHTML('body')).toContain('<div id="root">1</div>');
 
-  await rsbuild1.server.close();
-  await rsbuild2.server.close();
+  await rsbuild1.close();
+  await rsbuild2.close();
 });

--- a/e2e/cases/server/public-dir-with-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-template/index.test.ts
@@ -15,7 +15,7 @@ test('should serve publicDir for dev server correctly', async ({ page }) => {
   const title = await page.$('title');
   expect(await title?.innerText()).toBe('Hello');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should serve publicDir for preview server correctly', async ({

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -25,7 +25,7 @@ test('should serve publicDir for dev server correctly', async ({ page }) => {
 
   expect((await res?.body())?.toString().trim()).toBe('aaaa');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should serve custom publicDir for dev server correctly', async ({
@@ -56,7 +56,7 @@ test('should serve custom publicDir for dev server correctly', async ({
 
   expect((await res?.body())?.toString().trim()).toBe('aaaa111');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should not serve publicDir when publicDir is false', async ({ page }) => {
@@ -84,7 +84,7 @@ test('should not serve publicDir when publicDir is false', async ({ page }) => {
 
   expect(res?.status()).toBe(404);
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('should serve publicDir for preview server correctly', async ({

--- a/e2e/cases/server/writeToDisk.test.ts
+++ b/e2e/cases/server/writeToDisk.test.ts
@@ -21,7 +21,7 @@ test('writeToDisk default', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('writeToDisk false', async ({ page }) => {
@@ -44,7 +44,7 @@ test('writeToDisk false', async ({ page }) => {
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });
 
 test('writeToDisk true', async ({ page }) => {
@@ -67,5 +67,5 @@ test('writeToDisk true', async ({ page }) => {
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  await rsbuild.server.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/solid/hmr/index.test.ts
+++ b/e2e/cases/solid/hmr/index.test.ts
@@ -46,5 +46,5 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   // recover the source code
   fs.writeFileSync(filePath, sourceCodeB, 'utf-8');
-  rsbuild.server.close();
+  rsbuild.close();
 });

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -82,7 +82,7 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
   await expect(a).toHaveText('A: 5');
 
   fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
-  rsbuild.server.close();
+  rsbuild.close();
 });
 
 rspackOnlyTest(

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -168,9 +168,7 @@ export async function dev({
 
   return {
     ...result,
-    close: () => {
-      result.server.close();
-    },
+    close: () => result.server.close(),
   };
 }
 

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -164,7 +164,14 @@ export async function dev({
 
   const rsbuild = await createRsbuild(options, plugins);
 
-  return rsbuild.startDevServer();
+  const result = await rsbuild.startDevServer();
+
+  return {
+    ...result,
+    close: () => {
+      result.server.close();
+    },
+  };
 }
 
 export async function build({


### PR DESCRIPTION
## Summary

Align close server API in E2E code, use `rsbuild.close()` for both `dev` and `build`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
