### PR TITLE
docs: add Node.js profiling guide

### DIFF
--- a/packages/document/docs/en/config/performance/profile.mdx
+++ b/packages/document/docs/en/config/performance/profile.mdx
@@ -16,3 +16,7 @@ export default {
 ```
 
 When enabled, Rspack generates a JSON file with some statistics about the module that includes information about timing information for each module.
+
+### Node.js Profiling
+
+You can also analyze the overhead on the Node.js side, see [Node.js Profiling](/guide/optimization/build-performance#nodejs-profiling).

--- a/packages/document/docs/en/guide/optimization/build-performance.mdx
+++ b/packages/document/docs/en/guide/optimization/build-performance.mdx
@@ -4,9 +4,38 @@ Rsbuild optimizes build performance by default, but as the project becomes large
 
 This document provides some optional speed-up strategies, developers can choose some of them to improve the build performance.
 
-:::tip 📢 Notice
+:::tip
 The strategies in [Bundle Size Optimization](/guide/optimization/optimize-bundle) can also be used to improve build performance, so we won't repeat them here.
 :::
+
+## Performance Profiling
+
+Performing a performance analysis can help you identify performance bottlenecks in your project, allowing for targeted optimization.
+
+### Node.js Profiling
+
+In general, the performance overhead on the JS side will be greater than that on the Rust side, and you can use Node.js profiling to analyze the overhead on the JS side.
+
+Run the following command in the project root:
+
+```bash
+# dev
+node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js dev
+
+# build
+node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js build
+```
+
+The above commands will generate a cpuprofile file. We can use [speedscope](https://github.com/jlfwong/speedscope) to visualize this file:
+
+```bash
+# Install speedscope
+npm install -g speedscope
+
+# View cpuprofile content
+# Replace the name with the local file name
+speedscope CPU.date.000000.00000.0.001.cpuprofile
+```
 
 ## General optimization strategy
 

--- a/packages/document/docs/zh/config/performance/profile.mdx
+++ b/packages/document/docs/zh/config/performance/profile.mdx
@@ -16,3 +16,7 @@ export default {
 ```
 
 开启后，Rspack 在生成一些关于模块统计数据的 JSON 文件时，会将模块构建的耗时信息也包含进去。
+
+### Node.js Profiling
+
+你也可以分析 Node.js 侧的开销，参考 [Node.js Profiling](/guide/optimization/build-performance#nodejs-profiling)。

--- a/packages/document/docs/zh/guide/optimization/build-performance.mdx
+++ b/packages/document/docs/zh/guide/optimization/build-performance.mdx
@@ -4,9 +4,38 @@ Rsbuild 默认对构建性能进行了充分优化，但是随着业务场景变
 
 本文档提供了一些可选的提速策略，**开发者可以根据实际场景选取其中的部分策略**，从而进一步提升构建速度。
 
-:::tip 📢 注意
+:::tip
 在[优化产物体积](/guide/optimization/optimize-bundle)一文中介绍的策略也可以用于提升构建性能，这里不再重复介绍。
 :::
+
+## 性能分析
+
+进行性能分析可以帮助你确定项目中的性能瓶颈，从而采取针对性的优化。
+
+### Node.js Profiling
+
+通常而言，JS 侧的性能开销会大于 Rust 侧的性能开销，你可以使用 Node.js Profiling 分析 JS 侧的开销。
+
+在项目根目录执行以下命令：
+
+```bash
+# dev
+node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js dev
+
+# build
+node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js build
+```
+
+以上命令执行后会生成一个 cpuprofile 文件，我们可以使用 [speedscope](https://github.com/jlfwong/speedscope) 来可视化查看该文件：
+
+```bash
+# 安装 speedscope
+npm install -g speedscope
+
+# 查看 cpuprofile 内容
+# 请将文件名替换为本地文件的名称
+speedscope CPU.date.000000.00000.0.001.cpuprofile
+```
 
 ## 通用优化策略
 


### PR DESCRIPTION
## Summary

Add Node.js profiling guide, use [speedscope](https://github.com/jlfwong/speedscope) to visualize this file.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
