### PR TITLE
types: make RsbuildPluginAPI readonly

### DIFF
--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -218,7 +218,7 @@ export type TransformFn = (
 /**
  * Define a generic Rsbuild plugin API that provider can extend as needed.
  */
-export type RsbuildPluginAPI = {
+export type RsbuildPluginAPI = Readonly<{
   context: Readonly<RsbuildContext>;
   isPluginExists: PluginManager['isPluginExists'];
 
@@ -263,4 +263,4 @@ export type RsbuildPluginAPI = {
    * It will be stable in Rsbuild v0.6.0
    */
   transform: TransformFn;
-};
+}>;


### PR DESCRIPTION
## Summary

Make RsbuildPluginAPI readonly to prevent unexpected modifications.

https://github.com/web-infra-dev/rsbuild/pull/1972#discussion_r1550046959

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
