### PR TITLE
fix: allow to call loadConfig without options

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -107,7 +107,7 @@ export async function loadConfig({
   cwd?: string;
   path?: string;
   envMode?: string;
-}): Promise<{ content: RsbuildConfig; filePath: string | null }> {
+} = {}): Promise<{ content: RsbuildConfig; filePath: string | null }> {
   const configFilePath = resolveConfigPath(cwd, path);
 
   if (!configFilePath) {

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -14,7 +14,7 @@ const getRspackProvider = async () => {
 };
 
 export async function createRsbuild(
-  options: CreateRsbuildOptions,
+  options: CreateRsbuildOptions = {},
 ): Promise<RsbuildInstance> {
   const { rsbuildConfig = {} } = options;
 

--- a/packages/document/docs/en/api/javascript-api/core.mdx
+++ b/packages/document/docs/en/api/javascript-api/core.mdx
@@ -9,7 +9,9 @@ Create a Rsbuild instance object.
 - **Type:**
 
 ```ts
-function createRsbuild(options: CreateRsbuildOptions): Promise<RsbuildInstance>;
+function createRsbuild(
+  options?: CreateRsbuildOptions,
+): Promise<RsbuildInstance>;
 ```
 
 - **Example:**
@@ -47,7 +49,7 @@ Load Rsbuild configuration file.
 - **Type:**
 
 ```ts
-function loadConfig(params: {
+function loadConfig(params?: {
   // Default is process.cwd()
   cwd?: string;
   // Specify the configuration file, can be a relative or absolute path

--- a/packages/document/docs/zh/api/javascript-api/core.mdx
+++ b/packages/document/docs/zh/api/javascript-api/core.mdx
@@ -9,7 +9,9 @@
 - **类型：**
 
 ```ts
-function createRsbuild(options: CreateRsbuildOptions): Promise<RsbuildInstance>;
+function createRsbuild(
+  options?: CreateRsbuildOptions,
+): Promise<RsbuildInstance>;
 ```
 
 - **示例：**
@@ -47,7 +49,7 @@ type CreateRsbuildOptions = {
 - **类型：**
 
 ```ts
-function loadConfig(params: {
+function loadConfig(params?: {
   // 默认为 process.cwd()
   cwd?: string;
   // 指定配置文件路径，可以为相对路径或绝对路径


### PR DESCRIPTION
## Summary

Allow to call `loadConfig` and `createRsbuild` without options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
