### PR TITLE
feat(plugin-css-minimizer): export webpack-plugin to let users customize configurations

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-css-minimizer.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-css-minimizer.mdx
@@ -27,19 +27,10 @@ import { PackageManagerTabs } from '@theme';
 You can register the plugin in the `rsbuild.config.ts` file:
 
 ```ts title="rsbuild.config.ts"
-import {
-  pluginCssMinimizer,
-  CssMinimizerWebpackPlugin,
-} from '@rsbuild/plugin-css-minimizer';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 export default {
-  plugins: [
-    pluginCssMinimizer({
-      pluginOptions: {
-        minify: CssMinimizerWebpackPlugin.cssnanoMinify,
-      },
-    }),
-  ],
+  plugins: [pluginCssMinimizer()],
 };
 ```
 
@@ -56,6 +47,7 @@ The value of `pluginOptions` will be merged with the default options inside the 
 
 ```ts
 const defaultOptions = {
+  minify: CssMinimizerWebpackPlugin.cssnanoMinify,
   minimizerOptions: {
     preset: [
       'default',
@@ -89,4 +81,26 @@ pluginCssMinimizer({
     };
   },
 });
+```
+
+- **Example 3:** Switch to other tools for CSS minification
+
+```js
+import {
+  pluginCssMinimizer,
+  CssMinimizerWebpackPlugin,
+} from '@rsbuild/plugin-css-minimizer';
+
+pluginCssMinimizer({
+  pluginOptions: {
+    minify: CssMinimizerWebpackPlugin.cleanCssMinify,
+    minimizerOptions: {
+      level: {
+        1: {
+          roundingPrecision: "all=3,px=5",
+        },
+      },
+    },
+  },
+}),
 ```

--- a/packages/document/docs/en/plugins/list/plugin-css-minimizer.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-css-minimizer.mdx
@@ -27,10 +27,19 @@ import { PackageManagerTabs } from '@theme';
 You can register the plugin in the `rsbuild.config.ts` file:
 
 ```ts title="rsbuild.config.ts"
-import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
+import {
+  pluginCssMinimizer,
+  CssMinimizerWebpackPlugin,
+} from '@rsbuild/plugin-css-minimizer';
 
 export default {
-  plugins: [pluginCssMinimizer()],
+  plugins: [
+    pluginCssMinimizer({
+      pluginOptions: {
+        minify: CssMinimizerWebpackPlugin.cssnanoMinify,
+      },
+    }),
+  ],
 };
 ```
 

--- a/packages/document/docs/zh/plugins/list/plugin-css-minimizer.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-css-minimizer.mdx
@@ -27,10 +27,19 @@ import { PackageManagerTabs } from '@theme';
 你可以在 `rsbuild.config.ts` 文件中注册插件：
 
 ```ts title="rsbuild.config.ts"
-import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
+import {
+  pluginCssMinimizer,
+  CssMinimizerWebpackPlugin,
+} from '@rsbuild/plugin-css-minimizer';
 
 export default {
-  plugins: [pluginCssMinimizer()],
+  plugins: [
+    pluginCssMinimizer({
+      pluginOptions: {
+        minify: CssMinimizerWebpackPlugin.cssnanoMinify,
+      },
+    }),
+  ],
 };
 ```
 

--- a/packages/document/docs/zh/plugins/list/plugin-css-minimizer.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-css-minimizer.mdx
@@ -27,19 +27,10 @@ import { PackageManagerTabs } from '@theme';
 你可以在 `rsbuild.config.ts` 文件中注册插件：
 
 ```ts title="rsbuild.config.ts"
-import {
-  pluginCssMinimizer,
-  CssMinimizerWebpackPlugin,
-} from '@rsbuild/plugin-css-minimizer';
+import { pluginCssMinimizer } from '@rsbuild/plugin-css-minimizer';
 
 export default {
-  plugins: [
-    pluginCssMinimizer({
-      pluginOptions: {
-        minify: CssMinimizerWebpackPlugin.cssnanoMinify,
-      },
-    }),
-  ],
+  plugins: [pluginCssMinimizer()],
 };
 ```
 
@@ -56,6 +47,7 @@ export default {
 
 ```ts
 const defaultOptions = {
+  minify: CssMinimizerWebpackPlugin.cssnanoMinify,
   minimizerOptions: {
     preset: [
       'default',
@@ -89,4 +81,26 @@ pluginCssMinimizer({
     };
   },
 });
+```
+
+- **示例三：** 切换到其他工具进行 CSS 压缩
+
+```js
+import {
+  pluginCssMinimizer,
+  CssMinimizerWebpackPlugin,
+} from '@rsbuild/plugin-css-minimizer';
+
+pluginCssMinimizer({
+  pluginOptions: {
+    minify: CssMinimizerWebpackPlugin.cleanCssMinify,
+    minimizerOptions: {
+      level: {
+        1: {
+          roundingPrecision: "all=3,px=5",
+        },
+      },
+    },
+  },
+}),
 ```

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -43,6 +43,7 @@ export function applyCSSMinimizer(
 ) {
   const mergedOptions: CssMinimizerPluginOptions = mergeChainedOptions({
     defaults: {
+      minify: CssMinimizerWebpackPlugin.cssnanoMinify,
       minimizerOptions: getCssnanoDefaultOptions(),
     },
     options: options.pluginOptions,

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -5,6 +5,7 @@ import {
   type ChainedConfig,
   type ChainIdentifier,
 } from '@rsbuild/shared';
+import CssMinimizerWebpackPlugin from 'css-minimizer-webpack-plugin';
 import type CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 
 export type CssMinimizerPluginOptions = CssMinimizerPlugin.BasePluginOptions &
@@ -35,15 +36,11 @@ const getCssnanoDefaultOptions = (): CssNanoOptions => ({
   ],
 });
 
-export async function applyCSSMinimizer(
+export function applyCSSMinimizer(
   chain: BundlerChain,
   CHAIN_ID: ChainIdentifier,
   options: PluginCssMinimizerOptions = {},
 ) {
-  const { default: CssMinimizerPlugin } = await import(
-    'css-minimizer-webpack-plugin'
-  );
-
   const mergedOptions: CssMinimizerPluginOptions = mergeChainedOptions({
     defaults: {
       minimizerOptions: getCssnanoDefaultOptions(),
@@ -53,7 +50,7 @@ export async function applyCSSMinimizer(
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.CSS)
-    .use(CssMinimizerPlugin, [
+    .use(CssMinimizerWebpackPlugin, [
       // @ts-expect-error type mismatch
       mergedOptions,
     ])
@@ -71,8 +68,10 @@ export const pluginCssMinimizer = (
       const isMinimize = isProd && !config.output.disableMinimize;
 
       if (isMinimize) {
-        await applyCSSMinimizer(chain, CHAIN_ID, options);
+        applyCSSMinimizer(chain, CHAIN_ID, options);
       }
     });
   },
 });
+
+export { CssMinimizerWebpackPlugin };


### PR DESCRIPTION
## Summary

There are some constants to be exposed which is necessary for user custom-configuration in CssMinimizerWebpackPlugin.


```typescript
import { defineConfig } from '@rsbuild/core';
import {
  pluginCssMinimizer,
  CssMinimizerWebpackPlugin,
} from '@rsbuild/plugin-css-minimizer';

export default defineConfig({
  plugins: [
    pluginCssMinimizer({
      pluginOptions: {
        minify: CssMinimizerWebpackPlugin.lightningCssMinify,
        minimizerOptions: {
          // ...
        }
      },
    }),
  ],
});
```



## Related Links

no

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.

If this usage is recommended, I can update the document later
