### PR TITLE
fix: allow to move legal comments from HTML

### DIFF
--- a/e2e/cases/html/legal-comments/index.test.ts
+++ b/e2e/cases/html/legal-comments/index.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+import { build } from '@e2e/helper';
+
+test('should preserve legal comments in HTML by default', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  expect(html).toContain('@license test');
+});
+
+test('should remove legal comments in HTML when `output.legalComments` is `none`', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        legalComments: 'none',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  expect(html).not.toContain('@license test');
+});

--- a/e2e/cases/html/legal-comments/rsbuild.config.ts
+++ b/e2e/cases/html/legal-comments/rsbuild.config.ts
@@ -1,0 +1,5 @@
+export default {
+  html: {
+    template: './src/index.html',
+  },
+};

--- a/e2e/cases/html/legal-comments/src/index.html
+++ b/e2e/cases/html/legal-comments/src/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <script>
+      /**
+       * @license test
+       *
+       * Copyright (c) Test
+       */
+      function test() {}
+    </script>
+  </body>
+</html>

--- a/e2e/cases/html/title/src/empty.html
+++ b/e2e/cases/html/title/src/empty.html
@@ -1,3 +1,4 @@
-<!DOCTYPE html>
-<head></head>
+<!doctype html>
+<html>
+  <head></head>
 </html>

--- a/e2e/cases/html/title/src/plugin-options-title.html
+++ b/e2e/cases/html/title/src/plugin-options-title.html
@@ -1,5 +1,6 @@
-<!DOCTYPE html>
-<head>
-  <title><%= htmlWebpackPlugin.options.title %></title>
-</head>
+<!doctype html>
+<html>
+  <head>
+    <title><%= htmlWebpackPlugin.options.title %></title>
+  </head>
 </html>

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -2,14 +2,11 @@ import type {
   RsbuildConfig,
   NormalizedConfig,
   InspectConfigOptions,
-  MinifyJSOptions,
 } from './types';
 import { logger } from './logger';
 import { join } from 'node:path';
 import fse from '../compiled/fs-extra';
-import { pick, color, upperFirst, deepmerge } from './utils';
-import { getTerserMinifyOptions } from './minimize';
-import { parseMinifyOptions } from './minimize';
+import { pick, color, upperFirst } from './utils';
 
 export async function outputInspectConfigFiles({
   rsbuildConfig,
@@ -70,40 +67,6 @@ export async function outputInspectConfigFiles({
   logger.success(
     `Inspect config succeed, open following files to view the content: \n\n${fileInfos}\n`,
   );
-}
-
-export async function getHtmlMinifyOptions(
-  isProd: boolean,
-  config: NormalizedConfig,
-) {
-  if (
-    !isProd ||
-    !config.output.minify ||
-    !parseMinifyOptions(config).minifyHtml
-  ) {
-    return false;
-  }
-
-  const minifyJS: MinifyJSOptions = getTerserMinifyOptions(config);
-
-  const htmlMinifyDefaultOptions = {
-    removeComments: false,
-    useShortDoctype: true,
-    keepClosingSlash: true,
-    collapseWhitespace: true,
-    removeRedundantAttributes: true,
-    removeScriptTypeAttributes: true,
-    removeStyleLinkTypeAttributes: true,
-    removeEmptyAttributes: true,
-    minifyJS,
-    minifyCSS: true,
-    minifyURLs: true,
-  };
-
-  const htmlMinifyOptions = parseMinifyOptions(config).htmlOptions;
-  return typeof htmlMinifyOptions === 'object'
-    ? deepmerge(htmlMinifyDefaultOptions, htmlMinifyOptions)
-    : htmlMinifyDefaultOptions;
 }
 
 export async function stringifyConfig(config: unknown, verbose?: boolean) {

--- a/packages/shared/src/minimize.ts
+++ b/packages/shared/src/minimize.ts
@@ -1,8 +1,8 @@
 import { isObject } from './utils';
 import type {
-  HTMLPluginOptions,
-  NormalizedConfig,
   MinifyJSOptions,
+  NormalizedConfig,
+  HTMLPluginOptions,
 } from './types';
 import type { SwcJsMinimizerRspackPluginOptions } from '@rspack/core';
 import deepmerge from '../compiled/deepmerge';
@@ -31,21 +31,52 @@ function applyRemoveConsole(
   return options;
 }
 
-export function getTerserMinifyOptions(config: NormalizedConfig) {
+function getTerserMinifyOptions(config: NormalizedConfig) {
   const DEFAULT_OPTIONS: MinifyJSOptions = {
     mangle: {
-      // not need in rspack(swc)
-      // https://github.com/swc-project/swc/discussions/3373
       safari10: true,
     },
     format: {
       ascii_only: config.output.charset === 'ascii',
+      comments: config.output.legalComments !== 'none',
     },
   };
-
   const finalOptions = applyRemoveConsole(DEFAULT_OPTIONS, config);
-
   return finalOptions;
+}
+
+export async function getHtmlMinifyOptions(
+  isProd: boolean,
+  config: NormalizedConfig,
+) {
+  if (
+    !isProd ||
+    !config.output.minify ||
+    !parseMinifyOptions(config).minifyHtml
+  ) {
+    return false;
+  }
+
+  const minifyJS: MinifyJSOptions = getTerserMinifyOptions(config);
+
+  const htmlMinifyDefaultOptions = {
+    removeComments: false,
+    useShortDoctype: true,
+    keepClosingSlash: true,
+    collapseWhitespace: true,
+    removeRedundantAttributes: true,
+    removeScriptTypeAttributes: true,
+    removeStyleLinkTypeAttributes: true,
+    removeEmptyAttributes: true,
+    minifyJS,
+    minifyCSS: true,
+    minifyURLs: true,
+  };
+
+  const htmlMinifyOptions = parseMinifyOptions(config).htmlOptions;
+  return typeof htmlMinifyOptions === 'object'
+    ? deepmerge(htmlMinifyDefaultOptions, htmlMinifyOptions)
+    : htmlMinifyDefaultOptions;
 }
 
 export const getSwcMinimizerOptions = (config: NormalizedConfig) => {

--- a/packages/shared/src/minimize.ts
+++ b/packages/shared/src/minimize.ts
@@ -32,16 +32,20 @@ function applyRemoveConsole(
 }
 
 function getTerserMinifyOptions(config: NormalizedConfig) {
-  const DEFAULT_OPTIONS: MinifyJSOptions = {
+  const options: MinifyJSOptions = {
     mangle: {
       safari10: true,
     },
     format: {
       ascii_only: config.output.charset === 'ascii',
-      comments: config.output.legalComments !== 'none',
     },
   };
-  const finalOptions = applyRemoveConsole(DEFAULT_OPTIONS, config);
+
+  if (config.output.legalComments === 'none') {
+    options.format!.comments = false;
+  }
+
+  const finalOptions = applyRemoveConsole(options, config);
   return finalOptions;
 }
 


### PR DESCRIPTION
## Summary

Should allow to move legal comments from HTML, add back the deleted config from https://github.com/web-infra-dev/rsbuild/pull/1854/files.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
