### PR TITLE
docs: add reading jsconfig.json guide

### DIFF
--- a/packages/document/docs/en/guide/migration/cra.mdx
+++ b/packages/document/docs/en/guide/migration/cra.mdx
@@ -229,6 +229,20 @@ In the Rsbuild project, you can remove the dependency and code related to react-
 
 You can read [Browser Compatibility](/guide/advanced/browser-compatibility) to understand how Rsbuild handles polyfills.
 
+## Reading jsconfig.json
+
+In non-TypeScript projects, CRA supports reading the `paths` field in jsconfig.json as the path alias.
+
+If you want to use this feature in Rsbuild, you can set the [source.tsconfigPath](/config/source/tsconfig-path) option, so that Rsbuild can recognize the `paths` field in jsconfig.json.
+
+```js title="rsbuild.config.mjs"
+export default {
+  source: {
+    tsconfigPath: './jsconfig.json',
+  },
+};
+```
+
 ## CRACO Migration
 
 If your project is using [CRACO](https://craco.js.org) to override CRA configuration, you can refer to the table below for migration:

--- a/packages/document/docs/zh/guide/migration/cra.mdx
+++ b/packages/document/docs/zh/guide/migration/cra.mdx
@@ -229,6 +229,20 @@ CRA 提供了 [react-app-polyfill](https://www.npmjs.com/package/react-app-polyf
 
 你可以参考 [浏览器兼容性](/guide/advanced/browser-compatibility) 来了解 Rsbuild 是如何处理 polyfill 的。
 
+## 读取 jsconfig.json
+
+在非 TypeScript 项目中，CRA 支持读取 jsconfig.json 中的 `paths` 字段作为路径别名。
+
+如果你需要在 Rsbuild 中使用该特性，可以使用 [source.tsconfigPath](/config/source/tsconfig-path) 选项，使 Rsbuild 能够识别 jsconfig.json 中的 `paths` 字段。
+
+```js title="rsbuild.config.mjs"
+export default {
+  source: {
+    tsconfigPath: './jsconfig.json',
+  },
+};
+```
+
 ## CRACO 迁移
 
 如果你的项目使用了 [CRACO](https://craco.js.org) 来覆盖 CRA 的配置，可以参考下表来迁移：


### PR DESCRIPTION
## Summary

Add reading jsconfig.json guide to CRA migration guide.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2000

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
