### PR TITLE
fix(webpack): add rsbuild config to build dependencies

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -4,6 +4,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
 {
   "cache": {
     "buildDependencies": {
+      "rsbuildConfig": [
+        "/path/to/rsbuild.config.ts",
+      ],
       "tsconfig": [
         "<ROOT>/packages/compat/webpack/tests/tsconfig.json",
       ],

--- a/packages/compat/webpack/tests/default.test.ts
+++ b/packages/compat/webpack/tests/default.test.ts
@@ -5,7 +5,13 @@ describe('applyDefaultPlugins', () => {
   it('should apply default plugins correctly', async () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'development';
-    const rsbuild = await createStubRsbuild({});
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        _privateMeta: {
+          configFilePath: '/path/to/rsbuild.config.ts',
+        },
+      },
+    });
 
     const config = await rsbuild.unwrapConfig();
 

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,11 +1,8 @@
 import { join } from 'node:path';
 import { existsSync } from 'node:fs';
-import { color, isDev, logger } from '@rsbuild/shared';
+import { color, logger, type RsbuildMode } from '@rsbuild/shared';
 import { program, type Command } from '@rsbuild/shared/commander';
-import { loadEnv } from '../loadEnv';
-import { loadConfig, watchFiles } from '../config';
-import type { RsbuildMode } from '..';
-import { onBeforeRestartServer } from '../server/restart';
+import { init } from './init';
 
 export type CommonOptions = {
   config?: string;
@@ -28,82 +25,6 @@ export type InspectOptions = CommonOptions & {
 export type DevOptions = CommonOptions;
 
 export type PreviewOptions = CommonOptions;
-
-let commonOpts: CommonOptions = {};
-
-export async function init({
-  cliOptions,
-  isRestart,
-}: {
-  cliOptions?: CommonOptions;
-  isRestart?: boolean;
-}) {
-  if (cliOptions) {
-    commonOpts = cliOptions;
-  }
-
-  try {
-    const root = process.cwd();
-    const envs = loadEnv({
-      cwd: root,
-      mode: cliOptions?.envMode,
-    });
-
-    if (isDev()) {
-      onBeforeRestartServer(envs.cleanup);
-    }
-
-    const { content: config, filePath: configFilePath } = await loadConfig({
-      cwd: root,
-      path: commonOpts.config,
-      envMode: commonOpts.envMode,
-    });
-
-    const command = process.argv[2];
-    if (command === 'dev') {
-      const files = [...envs.filePaths];
-      if (configFilePath) {
-        files.push(configFilePath);
-      }
-
-      watchFiles(files);
-    }
-
-    const { createRsbuild } = await import('../createRsbuild');
-
-    config.source ||= {};
-    config.source.define = {
-      ...envs.publicVars,
-      ...config.source.define,
-    };
-
-    if (commonOpts.open && !config.dev?.startUrl) {
-      config.dev ||= {};
-      config.dev.startUrl = commonOpts.open;
-    }
-
-    if (commonOpts.host) {
-      config.server ||= {};
-      config.server.host = commonOpts.host;
-    }
-
-    if (commonOpts.port) {
-      config.server ||= {};
-      config.server.port = commonOpts.port;
-    }
-
-    return await createRsbuild({
-      cwd: root,
-      rsbuildConfig: config,
-    });
-  } catch (err) {
-    if (isRestart) {
-      logger.error(err);
-    } else {
-      throw err;
-    }
-  }
-}
 
 const applyCommonOptions = (command: Command) => {
   command

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,0 +1,81 @@
+import { isDev, logger } from '@rsbuild/shared';
+import { loadEnv } from '../loadEnv';
+import { loadConfig, watchFiles } from '../config';
+import { onBeforeRestartServer } from '../server/restart';
+import type { CommonOptions } from './commands';
+
+let commonOpts: CommonOptions = {};
+
+export async function init({
+  cliOptions,
+  isRestart,
+}: {
+  cliOptions?: CommonOptions;
+  isRestart?: boolean;
+}) {
+  if (cliOptions) {
+    commonOpts = cliOptions;
+  }
+
+  try {
+    const root = process.cwd();
+    const envs = loadEnv({
+      cwd: root,
+      mode: cliOptions?.envMode,
+    });
+
+    if (isDev()) {
+      onBeforeRestartServer(envs.cleanup);
+    }
+
+    const { content: config, filePath: configFilePath } = await loadConfig({
+      cwd: root,
+      path: commonOpts.config,
+      envMode: commonOpts.envMode,
+    });
+
+    const command = process.argv[2];
+    if (command === 'dev') {
+      const files = [...envs.filePaths];
+      if (configFilePath) {
+        files.push(configFilePath);
+      }
+
+      watchFiles(files);
+    }
+
+    const { createRsbuild } = await import('../createRsbuild');
+
+    config.source ||= {};
+    config.source.define = {
+      ...envs.publicVars,
+      ...config.source.define,
+    };
+
+    if (commonOpts.open && !config.dev?.startUrl) {
+      config.dev ||= {};
+      config.dev.startUrl = commonOpts.open;
+    }
+
+    if (commonOpts.host) {
+      config.server ||= {};
+      config.server.host = commonOpts.host;
+    }
+
+    if (commonOpts.port) {
+      config.server ||= {};
+      config.server.port = commonOpts.port;
+    }
+
+    return createRsbuild({
+      cwd: root,
+      rsbuildConfig: config,
+    });
+  } catch (err) {
+    if (isRestart) {
+      logger.error(err);
+    } else {
+      throw err;
+    }
+  }
+}

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { color, logger } from '@rsbuild/shared';
-import { init } from '../cli/commands';
+import { init } from '../cli/init';
 
 type Cleaner = () => Promise<unknown> | unknown;
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -196,6 +196,7 @@ export const pickRsbuildConfig = (
     'security',
     'performance',
     'moduleFederation',
+    '_privateMeta',
   ];
   return pick(rsbuildConfig, keys);
 };

--- a/packages/shared/src/types/config/index.ts
+++ b/packages/shared/src/types/config/index.ts
@@ -19,6 +19,13 @@ export type ModuleFederationConfig = {
 
 export type NormalizedModuleFederationConfig = ModuleFederationConfig;
 
+export type RsbuildConfigMeta = {
+  /**
+   * Path to the rsbuild config file
+   */
+  configFilePath: string;
+};
+
 /**
  * The shared Rsbuild config.
  * Can be used with both Rspack and Webpack.
@@ -35,6 +42,7 @@ export interface RsbuildConfig {
   performance?: PerformanceConfig;
   moduleFederation?: ModuleFederationConfig;
   provider?: RsbuildProvider<'rspack'> | RsbuildProvider<'webpack'>;
+  _privateMeta?: RsbuildConfigMeta;
 }
 
 export type NormalizedConfig = DeepReadonly<{
@@ -49,6 +57,7 @@ export type NormalizedConfig = DeepReadonly<{
   performance: NormalizedPerformanceConfig;
   moduleFederation?: ModuleFederationConfig;
   provider?: RsbuildProvider<'rspack'> | RsbuildProvider<'webpack'>;
+  _privateMeta?: RsbuildConfigMeta;
 }>;
 
 export * from './dev';


### PR DESCRIPTION
## Summary

- add rsbuild config to build dependencies.
- add `_privateMeta` field in the config object to store the config file path, this field is considered as a private filed and should not be used by users.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/1574

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
