### PR TITLE
feat(plugin-svgr): support for react query

### DIFF
--- a/e2e/cases/svg/svgr-query-react/index.test.ts
+++ b/e2e/cases/svg/svgr-query-react/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+import { build, gotoPage } from '@e2e/helper';
+
+test('should import default from SVG with react query correctly', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+  });
+
+  await gotoPage(page, rsbuild);
+
+  await expect(
+    page.evaluate(`document.getElementById('component').tagName === 'svg'`),
+  ).resolves.toBeTruthy();
+
+  // test svg asset
+  await expect(
+    page.evaluate(`document.getElementById('url').src`),
+  ).resolves.toMatch(/http:/);
+
+  await rsbuild.close();
+});

--- a/e2e/cases/svg/svgr-query-react/rsbuild.config.ts
+++ b/e2e/cases/svg/svgr-query-react/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default defineConfig({
+  plugins: [pluginReact(), pluginSvgr()],
+});

--- a/e2e/cases/svg/svgr-query-react/src/App.jsx
+++ b/e2e/cases/svg/svgr-query-react/src/App.jsx
@@ -1,0 +1,13 @@
+import url from './small.svg?url';
+import Component from './small.svg?react';
+
+function App() {
+  return (
+    <div>
+      <Component id="component" />
+      <img id="url" src={url} alt="url" />
+    </div>
+  );
+}
+
+export default App;

--- a/e2e/cases/svg/svgr-query-react/src/index.js
+++ b/e2e/cases/svg/svgr-query-react/src/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/e2e/cases/svg/svgr-query-react/src/small.svg
+++ b/e2e/cases/svg/svgr-query-react/src/small.svg
@@ -1,0 +1,3 @@
+<svg width="100" height="100" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red" />
+</svg>

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -15,6 +15,70 @@ exports[`svgr > 'configure SVGR options' 1`] = `
       "type": "asset/inline",
     },
     {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.32",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "datauri": "base64",
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
@@ -73,6 +137,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
         {
           "loader": "<ROOT>/packages/plugin-svgr/src/loader",
           "options": {
+            "exportType": "named",
             "svgo": true,
             "svgoConfig": {
               "datauri": "base64",
@@ -119,6 +184,69 @@ exports[`svgr > 'export default Component' 1`] = `
       "type": "asset/inline",
     },
     {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.32",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
@@ -177,6 +305,7 @@ exports[`svgr > 'export default Component' 1`] = `
         {
           "loader": "<ROOT>/packages/plugin-svgr/src/loader",
           "options": {
+            "exportType": "default",
             "svgo": true,
             "svgoConfig": {
               "plugins": [
@@ -215,6 +344,69 @@ exports[`svgr > 'export default url' 1`] = `
       "type": "asset/inline",
     },
     {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.32",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
@@ -273,6 +465,7 @@ exports[`svgr > 'export default url' 1`] = `
         {
           "loader": "<ROOT>/packages/plugin-svgr/src/loader",
           "options": {
+            "exportType": "named",
             "svgo": true,
             "svgoConfig": {
               "plugins": [

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -112,6 +112,7 @@ export const CHAIN_ID = {
     SVG: 'svg',
     SVG_URL: 'svg-asset-url',
     SVG_ASSET: 'svg-asset',
+    SVG_REACT: 'svg-react',
     SVG_INLINE: 'svg-asset-inline',
   },
   /** Predefined loaders */
@@ -134,7 +135,7 @@ export const CHAIN_ID = {
     VUE: 'vue',
     /** swc-loader */
     SWC: 'swc',
-    /** @svgr/webpack */
+    /** svgr */
     SVGR: 'svgr',
     /** plugin-image-compress svgo-loader */
     SVGO: 'svgo',

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,6 +1,5 @@
 import type {
   RsbuildConfig,
-  BundlerChainRule,
   NormalizedConfig,
   InspectConfigOptions,
 } from './types';
@@ -10,7 +9,6 @@ import type { minify } from 'terser';
 import fse from '../compiled/fs-extra';
 import { pick, color, upperFirst, deepmerge } from './utils';
 import { getTerserMinifyOptions } from './minimize';
-import type { RuleSetCondition } from '@rspack/core';
 import { parseMinifyOptions } from './minimize';
 
 export async function outputInspectConfigFiles({
@@ -136,50 +134,6 @@ export async function stringifyConfig(config: unknown, verbose?: boolean) {
 
   return stringify(config as any, { verbose });
 }
-
-export const chainStaticAssetRule = ({
-  rule,
-  maxSize,
-  filename,
-  assetType,
-  issuer,
-}: {
-  rule: BundlerChainRule;
-  maxSize: number;
-  filename: string;
-  assetType: string;
-  issuer?: RuleSetCondition;
-}) => {
-  // Rspack not support dataUrlCondition function
-  // forceNoInline: "foo.png?__inline=false" or "foo.png?url",
-  rule
-    .oneOf(`${assetType}-asset-url`)
-    .type('asset/resource')
-    .resourceQuery(/(__inline=false|url)/)
-    .set('generator', {
-      filename,
-    });
-
-  // forceInline: "foo.png?inline" or "foo.png?__inline",
-  rule
-    .oneOf(`${assetType}-asset-inline`)
-    .type('asset/inline')
-    .resourceQuery(/inline/);
-
-  // default: when size < dataUrlCondition.maxSize will inline
-  rule
-    .oneOf(`${assetType}-asset`)
-    .type('asset')
-    .parser({
-      dataUrlCondition: {
-        maxSize,
-      },
-    })
-    .set('generator', {
-      filename,
-    })
-    .set('issuer', issuer);
-};
 
 export const getDefaultStyledComponentsConfig = (
   isProd: boolean,


### PR DESCRIPTION
## Summary

Add support for `?react` query to transform SVG into React component.

```js
import Component from './small.svg?react';

function App() {
  return (
      <Component />
  );
}
```

This will become the recommended way to use SVGR, because:

- No longer depend on the deprecated `url-loader`.
- No longer rely on Rspack's issuer, which is inaccurate in some cases.
- Better for tree shaking, avoid duplicated code.
- Align with the `vite-plugin-svgr` usage.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/1766
- https://github.com/gregberge/svgr/issues/551
- https://github.com/facebook/create-react-app/issues/11213
- https://www.npmjs.com/package/vite-plugin-svgr

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
