### PR TITLE
fix: resolve error when fullySpecified rule after js rule

### DIFF
--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -33,6 +33,12 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     },
     "rules": [
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -123,12 +129,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -33,6 +33,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     },
     "rules": [
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -123,12 +129,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [
@@ -704,6 +704,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     },
     "rules": [
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -794,12 +800,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [
@@ -1421,6 +1421,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
     "rules": [
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -1499,12 +1505,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [
@@ -1844,6 +1844,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
         ],
       },
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -1934,12 +1940,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -50,6 +50,12 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     },
     "rules": [
       {
+        "resolve": {
+          "fullySpecified": false,
+        },
+        "test": /\\\\\\.m\\?js/,
+      },
+      {
         "include": [
           {
             "and": [
@@ -150,12 +156,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             },
           },
         ],
-      },
-      {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
       },
       {
         "oneOf": [


### PR DESCRIPTION
## Summary

in some cases (modern.js source-build integration case), get error when fullySpecified rule after js rule:

<img width="920" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/b88da047-952e-438c-9440-2b92834e8b35">

## Related Links

https://github.com/web-infra-dev/modern.js/actions/runs/7723370235/job/21053319458

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
