### PR TITLE
feat: support show overlay in the browser when compiler error

### DIFF
--- a/packages/core/src/client/hmr/createSocketUrl.ts
+++ b/packages/core/src/client/hmr/createSocketUrl.ts
@@ -11,7 +11,7 @@ type ParsedSearch = {
 export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
 export function parseParams(resourceQuery: string) {
-  // ?host=localhost&port=8080&path=modern_js_hmr_ws
+  // ?host=localhost&port=8080&path=rsbuild-hmr
   const searchParams = resourceQuery.substr(1).split('&');
   const options: Record<string, string> = {};
 

--- a/packages/core/src/client/hmr/createSocketUrl.ts
+++ b/packages/core/src/client/hmr/createSocketUrl.ts
@@ -10,7 +10,7 @@ type ParsedSearch = {
  */
 export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
-export function createSocketUrl(resourceQuery: string) {
+export function parseParams(resourceQuery: string) {
   // ?host=localhost&port=8080&path=modern_js_hmr_ws
   const searchParams = resourceQuery.substr(1).split('&');
   const options: Record<string, string> = {};
@@ -20,6 +20,10 @@ export function createSocketUrl(resourceQuery: string) {
     options[ary[0]] = decodeURIComponent(ary[1]);
   }
 
+  return options;
+}
+
+export function createSocketUrl(options: Record<string, string> = {}) {
   const currentLocation = self.location;
 
   return getSocketUrl(options as ParsedSearch, currentLocation);

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -7,7 +7,7 @@
 import type { StatsError } from '@rsbuild/shared';
 import { formatStatsMessages } from '../formatStats';
 import { createSocketUrl, parseParams } from './createSocketUrl';
-import { ErrorOverlay, overlayId } from './overlay'
+import { ErrorOverlay, overlayId } from './overlay';
 
 const options = parseParams(__resourceQuery);
 
@@ -22,12 +22,14 @@ let mostRecentCompilationHash: string | null = null;
 let hasCompileErrors = false;
 
 function createErrorOverlay(err: any) {
-  clearErrorOverlay()
-  document.body.appendChild(new ErrorOverlay(err))
+  clearErrorOverlay();
+  document.body.appendChild(new ErrorOverlay(err));
 }
 
 function clearErrorOverlay() {
-  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close())
+  // use NodeList's forEach api instead of dom.iterable
+  // biome-ignore lint/complexity/noForEach: <explanation>
+  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());
 }
 
 function clearOutdatedErrors() {

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -7,7 +7,7 @@
 import type { StatsError } from '@rsbuild/shared';
 import { formatStatsMessages } from '../formatStats';
 import { createSocketUrl, parseParams } from './createSocketUrl';
-import { ErrorOverlay, overlayId } from './overlay';
+import { createOverlay, clearOverlay } from './overlay';
 
 const options = parseParams(__resourceQuery);
 
@@ -20,17 +20,6 @@ const enableOverlay = options.overlay === 'true';
 let isFirstCompilation = true;
 let mostRecentCompilationHash: string | null = null;
 let hasCompileErrors = false;
-
-function createErrorOverlay(err: any) {
-  clearErrorOverlay();
-  document.body.appendChild(new ErrorOverlay(err));
-}
-
-function clearErrorOverlay() {
-  // use NodeList's forEach api instead of dom.iterable
-  // biome-ignore lint/complexity/noForEach: <explanation>
-  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());
-}
 
 function clearOutdatedErrors() {
   // Clean up outdated compile errors, if any.
@@ -113,7 +102,7 @@ function handleErrors(errors: StatsError[]) {
   }
 
   if (enableOverlay) {
-    createErrorOverlay(formatted.errors);
+    createOverlay(formatted.errors);
   }
 
   // Do not attempt to reload now.
@@ -196,7 +185,7 @@ function onMessage(e: MessageEvent<string>) {
   const message = JSON.parse(e.data);
   switch (message.type) {
     case 'hash':
-      clearErrorOverlay();
+      clearOverlay();
       handleAvailableHash(message.data);
       break;
     case 'still-ok':

--- a/packages/core/src/client/hmr/overlay.ts
+++ b/packages/core/src/client/hmr/overlay.ts
@@ -153,9 +153,8 @@ export class ErrorOverlay extends HTMLElement {
     const el = this.root.querySelector(selector)!;
 
     let curIndex = 0;
-    let match: RegExpExecArray | null;
-    fileRE.lastIndex = 0;
-    while ((match = fileRE.exec(text))) {
+    let match: RegExpExecArray | null = fileRE.exec(text);
+    while (match !== null) {
       const { 0: file, index } = match;
       if (index != null) {
         const frag = text.slice(curIndex, index);
@@ -170,6 +169,7 @@ export class ErrorOverlay extends HTMLElement {
         el.appendChild(link);
         curIndex += frag.length + file.length;
       }
+      match = fileRE.exec(text)
     }
 
     const frag = text.slice(curIndex);

--- a/packages/core/src/client/hmr/overlay.ts
+++ b/packages/core/src/client/hmr/overlay.ts
@@ -1,0 +1,200 @@
+interface ErrorPayload {
+  type: 'error';
+  err: string[];
+}
+
+const template = /*html*/ `
+<style>
+:host {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 99999;
+  --monospace: 'SFMono-Regular', Consolas,
+  'Liberation Mono', Menlo, Courier, monospace;
+  --red: #ff5555;
+  --window-background: #181818;
+  --window-color: #d8d8d8;
+}
+
+.backdrop {
+  position: fixed;
+  z-index: 99999;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow-y: scroll;
+  margin: 0;
+  background: rgba(0, 0, 0, 0.66);
+}
+
+.window {
+  font-family: var(--monospace);
+  line-height: 1.5;
+  width: 40%;
+  color: var(--window-color);
+  margin: 30px auto;
+  padding: 25px 40px;
+  position: relative;
+  background: var(--window-background);
+  border-radius: 6px 6px 8px 8px;
+  box-shadow: 0 19px 38px rgba(0,0,0,0.30), 0 15px 12px rgba(0,0,0,0.22);
+  overflow: hidden;
+  direction: ltr;
+  text-align: left;
+}
+
+pre {
+  font-family: var(--monospace);
+  font-size: 16px;
+  margin-top: 0;
+  margin-bottom: 1em;
+  overflow-x: scroll;
+  scrollbar-width: none;
+}
+
+pre::-webkit-scrollbar {
+  display: none;
+}
+
+.message {
+  line-height: 1.3;
+  font-weight: 600;
+  white-space: pre-wrap;
+}
+
+.title {
+  color: var(--red);
+}
+.message-body {
+  color: var(--window-color);
+}
+
+.file-link {
+  text-decoration: underline;
+  cursor: pointer;
+  color: rgb(0, 187, 187);
+}
+
+.close {
+  line-height: 1rem;
+  font-size: 1.5rem;
+  padding: 1rem;
+  cursor: pointer;
+  position: absolute;
+  right: 0px;
+  top: 0px;
+  background-color: transparent;
+  border: none;
+}
+</style>
+<div class="backdrop" part="backdrop">
+  <div class="window" part="window">
+    <div class="close">x</div>
+    <p class="title">Compile error:</p>
+    <pre class="message" part="message"><span class="message-body" part="message-body"></span></pre>
+  </div>
+</div>
+`;
+
+function ansiRegex({ onlyFirst = false } = {}) {
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+  ].join('|');
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g');
+}
+
+const regex = ansiRegex();
+
+function stripAnsi(content: string) {
+  if (typeof content !== 'string') {
+    throw new TypeError(`Expected a \`string\`, got \`${typeof content}\``);
+  }
+
+  return content.replace(regex, '');
+}
+
+const fileRE = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g;
+
+// Allow `ErrorOverlay` to extend `HTMLElement` even in environments where
+// `HTMLElement` was not originally defined.
+const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis;
+
+export class ErrorOverlay extends HTMLElement {
+  root: ShadowRoot;
+  closeOnEsc: (e: KeyboardEvent) => void;
+
+  constructor(message: ErrorPayload['err']) {
+    super();
+    this.root = this.attachShadow({ mode: 'open' });
+    this.root.innerHTML = template;
+
+    this.linkedText('.message-body', stripAnsi(message.join('/n')).trim());
+
+    this.root.querySelector('.window')!.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+
+    this.root.querySelector('.close')!.addEventListener('click', () => {
+      this.close();
+    });
+
+    this.addEventListener('click', () => {
+      this.close();
+    });
+
+    this.closeOnEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.code === 'Escape') {
+        this.close();
+      }
+    };
+
+    document.addEventListener('keydown', this.closeOnEsc);
+  }
+
+  linkedText(selector: string, text: string): void {
+    const el = this.root.querySelector(selector)!;
+    
+    let curIndex = 0;
+    let match: RegExpExecArray | null;
+    fileRE.lastIndex = 0;
+    while ((match = fileRE.exec(text))) {
+      const { 0: file, index } = match;
+      if (index != null) {
+        const frag = text.slice(curIndex, index);
+        el.appendChild(document.createTextNode(frag));
+        const link = document.createElement('a');
+        link.textContent = file;
+        link.className = 'file-link';
+
+        link.onclick = () => {
+          fetch(
+              `/__open-in-editor?file=${encodeURIComponent(file)}`,
+          );
+        };
+        el.appendChild(link);
+        curIndex += frag.length + file.length;
+      }
+    }
+
+    const frag = text.slice(curIndex);
+    el.appendChild(document.createTextNode(frag));
+  }
+
+  close(): void {
+    this.parentNode?.removeChild(this);
+    document.removeEventListener('keydown', this.closeOnEsc);
+  }
+}
+
+export const overlayId = 'rsbuild-error-overlay';
+
+const { customElements } = globalThis;
+if (customElements && !customElements.get(overlayId)) {
+  customElements.define(overlayId, ErrorOverlay);
+}

--- a/packages/core/src/client/hmr/overlay.ts
+++ b/packages/core/src/client/hmr/overlay.ts
@@ -127,7 +127,6 @@ const { HTMLElement = class {} as typeof globalThis.HTMLElement } = globalThis;
 
 export class ErrorOverlay extends HTMLElement {
   root: ShadowRoot;
-  closeOnEsc: (e: KeyboardEvent) => void;
 
   constructor(message: ErrorPayload['err']) {
     super();
@@ -140,6 +139,7 @@ export class ErrorOverlay extends HTMLElement {
       e.stopPropagation();
     });
 
+    // close overlay when click outside
     this.root.querySelector('.close')!.addEventListener('click', () => {
       this.close();
     });
@@ -147,19 +147,11 @@ export class ErrorOverlay extends HTMLElement {
     this.addEventListener('click', () => {
       this.close();
     });
-
-    this.closeOnEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' || e.code === 'Escape') {
-        this.close();
-      }
-    };
-
-    document.addEventListener('keydown', this.closeOnEsc);
   }
 
   linkedText(selector: string, text: string): void {
     const el = this.root.querySelector(selector)!;
-    
+
     let curIndex = 0;
     let match: RegExpExecArray | null;
     fileRE.lastIndex = 0;
@@ -173,9 +165,7 @@ export class ErrorOverlay extends HTMLElement {
         link.className = 'file-link';
 
         link.onclick = () => {
-          fetch(
-              `/__open-in-editor?file=${encodeURIComponent(file)}`,
-          );
+          fetch(`/__open-in-editor?file=${encodeURIComponent(file)}`);
         };
         el.appendChild(link);
         curIndex += frag.length + file.length;
@@ -188,7 +178,6 @@ export class ErrorOverlay extends HTMLElement {
 
   close(): void {
     this.parentNode?.removeChild(this);
-    document.removeEventListener('keydown', this.closeOnEsc);
   }
 }
 

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -19,7 +19,7 @@ const noop = () => {
 };
 
 function getHMRClientPath(client: DevMiddlewaresConfig['client'] = {}) {
-  // host=localhost&port=8080&path=modern_js_hmr_ws
+  // host=localhost&port=8080&path=rsbuild-hmr
   const params = Object.entries(client).reduce((query, [key, value]) => {
     return value ? `${query}&${key}=${value}` : `${query}`;
   }, '');

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -18,15 +18,15 @@ const noop = () => {
   // noop
 };
 
-function getHMRClientPath(client: DevMiddlewaresConfig['client']) {
-  const protocol = client?.protocol ? `&protocol=${client.protocol}` : '';
-  const host = client?.host ? `&host=${client.host}` : '';
-  const path = client?.path ? `&path=${client.path}` : '';
-  const port = client?.port ? `&port=${client.port}` : '';
+function getHMRClientPath(client: DevMiddlewaresConfig['client'] = {}) {
+  // host=localhost&port=8080&path=modern_js_hmr_ws
+  const params = Object.entries(client).reduce((query, [key, value]) => {
+    return value ? `${query}&${key}=${value}` : `${query}`;
+  }, '');
 
   const clientEntry = `${require.resolve(
     '@rsbuild/core/client/hmr',
-  )}?${host}${path}${port}${protocol}`;
+  )}?${params}`;
 
   // replace cjs with esm because we want to use the es5 version
   return clientEntry;

--- a/packages/document/docs/en/config/dev/client.mdx
+++ b/packages/document/docs/en/config/dev/client.mdx
@@ -14,6 +14,12 @@ type Client = {
   port?: string;
   /** Specify the host for the WebSocket request */
   host?: string;
+  /**
+   * Shows overlay in the browser when there are compiler errors
+   *
+   * This feature requires the current browser version to support [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
+   */
+  overlay?: boolean;
 };
 ```
 
@@ -26,6 +32,7 @@ const defaultConfig = {
   port: '',
   host: location.hostname,
   protocol: location.protocol === 'https:' ? 'wss' : 'ws',
+  overlay: false,
 };
 ```
 

--- a/packages/document/docs/zh/config/dev/client.mdx
+++ b/packages/document/docs/zh/config/dev/client.mdx
@@ -14,6 +14,12 @@ type Client = {
   port?: string;
   /** 指定 WebSocket 请求的 host */
   host?: string;
+  /**
+   * 当出现编译错误时，在浏览器中显示遮盖
+   *
+   * 该功能需要当前浏览器版本支持 [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
+   */
+  overlay?: boolean;
 };
 ```
 
@@ -26,6 +32,7 @@ const defaultConfig = {
   port: '',
   host: location.hostname,
   protocol: location.protocol === 'https:' ? 'wss' : 'ws',
+  overlay: false,
 };
 ```
 

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -55,6 +55,8 @@ export interface DevConfig {
     port?: string;
     host?: string;
     protocol?: 'ws' | 'wss';
+    /** Shows an overlay in the browser when there are compiler errors. */
+    overlay?: boolean;
   };
   /** Provides the ability to execute a custom function and apply custom middlewares */
   setupMiddlewares?: Array<


### PR DESCRIPTION
## Summary

support show overlay in the browser when compiler error:

<img width="930" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/ea694f64-f490-4fd3-abd8-f0078d97dd49">

Setting `dev.clientoverlay`  to true will enable the error overlay: 
```
export default defineConfig({
  dev: {
    client: {
      overlay: true,
     }
  }
});
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [ ] Documentation updated.
