### PR TITLE
fix(plugin-type-check): missing webpack peer dependency

### DIFF
--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "webpack": "^5.89.0",
     "fork-ts-checker-webpack-plugin": "9.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1291,6 +1291,9 @@ importers:
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
         version: 9.0.2(typescript@5.3.2)(webpack@5.89.0)
+      webpack:
+        specifier: ^5.89.0
+        version: 5.89.0
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -6248,6 +6251,7 @@ packages:
       electron-to-chromium: 1.4.650
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.22.3)
+    dev: false
 
   /browserslist@4.23.0:
     resolution: {integrity: sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==}
@@ -7445,6 +7449,7 @@ packages:
 
   /electron-to-chromium@1.4.650:
     resolution: {integrity: sha512-sYSQhJCJa4aGA1wYol5cMQgekDBlbVfTRavlGZVr3WZpDdOPcp6a6xUnFfrt8TqZhsBYYbDxJZCjGfHuGupCRQ==}
+    dev: false
 
   /electron-to-chromium@1.4.670:
     resolution: {integrity: sha512-hcijYOWjOtjKrKPtNA6tuLlA/bTLO3heFG8pQA6mLpq7dRydSWicXova5lyxDzp1iVJaYhK7J2OQlGE52KYn7A==}
@@ -13634,6 +13639,7 @@ packages:
       browserslist: 4.22.3
       escalade: 3.1.1
       picocolors: 1.0.0
+    dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
@@ -14132,7 +14138,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.10.0
       acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.22.3
+      browserslist: 4.23.0
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
       es-module-lexer: 1.3.1


### PR DESCRIPTION
## Summary

webpack is fork-ts-checker-webpack-plugin's peer dependency

![img_v3_0288_0e4f727d-294f-44e2-9711-b7aef1d27bcg](https://github.com/web-infra-dev/rsbuild/assets/22373761/f1ff912f-1c0f-4e89-868e-374fc2166d75)

![img_v3_0288_0ef330d9-5a35-48bb-b4d7-18b6742f3a0g](https://github.com/web-infra-dev/rsbuild/assets/22373761/18cd1523-f6a8-4f9d-bb2e-5ab7c3500f37)

<img width="943" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/97bdf253-abd7-4275-870b-7c31d684a54d">



## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
