### PR TITLE
feat(plugin-source-build): support merge user references config

### DIFF
--- a/e2e/cases/source-build/components/package.json
+++ b/e2e/cases/source-build/components/package.json
@@ -2,7 +2,6 @@
   "name": "@e2e/source-build-components",
   "private": true,
   "version": "1.0.0",
-  "source": "./src/index.tsx",
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

user references configurations can also used in rsbuild source build.

<img width="641" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/105dc180-0c49-43f7-8fd4-855696ca675f">


## Related Links

https://www.rspack.dev/config/resolve.html#resolvetsconfigreferences

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
