### PR TITLE
fix: print ipv6 url correctly

### DIFF
--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -69,7 +69,7 @@ const isLoopbackHost = (host: string) => {
 
 const getHostInUrl = (host: string) => {
   if (isIPv6(host)) {
-    return host === '::' ? '[::1]' : `${host}`;
+    return host === '::' ? '[::1]' : `[${host}]`;
   }
   return host;
 };


### PR DESCRIPTION
## Summary

should print `http://[::1]:8080/` instead of `http://::1:8080/`

<img width="562" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/b6bded4c-8233-4703-8037-46f58793f6e1">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
