### PR TITLE
chore: replace husky with simple-git-hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-npx --no-install nano-staged

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -14,7 +14,6 @@ ls:
 ignore:
   - .git
   - .nx
-  - .husky
   - .vscode
   - .github
   - .changeset

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "e2e:rspack": "cd ./e2e && pnpm test:rspack",
     "e2e:webpack": "cd ./e2e && pnpm test:webpack",
     "lint": "biome lint . --diagnostic-level=warn && ls-lint",
-    "prepare": "pnpm run build && husky",
+    "prepare": "pnpm run build && simple-git-hooks",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 pnpm run ut",
     "update-modern": "cd ./scripts/update-packages && pnpm start:modern",
     "update-rspack": "cd ./scripts/update-packages && pnpm start:rspack",
@@ -27,6 +27,9 @@
     "sort-package-json": "npx sort-package-json \"packages/*/package.json\" \"packages/compat/*/package.json\"",
     "ut": "vitest run",
     "ut:watch": "vitest"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx nano-staged"
   },
   "nano-staged": {
     "*.{md,mdx,json,css,less,scss}": "prettier --write",
@@ -44,10 +47,10 @@
     "@scripts/test-helper": "workspace:*",
     "check-dependency-version-consistency": "^4.1.0",
     "cross-env": "^7.0.3",
-    "husky": "^9.0.10",
     "nano-staged": "^0.8.0",
     "nx": "^18.0.4",
     "prettier": "^3.2.4",
+    "simple-git-hooks": "^2.10.0",
     "vitest": "^1.2.1"
   },
   "packageManager": "pnpm@8.15.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
-      husky:
-        specifier: ^9.0.10
-        version: 9.0.11
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
@@ -53,6 +50,9 @@ importers:
       prettier:
         specifier: ^3.2.4
         version: 3.2.5
+      simple-git-hooks:
+        specifier: ^2.10.0
+        version: 2.10.0
       vitest:
         specifier: ^1.2.1
         version: 1.3.1
@@ -8825,12 +8825,6 @@ packages:
     hasBin: true
     dev: true
 
-  /husky@9.0.11:
-    resolution: {integrity: sha512-AB6lFlbwwyIqMdHYhwPe+kjOC3Oc5P3nThEoW/AaO2BX3vJDjWPFxYLxokUZOo6RNX20He3AaT8sESs9NJcmEw==}
-    engines: {node: '>=18'}
-    hasBin: true
-    dev: true
-
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -12850,6 +12844,12 @@ packages:
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+    dev: true
+
+  /simple-git-hooks@2.10.0:
+    resolution: {integrity: sha512-TtCytVYfV77pILCkzVxpOSgYKHQyaO7fBI/iwG5bLGb0dIo/v/K1Y1IZ5DN40RQu6WNNJiN0gkuRvSYjxOhFog==}
+    hasBin: true
+    requiresBuild: true
     dev: true
 
   /sirv@2.0.4:


### PR DESCRIPTION
## Summary

- remove a root folder for a neater look 😌

⚠️👇🏻

for developers has cloned the repository, run the following commands to clean husky's residue (https://github.com/toplenboren/simple-git-hooks?tab=readme-ov-file#add-simple-git-hooks-to-the-project)

```
# [Optional] These 2 steps can be skipped for non-husky users
git config core.hooksPath .git/hooks/
rm -rf .git/hooks
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
