### PR TITLE
fix(server): do not cleanup NODE_ENV on restart

### DIFF
--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -77,7 +77,8 @@ export function loadEnv({
     }
 
     Object.keys(parsed).forEach((key) => {
-      // should not cleanup NODE_ENV
+      // do not cleanup NODE_ENV,
+      // otherwise the .env.${mode} file will not load
       if (key === 'NODE_ENV') {
         return;
       }

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -78,7 +78,7 @@ export function loadEnv({
 
     Object.keys(parsed).forEach((key) => {
       // do not cleanup NODE_ENV,
-      // otherwise the .env.${mode} file will not load
+      // otherwise the .env.${mode} file will not be loaded
       if (key === 'NODE_ENV') {
         return;
       }

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -72,12 +72,21 @@ export function loadEnv({
 
   let cleaned = false;
   const cleanup = () => {
-    if (cleaned) return;
+    if (cleaned) {
+      return;
+    }
+
     Object.keys(parsed).forEach((key) => {
+      // should not cleanup NODE_ENV
+      if (key === 'NODE_ENV') {
+        return;
+      }
+
       if (process.env[key] === parsed[key]) {
         delete process.env[key];
       }
     });
+
     cleaned = true;
   };
 


### PR DESCRIPTION
## Summary

Do not clean up NODE_ENV on server restart, otherwise the .env.${mode} file will not be loaded.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/1643

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
