### PR TITLE
test(e2e): add case for jsconfig#paths

### DIFF
--- a/e2e/cases/source/jsconfig-paths/index.test.ts
+++ b/e2e/cases/source/jsconfig-paths/index.test.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+
+rspackOnlyTest(
+  'tsconfig paths should work and override the alias config',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      rsbuildConfig: {
+        source: {
+          alias: {
+            '@common': './src/common2',
+          },
+          tsconfigPath: './jsconfig.json',
+        },
+      },
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('tsconfig paths worked');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'tsconfig paths should not work when aliasStrategy is "prefer-alias"',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      rsbuildConfig: {
+        source: {
+          alias: {
+            '@/common': './src/common2',
+          },
+          aliasStrategy: 'prefer-alias',
+          tsconfigPath: './jsconfig.json',
+        },
+      },
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const foo = page.locator('#foo');
+    await expect(foo).toHaveText('source.alias worked');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/source/jsconfig-paths/jsconfig.json
+++ b/e2e/cases/source/jsconfig-paths/jsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/common/*": ["./src/common/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/source/jsconfig-paths/src/common/test.js
+++ b/e2e/cases/source/jsconfig-paths/src/common/test.js
@@ -1,0 +1,1 @@
+export const content = 'tsconfig paths worked';

--- a/e2e/cases/source/jsconfig-paths/src/common2/test.js
+++ b/e2e/cases/source/jsconfig-paths/src/common2/test.js
@@ -1,0 +1,1 @@
+export const content = 'source.alias worked';

--- a/e2e/cases/source/jsconfig-paths/src/index.js
+++ b/e2e/cases/source/jsconfig-paths/src/index.js
@@ -1,0 +1,12 @@
+import { content } from '@/common/test';
+
+const testAliasEl = document.createElement('div');
+testAliasEl.id = 'foo';
+testAliasEl.innerHTML = content;
+document.body.appendChild(testAliasEl);
+
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);


### PR DESCRIPTION
## Summary

Add case for jsconfig#paths, see #2000

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2000

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
