### PR TITLE
fix(plugin-eslint): ignore dist folder by default

### DIFF
--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { Options } from 'eslint-webpack-plugin';
 
@@ -20,7 +21,7 @@ export const pluginEslint = (
   name: 'rsbuild:eslint',
 
   setup(api) {
-    const { enable = true } = options;
+    const { enable = true, eslintPluginOptions } = options;
 
     if (!enable) {
       return;
@@ -34,13 +35,20 @@ export const pluginEslint = (
       }
 
       const { default: ESLintPlugin } = await import('eslint-webpack-plugin');
-
-      const pluginOptions: Options = {
+      const defaultOptions = {
         extensions: ['js', 'jsx', 'mjs', 'cjs', 'ts', 'tsx', 'mts', 'cts'],
-        ...options.eslintPluginOptions,
+        exclude: [
+          'node_modules',
+          path.relative(api.context.rootPath, api.context.distPath),
+        ],
       };
 
-      chain.plugin(CHAIN_ID.PLUGIN.ESLINT).use(ESLintPlugin, [pluginOptions]);
+      chain.plugin(CHAIN_ID.PLUGIN.ESLINT).use(ESLintPlugin, [
+        {
+          ...defaultOptions,
+          ...eslintPluginOptions,
+        },
+      ]);
     });
   },
 });

--- a/packages/plugin-eslint/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-eslint/tests/__snapshots__/index.test.ts.snap
@@ -43,6 +43,10 @@ exports[`plugin-type-check > should apply eslint-webpack-plugin correctly 1`] = 
         "cacheLocation": "node_modules/.cache/eslint-webpack-plugin/.eslintcache",
         "emitError": true,
         "emitWarning": true,
+        "exclude": [
+          "node_modules",
+          "dist",
+        ],
         "extensions": [
           "js",
           "jsx",

--- a/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
@@ -66,35 +66,3 @@ exports[`plugin-type-check > should apply fork-ts-checker-webpack-plugin correct
   ],
 }
 `;
-
-exports[`plugin-type-check > should only apply one ts-checker plugin when there is multiple targets 1`] = `
-{
-  "plugins": [
-    ForkTsCheckerWebpackPlugin {
-      "options": {
-        "issue": {
-          "exclude": [
-            {
-              "file": "**/*.(spec|test).ts",
-            },
-            {
-              "file": "**/node_modules/**/*",
-            },
-          ],
-        },
-        "logger": {
-          "error": [Function],
-          "log": [Function],
-        },
-        "typescript": {
-          "build": false,
-          "configFile": "<ROOT>/packages/plugin-type-check/tests/tsconfig.json",
-          "memoryLimit": 8192,
-          "mode": "readonly",
-          "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
-        },
-      },
-    },
-  ],
-}
-`;


### PR DESCRIPTION
## Summary

- Let plugin-eslint ignore the dist folder by default.
- Remove an unused snapshot.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
