### PR TITLE
Release v0.4.13

### DIFF
--- a/.changeset/soft-dryers-brake.md
+++ b/.changeset/soft-dryers-brake.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-release: 0.4.13

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-esbuild/package.json
+++ b/packages/compat/plugin-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-esbuild",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Esbuild plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/document",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Shared documentation of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/monorepo-utils",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "The monorepo utils of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-mdx",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Mdx plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -57,7 +57,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-toml",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "TOML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-yaml",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "YAML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.12"
+    "@rsbuild/core": "workspace:^0.4.13"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsbuild/prebundle",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.4.12",
+  "version": "0.4.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@rsbuild/tsconfig",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "private": true
 }

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/update-packages",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "private": true,
   "scripts": {
     "start:modern": "tsx ./src/modern.ts",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.4.13 -->

## What's Changed
### New Features 🎉
* feat: allow output.dataUriLimit to be a number by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1755
### Bug Fixes 🐞
* fix: print ipv6 url correctly by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/1756
* fix: html-rspack-plugin peer dependency issue by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1762
* fix: emit assets to server dist folder correctly by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1763
* fix: failed to print size of multiple targets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1764
* fix: incorrect node addons path by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1767
* fix: use raw loader to handle Node addons by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1768
* fix(core): call `onAfterBuild` on every build by @xc2 in https://github.com/web-infra-dev/rsbuild/pull/1771
### Document 📖
* docs: add assetPrefix path types tip by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1757
* docs: add ipv6 setup guide by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/1759
* docs: update hooks documents by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1772
### Other Changes
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1711
* chore(deps): bump Rspress v1.14.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1760
* test(e2e): import node addon from node_modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1770
* chore: bump biome v1.6.0 and fix errors by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1773
* chore(deps): bump typescript v5.4 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1774


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.4.12...v0.4.13