### PR TITLE
chore(deps): bump html-rspack-plugin 5.6.1

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -1,15 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { pluginRem } from '@rsbuild/plugin-rem';
 
 export default defineConfig({
-  plugins: [
-    pluginReact(),
-    pluginRem({
-      inlineRuntime: false,
-    }),
-  ],
-  html: {
-    crossorigin: 'use-credentials',
-  },
+  plugins: [pluginReact()],
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -1,6 +1,15 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginRem } from '@rsbuild/plugin-rem';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginRem({
+      inlineRuntime: false,
+    }),
+  ],
+  html: {
+    crossorigin: 'use-credentials',
+  },
 });

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/shared": "workspace:*",
     "fast-glob": "^3.3.1",
     "globby": "^11.1.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
     "mini-css-extract-plugin": "2.8.0",
     "postcss": "^8.4.33",
     "terser-webpack-plugin": "5.3.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "@rspack/core": "0.5.5",
     "@swc/helpers": "0.5.3",
     "core-js": "~3.32.2",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
     "postcss": "^8.4.33"
   },
   "devDependencies": {

--- a/packages/core/src/rspack/HtmlAppIconPlugin.ts
+++ b/packages/core/src/rspack/HtmlAppIconPlugin.ts
@@ -35,7 +35,6 @@ export class HtmlAppIconPlugin {
     // add html asset tags
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .alterAssetTagGroups.tap(this.name, (data) => {
           const publicPath = getPublicPathFromCompiler(compiler);

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -58,7 +58,6 @@ export class HtmlBasicPlugin {
 
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .alterAssetTagGroups.tap(this.name, (data) => {
           const entryName = data.plugin.options?.entryName;

--- a/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
+++ b/packages/core/src/rspack/HtmlCrossOriginPlugin.ts
@@ -38,7 +38,6 @@ export class HtmlCrossOriginPlugin implements RspackPluginInstance {
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .alterAssetTags.tap(this.name, (alterAssetTags) => {
           const {

--- a/packages/core/src/rspack/HtmlNetworkPerformancePlugin.ts
+++ b/packages/core/src/rspack/HtmlNetworkPerformancePlugin.ts
@@ -46,7 +46,6 @@ export class HtmlNetworkPerformancePlugin implements RspackPluginInstance {
       `HTML${this.type}Plugin`,
       (compilation: Compilation) => {
         getHTMLPlugin()
-          // @ts-expect-error compilation type mismatch
           .getHooks(compilation)
           .alterAssetTagGroups.tap(
             `HTML${upperFirst(this.type)}Plugin`,

--- a/packages/core/src/rspack/HtmlNoncePlugin.ts
+++ b/packages/core/src/rspack/HtmlNoncePlugin.ts
@@ -23,7 +23,6 @@ export class HtmlNoncePlugin implements RspackPluginInstance {
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .alterAssetTags.tap(this.name, (alterAssetTags) => {
           const {

--- a/packages/core/src/rspack/HtmlTagsPlugin.ts
+++ b/packages/core/src/rspack/HtmlTagsPlugin.ts
@@ -74,7 +74,6 @@ export class HtmlTagsPlugin {
   apply(compiler: Compiler) {
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       const compilationHash = compilation.hash || '';
-      // @ts-expect-error compilation type mismatch
       const hooks = getHTMLPlugin().getHooks(compilation);
       hooks.alterAssetTagGroups.tap(this.name, (params) => {
         // skip unmatched file and empty tag list.

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -222,7 +222,6 @@ export class InlineChunkHtmlPlugin {
       const tagFunction = (tag: HtmlTagObject) =>
         this.getInlinedTag(publicPath, tag, compilation);
 
-      // @ts-expect-error compilation type mismatch
       const hooks = getHTMLPlugin().getHooks(compilation);
 
       hooks.alterAssetTagGroups.tap(this.name, (assets) => {

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -190,7 +190,6 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   apply(compiler: Compiler): void {
     compiler.hooks.compilation.tap(this.constructor.name, (compilation) => {
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .beforeAssetTagGeneration.tap(
           `HTML${upperFirst(this.type)}Plugin`,
@@ -208,7 +207,6 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
         );
 
       getHTMLPlugin()
-        // @ts-expect-error compilation type mismatch
         .getHooks(compilation)
         .alterAssetTags.tap(
           `HTML${upperFirst(this.type)}Plugin`,

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/serialize-javascript": "^5.0.1",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
     "terser": "5.28.1",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -87,7 +87,6 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       // the behavior of inject/modify tags in afterTemplateExecution hook will not take effect when inject option is false
-      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
         this.name,
         async (data) => {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
     "typescript": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -124,7 +124,6 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
     }
 
     compiler.hooks.compilation.tap(this.name, (compilation) => {
-      // @ts-expect-error compilation type mismatch
       this.HtmlPlugin.getHooks(compilation).alterAssetTags.tapPromise(
         this.name,
         async (data) => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -136,7 +136,7 @@
   },
   "devDependencies": {
     "@types/node": "16.x",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
     "mini-css-extract-plugin": "2.8.0",
     "terser": "5.28.1",
     "terser-webpack-plugin": "5.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -641,8 +641,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.6.1
+        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0)
       mini-css-extract-plugin:
         specifier: 2.8.0
         version: 2.8.0(webpack@5.89.0)
@@ -684,8 +684,8 @@ importers:
         specifier: ~3.32.2
         version: 3.32.2
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.6.1
+        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0)
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
@@ -789,8 +789,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.4
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.6.1
+        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0)
       terser:
         specifier: 5.28.1
         version: 5.28.1
@@ -1102,8 +1102,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.6.1
+        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0)
       typescript:
         specifier: ^5.3.0
         version: 5.3.2
@@ -1444,8 +1444,8 @@ importers:
         specifier: 16.x
         version: 16.18.59
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.0
-        version: /html-rspack-plugin@5.6.0
+        specifier: npm:html-rspack-plugin@5.6.1
+        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0)
       mini-css-extract-plugin:
         specifier: 2.8.0
         version: 2.8.0(webpack@5.89.0)
@@ -4095,24 +4095,20 @@ packages:
     dependencies:
       '@module-federation/runtime': 0.0.8
       '@module-federation/webpack-bundler-runtime': 0.0.8
-    dev: false
 
   /@module-federation/runtime@0.0.8:
     resolution: {integrity: sha512-Hi9g10aHxHdQ7CbchSvke07YegYwkf162XPOmixNmJr5Oy4wVa2d9yIVSrsWFhBRbbvM5iJP6GrSuEq6HFO3ug==}
     dependencies:
       '@module-federation/sdk': 0.0.8
-    dev: false
 
   /@module-federation/sdk@0.0.8:
     resolution: {integrity: sha512-lkasywBItjUTNT0T0IskonDE2E/2tXE9UhUCPVoDL3NteDUSFGg4tpkF+cey1pD8mHh0XJcGrCuOW7s96peeAg==}
-    dev: false
 
   /@module-federation/webpack-bundler-runtime@0.0.8:
     resolution: {integrity: sha512-ULwrTVzF47+6XnWybt6SIq97viEYJRv4P/DByw5h7PSX9PxSGyMm5pHfXdhcb7tno7VknL0t2V8F48fetVL9kA==}
     dependencies:
       '@module-federation/runtime': 0.0.8
       '@module-federation/sdk': 0.0.8
-    dev: false
 
   /@napi-rs/image-android-arm-eabi@1.7.0:
     resolution: {integrity: sha512-lpyqxaIYUrdk096xoJjvPGin5jY1Ehor0RxryqDvowGUhVU3TDgolsjjuFPEki3cfvV6zzAm7bWUkmxIci2zaw==}
@@ -4500,7 +4496,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-darwin-x64@0.5.5:
@@ -4508,7 +4503,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-gnu@0.5.5:
@@ -4516,7 +4510,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-arm64-musl@0.5.5:
@@ -4524,7 +4517,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-gnu@0.5.5:
@@ -4532,7 +4524,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-linux-x64-musl@0.5.5:
@@ -4540,7 +4531,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-arm64-msvc@0.5.5:
@@ -4548,7 +4538,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-ia32-msvc@0.5.5:
@@ -4556,7 +4545,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding-win32-x64-msvc@0.5.5:
@@ -4564,7 +4552,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rspack/binding@0.5.5:
@@ -4579,7 +4566,6 @@ packages:
       '@rspack/binding-win32-arm64-msvc': 0.5.5
       '@rspack/binding-win32-ia32-msvc': 0.5.5
       '@rspack/binding-win32-x64-msvc': 0.5.5
-    dev: false
 
   /@rspack/core@0.5.5(@swc/helpers@0.5.3):
     resolution: {integrity: sha512-fsYPOE6HIGMAol8TiNsstvC2QfCo1NLpagzhu9c/ptNKLxKGGjxXrQ3ekjXbtvHnPhLJbonN6nWHN2Ee3boDFA==}
@@ -4605,7 +4591,6 @@ packages:
       webpack-sources: 3.2.3
       zod: 3.22.4
       zod-validation-error: 1.3.1(zod@3.22.4)
-    dev: false
 
   /@rspack/plugin-react-refresh@0.5.5(react-refresh@0.14.0):
     resolution: {integrity: sha512-vSYtIkoXSRhGLkE7fci5fW/tgpod1Mgps46sNe3FQ0ENP/ZfCTCFdVvuOSba4Kubcv8UWr/yd1CBjVuQIZR5eQ==}
@@ -8205,7 +8190,6 @@ packages:
 
   /graceful-fs@4.2.10:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==}
-    dev: false
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -8527,12 +8511,22 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /html-rspack-plugin@5.6.0:
-    resolution: {integrity: sha512-4jrAQEEt9JCcGbeP7dFV1d42RF6IA9nYWoqK5i+rncdPPMz6eVHt1scPy9722brams7/SndzJhoIxN0Hw7T4ZA==}
+  /html-rspack-plugin@5.6.1(@rspack/core@0.5.5)(webpack@5.89.0):
+    resolution: {integrity: sha512-HxBMh931QBxzUAA12j4iPIK1yVgnQrz3ziU/CHU7hUWuolpCy+wcUgcn9Zy4YPsq8PisE9lSg2K8+3i0a//H8A==}
     engines: {node: '>=10.13.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      webpack: ^5.20.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
     dependencies:
+      '@rspack/core': 0.5.5(@swc/helpers@0.5.3)
       lodash: 4.17.21
       tapable: 2.2.1
+      webpack: 5.89.0
 
   /html-tags@2.0.0:
     resolution: {integrity: sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==}
@@ -9113,7 +9107,6 @@ packages:
   /json-parse-even-better-errors@3.0.0:
     resolution: {integrity: sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-    dev: false
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -13080,7 +13073,6 @@ packages:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
-    dev: false
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -13279,7 +13271,6 @@ packages:
     dependencies:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
-    dev: false
 
   /terser-webpack-plugin@5.3.10(esbuild@0.19.8)(webpack@5.89.0):
     resolution: {integrity: sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==}
@@ -14491,11 +14482,9 @@ packages:
       zod: ^3.18.0
     dependencies:
       zod: 3.22.4
-    dev: false
 
   /zod@3.22.4:
     resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
-    dev: false
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}


### PR DESCRIPTION
## Summary

Bump html-rspack-plugin 5.6.1 to fix the compilation type issue.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
