### PR TITLE
fix(plugin-swc): build error when set transformLodash false

### DIFF
--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -70,6 +70,7 @@ const PLUGIN_ONLY_OPTIONS: (keyof ObjPluginSwcOptions)[] = [
   'jsMinify',
   'cssMinify',
   'overrides',
+  'transformLodash',
   'test',
   'exclude',
   'include' as unknown as keyof ObjPluginSwcOptions, // include is not in SWC config, but we need it as loader condition


### PR DESCRIPTION
## Summary

should remove transformLodash option when pass to swc-plugin
![img_v3_0286_ef7ae9b8-7fc7-4327-8771-9e4e8bcf250g](https://github.com/web-infra-dev/rsbuild/assets/22373761/8bb09384-7d2f-4e4c-a9ed-8fb0da488167)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
