### PR TITLE
feat: enable new tree shaking in production

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -54,6 +54,7 @@
     "svgr",
     "systemjs",
     "transpiling",
+    "treeshaking",
     "tsbuildinfo",
     "unocss",
     "vitest",

--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -6,11 +6,22 @@ import type { RsbuildPlugin } from '../../types';
 export const pluginTransition = (): RsbuildPlugin => ({
   name: 'rsbuild:transition',
 
-  setup() {
+  setup(api) {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
 
     // improve kill process performance
     // https://github.com/web-infra-dev/rspack/pull/5486
     process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
+
+    api.modifyRspackConfig((config, { isProd }) => {
+      // only enable new tree shaking in production build,
+      // because Rspack still has some problems when using it in dev mode.
+      // such as https://github.com/web-infra-dev/rspack/issues/5887
+      if (isProd) {
+        config.experiments ||= {};
+        config.experiments.rspackFuture ||= {};
+        config.experiments.rspackFuture.newTreeshaking = true;
+      }
+    });
   },
 });

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -723,6 +723,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "newTreeshaking": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary


Rsbuild v0.5.0 will enable the Rspack's [new tree shaking](https://www.rspack.dev/config/experiments.html#experimentsrspackfuturenewtreeshaking) in production build. This will significantly optimize the tree shaking algorithm, making the bundle size smaller in the production build.

If you encounter any issues with the new tree shaking in your project, you can report it to the Rspack repository through an issue. You can also manually switch to old tree shaking:

```js
// rsbuild.config.ts
import { defineConfig } from '@rsbuild/core';

export default defineConfig({
  tools: {
    rspack: {
      experiments: {
        rspackFuture: {
          newTreeshaking: false,
        },
      },
    },
  },
});
```

Note that Rsbuild only enable new tree shaking in production build, because Rspack still has some problems when using it in dev mode. Such as https://github.com/web-infra-dev/rspack/issues/5887

## Related Links

https://github.com/web-infra-dev/rspack/issues/5887

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
