### PR TITLE
docs: generate both rss and atom types

### DIFF
--- a/packages/document/docs/en/index.md
+++ b/packages/document/docs/en/index.md
@@ -1,7 +1,9 @@
 ---
 pageType: home
 
-link-rss: releases
+link-rss: 
+  - releases-rss
+  - releases-atom
 
 hero:
   name: Rsbuild

--- a/packages/document/docs/zh/index.md
+++ b/packages/document/docs/zh/index.md
@@ -1,7 +1,9 @@
 ---
 pageType: home
 
-link-rss: releases-zh
+link-rss:
+  - releases-rss-zh
+  - releases-atom-zh
 
 hero:
   name: Rsbuild

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -13,16 +13,39 @@ export default defineConfig({
       siteUrl: 'https://rsbuild.dev',
       feed: [
         {
-          id: 'releases',
+          id: 'releases-rss',
           test: '/community/releases/v',
           title: 'Rsbuild Releases',
-          language: 'en-US',
+          language: 'en',
+          output: {
+            type: 'rss',
+          },
         },
         {
-          id: 'releases-zh',
+          id: 'releases-atom',
+          test: '/community/releases/v',
+          title: 'Rsbuild Releases',
+          language: 'en',
+          output: {
+            type: 'atom',
+            filename: 'releases-atom.xml',
+          },
+        },
+        {
+          id: 'releases-rss-zh',
           test: '/zh/community/releases/v',
           title: 'Rsbuild Releases',
           language: 'zh-CN',
+        },
+        {
+          id: 'releases-atom-zh',
+          test: '/zh/community/releases/v',
+          title: 'Rsbuild Releases',
+          language: 'zh-CN',
+          output: {
+            type: 'atom',
+            filename: 'releases-atom-zh.xml',
+          },
         },
       ],
     }),

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
           language: 'en',
           output: {
             type: 'rss',
+            filename: 'releases-rss.xml',
           },
         },
         {
@@ -28,7 +29,6 @@ export default defineConfig({
           language: 'en',
           output: {
             type: 'atom',
-            filename: 'releases-atom.xml',
           },
         },
         {
@@ -36,6 +36,10 @@ export default defineConfig({
           test: '/zh/community/releases/v',
           title: 'Rsbuild Releases',
           language: 'zh-CN',
+          output: {
+            type: 'rss',
+            filename: 'releases-rss-zh.xml',
+          },
         },
         {
           id: 'releases-atom-zh',
@@ -44,7 +48,6 @@ export default defineConfig({
           language: 'zh-CN',
           output: {
             type: 'atom',
-            filename: 'releases-atom-zh.xml',
           },
         },
       ],


### PR DESCRIPTION
## Summary

Generate both rss and atom types to support more RSS readers, such as https://www.inoreader.com/

## Related Links

https://github.com/web-infra-dev/rspress/issues/828

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
