### PR TITLE
fix: disable default split chunks rules for MF

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -90,6 +90,28 @@ export function pluginModuleFederation(): RsbuildPlugin {
     name: 'rsbuild:module-federation',
 
     setup(api) {
+      api.modifyRsbuildConfig({
+        order: 'post',
+        handler: (config) => {
+          /**
+           * Currently, splitChunks will take precedence over module federation shared modules.
+           * So we need to disable the default split chunks rules to make shared modules to work properly.
+           * @see https://github.com/module-federation/module-federation-examples/issues/3161
+           */
+          if (
+            config.moduleFederation?.options &&
+            config.performance?.chunkSplit?.strategy === 'split-by-experience'
+          ) {
+            config.performance.chunkSplit = {
+              ...config.performance.chunkSplit,
+              strategy: 'custom',
+            };
+          }
+
+          return config;
+        },
+      });
+
       api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
         const config = api.getNormalizedConfig();
 

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -266,8 +266,7 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
         // Patch the override config difference between the `custom` strategy and other strategy.
         const override =
           chunkSplit.strategy === 'custom'
-            ? // `chunkSplit.splitChunks` compat for Eden
-              chunkSplit.splitChunks ?? chunkSplit.override
+            ? chunkSplit.splitChunks ?? chunkSplit.override
             : chunkSplit.override;
 
         // Apply different strategy

--- a/packages/document/docs/en/config/module-federation/options.mdx
+++ b/packages/document/docs/en/config/module-federation/options.mdx
@@ -4,15 +4,20 @@
 - **Default:** `undefined`
 - **Version:** `>= 0.4.0`
 
-Used to configure the Rspack module federation plugin.
+Used to configure the Rspack's module federation plugin.
 
-After setting the `moduleFederation.options` option, Rsbuild will take the following actions to ensure that the module federation runs correctly:
+## Introduction
+
+When using module federation, it is recommended that you use the `moduleFederation.options` option provided by Rsbuild. This option will automatically adjust some related configurations to ensure that the module federation application can run correctly.
+
+When you set the `moduleFederation.options` option, Rsbuild will take the following actions:
 
 - Automatically register the [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) plugin, and pass the value of `options` to the plugin.
-- Set the default value of the Rspack `output.publicPath` config to `'auto'`.
-- Turn off the splitChunks rules of the remote entry.
+- Set the default value of Rspack's [output.publicPath](https://rspack.dev/config/output#outputpublicpath) configuration to `'auto'`.
+- Turn off the `split-by-experience` rules in Rsbuild's [performance.chunkSplit](/config/performance/chunk-split) as it may conflict with shared modules, refer to [#3161](https://github.com/module-federation/module-federation-examples/issues/3161).
+- Turn off the splitChunks rule of remote entry.
 
-## Options
+## Usage
 
 The type of `moduleFederation.options` is exactly the same as the ModuleFederationPlugin plugin of Rspack:
 

--- a/packages/document/docs/zh/config/module-federation/options.mdx
+++ b/packages/document/docs/zh/config/module-federation/options.mdx
@@ -6,13 +6,18 @@
 
 用于配置 Rspack 模块联邦插件。
 
-设置 `moduleFederation.options` 选项后，Rsbuild 会执行以下操作，以保证模块联邦可以正确运行：
+## 介绍
+
+在使用模块联邦时，我们推荐你使用 Rsbuild 提供的 `moduleFederation.options` 选项，这个选项会自动调整一些相关的配置，以保证模块联邦应用可以正确运行。
+
+当你设置 `moduleFederation.options` 选项后，Rsbuild 会执行以下操作：
 
 - 自动注册 [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) 插件，并将 `options` 的值透传给插件。
-- 将 Rspack `output.publicPath` 配置的默认值设置为 `'auto'`。
+- 将 Rspack [output.publicPath](https://rspack.dev/config/output#outputpublicpath) 配置的默认值设置为 `'auto'`。
+- 关闭 Rsbuild [performance.chunkSplit](/config/performance/chunk-split) 中 `split-by-experience` 相关的规则，因为这可能会与 shared modules 冲突，参考 [#3161](https://github.com/module-federation/module-federation-examples/issues/3161)。
 - 关闭 remote entry 的 splitChunks 规则。
 
-## 选项
+## 用法
 
 `moduleFederation.options` 的类型与 Rspack 的 ModuleFederationPlugin 插件完全一致：
 

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -27,7 +27,7 @@ export const applySplitChunksRule = (
 
     const extraGroups: Record<string, (string | RegExp)[]> = {};
 
-    if (options.react && !config.moduleFederation) {
+    if (options.react) {
       extraGroups.react = [
         'react',
         'react-dom',


### PR DESCRIPTION
## Summary

Currently, splitChunks will take precedence over module federation shared modules. So we need to disable the default split chunks rules to make shared modules to work properly.

> See https://github.com/module-federation/module-federation-examples/issues/3161

## Related Links

The motivation for this PR is to completely resolve the issues addressed in #1942

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated.
- [x] Documentation updated.
