### PR TITLE
fix: avoid merge provider object

### DIFF
--- a/packages/shared/src/mergeRsbuildConfig.ts
+++ b/packages/shared/src/mergeRsbuildConfig.ts
@@ -9,6 +9,7 @@ const OVERRIDE_PATH = [
   'output.targets',
   'server.printUrls',
   'dev.startUrl',
+  'provider',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Add `rsbuildConfig.provider` to override path list to avoid merge provider object.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
