### PR TITLE
fix: allow to use error overlay when hmr is disabled

### DIFF
--- a/packages/core/src/client/hmr/createSocketUrl.ts
+++ b/packages/core/src/client/hmr/createSocketUrl.ts
@@ -1,19 +1,14 @@
-type ParsedSearch = {
-  host: string;
-  port: string;
-  path: string;
-  protocol?: 'ws' | 'wss';
-};
+import type { ClientConfig } from '@rsbuild/shared';
 
 /**
  * hmr socket connect path
  */
 export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
-export function createSocketUrl(options: Record<string, string> = {}) {
+export function createSocketUrl(options: ClientConfig = {}) {
   const currentLocation = self.location;
 
-  return getSocketUrl(options as ParsedSearch, currentLocation);
+  return getSocketUrl(options, currentLocation);
 }
 
 export function formatURL({
@@ -41,7 +36,7 @@ export function formatURL({
   return `${protocol}${colon}//${hostname}:${port}${pathname}`;
 }
 
-function getSocketUrl(urlParts: ParsedSearch, location: Location) {
+function getSocketUrl(urlParts: ClientConfig, location: Location) {
   const { host, port, path, protocol } = urlParts;
 
   return formatURL({

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -2,7 +2,7 @@
  * This has been adapted from `create-react-app`, authored by Facebook, Inc.
  * see: https://github.com/facebookincubator/create-react-app/tree/master/packages/react-dev-utils
  *
- * Tips: this package will be bundled and running in the browser, do not import from the entry of @rsbuild/core.
+ * Tips: this package will be bundled and running in the browser, do not import any Node.js modules.
  */
 import type { StatsError, ClientConfig } from '@rsbuild/shared';
 import { formatStatsMessages } from '../formatStats';

--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -4,11 +4,11 @@
  *
  * Tips: this package will be bundled and running in the browser, do not import from the entry of @rsbuild/core.
  */
-import type { StatsError } from '@rsbuild/shared';
+import type { StatsError, ClientConfig } from '@rsbuild/shared';
 import { formatStatsMessages } from '../formatStats';
 import { createSocketUrl } from './createSocketUrl';
 
-const options = RSBUILD_HMR_OPTIONS;
+const options: ClientConfig = RSBUILD_CLIENT_CONFIG;
 
 // Connect to Dev Server
 const socketUrl = createSocketUrl(options);
@@ -30,15 +30,15 @@ function clearOutdatedErrors() {
 }
 
 let createOverlay: undefined | ((err: string[]) => void);
-let clearOverlay: undefined | (() => void);   
+let clearOverlay: undefined | (() => void);
 
 export const registerOverlay = (options: {
-  createOverlay: ((err: string[]) => void);
-  clearOverlay: (() => void)
+  createOverlay: (err: string[]) => void;
+  clearOverlay: () => void;
 }) => {
   createOverlay = options.createOverlay;
   clearOverlay = options.clearOverlay;
-}
+};
 
 // Successful compilation.
 function handleSuccess() {

--- a/packages/core/src/client/hmr/types.d.ts
+++ b/packages/core/src/client/hmr/types.d.ts
@@ -1,5 +1,5 @@
 declare let module: any;
 
-declare let RSBUILD_HMR_OPTIONS: Record<string, any>;
+declare let RSBUILD_CLIENT_CONFIG: ClientConfig;
 
 declare let __webpack_hash__: string;

--- a/packages/core/src/provider/devMiddleware.ts
+++ b/packages/core/src/provider/devMiddleware.ts
@@ -10,22 +10,22 @@ import type { Compiler, MultiCompiler } from '@rspack/core';
 
 function applyHMREntry({
   compiler,
-  hmrClientPaths,
-  RSBUILD_HMR_OPTIONS,
+  clientPaths,
+  clientConfig = {},
 }: {
   compiler: Compiler;
-  hmrClientPaths: string[];
-  RSBUILD_HMR_OPTIONS: DevConfig['client'];
+  clientPaths: string[];
+  clientConfig: DevConfig['client'];
 }) {
   if (!isClientCompiler(compiler)) {
     return;
   }
 
   new compiler.webpack.DefinePlugin({
-    RSBUILD_HMR_OPTIONS: JSON.stringify(RSBUILD_HMR_OPTIONS),
+    RSBUILD_CLIENT_CONFIG: JSON.stringify(clientConfig),
   }).apply(compiler);
 
-  for (const clientPath of hmrClientPaths) {
+  for (const clientPath of clientPaths) {
     new compiler.webpack.EntryPlugin(compiler.context, clientPath, {
       name: undefined,
     }).apply(compiler);
@@ -35,15 +35,14 @@ function applyHMREntry({
 export const getDevMiddleware =
   (multiCompiler: Compiler | MultiCompiler): NonNullable<DevMiddleware> =>
   (options) => {
-    const { hmrClientPaths, RSBUILD_HMR_OPTIONS, callbacks, ...restOptions } =
-      options;
+    const { clientPaths, clientConfig, callbacks, ...restOptions } = options;
 
     const setupCompiler = (compiler: Compiler) => {
-      if (hmrClientPaths) {
+      if (clientPaths) {
         applyHMREntry({
           compiler,
-          hmrClientPaths,
-          RSBUILD_HMR_OPTIONS,
+          clientPaths,
+          clientConfig,
         });
       }
       // register hooks for each compilation, update socket stats if recompiled

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -20,6 +20,15 @@ export type ServerAPIs = {
   ) => void;
 };
 
+export type ClientConfig = {
+  path?: string;
+  port?: string;
+  host?: string;
+  protocol?: 'ws' | 'wss';
+  /** Shows an overlay in the browser when there are compiler errors. */
+  overlay?: boolean;
+};
+
 export interface DevConfig {
   /**
    * Whether to enable Hot Module Replacement.
@@ -48,16 +57,8 @@ export interface DevConfig {
    * Whether to display progress bar during compilation.
    */
   progressBar?: boolean | ProgressBarConfig;
-
-  /** config of hmr client. */
-  client?: {
-    path?: string;
-    port?: string;
-    host?: string;
-    protocol?: 'ws' | 'wss';
-    /** Shows an overlay in the browser when there are compiler errors. */
-    overlay?: boolean;
-  };
+  /** config of Rsbuild client code. */
+  client?: ClientConfig;
   /** Provides the ability to execute a custom function and apply custom middlewares */
   setupMiddlewares?: Array<
     (

--- a/packages/shared/src/types/server.ts
+++ b/packages/shared/src/types/server.ts
@@ -1,6 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
-import type { NextFunction, RequestHandler, ServerAPIs, DevConfig } from './config/dev';
+import type {
+  NextFunction,
+  RequestHandler,
+  ServerAPIs,
+  DevConfig,
+} from './config/dev';
 import type { RspackCompiler, RspackMultiCompiler } from './rspack';
 import type { Server as ConnectServer } from '../../compiled/connect';
 
@@ -21,8 +26,8 @@ export type MiddlewareCallbacks = {
 
 export type DevMiddlewareOptions = {
   /** To ensure HMR works, the devMiddleware need inject the hmr client path into page when HMR enable. */
-  hmrClientPaths?: string[];
-  RSBUILD_HMR_OPTIONS: DevConfig['client'];
+  clientPaths?: string[];
+  clientConfig: DevConfig['client'];
   publicPath?: string;
 
   /** The options need by compiler middleware (like webpackMiddleware) */


### PR DESCRIPTION
## Summary

Allow to use error overlay when hmr is disabled:

```js
export default defineConfig({
  dev: {
    client: {
      overlay: true,
    },
    hmr: false,
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
