### PR TITLE
fix: html-rspack-plugin peer dependency issue

### DIFF
--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/shared": "workspace:*",
     "fast-glob": "^3.3.1",
     "globby": "^11.1.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "mini-css-extract-plugin": "2.8.1",
     "postcss": "^8.4.33",
     "terser-webpack-plugin": "5.3.10",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "@rspack/core": "0.5.6",
     "@swc/helpers": "0.5.3",
     "core-js": "~3.32.2",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "postcss": "^8.4.33"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/serialize-javascript": "^5.0.1",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "terser": "5.29.1",
     "typescript": "^5.3.0"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "typescript": "^5.3.0"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -136,7 +136,7 @@
   },
   "devDependencies": {
     "@types/node": "16.x",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.1",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "mini-css-extract-plugin": "2.8.1",
     "terser": "5.29.1",
     "terser-webpack-plugin": "5.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,8 +652,8 @@ importers:
         specifier: ^11.1.0
         version: 11.1.0
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.1
-        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3)
+        specifier: npm:html-rspack-plugin@5.6.2
+        version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.6)
       mini-css-extract-plugin:
         specifier: 2.8.1
         version: 2.8.1(webpack@5.90.3)
@@ -695,8 +695,8 @@ importers:
         specifier: ~3.32.2
         version: 3.32.2
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.1
-        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3)
+        specifier: npm:html-rspack-plugin@5.6.2
+        version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.6)
       postcss:
         specifier: ^8.4.33
         version: 8.4.35
@@ -800,8 +800,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.4
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.1
-        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3)
+        specifier: npm:html-rspack-plugin@5.6.2
+        version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.6)
       terser:
         specifier: 5.29.1
         version: 5.29.1
@@ -1135,8 +1135,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.1
-        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3)
+        specifier: npm:html-rspack-plugin@5.6.2
+        version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.6)
       typescript:
         specifier: ^5.3.0
         version: 5.3.3
@@ -1474,8 +1474,8 @@ importers:
         specifier: 16.x
         version: 16.18.84
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.6.1
-        version: /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3)
+        specifier: npm:html-rspack-plugin@5.6.2
+        version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.6)
       mini-css-extract-plugin:
         specifier: 2.8.1
         version: 2.8.1(webpack@5.90.3)
@@ -8660,22 +8660,18 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /html-rspack-plugin@5.6.1(@rspack/core@0.5.6)(webpack@5.90.3):
-    resolution: {integrity: sha512-HxBMh931QBxzUAA12j4iPIK1yVgnQrz3ziU/CHU7hUWuolpCy+wcUgcn9Zy4YPsq8PisE9lSg2K8+3i0a//H8A==}
+  /html-rspack-plugin@5.6.2(@rspack/core@0.5.6):
+    resolution: {integrity: sha512-cPGwV3odvKJ7DBAG/DxF5e0nMMvBl1zGfyDciT2xMETRrIwajwC7LtEB3cf7auoGMK6xJOOLjWJgaKHLu/FzkQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
-      webpack: ^5.20.0
     peerDependenciesMeta:
       '@rspack/core':
-        optional: true
-      webpack:
         optional: true
     dependencies:
       '@rspack/core': 0.5.6(@swc/helpers@0.5.3)
       lodash: 4.17.21
       tapable: 2.2.1
-      webpack: 5.90.3
 
   /html-tags@2.0.0:
     resolution: {integrity: sha512-+Il6N8cCo2wB/Vd3gqy/8TZhTD3QvcVeQLCnZiGkGCH3JP28IgGAY41giccp2W4R3jfyJPAP318FQTa1yU7K7g==}


### PR DESCRIPTION
## Summary

FIx the webpack peer dependencies of html-rspack-plugin will generate unexpected transitivePeerDependencies when using pnpm.

see: https://github.com/rspack-contrib/html-rspack-plugin/pull/6

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
