### PR TITLE
docs(plugin-svgr): add tip for named export

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-svgr.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-svgr.mdx
@@ -141,6 +141,10 @@ import logo from './logo.svg?url';
 console.log(logo); // => asset url
 ```
 
+:::tip
+When `svgDefaultExport` is set to `'component'`, the named imports (ReactComponent) cannot be used.
+:::
+
 ## Type Declaration
 
 When you reference an SVG asset in TypeScript code, TypeScript may prompt that the module is missing a type definition:
@@ -165,9 +169,7 @@ If you set `svgDefaultExport` to `'component'`, then change the type declaration
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```

--- a/packages/document/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-svgr.mdx
@@ -141,6 +141,10 @@ import logo from './logo.svg?url';
 console.log(logo); // => 资源 url
 ```
 
+:::tip
+当 `svgDefaultExport` 被设置为 `'component'` 时，具名导入（ReactComponent）将无法使用。
+:::
+
 ## 类型声明
 
 当你在 TypeScript 代码中引用 SVG 资源时，TypeScript 可能会提示该模块缺少类型定义：
@@ -165,9 +169,7 @@ declare module '*.svg' {
 
 ```ts
 declare module '*.svg' {
-  export const ReactComponent: React.FunctionComponent<
-    React.SVGProps<SVGSVGElement>
-  >;
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
 }
 ```


### PR DESCRIPTION
## Summary

When `svgDefaultExport` is set to `'component'`, the named imports (ReactComponent) cannot be used.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
