### PR TITLE
fix(plugin-rem): runtime code should inject at head end

### DIFF
--- a/e2e/cases/html/rem/index.test.ts
+++ b/e2e/cases/html/rem/index.test.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { build } from '@e2e/helper';
+import { pluginRem } from '@rsbuild/plugin-rem';
+
+test('html with rem runtime code', async () => {
+  const viewportValue =
+    'width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover';
+  const remRuntimeCodeKeyWord = 'setRootPixel';
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginRem()],
+      source: {
+        entry: {
+          index: path.resolve(__dirname, './src/index.js'),
+        },
+      },
+      html: {
+        meta: {
+          viewport: viewportValue,
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  expect(html).toContain(remRuntimeCodeKeyWord);
+
+  expect(html).toContain(viewportValue);
+  expect(html.indexOf(remRuntimeCodeKeyWord)).toBeGreaterThan(
+    html.indexOf(viewportValue),
+  );
+});

--- a/e2e/cases/html/rem/src/index.js
+++ b/e2e/cases/html/rem/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -155,7 +155,7 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
           } else {
             const publicPath = getPublicPathFromCompiler(compiler);
             const url = withPublicPath(await this.getScriptPath(), publicPath);
-            data.headTags.push({
+            data.headTags.unshift({
               ...scriptTag,
               attributes: {
                 ...scriptTag.attributes,

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -148,14 +148,14 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
           const scriptTag = generateScriptTag();
 
           if (this.options.inlineRuntime) {
-            data.headTags.unshift({
+            data.headTags.push({
               ...scriptTag,
               innerHTML: await getRuntimeCode(),
             });
           } else {
             const publicPath = getPublicPathFromCompiler(compiler);
             const url = withPublicPath(await this.getScriptPath(), publicPath);
-            data.headTags.unshift({
+            data.headTags.push({
               ...scriptTag,
               attributes: {
                 ...scriptTag.attributes,


### PR DESCRIPTION
## Summary

At iOS webview, the meta of viewport should be placed before the rem runtime code.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
