### PR TITLE
docs: enable SSG for overview page

### DIFF
--- a/packages/document/src/components/Overview.tsx
+++ b/packages/document/src/components/Overview.tsx
@@ -1,4 +1,3 @@
-import { NoSSR } from 'rspress/runtime';
 import { useUrl } from '../utils';
 import styles from './Overview.module.scss';
 
@@ -32,9 +31,5 @@ export default function Overview() {
     </>
   ));
 
-  return (
-    <NoSSR>
-      <div className={styles.root}>{Nodes}</div>
-    </NoSSR>
-  );
+  return <div className={styles.root}>{Nodes}</div>;
 }


### PR DESCRIPTION
## Summary

Enable SSG for overview page as Rspress has supported it.

## Related Links

https://github.com/web-infra-dev/rspress/pull/684

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
