### PR TITLE
fix(overlay): detect document, respect overlay option

### DIFF
--- a/.changeset/itchy-lions-battle.md
+++ b/.changeset/itchy-lions-battle.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix(overlay): detect document, respect overlay option

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -185,7 +185,9 @@ function onMessage(e: MessageEvent<string>) {
   const message = JSON.parse(e.data);
   switch (message.type) {
     case 'hash':
-      clearOverlay();
+      if (enableOverlay) {
+        clearOverlay();
+      }
       handleAvailableHash(message.data);
       break;
     case 'still-ok':

--- a/packages/core/src/client/hmr/overlay.ts
+++ b/packages/core/src/client/hmr/overlay.ts
@@ -170,7 +170,7 @@ const documentAvailable = typeof document !== 'undefined';
 export function createOverlay(err: string[]) {
   if (!documentAvailable) {
     console.info(
-      'Failed to display Rsbuild overlay since document is not available, considering turning off the overlay option.',
+      'Failed to display Rsbuild overlay since document is not available, considering turning off the `dev.client.overlay` option.',
     );
     return;
   }

--- a/packages/core/src/client/hmr/overlay.ts
+++ b/packages/core/src/client/hmr/overlay.ts
@@ -165,12 +165,25 @@ if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay);
 }
 
+const documentAvailable = typeof document !== 'undefined';
+
 export function createOverlay(err: string[]) {
+  if (!documentAvailable) {
+    console.info(
+      'Failed to display Rsbuild overlay since document is not available, considering turning off the overlay option.',
+    );
+    return;
+  }
+
   clearOverlay();
   document.body.appendChild(new ErrorOverlay(err));
 }
 
 export function clearOverlay() {
+  if (!documentAvailable) {
+    return;
+  }
+
   // use NodeList's forEach api instead of dom.iterable
   // biome-ignore lint/complexity/noForEach: <explanation>
   document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());


### PR DESCRIPTION
## Summary

## Related Links

- detect `document` object to detemine showing overlay
- `clearOverlay` respect overlay option

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
