### PR TITLE
fix: no need to set crossorigin if publicPath is auto

### DIFF
--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -34,6 +34,26 @@ test('should not apply crossOrigin when same origin', async () => {
   expect(html).not.toContain('crossorigin');
 });
 
+test('should not apply crossOrigin if assetPrefix is auto', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        scriptLoading: 'blocking',
+        crossorigin: 'anonymous',
+      },
+      output: {
+        assetPrefix: 'auto',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).not.toContain('crossorigin');
+});
+
 test('should apply crossOrigin when crossorigin is "anonymous" and not same origin', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
+++ b/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
@@ -1,4 +1,4 @@
-import type { CrossOrigin } from '@rsbuild/shared';
+import { getPublicPathFromCompiler, type CrossOrigin } from '@rsbuild/shared';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 import { getHTMLPlugin } from '../provider/htmlPluginUtil';
 
@@ -18,14 +18,17 @@ export class HtmlCrossOriginPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
-    if (
-      !this.crossOrigin ||
-      // align with crossOriginLoading logic
-      // https://github.com/web-infra-dev/rspack/blob/bc8e67b5419adda15c2b389517c9b37d02c8240f/crates/rspack_plugin_runtime/src/runtime_module/load_script.rs#L39
-      (compiler.options.output.publicPath === '/' &&
-        this.crossOrigin !== ('use-credentials' as const))
-    ) {
+    if (!this.crossOrigin) {
       return;
+    }
+
+    // align with webpack crossOriginLoading logic
+    // see: https://github.com/webpack/webpack/blob/611bded369b5a9ea695f2669b25a6f88b67d7826/lib/runtime/LoadScriptRuntimeModule.js#L100-L111
+    if (this.crossOrigin !== 'use-credentials') {
+      const publicPath = getPublicPathFromCompiler(compiler);
+      if (publicPath === '' || publicPath === '/') {
+        return;
+      }
     }
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {

--- a/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
+++ b/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
@@ -1,4 +1,4 @@
-import { getPublicPathFromCompiler, type CrossOrigin } from '@rsbuild/shared';
+import { DEFAULT_ASSET_PREFIX, type CrossOrigin } from '@rsbuild/shared';
 import type { Compiler, RspackPluginInstance } from '@rspack/core';
 import { getHTMLPlugin } from '../provider/htmlPluginUtil';
 
@@ -22,11 +22,16 @@ export class HtmlCrossOriginPlugin implements RspackPluginInstance {
       return;
     }
 
-    // align with webpack crossOriginLoading logic
+    // no need to set crossorigin="anonymous" if asset domain is the same as
+    // the page domain, align with webpack's crossOriginLoading logic.
     // see: https://github.com/webpack/webpack/blob/611bded369b5a9ea695f2669b25a6f88b67d7826/lib/runtime/LoadScriptRuntimeModule.js#L100-L111
     if (this.crossOrigin !== 'use-credentials') {
-      const publicPath = getPublicPathFromCompiler(compiler);
-      if (publicPath === '' || publicPath === '/') {
+      const { publicPath } = compiler.options.output;
+      if (
+        !publicPath ||
+        publicPath === DEFAULT_ASSET_PREFIX ||
+        publicPath === 'auto'
+      ) {
         return;
       }
     }

--- a/packages/document/docs/en/config/html/crossorigin.mdx
+++ b/packages/document/docs/en/config/html/crossorigin.mdx
@@ -15,20 +15,35 @@ export default {
   html: {
     crossorigin: 'anonymous',
   },
+  output: {
+    assetPrefix: 'https://example.com',
+  },
 };
 ```
 
 After compilation, the `<script>` tag in HTML becomes:
 
 ```html
-<script defer src="/static/js/main.js" crossorigin="anonymous"></script>
+<script
+  defer
+  src="https://example.com/static/js/main.js"
+  crossorigin="anonymous"
+></script>
 ```
 
 The `<style>` tag becomes:
 
 ```html
-<link href="/static/css/main.css" rel="stylesheet" crossorigin="anonymous" />
+<link
+  href="https://example.com/static/css/main.css"
+  rel="stylesheet"
+  crossorigin="anonymous"
+/>
 ```
+
+:::tip
+If the domain of static assets is the same as the current page, Rsbuild will not add the crossorigin="anonymous" attribute, as this attribute is not required for non-cross-domain scenario.
+:::
 
 ### Optional Values
 

--- a/packages/document/docs/zh/config/html/crossorigin.mdx
+++ b/packages/document/docs/zh/config/html/crossorigin.mdx
@@ -15,20 +15,35 @@ export default {
   html: {
     crossorigin: 'anonymous',
   },
+  output: {
+    assetPrefix: 'https://example.com',
+  },
 };
 ```
 
-编译后，HTML 中的 `<script>` 标签变为：
+构建后，HTML 中的 `<script>` 标签变为：
 
 ```html
-<script defer src="/static/js/main.js" crossorigin="anonymous"></script>
+<script
+  defer
+  src="https://example.com/static/js/main.js"
+  crossorigin="anonymous"
+></script>
 ```
 
 `<style>` 标签变为：
 
 ```html
-<link href="/static/css/main.css" rel="stylesheet" crossorigin="anonymous" />
+<link
+  href="https://example.com/static/css/main.css"
+  rel="stylesheet"
+  crossorigin="anonymous"
+/>
 ```
+
+:::tip
+如果静态资源的域名和当前页面的域名一致，那么 Rsbuild 将不会添加 crossorigin="anonymous" 属性，因为非跨域情况下不需要此属性。
+:::
 
 ### 可选值
 


### PR DESCRIPTION
## Summary

no need to set crossorigin="anonymous" if asset domain is the same as the page domain, align with webpack's crossOriginLoading logic.

## Related Links

https://github.com/webpack/webpack/blob/611bded369b5a9ea695f2669b25a6f88b67d7826/lib/runtime/LoadScriptRuntimeModule.js#L100-L111

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
