### PR TITLE
feat: allow to add dependency in transform API

### DIFF
--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -24,6 +24,7 @@ export default async function transform(
     resource: this.resource,
     resourcePath: this.resourcePath,
     resourceQuery: this.resourceQuery,
+    addDependency: this.addDependency,
   });
 
   if (result === null || result === undefined) {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -176,7 +176,10 @@ type TransformResult =
       map?: string | RspackSourceMap | null;
     };
 
-export type TransformHandler = (params: {
+export type TransformHandler = (context: {
+  /**
+   * The code of the module.
+   */
   code: string;
   /**
    * The absolute path of the module, including the query.
@@ -193,6 +196,12 @@ export type TransformHandler = (params: {
    * @example '?foo=123'
    */
   resourceQuery: string;
+  /**
+   * Add an additional file as the dependency.
+   * The file will be watched and changes to the file will trigger rebuild.
+   * @param file The absolute path of the module.
+   */
+  addDependency: (file: string) => void;
 }) => MaybePromise<TransformResult>;
 
 export type TransformFn = (


### PR DESCRIPTION
## Summary

Allow to add dependency in transform API, `addDependency` is a commonly used API and we need to add it to refactor the Rsbuild Pug plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
