### PR TITLE
feat: add tools.swc config to configure builtin swc-loader

### DIFF
--- a/.changeset/wicked-rules-drive.md
+++ b/.changeset/wicked-rules-drive.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.4.11

--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -4,6 +4,7 @@ import {
   SCRIPT_REGEX,
   getJsSourceMap,
   getCoreJsVersion,
+  mergeChainedOptions,
   applyScriptCondition,
   getBrowserslistWithDefault,
   type Polyfill,
@@ -100,10 +101,15 @@ export const pluginSwc = (): RsbuildPlugin => ({
           }
         }
 
+        const mergedSwcConfig = mergeChainedOptions({
+          defaults: swcConfig,
+          options: config.tools.swc,
+        });
+
         rule
           .use(CHAIN_ID.USE.SWC)
           .loader(builtinSwcLoaderName)
-          .options(swcConfig);
+          .options(mergedSwcConfig);
 
         /**
          * If a script is imported with data URI, it can be compiled by babel too.
@@ -123,7 +129,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           .use(CHAIN_ID.USE.SWC)
           .loader(builtinSwcLoaderName)
           // Using cloned options to keep options separate from each other
-          .options(cloneDeep(swcConfig));
+          .options(cloneDeep(mergedSwcConfig));
       },
     });
   },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -464,6 +464,134 @@ exports[`plugin-swc > should add pluginImport 1`] = `
 ]
 `;
 
+exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] = `
+[
+  {
+    "include": [
+      {
+        "and": [
+          "<ROOT>/packages/core/tests",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "jsc": {
+            "externalHelpers": false,
+          },
+        },
+      },
+    ],
+  },
+  {
+    "mimetype": {
+      "or": [
+        "text/javascript",
+        "application/javascript",
+      ],
+    },
+    "resolve": {
+      "fullySpecified": false,
+    },
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "jsc": {
+            "externalHelpers": false,
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader options 1`] = `
+[
+  {
+    "include": [
+      {
+        "and": [
+          "<ROOT>/packages/core/tests",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "coreJs": "3.32",
+            "mode": "usage",
+            "shippedProposals": true,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "externalHelpers": false,
+          },
+          "sourceMaps": true,
+        },
+      },
+    ],
+  },
+  {
+    "mimetype": {
+      "or": [
+        "text/javascript",
+        "application/javascript",
+      ],
+    },
+    "resolve": {
+      "fullySpecified": false,
+    },
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "coreJs": "3.32",
+            "mode": "usage",
+            "shippedProposals": true,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "externalHelpers": false,
+          },
+          "sourceMaps": true,
+        },
+      },
+    ],
+  },
+]
+`;
+
 exports[`plugin-swc > should disable all pluginImport 1`] = `
 {
   "entry": {

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -128,6 +128,50 @@ describe('plugin-swc', () => {
       expect(bundlerConfig).toMatchSnapshot();
     });
   });
+
+  it('should allow to use `tools.swc` to configure swc-loader options', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        tools: {
+          swc: {
+            jsc: {
+              externalHelpers: false,
+            },
+          },
+        },
+      },
+      plugins: [pluginSwc()],
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+
+    bundlerConfigs.forEach((bundlerConfig) => {
+      expect(bundlerConfig.module?.rules).toMatchSnapshot();
+    });
+  });
+
+  it('should allow to use `tools.swc` to be function type', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        tools: {
+          swc() {
+            return {
+              jsc: {
+                externalHelpers: false,
+              },
+            };
+          },
+        },
+      },
+      plugins: [pluginSwc()],
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+
+    bundlerConfigs.forEach((bundlerConfig) => {
+      expect(bundlerConfig.module?.rules).toMatchSnapshot();
+    });
+  });
 });
 
 async function matchConfigSnapshot(rsbuildConfig: RsbuildConfig) {

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -19,7 +19,11 @@ import type {
 } from '../thirdParty';
 import type { BundlerChain } from '../bundlerConfig';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
-import type { RspackConfig, RspackRule } from '../rspack';
+import type {
+  BuiltinSwcLoaderOptions,
+  RspackConfig,
+  RspackRule,
+} from '../rspack';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
 import type { BundlerPluginInstance } from '../bundlerConfig';
 import type {
@@ -28,6 +32,8 @@ import type {
 } from '../plugin';
 
 export type { HTMLPluginOptions };
+
+export type ToolsSwcConfig = ChainedConfig<BuiltinSwcLoaderOptions>;
 
 export type ToolsAutoprefixerConfig = ChainedConfig<AutoprefixerOptions>;
 
@@ -124,6 +130,10 @@ export interface ToolsConfig {
    * Configure the html-webpack-plugin.
    */
   htmlPlugin?: false | ToolsHtmlPluginConfig;
+  /**
+   * Configure the `builtin:swc-loader` of Rspack.
+   */
+  swc?: ToolsSwcConfig;
   /**
    * Configure Rspack.
    * @requires rspack

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -20,9 +20,9 @@ import type {
 import type { BundlerChain } from '../bundlerConfig';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
 import type {
-  BuiltinSwcLoaderOptions,
-  RspackConfig,
   RspackRule,
+  RspackConfig,
+  BuiltinSwcLoaderOptions,
 } from '../rspack';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
 import type { BundlerPluginInstance } from '../bundlerConfig';


### PR DESCRIPTION
## Summary

Add tools.swc config to configure builtin swc-loader, this can be useful to enable some rspack experiments features, such as relay or emotion.

I will add the document later.

## Related Links

https://www.rspack.dev/guide/builtin-swc-loader.html#optionsrspackexperiments

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
