### PR TITLE
docs: recommend using Node.js 20

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ own GitHub account and then [clone](https://help.github.com/articles/cloning-a-r
 
 ### Install Node.js
 
-We recommend using Node.js 18. You can check your currently used Node.js version with the following command:
+We recommend using Node.js 20. You can check your currently used Node.js version with the following command:
 
 ```bash
 node -v
@@ -21,17 +21,17 @@ node -v
 
 If you do not have Node.js installed in your current environment, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install it.
 
-Here is an example of how to install the Node.js 18 LTS version via nvm:
+Here is an example of how to install the Node.js 20 LTS version via nvm:
 
 ```bash
-# Install the LTS version of Node.js 18
-nvm install 18 --lts
+# Install the LTS version of Node.js 20
+nvm install 20 --lts
 
-# Make the newly installed Node.js 18 as the default version
-nvm alias default 18
+# Make the newly installed Node.js 20 as the default version
+nvm alias default 20
 
-# Switch to the newly installed Node.js 18
-nvm use 18
+# Switch to the newly installed Node.js 20
+nvm use 20
 ```
 
 ### Install pnpm

--- a/packages/document/docs/en/guide/start/quick-start.mdx
+++ b/packages/document/docs/en/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## Setup Environment
 
-Before getting started, you will need to install [Node.js](https://nodejs.org/), and ensure that your Node.js version is not lower than 16. **We recommend using the LTS version of Node.js 18.**
+Before getting started, you will need to install [Node.js](https://nodejs.org/), and ensure that your Node.js version >= 16. **We recommend using the LTS version of Node.js 20.**
 
 You can check the currently used Node.js version with the following command:
 
@@ -10,24 +10,20 @@ You can check the currently used Node.js version with the following command:
 node -v
 ```
 
-If you do not have Node.js installed in your current environment, or the installed version is lower than 16, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install the required version.
+If you do not have Node.js installed in your current environment, or the installed version is too low, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install the required version.
 
-Here is an example of how to install the Node.js 18 LTS version via nvm:
+Here is an example of how to install the Node.js 20 LTS version via nvm:
 
 ```bash
-# Install the long-term support version of Node.js 18
-nvm install 18 --lts
+# Install the long-term support version of Node.js 20
+nvm install 20 --lts
 
-# Make the newly installed Node.js 18 as the default version
-nvm alias default 18
+# Make the newly installed Node.js 20 as the default version
+nvm alias default 20
 
-# Switch to the newly installed Node.js 18
-nvm use 18
+# Switch to the newly installed Node.js 20
+nvm use 20
 ```
-
-:::tip nvm and fnm
-Both nvm and fnm are Node.js version management tools. Relatively speaking, nvm is more mature and stable, while fnm is implemented using Rust, which provides better performance than nvm.
-:::
 
 ## Creating an Rsbuild Project
 

--- a/packages/document/docs/zh/guide/start/quick-start.mdx
+++ b/packages/document/docs/zh/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## 环境准备
 
-在开始使用前，你需要安装 [Node.js](https://nodejs.org/)，并保证 Node.js 版本不低于 16，**我们推荐使用 Node.js 18 的 LTS 版本**。
+在开始使用前，你需要安装 [Node.js](https://nodejs.org/)，并保证 Node.js 版本 >= 16，**我们推荐使用 Node.js 20 的 LTS 版本**。
 
 你可以通过以下命令检查当前使用的 Node.js 版本：
 
@@ -10,24 +10,20 @@
 node -v
 ```
 
-如果你当前的环境中尚未安装 Node.js，或是安装的版本低于 16，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装需要的版本。
+如果你当前的环境中尚未安装 Node.js，或是安装的版本过低，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装需要的版本。
 
-下面是通过 nvm 安装 Node.js 18 LTS 版本的例子：
+下面是通过 nvm 安装 Node.js 20 LTS 版本的例子：
 
 ```bash
-# 安装 Node.js 18 的长期支持版本
-nvm install 18 --lts
+# 安装 Node.js 20 的长期支持版本
+nvm install 20 --lts
 
-# 将刚安装的 Node.js 18 设置为默认版本
-nvm alias default 18
+# 将刚安装的 Node.js 20 设置为默认版本
+nvm alias default 20
 
-# 切换到刚安装的 Node.js 18
-nvm use 18
+# 切换到刚安装的 Node.js 20
+nvm use 20
 ```
-
-:::tip nvm 和 fnm
-nvm 和 fnm 都是 Node.js 版本管理工具。相对来说，nvm 较为成熟和稳定，而 fnm 是使用 Rust 实现的，比 nvm 提供了更好的性能。
-:::
 
 ## 创建 Rsbuild 项目
 


### PR DESCRIPTION
## Summary

Recommend using Node.js 20 in the quick start document.

Rsbuild still supports Node.js 16, but some 3rd party dependencies are going to drop Node.js 16 support. Therefore, we recommend users to use higher versions of Node.js in preparation for deprecating lower versions of Node.js in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
