### PR TITLE
feat: print tips if resolve Node.js builtin module failed

### DIFF
--- a/e2e/cases/node-polyfill-tip/index.test.ts
+++ b/e2e/cases/node-polyfill-tip/index.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test';
+import { build, proxyConsole } from '@e2e/helper';
+
+test('should print tips if resolve Node.js builtin module failed', async () => {
+  const { logs, restore } = proxyConsole();
+
+  try {
+    await build({ cwd: __dirname });
+  } catch (err) {}
+
+  restore();
+  expect(
+    logs.some((log) =>
+      log.includes(
+        '"querystring" is a built-in Node.js module and cannot be imported in client-side code',
+      ),
+    ),
+  );
+});

--- a/e2e/cases/node-polyfill-tip/src/index.js
+++ b/e2e/cases/node-polyfill-tip/src/index.js
@@ -1,0 +1,6 @@
+// biome-ignore lint: node polyfill only supports non-prefix usage
+import querystring from 'querystring';
+
+querystring.stringify({
+  foo: 'bar',
+});

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -96,6 +96,75 @@ export const getCompiledPath = (packageName: string) => {
 
 export const BUILTIN_LOADER = 'builtin:';
 
+const addNodePolyfillTip = (message: string) => {
+  if (!message.includes(`Can't resolve`)) {
+    return;
+  }
+
+  const matchArray = message.match(/Can't resolve '(\w+)'/);
+  if (!matchArray) {
+    return;
+  }
+
+  const moduleName = matchArray[1];
+  const nodeModules = [
+    'assert',
+    'buffer',
+    'console',
+    'constants',
+    'crypto',
+    'domain',
+    'events',
+    'http',
+    'https',
+    'os',
+    'path',
+    'punycode',
+    'process',
+    'querystring',
+    'stream',
+    '_stream_duplex',
+    '_stream_passthrough',
+    '_stream_readable',
+    '_stream_transform',
+    '_stream_writable',
+    'string_decoder',
+    'sys',
+    'timers',
+    'tty',
+    'url',
+    'util',
+    'vm',
+    'zlib',
+  ];
+
+  if (moduleName && nodeModules.includes(moduleName)) {
+    const tips = [
+      `Tip: "${moduleName}" is a built-in Node.js module and cannot be imported in client-side code.`,
+      `Check if you need to import Node.js module. If needed, you can use "@rsbuild/plugin-node-polyfill".`,
+    ];
+    return `${message}\n\n${color.yellow(tips.join('\n'))}`;
+  }
+};
+
+function formatErrorMessage(errors: string[]) {
+  const messages = errors.map((error) => addNodePolyfillTip(error));
+
+  const text = `${messages.join('\n\n')}\n`;
+  const isTerserError = text.includes('from Terser');
+  const title = color.bold(
+    color.red(isTerserError ? 'Minify error: ' : 'Compile error: '),
+  );
+
+  const tip = color.yellow(
+    isTerserError
+      ? 'Failed to minify with terser, check for syntax errors.'
+      : 'Failed to compile, check the errors for troubleshooting.',
+  );
+
+  return `${title}\n${tip}\n${text}`;
+}
+
 export function formatStats(stats: Stats | MultiStats) {
   const statsData = stats.toJson({
     preset: 'errors-warnings',
@@ -104,19 +173,8 @@ export function formatStats(stats: Stats | MultiStats) {
   const { errors, warnings } = formatStatsMessages(statsData);
 
   if (errors.length) {
-    const errorMsgs = `${errors.join('\n\n')}\n`;
-    const isTerserError = errorMsgs.includes('from Terser');
-    const title = color.bold(
-      color.red(isTerserError ? 'Minify error: ' : 'Compile error: '),
-    );
-    const tip = color.yellow(
-      isTerserError
-        ? 'Failed to minify with terser, check for syntax errors.'
-        : 'Failed to compile, check the errors for troubleshooting.',
-    );
-
     return {
-      message: `${title}\n${tip}\n${errorMsgs}`,
+      message: formatErrorMessage(errors),
       level: 'error',
     };
   }


### PR DESCRIPTION
## Summary

Print tips if resolve Node.js builtin module failed (this is a common issue):

<img width="990" alt="Screenshot 2024-02-01 at 21 53 30" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/5109882e-a469-4cb2-9264-0cc3d0851a07">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
