### PR TITLE
fix: support output childCompiler error

### DIFF
--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -186,12 +186,22 @@ function formatErrorMessage(errors: string[]) {
 export const getAllStatsErrors = (statsData: StatsCompilation) => {
   // stats error + childCompiler error
   // only append child errors when stats error does not exist, because some errors will exist in both stats and childCompiler
-  return statsData.errorsCount && statsData.errors?.length === 0 ? statsData.children?.reduce<StatsError[]>((errors, curr) => errors.concat(curr.errors || []), []) : statsData.errors;
-}
+  return statsData.errorsCount && statsData.errors?.length === 0
+    ? statsData.children?.reduce<StatsError[]>(
+        (errors, curr) => errors.concat(curr.errors || []),
+        [],
+      )
+    : statsData.errors;
+};
 
 export const getAllStatsWarnings = (statsData: StatsCompilation) => {
-  return statsData.warningsCount && statsData.warnings?.length === 0 ? statsData.children?.reduce<StatsError[]>((warnings, curr) => warnings.concat(curr.warnings || []), []) : statsData.warnings;
-}
+  return statsData.warningsCount && statsData.warnings?.length === 0
+    ? statsData.children?.reduce<StatsError[]>(
+        (warnings, curr) => warnings.concat(curr.warnings || []),
+        [],
+      )
+    : statsData.warnings;
+};
 
 export function formatStats(stats: Stats | MultiStats) {
   const statsData = stats.toJson({

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -5,11 +5,13 @@ import {
   type Stats,
   type MultiStats,
   type SharedCompiledPkgNames,
+  type StatsError,
 } from '@rsbuild/shared';
 import { fse } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 import { awaitableGetter, type Plugins } from '@rsbuild/shared';
 import { formatStatsMessages } from '../client/formatStats';
+import type { StatsCompilation } from '@rspack/core';
 
 export const applyDefaultPlugins = (plugins: Plugins) =>
   awaitableGetter<RsbuildPlugin>([
@@ -181,12 +183,26 @@ function formatErrorMessage(errors: string[]) {
   return `${title}\n${tip}\n${text}`;
 }
 
+export const getAllStatsErrors = (statsData: StatsCompilation) => {
+  // stats error + childCompiler error
+  // only append child errors when stats error does not exist, because some errors will exist in both stats and childCompiler
+  return statsData.errorsCount && statsData.errors?.length === 0 ? statsData.children?.reduce<StatsError[]>((errors, curr) => errors.concat(curr.errors || []), []) : statsData.errors;
+}
+
+export const getAllStatsWarnings = (statsData: StatsCompilation) => {
+  return statsData.warningsCount && statsData.warnings?.length === 0 ? statsData.children?.reduce<StatsError[]>((warnings, curr) => warnings.concat(curr.warnings || []), []) : statsData.warnings;
+}
+
 export function formatStats(stats: Stats | MultiStats) {
   const statsData = stats.toJson({
     preset: 'errors-warnings',
+    children: true,
   });
 
-  const { errors, warnings } = formatStatsMessages(statsData);
+  const { errors, warnings } = formatStatsMessages({
+    errors: getAllStatsErrors(statsData),
+    warnings: getAllStatsWarnings(statsData),
+  });
 
   if (errors.length) {
     return {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -176,7 +176,7 @@ export class SocketServer {
     }
 
     this.sockWrite('hash', stats.hash);
-  
+
     if (stats.errorsCount) {
       return this.sockWrite('errors', getAllStatsErrors(stats));
     }

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
 import ws from '../../compiled/ws';
 import { logger, type Stats, type DevMiddlewaresConfig } from '@rsbuild/shared';
+import { getAllStatsErrors, getAllStatsWarnings } from '../provider/shared';
 
 interface ExtWebSocket extends ws {
   isAlive: boolean;
@@ -144,8 +145,11 @@ export class SocketServer {
       hash: true,
       assets: true,
       warnings: true,
+      warningsCount: true,
       errors: true,
+      errorsCount: true,
       errorDetails: false,
+      children: true,
     };
 
     return curStats.toJson(defaultStats);
@@ -163,7 +167,7 @@ export class SocketServer {
     const shouldEmit =
       !force &&
       stats &&
-      (!stats.errors || stats.errors.length === 0) &&
+      !stats.errorsCount &&
       stats.assets &&
       stats.assets.every((asset: any) => !asset.emitted);
 
@@ -172,12 +176,12 @@ export class SocketServer {
     }
 
     this.sockWrite('hash', stats.hash);
-
-    if (stats.errors && stats.errors.length > 0) {
-      return this.sockWrite('errors', stats.errors);
+  
+    if (stats.errorsCount) {
+      return this.sockWrite('errors', getAllStatsErrors(stats));
     }
-    if (stats.warnings && stats.warnings.length > 0) {
-      return this.sockWrite('warnings', stats.warnings);
+    if (stats.warningsCount) {
+      return this.sockWrite('warnings', getAllStatsWarnings(stats));
     }
     return this.sockWrite('ok');
   }


### PR DESCRIPTION
## Summary

support output childCompiler error since some error only appear in stats.childern

![img_v3_029e_40b70d53-5fad-4b26-9ff5-235ca33b925g](https://github.com/web-infra-dev/rsbuild/assets/22373761/13530309-ee61-4530-9432-6453659870aa)

before:
<img width="511" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/24d93800-ceb3-46f2-8de7-0affda9dff27">

after:
<img width="689" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/99c5d0da-2df4-4532-844b-b062f361d0c1">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
