### PR TITLE
test(e2e): proxy tilde deprecation warning

### DIFF
--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -1,7 +1,9 @@
 import { expect, test } from '@playwright/test';
-import { build } from '@e2e/helper';
+import { build, proxyConsole } from '@e2e/helper';
 
 test('should compile common css import correctly', async () => {
+  const { restore, logs } = proxyConsole();
+
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {
@@ -16,7 +18,14 @@ test('should compile common css import correctly', async () => {
   const files = await rsbuild.unwrapOutputJSON();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
+  // there will be a deprecation log for `~`.
+  expect(
+    logs.some((log) => log.includes(`a request starts with '~' is deprecated`)),
+  );
+
   expect(files[cssFiles]).toEqual(
     'html{min-height:100%}#a{color:red}#b{color:blue}',
   );
+
+  restore();
 });

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,9 +1,11 @@
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { build } from '@e2e/helper';
+import { build, proxyConsole } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';
 
 test('should compile nested npm import correctly', async () => {
+  const { restore, logs } = proxyConsole();
+
   fse.copySync(
     path.resolve(__dirname, '_node_modules'),
     path.resolve(__dirname, 'node_modules'),
@@ -19,4 +21,11 @@ test('should compile nested npm import correctly', async () => {
   expect(files[cssFiles]).toEqual(
     '#b{color:yellow}#c{color:green}#a{font-size:10px}html{font-size:18px}',
   );
+
+  // there will be a deprecation log for `~`.
+  expect(
+    logs.some((log) => log.includes(`a request starts with '~' is deprecated`)),
+  );
+
+  restore();
 });


### PR DESCRIPTION
## Summary

Proxy tilde deprecation warning to keep the e2e logs clean.

<img width="986" alt="Screenshot 2024-03-12 at 19 12 16" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/506cd592-7200-4ca9-8512-656c633f0f17">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
