### PR TITLE
feat: support for set different alias by target

### DIFF
--- a/.changeset/sweet-parents-act.md
+++ b/.changeset/sweet-parents-act.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+release: 0.4.3

--- a/e2e/cases/source/alias-by-target/index.test.ts
+++ b/e2e/cases/source/alias-by-target/index.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@playwright/test';
+import { build } from '@e2e/helper';
+
+test('should allow to set alias by build target', async ({ page }) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const fileNames = Object.keys(files);
+  const webIndex = fileNames.find(
+    (file) => file.includes('static/js') && file.includes('index.js'),
+  );
+  const nodeIndex = fileNames.find((file) => file.includes('server/index'));
+
+  expect(files[webIndex!]).toContain('for web target');
+  expect(files[nodeIndex!]).toContain('for node target');
+});

--- a/e2e/cases/source/alias-by-target/rsbuild.config.ts
+++ b/e2e/cases/source/alias-by-target/rsbuild.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    alias(config, { target }) {
+      if (target === 'web') {
+        config['@common'] = './src/common';
+      } else if (target === 'node') {
+        config['@common'] = './src/common2';
+      }
+    },
+  },
+  output: {
+    targets: ['web', 'node'],
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/source/alias-by-target/src/common/test.js
+++ b/e2e/cases/source/alias-by-target/src/common/test.js
@@ -1,0 +1,1 @@
+export const content = 'for web target';

--- a/e2e/cases/source/alias-by-target/src/common2/test.js
+++ b/e2e/cases/source/alias-by-target/src/common2/test.js
@@ -1,0 +1,1 @@
+export const content = 'for node target';

--- a/e2e/cases/source/alias-by-target/src/index.js
+++ b/e2e/cases/source/alias-by-target/src/index.js
@@ -1,0 +1,3 @@
+import { content } from '@common/test';
+
+console.log(content);

--- a/e2e/cases/source/alias-by-target/tsconfig.json
+++ b/e2e/cases/source/alias-by-target/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+  },
+  "include": ["src"],
+}

--- a/packages/document/docs/en/config/source/alias.mdx
+++ b/packages/document/docs/en/config/source/alias.mdx
@@ -58,6 +58,22 @@ export default {
 };
 ```
 
+The function provides a `target` argument, which can be used to determine the build target environment, such as setting different aliases for web outputs and node outputs.
+
+```js
+export default {
+  source: {
+    alias: (alias, { target }) => {
+      if (target === 'node') {
+        alias['@common'] = './src/node/common';
+      } else if (target === 'web') {
+        alias['@common'] = './src/web/common';
+      }
+    },
+  },
+};
+```
+
 ### Exact Matching
 
 By default, `source.alias` will automatically match sub-paths, for example, with the following configuration:

--- a/packages/document/docs/en/config/tools/bundler-chain.mdx
+++ b/packages/document/docs/en/config/tools/bundler-chain.mdx
@@ -84,7 +84,7 @@ export default {
 
 - **Type:** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
-The `target` parameter can be used to determine the current environment. For example:
+The `target` parameter can be used to determine the build target environment. For example:
 
 ```js
 export default {

--- a/packages/document/docs/en/config/tools/rspack.mdx
+++ b/packages/document/docs/en/config/tools/rspack.mdx
@@ -108,7 +108,7 @@ export default {
 
 - **Type:** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
-The `target` parameter can be used to determine the current target. For example:
+The `target` parameter can be used to determine the build target environment. For example:
 
 ```js
 export default {

--- a/packages/document/docs/zh/config/source/alias.mdx
+++ b/packages/document/docs/zh/config/source/alias.mdx
@@ -58,6 +58,22 @@ export default {
 };
 ```
 
+函数提供了 target 参数，可以用于判断构建的目标运行时环境，比如针对 web 产物和 node 产物设置不同的 alias：
+
+```js
+export default {
+  source: {
+    alias: (alias, { target }) => {
+      if (target === 'node') {
+        alias['@common'] = './src/node/common';
+      } else if (target === 'web') {
+        alias['@common'] = './src/web/common';
+      }
+    },
+  },
+};
+```
+
 ### 精确匹配
 
 默认情况，`source.alias` 会自动匹配子路径，比如以下配置：

--- a/packages/document/docs/zh/config/tools/bundler-chain.mdx
+++ b/packages/document/docs/zh/config/tools/bundler-chain.mdx
@@ -87,7 +87,7 @@ export default {
 
 - **类型：** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
-通过 target 参数可以判断当前构建的目标运行时环境。比如：
+通过 target 参数可以判断构建的目标运行时环境。比如：
 
 ```js
 export default {

--- a/packages/document/docs/zh/config/tools/rspack.mdx
+++ b/packages/document/docs/zh/config/tools/rspack.mdx
@@ -108,7 +108,7 @@ export default {
 
 - **类型：** `'web' | 'node' | 'web-worker' | 'service-worker'`
 
-通过 target 参数可以判断当前构建的目标运行时环境。比如：
+通过 target 参数可以判断构建的目标运行时环境。比如：
 
 ```js
 export default {

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -1,5 +1,5 @@
-import type { RsbuildEntry } from '../rsbuild';
-import type { ChainedConfig } from '../utils';
+import type { RsbuildEntry, RsbuildTarget } from '../rsbuild';
+import type { ChainedConfigWithUtils } from '../utils';
 import type { RuleSetCondition } from '@rspack/core';
 
 export type Alias = Record<string, string | false | (string | false)[]>;
@@ -24,7 +24,7 @@ export interface SourceConfig {
    * Create aliases to import or require certain modules,
    * same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
    */
-  alias?: ChainedConfig<Alias>;
+  alias?: ChainedConfigWithUtils<Alias, { target: RsbuildTarget }>;
   /**
    * Used to control the priority between the `paths` option in `tsconfig.json`
    * and the `alias` option in the bundler.
@@ -84,7 +84,7 @@ export type TransformImport = {
 
 export interface NormalizedSourceConfig extends SourceConfig {
   define: Define;
-  alias: ChainedConfig<Alias>;
+  alias: ChainedConfigWithUtils<Alias, { target: RsbuildTarget }>;
   aliasStrategy: AliasStrategy;
   preEntry: string[];
   decorators: Required<Decorators>;


### PR DESCRIPTION
## Summary

Support for set different alias by target:

```js
export default {
  source: {
    alias: (alias, { target }) => {
      if (target === 'node') {
        alias['@common'] = './src/node/common';
      } else if (target === 'web') {
        alias['@common'] = './src/web/common';
      }
    },
  },
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1565

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
