### PR TITLE
test(workflow): using new M1 macOS runner

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
   # ======== ut ========
   ut-mac:
     # run ut in MacOS, as SWC cases will fail in Ubuntu CI
-    runs-on: macos-latest
+    runs-on: macos-14
     strategy:
       matrix:
         node-version: [18.x] 

--- a/scripts/skipCI.js
+++ b/scripts/skipCI.js
@@ -3,7 +3,7 @@ const { execSync } = require('node:child_process');
 const SKIP_FOLDERS = [
   'cspell.json',
   '.changeset',
-  // '.github',
+  '.github',
   '.vscode',
   'packages/document',
   'scripts/skipCI.js',

--- a/scripts/skipCI.js
+++ b/scripts/skipCI.js
@@ -3,7 +3,7 @@ const { execSync } = require('node:child_process');
 const SKIP_FOLDERS = [
   'cspell.json',
   '.changeset',
-  '.github',
+  // '.github',
   '.vscode',
   'packages/document',
   'scripts/skipCI.js',


### PR DESCRIPTION
## Summary

Using new M1 macOS runner to make CI faster.

- old:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/5320c3b1-7e3d-478e-9010-fe108592638b)

- new:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/3c5244f0-90dc-4697-828a-7700f803925b)

## Related Links

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
