### PR TITLE
chore: remove ts-expect-error comment for dependOn

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -161,8 +161,11 @@ function getChunks(
   entryValue: string | string[] | EntryDescription,
 ): string[] {
   if (isPlainObject(entryValue)) {
-    // @ts-expect-error Rspack do not support dependOn yet
-    const { dependOn } = entryValue as EntryDescription;
+    const { dependOn } = entryValue as EntryDescription & {
+      // TODO: remove this after bumping Rspack v0.6
+      // https://github.com/web-infra-dev/rspack/pull/6069
+      dependOn?: string | string[] | undefined;
+    };
     if (Array.isArray(dependOn)) {
       return [...dependOn, entryName];
     }


### PR DESCRIPTION
## Summary

Remove ts-expect-error comment for dependOn as it breaks the Rspack ecosystem CI.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f3256eff-359f-4f0e-8817-21010575eec7)

## Related Links

- https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/8519320171/job/23333117046#step:7:150
- https://github.com/web-infra-dev/rspack/pull/6069

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
