### PR TITLE
test(e2e/plugin-babel): babel/decorator test -> rspackOnlyTest

### DIFF
--- a/e2e/cases/babel/decorator/index.test.ts
+++ b/e2e/cases/babel/decorator/index.test.ts
@@ -1,78 +1,81 @@
-import test, { expect } from '@playwright/test';
-import { build, gotoPage } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
-test('should support legacy decorators and source.decorators.version in TypeScript', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    runServer: true,
-    plugins: [pluginBabel()],
-  });
+rspackOnlyTest(
+  'should support legacy decorators and source.decorators.version in TypeScript',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [pluginBabel()],
+    });
 
-  await gotoPage(page, rsbuild);
-  expect(await page.evaluate('window.aaa')).toBe('hello');
-  expect(await page.evaluate('window.bbb')).toBe('world');
-  expect(await page.evaluate('window.FooService')).toBeTruthy();
-  await rsbuild.close();
-});
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.aaa')).toBe('hello');
+    expect(await page.evaluate('window.bbb')).toBe('world');
+    expect(await page.evaluate('window.FooService')).toBeTruthy();
+    await rsbuild.close();
+  },
+);
 
-test('should support legacy decorators and source.decorators.version in JavaScript', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    runServer: true,
-    plugins: [pluginBabel()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          index: './src/jsIndex.js',
+rspackOnlyTest(
+  'should support legacy decorators and source.decorators.version in JavaScript',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [pluginBabel()],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: './src/jsIndex.js',
+          },
         },
       },
-    },
-  });
+    });
 
-  await gotoPage(page, rsbuild);
-  expect(await page.evaluate('window.aaa')).toBe('hello');
-  expect(await page.evaluate('window.bbb')).toBe('world');
-  expect(await page.evaluate('window.FooService')).toBeTruthy();
-  await rsbuild.close();
-});
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.aaa')).toBe('hello');
+    expect(await page.evaluate('window.bbb')).toBe('world');
+    expect(await page.evaluate('window.FooService')).toBeTruthy();
+    await rsbuild.close();
+  },
+);
 
-test('should work together with user custom @babel/preset-env config', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    runServer: true,
-    plugins: [
-      pluginBabel({
-        babelLoaderOptions(_, { addPresets }) {
-          addPresets([
-            [
-              '@babel/preset-env',
-              {
-                include: ['@babel/plugin-transform-class-properties'],
-              },
-            ],
-          ]);
-        },
-      }),
-    ],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          index: './src/jsIndex.js',
+rspackOnlyTest(
+  'should work together with user custom @babel/preset-env config',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      plugins: [
+        pluginBabel({
+          babelLoaderOptions(_, { addPresets }) {
+            addPresets([
+              [
+                '@babel/preset-env',
+                {
+                  include: ['@babel/plugin-transform-class-properties'],
+                },
+              ],
+            ]);
+          },
+        }),
+      ],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: './src/jsIndex.js',
+          },
         },
       },
-    },
-  });
+    });
 
-  await gotoPage(page, rsbuild);
-  expect(await page.evaluate('window.aaa')).toBe('hello');
-  expect(await page.evaluate('window.bbb')).toBe('world');
-  expect(await page.evaluate('window.FooService')).toBeTruthy();
-  await rsbuild.close();
-});
+    await gotoPage(page, rsbuild);
+    expect(await page.evaluate('window.aaa')).toBe('hello');
+    expect(await page.evaluate('window.bbb')).toBe('world');
+    expect(await page.evaluate('window.FooService')).toBeTruthy();
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/babel/decorator/src/jsIndex.js
+++ b/e2e/cases/babel/decorator/src/jsIndex.js
@@ -1,4 +1,4 @@
-import { FooService } from './decorator';
+import { FooService } from './jsDecorator';
 
 console.log(FooService);
 


### PR DESCRIPTION
## Summary
1. small fix: import the file 'jsDecorator.js'
2. test -> rspackOnlyTest
in webpack we use [uni-builder:babel](https://github.com/web-infra-dev/modern.js/blob/8a63297a72e93fc23335fbaae5aaed4a9cd693ae/packages/cli/uni-builder/src/webpack/plugins/babel.ts#L40) instead of @rsbuild/plugin-babel and already be tested [here](https://github.com/web-infra-dev/rsbuild/blob/a9a8eb085a286e135e4691d8b41ca080d74fcade/packages/babel-preset/tests/node.test.ts#L25)

## Related Links
no
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
