### PR TITLE
fix: skip prenonnect when HTML is disabled

### DIFF
--- a/packages/core/src/plugins/networkPerformance.ts
+++ b/packages/core/src/plugins/networkPerformance.ts
@@ -1,36 +1,35 @@
+import { isHtmlDisabled } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginNetworkPerformance = (): RsbuildPlugin => ({
   name: 'rsbuild:network-performance',
 
   setup(api) {
-    api.modifyBundlerChain(
-      async (chain, { CHAIN_ID, isServer, isWebWorker, isServiceWorker }) => {
-        const config = api.getNormalizedConfig();
-        const {
-          performance: { dnsPrefetch, preconnect },
-        } = config;
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
+      const config = api.getNormalizedConfig();
+      const {
+        performance: { dnsPrefetch, preconnect },
+      } = config;
 
-        if (isServer || isWebWorker || isServiceWorker) {
-          return;
-        }
+      if (isHtmlDisabled(config, target)) {
+        return;
+      }
 
-        const { HtmlNetworkPerformancePlugin } = await import(
-          '../rspack/HtmlNetworkPerformancePlugin'
-        );
+      const { HtmlNetworkPerformancePlugin } = await import(
+        '../rspack/HtmlNetworkPerformancePlugin'
+      );
 
-        if (dnsPrefetch) {
-          chain
-            .plugin(CHAIN_ID.PLUGIN.HTML_DNS_PREFETCH)
-            .use(HtmlNetworkPerformancePlugin, [dnsPrefetch, 'dnsPrefetch']);
-        }
+      if (dnsPrefetch) {
+        chain
+          .plugin(CHAIN_ID.PLUGIN.HTML_DNS_PREFETCH)
+          .use(HtmlNetworkPerformancePlugin, [dnsPrefetch, 'dnsPrefetch']);
+      }
 
-        if (preconnect) {
-          chain
-            .plugin(CHAIN_ID.PLUGIN.HTML_PRECONNECT)
-            .use(HtmlNetworkPerformancePlugin, [preconnect, 'preconnect']);
-        }
-      },
-    );
+      if (preconnect) {
+        chain
+          .plugin(CHAIN_ID.PLUGIN.HTML_PRECONNECT)
+          .use(HtmlNetworkPerformancePlugin, [preconnect, 'preconnect']);
+      }
+    });
   },
 });


### PR DESCRIPTION
## Summary

Skip `performance.prenonnect` and `performance.dnsPrefetch` when HTML is disabled.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
