### PR TITLE
docs: add extend-middleware guide

### DIFF
--- a/packages/document/docs/en/guide/basic/server.md
+++ b/packages/document/docs/en/guide/basic/server.md
@@ -93,3 +93,31 @@ Rsbuild dev server and the dev server of Rspack CLI (`@rspack/dev-server`) share
 :::tip
 Rsbuild applications cannot use Rspack's [devServer](https://rspack.dev/config/dev-server) config. You can configure the behavior of the server through Rsbuild's `dev` and `server` configs, see [Config Overview](/config/index) for details.
 :::
+
+## Extend middleware
+
+Rsbuild does not use any framework, and the `req` and `res` in the Rsbuild middleware are all native Node objects.
+
+This means that when you migrate from other server-side frameworks (such as Express), the original middleware may not necessarily be used directly in Rsbuild. For example, the `req.params`,`req.path`, `req.search`, `req.query` and other objects provided by Express cannot be accessed in the Rsbuild middleware.
+
+If you want the middleware you originally used to still be available in Rsbuild, you can use the following method to pass in the server-side application as middleware:
+
+```ts file=rsbuild.config.ts
+import expressMiddleware from 'my-express-middleware';
+import express from 'express';
+
+// Initialize Express app
+const app = express();
+
+app.use(expressMiddleware);
+
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middleware) => {
+        middleware.unshift(app);
+      },
+    ],
+  },
+};
+```

--- a/packages/document/docs/en/guide/basic/server.md
+++ b/packages/document/docs/en/guide/basic/server.md
@@ -100,7 +100,7 @@ Rsbuild server does not use any Node.js frameworks, and the `req` and `res` prov
 
 This means that when you migrate from other server-side frameworks (such as Express), the original middleware may not necessarily be used directly in Rsbuild. For example, the `req.params`,`req.path`, `req.search`, `req.query` and other properties provided by Express cannot be accessed in the Rsbuild middleware.
 
-If you want the middleware you originally used to still be available in Rsbuild, you can use the following method to pass in the server-side application as middleware:
+If you need to use existing middleware in Rsbuild, this can be done by passing the server application as middleware as follows:
 
 ```ts title="rsbuild.config.ts"
 import expressMiddleware from 'my-express-middleware';

--- a/packages/document/docs/en/guide/basic/server.md
+++ b/packages/document/docs/en/guide/basic/server.md
@@ -96,7 +96,7 @@ Rsbuild applications cannot use Rspack's [devServer](https://rspack.dev/config/d
 
 ## Extend middleware
 
-Rsbuild does not use any framework, and the `req` and `res` in the Rsbuild middleware are all native Node objects.
+Rsbuild server does not use any Node.js frameworks, and the `req` and `res` provided by Rsbuild middleware are both native Node.js objects.
 
 This means that when you migrate from other server-side frameworks (such as Express), the original middleware may not necessarily be used directly in Rsbuild. For example, the `req.params`,`req.path`, `req.search`, `req.query` and other properties provided by Express cannot be accessed in the Rsbuild middleware.
 

--- a/packages/document/docs/en/guide/basic/server.md
+++ b/packages/document/docs/en/guide/basic/server.md
@@ -102,7 +102,7 @@ This means that when you migrate from other server-side frameworks (such as Expr
 
 If you want the middleware you originally used to still be available in Rsbuild, you can use the following method to pass in the server-side application as middleware:
 
-```ts file=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 import expressMiddleware from 'my-express-middleware';
 import express from 'express';
 

--- a/packages/document/docs/en/guide/basic/server.md
+++ b/packages/document/docs/en/guide/basic/server.md
@@ -98,7 +98,7 @@ Rsbuild applications cannot use Rspack's [devServer](https://rspack.dev/config/d
 
 Rsbuild does not use any framework, and the `req` and `res` in the Rsbuild middleware are all native Node objects.
 
-This means that when you migrate from other server-side frameworks (such as Express), the original middleware may not necessarily be used directly in Rsbuild. For example, the `req.params`,`req.path`, `req.search`, `req.query` and other objects provided by Express cannot be accessed in the Rsbuild middleware.
+This means that when you migrate from other server-side frameworks (such as Express), the original middleware may not necessarily be used directly in Rsbuild. For example, the `req.params`,`req.path`, `req.search`, `req.query` and other properties provided by Express cannot be accessed in the Rsbuild middleware.
 
 If you want the middleware you originally used to still be available in Rsbuild, you can use the following method to pass in the server-side application as middleware:
 

--- a/packages/document/docs/zh/guide/basic/server.md
+++ b/packages/document/docs/zh/guide/basic/server.md
@@ -99,7 +99,7 @@ Rsbuild 应用不能使用 Rspack 的 [devServer](https://rspack.dev/config/dev-
 Rsbuild server 未使用任何 Node.js 框架，Rsbuild 中间件提供的 req 和 res 均为 Node.js 原生对象。
 这意味着，当你从其他服务端框架迁移时（如 Express），原本的中间件不一定能直接在 Rsbuild 中使用，例如，无法在 Rsbuild 中间件中访问 Express 所提供的 `req.params`、`req.path`、`req.search`、`req.query` 等属性。
 
-如果你希望原本使用的中间件在 Rsbuild 中仍然可用，可以使用以下方式，将服务端应用作为中间件传入：
+如果你需要在 Rsbuild 中使用原有的中间件，可以采取以下方式，将服务端应用作为中间件传入：
 
 ```ts file=rsbuild.config.ts
 import expressMiddleware from 'my-express-middleware';

--- a/packages/document/docs/zh/guide/basic/server.md
+++ b/packages/document/docs/zh/guide/basic/server.md
@@ -93,3 +93,30 @@ Rsbuild 的开发服务器与 Rspack CLI 的开发服务器（`@rspack/dev-serve
 :::tip
 Rsbuild 应用不能使用 Rspack 的 [devServer](https://rspack.dev/config/dev-server) 配置项。你可以通过 Rsbuild 的 `dev` 和 `server` 配置 Server 的行为，详见 [Config 总览](/config/index)。
 :::
+
+## 扩展中间件
+
+Rsbuild 中没有使用任何框架，Rsbuild 中间件中的 req 和 res 都是 Node 原生对象。
+这意味着，当你从其他服务端框架迁移时（如 Express），原本的中间件不一定能直接在 Rsbuild 中使用，例如，无法在 Rsbuild 中间件中访问 Express 所提供的 `req.params`、`req.path`、`req.search`、`req.query` 等对象。
+
+如果你希望原本使用的中间件在 Rsbuild 中仍然可用，可以使用以下方式，将服务端应用作为中间件传入：
+
+```ts file=rsbuild.config.ts
+import expressMiddleware from 'my-express-middleware';
+import express from 'express';
+
+// 初始化 Express app
+const app = express();
+
+app.use(expressMiddleware);
+
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middleware) => {
+        middleware.unshift(app);
+      },
+    ],
+  },
+};
+```

--- a/packages/document/docs/zh/guide/basic/server.md
+++ b/packages/document/docs/zh/guide/basic/server.md
@@ -96,7 +96,7 @@ Rsbuild 应用不能使用 Rspack 的 [devServer](https://rspack.dev/config/dev-
 
 ## 扩展中间件
 
-Rsbuild 中没有使用任何框架，Rsbuild 中间件中的 req 和 res 都是 Node 原生对象。
+Rsbuild server 未使用任何 Node.js 框架，Rsbuild 中间件提供的 req 和 res 均为 Node.js 原生对象。
 这意味着，当你从其他服务端框架迁移时（如 Express），原本的中间件不一定能直接在 Rsbuild 中使用，例如，无法在 Rsbuild 中间件中访问 Express 所提供的 `req.params`、`req.path`、`req.search`、`req.query` 等对象。
 
 如果你希望原本使用的中间件在 Rsbuild 中仍然可用，可以使用以下方式，将服务端应用作为中间件传入：

--- a/packages/document/docs/zh/guide/basic/server.md
+++ b/packages/document/docs/zh/guide/basic/server.md
@@ -101,7 +101,7 @@ Rsbuild server 未使用任何 Node.js 框架，Rsbuild 中间件提供的 req �
 
 如果你需要在 Rsbuild 中使用原有的中间件，可以采取以下方式，将服务端应用作为中间件传入：
 
-```ts file=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 import expressMiddleware from 'my-express-middleware';
 import express from 'express';
 

--- a/packages/document/docs/zh/guide/basic/server.md
+++ b/packages/document/docs/zh/guide/basic/server.md
@@ -97,7 +97,7 @@ Rsbuild 应用不能使用 Rspack 的 [devServer](https://rspack.dev/config/dev-
 ## 扩展中间件
 
 Rsbuild server 未使用任何 Node.js 框架，Rsbuild 中间件提供的 req 和 res 均为 Node.js 原生对象。
-这意味着，当你从其他服务端框架迁移时（如 Express），原本的中间件不一定能直接在 Rsbuild 中使用，例如，无法在 Rsbuild 中间件中访问 Express 所提供的 `req.params`、`req.path`、`req.search`、`req.query` 等对象。
+这意味着，当你从其他服务端框架迁移时（如 Express），原本的中间件不一定能直接在 Rsbuild 中使用，例如，无法在 Rsbuild 中间件中访问 Express 所提供的 `req.params`、`req.path`、`req.search`、`req.query` 等属性。
 
 如果你希望原本使用的中间件在 Rsbuild 中仍然可用，可以使用以下方式，将服务端应用作为中间件传入：
 


### PR DESCRIPTION
## Summary

Introduce how to use other server-side framework's middleware in Rsbuild.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
