### PR TITLE
fix: progress plugin custom prefix not work

### DIFF
--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -72,12 +72,22 @@ export function loadEnv({
 
   let cleaned = false;
   const cleanup = () => {
-    if (cleaned) return;
+    if (cleaned) {
+      return;
+    }
+
     Object.keys(parsed).forEach((key) => {
+      // do not cleanup NODE_ENV,
+      // otherwise the .env.${mode} file will not be loaded
+      if (key === 'NODE_ENV') {
+        return;
+      }
+
       if (process.env[key] === parsed[key]) {
         delete process.env[key];
       }
     });
+
     cleaned = true;
   };
 

--- a/packages/core/src/provider/plugins/progress.ts
+++ b/packages/core/src/provider/plugins/progress.ts
@@ -15,12 +15,7 @@ export const pluginProgress = (): RsbuildPlugin => ({
         return;
       }
 
-      let prefix;
-      if (options === true) {
-        prefix = TARGET_ID_MAP[target];
-      } else {
-        prefix = options.id ?? TARGET_ID_MAP[target];
-      }
+      const prefix = options !== true ? options.id : TARGET_ID_MAP[target];
 
       const { ProgressPlugin } = await import('@rspack/core');
       chain.plugin(CHAIN_ID.PLUGIN.PROGRESS).use(ProgressPlugin, [

--- a/packages/core/src/provider/plugins/progress.ts
+++ b/packages/core/src/provider/plugins/progress.ts
@@ -15,7 +15,10 @@ export const pluginProgress = (): RsbuildPlugin => ({
         return;
       }
 
-      const prefix = options !== true ? options.id : TARGET_ID_MAP[target];
+      const prefix =
+        options !== true && options.id !== undefined
+          ? options.id
+          : TARGET_ID_MAP[target];
 
       const { ProgressPlugin } = await import('@rspack/core');
       chain.plugin(CHAIN_ID.PLUGIN.PROGRESS).use(ProgressPlugin, [

--- a/packages/core/src/provider/plugins/progress.ts
+++ b/packages/core/src/provider/plugins/progress.ts
@@ -15,11 +15,17 @@ export const pluginProgress = (): RsbuildPlugin => ({
         return;
       }
 
-      const { ProgressPlugin } = await import('@rspack/core');
+      let prefix;
+      if (options === true) {
+        prefix = TARGET_ID_MAP[target];
+      } else {
+        prefix = options.id ?? TARGET_ID_MAP[target];
+      }
 
+      const { ProgressPlugin } = await import('@rspack/core');
       chain.plugin(CHAIN_ID.PLUGIN.PROGRESS).use(ProgressPlugin, [
         {
-          prefix: TARGET_ID_MAP[target],
+          prefix,
           ...(options === true ? {} : options),
         },
       ]);


### PR DESCRIPTION
## Summary

Fix progress plugin custom prefix not work.

[The docs](https://rsbuild.dev/zh/config/dev/progress-bar) says can modify the progress bar id by setting, but it's not working.

```
export default {
  dev: {
    progressBar: {
      id: 'Some Text',
    },
  },
};
```

Use `progressBar.id` as prefix if it exist.

### before
![image](https://github.com/web-infra-dev/rsbuild/assets/25167721/e0290ed4-ef12-4a5e-94a8-634ad5644a95)

### after
![image](https://github.com/web-infra-dev/rsbuild/assets/25167721/327ae947-f62b-4321-a5c5-cf0f361e511b)


## Related Links

<!--- Provide links of related issues or pages -->
- docs: https://rsbuild.dev/zh/config/dev/progress-bar

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
