### PR TITLE
refactor: use import.meta.webpackHot to replace module.hot

### DIFF
--- a/packages/core/modern.config.ts
+++ b/packages/core/modern.config.ts
@@ -17,11 +17,7 @@ export default defineConfig({
         hmr: 'src/client/hmr/index.ts',
       },
       outDir: './dist/client',
-      // fix `module.hot` not works (avoid inject module as local variable)
-      esbuildOptions: (options) => {
-        options.format = undefined;
-        return options;
-      },
+      autoExtension: true,
       // bundle shared deps when used in client
       autoExternal: false,
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,9 +22,9 @@
       "types": "./dist/server/index.d.ts",
       "default": "./dist/server/index.js"
     },
-    "./client/*": {
-      "types": "./dist/client/*.d.ts",
-      "default": "./dist/client/*.js"
+    "./client/hmr": {
+      "types": "./dist/client/hmr/index.d.ts",
+      "default": "./dist/client/hmr.mjs"
     },
     "./plugins/*": {
       "types": "./dist/plugins/*.d.ts",

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -8,9 +8,6 @@ import type { StatsError } from '@rsbuild/shared';
 import { formatStatsMessages } from '../formatStats';
 import { createSocketUrl } from './createSocketUrl';
 
-// declare any to fix the type of `module.hot`
-declare const module: any;
-
 // Connect to Dev Server
 const socketUrl = createSocketUrl(__resourceQuery);
 
@@ -119,7 +116,7 @@ function isUpdateAvailable() {
 
 // webpack disallows updates in other states.
 function canApplyUpdates() {
-  return module.hot.status() === 'idle';
+  return import.meta.webpackHot.status() === 'idle';
 }
 
 // Attempt to update code on the fly, fall back to a hard reload.
@@ -129,7 +126,7 @@ function tryApplyUpdates() {
     return;
   }
 
-  if (!module.hot) {
+  if (!import.meta.webpackHot) {
     // HotModuleReplacementPlugin is not in Rspack configuration.
     window.location.reload();
     return;
@@ -139,7 +136,10 @@ function tryApplyUpdates() {
     return;
   }
 
-  function handleApplyUpdates(err: any, updatedModules: any) {
+  function handleApplyUpdates(
+    err: unknown,
+    updatedModules: (string | number)[] | null,
+  ) {
     const wantsForcedReload = err || !updatedModules;
     if (wantsForcedReload) {
       window.location.reload();
@@ -153,19 +153,14 @@ function tryApplyUpdates() {
   }
 
   // https://webpack.js.org/concepts/hot-module-replacement
-  const result = module.hot.check(/* autoApply */ true, handleApplyUpdates);
-
-  // // webpack 2 returns a Promise instead of invoking a callback
-  if (result?.then) {
-    result.then(
-      (updatedModules: any) => {
-        handleApplyUpdates(null, updatedModules);
-      },
-      (err: any) => {
-        handleApplyUpdates(err, null);
-      },
-    );
-  }
+  import.meta.webpackHot.check(true).then(
+    (updatedModules) => {
+      handleApplyUpdates(null, updatedModules);
+    },
+    (err) => {
+      handleApplyUpdates(err, null);
+    },
+  );
 }
 
 const MAX_RETRIES = 100;
@@ -179,7 +174,7 @@ function onOpen() {
   }
 }
 
-function onMessage(e: MessageEvent<any>) {
+function onMessage(e: MessageEvent<string>) {
   const message = JSON.parse(e.data);
   switch (message.type) {
     case 'hash':

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,12 +4,13 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "rootDir": "src",
-    "composite": true
+    "composite": true,
+    "types": ["webpack/module"],
   },
   "references": [
     {
-      "path": "../shared"
-    }
+      "path": "../shared",
+    },
   ],
-  "include": ["src"]
+  "include": ["src"],
 }


### PR DESCRIPTION
## Summary

Use import.meta.webpackHot to replace module.hot, which is more ESM-friendly and type safe.

## Related Links

https://webpack.js.org/api/hot-module-replacement/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
