### PR TITLE
chore: mark transform API as experimental

### DIFF
--- a/.changeset/dirty-pumas-walk.md
+++ b/.changeset/dirty-pumas-walk.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+release: 0.5.7

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -248,5 +248,10 @@ export type RsbuildPluginAPI = {
   expose: <T = any>(id: string | symbol, api: T) => void;
   useExposed: <T = any>(id: string | symbol) => T | undefined;
 
+  /**
+   * @experimental
+   * This is an experimental and may introduce breaking change in patch releases.
+   * It will be stable in Rsbuild v0.6.0
+   */
   transform: TransformFn;
 };


### PR DESCRIPTION
## Summary

Mark transform API as experimental.

We still need some time to test and improve the transform API before v0.6.0.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
