### PR TITLE
feat: support apply some stats options

### DIFF
--- a/e2e/cases/stats/stats-options/index.test.ts
+++ b/e2e/cases/stats/stats-options/index.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test';
+import { build, proxyConsole } from '@e2e/helper';
+
+test('should log warning by default', async () => {
+  const { restore, logs } = proxyConsole();
+
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {},
+  });
+
+  expect(
+    logs.some((log) =>
+      log.includes('Using / for division outside of calc() is deprecated'),
+    ),
+  );
+
+  restore();
+});
+
+test('should not log warning when set stats.warnings false', async () => {
+  const { restore, logs } = proxyConsole();
+
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      tools: {
+        bundlerChain: (chain) => {
+          chain.stats({
+            warnings: false,
+          });
+        },
+      },
+    },
+  });
+
+  expect(
+    logs.some((log) =>
+      log.includes('Using / for division outside of calc() is deprecated'),
+    ),
+  ).toBeFalsy();
+
+  restore();
+});

--- a/e2e/cases/stats/stats-options/src/App.scss
+++ b/e2e/cases/stats/stats-options/src/App.scss
@@ -1,0 +1,3 @@
+body {
+  font-size: 50 / 16 * 1px;
+}

--- a/e2e/cases/stats/stats-options/src/index.tsx
+++ b/e2e/cases/stats/stats-options/src/index.tsx
@@ -1,0 +1,2 @@
+import './App.scss';
+

--- a/packages/compat/webpack/src/core/createCompiler.ts
+++ b/packages/compat/webpack/src/core/createCompiler.ts
@@ -9,6 +9,7 @@ import {
 } from '@rsbuild/shared';
 import {
   formatStats,
+  getStatsOptions,
   getDevMiddleware,
   type InternalContext,
 } from '@rsbuild/core/provider';
@@ -38,7 +39,7 @@ export async function createCompiler({
     | Rspack.MultiCompiler;
 
   const done = async (stats: unknown) => {
-    const { message, level } = formatStats(stats as Stats);
+    const { message, level } = formatStats(stats as Stats, getStatsOptions(compiler));
 
     if (level === 'error') {
       logger.error(message);

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -106,6 +106,8 @@ async function printFileSizes(
       const origin = stats.toJson({
         all: false,
         assets: true,
+        // TODO: need supported in rspack
+        // @ts-expect-error
         cachedAssets: true,
         groupAssetsByInfo: false,
         groupAssetsByPath: false,

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -19,6 +19,7 @@ import type { InternalContext } from '../types';
 import type { StatsCompilation } from '@rspack/core';
 import {
   formatStats,
+  getStatsOptions,
   rspackMinVersion,
   isSatisfyRspackVersion,
 } from './shared';
@@ -98,7 +99,7 @@ export async function createCompiler({
       }
     }
 
-    const { message, level } = formatStats(stats);
+    const { message, level } = formatStats(stats, getStatsOptions(compiler));
 
     if (level === 'error') {
       logger.error(message);

--- a/packages/core/src/provider/index.ts
+++ b/packages/core/src/provider/index.ts
@@ -8,7 +8,7 @@ export { getPluginAPI } from './initPlugins';
 export { applyBaseCSSRule, applyCSSModuleRule } from './plugins/css';
 export type { InternalContext } from '../types';
 export { setHTMLPlugin, getHTMLPlugin } from './htmlPluginUtil';
-export { formatStats } from './shared';
+export { formatStats, getStatsOptions } from './shared';
 export { getChainUtils } from './rspackConfig';
 export { applySwcDecoratorConfig } from './plugins/swc';
 export { getDevMiddleware } from './devMiddleware';

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -223,7 +223,7 @@ export function getStatsOptions(
     } as unknown as StatsValue;
   }
 
-  return compiler.options ? compiler.options.stats as StatsValue: undefined;
+  return compiler.options ? compiler.options.stats as StatsValue : undefined;
 }
 
 export function formatStats(

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -175,6 +175,10 @@ function formatErrorMessage(errors: string[]) {
     color.red(isTerserError ? 'Minify error: ' : 'Compile error: '),
   );
 
+  if (!errors.length) {
+    return `${title}\n${color.yellow(`For more details, please setting 'stats.errors: true' `)}`;
+  }
+
   const tip = color.yellow(
     isTerserError
       ? 'Failed to minify with terser, check for syntax errors.'
@@ -241,17 +245,18 @@ export function formatStats(
     warnings: getAllStatsWarnings(statsData),
   });
 
-  if (errors.length) {
+  if (stats.hasErrors()) {
     return {
       message: formatErrorMessage(errors),
       level: 'error',
     };
   }
 
-  if (warnings.length) {
+  if (stats.hasWarnings()) {
     const title = color.bold(color.yellow('Compile Warning: \n'));
+
     return {
-      message: `${title}${`${warnings.join('\n\n')}\n`}`,
+      message: `${title}${`${warnings.join('\n\n') || color.yellow("For more details, please setting 'stats.warnings: true'")}\n`}`,
       level: 'warning',
     };
   }

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path';
 import {
   color,
   getSharedPkgCompiledPath,
+  isMultiCompiler,
   type Stats,
   type MultiStats,
   type SharedCompiledPkgNames,
@@ -11,7 +12,7 @@ import { fse } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 import { awaitableGetter, type Plugins } from '@rsbuild/shared';
 import { formatStatsMessages } from '../client/formatStats';
-import type { StatsCompilation } from '@rspack/core';
+import type { StatsCompilation, StatsValue } from '@rspack/core';
 
 export const applyDefaultPlugins = (plugins: Plugins) =>
   awaitableGetter<RsbuildPlugin>([
@@ -207,11 +208,33 @@ export const getAllStatsWarnings = (statsData: StatsCompilation) => {
   return statsData.warnings;
 };
 
-export function formatStats(stats: Stats | MultiStats) {
-  const statsData = stats.toJson({
-    preset: 'errors-warnings',
-    children: true,
-  });
+export function getStatsOptions(
+  compiler: Parameters<typeof isMultiCompiler>[0],
+): StatsValue | undefined {
+  if (isMultiCompiler(compiler)) {
+    return {
+      children: compiler.compilers.map((compiler) =>
+        compiler.options ? compiler.options.stats : undefined,
+      ),
+    } as unknown as StatsValue;
+  }
+
+  return compiler.options ? compiler.options.stats as StatsValue: undefined;
+}
+
+export function formatStats(
+  stats: Stats | MultiStats,
+  options: StatsValue = {},
+) {
+  const statsData = stats.toJson(
+    typeof options === 'object'
+      ? {
+          preset: 'errors-warnings',
+          children: true,
+          ...options,
+        }
+      : options,
+  );
 
   const { errors, warnings } = formatStatsMessages({
     errors: getAllStatsErrors(statsData),

--- a/packages/shared/src/types/stats.ts
+++ b/packages/shared/src/types/stats.ts
@@ -1,27 +1,17 @@
 import type {
   Compilation,
-  StatsOptions as RspackStatsOptions,
+  StatsValue,
   StatsCompilation,
 } from '@rspack/core';
 
 export type { StatsError, StatsAsset } from '@rspack/core';
 
-type StatsOptions = RspackStatsOptions & {
-  /** Rspack not support below opts */
-  cachedAssets?: boolean;
-  groupAssetsByInfo?: boolean;
-  groupAssetsByPath?: boolean;
-  groupAssetsByChunk?: boolean;
-  groupAssetsByExtension?: boolean;
-  groupAssetsByEmitStatus?: boolean;
-};
-
 export declare class Stats {
   constructor(statsJson: any);
   hasErrors(): boolean;
   hasWarnings(): boolean;
-  toJson(opts?: StatsOptions): StatsCompilation;
-  toString(opts?: StatsOptions): string;
+  toJson(opts?: StatsValue): StatsCompilation;
+  toString(opts?: StatsValue): string;
   compilation: Compilation;
 }
 
@@ -29,6 +19,6 @@ export declare class MultiStats {
   stats: Stats[];
   hasErrors(): boolean;
   hasWarnings(): boolean;
-  toJson(options?: StatsOptions): StatsCompilation;
-  toString(options?: StatsOptions): string;
+  toJson(options?: StatsValue): StatsCompilation;
+  toString(options?: StatsValue): string;
 }


### PR DESCRIPTION
## Summary

some [stats options](https://www.rspack.dev/config/stats.html) can be worked in Rsbuild, such as stats.preset / errors / warnings / children. 

default value:

```
{
  preset: 'errors-warnings',
  children: true,
}
```

before:
<img width="959" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/2d3ac496-64a3-4b71-8746-6832c0ca3f5e">


after:
<img width="768" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/b281458d-d20a-446b-b3f5-6899c720c731">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
