### PR TITLE
chore: set styleLoader.esModule default true

### DIFF
--- a/e2e/cases/css/style-loader/.gitignore
+++ b/e2e/cases/css/style-loader/.gitignore
@@ -1,0 +1,1 @@
+test-src/

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -41,6 +41,11 @@ test('should inline style when injectStyles is true', async ({ page }) => {
 rspackOnlyTest(
   'hmr should work well when injectStyles is true',
   async ({ page }) => {
+    // HMR cases will fail in Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     await fse.copy(join(fixtures, 'src'), join(fixtures, 'test-src'));
 
     const rsbuild = await dev({

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
 import { join } from 'node:path';
@@ -38,45 +38,48 @@ test('should inline style when injectStyles is true', async ({ page }) => {
   await rsbuild.close();
 });
 
-test('hmr should work well when injectStyles is true', async ({ page }) => {
-  await fse.copy(join(fixtures, 'src'), join(fixtures, 'test-src'));
+rspackOnlyTest(
+  'hmr should work well when injectStyles is true',
+  async ({ page }) => {
+    await fse.copy(join(fixtures, 'src'), join(fixtures, 'test-src'));
 
-  const rsbuild = await dev({
-    cwd: fixtures,
-    rsbuildConfig: {
-      source: {
-        entry: {
-          index: join(fixtures, 'test-src/index.ts'),
+    const rsbuild = await dev({
+      cwd: fixtures,
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: join(fixtures, 'test-src/index.ts'),
+          },
         },
       },
-    },
-  });
+    });
 
-  await gotoPage(page, rsbuild);
+    await gotoPage(page, rsbuild);
 
-  // scss worked
-  const header = page.locator('#header');
-  await expect(header).toHaveCSS('font-size', '20px');
+    // scss worked
+    const header = page.locator('#header');
+    await expect(header).toHaveCSS('font-size', '20px');
 
-  // less worked
-  const title = page.locator('#title');
-  await expect(title).toHaveCSS('font-size', '20px');
+    // less worked
+    const title = page.locator('#title');
+    await expect(title).toHaveCSS('font-size', '20px');
 
-  const locatorKeep = page.locator('#test-keep');
-  const keepNum = await locatorKeep.innerHTML();
+    const locatorKeep = page.locator('#test-keep');
+    const keepNum = await locatorKeep.innerHTML();
 
-  const filePath = join(fixtures, 'test-src/App.module.less');
+    const filePath = join(fixtures, 'test-src/App.module.less');
 
-  await fse.writeFile(
-    filePath,
-    fse.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
-  );
+    await fse.writeFile(
+      filePath,
+      fse.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
+    );
 
-  // css hmr works well
-  await expect(title).toHaveCSS('font-size', '40px');
+    // css hmr works well
+    await expect(title).toHaveCSS('font-size', '40px');
 
-  // #test-keep should unchanged when css hmr
-  await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
+    // #test-keep should unchanged when css hmr
+    await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,6 +1,7 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build, dev, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { pluginReact } from '@rsbuild/plugin-react';
+import { fse } from '@rsbuild/shared';
+import { join } from 'node:path';
 
 const fixtures = __dirname;
 
@@ -8,12 +9,6 @@ test('should inline style when injectStyles is true', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
     runServer: true,
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      output: {
-        injectStyles: true,
-      },
-    },
   });
 
   await gotoPage(page, rsbuild);
@@ -37,8 +32,51 @@ test('should inline style when injectStyles is true', async ({ page }) => {
   await expect(header).toHaveCSS('font-size', '20px');
 
   // less worked
-  const title = page.locator('#header');
+  const title = page.locator('#title');
   await expect(title).toHaveCSS('font-size', '20px');
+
+  await rsbuild.close();
+});
+
+test('hmr should work well when injectStyles is true', async ({ page }) => {
+  await fse.copy(join(fixtures, 'src'), join(fixtures, 'test-src'));
+
+  const rsbuild = await dev({
+    cwd: fixtures,
+    rsbuildConfig: {
+      source: {
+        entry: {
+          index: join(fixtures, 'test-src/index.ts'),
+        },
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  // scss worked
+  const header = page.locator('#header');
+  await expect(header).toHaveCSS('font-size', '20px');
+
+  // less worked
+  const title = page.locator('#title');
+  await expect(title).toHaveCSS('font-size', '20px');
+
+  const locatorKeep = page.locator('#test-keep');
+  const keepNum = await locatorKeep.innerHTML();
+
+  const filePath = join(fixtures, 'test-src/App.module.less');
+
+  await fse.writeFile(
+    filePath,
+    fse.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
+  );
+
+  // css hmr works well
+  await expect(title).toHaveCSS('font-size', '40px');
+
+  // #test-keep should unchanged when css hmr
+  await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
 
   await rsbuild.close();
 });

--- a/e2e/cases/css/style-loader/rsbuild.config.ts
+++ b/e2e/cases/css/style-loader/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  output: {
+    injectStyles: true,
+  },
+  plugins: [pluginReact()],
+});

--- a/e2e/cases/css/style-loader/src/index.ts
+++ b/e2e/cases/css/style-loader/src/index.ts
@@ -7,3 +7,11 @@ if (container) {
   const root = createRoot(container);
   root.render(React.createElement(App));
 }
+
+const num = Math.ceil(Math.random() * 100);
+const testEl = document.createElement('div');
+testEl.id = 'test-keep';
+
+testEl.innerHTML = String(num);
+
+document.body.appendChild(testEl);

--- a/packages/core/src/provider/plugins/css.ts
+++ b/packages/core/src/provider/plugins/css.ts
@@ -58,10 +58,7 @@ export async function applyBaseCSSRule({
 
     if (!isServer && !isWebWorker) {
       const styleLoaderOptions = mergeChainedOptions({
-        defaults: {
-          // todo: hmr does not work while esModule is true
-          esModule: false,
-        },
+        defaults: {},
         options: config.tools.styleLoader,
       });
 

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -386,9 +386,6 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
         "use": [
           {
             "loader": "<ROOT>/packages/shared/compiled/style-loader",
-            "options": {
-              "esModule": false,
-            },
           },
           {
             "loader": "<ROOT>/packages/shared/compiled/css-loader",
@@ -574,9 +571,6 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
         "use": [
           {
             "loader": "<ROOT>/packages/shared/compiled/style-loader",
-            "options": {
-              "esModule": false,
-            },
           },
           {
             "loader": "<ROOT>/packages/shared/compiled/css-loader",
@@ -1025,9 +1019,6 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
         "use": [
           {
             "loader": "<ROOT>/packages/shared/compiled/style-loader",
-            "options": {
-              "esModule": false,
-            },
           },
           {
             "loader": "<ROOT>/packages/shared/compiled/css-loader",


### PR DESCRIPTION
## Summary

Setting styleLoader.esModule to false is to temporarily solve the hmr problem, which has now been fixed by Rspack

<img width="1408" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/3be79428-74ef-440b-b9cb-ec0fec3d16bb">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
