### PR TITLE
fix: display more accurate compile times

### DIFF
--- a/.changeset/ten-balloons-jog.md
+++ b/.changeset/ten-balloons-jog.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+release: 0.4.4

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -250,9 +250,9 @@ export function pick<T, U extends keyof T>(obj: T, keys: ReadonlyArray<U>) {
 }
 
 export const prettyTime = (seconds: number) => {
-  const format = (time: string) => color.bold(Number(time));
+  const format = (time: string) => color.bold(time);
 
-  if (seconds < 1) {
+  if (seconds < 10) {
     const digits = seconds >= 0.01 ? 2 : 3;
     return `${format(seconds.toFixed(digits))} s`;
   }

--- a/packages/shared/tests/prettyTime.test.ts
+++ b/packages/shared/tests/prettyTime.test.ts
@@ -4,7 +4,7 @@ test('should pretty time correctly', () => {
   expect(prettyTime(0.0012)).toEqual('0.001 s');
   expect(prettyTime(0.0123)).toEqual('0.01 s');
   expect(prettyTime(0.1234)).toEqual('0.12 s');
-  expect(prettyTime(1.234)).toEqual('1.2 s');
+  expect(prettyTime(1.234)).toEqual('1.23 s');
   expect(prettyTime(12.34)).toEqual('12.3 s');
   expect(prettyTime(123.4)).toEqual('2.06 m');
   expect(prettyTime(1234)).toEqual('20.57 m');


### PR DESCRIPTION
## Summary

Display more accurate compile times, this is useful for observing compile time changes.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
