### PR TITLE
chore(workflow): let renovate ignore engines.node

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,6 +65,7 @@
 		// buffer v6 has compatibility issues as node polyfill
 		"buffer",
 		// align Node.js version minimum requirements
-		"@types/node"
+		"@types/node",
+		"node"
 	]
 }


### PR DESCRIPTION
## Summary

Let renovate ignore engines.node, this should be manually upgraded.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1929

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
