### PR TITLE
types: fix cacheGroups type mismatch

### DIFF
--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -53,6 +53,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
+      // @ts-expect-error cacheGroups type mismatch
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -53,7 +53,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
-      // @ts-expect-error cacheGroups type mismatch
+      // @ts-expect-error Rspack and Webpack uses different cacheGroups type
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -44,7 +44,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
-      // @ts-expect-error cacheGroups type mismatch
+      // @ts-expect-error Rspack and Webpack uses different cacheGroups type
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -44,6 +44,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
+      // @ts-expect-error cacheGroups type mismatch
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),

--- a/packages/plugin-vue2/src/splitChunks.ts
+++ b/packages/plugin-vue2/src/splitChunks.ts
@@ -40,7 +40,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
-      // @ts-expect-error cacheGroups type mismatch
+      // @ts-expect-error Rspack and Webpack uses different cacheGroups type
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),

--- a/packages/plugin-vue2/src/splitChunks.ts
+++ b/packages/plugin-vue2/src/splitChunks.ts
@@ -40,6 +40,7 @@ export const applySplitChunksRule = (
 
     chain.optimization.splitChunks({
       ...currentConfig,
+      // @ts-expect-error cacheGroups type mismatch
       cacheGroups: {
         ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
         ...createCacheGroups(extraGroups),


### PR DESCRIPTION
## Summary

Fix cacheGroups type mismatch, Rspack and Webpack uses different cacheGroups type

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
