### PR TITLE
test(e2e): enable moment local case

### DIFF
--- a/e2e/cases/moment/index.test.ts
+++ b/e2e/cases/moment/index.test.ts
@@ -1,8 +1,7 @@
 import { expect, test } from '@playwright/test';
-import { build, webpackOnlyTest } from '@e2e/helper';
+import { build } from '@e2e/helper';
 
-// todo: https://github.com/web-infra-dev/rspack/issues/3346
-webpackOnlyTest('removeMomentLocale false (default)', async () => {
+test('removeMomentLocale false (default)', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {


### PR DESCRIPTION
## Summary

Enable the moment local case for Rspack since Rspack has provided aliasedRequire support.

## Related Links

https://github.com/web-infra-dev/rspack/issues/3346

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
