### PR TITLE
feat(deps): bump core-js from v3.32 to v3.36

### DIFF
--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -59,7 +59,7 @@
     "@babel/types": "^7.23.0",
     "@types/babel__core": "^7.20.3",
     "babel-plugin-dynamic-import-node": "2.3.3",
-    "core-js": "~3.32.2"
+    "core-js": "~3.36.0"
   },
   "devDependencies": {
     "@rsbuild/plugin-babel": "workspace:*",

--- a/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -231,7 +231,7 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "bugfixes": true,
         "corejs": {
           "proposals": true,
-          "version": "3.32",
+          "version": "3.36",
         },
         "exclude": [
           "transform-typeof-symbol",
@@ -284,7 +284,7 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "bugfixes": true,
         "corejs": {
           "proposals": true,
-          "version": "3.32",
+          "version": "3.36",
         },
         "exclude": [
           "transform-typeof-symbol",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -41,7 +41,7 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.3",
-    "core-js": "~3.32.2",
+    "core-js": "~3.36.0",
     "lodash": "^4.17.21"
   },
   "devDependencies": {

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -27,7 +27,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -88,7 +88,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -160,7 +160,7 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -221,7 +221,7 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -292,7 +292,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "node >= 16",
@@ -350,7 +350,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "node >= 16",
@@ -418,7 +418,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -479,7 +479,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -550,7 +550,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -611,7 +611,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -682,7 +682,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 4`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -743,7 +743,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 4`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -853,7 +853,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.32",
+            "coreJs": "3.36",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -906,7 +906,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.32",
+            "coreJs": "3.36",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -967,7 +967,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.32",
+            "coreJs": "3.36",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -1057,7 +1057,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -1118,7 +1118,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.5.7",
     "@swc/helpers": "0.5.3",
-    "core-js": "~3.32.2",
+    "core-js": "~3.36.0",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "postcss": "^8.4.33"
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -57,7 +57,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -102,7 +102,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -57,7 +57,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -102,7 +102,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -760,7 +760,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -805,7 +805,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -1952,7 +1952,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -1997,7 +1997,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -28,7 +28,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -73,7 +73,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -143,7 +143,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -185,7 +185,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -253,7 +253,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -295,7 +295,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -363,7 +363,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -415,7 +415,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -536,7 +536,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.32",
+            "coreJs": "3.36",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -581,7 +581,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.32",
+            "coreJs": "3.36",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -642,7 +642,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -687,7 +687,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -972,7 +972,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1016,7 +1016,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1086,7 +1086,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -1131,7 +1131,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -1203,7 +1203,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1247,7 +1247,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1420,7 +1420,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -1465,7 +1465,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.32",
+                  "coreJs": "3.36",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -24,7 +24,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.32",
+          "coreJs": "3.36",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-mdx > should allow to configure mdx loader 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.32",
+          "coreJs": "3.36",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [
@@ -54,7 +54,7 @@ exports[`plugin-mdx > should register mdx loader correctly 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.32",
+          "coreJs": "3.36",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -74,7 +74,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -124,7 +124,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.32",
+                "coreJs": "3.36",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -20,7 +20,7 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.32",
+          "coreJs": "3.36",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [
@@ -134,7 +134,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.32",
+          "coreJs": "3.36",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -22,7 +22,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -101,7 +101,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -191,7 +191,7 @@ exports[`svgr > 'export default Component' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -269,7 +269,7 @@ exports[`svgr > 'export default Component' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -351,7 +351,7 @@ exports[`svgr > 'export default url' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -429,7 +429,7 @@ exports[`svgr > 'export default url' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.32",
+              "coreJs": "3.36",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,8 +567,8 @@ importers:
         specifier: 2.3.3
         version: 2.3.3
       core-js:
-        specifier: ~3.32.2
-        version: 3.32.2
+        specifier: ~3.36.0
+        version: 3.36.0
     devDependencies:
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -620,8 +620,8 @@ importers:
         specifier: 0.5.3
         version: 0.5.3
       core-js:
-        specifier: ~3.32.2
-        version: 3.32.2
+        specifier: ~3.36.0
+        version: 3.36.0
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -697,8 +697,8 @@ importers:
         specifier: 0.5.3
         version: 0.5.3
       core-js:
-        specifier: ~3.32.2
-        version: 3.32.2
+        specifier: ~3.36.0
+        version: 3.36.0
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.6.2
         version: /html-rspack-plugin@5.6.2(@rspack/core@0.5.7)
@@ -6871,8 +6871,8 @@ packages:
     dependencies:
       browserslist: 4.23.0
 
-  /core-js@3.32.2:
-    resolution: {integrity: sha512-pxXSw1mYZPDGvTQqEc5vgIb83jGQKFGYWY76z4a7weZXUolw3G+OvpZqSRcfYOoOVUQJYEPsWeQK8pKEnUtWxQ==}
+  /core-js@3.36.0:
+    resolution: {integrity: sha512-mt7+TUBbTFg5+GngsAxeKBTl5/VS0guFeJacYge9OmHb+m058UwwIm41SE9T4Den7ClatV57B6TYTuJ0CX1MAw==}
     requiresBuild: true
     dev: false
 


### PR DESCRIPTION
## Summary

Bump core-js from v3.32 to v3.36 to include the latest polyfills (note that this will increase the bundle size if use `polyfill: 'entry'`).

## Related Links

see: https://github.com/zloirock/core-js/releases

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
