### PR TITLE
feat(plugin-svgr): add mixedImport option

### DIFF
--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -25,6 +25,12 @@ export type PluginSvgrOptions = {
    * @deprecated use `svgrOptions.exportType` instead
    */
   svgDefaultExport?: SvgDefaultExport;
+
+  /**
+   * Whether to allow the use of default import and named import at the same time.
+   * @default true
+   */
+  mixedImport?: boolean;
 };
 
 function getSvgoDefaultConfig() {
@@ -53,6 +59,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {
       const config = api.getNormalizedConfig();
+      const { svgDefaultExport = 'url', mixedImport = true } = options;
       const distDir = getDistPath(config, 'svg');
       const filename = getFilename(config, 'svg', isProd);
       const outputName = path.posix.join(distDir, filename);
@@ -101,6 +108,11 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         } satisfies Config)
         .end();
 
+      // SVG in JS files
+      const exportType =
+        svgrOptions.exportType ??
+        (svgDefaultExport === 'url' ? 'named' : 'default');
+
       // SVG in non-JS files
       // default: when size < dataUrlCondition.maxSize will inline
       rule
@@ -114,36 +126,34 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         .set('generator', {
           filename: outputName,
         })
-        .set('issuer', {
-          // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
-          not: [SCRIPT_REGEX],
+        .when(mixedImport, (c) => {
+          c.set('issuer', {
+            // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
+            not: [SCRIPT_REGEX],
+          });
         });
 
-      // SVG in JS files
-      const { svgDefaultExport = 'url' } = options;
-      const exportType =
-        svgrOptions.exportType ??
-        (svgDefaultExport === 'url' ? 'named' : 'default');
-
-      rule
-        .oneOf(CHAIN_ID.ONE_OF.SVG)
-        .type('javascript/auto')
-        .use(CHAIN_ID.USE.SVGR)
-        .loader(path.resolve(__dirname, './loader'))
-        .options({
-          ...svgrOptions,
-          exportType,
-        })
-        .end()
-        .when(exportType === 'named', (c) =>
-          c
-            .use(CHAIN_ID.USE.URL)
-            .loader(path.join(__dirname, '../compiled', 'url-loader'))
-            .options({
-              limit: maxSize,
-              name: outputName,
-            }),
-        );
+      if (mixedImport) {
+        rule
+          .oneOf(CHAIN_ID.ONE_OF.SVG)
+          .type('javascript/auto')
+          .use(CHAIN_ID.USE.SVGR)
+          .loader(path.resolve(__dirname, './loader'))
+          .options({
+            ...svgrOptions,
+            exportType,
+          })
+          .end()
+          .when(exportType === 'named', (c) =>
+            c
+              .use(CHAIN_ID.USE.URL)
+              .loader(path.join(__dirname, '../compiled', 'url-loader'))
+              .options({
+                limit: maxSize,
+                name: outputName,
+              }),
+          );
+      }
 
       // apply current JS transform rule to SVGR rules
       const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -113,27 +113,26 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         svgrOptions.exportType ??
         (svgDefaultExport === 'url' ? 'named' : 'default');
 
-      // SVG in non-JS files
-      // default: when size < dataUrlCondition.maxSize will inline
-      rule
+      // SVG as assets
+      const svgAssetRule = rule
         .oneOf(CHAIN_ID.ONE_OF.SVG_ASSET)
         .type('asset')
         .parser({
+          // Inline SVG if size < maxSize 
           dataUrlCondition: {
             maxSize,
           },
         })
         .set('generator', {
           filename: outputName,
-        })
-        .when(mixedImport, (c) => {
-          c.set('issuer', {
-            // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
-            not: [SCRIPT_REGEX],
-          });
         });
 
-      if (mixedImport) {
+      if (mixedImport || exportType === 'default') {
+        svgAssetRule.set('issuer', {
+          // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
+          not: [SCRIPT_REGEX],
+        });
+
         rule
           .oneOf(CHAIN_ID.ONE_OF.SVG)
           .type('javascript/auto')

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -79,22 +79,9 @@ exports[`svgr > 'configure SVGR options' 1`] = `
       ],
     },
     {
-      "generator": {
-        "filename": "static/svg/[name].[contenthash:8].svg",
-      },
-      "issuer": {
-        "not": [
-          /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        ],
-      },
-      "parser": {
-        "dataUrlCondition": {
-          "maxSize": 10000,
-        },
-      },
-      "type": "asset",
-    },
-    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+      ],
       "type": "javascript/auto",
       "use": [
         {
@@ -164,12 +151,339 @@ exports[`svgr > 'configure SVGR options' 1`] = `
         },
       ],
     },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 10000,
+        },
+      },
+      "type": "asset",
+    },
   ],
   "test": /\\\\\\.svg\\$/,
 }
 `;
 
-exports[`svgr > 'export default Component' 1`] = `
+exports[`svgr > 'exportType default / mixedImport false' 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /inline/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.36",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.36",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 10000,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
+exports[`svgr > 'exportType default / mixedImport true' 1`] = `
+{
+  "oneOf": [
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "type": "asset/resource",
+    },
+    {
+      "resourceQuery": /inline/,
+      "type": "asset/inline",
+    },
+    {
+      "resourceQuery": /react/,
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.36",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+      ],
+      "type": "javascript/auto",
+      "use": [
+        {
+          "loader": "builtin:swc-loader",
+          "options": {
+            "env": {
+              "coreJs": "3.36",
+              "mode": "usage",
+              "shippedProposals": true,
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+            "isModule": "unknown",
+            "jsc": {
+              "externalHelpers": true,
+              "parser": {
+                "decorators": true,
+                "syntax": "typescript",
+                "tsx": true,
+              },
+              "preserveAllComments": true,
+              "transform": {
+                "decoratorMetadata": true,
+                "legacyDecorator": true,
+                "react": {
+                  "development": false,
+                  "refresh": true,
+                  "runtime": "automatic",
+                },
+                "useDefineForClassFields": false,
+              },
+            },
+            "sourceMaps": true,
+          },
+        },
+        {
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "options": {
+            "exportType": "default",
+            "svgo": true,
+            "svgoConfig": {
+              "plugins": [
+                {
+                  "name": "preset-default",
+                  "params": {
+                    "overrides": {
+                      "removeViewBox": false,
+                    },
+                  },
+                },
+                "prefixIds",
+              ],
+            },
+          },
+        },
+      ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 10000,
+        },
+      },
+      "type": "asset",
+    },
+  ],
+  "test": /\\\\\\.svg\\$/,
+}
+`;
+
+exports[`svgr > 'exportType named / mixedImport false' 1`] = `
 {
   "oneOf": [
     {
@@ -250,11 +564,6 @@ exports[`svgr > 'export default Component' 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "issuer": {
-        "not": [
-          /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        ],
-      },
       "parser": {
         "dataUrlCondition": {
           "maxSize": 10000,
@@ -262,74 +571,12 @@ exports[`svgr > 'export default Component' 1`] = `
       },
       "type": "asset",
     },
-    {
-      "type": "javascript/auto",
-      "use": [
-        {
-          "loader": "builtin:swc-loader",
-          "options": {
-            "env": {
-              "coreJs": "3.36",
-              "mode": "usage",
-              "shippedProposals": true,
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
-            },
-            "isModule": "unknown",
-            "jsc": {
-              "externalHelpers": true,
-              "parser": {
-                "decorators": true,
-                "syntax": "typescript",
-                "tsx": true,
-              },
-              "preserveAllComments": true,
-              "transform": {
-                "decoratorMetadata": true,
-                "legacyDecorator": true,
-                "react": {
-                  "development": false,
-                  "refresh": true,
-                  "runtime": "automatic",
-                },
-                "useDefineForClassFields": false,
-              },
-            },
-            "sourceMaps": true,
-          },
-        },
-        {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
-          "options": {
-            "exportType": "default",
-            "svgo": true,
-            "svgoConfig": {
-              "plugins": [
-                {
-                  "name": "preset-default",
-                  "params": {
-                    "overrides": {
-                      "removeViewBox": false,
-                    },
-                  },
-                },
-                "prefixIds",
-              ],
-            },
-          },
-        },
-      ],
-    },
   ],
   "test": /\\\\\\.svg\\$/,
 }
 `;
 
-exports[`svgr > 'export default url' 1`] = `
+exports[`svgr > 'exportType named / mixedImport true' 1`] = `
 {
   "oneOf": [
     {
@@ -407,22 +654,9 @@ exports[`svgr > 'export default url' 1`] = `
       ],
     },
     {
-      "generator": {
-        "filename": "static/svg/[name].[contenthash:8].svg",
-      },
-      "issuer": {
-        "not": [
-          /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        ],
-      },
-      "parser": {
-        "dataUrlCondition": {
-          "maxSize": 10000,
-        },
-      },
-      "type": "asset",
-    },
-    {
+      "issuer": [
+        /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+      ],
       "type": "javascript/auto",
       "use": [
         {
@@ -490,6 +724,17 @@ exports[`svgr > 'export default url' 1`] = `
           },
         },
       ],
+    },
+    {
+      "generator": {
+        "filename": "static/svg/[name].[contenthash:8].svg",
+      },
+      "parser": {
+        "dataUrlCondition": {
+          "maxSize": 10000,
+        },
+      },
+      "type": "asset",
     },
   ],
   "test": /\\\\\\.svg\\$/,

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -7,15 +7,39 @@ import { SVG_REGEX } from '@rsbuild/shared';
 describe('svgr', () => {
   const cases: Array<{ name: string; pluginConfig: PluginSvgrOptions }> = [
     {
-      name: 'export default url',
-      pluginConfig: {},
+      name: 'exportType named / mixedImport true',
+      pluginConfig: {
+        svgrOptions: {
+          exportType: 'named',
+        },
+        mixedImport: true,
+      },
     },
     {
-      name: 'export default Component',
+      name: 'exportType named / mixedImport false',
+      pluginConfig: {
+        svgrOptions: {
+          exportType: 'named',
+        },
+        mixedImport: false,
+      },
+    },
+    {
+      name: 'exportType default / mixedImport false',
       pluginConfig: {
         svgrOptions: {
           exportType: 'default',
         },
+        mixedImport: false,
+      },
+    },
+    {
+      name: 'exportType default / mixedImport true',
+      pluginConfig: {
+        svgrOptions: {
+          exportType: 'default',
+        },
+        mixedImport: true,
       },
     },
     {


### PR DESCRIPTION
## Summary

Add `mixedImport` option for `@rsbuild/plugin-svgr`.

```js
// mixedImport: true
import url, { ReactComponent as Foo } from 'foo.svg';

// mixedImport: false
import url from 'foo.svg';
import Foo from 'foo.svg?react';
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
