### PR TITLE
chore: add browserslist to es version helper

### DIFF
--- a/packages/shared/src/getBrowserslist.ts
+++ b/packages/shared/src/getBrowserslist.ts
@@ -51,3 +51,84 @@ export async function getBrowserslistWithDefault(
 
   return DEFAULT_BROWSERSLIST[target];
 }
+
+enum ESVersion {
+  es5 = 0,
+  es6 = 1,
+  es2016 = 2,
+  es2017 = 3,
+}
+
+// the minimal version for [es6, es2016, es2017]
+const ES_VERSIONS_MAP: Record<string, number[]> = {
+  chrome: [51, 52, 57],
+  edge: [15, 15, 15],
+  safari: [10, 10.3, 11],
+  firefox: [54, 54, 54],
+  opera: [38, 39, 44],
+  samsung: [5, 6.2, 6.2],
+};
+
+const renameBrowser = (name: string) => {
+  if (name === 'ios_saf') {
+    return 'safari';
+  }
+  return name;
+};
+
+const getESVersionStr = (esVersion: ESVersion) => {
+  switch (esVersion) {
+    case ESVersion.es5:
+      return 'es5';
+    case ESVersion.es6:
+      return 'es6';
+    case ESVersion.es2016:
+      return 'es2016';
+    case ESVersion.es2017:
+      return 'es2017';
+  }
+};
+
+export function browserslistToESVersion(
+  browsers: string[],
+): ReturnType<typeof getESVersionStr> {
+  const projectBrowsers = browserslist(browsers, {
+    ignoreUnknownVersions: true,
+  });
+
+  let esVersion: ESVersion = ESVersion.es2017;
+
+  for (const item of projectBrowsers) {
+    const pairs = item.split(' ');
+
+    // skip invalid item
+    if (pairs.length < 2) {
+      continue;
+    }
+
+    const browser = renameBrowser(pairs[0]);
+    const version = Number(pairs[1]);
+
+    // IE / Android 4.x ~ 5.x only supports es5
+    if (browser === 'ie' || (browser === 'android' && Number(version) < 6)) {
+      esVersion = ESVersion.es5;
+      break;
+    }
+
+    // skip unknown browsers
+    const versions = ES_VERSIONS_MAP[browser];
+    if (!versions) {
+      continue;
+    }
+
+    if (version < versions[0]) {
+      esVersion = Math.min(ESVersion.es5, esVersion);
+    } else if (version < versions[1]) {
+      esVersion = Math.min(ESVersion.es6, esVersion);
+    } else if (version < versions[2]) {
+      esVersion = Math.min(ESVersion.es2016, esVersion);
+    }
+  }
+
+  return getESVersionStr(esVersion);
+}

--- a/packages/shared/tests/getBrowserslist.test.ts
+++ b/packages/shared/tests/getBrowserslist.test.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_BROWSERSLIST } from '../src';
-import { getBrowserslistWithDefault } from '../src/getBrowserslist';
+import {
+  browserslistToESVersion,
+  getBrowserslistWithDefault,
+} from '../src/getBrowserslist';
 
 describe('getBrowserslistWithDefault', () => {
   it('should get default browserslist correctly', async () => {
@@ -98,4 +101,61 @@ describe('getBrowserslistWithDefault', () => {
       ),
     ).toEqual(override.node);
   });
+});
+
+describe('browserslistToESVersion', () => {
+  test('should get ecma version correctly', () => {
+    expect(browserslistToESVersion(['iOS 8'])).toEqual('es5');
+    expect(browserslistToESVersion(['ie >= 11'])).toEqual('es5');
+    expect(browserslistToESVersion(['android >= 4.4'])).toEqual('es5');
+    expect(browserslistToESVersion(['Chrome >= 33'])).toEqual('es5');
+    expect(browserslistToESVersion(['Edge >= 12'])).toEqual('es5');
+    expect(browserslistToESVersion(['Edge >= 15'])).toEqual('es2017');
+    expect(browserslistToESVersion(['Chrome >= 53'])).toEqual('es2016');
+    expect(browserslistToESVersion(['ie >= 11', 'Chrome >= 53'])).toEqual(
+      'es5',
+    );
+    expect(browserslistToESVersion(['Edge >= 15', 'Chrome >= 53'])).toEqual(
+      'es2016',
+    );
+    expect(
+      browserslistToESVersion([
+        'iOS >= 9',
+        'Android >= 4.4',
+        'last 2 versions',
+        '> 0.2%',
+        'not dead',
+      ]),
+    ).toEqual('es5');
+    expect(
+      browserslistToESVersion([
+        'chrome >= 87',
+        'edge >= 88',
+        'firefox >= 78',
+        'safari >= 14',
+      ]),
+    ).toEqual('es2017');
+    expect(
+      browserslistToESVersion([
+        'last 1 chrome version',
+        'last 1 firefox version',
+        'last 1 safari version',
+      ]),
+    ).toEqual('es2017');
+    expect(
+      browserslistToESVersion([
+        'iOS >= 10',
+        'Chrome >= 51',
+        '> 0.5%',
+        'not dead',
+        'not op_mini all',
+      ]),
+    ).toEqual('es6');
+  });
+  expect(browserslistToESVersion(['fully supports es6'])).toEqual('es6');
+  expect(browserslistToESVersion(['fully supports es6-module'])).toEqual(
+    'es2017',
+  );
+  expect(browserslistToESVersion(['ie 11', 'baidu 7.12'])).toEqual('es5');
+  expect(browserslistToESVersion(['ios_saf 11'])).toEqual('es2017');
 });


### PR DESCRIPTION
## Summary

This PR implements a helper to convert browserslist to ECMAScript version, it can be used to:

- Set precise Rspack target to reduce Rspack runtime code size. https://www.rspack.dev/config/target.html
- Help the check syntax plugin to get correct ECMAScript version. 

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/3f4bb41f-b0ee-4dbd-b084-481a2fc772b3)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
