### PR TITLE
docs: remove outdated lodash FAQ

### DIFF
--- a/packages/document/docs/en/guide/faq/exceptions.md
+++ b/packages/document/docs/en/guide/faq/exceptions.md
@@ -168,36 +168,6 @@ If there is an error that `core-js` cannot be found, there may be several reason
 
 ---
 
-### Compilation error after referencing a type from lodash
-
-If the `@types/lodash` package is installed in your project, you may import some types from `lodash`, such as the `DebouncedFunc` type:
-
-```ts
-import { debounce, DebouncedFunc } from 'lodash';
-```
-
-Rsbuild will throw an error after compiling the above code:
-
-```bash
-Syntax error: /project/src/index.ts: The lodash method `DebouncedFunc` is not a known module.
-Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.
-```
-
-The reason is that Rsbuild has enabled the [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) plugin by default to optimize the bundle size of lodash, but Babel cannot distinguish between "value" and "type", which resulting in an exception in the compiled code.
-
-The solution is to use TypeScript's `import type` syntax to explicitly declare the `DebouncedFunc` type:
-
-```ts
-import { debounce } from 'lodash';
-import type { DebouncedFunc } from 'lodash';
-```
-
-:::tip
-In any case, it is recommended to use `import type` to import types, this will help the compiler to identify the type.
-:::
-
----
-
 ### Division in Less file doesn't work?
 
 Compared with the v3 version, the Less v4 version has some differences in the way of writing division:

--- a/packages/document/docs/zh/guide/faq/exceptions.md
+++ b/packages/document/docs/zh/guide/faq/exceptions.md
@@ -172,36 +172,6 @@ Module not found: Can't resolve 'core-js/modules/es.error.cause.js'
 
 ---
 
-### 从 lodash 中引用类型后出现编译报错？
-
-当你的项目中安装了 `@types/lodash` 包时，你可能会从 `lodash` 中引用一些类型，比如引用 `DebouncedFunc` 类型：
-
-```ts
-import { debounce, DebouncedFunc } from 'lodash';
-```
-
-上述代码会在编译后产生如下报错：
-
-```bash
-SyntaxError: /project/src/index.ts: The 'lodash' method `DebouncedFunc` is not a known module.
-Please report bugs to https://github.com/lodash/babel-plugin-lodash/issues.
-```
-
-这个问题的原因是 Rsbuild 默认开启了 [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) 插件来优化 lodash 产物体积，但 Babel 无法区别「值」和「类型」，导致编译后的代码出现异常。
-
-解决方法是使用 TypeScript 的 `import type` 语法，对 `DebouncedFunc` 类型进行显式声明：
-
-```ts
-import { debounce } from 'lodash';
-import type { DebouncedFunc } from 'lodash';
-```
-
-:::tip
-在任意情况下，我们都推荐使用 `import type` 来引用类型，这对于编译器识别类型会有很大帮助。
-:::
-
----
-
 ### Less 文件中的除法不生效？
 
 Less v4 版本与 v3 版本相比，除法的写法有一些区别：


### PR DESCRIPTION
## Summary

Remove outdated lodash FAQ as Rsbuild does not use the babel-plugin-lodash.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
