### PR TITLE
docs: integrate rsbuild-plugin-google-analytics

### DIFF
--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -26,6 +26,7 @@
     "@types/react": "^18.2.69",
     "@types/react-dom": "^18.2.22",
     "fast-glob": "^3.3.2",
+    "rsbuild-plugin-google-analytics": "1.0.0-beta.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rsfamily-nav-icon": "^1.0.2",

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^18.2.69",
     "@types/react-dom": "^18.2.22",
     "fast-glob": "^3.3.2",
-    "rsbuild-plugin-google-analytics": "1.0.0-beta.1",
+    "rsbuild-plugin-google-analytics": "1.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rsfamily-nav-icon": "^1.0.2",

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { defineConfig } from 'rspress/config';
 import { rsbuildPluginOverview } from './src/rsbuildPluginOverview';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
+import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 
 function getMeta(name: string, value: string) {
   return {
@@ -77,7 +78,10 @@ export default defineConfig({
     },
   },
   builderConfig: {
-    plugins: [rsbuildPluginOverview],
+    plugins: [
+      rsbuildPluginOverview,
+      pluginGoogleAnalytics({ id: 'G-L6BZ6TKW4R' }),
+    ],
     source: {
       alias: {
         '@components': path.join(__dirname, 'src/components'),
@@ -98,24 +102,6 @@ export default defineConfig({
         ...getMeta('twitter:site', '@rspack_dev'),
         ...getMeta('twitter:card', 'summary_large_image'),
       },
-      tags: [
-        // Configure Google Analytics
-        {
-          tag: 'script',
-          attrs: {
-            async: true,
-            src: 'https://www.googletagmanager.com/gtag/js?id=G-L6BZ6TKW4R',
-          },
-        },
-        {
-          tag: 'script',
-          children: `
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', 'G-L6BZ6TKW4R');`,
-        },
-      ],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,8 +755,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       rsbuild-plugin-google-analytics:
-        specifier: 1.0.0-beta.1
-        version: 1.0.0-beta.1(@rsbuild/core@packages+core)
+        specifier: 1.0.0
+        version: 1.0.0(@rsbuild/core@packages+core)
       rsfamily-nav-icon:
         specifier: ^1.0.2
         version: 1.0.2
@@ -12830,8 +12830,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rsbuild-plugin-google-analytics@1.0.0-beta.1(@rsbuild/core@packages+core):
-    resolution: {integrity: sha512-jf7ZwXW0LHKIRjYRCvW6ibZnI8HpQ7NzKXcIOPRL6itzCG2KH5Vt40WjyQFbfPcjMe7HR8caaUmBvoNPTgmRIg==}
+  /rsbuild-plugin-google-analytics@1.0.0(@rsbuild/core@packages+core):
+    resolution: {integrity: sha512-Z2hVetWq48QT+X/HMmtp+YTxzPw+ujt/KUrbQXn98LmUDYqJyGSCBAjit8atAoRiThUSKlkG+NU3+zkFvKoLdA==}
     peerDependencies:
       '@rsbuild/core': link:packages/core
     peerDependenciesMeta:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -754,6 +754,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      rsbuild-plugin-google-analytics:
+        specifier: 1.0.0-beta.1
+        version: 1.0.0-beta.1(@rsbuild/core@packages+core)
       rsfamily-nav-icon:
         specifier: ^1.0.2
         version: 1.0.2
@@ -12825,6 +12828,17 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.13.0
       '@rollup/rollup-win32-x64-msvc': 4.13.0
       fsevents: 2.3.3
+    dev: true
+
+  /rsbuild-plugin-google-analytics@1.0.0-beta.1(@rsbuild/core@packages+core):
+    resolution: {integrity: sha512-jf7ZwXW0LHKIRjYRCvW6ibZnI8HpQ7NzKXcIOPRL6itzCG2KH5Vt40WjyQFbfPcjMe7HR8caaUmBvoNPTgmRIg==}
+    peerDependencies:
+      '@rsbuild/core': link:packages/core
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+    dependencies:
+      '@rsbuild/core': link:packages/core
     dev: true
 
   /rsfamily-nav-icon@1.0.2:


### PR DESCRIPTION
## Summary

Integrate rsbuild-plugin-google-analytics to the Rsbuild website.

## Related Links

https://github.com/rspack-contrib/rsbuild-plugin-google-analytics

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
