### PR TITLE
fix: keep html-entry-plugin registration order stable

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -208,7 +208,7 @@ export const pluginHtml = (): RsbuildPlugin => ({
         const htmlPaths = api.getHTMLPaths();
         const htmlInfoMap: Record<string, HtmlInfo> = {};
 
-        await Promise.all(
+        const finalOptions = await Promise.all(
           entryNames.map(async (entryName) => {
             const entryValue = entries[entryName].values();
             const chunks = getChunks(
@@ -279,11 +279,16 @@ export const pluginHtml = (): RsbuildPlugin => ({
               },
             });
 
-            chain
-              .plugin(`${CHAIN_ID.PLUGIN.HTML}-${entryName}`)
-              .use(HtmlPlugin, [finalOptions]);
+            return finalOptions;
           }),
         );
+
+        // keep html entry plugin registration order stable based on entryNames
+        entryNames.forEach((entryName, index) => {
+          chain
+          .plugin(`${CHAIN_ID.PLUGIN.HTML}-${entryName}`)
+          .use(HtmlPlugin, [finalOptions[index]]);
+        })
 
         const { HtmlBasicPlugin } = await import('../rspack/HtmlBasicPlugin');
 


### PR DESCRIPTION
## Summary

we should keep html-entry-plugin registration order stable based on entryNames.

`Promise.all` cannot make the html-entry-plugin registration order stable, and changes in the plugin registration order will cause runtime hash to change.

<img width="651" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/341621c0-3a21-42a5-9a97-b53de61e9879">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
