### PR TITLE
chore: move babel plugin name constant

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -2,5 +2,4 @@ export const PLUGIN_SWC_NAME = 'rsbuild:swc';
 export const PLUGIN_CSS_NAME = 'rsbuild:css';
 export const PLUGIN_LESS_NAME = 'rsbuild:less';
 export const PLUGIN_SASS_NAME = 'rsbuild:sass';
-export const PLUGIN_BABEL_NAME = 'rsbuild:babel';
 export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,7 +19,6 @@ export {
   PLUGIN_CSS_NAME,
   PLUGIN_SASS_NAME,
   PLUGIN_LESS_NAME,
-  PLUGIN_BABEL_NAME,
   PLUGIN_STYLUS_NAME,
 } from './constants';
 

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,14 +1,16 @@
 import path from 'node:path';
-import { PLUGIN_BABEL_NAME, type RsbuildPlugin } from '@rsbuild/core';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import {
+  isProd,
   castArray,
   cloneDeep,
   SCRIPT_REGEX,
-  isProd,
   type Decorators,
 } from '@rsbuild/shared';
 import { applyUserBabelConfig, BABEL_JS_RULE } from './helper';
 import type { PluginBabelOptions } from './types';
+
+export const PLUGIN_BABEL_NAME = 'rsbuild:babel';
 
 /**
  * The `@babel/preset-typescript` default options.
@@ -40,8 +42,6 @@ export const getDefaultBabelOptions = (decorators: Decorators) => {
     ],
   };
 };
-
-export { PLUGIN_BABEL_NAME };
 
 export const pluginBabel = (
   options: PluginBabelOptions = {},


### PR DESCRIPTION
## Summary

Move babel plugin name constant to `@rsbuild/plugin-babel`, this is a small breaking change. As far as I know, no external users are currently using this constant.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
