### PR TITLE
fix(plugin-solid): downgrade solid-refresh to v0.6.3

### DIFF
--- a/e2e/cases/solid/ref/index.test.ts
+++ b/e2e/cases/solid/ref/index.test.ts
@@ -1,0 +1,16 @@
+import { expect } from '@playwright/test';
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+
+// https://github.com/web-infra-dev/rsbuild/issues/1963
+rspackOnlyTest('Solid ref should work', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+  });
+
+  await gotoPage(page, rsbuild);
+
+  const test = page.locator('#test');
+  await expect(test).toHaveText('abc');
+
+  rsbuild.close();
+});

--- a/e2e/cases/solid/ref/rsbuild.config.ts
+++ b/e2e/cases/solid/ref/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { pluginBabel } from '@rsbuild/plugin-babel';
+import { pluginSolid } from '@rsbuild/plugin-solid';
+
+export default {
+  plugins: [
+    pluginBabel({
+      include: /\.(?:jsx|tsx)$/,
+      exclude: /[\\/]node_modules[\\/]/,
+    }),
+    pluginSolid(),
+  ],
+};

--- a/e2e/cases/solid/ref/src/App.jsx
+++ b/e2e/cases/solid/ref/src/App.jsx
@@ -1,0 +1,8 @@
+import { createSignal } from 'solid-js';
+
+const App = () => {
+  const [el, setEl] = createSignal();
+  return <div id="test" ref={setEl}>abc</div>;
+};
+
+export default App;

--- a/e2e/cases/solid/ref/src/index.jsx
+++ b/e2e/cases/solid/ref/src/index.jsx
@@ -1,0 +1,4 @@
+import { render } from 'solid-js/web';
+import App from './App';
+
+render(() => <App />, document.getElementById('root'));

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -30,7 +30,7 @@
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "babel-preset-solid": "^1.8.16",
-    "solid-refresh": "0.7.5"
+    "solid-refresh": "0.6.3"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1198,8 +1198,8 @@ importers:
         specifier: ^1.8.16
         version: 1.8.16(@babel/core@7.24.3)
       solid-refresh:
-        specifier: 0.7.5
-        version: 0.7.5(solid-js@1.8.16)
+        specifier: 0.6.3
+        version: 0.6.3(solid-js@1.8.16)
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -13158,12 +13158,13 @@ packages:
       seroval-plugins: 1.0.4(seroval@1.0.4)
     dev: false
 
-  /solid-refresh@0.7.5(solid-js@1.8.16):
-    resolution: {integrity: sha512-ZYMbjWsy7IwSF3+oZCNnReiTYSyCAFRvC7oLUKxxh1wPa6/6YIWqsxa+Ma2kM4F/ypWT69B1c0fmKeZRdLueGw==}
+  /solid-refresh@0.6.3(solid-js@1.8.16):
+    resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
     peerDependencies:
       solid-js: ^1.3
     dependencies:
-      '@babel/generator': 7.23.6
+      '@babel/generator': 7.24.1
+      '@babel/helper-module-imports': 7.24.3
       '@babel/types': 7.24.0
       solid-js: 1.8.16
     dev: false


### PR DESCRIPTION
## Summary

Downgrade solid-refresh to v0.6.3.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/1963

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
