### PR TITLE
refactor(plugin-preact): modify rsbuild config directly

### DIFF
--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -30,7 +30,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@scripts/test-helper": "workspace:*",
     "@types/node": "16.x",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-preact/tests/index.test.ts
+++ b/packages/plugin-preact/tests/index.test.ts
@@ -1,34 +1,38 @@
-import { expect, describe, it, vi } from 'vitest';
+import { expect, describe, it } from 'vitest';
 import { pluginPreact } from '../src';
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createRsbuild } from '@rsbuild/core';
 
 describe('plugins/preact', () => {
+  const preactAlias = {
+    react: 'preact/compat',
+    'react-dom': 'preact/compat',
+    'react-dom/test-utils': 'preact/test-utils',
+    'react/jsx-runtime': 'preact/jsx-runtime',
+  };
+
   it('should apply react aliases by default', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginPreact()],
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [pluginPreact()],
+      },
     });
 
-    const config = await rsbuild.unwrapConfig();
-    expect(config.resolve.alias).toMatchInlineSnapshot(`
-      {
-        "react": "preact/compat",
-        "react-dom": "preact/compat",
-        "react-dom/test-utils": "preact/test-utils",
-        "react/jsx-runtime": "preact/jsx-runtime",
-      }
-    `);
+    const configs = await rsbuild.initConfigs();
+    expect(configs[0].resolve?.alias).toMatchObject(preactAlias);
   });
 
   it('should not apply react aliases if reactAliasesEnabled is false', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [
-        pluginPreact({
-          reactAliasesEnabled: false,
-        }),
-      ],
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginPreact({
+            reactAliasesEnabled: false,
+          }),
+        ],
+      },
     });
 
-    const config = await rsbuild.unwrapConfig();
-    expect(config.resolve?.alias).toBeFalsy();
+    const configs = await rsbuild.initConfigs();
+    expect(configs[0].resolve?.alias).not.toMatchObject(preactAlias);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1065,9 +1065,6 @@ importers:
       '@rsbuild/core':
         specifier: link:../core
         version: link:../core
-      '@scripts/test-helper':
-        specifier: workspace:*
-        version: link:../../scripts/test-helper
       '@types/node':
         specifier: 16.x
         version: 16.18.84


### PR DESCRIPTION
## Summary

Use `api.modifyRsbuildConfig` instead of `api.modifyBundlerChain` in the preact plugin. This way the plugin does not need to depend on the `modifySwcLoaderOptions` helper and becomes more independent.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
