### PR TITLE
fix: revert new tree shaking

### DIFF
--- a/.changeset/lazy-terms-perform.md
+++ b/.changeset/lazy-terms-perform.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.5.1

--- a/packages/core/src/provider/plugins/transition.ts
+++ b/packages/core/src/provider/plugins/transition.ts
@@ -6,22 +6,22 @@ import type { RsbuildPlugin } from '../../types';
 export const pluginTransition = (): RsbuildPlugin => ({
   name: 'rsbuild:transition',
 
-  setup(api) {
+  setup() {
     process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
 
     // improve kill process performance
     // https://github.com/web-infra-dev/rspack/pull/5486
     process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
 
-    api.modifyRspackConfig((config, { isProd }) => {
-      // only enable new tree shaking in production build,
-      // because Rspack still has some problems when using it in dev mode.
-      // such as https://github.com/web-infra-dev/rspack/issues/5887
-      if (isProd) {
-        config.experiments ||= {};
-        config.experiments.rspackFuture ||= {};
-        config.experiments.rspackFuture.newTreeshaking = true;
-      }
-    });
+    // api.modifyRspackConfig((config, { isProd }) => {
+    // only enable new tree shaking in production build,
+    // because Rspack still has some problems when using it in dev mode.
+    // such as https://github.com/web-infra-dev/rspack/issues/5887
+    // if (isProd) {
+    //   config.experiments ||= {};
+    //   config.experiments.rspackFuture ||= {};
+    //   config.experiments.rspackFuture.newTreeshaking = true;
+    // }
+    // });
   },
 });

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -721,9 +721,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "rspackFuture": {
-      "newTreeshaking": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary

Revert new tree shaking as it breaks the CSS modules in the doc website.

## Related Links

https://github.com/web-infra-dev/rspack/issues/5968

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
