### PR TITLE
fix: failed to print size of multiple targets

### DIFF
--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -49,7 +49,7 @@ export const build = async (
 
   const { stats } = await new Promise<{ stats?: Stats | MultiStats }>(
     (resolve, reject) => {
-      compiler.run((err: any, stats?: Stats) => {
+      compiler.run((err: any, stats?: Stats | MultiStats) => {
         if (err || stats?.hasErrors()) {
           const buildError = err || new Error('Rspack build failed!');
           reject(buildError);

--- a/packages/shared/src/types/stats.ts
+++ b/packages/shared/src/types/stats.ts
@@ -1,4 +1,5 @@
 import type {
+  Compilation,
   StatsOptions as RspackStatsOptions,
   StatsCompilation,
 } from '@rspack/core';
@@ -21,6 +22,7 @@ export declare class Stats {
   hasWarnings(): boolean;
   toJson(opts?: StatsOptions): StatsCompilation;
   toString(opts?: StatsOptions): string;
+  compilation: Compilation;
 }
 
 export declare class MultiStats {


### PR DESCRIPTION
## Summary

Fix failed to print size of multiple targets.

<img width="1011" alt="Screenshot 2024-03-08 at 16 22 05" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/2e74818c-318a-4ceb-aaab-ed668f5aa03f">

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1763

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
