### PR TITLE
fix: avoid adding unexpected trailing slash to href

### DIFF
--- a/e2e/cases/html-tags/basic/index.test.ts
+++ b/e2e/cases/html-tags/basic/index.test.ts
@@ -11,7 +11,14 @@ test('should inject tags correctly', async () => {
   const indexHtml =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
-  expect(indexHtml.match(/foo\.js/)).toBeTruthy();
-  expect(indexHtml.match(/src="https:\/\/www\.cdn\.com\/foo\.js/)).toBeTruthy();
-  expect(indexHtml.match(/content="origin"/)).toBeTruthy();
+  expect(indexHtml.includes('<script src="/foo.js"></script>')).toBeTruthy();
+  expect(
+    indexHtml.includes('<script src="https://www.cdn.com/foo.js"></script>'),
+  ).toBeTruthy();
+  expect(
+    indexHtml.includes('<meta name="referrer" content="origin">'),
+  ).toBeTruthy();
+  expect(
+    indexHtml.includes('<link ref="preconnect" href="https://example.com">'),
+  ).toBeTruthy();
 });

--- a/e2e/cases/html-tags/basic/rsbuild.config.ts
+++ b/e2e/cases/html-tags/basic/rsbuild.config.ts
@@ -6,6 +6,10 @@ export default {
       { tag: 'script', attrs: { src: 'bar.js' }, append: false },
       { tag: 'script', attrs: { src: 'baz.js' }, append: false },
       { tag: 'meta', attrs: { name: 'referrer', content: 'origin' } },
+      {
+        tag: 'link',
+        attrs: { ref: 'preconnect', href: 'https://example.com' },
+      },
     ],
   },
 };

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -25,7 +25,8 @@ export const withPublicPath = (str: string, base: string) => {
   // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
   try {
-    return new URL(str).toString();
+    new URL(str).toString();
+    return str;
   } catch {}
 
   if (base.startsWith('http')) {


### PR DESCRIPTION
## Summary

- Input:

```js
export default defineConfig({
  html: {
    tags: [
      {
        tag: 'link',
        attrs: {
          rel: 'preconnect',
          href: 'https://example.com',
        },
      },
    ],
  },
});
```

- Current output:

```html
<link ref="preconnect" href="https://example.com/">
```

- Expected output:

```html
<link ref="preconnect" href="https://example.com">
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
