### PR TITLE
Release v0.4.15

### DIFF
--- a/.changeset/dull-geckos-double.md
+++ b/.changeset/dull-geckos-double.md
@@ -1,5 +1,0 @@
----
-"@rsbuild/core": patch
----
-
-release: 0.4.15

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-esbuild/package.json
+++ b/packages/compat/plugin-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-esbuild",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Esbuild plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/document",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Shared documentation of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/monorepo-utils",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "The monorepo utils of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-mdx",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Mdx plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -57,7 +57,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-toml",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "TOML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-yaml",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "YAML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.4.14"
+    "@rsbuild/core": "workspace:^0.4.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsbuild/prebundle",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.4.14",
+  "version": "0.4.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@rsbuild/tsconfig",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "private": true
 }

--- a/scripts/update-packages/package.json
+++ b/scripts/update-packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scripts/update-packages",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "private": true,
   "scripts": {
     "start:modern": "tsx ./src/modern.ts",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.4.15 -->

## What's Changed
### New Features 🎉
* feat(deps): bump rspack to 0.5.7 by @LingyuCoder in https://github.com/web-infra-dev/rsbuild/pull/1795
* feat(deps): bump core-js from v3.32 to v3.36 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1802
* feat: support for SWC experimental plugins by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1796
### Bug Fixes 🐞
* fix: remove temp condition names by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1791
* fix(plugin-svgr): prefer using svgrOptions.exportType option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1789
### Document 📖
* docs: prefer route link instead of redirect by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1792
* docs: add tailwindcss package installation tip by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1800
### Other Changes
* chore(webpack): remove unused modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1788
* chore(deps): update dependency svelte-loader to v3.2.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1793
* chore(deps): update dependency @types/lodash to v4.17.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/1799
* chore(nx): enable inputs of dependencies by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/1801
* test(e2e): proxy tilde deprecation warning by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1803

## New Contributors
* @LingyuCoder made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/1795

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.4.14...v0.4.15