### PR TITLE
fix: set correct rspack target based on browserslist

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -530,7 +530,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;
@@ -1118,7 +1118,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;
@@ -1849,7 +1849,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "target": [
     "webworker",
-    "es5",
+    "es2017",
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -697,7 +697,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -698,7 +698,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;
@@ -1469,7 +1469,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;
@@ -2599,7 +2599,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;

--- a/packages/core/tests/target.test.ts
+++ b/packages/core/tests/target.test.ts
@@ -20,16 +20,16 @@ describe('plugin-target', () => {
     },
     {
       browserslist: ['foo'],
-      expected: { target: ['web', 'browserslist'] },
+      expected: { target: ['web', 'es2017'] },
     },
     {
       browserslist: null,
-      expected: { target: ['web', 'es5'] },
+      expected: { target: ['web', 'es2017'] },
     },
     {
       targets: ['web-worker' as const],
       browserslist: null,
-      expected: { target: ['webworker', 'es5'] },
+      expected: { target: ['webworker', 'es2017'] },
     },
   ];
 

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -745,7 +745,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "target": [
     "web",
-    "es5",
+    "es2017",
   ],
 }
 `;

--- a/packages/shared/src/getBrowserslist.ts
+++ b/packages/shared/src/getBrowserslist.ts
@@ -98,7 +98,7 @@ export function browserslistToESVersion(browsers: string[]) {
     }
 
     // IE / Android 4.x ~ 5.x only supports es5
-    if (browser === 'ie' || (browser === 'android' && Number(version) < 6)) {
+    if (browser === 'ie' || (browser === 'android' && version < 6)) {
       esVersion = ESVersion.es5;
       break;
     }


### PR DESCRIPTION
## Summary

Set correct rspack target based on browserslist, this change can fix some warning logs, such as:

<img width="988" alt="Screenshot 2024-03-15 at 11 25 18" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/4772e718-bb8b-4a51-9f49-8853248304ec">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
