### PR TITLE
chore(babel-preset): remove shared dependency

### DIFF
--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -57,13 +57,12 @@
     "@babel/preset-typescript": "^7.23.2",
     "@babel/runtime": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "@rsbuild/plugin-babel": "workspace:*",
-    "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "core-js": "~3.32.2"
   },
   "devDependencies": {
+    "@rsbuild/plugin-babel": "workspace:*",
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },

--- a/packages/babel-preset/src/base.ts
+++ b/packages/babel-preset/src/base.ts
@@ -1,4 +1,3 @@
-import { isTest } from '@rsbuild/shared';
 import type { BabelConfig, BasePresetOptions } from './types';
 
 export const generateBaseConfig = (
@@ -20,7 +19,7 @@ export const generateBaseConfig = (
       require.resolve('@babel/preset-env'),
       {
         // Jest only supports commonjs
-        modules: isTest() ? 'commonjs' : false,
+        modules: process.env.NODE_ENV === 'test' ? 'commonjs' : false,
         exclude: ['transform-typeof-symbol'],
         ...presetEnv,
       },

--- a/packages/babel-preset/src/node.ts
+++ b/packages/babel-preset/src/node.ts
@@ -1,22 +1,13 @@
-import { deepmerge } from '@rsbuild/shared';
 import { generateBaseConfig } from './base';
 import type { BabelConfig, NodePresetOptions } from './types';
 
 export const getBabelConfigForNode = (options: NodePresetOptions = {}) => {
-  let mergedOptions = options;
-
-  if (!options.presetEnv || !options.presetEnv.targets) {
-    mergedOptions = deepmerge(
-      {
-        presetEnv: {
-          targets: ['node >= 16'],
-        },
-      },
-      options,
-    );
+  if (options.presetEnv !== false) {
+    options.presetEnv ||= {};
+    options.presetEnv.targets ||= ['node >= 16'];
   }
 
-  const config = generateBaseConfig(mergedOptions);
+  const config = generateBaseConfig(options);
 
   config.plugins?.push(require.resolve('babel-plugin-dynamic-import-node'));
 

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -33,8 +33,8 @@ const getDefaultPresetEnvOption = (options: WebPresetOptions) => {
 export const getBabelConfigForWeb = (options: WebPresetOptions) => {
   if (options.presetEnv !== false) {
     options.presetEnv = {
-      ...options.presetEnv,
       ...getDefaultPresetEnvOption(options),
+      ...options.presetEnv,
     };
   }
 

--- a/packages/babel-preset/src/web.ts
+++ b/packages/babel-preset/src/web.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { generateBaseConfig } from './base';
 import type { BabelConfig, WebPresetOptions } from './types';
+import type { PresetEnvOptions } from '@rsbuild/plugin-babel';
 
 const getCoreJsVersion = (corejsPkgPath: string) => {
   try {
@@ -13,7 +14,9 @@ const getCoreJsVersion = (corejsPkgPath: string) => {
   }
 };
 
-const getDefaultPresetEnvOption = (options: WebPresetOptions) => {
+const getDefaultPresetEnvOption = (
+  options: WebPresetOptions,
+): PresetEnvOptions | false => {
   if (options.presetEnv === false) {
     return false;
   }

--- a/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/node.test.ts.snap
@@ -79,3 +79,18 @@ exports[`should provide node preset as expected 1`] = `
   ],
 }
 `;
+
+exports[`should provide node preset as expected when presetEnv is false 1`] = `
+[
+  [
+    "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+    {
+      "allExtensions": true,
+      "allowDeclareFields": true,
+      "allowNamespaces": true,
+      "isTSX": true,
+      "optimizeConstEnums": true,
+    },
+  ],
+]
+`;

--- a/packages/babel-preset/tests/node.test.ts
+++ b/packages/babel-preset/tests/node.test.ts
@@ -13,3 +13,11 @@ test('should allow to override target node version', () => {
     }),
   ).toMatchSnapshot();
 });
+
+test('should provide node preset as expected when presetEnv is false', () => {
+  expect(
+    getBabelConfigForNode({
+      presetEnv: false,
+    }).presets,
+  ).toMatchSnapshot();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -522,12 +522,6 @@ importers:
       '@babel/types':
         specifier: ^7.23.0
         version: 7.23.0
-      '@rsbuild/plugin-babel':
-        specifier: workspace:*
-        version: link:../plugin-babel
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/babel__core':
         specifier: ^7.20.3
         version: 7.20.3
@@ -538,6 +532,9 @@ importers:
         specifier: ~3.32.2
         version: 3.32.2
     devDependencies:
+      '@rsbuild/plugin-babel':
+        specifier: workspace:*
+        version: link:../plugin-babel
       '@types/node':
         specifier: 16.x
         version: 16.18.59


### PR DESCRIPTION
## Summary

Remove `@rsbuild/shared` dependency from `@rsbuild/babel-preset`, because babel-preset is used by many Modern.js packages, we do not want these packages to depend on `@rspack/core` (which is very large).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
