### PR TITLE
test(e2e): add case for package.json#imports

### DIFF
--- a/e2e/cases/resolve-pkg-imports/index.test.ts
+++ b/e2e/cases/resolve-pkg-imports/index.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test';
+import { dev, build, gotoPage } from '@e2e/helper';
+
+test('should resolve package.json#imports correctly in dev build', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+  });
+
+  await gotoPage(page, rsbuild);
+  const foo = page.locator('#foo');
+  await expect(foo).toHaveText('foo');
+  const test = page.locator('#test');
+  await expect(test).toHaveText('test');
+
+  await rsbuild.close();
+});
+
+test('should resolve package.json#imports correctly in prod build', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+  });
+
+  await gotoPage(page, rsbuild);
+
+  const foo = page.locator('#foo');
+  await expect(foo).toHaveText('foo');
+  const test = page.locator('#test');
+  await expect(test).toHaveText('test');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/resolve-pkg-imports/package.json
+++ b/e2e/cases/resolve-pkg-imports/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@e2e/resolve-pkg-imports",
+  "version": "1.0.0",
+  "imports": {
+    "#foo": "./src/foo.js",
+    "#common/*": "./src/common/*.js"
+  }
+}

--- a/e2e/cases/resolve-pkg-imports/src/common/test.js
+++ b/e2e/cases/resolve-pkg-imports/src/common/test.js
@@ -1,0 +1,1 @@
+export const test = 'test';

--- a/e2e/cases/resolve-pkg-imports/src/foo.js
+++ b/e2e/cases/resolve-pkg-imports/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo';

--- a/e2e/cases/resolve-pkg-imports/src/index.js
+++ b/e2e/cases/resolve-pkg-imports/src/index.js
@@ -1,0 +1,12 @@
+import { foo } from '#foo';
+import { test } from '#common/test';
+
+const fooEl = document.createElement('div');
+fooEl.id = foo;
+fooEl.innerHTML = foo;
+document.body.appendChild(fooEl);
+
+const testEl = document.createElement('div');
+testEl.id = test;
+testEl.innerHTML = test;
+document.body.appendChild(testEl);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,8 @@ importers:
         specifier: ^15.7.12
         version: 15.7.12
 
+  e2e/cases/resolve-pkg-imports: {}
+
   e2e/cases/rsdoctor/mock: {}
 
   e2e/cases/server/custom-server:


### PR DESCRIPTION
## Summary

Add E2E case for package.json#imports.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/2000
- https://nodejs.org/docs/latest/api/packages.html#imports

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
