### PR TITLE
docs: Correct import lightnincss -> lightningcss

### DIFF
--- a/packages/document/docs/en/plugins/list/plugin-lightningcss.mdx
+++ b/packages/document/docs/en/plugins/list/plugin-lightningcss.mdx
@@ -54,7 +54,7 @@ const defaultOptions = {
 - **Example:** Enable or disable lightningcss features, which can be configured by importing a lightningcss instance from the plugin.
 
 ```ts
-import { lightnincss, pluginLightningcss } from '@rsbuild/plugin-lightningcss';
+import { lightningcss, pluginLightningcss } from '@rsbuild/plugin-lightningcss';
 
 pluginLightningcss({
   transform: {
@@ -112,7 +112,7 @@ const defaultOptions = {
 - **Example:** Disable lightning CSS minify for `ColorFunctions` and `HexAlphaColors`
 
 ```ts
-import { lightnincss, pluginLightningcss } from '@rsbuild/plugin-lightningcss';
+import { lightningcss, pluginLightningcss } from '@rsbuild/plugin-lightningcss';
 
 pluginLightningcss({
   minify: {


### PR DESCRIPTION
## Summary
This PR corrects a spelling error in the import statement in code example. The original import statement included `lightnincss`, which has been corrected to `lightningcss`.