### PR TITLE
perf: remove duplicate autoprefixer plugin

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/css.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/css.test.ts.snap
@@ -66,7 +66,10 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "Chrome 80",
@@ -125,7 +128,10 @@ exports[`plugin-css > should remove some postcss plugins based on browserslist 1
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "Chrome 100",

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -183,7 +183,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -239,7 +242,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -309,7 +315,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -685,7 +694,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -741,7 +753,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -811,7 +826,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -262,7 +262,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -303,7 +306,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -350,7 +356,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -401,7 +410,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -458,7 +470,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -513,7 +528,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -38,7 +38,10 @@ exports[`plugin-css > should apply custom css-modules-typescript-loader when ena
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -88,7 +91,10 @@ exports[`plugin-css > should apply custom css-modules-typescript-loader when ena
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -158,7 +164,10 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "Chrome 80",
@@ -193,7 +202,10 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "Chrome 80",
@@ -257,7 +269,10 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -298,7 +313,10 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -414,7 +432,10 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -467,7 +488,10 @@ exports[`plugin-less > should add less-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -518,7 +542,10 @@ exports[`plugin-less > should add less-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -599,7 +626,10 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -665,7 +695,10 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -719,7 +752,10 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -785,7 +821,10 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -836,7 +875,10 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -902,7 +944,10 @@ exports[`plugin-sass > should add sass-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -957,7 +1002,10 @@ exports[`plugin-sass > should add sass-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1042,7 +1090,10 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
               "postcssOptions": {
                 "config": false,
                 "plugins": [
-                  [Function],
+                  {
+                    "Once": [Function],
+                    "postcssPlugin": "postcss-flexbugs-fixes",
+                  },
                   {
                     "browsers": [
                       "chrome >= 87",
@@ -1112,7 +1163,10 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1170,7 +1224,10 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -262,7 +262,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -303,7 +306,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -350,7 +356,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -401,7 +410,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -458,7 +470,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -513,7 +528,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -933,7 +951,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -974,7 +995,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1021,7 +1045,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1072,7 +1099,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1129,7 +1159,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -1184,7 +1217,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2073,7 +2109,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2114,7 +2153,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2161,7 +2203,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2212,7 +2257,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2269,7 +2317,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -2324,7 +2375,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/document/docs/en/config/tools/autoprefixer.mdx
+++ b/packages/document/docs/en/config/tools/autoprefixer.mdx
@@ -4,15 +4,19 @@
 - **Default:**
 
 ```js
-{
+const defaultConfig = {
   flexbox: 'no-2009',
   // Depends on the browserslist config in the project
   // and the `output.overrideBrowserslist` (higher priority) config
   overrideBrowserslist: browserslist,
-}
+};
 ```
 
-You can modify the config of [autoprefixer](https://github.com/postcss/autoprefixer) by `tools.autoprefixer`.
+Use `tools.autoprefixer` to modify the configuration of the [autoprefixer](https://github.com/postcss/autoprefixer) plugin that is built into Rsbuild.
+
+:::tip
+If you have registered the autoprefixer plugin in the project yourself, `tools.autoprefixer` will not work.
+:::
 
 ### Object Type
 

--- a/packages/document/docs/en/guide/basic/css-usage.md
+++ b/packages/document/docs/en/guide/basic/css-usage.md
@@ -50,6 +50,10 @@ Rsbuild has some builtin PostCSS plugins, which will perform the following trans
 - [autoprefixer](https://github.com/postcss/autoprefixer): we have enabled [autoprefixer](https://github.com/postcss/autoprefixer) to add vendor prefixes to CSS rules. If you want to configure the target browser, you can use [browserslist](/guide/advanced/browserslist).
 - [postcss-flexbugs-fixes](https://npmjs.com/package/postcss-flexbugs-fixes): Used to fix known [Flex Bugs](https://github.com/philipwalton/flexbugs).
 
+:::tip
+If the autoprefixer plugin is already registered in your project, Rsbuild will not register the autoprefixer plugin again.
+:::
+
 ## Using CSS Modules
 
 Please read the [Using CSS Modules](/guide/basic/css-modules) chapter for a complete usage of CSS Modules.

--- a/packages/document/docs/zh/config/tools/autoprefixer.mdx
+++ b/packages/document/docs/zh/config/tools/autoprefixer.mdx
@@ -4,15 +4,19 @@
 - **默认值：**
 
 ```js
-{
+const defaultConfig = {
   flexbox: 'no-2009',
   // browserslist 取决于项目中的 browserslist 配置
   // 以及 `output.overrideBrowserslist`(优先级更高) 配置
   overrideBrowserslist: browserslist,
-}
+};
 ```
 
-通过 `tools.autoprefixer` 可以修改 [autoprefixer](https://github.com/postcss/autoprefixer) 的配置。
+通过 `tools.autoprefixer` 可以修改 Rsbuild 内置的 [autoprefixer](https://github.com/postcss/autoprefixer) 插件的配置。
+
+:::tip
+如果你的项目中自行注册了 autoprefixer 插件，`tools.autoprefixer` 将不会生效。
+:::
 
 ### Object 类型
 

--- a/packages/document/docs/zh/guide/basic/css-usage.md
+++ b/packages/document/docs/zh/guide/basic/css-usage.md
@@ -50,6 +50,10 @@ Rsbuild 内置了一些 PostCSS 插件，会对 CSS 进行以下转换：
 - [autoprefixer](https://github.com/postcss/autoprefixer)：在默认情况下，我们开启了 autoprefixer 来自动补齐 CSS 的浏览器前缀。如果你需要配置目标浏览器，可以使用 [browserslist](/guide/advanced/browserslist) 进行配置。
 - [postcss-flexbugs-fixes](https://npmjs.com/package/postcss-flexbugs-fixes)：用于修复已知的 [Flex Bugs](https://github.com/philipwalton/flexbugs)。
 
+:::tip
+如果你的项目中已经注册了 autoprefixer 插件，Rsbuild 不会再次注册 autoprefixer 插件。
+:::
+
 ## 使用 CSS Modules
 
 请阅读 [使用 CSS Modules](/guide/basic/css-modules) 章节来了解 CSS Modules 的完整用法。

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -289,7 +289,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -330,7 +333,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -377,7 +383,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -428,7 +437,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -485,7 +497,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -540,7 +555,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,10 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -76,7 +79,10 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -152,7 +158,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -199,7 +208,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -252,7 +264,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -309,7 +324,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -372,7 +390,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -433,7 +454,10 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -542,7 +566,10 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -589,7 +616,10 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -689,7 +719,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -736,7 +769,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -789,7 +825,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -846,7 +885,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -909,7 +951,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -970,7 +1015,10 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -20,7 +20,10 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -67,7 +70,10 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -129,7 +135,10 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -179,7 +188,10 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/plugin-stylus/tests/__snapshots__/rspack.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/rspack.test.ts.snap
@@ -20,7 +20,10 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -67,7 +70,10 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -129,7 +135,10 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",
@@ -179,7 +188,10 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
                   "postcssOptions": {
                     "config": false,
                     "plugins": [
-                      [Function],
+                      {
+                        "Once": [Function],
+                        "postcssPlugin": "postcss-flexbugs-fixes",
+                      },
                       {
                         "browsers": [
                           "chrome >= 87",

--- a/packages/shared/tests/css.test.ts
+++ b/packages/shared/tests/css.test.ts
@@ -1,4 +1,10 @@
-import { isCssModules, normalizeCssLoaderOptions } from '../src/css';
+import {
+  isCssModules,
+  applyAutoprefixer,
+  normalizeCssLoaderOptions,
+} from '../src/css';
+import autoprefixer from '../compiled/autoprefixer';
+import type { NormalizedConfig } from '../src';
 
 describe('normalizeCssLoaderOptions', () => {
   it('should enable exportOnlyLocals correctly', () => {
@@ -71,4 +77,23 @@ it('check isCssModules', () => {
       auto: /\.module\./i,
     }),
   ).toBeFalsy();
+});
+
+it('should not apply autoprefixer if user config contains autoprefixer', async () => {
+  const config = {
+    tools: {},
+  } as NormalizedConfig;
+
+  expect(
+    (await applyAutoprefixer([autoprefixer()], ['Chrome >= 100'], config))
+      .length,
+  ).toEqual(1);
+
+  expect(
+    (await applyAutoprefixer([autoprefixer], ['Chrome >= 100'], config)).length,
+  ).toEqual(1);
+
+  expect(
+    (await applyAutoprefixer([], ['Chrome >= 100'], config)).length,
+  ).toEqual(1);
 });


### PR DESCRIPTION
## Summary

Check if autoprefixer is already registered in the user project. If the autoprefixer plugin is already registered in your project, Rsbuild will not register the autoprefixer plugin again.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
