### PR TITLE
feat(server): return 404 code when xxx.hot-update.json file not found

### DIFF
--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -122,6 +122,16 @@ const applyDefaultMiddlewares = async ({
     upgradeEvents.push(
       compileMiddlewareAPI.onUpgrade.bind(compileMiddlewareAPI),
     );
+
+    middlewares.push((req,res, next) => {
+      // [prevFullHash].hot-update.json will 404 (expected) when rsbuild restart and some file changed
+      if (req.url?.endsWith('.hot-update.json')) {
+        res.statusCode = 404;
+        res.end();
+      } else {
+        next();
+      } 
+    });
   }
 
   if (dev.publicDir !== false && dev.publicDir?.name) {

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -123,7 +123,7 @@ const applyDefaultMiddlewares = async ({
       compileMiddlewareAPI.onUpgrade.bind(compileMiddlewareAPI),
     );
 
-    middlewares.push((req,res, next) => {
+    middlewares.push((req, res, next) => {
       // [prevFullHash].hot-update.json will 404 (expected) when rsbuild restart and some file changed
       if (req.url?.endsWith('.hot-update.json')) {
         res.statusCode = 404;


### PR DESCRIPTION
## Summary

Return 404 code in rsbuild dev server when `xxx.hot-update.json` file not found, so that some other frameworks which use custom server (such as modern.js) don't need to handle `.hot-update.json` file.

<img width="882" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/6d9830da-6e24-47da-9a47-fef14c1c59e4">

currently, in modern.js:
![image](https://github.com/web-infra-dev/rsbuild/assets/22373761/afc43f86-6ab5-4448-84d9-159b1729bed3)


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
