### PR TITLE
chore(workflow): let renovate bump package.json

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,7 +6,9 @@
 		// Use chore as semantic commit type for commit messages
 		{
 			"matchPackagePatterns": ["*"],
-			"semanticCommitType": "chore"
+			"semanticCommitType": "chore",
+			// always bump package.json
+			"rangeStrategy": "bump"
 		},
 		{
 			"groupName": "babel",


### PR DESCRIPTION
## Summary

Let renovate bump package.json instead of update lockfile.

## Related Links

https://docs.renovatebot.com/configuration-options/#rangestrategy

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
