### PR TITLE
docs: fix pluginLightningcss unnecessary `transform` object key

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-lightningcss.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-lightningcss.mdx
@@ -68,14 +68,12 @@ pluginLightningcss({
 ```ts
 pluginLightningcss({
   transform: {
-    transform: {
-      visitor: {
-        Length(len) {
-          return {
-            unit: 'rem',
-            value: len.value,
-          };
-        },
+    visitor: {
+      Length(len) {
+        return {
+          unit: 'rem',
+          value: len.value,
+        };
       },
     },
   },

--- a/packages/document/docs/zh/plugins/list/plugin-lightningcss.mdx
+++ b/packages/document/docs/zh/plugins/list/plugin-lightningcss.mdx
@@ -68,14 +68,12 @@ pluginLightningcss({
 ```ts
 pluginLightningcss({
   transform: {
-    transform: {
-      visitor: {
-        Length(len) {
-          return {
-            unit: 'rem',
-            value: len.value,
-          };
-        },
+    visitor: {
+      Length(len) {
+        return {
+          unit: 'rem',
+          value: len.value,
+        };
       },
     },
   },


### PR DESCRIPTION
## Summary

unnecessary `transform` object key

## Related Links

<!--- Provide links of related issues or pages -->

No

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
