### PR TITLE
chore(workflow): remove .nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,0 @@
-lts/hydrogen

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "packageManager": "pnpm@8.15.5",
   "engines": {
-    "node": ">=16.18.1",
+    "node": ">=18.0.0",
     "pnpm": ">=8.7.0"
   },
   "pnpm": {


### PR DESCRIPTION
## Summary

It is allowed to use Node 18 or 20 when developing Rsbuild, so we can remove the `.nvmrc` file and just use `engines.node` to limit the version range.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
