### PR TITLE
feat: allow tools.htmlPlugin to be true

### DIFF
--- a/e2e/cases/umd/basic/rsbuild.config.ts
+++ b/e2e/cases/umd/basic/rsbuild.config.ts
@@ -11,6 +11,6 @@ export default defineConfig({
     template: './src/index.html',
   },
   tools: {
-    htmlPlugin: {},
+    htmlPlugin: true,
   },
 });

--- a/e2e/cases/umd/export-array/rsbuild.config.ts
+++ b/e2e/cases/umd/export-array/rsbuild.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
     template: './src/index.html',
   },
   tools: {
-    htmlPlugin: {},
+    htmlPlugin: true,
   },
 });

--- a/e2e/cases/umd/export/rsbuild.config.ts
+++ b/e2e/cases/umd/export/rsbuild.config.ts
@@ -12,6 +12,6 @@ export default defineConfig({
     template: './src/index.html',
   },
   tools: {
-    htmlPlugin: {},
+    htmlPlugin: true,
   },
 });

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -304,7 +304,10 @@ export const pluginHtml = (): RsbuildPlugin => ({
 
             const finalOptions = mergeChainedOptions({
               defaults: pluginOptions,
-              options: config.tools.htmlPlugin,
+              options:
+                typeof config.tools.htmlPlugin === 'boolean'
+                  ? {}
+                  : config.tools.htmlPlugin,
               utils: {
                 entryName,
                 entryValue,

--- a/packages/document/docs/en/config/tools/html-plugin.mdx
+++ b/packages/document/docs/en/config/tools/html-plugin.mdx
@@ -1,6 +1,6 @@
 # tools.htmlPlugin
 
-- **Type:** `false | Object | Function`
+- **Type:** `boolean | Object | Function`
 - **Default:**
 
 ```js

--- a/packages/document/docs/zh/config/tools/html-plugin.mdx
+++ b/packages/document/docs/zh/config/tools/html-plugin.mdx
@@ -1,6 +1,6 @@
 # tools.htmlPlugin
 
-- **类型：** `false | Object | Function`
+- **类型：** `boolean | Object | Function`
 - **默认值：**
 
 ```js

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -129,7 +129,7 @@ export interface ToolsConfig {
   /**
    * Configure the html-webpack-plugin.
    */
-  htmlPlugin?: false | ToolsHtmlPluginConfig;
+  htmlPlugin?: boolean | ToolsHtmlPluginConfig;
   /**
    * Configure the `builtin:swc-loader` of Rspack.
    */


### PR DESCRIPTION
## Summary

Allow tools.htmlPlugin to be true, this can be helpful to force generating HTML files when using the UMD plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
