### PR TITLE
chore: adjust params order of transform API

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform/myPlugin.ts
@@ -3,20 +3,14 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 export const myPlugin: RsbuildPlugin = {
   name: 'my-plugin',
   setup(api) {
-    api.transform(
-      ({ code }) => {
-        return code.replace('red', 'blue');
-      },
-      { test: /\.css$/ },
-    );
+    api.transform({ test: /\.css$/ }, ({ code }) => {
+      return code.replace('red', 'blue');
+    });
 
-    api.transform(
-      ({ code }) => {
-        return {
-          code: code.replace('hello', 'world'),
-        };
-      },
-      { test: /\.js$/ },
-    );
+    api.transform({ test: /\.js$/ }, ({ code }) => {
+      return {
+        code: code.replace('hello', 'world'),
+      };
+    });
   },
 };

--- a/examples/webpack/rsbuild.config.ts
+++ b/examples/webpack/rsbuild.config.ts
@@ -5,7 +5,4 @@ import { webpackProvider } from '@rsbuild/webpack';
 export default defineConfig({
   plugins: [pluginSwc()],
   provider: webpackProvider,
-  output: {
-    targets: ['web', 'node'],
-  },
 });

--- a/packages/core/src/provider/initPlugins.ts
+++ b/packages/core/src/provider/initPlugins.ts
@@ -108,8 +108,8 @@ export function getPluginAPI({
   let transformId = 0;
   const transformer: Record<string, TransformHandler> = {};
 
-  const transform: TransformFn = (handler, descriptor = {}) => {
-    const id = `rsbuild-transform-${transformId}`;
+  const transform: TransformFn = (descriptor, handler) => {
+    const id = `rsbuild-transform-${transformId++}`;
 
     transformer[id] = handler;
 
@@ -127,8 +127,6 @@ export function getPluginAPI({
 
       applyTransformPlugin(chain, transformer);
     });
-
-    transformId++;
   };
 
   onExitProcess(() => {

--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -14,7 +14,7 @@ export default async function transform(
     return bypass();
   }
 
-  const transform = this._compiler?.__rsbuildTransformer[transformId];
+  const transform = this._compiler?.__rsbuildTransformer?.[transformId];
   if (!transform) {
     return bypass();
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,7 +11,7 @@ import type { Hooks } from './initHooks';
 
 declare module '@rspack/core' {
   interface Compiler {
-    __rsbuildTransformer: Record<string, TransformHandler>;
+    __rsbuildTransformer?: Record<string, TransformHandler>;
   }
 }
 

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -196,14 +196,14 @@ export type TransformHandler = (params: {
 }) => MaybePromise<TransformResult>;
 
 export type TransformFn = (
-  handler: TransformHandler,
-  descriptor?: {
+  descriptor: {
     /**
      * Include modules that match the test assertion., the same as `rule.test`
      * @see https://rspack.dev/config/module#ruletest
      */
     test?: RuleSetCondition;
   },
+  handler: TransformHandler,
 ) => void;
 
 /**


### PR DESCRIPTION
## Summary

Adjust the params order of transform API to pass the descriptor as the first param. This helps users avoid forgetting to pass in `test` and transforming too many modules.

```js
api.transform({ test: /\.js$/ }, ({ code }) => {
  return code;
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
