### PR TITLE
feat: add emitFile to transform API

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform/index.test.ts
@@ -13,7 +13,11 @@ test('should allow plugin to transform code', async () => {
   const indexCss = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.css'),
   );
+  const helloTxt = Object.keys(files).find((file) =>
+    file.includes('hello.txt'),
+  );
 
   expect(files[indexJs!].includes('world')).toBeTruthy();
   expect(files[indexCss!].includes('blue')).toBeTruthy();
+  expect(files[helloTxt!].includes('hello world')).toBeTruthy();
 });

--- a/e2e/cases/plugin-api/plugin-transform/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform/myPlugin.ts
@@ -7,7 +7,8 @@ export const myPlugin: RsbuildPlugin = {
       return code.replace('red', 'blue');
     });
 
-    api.transform({ test: /\.js$/ }, ({ code }) => {
+    api.transform({ test: /\.js$/ }, ({ code, emitFile }) => {
+      emitFile('static/hello.txt', 'hello world');
       return {
         code: code.replace('hello', 'world'),
       };

--- a/packages/core/src/rspack/transformLoader.ts
+++ b/packages/core/src/rspack/transformLoader.ts
@@ -1,5 +1,5 @@
 import type { LoaderContext } from '@rspack/core';
-import type { RspackSourceMap } from '@rsbuild/shared';
+import type { TransformContext, RspackSourceMap } from '@rsbuild/shared';
 
 export default async function transform(
   this: LoaderContext<{ id: string }>,
@@ -25,6 +25,7 @@ export default async function transform(
     resourcePath: this.resourcePath,
     resourceQuery: this.resourceQuery,
     addDependency: this.addDependency,
+    emitFile: this.emitFile as TransformContext['emitFile'],
   });
 
   if (result === null || result === undefined) {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -176,7 +176,7 @@ type TransformResult =
       map?: string | RspackSourceMap | null;
     };
 
-export type TransformHandler = (context: {
+export type TransformContext = {
   /**
    * The code of the module.
    */
@@ -199,10 +199,27 @@ export type TransformHandler = (context: {
   /**
    * Add an additional file as the dependency.
    * The file will be watched and changes to the file will trigger rebuild.
-   * @param file The absolute path of the module.
+   * @param file The absolute path of the module
    */
   addDependency: (file: string) => void;
-}) => MaybePromise<TransformResult>;
+  /**
+   * Emits a file to the build output.
+   * @param name file name of the asset
+   * @param content the source of the asset
+   * @param sourceMap source map of the asset
+   * @param assetInfo additional asset information
+   */
+  emitFile: (
+    name: string,
+    content: string | Buffer,
+    sourceMap?: string,
+    assetInfo?: Record<string, any>,
+  ) => void;
+};
+
+export type TransformHandler = (
+  context: TransformContext,
+) => MaybePromise<TransformResult>;
 
 export type TransformFn = (
   descriptor: {


### PR DESCRIPTION
## Summary

Add emitFile to transform API:

```js
api.transform({ test: /\.js$/ }, ({ code, emitFile }) => {
  emitFile('static/hello.txt', 'hello world');

  return {
    code: code.replace('hello', 'world'),
  };
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
