### PR TITLE
fix(plugin-type-check): options type should be non nullable

### DIFF
--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -9,9 +9,9 @@ import {
 } from '@rsbuild/shared';
 import type ForkTSCheckerPlugin from 'fork-ts-checker-webpack-plugin';
 
-type ForkTsCheckerOptions = ConstructorParameters<
-  typeof ForkTSCheckerPlugin
->[0];
+type ForkTsCheckerOptions = NonNullable<
+  ConstructorParameters<typeof ForkTSCheckerPlugin>[0]
+>;
 
 export type PluginTypeCheckerOptions = {
   /**

--- a/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
@@ -30,6 +30,34 @@ exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-p
 }
 `;
 
+exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-plugin options via function 1`] = `
+{
+  "plugins": [
+    ForkTsCheckerWebpackPlugin {
+      "options": {
+        "async": false,
+        "issue": {
+          "exclude": [
+            [Function],
+          ],
+        },
+        "logger": {
+          "error": [Function],
+          "log": [Function],
+        },
+        "typescript": {
+          "build": false,
+          "configFile": "<ROOT>/packages/plugin-type-check/tests/tsconfig.json",
+          "memoryLimit": 8192,
+          "mode": "readonly",
+          "typescriptPath": "<ROOT>/node_modules/<PNPM_INNER>/typescript/lib/typescript.js",
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`plugin-type-check > should apply fork-ts-checker-webpack-plugin correctly 1`] = `
 {
   "plugins": [

--- a/packages/plugin-type-check/tests/index.test.ts
+++ b/packages/plugin-type-check/tests/index.test.ts
@@ -36,6 +36,24 @@ describe('plugin-type-check', () => {
     expect(config).toMatchSnapshot();
   });
 
+  it('should allow to configure fork-ts-checker-webpack-plugin options via function', async () => {
+    const rsbuild = await createStubRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {},
+      plugins: [
+        pluginTypeCheck({
+          forkTsCheckerOptions(options) {
+            options.async = false;
+            return options;
+          },
+        }),
+      ],
+    });
+
+    const config = await rsbuild.unwrapConfig();
+    expect(config).toMatchSnapshot();
+  });
+
   it('should only apply one ts-checker plugin when there is multiple targets', async () => {
     const rsbuild = await createStubRsbuild({
       cwd: __dirname,


### PR DESCRIPTION
## Summary

The options type of plugin-type-check should be non nullable.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
