### PR TITLE
types: export more hook fn types

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,22 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  tools: {
-    rspack: {
-      module: {
-        rules: [
-          {
-            issuer: {
-              and: [
-                '<ROOT>/packages/core/tests',
-                {
-                  not: /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
-            },
-          },
-        ],
-      },
-    },
-  },
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,5 +74,9 @@ export type {
   OnBeforeCreateCompilerFn,
   OnCloseDevServerFn,
   OnDevCompileDoneFn,
+  ModifyBundlerChainFn,
+  ModifyRspackConfigFn,
   ModifyRsbuildConfigFn,
+  TransformFn,
+  TransformHandler,
 } from '@rsbuild/shared';

--- a/packages/document/docs/en/api/javascript-api/types.mdx
+++ b/packages/document/docs/en/api/javascript-api/types.mdx
@@ -150,3 +150,7 @@ const rspackConfig: Rspack.Configuration = {};
 - OnCloseDevServerFn
 - OnDevCompileDoneFn
 - ModifyRsbuildConfigFn
+- ModifyBundlerChainFn
+- ModifyRspackConfigFn
+- TransformFn,
+- TransformHandler

--- a/packages/document/docs/zh/api/javascript-api/types.mdx
+++ b/packages/document/docs/zh/api/javascript-api/types.mdx
@@ -150,3 +150,7 @@ const rspackConfig: Rspack.Configuration = {};
 - OnCloseDevServerFn
 - OnDevCompileDoneFn
 - ModifyRsbuildConfigFn
+- ModifyBundlerChainFn
+- ModifyRspackConfigFn
+- TransformFn,
+- TransformHandler


### PR DESCRIPTION
## Summary

Export more hook fn types, such as `ModifyBundlerChainFn` and `ModifyRspackConfigFn`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
