### PR TITLE
chore: replace get-packages with monorepo-utils

### DIFF
--- a/.github/workflows/update-modern.yml
+++ b/.github/workflows/update-modern.yml
@@ -22,13 +22,13 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Update Modern
         run: pnpm run update-modern
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Create commits
         run: |

--- a/.github/workflows/update-rspress.yml
+++ b/.github/workflows/update-rspress.yml
@@ -22,13 +22,13 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts
+        run: pnpm install
 
       - name: Update Rspress
         run: pnpm run update-rspress
 
       - name: Install Dependencies
-        run: pnpm install --ignore-scripts --no-frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Create commits
         run: |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1717,9 +1717,9 @@ importers:
 
   scripts/update-packages:
     dependencies:
-      '@manypkg/get-packages':
-        specifier: ^1.1.3
-        version: 1.1.3
+      '@rsbuild/monorepo-utils':
+        specifier: workspace:*
+        version: link:../../packages/monorepo-utils
       fs-extra:
         specifier: ^11.1.1
         version: 11.2.0

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -8,7 +8,7 @@
     "start:rspress": "tsx ./src/rspress.ts"
   },
   "dependencies": {
-    "@manypkg/get-packages": "^1.1.3",
+    "@rsbuild/monorepo-utils": "workspace:*",
     "fs-extra": "^11.1.1"
   },
   "devDependencies": {

--- a/scripts/update-packages/src/modern.ts
+++ b/scripts/update-packages/src/modern.ts
@@ -3,8 +3,7 @@
  */
 import path from 'node:path';
 import fs from 'fs-extra';
-import { getPackages } from '@manypkg/get-packages';
-import { getPackageVersion } from './utils';
+import { getPackages, getPackageVersion } from './utils';
 
 async function run() {
   const modernVersion = process.env.MODERN_VERSION || 'latest';

--- a/scripts/update-packages/src/rspack.ts
+++ b/scripts/update-packages/src/rspack.ts
@@ -3,8 +3,7 @@
  */
 import path from 'node:path';
 import fs from 'fs-extra';
-import { getPackages } from '@manypkg/get-packages';
-import { getPackageVersion } from './utils';
+import { getPackages, getPackageVersion } from './utils';
 
 async function run() {
   // eg. pnpm update-rspack 0.4.3-canary-xxx

--- a/scripts/update-packages/src/utils.ts
+++ b/scripts/update-packages/src/utils.ts
@@ -1,7 +1,24 @@
 import { execSync } from 'node:child_process';
+import { getPnpmMonorepoSubProjects } from '@rsbuild/monorepo-utils';
+import { readJSONSync } from 'fs-extra';
+import { join } from 'node:path';
 
 export function getPackageVersion(packageName: string) {
   const command = `npm view ${packageName} version --registry=https://registry.npmjs.org/`;
   const result = execSync(command, { encoding: 'utf-8' });
   return result.trim();
+}
+
+export async function getPackages(root: string) {
+  const projects = await getPnpmMonorepoSubProjects(root);
+
+  const packages = projects.map((project) => {
+    const pkgJson = readJSONSync(join(project.dir, 'package.json'));
+    return {
+      packageJson: pkgJson,
+      dir: project.dir,
+    };
+  });
+
+  return { packages };
 }


### PR DESCRIPTION
## Summary

Replace get-packages with monorepo-utils.

## Related Links

close https://github.com/web-infra-dev/rsbuild/pull/1593

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
