### PR TITLE
test(plugin-lightningcss): add plugin-lightningcss using webpack and fix plugin-stylus test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -23,7 +23,7 @@
     "jiti",
     "jscpuprofile",
     "jsesc",
-    "lightingcss",
+    "lightningcss",
     "longpaths",
     "manypkg",
     "napi",

--- a/e2e/cases/css/lightningcss/index.test.ts
+++ b/e2e/cases/css/lightningcss/index.test.ts
@@ -1,34 +1,36 @@
-import { type Page, expect } from '@playwright/test';
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { test, type Page, expect } from '@playwright/test';
+import { build, gotoPage } from '@e2e/helper';
 import { pluginLightningcss } from '@rsbuild/plugin-lightningcss';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
+import { pluginSwc } from '@rsbuild/plugin-swc';
 
-rspackOnlyTest(
-  'should minimize CSS correctly by lightningcss-minify',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      rsbuildConfig: {
-        html: {
-          template: './src/index.html',
-        },
-        plugins: [
-          pluginLightningcss({
-            transform: false,
-          }),
-        ],
+test('should minimize CSS correctly by lightningcss-minify', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        template: './src/index.html',
       },
-    });
-    const files = await rsbuild.unwrapOutputJSON();
+      plugins:
+        process.env.PROVIDE_TYPE === 'rspack'
+          ? [
+              pluginLightningcss({
+                transform: false,
+              }),
+            ]
+          : [pluginSwc(), pluginLightningcss({ transform: false })],
+    },
+  });
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const files = await rsbuild.unwrapOutputJSON();
 
-    expect(content).toContain(
-      '.test-minify{color:#ffff00b3;background-color:#545c3d;border-color:#669;width:200px;height:calc(75.37% - 763.5px);transition:background .2s;transform:translateY(50px)}',
-    );
-  },
-);
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+  expect(content).toContain(
+    '.test-minify{color:#ffff00b3;background-color:#545c3d;border-color:#669;width:200px;height:calc(75.37% - 763.5px);transition:background .2s;transform:translateY(50px)}',
+  );
+});
 
 async function expectPageToBeNormal(
   page: Page,
@@ -54,54 +56,52 @@ async function expectPageToBeNormal(
   await rsbuild.close();
 }
 
-rspackOnlyTest(
-  'should transform css by lightningcss-loader and work normally with other pre-processors',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      runServer: true,
-      rsbuildConfig: {
-        html: {
-          template: './src/index.html',
-        },
-        plugins: [
-          pluginLightningcss({
-            minify: false,
-          }),
-        ],
+test('should transform css by lightningcss-loader and work normally with other pre-processors', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+    rsbuildConfig: {
+      html: {
+        template: './src/index.html',
       },
-    });
-    const bundlerConfigs = await rsbuild.instance.initConfigs();
-    expect(bundlerConfigs[0]).not.toContain('postcss-loader');
-    await expectPageToBeNormal(page, rsbuild);
-  },
-);
+      plugins: [
+        pluginLightningcss({
+          minify: false,
+        }),
+      ],
+    },
+  });
+  const bundlerConfigs = await rsbuild.instance.initConfigs();
+  expect(bundlerConfigs[0]).not.toContain('postcss-loader');
+  await expectPageToBeNormal(page, rsbuild);
+});
 
-rspackOnlyTest(
-  'should transform css by lightningcss-loader and work with @rsbuild/plugin-stylus',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      runServer: true,
-      rsbuildConfig: {
-        html: {
-          template: './src/index.html',
-        },
-        source: {
-          entry: {
-            index: './src/_styl.js',
-          },
-        },
-        plugins: [
-          pluginStylus(),
-          pluginLightningcss({
-            minify: false,
-          }),
-        ],
+test('should transform css by lightningcss-loader and work with @rsbuild/plugin-stylus', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+    rsbuildConfig: {
+      html: {
+        template: './src/index.html',
       },
-    });
-    const bundlerConfigs = await rsbuild.instance.initConfigs();
-    expect(bundlerConfigs[0]).not.toContain('postcss-loader');
-    await expectPageToBeNormal(page, rsbuild);
-  },
-);
+      source: {
+        entry: {
+          index: './src/_styl.js',
+        },
+      },
+      plugins: [
+        pluginStylus(),
+        pluginLightningcss({
+          minify: false,
+        }),
+      ],
+    },
+  });
+  const bundlerConfigs = await rsbuild.instance.initConfigs();
+  expect(bundlerConfigs[0]).not.toContain('postcss-loader');
+  await expectPageToBeNormal(page, rsbuild);
+});

--- a/e2e/cases/css/lightningcss/index.test.ts
+++ b/e2e/cases/css/lightningcss/index.test.ts
@@ -94,7 +94,7 @@ test('should transform css by lightningcss-loader and work with @rsbuild/plugin-
         },
       },
       plugins: [
-        pluginStylus(),
+        pluginStylus(), // must before pluginLightningcss
         pluginLightningcss({
           minify: false,
         }),
@@ -104,4 +104,7 @@ test('should transform css by lightningcss-loader and work with @rsbuild/plugin-
   const bundlerConfigs = await rsbuild.instance.initConfigs();
   expect(bundlerConfigs[0]).not.toContain('postcss-loader');
   await expectPageToBeNormal(page, rsbuild);
+
+  const stylusModuleLocator = page.locator('#test-stylus');
+  await expect(stylusModuleLocator).toHaveCSS('color', 'rgb(165, 42, 42)');
 });

--- a/e2e/cases/css/lightningcss/src/_styl.js
+++ b/e2e/cases/css/lightningcss/src/_styl.js
@@ -13,5 +13,5 @@ scssDom.innerHTML = JSON.stringify(b);
 scssDom.setAttribute('class', b['test-scss']);
 
 const stylusDom = document.getElementById('test-stylus');
-scssDom.innerHTML = JSON.stringify(c);
-scssDom.setAttribute('class', c['test-stylus']);
+stylusDom.innerHTML = JSON.stringify(c);
+stylusDom.setAttribute('class', c['test-stylus']);

--- a/e2e/cases/css/lightningcss/src/c.module.styl
+++ b/e2e/cases/css/lightningcss/src/c.module.styl
@@ -1,5 +1,5 @@
 .test-stylus
   text-align: center;
-  color: red;
+  color: brown;
   font-size: 20px;
 


### PR DESCRIPTION
## Summary

support webpack tests

At present, the execution order of rsbuild plugins is awkward in someway. I don't know if this meets expectations, and there are some usage burdens for users.

Lightningcss plugin has to be behind pluginStylus and pluginSwc if users use these plugins together

```ts
plugins: [pluginSwc(), pluginStylus(), pluginLightningCss(), pluginCssMinimizer()]
```

result
```js
// [bunder].config.js
 	minimizer: [
      /* config.optimization.minimizer('swc') */
      new SwcMinimizerPlugin({  // minify both css and js
        jsMinify: undefined,
        cssMinify: undefined,
      }),
      /* config.optimization.minimizer('css') */
      new CssMinimizerPlugin(), // minify js
    ],
```

I'm not sure if this problem will be encountered when developing other plugins.

## Related Links

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
