### PR TITLE
feat: support configuring entry by target

### DIFF
--- a/e2e/cases/source/multiple-entry/index.test.ts
+++ b/e2e/cases/source/multiple-entry/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { build } from '@e2e/helper';
 
-test('should allow to set alias by build target', async () => {
+test('should allow to set entry by build target', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });

--- a/e2e/cases/source/multiple-entry/rsbuild.config.ts
+++ b/e2e/cases/source/multiple-entry/rsbuild.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry(entry, { target }) {
+      if (target === 'web') {
+        entry.index = './src/index.client.js';
+      } else if (target === 'node') {
+        entry.index = './src/index.server.js';
+      }
+      return entry;
+    },
+  },
+  output: {
+    targets: ['web', 'node'],
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/source/multiple-entry/src/index.client.js
+++ b/e2e/cases/source/multiple-entry/src/index.client.js
@@ -1,0 +1,1 @@
+console.log('for web target');

--- a/e2e/cases/source/multiple-entry/src/index.server.js
+++ b/e2e/cases/source/multiple-entry/src/index.server.js
@@ -1,0 +1,1 @@
+console.log('for node target');

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,34 +1,59 @@
-import { color, castArray, createVirtualModule } from '@rsbuild/shared';
-import type { RsbuildPlugin } from '../types';
+import {
+  color,
+  castArray,
+  createVirtualModule,
+  mergeChainedOptions,
+  type RsbuildEntry,
+  type RsbuildTarget,
+} from '@rsbuild/shared';
+import type { NormalizedConfig, RsbuildConfig, RsbuildPlugin } from '../types';
 import type { EntryDescription } from '@rspack/core';
+
+export function getEntryObject(
+  config: RsbuildConfig | NormalizedConfig,
+  target: RsbuildTarget,
+): RsbuildEntry {
+  if (!config.source?.entry) {
+    return {};
+  }
+
+  return mergeChainedOptions({
+    defaults: {},
+    options: config.source?.entry,
+    utils: { target },
+  });
+}
 
 export const pluginEntry = (): RsbuildPlugin => ({
   name: 'rsbuild:entry',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { isServer, isServiceWorker }) => {
-      const { entry } = api.context;
-      const config = api.getNormalizedConfig();
-      const { preEntry } = config.source;
+    api.modifyBundlerChain(
+      async (chain, { target, isServer, isServiceWorker }) => {
+        const config = api.getNormalizedConfig();
+        const { preEntry } = config.source;
+        const entry =
+          target === 'web' ? api.context.entry : getEntryObject(config, target);
 
-      const injectCoreJsEntry =
-        config.output.polyfill === 'entry' && !isServer && !isServiceWorker;
+        const injectCoreJsEntry =
+          config.output.polyfill === 'entry' && !isServer && !isServiceWorker;
 
-      Object.keys(entry).forEach((entryName) => {
-        const entryPoint = chain.entry(entryName);
-        const addEntry = (item: string | EntryDescription) => {
-          entryPoint.add(item);
-        };
+        Object.keys(entry).forEach((entryName) => {
+          const entryPoint = chain.entry(entryName);
+          const addEntry = (item: string | EntryDescription) => {
+            entryPoint.add(item);
+          };
 
-        preEntry.forEach(addEntry);
+          preEntry.forEach(addEntry);
 
-        if (injectCoreJsEntry) {
-          addEntry(createVirtualModule('import "core-js";'));
-        }
+          if (injectCoreJsEntry) {
+            addEntry(createVirtualModule('import "core-js";'));
+          }
 
-        castArray(entry[entryName]).forEach(addEntry);
-      });
-    });
+          castArray(entry[entryName]).forEach(addEntry);
+        });
+      },
+    );
 
     api.onBeforeCreateCompiler(({ bundlerConfigs }) => {
       if (bundlerConfigs.every((config) => !config.entry)) {

--- a/packages/core/src/provider/createContext.ts
+++ b/packages/core/src/provider/createContext.ts
@@ -12,6 +12,7 @@ import {
 import type { InternalContext } from '../types';
 import { initHooks } from './initHooks';
 import { withDefaultConfig } from './config';
+import { getEntryObject } from '../plugins/entry';
 
 function getAbsolutePath(root: string, filepath: string) {
   return isAbsolute(filepath) ? filepath : join(root, filepath);
@@ -40,7 +41,7 @@ async function createContextByConfig(
   const tsconfigPath = config.source?.tsconfigPath;
 
   const context: RsbuildContext = {
-    entry: config.source?.entry || {},
+    entry: getEntryObject(config, 'web'),
     targets: config.output?.targets || [],
     version: RSBUILD_VERSION,
     rootPath,
@@ -63,8 +64,9 @@ export function updateContextByNormalizedConfig(
   context.distPath = getAbsoluteDistPath(context.rootPath, config);
 
   if (config.source.entry) {
-    context.entry = config.source.entry;
+    context.entry = getEntryObject(config, 'web');
   }
+
   if (config.source.tsconfigPath) {
     context.tsconfigPath = getAbsolutePath(
       context.rootPath,

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -39,7 +39,7 @@ export interface SourceConfig {
   /**
    * Set the entry modules.
    */
-  entry?: RsbuildEntry;
+  entry?: ChainedConfigWithUtils<RsbuildEntry, { target: RsbuildTarget }>;
   /**
    * Specifies that certain files that will be excluded from compilation.
    */


### PR DESCRIPTION
## Summary

Support configuring entry by target, this is useful for implementing SSR:

```js
import { defineConfig } from '@rsbuild/core';

export default defineConfig({
  source: {
    entry(entry, { target }) {
      if (target === 'web') {
        entry.index = './src/index.client.js';
      } else if (target === 'node') {
        entry.index = './src/index.server.js';
      }
      return entry;
    },
  },
  output: {
    targets: ['web', 'node'],
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
