### PR TITLE
types: improve tools.styleLoader typing

### DIFF
--- a/.changeset/mean-pants-chew.md
+++ b/.changeset/mean-pants-chew.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/shared': patch
+'@rsbuild/core': patch
+---
+
+release: 0.4.1

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -60,7 +60,6 @@ export async function applyBaseCSSRule({
       const styleLoaderOptions = mergeChainedOptions({
         defaults: {
           // todo: hmr does not work while esModule is true
-          // @ts-expect-error
           esModule: false,
         },
         options: config.tools.styleLoader,

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -107,7 +107,40 @@ export type StyleLoaderInjectType =
   | 'linkTag';
 
 export interface StyleLoaderOptions {
+  /**
+   * By default, style-loader generates JS modules that use the ES modules syntax.
+   * There are some cases in which using ES modules is beneficial, like in the case of module concatenation and tree shaking.
+   *
+   * @default true
+   */
+  esModule?: boolean;
+  /**
+   * Allows to setup how styles will be injected into the DOM.
+   *
+   * @default 'styleTag'
+   */
   injectType?: StyleLoaderInjectType;
+  /**
+   * If defined, the style-loader will attach given attributes with their values on <style> / <link> element.
+   * @default {}
+   */
   attributes?: Record<string, string>;
+  /**
+   * By default, the style-loader appends <style>/<link> elements to the end of the style target, which is the <head> tag of the page unless specified by insert.
+   * This will cause CSS created by the loader to take priority over CSS already present in the target.
+   * You can use other values if the standard behavior is not suitable for you, but we do not recommend doing this.
+   *
+   * @default 'head'
+   */
   insert?: string | ((element: HTMLElement) => void);
+  /**
+   * Allows to setup absolute path to custom function that allows to override default behavior styleTagTransform.
+   */
+  styleTagTransform?:
+    | string
+    | ((
+        css: string,
+        styleElement: HTMLStyleElement,
+        options: Record<string, any>,
+      ) => void);
 }


### PR DESCRIPTION
## Summary

Improve tools.styleLoader typing.

## Related Links

https://github.com/webpack-contrib/style-loader

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
