### PR TITLE
feat: add new transform plugin API

### DIFF
--- a/packages/core/src/provider/initPlugins.ts
+++ b/packages/core/src/provider/initPlugins.ts
@@ -117,7 +117,7 @@ export function getPluginAPI({
       rule
         .use(id)
         .loader(join(__dirname, '../rspack/transformLoader'))
-        .options({ transformId: id });
+        .options({ id });
 
       if (!chain.plugins.get(TRANSFORM_PLUGIN_NAME)) {
         chain

--- a/packages/core/src/provider/initPlugins.ts
+++ b/packages/core/src/provider/initPlugins.ts
@@ -108,10 +108,10 @@ export function getPluginAPI({
   let transformId = 0;
   const transformer: Record<string, TransformHandler> = {};
 
-  const transform: TransformFn = (descriptor) => {
+  const transform: TransformFn = (handler, descriptor = {}) => {
     const id = `rsbuild-transform-${transformId}`;
 
-    transformer[id] = descriptor.handler;
+    transformer[id] = handler;
 
     hooks.modifyBundlerChain.tap((chain) => {
       const rule = chain.module.rule(id);

--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -1,14 +1,6 @@
 import type { LoaderContext } from '@rspack/core';
 import type { RspackSourceMap, TransformHandler } from '@rsbuild/shared';
 
-const getTransformId = (query: string | { transformId: string }) => {
-  if (typeof query === 'string') {
-    const searchParams = new URLSearchParams(query);
-    return searchParams.get('transformId');
-  }
-  return query.transformId;
-};
-
 declare module '@rspack/core' {
   interface Compiler {
     __rsbuildTransformer: Record<string, TransformHandler>;
@@ -16,14 +8,14 @@ declare module '@rspack/core' {
 }
 
 export default async function transform(
-  this: LoaderContext<{ transformId: string }>,
+  this: LoaderContext<{ id: string }>,
   source: string,
   map?: string | RspackSourceMap,
 ) {
   const callback = this.async();
   const bypass = () => callback(null, source, map);
 
-  const transformId = getTransformId(this.query);
+  const transformId = this.getOptions().id;
   if (!transformId) {
     return bypass();
   }

--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -1,0 +1,52 @@
+import type { LoaderContext } from '@rspack/core';
+import type { RspackSourceMap, TransformHandler } from '@rsbuild/shared';
+
+const getTransformId = (query: string | { transformId: string }) => {
+  if (typeof query === 'string') {
+    const searchParams = new URLSearchParams(query);
+    return searchParams.get('transformId');
+  }
+  return query.transformId;
+};
+
+declare module '@rspack/core' {
+  interface Compiler {
+    __rsbuildTransformer: Record<string, TransformHandler>;
+  }
+}
+
+export default async function transform(
+  this: LoaderContext<{ transformId: string }>,
+  source: string,
+  map?: string | RspackSourceMap,
+) {
+  const callback = this.async();
+  const bypass = () => callback(null, source, map);
+
+  const transformId = getTransformId(this.query);
+  if (!transformId) {
+    return bypass();
+  }
+
+  const transform = this._compiler?.__rsbuildTransformer[transformId];
+  if (!transform) {
+    return bypass();
+  }
+
+  const result = await transform({
+    code: source,
+    resource: this.resource,
+  });
+
+  if (result === null || result === undefined) {
+    return bypass();
+  }
+
+  if (typeof result === 'string') {
+    return callback(null, result, map);
+  }
+
+  const useMap = map !== undefined && map !== null;
+  const finalMap = result.map ?? map;
+  callback(null, result.code, useMap ? finalMap : undefined);
+}

--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -1,11 +1,5 @@
 import type { LoaderContext } from '@rspack/core';
-import type { RspackSourceMap, TransformHandler } from '@rsbuild/shared';
-
-declare module '@rspack/core' {
-  interface Compiler {
-    __rsbuildTransformer: Record<string, TransformHandler>;
-  }
-}
+import type { RspackSourceMap } from '@rsbuild/shared';
 
 export default async function transform(
   this: LoaderContext<{ id: string }>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,8 +5,15 @@ import type {
   RsbuildContext,
   NormalizedConfig,
   RsbuildPluginAPI,
+  TransformHandler,
 } from '@rsbuild/shared';
 import type { Hooks } from './initHooks';
+
+declare module '@rspack/core' {
+  interface Compiler {
+    __rsbuildTransformer: Record<string, TransformHandler>;
+  }
+}
 
 export type { RsbuildPlugin, RsbuildPlugins, RsbuildPluginAPI };
 

--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -154,7 +154,7 @@ function ModifyRsbuildConfig(
   callback: (
     config: RsbuildConfig,
     utils: ModifyRsbuildConfigUtils,
-  ) => PromiseOrNot<RsbuildConfig | void>,
+  ) => MaybePromise<RsbuildConfig | void>,
 ): void;
 ```
 

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -154,7 +154,7 @@ function ModifyRsbuildConfig(
   callback: (
     config: RsbuildConfig,
     utils: ModifyRsbuildConfigUtils,
-  ) => PromiseOrNot<RsbuildConfig | void>,
+  ) => MaybePromise<RsbuildConfig | void>,
 ): void;
 ```
 

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -1,6 +1,6 @@
 import type { ChainIdentifier } from '../chain';
 import type { Stats, MultiStats } from './stats';
-import type { NodeEnv, PromiseOrNot } from './utils';
+import type { NodeEnv, MaybePromise } from './utils';
 import type { RsbuildTarget } from './rsbuild';
 import type { BundlerChain } from './bundlerConfig';
 import type { Rspack, RspackConfig } from './rspack';
@@ -9,23 +9,23 @@ import type { WebpackConfig } from './thirdParty';
 
 export type OnBeforeBuildFn<B = 'rspack'> = (params: {
   bundlerConfigs?: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
 export type OnAfterBuildFn = (params: {
   isFirstCompile: boolean;
   stats?: Stats | MultiStats;
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
-export type OnCloseDevServerFn = () => PromiseOrNot<void>;
+export type OnCloseDevServerFn = () => MaybePromise<void>;
 
 export type OnDevCompileDoneFn = (params: {
   isFirstCompile: boolean;
   stats: Stats | MultiStats;
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
-export type OnBeforeStartDevServerFn = () => PromiseOrNot<void>;
+export type OnBeforeStartDevServerFn = () => MaybePromise<void>;
 
-export type OnBeforeStartProdServerFn = () => PromiseOrNot<void>;
+export type OnBeforeStartProdServerFn = () => MaybePromise<void>;
 
 export type Routes = Array<{
   entryName: string;
@@ -35,20 +35,20 @@ export type Routes = Array<{
 export type OnAfterStartDevServerFn = (params: {
   port: number;
   routes: Routes;
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
 export type OnAfterStartProdServerFn = (params: {
   port: number;
   routes: Routes;
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
 export type OnBeforeCreateCompilerFn<B = 'rspack'> = (params: {
   bundlerConfigs: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
-}) => PromiseOrNot<void>;
+}) => MaybePromise<void>;
 
 export type OnAfterCreateCompilerFn<
   Compiler = Rspack.Compiler | Rspack.MultiCompiler,
-> = (params: { compiler: Compiler }) => PromiseOrNot<void>;
+> = (params: { compiler: Compiler }) => MaybePromise<void>;
 
 export type OnExitFn = () => void;
 
@@ -60,7 +60,7 @@ export type ModifyRsbuildConfigUtils = {
 export type ModifyRsbuildConfigFn = (
   config: RsbuildConfig,
   utils: ModifyRsbuildConfigUtils,
-) => PromiseOrNot<RsbuildConfig | void>;
+) => MaybePromise<RsbuildConfig | void>;
 
 export type ModifyChainUtils = {
   env: NodeEnv;
@@ -96,7 +96,7 @@ export type ModifyBundlerChainUtils = ModifyChainUtils & {
 export type ModifyBundlerChainFn = (
   chain: BundlerChain,
   utils: ModifyBundlerChainUtils,
-) => PromiseOrNot<void>;
+) => MaybePromise<void>;
 
 export type CreateAsyncHook<Callback extends (...args: any[]) => any> = {
   tap: (cb: Callback) => void;

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -21,8 +21,9 @@ import type {
   NormalizedConfig,
   ModifyRspackConfigUtils,
 } from './config';
-import type { PromiseOrNot } from './utils';
-import type { RspackConfig } from './rspack';
+import type { MaybePromise } from './utils';
+import type { RspackConfig, RspackSourceMap } from './rspack';
+import type { RuleSetCondition } from '@rspack/core';
 import type {
   RuleSetRule,
   WebpackPluginInstance,
@@ -107,7 +108,7 @@ export type RsbuildPlugin = {
    * This function is called once when the plugin is initialized.
    * @param api provides the context info, utility functions and lifecycle hooks.
    */
-  setup: (api: RsbuildPluginAPI) => PromiseOrNot<void>;
+  setup: (api: RsbuildPluginAPI) => MaybePromise<void>;
   /**
    * Declare the names of pre-plugins, which will be executed before the current plugin.
    */
@@ -168,6 +169,23 @@ type PluginHook<T extends (...args: any[]) => any> = (
   options: T | HookDescriptor<T>,
 ) => void;
 
+type TransformResult =
+  | string
+  | {
+      code: string;
+      map?: string | RspackSourceMap | null;
+    };
+
+export type TransformHandler = (params: {
+  code: string;
+  resource: string;
+}) => MaybePromise<TransformResult>;
+
+export type TransformFn = (descriptor: {
+  test?: RuleSetCondition;
+  handler: TransformHandler;
+}) => void;
+
 /**
  * Define a generic Rsbuild plugin API that provider can extend as needed.
  */
@@ -209,4 +227,6 @@ export type RsbuildPluginAPI = {
    */
   expose: <T = any>(id: string | symbol, api: T) => void;
   useExposed: <T = any>(id: string | symbol) => T | undefined;
+
+  transform: TransformFn;
 };

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -181,10 +181,12 @@ export type TransformHandler = (params: {
   resource: string;
 }) => MaybePromise<TransformResult>;
 
-export type TransformFn = (descriptor: {
-  test?: RuleSetCondition;
-  handler: TransformHandler;
-}) => void;
+export type TransformFn = (
+  handler: TransformHandler,
+  descriptor?: {
+    test?: RuleSetCondition;
+  },
+) => void;
 
 /**
  * Define a generic Rsbuild plugin API that provider can extend as needed.

--- a/packages/shared/src/types/rspack.ts
+++ b/packages/shared/src/types/rspack.ts
@@ -164,3 +164,13 @@ export type BuiltinSwcLoaderOptions = {
     };
   };
 };
+
+export type RspackSourceMap = {
+  version: number;
+  sources: string[];
+  mappings: string;
+  file?: string;
+  sourceRoot?: string;
+  sourcesContent?: string[];
+  names?: string[];
+};

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -6,7 +6,7 @@ export type Falsy = false | null | undefined;
 
 export type ArrayOrNot<T> = T | T[];
 
-export type PromiseOrNot<T> = T | Promise<T>;
+export type MaybePromise<T> = T | Promise<T>;
 
 export type NodeEnv = 'development' | 'production' | 'test';
 


### PR DESCRIPTION
## Summary

Add new transform plugin API. 

This is similar to rollup's transform and can be used as an intuitive way to call Rspack loader.

For example, implement a Pug plugin to compile `.pug` files:

```js
import pug from 'pug';
import type { RsbuildPlugin } from '@rsbuild/core';

export const pluginPug = (): RsbuildPlugin => ({
  name: 'rsbuild:pug',

  setup(api) {
    api.transform(
      ({ code }) => {
        const templateCode = pug.compileClient(code, {});
        return `${templateCode}; module.exports = template;`;
      },
      { test: /\.pug$/ },
    );
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
