### PR TITLE
fix: incorrect script URL in Windows

### DIFF
--- a/e2e/cases/output/rem/tests/index.test.ts
+++ b/e2e/cases/output/rem/tests/index.test.ts
@@ -83,4 +83,9 @@ test('should extract runtime code when inlineRuntime is false', async () => {
   expect(htmlFile).toBeTruthy();
   expect(retryFile).toBeTruthy();
   expect(files[htmlFile!].includes('function setRootPixel')).toBeFalsy();
+  expect(
+    files[htmlFile!].match(
+      /<script src="\/static\/js\/convert-rem.\w+.\w+.\w+.js"/,
+    ),
+  );
 });

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -54,7 +54,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
 
   async getScriptPath() {
     if (!this.scriptPath) {
-      this.scriptPath = path.join(
+      this.scriptPath = path.posix.join(
         this.distDir,
         `assets-retry.${RSBUILD_VERSION}.js`,
       );

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -81,7 +81,7 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
 
   async getScriptPath() {
     if (!this.scriptPath) {
-      this.scriptPath = path.join(
+      this.scriptPath = path.posix.join(
         this.distDir,
         `convert-rem.${RSBUILD_VERSION}.js`,
       );


### PR DESCRIPTION
## Summary

Fix incorrect script URL in Windows, should use `path.posix.path` to join URL.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
