### PR TITLE
fix(server): not proxy websocket by default

### DIFF
--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -68,7 +68,10 @@ export const createProxyMiddleware = (proxyOptions: ProxyOptions) => {
     };
 
     middlewares.push(middleware);
-    proxyMiddlewares.push(proxyMiddleware);
+
+    // only proxy WebSocket request when user specified
+    // fix WebSocket error when user forget filter hmr path
+    opts.ws && proxyMiddlewares.push(proxyMiddleware);
   }
 
   const handleUpgrade: UpgradeEvent = (req, socket, head) => {

--- a/packages/document/docs/en/config/server/proxy.mdx
+++ b/packages/document/docs/en/config/server/proxy.mdx
@@ -56,6 +56,24 @@ export default {
 };
 ```
 
+### Proxy WebSocket
+
+If you want to proxy WebSocket requests, you can enable it through set `ws` to `true`:
+
+```js
+export default {
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        pathRewrite: { '^/api': '' },
+        ws: true,
+      },
+    },
+  },
+};
+```
+
 ## Options
 
 The Rsbuild Server Proxy makes use of the [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) package. Check out its documentation for more advanced usages.

--- a/packages/document/docs/en/config/server/proxy.mdx
+++ b/packages/document/docs/en/config/server/proxy.mdx
@@ -64,9 +64,8 @@ If you want to proxy WebSocket requests, you can enable it through set `ws` to `
 export default {
   server: {
     proxy: {
-      '/api': {
+      '/rsbuild-hmr': {
         target: 'http://localhost:3000',
-        pathRewrite: { '^/api': '' },
         ws: true,
       },
     },

--- a/packages/document/docs/en/config/server/proxy.mdx
+++ b/packages/document/docs/en/config/server/proxy.mdx
@@ -65,7 +65,7 @@ export default {
   server: {
     proxy: {
       '/rsbuild-hmr': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:3000', // will proxy to ws://localhost:3000/rsbuild-hmr
         ws: true,
       },
     },

--- a/packages/document/docs/zh/config/server/proxy.mdx
+++ b/packages/document/docs/zh/config/server/proxy.mdx
@@ -56,6 +56,24 @@ export default {
 };
 ```
 
+### 代理 WebSocket 请求
+
+如果你希望代理 WebSocket 请求，可以通过 `ws` 开启：
+
+```js
+export default {
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        pathRewrite: { '^/api': '' },
+        ws: true,
+      },
+    },
+  },
+};
+```
+
 ## 选项
 
 Rsbuild Server Proxy 基于 [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware/tree/2.x) 实现。你可以使用 http-proxy-middleware 的所有配置项，具体可以查看文档。

--- a/packages/document/docs/zh/config/server/proxy.mdx
+++ b/packages/document/docs/zh/config/server/proxy.mdx
@@ -65,7 +65,7 @@ export default {
   server: {
     proxy: {
       '/rsbuild-hmr': {
-        target: 'http://localhost:3000',
+        target: 'http://localhost:3000', // 将会代理到 ws://localhost:3000/rsbuild-hmr
         ws: true,
       },
     },

--- a/packages/document/docs/zh/config/server/proxy.mdx
+++ b/packages/document/docs/zh/config/server/proxy.mdx
@@ -64,9 +64,8 @@ export default {
 export default {
   server: {
     proxy: {
-      '/api': {
+      '/rsbuild-hmr': {
         target: 'http://localhost:3000',
-        pathRewrite: { '^/api': '' },
         ws: true,
       },
     },


### PR DESCRIPTION
## Summary


fix WebSocket connect error when user use proxy and forget exclude hmr path (proxy WebSocket to a wrong path )

![img_v3_027q_5a5db243-f541-4b67-8137-ab60c093707g](https://github.com/web-infra-dev/rsbuild/assets/22373761/fc8a9941-e7eb-48de-9b81-2ddafde2cac9)


![img_v3_027q_720cdf39-fd5e-4a52-87e0-a154418d4dag](https://github.com/web-infra-dev/rsbuild/assets/22373761/b7fe3edd-10cd-44e7-ab1d-5e05c3769236)


This behavior is similar to the following code behavior, because`raw.proxyOptions.ws` default value is `undefined`:

https://github.com/web-infra-dev/rsbuild/pull/604/files#diff-0c9eec60641329e501f974ce5a16dedcb9c71b546219802c43a9a3687bdd3892L77

<img width="601" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/37d8979d-a338-413d-9ea8-c2aeb03804a9">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
