### PR TITLE
chore(plugin-rem): use alterAssetTags to insert script

### DIFF
--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -125,7 +125,7 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       // @ts-expect-error compilation type mismatch
-      this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
+      this.HtmlPlugin.getHooks(compilation).alterAssetTags.tapPromise(
         this.name,
         async (data) => {
           const isExclude = this.options.excludeEntries.find((item: string) => {
@@ -148,14 +148,15 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
           const scriptTag = generateScriptTag();
 
           if (this.options.inlineRuntime) {
-            data.headTags.push({
+            // At iOS webview, the meta of viewport should be placed before the rem runtime code.
+            data.assetTags.scripts.unshift({
               ...scriptTag,
               innerHTML: await getRuntimeCode(),
             });
           } else {
             const publicPath = getPublicPathFromCompiler(compiler);
             const url = withPublicPath(await this.getScriptPath(), publicPath);
-            data.headTags.unshift({
+            data.assetTags.scripts.unshift({
               ...scriptTag,
               attributes: {
                 ...scriptTag.attributes,

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -148,7 +148,6 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
           const scriptTag = generateScriptTag();
 
           if (this.options.inlineRuntime) {
-            // At iOS webview, the meta of viewport should be placed before the rem runtime code.
             data.assetTags.scripts.unshift({
               ...scriptTag,
               innerHTML: await getRuntimeCode(),


### PR DESCRIPTION
## Summary

Use alterAssetTags to insert script, make sure the rem runtime code is after the meta tag and before the user scripts.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/eff0d9d8-bec8-4187-9bcc-7f7936cc17a6)

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1664

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
