### PR TITLE
fix: onDevCompileDone hook async not work

### DIFF
--- a/packages/compat/webpack/src/core/build.ts
+++ b/packages/compat/webpack/src/core/build.ts
@@ -4,7 +4,7 @@ import {
   logger,
   getNodeEnv,
   setNodeEnv,
-  isMultiCompiler,
+  onCompileDone,
   type Stats,
   type Rspack,
   type MultiStats,
@@ -52,40 +52,7 @@ export const build = async (
     await p;
   };
 
-  // MultiCompiler does not supports `done.tapPromise`
-  if (isMultiCompiler(compiler)) {
-    const { compilers } = compiler;
-    const compilerStats: Stats[] = [];
-    let doneCompilers = 0;
-
-    for (let index = 0; index < compilers.length; index++) {
-      const compiler = compilers[index];
-      const compilerIndex = index;
-      let compilerDone = false;
-
-      compiler.hooks.done.tapPromise('rsbuild:done', async (stats) => {
-        if (!compilerDone) {
-          compilerDone = true;
-          doneCompilers++;
-        }
-
-        compilerStats[compilerIndex] = stats;
-
-        if (doneCompilers === compilers.length) {
-          await onDone(new WebpackMultiStats(compilerStats));
-        }
-      });
-
-      compiler.hooks.invalid.tap('rsbuild:done', () => {
-        if (compilerDone) {
-          compilerDone = false;
-          doneCompilers--;
-        }
-      });
-    }
-  } else {
-    compiler.hooks.done.tapPromise('rsbuild:done', onDone);
-  }
+  onCompileDone(compiler, onDone, WebpackMultiStats);
 
   if (watch) {
     compiler.watch({}, (err) => {

--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -2,7 +2,7 @@ import {
   debug,
   isDev,
   logger,
-  isMultiCompiler,
+  onCompileDone,
   type Stats,
   type Rspack,
   type RspackConfig,
@@ -14,6 +14,8 @@ import {
 } from '@rsbuild/core/provider';
 import type { WebpackConfig } from '../types';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
+// @ts-expect-error
+import WebpackMultiStats from 'webpack/lib/MultiStats';
 
 export async function createCompiler({
   context,
@@ -57,12 +59,7 @@ export async function createCompiler({
 
   let isFirstCompile = true;
 
-  // MultiCompiler does not supports `done.tapPromise`
-  if (isMultiCompiler(compiler)) {
-    compiler.hooks.done.tap('rsbuild:done', done);
-  } else {
-    compiler.hooks.done.tapPromise('rsbuild:done', done);
-  }
+  onCompileDone(compiler, done, WebpackMultiStats);
 
   await context.hooks.onAfterCreateCompiler.call({
     compiler,

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -6,7 +6,9 @@ import {
   logger,
   prettyTime,
   TARGET_ID_MAP,
-  isMultiCompiler,
+  onCompileDone,
+  type Stats,
+  type MultiStats,
   type RspackConfig,
   type RspackCompiler,
   type RspackMultiCompiler,
@@ -14,7 +16,7 @@ import {
 } from '@rsbuild/shared';
 import { initConfigs, type InitConfigsOptions } from './initConfigs';
 import type { InternalContext } from '../types';
-import type { Stats, MultiStats, StatsCompilation } from '@rspack/core';
+import type { StatsCompilation } from '@rspack/core';
 import {
   formatStats,
   rspackMinVersion,
@@ -116,12 +118,14 @@ export async function createCompiler({
     isFirstCompile = false;
   };
 
-  // MultiCompiler does not supports `done.tapPromise`
-  if (isMultiCompiler(compiler)) {
-    compiler.hooks.done.tap('rsbuild:done', done);
-  } else {
-    compiler.hooks.done.tapPromise('rsbuild:done', done);
-  }
+  const { MultiStats: MultiStatsStor } = await import('@rspack/core');
+
+  onCompileDone(
+    compiler,
+    done,
+    // @ts-expect-error type mismatch
+    MultiStatsStor,
+  );
 
   await context.hooks.onAfterCreateCompiler.call({ compiler });
   debug('create compiler done');


### PR DESCRIPTION
## Summary

Fix onDevCompileDone hook async not work.

The MultiCompiler of Rspack / webpack does not supports `done.tapPromise`, so we need to use the `done` hook of `MultiCompiler.compilers` to implement it.

## Related Links

The same as https://github.com/web-infra-dev/rsbuild/pull/1955

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
