### PR TITLE
feat: enable error overlay by default

### DIFF
--- a/e2e/cases/server/overlay/rsbuild.config.ts
+++ b/e2e/cases/server/overlay/rsbuild.config.ts
@@ -3,9 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  dev: {
-    client: {
-      overlay: true
-    }
-  }
 });

--- a/packages/core/src/provider/config.ts
+++ b/packages/core/src/provider/config.ts
@@ -40,6 +40,9 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
   liveReload: true,
   assetPrefix: DEFAULT_ASSET_PREFIX,
   startUrl: false,
+  client: {
+    overlay: true,
+  },
 });
 
 const getDefaultServerConfig = (): NormalizedServerConfig => ({

--- a/packages/document/docs/en/config/dev/client.mdx
+++ b/packages/document/docs/en/config/dev/client.mdx
@@ -16,7 +16,6 @@ type Client = {
   host?: string;
   /**
    * Shows overlay in the browser when there are compiler errors
-   *
    * This feature requires the current browser version to support [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
    */
   overlay?: boolean;
@@ -32,7 +31,7 @@ const defaultConfig = {
   port: '',
   host: location.hostname,
   protocol: location.protocol === 'https:' ? 'wss' : 'ws',
-  overlay: false,
+  overlay: true,
 };
 ```
 

--- a/packages/document/docs/zh/config/dev/client.mdx
+++ b/packages/document/docs/zh/config/dev/client.mdx
@@ -16,7 +16,6 @@ type Client = {
   host?: string;
   /**
    * 当出现编译错误时，在浏览器中显示遮盖
-   *
    * 该功能需要当前浏览器版本支持 [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)
    */
   overlay?: boolean;
@@ -32,7 +31,7 @@ const defaultConfig = {
   port: '',
   host: location.hostname,
   protocol: location.protocol === 'https:' ? 'wss' : 'ws',
-  overlay: false,
+  overlay: true,
 };
 ```
 


### PR DESCRIPTION
## Summary


Starting from v0.6, the default value of `dev.client.overlay` is `true`. This means that the error overlay is displayed by default when there are compilation errors.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/bef558ba-5ce2-415d-a5ca-e1730f427b5c)

You can disable it by setting `dev.client.overlay` to `false`:

```js
// rsbuild.config.ts
export default defineConfig({
  dev: {
    client: {
      overlay: false,
    },
  },
});
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/1970

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
