### PR TITLE
fix(create-rsbuild): remove vue3 deprecated plugin (TypeScript Vue Plugin)

### DIFF
--- a/packages/create-rsbuild/template-vue3-js/.vscode/extensions.json
+++ b/packages/create-rsbuild/template-vue3-js/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }

--- a/packages/create-rsbuild/template-vue3-ts/.vscode/extensions.json
+++ b/packages/create-rsbuild/template-vue3-ts/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
TypeScript Vue Plugin (Volar)  has been  deprecated

<img width="569" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/37658262/cd6a2627-4b24-42f5-be67-73b26080186f">


https://github.com/vuejs/language-tools/releases/tag/v2.0.0