### PR TITLE
feat: support for plugin communication

### DIFF
--- a/e2e/cases/javascript-api/plugin-expose/index.test.ts
+++ b/e2e/cases/javascript-api/plugin-expose/index.test.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
+
+type ParentAPI = {
+  initial: number;
+  double: (val: number) => number;
+};
+
+test('should allow plugin to expose and consume API', async () => {
+  const parentSymbol = Symbol('parent-api');
+
+  const pluginParent: RsbuildPlugin = {
+    name: 'plugin-parent',
+    setup(api) {
+      api.expose<ParentAPI>(parentSymbol, {
+        initial: 1,
+        double: (val: number) => val * 2,
+      });
+    },
+  };
+
+  const pluginChild: RsbuildPlugin = {
+    name: 'plugin-child',
+    setup(api) {
+      const parentAPI = api.useExposed<ParentAPI>(parentSymbol);
+      expect(parentAPI?.double(parentAPI.initial)).toEqual(2);
+    },
+  };
+
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [pluginParent, pluginChild],
+    },
+  });
+
+  await rsbuild.build();
+});

--- a/e2e/cases/javascript-api/plugin-expose/src/index.js
+++ b/e2e/cases/javascript-api/plugin-expose/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/packages/core/src/provider/initPlugins.ts
+++ b/packages/core/src/provider/initPlugins.ts
@@ -63,12 +63,26 @@ export function getPluginAPI({
     );
   };
 
+  const exposed: Array<{ id: string | symbol; api: any }> = [];
+
+  const expose = (id: string | symbol, api: any) => {
+    exposed.push({ id, api });
+  };
+  const useExposed = (id: string | symbol) => {
+    const matched = exposed.find((item) => item.id === id);
+    if (matched) {
+      return matched.api;
+    }
+  };
+
   onExitProcess(() => {
     hooks.onExit.call();
   });
 
   return {
     context: publicContext,
+    expose,
+    useExposed,
     getHTMLPaths,
     getRsbuildConfig,
     getNormalizedConfig,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -203,4 +203,10 @@ export type RsbuildPluginAPI = {
   getHTMLPaths: () => Record<string, string>;
   getRsbuildConfig: GetRsbuildConfig;
   getNormalizedConfig: () => NormalizedConfig;
+
+  /**
+   * For plugin communication
+   */
+  expose: <T = any>(id: string | symbol, api: T) => void;
+  useExposed: <T = any>(id: string | symbol) => T | undefined;
 };


### PR DESCRIPTION
## Summary

This PR introduced two new plugin API for plugin communication:

```js
const parentSymbol = Symbol('parent-api');

const pluginParent: RsbuildPlugin = {
  name: 'plugin-parent',
  setup(api) {
    api.expose<ParentAPI>(parentSymbol, {
      initial: 1,
      double: (val: number) => val * 2,
    });
  },
};

const pluginChild: RsbuildPlugin = {
  name: 'plugin-child',
  setup(api) {
    const parentAPI = api.useExposed<ParentAPI>(parentSymbol);
    expect(parentAPI?.double(parentAPI.initial)).toEqual(2);
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
