### PR TITLE
fix: should not depend on uni builder plugin names

### DIFF
--- a/packages/compat/plugin-esbuild/src/index.ts
+++ b/packages/compat/plugin-esbuild/src/index.ts
@@ -1,5 +1,5 @@
 import { JS_REGEX, TS_REGEX, applyScriptCondition } from '@rsbuild/shared';
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type {
   LoaderOptions,
   MinifyPluginOptions,
@@ -15,8 +15,6 @@ export function pluginEsbuild(
 ): RsbuildPlugin {
   return {
     name: 'rsbuild-webpack:esbuild',
-
-    pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel'],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { PLUGIN_SWC_NAME, PLUGIN_BABEL_NAME } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,
   DEFAULT_BROWSERSLIST,
@@ -22,111 +21,112 @@ import { SwcMinimizerPlugin } from './minimizer';
  * - Add swc minifier plugin
  */
 export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
-  name: PLUGIN_SWC_NAME,
-
-  pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel'],
+  name: 'rsbuild-webpack:swc',
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {
       return;
     }
 
-    api.modifyBundlerChain(async (chain, utils) => {
-      const { CHAIN_ID, isProd } = utils;
-      const rsbuildConfig = api.getNormalizedConfig();
-      const { rootPath } = api.context;
+    api.modifyBundlerChain({
+      order: 'pre',
+      handler: async (chain, utils) => {
+        const { CHAIN_ID, isProd } = utils;
+        const rsbuildConfig = api.getNormalizedConfig();
+        const { rootPath } = api.context;
 
-      const swcConfigs = await applyPluginConfig(
-        options,
-        utils,
-        rsbuildConfig,
-        rootPath,
-      );
+        const swcConfigs = await applyPluginConfig(
+          options,
+          utils,
+          rsbuildConfig,
+          rootPath,
+        );
 
-      // If babel plugin is used, replace babel-loader
-      if (chain.module.rules.get(CHAIN_ID.RULE.JS)) {
-        chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.BABEL);
-        chain.module.delete(CHAIN_ID.RULE.TS);
-      } else {
-        applyScriptCondition({
-          rule: chain.module.rule(CHAIN_ID.RULE.JS),
-          config: rsbuildConfig,
-          context: api.context,
-          includes: [],
-          excludes: [],
-        });
-      }
+        // If babel plugin is used, replace babel-loader
+        if (chain.module.rules.get(CHAIN_ID.RULE.JS)) {
+          chain.module.rule(CHAIN_ID.RULE.JS).uses.delete(CHAIN_ID.USE.BABEL);
+          chain.module.delete(CHAIN_ID.RULE.TS);
+        } else {
+          applyScriptCondition({
+            rule: chain.module.rule(CHAIN_ID.RULE.JS),
+            config: rsbuildConfig,
+            context: api.context,
+            includes: [],
+            excludes: [],
+          });
+        }
 
-      for (let i = 0; i < swcConfigs.length; i++) {
-        const { test, include, exclude, swcConfig } = swcConfigs[i];
+        for (let i = 0; i < swcConfigs.length; i++) {
+          const { test, include, exclude, swcConfig } = swcConfigs[i];
 
-        const ruleId =
-          i > 0 ? CHAIN_ID.RULE.JS + i.toString() : CHAIN_ID.RULE.JS;
-        const rule = chain.module.rule(ruleId);
+          const ruleId =
+            i > 0 ? CHAIN_ID.RULE.JS + i.toString() : CHAIN_ID.RULE.JS;
+          const rule = chain.module.rule(ruleId);
 
-        // Insert swc loader and plugin
-        rule
-          .test(test || SCRIPT_REGEX)
-          .use(CHAIN_ID.USE.SWC)
-          .loader(path.resolve(__dirname, './loader'))
-          .options(removeUselessOptions(swcConfig) satisfies TransformConfig);
+          // Insert swc loader and plugin
+          rule
+            .test(test || SCRIPT_REGEX)
+            .use(CHAIN_ID.USE.SWC)
+            .loader(path.resolve(__dirname, './loader'))
+            .options(removeUselessOptions(swcConfig) satisfies TransformConfig);
 
-        if (include) {
-          for (const extra of include) {
-            rule.include.add(extra);
+          if (include) {
+            for (const extra of include) {
+              rule.include.add(extra);
+            }
+          }
+
+          if (exclude) {
+            for (const extra of exclude) {
+              rule.exclude.add(extra);
+            }
           }
         }
 
-        if (exclude) {
-          for (const extra of exclude) {
-            rule.exclude.add(extra);
-          }
+        // first config is the main config
+        const mainConfig = swcConfigs[0].swcConfig;
+
+        if (chain.module.rules.get(CHAIN_ID.RULE.JS_DATA_URI)) {
+          chain.module
+            .rule(CHAIN_ID.RULE.JS_DATA_URI)
+            .uses.delete(CHAIN_ID.USE.BABEL)
+            .end();
         }
-      }
 
-      // first config is the main config
-      const mainConfig = swcConfigs[0].swcConfig;
-
-      if (chain.module.rules.get(CHAIN_ID.RULE.JS_DATA_URI)) {
         chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)
-          .uses.delete(CHAIN_ID.USE.BABEL)
-          .end();
-      }
+          .mimetype({
+            or: ['text/javascript', 'application/javascript'],
+          })
+          .use(CHAIN_ID.USE.SWC)
+          .loader(path.resolve(__dirname, './loader'))
+          .options(removeUselessOptions(mainConfig) satisfies TransformConfig);
 
-      chain.module
-        .rule(CHAIN_ID.RULE.JS_DATA_URI)
-        .mimetype({
-          or: ['text/javascript', 'application/javascript'],
-        })
-        .use(CHAIN_ID.USE.SWC)
-        .loader(path.resolve(__dirname, './loader'))
-        .options(removeUselessOptions(mainConfig) satisfies TransformConfig);
+        if (checkUseMinify(mainConfig, rsbuildConfig, isProd)) {
+          // Insert swc minify plugin
+          // @ts-expect-error webpack-chain missing minimizers type
+          const minimizersChain = chain.optimization.minimizers;
 
-      if (checkUseMinify(mainConfig, rsbuildConfig, isProd)) {
-        // Insert swc minify plugin
-        // @ts-expect-error webpack-chain missing minimizers type
-        const minimizersChain = chain.optimization.minimizers;
+          if (mainConfig.jsMinify !== false) {
+            minimizersChain.delete(CHAIN_ID.MINIMIZER.JS).end();
+          }
 
-        if (mainConfig.jsMinify !== false) {
-          minimizersChain.delete(CHAIN_ID.MINIMIZER.JS).end();
+          if (mainConfig.cssMinify !== false) {
+            minimizersChain.delete(CHAIN_ID.MINIMIZER.CSS).end();
+          }
+
+          minimizersChain
+            .end()
+            .minimizer(CHAIN_ID.MINIMIZER.SWC)
+            .use(SwcMinimizerPlugin, [
+              {
+                jsMinify: mainConfig.jsMinify ?? mainConfig.jsc?.minify,
+                cssMinify: mainConfig.cssMinify,
+                rsbuildConfig,
+              },
+            ]);
         }
-
-        if (mainConfig.cssMinify !== false) {
-          minimizersChain.delete(CHAIN_ID.MINIMIZER.CSS).end();
-        }
-
-        minimizersChain
-          .end()
-          .minimizer(CHAIN_ID.MINIMIZER.SWC)
-          .use(SwcMinimizerPlugin, [
-            {
-              jsMinify: mainConfig.jsMinify ?? mainConfig.jsc?.minify,
-              cssMinify: mainConfig.cssMinify,
-              rsbuildConfig,
-            },
-          ]);
-      }
+      },
     });
   },
 });

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { SolidPresetOptions } from './types';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
@@ -15,8 +15,6 @@ export const PLUGIN_SOLID_NAME = 'rsbuild:solid';
 export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
   return {
     name: PLUGIN_SOLID_NAME,
-
-    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isDev }) => {

--- a/packages/plugin-source-build/src/index.ts
+++ b/packages/plugin-source-build/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { TS_CONFIG_FILE } from '@rsbuild/shared';
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import {
   filterByField,
   getDependentProjects,
@@ -52,8 +52,6 @@ export function pluginSourceBuild(
 
   return {
     name: PLUGIN_SOURCE_BUILD_NAME,
-
-    pre: [PLUGIN_BABEL_NAME, 'uni-builder:babel', 'uni-builder:ts-loader'],
 
     setup(api) {
       const projectRootPath = api.context.rootPath;

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -9,11 +9,7 @@ import {
   chainStaticAssetRule,
 } from '@rsbuild/shared';
 import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
-import {
-  PLUGIN_BABEL_NAME,
-  PLUGIN_SWC_NAME,
-  type RsbuildPlugin,
-} from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { Config } from '@svgr/core';
 
 export type SvgDefaultExport = 'component' | 'url';
@@ -53,13 +49,7 @@ function getSvgoDefaultConfig() {
 export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
   name: 'rsbuild:svgr',
 
-  pre: [
-    // SVGR needs to reuse the SWC loader options with react config
-    PLUGIN_SWC_NAME,
-    PLUGIN_REACT_NAME,
-    PLUGIN_BABEL_NAME,
-    'uni-builder:babel',
-  ],
+  pre: [PLUGIN_REACT_NAME],
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import type { VueJSXPluginOptions } from '@vue/babel-plugin-jsx';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
@@ -13,8 +13,6 @@ export type PluginVueJsxOptions = {
 export function pluginVueJsx(options: PluginVueJsxOptions = {}): RsbuildPlugin {
   return {
     name: 'rsbuild:vue-jsx',
-
-    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -1,4 +1,4 @@
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
 
 type VueJSXPresetOptions = {
@@ -36,8 +36,6 @@ export type PluginVueOptions = {
 export function pluginVue2Jsx(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
     name: 'rsbuild:vue2-jsx',
-
-    pre: [PLUGIN_BABEL_NAME],
 
     setup(api) {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {


### PR DESCRIPTION
## Summary

Should not depend on uni builder plugin names in Rsbuild.

This is a breaking change for Modern.js and will be released in v0.4.0.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
