### PR TITLE
feat: support decorator syntax when use babel plugin

### DIFF
--- a/e2e/cases/decorator/2022-03/index.test.ts
+++ b/e2e/cases/decorator/2022-03/index.test.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { build, gotoPage } from '@e2e/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should run stage 3 decorators correctly', async ({ page }) => {
   const rsbuild = await build({
@@ -14,3 +15,21 @@ test('should run stage 3 decorators correctly', async ({ page }) => {
 
   await rsbuild.close();
 });
+
+rspackOnlyTest(
+  'should run stage 3 decorators correctly with babel-plugin',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [pluginBabel()],
+    });
+
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.message')).toBe('hello');
+    expect(await page.evaluate('window.method')).toBe('targetMethod');
+    expect(await page.evaluate('window.field')).toBe('message');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/decorator/basic/index.test.ts
+++ b/e2e/cases/decorator/basic/index.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
-import { build, gotoPage } from '@e2e/helper';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should use legacy decorators by default', async ({ page }) => {
   const rsbuild = await build({
@@ -33,3 +34,44 @@ test('should allow to use stage 3 decorators', async ({ page }) => {
 
   await rsbuild.close();
 });
+
+rspackOnlyTest(
+  'should use legacy decorators with babel-plugin',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [pluginBabel()],
+    });
+
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.aaa')).toBe('hello!');
+    expect(await page.evaluate('window.bbb')).toBe('world');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should allow to use stage 3 decorators with babel-plugin',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [pluginBabel()],
+      rsbuildConfig: {
+        source: {
+          decorators: {
+            version: '2022-03',
+          },
+        },
+      },
+    });
+
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.aaa')).toBe('hello!');
+    expect(await page.evaluate('window.bbb')).toBe('world');
+
+    await rsbuild.close();
+  },
+);

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -29,6 +29,8 @@
   "dependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-typescript": "^7.23.2",
+    "@babel/plugin-proposal-decorators": "^7.23.2",
+    "@babel/plugin-transform-class-properties": "^7.23.2",
     "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "upath": "2.0.1"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -30,7 +30,7 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-typescript": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.23.2",
-    "@babel/plugin-transform-class-properties": "^7.23.2",
+    "@babel/plugin-transform-class-static-block": "^7.23.4",
     "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "upath": "2.0.1"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -30,7 +30,6 @@
     "@babel/core": "^7.23.2",
     "@babel/preset-typescript": "^7.23.2",
     "@babel/plugin-proposal-decorators": "^7.23.2",
-    "@babel/plugin-transform-class-static-block": "^7.23.4",
     "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "upath": "2.0.1"

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,6 +1,12 @@
 import path from 'node:path';
 import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
-import { castArray, cloneDeep, SCRIPT_REGEX, isProd } from '@rsbuild/shared';
+import {
+  castArray,
+  cloneDeep,
+  SCRIPT_REGEX,
+  isProd,
+  type Decorators,
+} from '@rsbuild/shared';
 import { applyUserBabelConfig, BABEL_JS_RULE } from './helper';
 import type { PluginBabelOptions } from './types';
 
@@ -17,22 +23,14 @@ export const DEFAULT_BABEL_PRESET_TYPESCRIPT_OPTIONS = {
   isTSX: true,
 };
 
-export const getDefaultBabelOptions = () => {
+export const getDefaultBabelOptions = (decorators: Decorators) => {
   return {
     babelrc: false,
     configFile: false,
     compact: isProd(),
     plugins: [
-      [
-        require.resolve('@babel/plugin-proposal-decorators'),
-        {
-          decoratorsBeforeExport: true,
-        },
-      ],
-      [
-        require.resolve('@babel/plugin-transform-class-properties'),
-        { loose: true },
-      ],
+      [require.resolve('@babel/plugin-proposal-decorators'), decorators],
+      require.resolve('@babel/plugin-transform-class-static-block'),
     ],
     presets: [
       // TODO: only apply preset-typescript for ts file (isTSX & allExtensions false)
@@ -53,8 +51,9 @@ export const pluginBabel = (
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+      const config = api.getNormalizedConfig();
       const getBabelOptions = () => {
-        const baseConfig = getDefaultBabelOptions();
+        const baseConfig = getDefaultBabelOptions(config.source.decorators);
 
         const userBabelConfig = applyUserBabelConfig(
           cloneDeep(baseConfig),

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -22,7 +22,18 @@ export const getDefaultBabelOptions = () => {
     babelrc: false,
     configFile: false,
     compact: isProd(),
-    plugins: [],
+    plugins: [
+      [
+        require.resolve('@babel/plugin-proposal-decorators'),
+        {
+          decoratorsBeforeExport: true,
+        },
+      ],
+      [
+        require.resolve('@babel/plugin-transform-class-properties'),
+        { loose: true },
+      ],
+    ],
     presets: [
       // TODO: only apply preset-typescript for ts file (isTSX & allExtensions false)
       [

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -30,7 +30,6 @@ export const getDefaultBabelOptions = (decorators: Decorators) => {
     compact: isProd(),
     plugins: [
       [require.resolve('@babel/plugin-proposal-decorators'), decorators],
-      require.resolve('@babel/plugin-transform-class-static-block'),
     ],
     presets: [
       // TODO: only apply preset-typescript for ts file (isTSX & allExtensions false)

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -57,7 +57,14 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
         "babelrc": false,
         "compact": false,
         "configFile": false,
-        "plugins": [],
+        "plugins": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+            {
+              "version": "legacy",
+            },
+          ],
+        ],
         "presets": [
           [
             "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
@@ -89,7 +96,14 @@ exports[`plugins/babel > should set babel-loader 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
@@ -125,6 +139,12 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 [
                   "babel-plugin-import",
                   {

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -13,7 +13,14 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
@@ -55,7 +62,14 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
@@ -94,7 +108,14 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",

--- a/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
@@ -23,7 +23,14 @@ exports[`plugin-source-build > should allow to set resolve priority 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",

--- a/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
@@ -15,6 +15,12 @@ exports[`plugin-vue-jsx > should allow to configure jsx babel plugin options 1`]
               "configFile": false,
               "plugins": [
                 [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                [
                   "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
                   {
                     "transformOn": false,
@@ -57,6 +63,12 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly 1`] = `
               "configFile": false,
               "plugins": [
                 [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+                [
                   "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
                   {},
                 ],
@@ -96,6 +108,12 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly in rspack mode
               "compact": false,
               "configFile": false,
               "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@vue/babel-plugin-jsx/dist/index.js",
                   {},

--- a/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
@@ -13,7 +13,14 @@ exports[`plugin-vue2-jsx > should allow to configure jsx babel plugin options 1`
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
@@ -54,7 +61,14 @@ exports[`plugin-vue2-jsx > should apply jsx babel plugin correctly 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
-              "plugins": [],
+              "plugins": [
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+                  {
+                    "version": "legacy",
+                  },
+                ],
+              ],
               "presets": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,9 +787,9 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
-      '@babel/plugin-transform-class-properties':
-        specifier: ^7.23.2
-        version: 7.23.3(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-static-block':
+        specifier: ^7.23.4
+        version: 7.23.4(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
@@ -2429,17 +2429,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.2):
-    resolution: {integrity: sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
-      '@babel/helper-plugin-utils': 7.22.5
-    dev: false
-
   /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}
     engines: {node: '>=6.9.0'}
@@ -2450,6 +2439,18 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+
+  /@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.2):
+    resolution: {integrity: sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.12.0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+    dev: false
 
   /@babel/plugin-transform-classes@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -784,6 +784,12 @@ importers:
       '@babel/core':
         specifier: ^7.23.2
         version: 7.23.2
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.23.2
+        version: 7.23.2(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.23.2
+        version: 7.23.3(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
@@ -2422,6 +2428,17 @@ packages:
       '@babel/core': 7.23.2
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
+
+  /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.2):
+    resolution: {integrity: sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.23.2
+      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+    dev: false
 
   /@babel/plugin-transform-class-static-block@7.22.11(@babel/core@7.23.2):
     resolution: {integrity: sha512-GMM8gGmqI7guS/llMFk1bJDkKfn3v3C4KHK9Yg1ey5qcHcOlKb0QvcMrgzvxo+T03/4szNh5lghY+fEC98Kq9g==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -787,9 +787,6 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
-      '@babel/plugin-transform-class-static-block':
-        specifier: ^7.23.4
-        version: 7.23.4(@babel/core@7.23.2)
       '@babel/preset-typescript':
         specifier: ^7.23.2
         version: 7.23.2(@babel/core@7.23.2)
@@ -2439,18 +2436,6 @@ packages:
       '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
-
-  /@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.2):
-    resolution: {integrity: sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
-    dependencies:
-      '@babel/core': 7.23.2
-      '@babel/helper-create-class-features-plugin': 7.22.15(@babel/core@7.23.2)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
-    dev: false
 
   /@babel/plugin-transform-classes@7.22.15(@babel/core@7.23.2):
     resolution: {integrity: sha512-VbbC3PGjBdE0wAWDdHM9G8Gm977pnYI0XpqMd6LrKISj8/DJXEsWqgRuTYaNE9Bv0JGhTZUzHDlMk18IpOuoqw==}


### PR DESCRIPTION
## Summary

`source.decorators` config should also supported in babel plugin.

https://rsbuild.dev/config/source/decorators

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
