### PR TITLE
docs: add security.nonce config

### DIFF
--- a/packages/document/docs/en/config/_meta.json
+++ b/packages/document/docs/en/config/_meta.json
@@ -39,5 +39,10 @@
     "type": "dir",
     "name": "performance",
     "label": "performance"
+  },
+  {
+    "type": "dir",
+    "name": "security",
+    "label": "security"
   }
 ]

--- a/packages/document/docs/en/config/security/nonce.md
+++ b/packages/document/docs/en/config/security/nonce.md
@@ -1,0 +1,33 @@
+# nonce
+
+- **Type:**
+
+```ts
+type Nonce = string;
+```
+
+- **Default:** `undefined`
+
+Add a random attribute value --- nonce, to the scripts resources introduced for HTML. This allows the browser to determine whether the script can be executed when it parses inline scripts with matching nonce values.
+
+#### Introduce nonce
+
+The nonce mechanism plays a crucial role in Content Security Policy (CSP), enhancing webpage security. It allows developers to define a unique and random string value, i.e., nonce, for inline `<script>` tags within CSP.
+
+When the browser parses inline scripts with matching nonce values, it allows them to be executed or applied, otherwise CSP will prevent them from running. This effectively prevents potential Cross-Site Scripting (XSS) attacks. It's worth noting that a new nonce value should be generated each time the page is accessed.
+
+For more information about nonce, you can check [nonce - MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)。
+
+### Example
+
+By default, `nonce` is not enabled，You can define this value based on your needs:
+
+```js
+export default {
+  security: {
+    nonce: 'my-project-nonce',
+  },
+};
+```
+
+Typically, we can define a fixed value in the project, and replace it with a random value on downstream servers such as Nginx, Web Server, gateway, etc.

--- a/packages/document/docs/en/guide/basic/configure-rsbuild.mdx
+++ b/packages/document/docs/en/guide/basic/configure-rsbuild.mdx
@@ -31,6 +31,9 @@ export default {
   performance: {
     // options for build performance and runtime performance
   },
+  security: {
+    // options for security
+  },
 };
 ```
 

--- a/packages/document/docs/zh/config/_meta.json
+++ b/packages/document/docs/zh/config/_meta.json
@@ -39,5 +39,10 @@
     "type": "dir",
     "name": "performance",
     "label": "performance"
+  },
+  {
+    "type": "dir",
+    "name": "security",
+    "label": "security"
   }
 ]

--- a/packages/document/docs/zh/config/security/nonce.md
+++ b/packages/document/docs/zh/config/security/nonce.md
@@ -1,0 +1,33 @@
+# nonce
+
+- **类型：**
+
+```ts
+type Nonce = string;
+```
+
+- **默认值：** `undefined`
+
+为 HTML 所引入的脚本资源添加随机属性值 nonce，使浏览器在解析到带有匹配 nonce 值的内联脚本时，能判断该脚本是否能执行。
+
+#### nonce 介绍
+
+nonce 机制在 Content Security Policy（CSP，内容安全策略）中起到关键作用，用于提升网页安全性。其允许开发者在 CSP 中为内联 `<script>` 标签定义一个唯一且随机的字符串值，即 `nonce`。
+
+浏览器在解析到带有匹配 `nonce` 值的内联脚本时，会允许其执行或应用，否则 CSP 将阻止其运行。这样可以有效地防止潜在的跨站脚本（XSS）攻击。值得注意的是，每次页面加载时，都应该生成新的 nonce 值。
+
+关于 nonce 的更多内容，可以查看 [nonce - MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce)。
+
+### 示例
+
+默认情况下，不会开启 `nonce`，你可以按照需求定义该值：
+
+```js
+export default {
+  security: {
+    nonce: 'my-project-nonce',
+  },
+};
+```
+
+通常，我们可以在项目中可以定义一个固定值，并在 Nginx、Web Server、网关等响应下游的服务器上，统一替换成随机值即可。

--- a/packages/document/docs/zh/guide/basic/configure-rsbuild.mdx
+++ b/packages/document/docs/zh/guide/basic/configure-rsbuild.mdx
@@ -31,6 +31,9 @@ export default {
   performance: {
     // 与构建性能、运行时性能有关的选项
   },
+  security: {
+    // 与安全有关的选项
+  },
 };
 ```
 


### PR DESCRIPTION
## Summary
`security.nonce` is supported in rsbuild, but missing in document.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
