### PR TITLE
feat: support configuring hash format

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "estree",
     "flac",
     "flexbugs",
+    "fullhash",
     "icss",
     "imagex",
     "jiti",

--- a/e2e/cases/filename-hash/index.test.ts
+++ b/e2e/cases/filename-hash/index.test.ts
@@ -1,0 +1,26 @@
+import { expect } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+
+rspackOnlyTest('should allow to set hash format to fullhash', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  let firstHash: string;
+
+  filenames.forEach((filename) => {
+    if (!filename.includes('static')) {
+      return;
+    }
+
+    const hash = filename.match(/[a-f0-9]{12}\.js/)![0];
+    if (!firstHash) {
+      firstHash = hash;
+    } else {
+      expect(hash).toEqual(firstHash);
+    }
+  });
+});

--- a/e2e/cases/filename-hash/rsbuild.config.ts
+++ b/e2e/cases/filename-hash/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  output: {
+    filenameHash: 'fullhash:12',
+    sourceMap: {
+      js: false,
+      css: false,
+    },
+  },
+});

--- a/e2e/cases/filename-hash/src/index.js
+++ b/e2e/cases/filename-hash/src/index.js
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+console.log(React, ReactDOM);

--- a/packages/document/docs/en/config/output/filename-hash.mdx
+++ b/packages/document/docs/en/config/output/filename-hash.mdx
@@ -1,6 +1,6 @@
 # output.filenameHash
 
-- **Type:** `boolean`
+- **Type:** `boolean | string`
 - **Default:** `true`
 - **Version:** `>= 0.4.0`
 
@@ -32,8 +32,28 @@ dist/static/css/index.css
 dist/static/js/index.js
 ```
 
+### Hash Format
+
+The default hash format is `contenthash:8`, which generates an 8-bit hash based on the content of the file.
+
+You can set `output.filenameHash` to other formats supported by Rspack and customize the length.
+
+```js
+export default {
+  output: {
+    filenameHash: 'fullhash:16',
+  },
+};
+```
+
+The optional hash formats are:
+
+- `fullhash`: The hash value of the entire compilation. If any file changes, the hash values of all output files in the entire project will change.
+- `chunkhash`: The hash value of the chunk. The hash value will only change when the content of the chunk (and its included modules) changes.
+- `contenthash`: The hash value of the file content. The hash value will only change when the content of the file itself changes.
+
 ### Notes
 
-- You can use [output.filename](/config/output/filename) to modify the length or format of the hash. `output.filename` has a higher priority than `output.filenameHash`.
+- [output.filename](/config/output/filename) has a higher priority than `output.filenameHash`.
 - By default, when the target is not `web`, the hash will not be included in the filename of the output files, such as Node.js bundles.
 - By default, the development build filename does not include a hash.

--- a/packages/document/docs/zh/config/output/filename-hash.mdx
+++ b/packages/document/docs/zh/config/output/filename-hash.mdx
@@ -1,6 +1,6 @@
 # output.filenameHash
 
-- **类型：** `boolean`
+- **类型：** `boolean | string`
 - **默认值：** `true`
 - **版本：** `>= 0.4.0`
 
@@ -32,8 +32,28 @@ dist/static/css/index.css
 dist/static/js/index.js
 ```
 
+### hash 格式
+
+hash 的默认格式为 `contenthash:8`，即基于文件内容生成 8 位 hash。
+
+你可以将 `output.filenameHash` 设置为 Rspack 支持的其他格式，并自定义长度。
+
+```js
+export default {
+  output: {
+    filenameHash: 'fullhash:16',
+  },
+};
+```
+
+可选的 hash 格式为：
+
+- `fullhash`：整个编译过程的哈希值，如果任何一个文件发生变动，整个项目的所有输出文件的哈希值都会改变
+- `chunkhash`：chunk 的哈希值，如果 chunk 内容（及其包含的模块）发生改变，哈希值才会改变。
+- `contenthash`：文件内容的哈希值，只有当文件本身的内容发生变更时，哈希值才会改变。
+
 ### 注意事项
 
-- 你可以使用 [output.filename](/config/output/filename) 来修改 hash 的长度或格式，`output.filename` 的优先级高于 `output.filenameHash`。
+- [output.filename](/config/output/filename) 的优先级高于 `output.filenameHash`。
 - 默认情况下，当 target 不是 `web` 时，产物的文件名不会包含 hash，比如 Node.js 产物。
 - 默认情况下，开发环境构建产物的文件名不会包含 hash。

--- a/packages/shared/src/fs.ts
+++ b/packages/shared/src/fs.ts
@@ -57,7 +57,15 @@ export const getFilename = (
   isProd: boolean,
 ) => {
   const { filename, filenameHash } = config.output;
-  const hash = filenameHash ? '.[contenthash:8]' : '';
+
+  const getHash = () => {
+    if (typeof filenameHash === 'string') {
+      return filenameHash ? `.[${filenameHash}]` : '';
+    }
+    return filenameHash ? '.[contenthash:8]' : '';
+  };
+
+  const hash = getHash();
 
   switch (type) {
     case 'js':

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -158,7 +158,7 @@ export interface OutputConfig {
   /**
    * Whether to add filename hash after production build.
    */
-  filenameHash?: boolean;
+  filenameHash?: boolean | string;
   /**
    * Whether to generate a TypeScript declaration file for CSS modules.
    */
@@ -201,7 +201,7 @@ export interface NormalizedOutputConfig extends OutputConfig {
     js?: RspackConfig['devtool'];
     css: boolean;
   };
-  filenameHash: boolean;
+  filenameHash: boolean | string;
   assetPrefix: string;
   dataUriLimit: NormalizedDataUriLimit;
   disableMinimize: boolean;


### PR DESCRIPTION
## Summary

Support configuring hash format.


```js
export default {
  output: {
    filenameHash: 'fullhash:16',
  },
};
```

The optional hash formats are:

- `fullhash`: The hash value of the entire compilation. If any file changes, the hash values of all output files in the entire project will change.
- `chunkhash`: The hash value of the chunk. The hash value will only change when the content of the chunk (and its included modules) changes.
- `contenthash`: The hash value of the file content. The hash value will only change when the content of the file itself changes.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
