### PR TITLE
chore(plugin-type-check): improve the running log

### DIFF
--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -104,11 +104,8 @@ export const pluginTypeCheck = (
           mergeFn: deepmerge,
         });
 
-        if (api.context.bundlerType === 'rspack' && isProd) {
-          logger.info('Ts checker running...');
-          logger.info(
-            'Ts checker is running slowly and will block builds until it is complete, please be patient and wait.',
-          );
+        if (isProd) {
+          logger.info('Type checker is enabled. It may take some time.');
         }
 
         chain


### PR DESCRIPTION
## Summary

Improve the running log of plugin-type-check. The previous one is too long.

<img width="660" alt="Screenshot 2024-03-15 at 17 45 55" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/07e16f44-1178-4e3f-b973-4f8ee96e65c2">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
