### PR TITLE
fix: less default resolve directory

### DIFF
--- a/packages/compat/webpack/src/plugins/less.ts
+++ b/packages/compat/webpack/src/plugins/less.ts
@@ -21,6 +21,7 @@ export function pluginLess(): RsbuildPlugin {
         const { options, excludes } = getLessLoaderOptions(
           config.tools.less,
           config.output.sourceMap.css,
+          api.context.rootPath,
         );
         const rule = chain.module
           .rule(utils.CHAIN_ID.RULE.LESS)

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -338,6 +338,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               "implementation": "<ROOT>/packages/shared/compiled/less",
               "lessOptions": {
                 "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/packages/compat/webpack/tests/node_modules",
+                ],
               },
               "sourceMap": false,
             },
@@ -837,6 +840,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
               "implementation": "<ROOT>/packages/shared/compiled/less",
               "lessOptions": {
                 "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/packages/compat/webpack/tests/node_modules",
+                ],
               },
               "sourceMap": false,
             },
@@ -1294,6 +1300,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "implementation": "<ROOT>/packages/shared/compiled/less",
               "lessOptions": {
                 "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/packages/compat/webpack/tests/node_modules",
+                ],
               },
               "sourceMap": false,
             },
@@ -1652,6 +1661,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               "implementation": "<ROOT>/packages/shared/compiled/less",
               "lessOptions": {
                 "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/packages/compat/webpack/tests/node_modules",
+                ],
               },
               "sourceMap": false,
             },

--- a/packages/core/src/provider/plugins/less.ts
+++ b/packages/core/src/provider/plugins/less.ts
@@ -20,6 +20,7 @@ export function pluginLess(): RsbuildPlugin {
         const { excludes, options } = getLessLoaderOptions(
           config.tools.less,
           config.output.sourceMap.css,
+          api.context.rootPath,
         );
 
         excludes.forEach((item) => {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -379,6 +379,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -429,6 +432,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -491,6 +491,9 @@ exports[`plugin-less > should add less-loader 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -541,6 +544,9 @@ exports[`plugin-less > should add less-loader 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -621,6 +627,9 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
               "implementation": "<ROOT>/packages/shared/compiled/less",
               "lessOptions": {
                 "javascriptEnabled": true,
+                "paths": [
+                  "<ROOT>/packages/core/tests/node_modules",
+                ],
               },
               "sourceMap": false,
             },
@@ -686,6 +695,9 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -739,6 +751,9 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -804,6 +819,9 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": false,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -854,6 +872,9 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": false,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -379,6 +379,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -429,6 +432,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -1044,6 +1050,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -1094,6 +1103,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -1657,6 +1669,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -1676,6 +1691,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -2178,6 +2196,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -2228,6 +2249,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/core/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },

--- a/packages/document/docs/en/config/tools/less.mdx
+++ b/packages/document/docs/en/config/tools/less.mdx
@@ -7,6 +7,7 @@
 const defaultOptions = {
   lessOptions: {
     javascriptEnabled: true,
+    paths: [path.join(rootPath, 'node_modules')],
   },
   sourceMap: rsbuildConfig.output.sourceMap.css,
 };

--- a/packages/document/docs/zh/config/tools/less.mdx
+++ b/packages/document/docs/zh/config/tools/less.mdx
@@ -7,6 +7,7 @@
 const defaultOptions = {
   lessOptions: {
     javascriptEnabled: true,
+    paths: [path.join(rootPath, 'node_modules')],
   },
   sourceMap: rsbuildConfig.output.sourceMap.css,
 };

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -406,6 +406,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-react/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -456,6 +459,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-react/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -285,6 +285,9 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-rem/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -341,6 +344,9 @@ exports[`plugin-rem > should order plugins and run rem plugin with default confi
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-rem/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -814,6 +820,9 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-rem/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },
@@ -870,6 +879,9 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
                   "implementation": "<ROOT>/packages/shared/compiled/less",
                   "lessOptions": {
                     "javascriptEnabled": true,
+                    "paths": [
+                      "<ROOT>/packages/plugin-rem/tests/node_modules",
+                    ],
                   },
                   "sourceMap": false,
                 },

--- a/packages/shared/src/getLoaderOptions.ts
+++ b/packages/shared/src/getLoaderOptions.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type {
   ToolsSassConfig,
   ToolsLessConfig,
@@ -58,6 +59,7 @@ export const getSassLoaderOptions = (
 export const getLessLoaderOptions = (
   rsbuildLessConfig: ToolsLessConfig | undefined,
   isUseCssSourceMap: boolean,
+  rootPath: string,
 ) => {
   const excludes: (RegExp | string)[] = [];
 
@@ -68,6 +70,9 @@ export const getLessLoaderOptions = (
   const defaultLessLoaderOptions: LessLoaderOptions = {
     lessOptions: {
       javascriptEnabled: true,
+      // let less resolve from node_modules in the current root directory,
+      // Avoid resolving from wrong node_modules.
+      paths: [path.join(rootPath, 'node_modules')],
     },
     sourceMap: isUseCssSourceMap,
     implementation: getSharedPkgCompiledPath('less'),


### PR DESCRIPTION
## Summary

Fix less default resolve directory.

Let less resolve from node_modules in the current root directory, to avoid resolving from wrong node_modules.

![img_v3_027o_44752ed5-5389-431b-9602-1953c8984ebg](https://github.com/web-infra-dev/rsbuild/assets/7237365/ef731b40-b674-4aca-b394-598b28af4d00)

## Related Links

https://lesscss.org/usage/#less-options-include-paths

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
