### PR TITLE
fix(plugin-react): no chunk group of react if federation enabled

### DIFF
--- a/.changeset/thin-worms-build.md
+++ b/.changeset/thin-worms-build.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-react': patch
+---
+
+Disable react chunk groups when module federation is in use

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -27,7 +27,7 @@ export const applySplitChunksRule = (
 
     const extraGroups: Record<string, (string | RegExp)[]> = {};
 
-    if (options.react) {
+    if (options.react && !config.moduleFederation) {
       extraGroups.react = [
         'react',
         'react-dom',


### PR DESCRIPTION
## Summary
Resolves chunk issue where excessive bloat is downloaded if federation is applied 

## Related Links

<!--- Provide links of related issues or pages -->
before:
<img width="1750" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/25274700/bf3dce98-9559-40fd-9246-ed30b3e56454">

after:
<img width="1750" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/25274700/eb643136-5de8-4522-b55b-d1eae308bd6f">

While more chunks are emitted, they are smaller and do not cause module duplication 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated.
- [ ] Documentation updated.
