### PR TITLE
breaking change: loadConfig method return value changed

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -107,7 +107,7 @@ const updateConfigForTest = async (
   cwd: string = process.cwd(),
 ) => {
   const { loadConfig, mergeRsbuildConfig } = await import('@rsbuild/core');
-  const loadedConfig = await loadConfig({
+  const { content: loadedConfig } = await loadConfig({
     cwd,
   });
 

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { color, isDev, logger } from '@rsbuild/shared';
 import { program, type Command } from '@rsbuild/shared/commander';
 import { loadEnv } from '../loadEnv';
-import { loadConfigV2, watchFiles } from './config';
+import { loadConfig, watchFiles } from './config';
 import type { RsbuildMode } from '..';
 import { onBeforeRestartServer } from '../server/restart';
 
@@ -53,7 +53,7 @@ export async function init({
       onBeforeRestartServer(envs.cleanup);
     }
 
-    const { content: config, filePath: configFilePath } = await loadConfigV2({
+    const { content: config, filePath: configFilePath } = await loadConfig({
       cwd: root,
       path: commonOpts.config,
       envMode: commonOpts.envMode,

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -67,6 +67,8 @@ const { content } = await loadConfig();
 console.log(content); // -> Rsbuild config object
 ```
 
+If the Rsbuild config file does not exist in the cwd directory, the return value of the loadConfig method is `{ content: {}, filePath: null }`.
+
 ## loadEnv
 
 Load the `.env` file and return all environment variables starting with the specified prefixes.

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -51,7 +51,10 @@ function loadConfig(params: {
   cwd: string;
   // Specify the configuration file, can be a relative or absolute path
   path?: string;
-}): Promise<RsbuildConfig>;
+}): Promise<{
+  content: RsbuildConfig;
+  filePath: string | null;
+}>;
 ```
 
 - **Example:**
@@ -59,9 +62,9 @@ function loadConfig(params: {
 ```ts
 import { loadConfig } from '@rsbuild/core';
 
-const config = await loadConfig();
+const { content } = await loadConfig();
 
-console.log(config); // -> RsbuildConfig
+console.log(content); // -> Rsbuild config object
 ```
 
 ## loadEnv

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -51,7 +51,10 @@ function loadConfig(params: {
   cwd: string;
   // 指定配置文件路径，可以为相对路径或绝对路径
   path?: string;
-}): Promise<RsbuildConfig>;
+}): Promise<{
+  content: RsbuildConfig;
+  filePath: string | null;
+}>;
 ```
 
 - **示例：**
@@ -59,9 +62,9 @@ function loadConfig(params: {
 ```ts
 import { loadConfig } from '@rsbuild/core';
 
-const config = await loadConfig();
+const { content } = await loadConfig();
 
-console.log(config); // -> RsbuildConfig
+console.log(content); // -> Rsbuild config object
 ```
 
 ## loadEnv

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -67,6 +67,8 @@ const { content } = await loadConfig();
 console.log(content); // -> Rsbuild config object
 ```
 
+如果 cwd 目录下不存在 Rsbuild 配置文件，loadConfig 方法的返回值为 `{ content: {}, filePath: null }`。
+
 ## loadEnv
 
 加载 `.env` 文件，并返回所有以 prefixes 开头的环境变量。


### PR DESCRIPTION
## Summary

The `loadConfig` method now returns both the contents of the config and the path to the config file:

```js
import { loadConfig } from '@rsbuild/core';

// v0.3
const config = await loadConfig();

// v0.4
const { content, filePath } = await loadConfig();
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1420

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
