### PR TITLE
refactor: simplify html.tags implementation

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -467,9 +467,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {
@@ -1033,9 +1031,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -80,9 +80,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
   HtmlBasicPlugin {
     "name": "HtmlBasicPlugin",
     "options": {
-      "info": {
-        "index": {},
-      },
+      "index": {},
     },
   },
   DefinePlugin {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -289,7 +289,7 @@ export const pluginHtml = (): RsbuildPlugin => ({
 
         chain
           .plugin(CHAIN_ID.PLUGIN.HTML_BASIC)
-          .use(HtmlBasicPlugin, [{ info: htmlInfoMap }]);
+          .use(HtmlBasicPlugin, [htmlInfoMap]);
 
         if (config.security) {
           const { nonce } = config.security;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -664,9 +664,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -664,9 +664,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {
@@ -1427,9 +1425,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {
@@ -2565,9 +2561,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -118,36 +118,34 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "foo": {
-            "tagConfig": {
-              "append": true,
-              "hash": false,
-              "publicPath": true,
-              "tags": [
-                {
-                  "attrs": {
-                    "src": "jq.js",
-                  },
-                  "tag": "script",
+        "foo": {
+          "tagConfig": {
+            "append": true,
+            "hash": false,
+            "publicPath": true,
+            "tags": [
+              {
+                "attrs": {
+                  "src": "jq.js",
                 },
-              ],
-            },
+                "tag": "script",
+              },
+            ],
           },
-          "main": {
-            "tagConfig": {
-              "append": true,
-              "hash": false,
-              "publicPath": true,
-              "tags": [
-                {
-                  "attrs": {
-                    "src": "jq.js",
-                  },
-                  "tag": "script",
+        },
+        "main": {
+          "tagConfig": {
+            "append": true,
+            "hash": false,
+            "publicPath": true,
+            "tags": [
+              {
+                "attrs": {
+                  "src": "jq.js",
                 },
-              ],
-            },
+                "tag": "script",
+              },
+            ],
           },
         },
       },
@@ -195,9 +193,7 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -268,9 +264,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -340,9 +334,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -450,9 +442,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -522,9 +512,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -594,9 +582,7 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -666,9 +652,7 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
   ],
@@ -793,10 +777,8 @@ exports[`plugin-html > should support multi entry 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "foo": {},
-          "main": {},
-        },
+        "foo": {},
+        "main": {},
       },
     },
   ],

--- a/packages/core/tests/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inlineChunk.test.ts.snap
@@ -101,9 +101,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineScrip
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     InlineChunkHtmlPlugin {
@@ -223,9 +221,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineStyle
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     InlineChunkHtmlPlugin {

--- a/packages/document/docs/en/config/html/tags.mdx
+++ b/packages/document/docs/en/config/html/tags.mdx
@@ -1,6 +1,6 @@
 # html.tags
 
-- **Type:** `ArrayOrNot<HtmlInjectTag | HtmlInjectTagHandler>`
+- **Type:** `ArrayOrNot<HtmlTag | HtmlTagHandler>`
 - **Default:** `undefined`
 
 Modifies the tags that are injected into the HTML page.
@@ -8,7 +8,7 @@ Modifies the tags that are injected into the HTML page.
 ## Tag Object
 
 ```ts
-export interface HtmlInjectTag {
+type HtmlTag = {
   tag: string;
   attrs?: Record<string, string | boolean | null | undefined>;
   children?: string;
@@ -23,7 +23,7 @@ export interface HtmlInjectTag {
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head#see_also}
    */
   head?: boolean;
-}
+};
 ```
 
 A tag object can be used to describe the tag to be injected and the location of the injection can be controlled by the parameters.
@@ -75,17 +75,17 @@ You can also pass functions to those fields to control the path joining.
 ## Tags Handler
 
 ```ts
-type HtmlInjectTagUtils = {
+type HtmlTagUtils = {
   hash: string;
   entryName: string;
   outputName: string;
   publicPath: string;
 };
 
-type HtmlInjectTagHandler = (
-  tags: HtmlInjectTag[],
-  utils: HtmlInjectTagUtils,
-) => HtmlInjectTag[] | void;
+type HtmlTagHandler = (
+  tags: HtmlTag[],
+  utils: HtmlTagUtils,
+) => HtmlTag[] | void;
 ```
 
 `html.tags` can also accept functions that can arbitrarily modify tags by writing logic to the callback, often used to ensure the relative position of tags while inserting them.

--- a/packages/document/docs/zh/config/html/tags.mdx
+++ b/packages/document/docs/zh/config/html/tags.mdx
@@ -1,6 +1,6 @@
 # html.tags
 
-- **类型：** `ArrayOrNot<HtmlInjectTag | HtmlInjectTagHandler>`
+- **类型：** `ArrayOrNot<HtmlTag | HtmlTagHandler>`
 - **默认值：** `undefined`
 
 添加和修改最终注入到 HTML 页面的标签。
@@ -8,7 +8,7 @@
 ## 对象形式
 
 ```ts
-export interface HtmlInjectTag {
+type HtmlTag = {
   tag: string;
   attrs?: Record<string, string | boolean | null | undefined>;
   children?: string;
@@ -23,7 +23,7 @@ export interface HtmlInjectTag {
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head#see_also}
    */
   head?: boolean;
-}
+};
 ```
 
 对象形式的配置项可以用于描述需要注入的标签，并可以通过参数控制注入的位置：
@@ -75,17 +75,17 @@ export default {
 ## 函数形式
 
 ```ts
-type HtmlInjectTagUtils = {
+type HtmlTagUtils = {
   hash: string;
   entryName: string;
   outputName: string;
   publicPath: string;
 };
 
-type HtmlInjectTagHandler = (
-  tags: HtmlInjectTag[],
-  utils: HtmlInjectTagUtils,
-) => HtmlInjectTag[] | void;
+type HtmlTagHandler = (
+  tags: HtmlTag[],
+  utils: HtmlTagUtils,
+) => HtmlTag[] | void;
 ```
 
 `html.tags` 也支持传入回调函数，通过在回调中编写逻辑可以任意修改标签列表，常用于修改标签列表或是在插入标签的同时确保其相对位置。

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -702,9 +702,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     HtmlBasicPlugin {
       "name": "HtmlBasicPlugin",
       "options": {
-        "info": {
-          "index": {},
-        },
+        "index": {},
       },
     },
     DefinePlugin {

--- a/packages/shared/src/types/config/html.ts
+++ b/packages/shared/src/types/config/html.ts
@@ -26,7 +26,7 @@ export type MetaOptions = {
   [name: string]: string | false | MetaAttrs;
 };
 
-export interface HtmlInjectTag {
+export type HtmlTag = {
   tag: string;
   attrs?: Record<string, string | boolean | null | undefined>;
   children?: string;
@@ -34,21 +34,21 @@ export interface HtmlInjectTag {
   publicPath?: boolean | string | ((url: string, publicPath: string) => string);
   append?: boolean;
   head?: boolean;
-}
+};
 
-export type HtmlInjectTagUtils = {
+export type HtmlTagUtils = {
+  hash: string;
   entryName: string;
   outputName: string;
   publicPath: string;
-  hash: string;
 };
 
-export type HtmlInjectTagHandler = (
-  tags: HtmlInjectTag[],
-  utils: HtmlInjectTagUtils,
-) => HtmlInjectTag[] | void;
+export type HtmlTagHandler = (
+  tags: HtmlTag[],
+  utils: HtmlTagUtils,
+) => HtmlTag[] | void;
 
-export type HtmlInjectTagDescriptor = HtmlInjectTag | HtmlInjectTagHandler;
+export type HtmlTagDescriptor = HtmlTag | HtmlTagHandler;
 
 type ChainedHtmlOption<O> = ChainedConfigCombineUtils<O, { entryName: string }>;
 
@@ -68,7 +68,7 @@ export interface HtmlConfig {
   /**
    * Inject custom html tags into the output html files.
    */
-  tags?: ArrayOrNot<HtmlInjectTagDescriptor>;
+  tags?: ArrayOrNot<HtmlTagDescriptor>;
   /**
    * Set the favicon icon for all pages.
    */


### PR DESCRIPTION
## Summary

Simplify html.tags implementation, extract the functions and rename the types.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [x] Documentation updated.
