### PR TITLE
perf(plugin-react): reduce deepmerge overhead

### DIFF
--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -1,9 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import {
-  deepmerge,
-  modifySwcLoaderOptions,
-  type SwcReactConfig,
-} from '@rsbuild/shared';
+import { modifySwcLoaderOptions, type SwcReactConfig } from '@rsbuild/shared';
 
 export type PluginPreactOptions = {
   /**
@@ -39,14 +35,14 @@ export const pluginPreact = (
 
       modifySwcLoaderOptions({
         chain,
-        modifier: (options) => {
-          return deepmerge(options, {
-            jsc: {
-              transform: {
-                react: reactOptions,
-              },
-            },
-          });
+        modifier: (opts) => {
+          opts.jsc ??= {};
+          opts.jsc.transform ??= {};
+          opts.jsc.transform.react = {
+            ...opts.jsc.transform.react,
+            ...reactOptions,
+          };
+          return opts;
         },
       });
     });

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import {
-  deepmerge,
   isUsingHMR,
   modifySwcLoaderOptions,
   type SwcReactConfig,
@@ -27,14 +26,14 @@ export const applyBasicReactSupport = (
 
     modifySwcLoaderOptions({
       chain,
-      modifier: (options) => {
-        return deepmerge(options, {
-          jsc: {
-            transform: {
-              react: reactOptions,
-            },
-          },
-        });
+      modifier: (opts) => {
+        opts.jsc ??= {};
+        opts.jsc.transform ??= {};
+        opts.jsc.transform.react = {
+          ...opts.jsc.transform.react,
+          ...reactOptions,
+        };
+        return opts;
       },
     });
 


### PR DESCRIPTION
## Summary

Reduce deepmerge overhead, shallow merge is faster and do not need to create new object.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
