### PR TITLE
test(e2e): fix unstable server.port case

### DIFF
--- a/e2e/cases/server/dev.test.ts
+++ b/e2e/cases/server/dev.test.ts
@@ -85,49 +85,6 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
   await rsbuild.close();
 });
 
-test('dev.port & output.distPath', async ({ page }) => {
-  const errors: string[] = [];
-  page.on('pageerror', (err) => errors.push(err.message));
-
-  const rsbuild = await dev({
-    cwd: join(fixtures, 'basic'),
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      dev: {
-        writeToDisk: true,
-      },
-      server: {
-        port: 3000,
-      },
-      output: {
-        distPath: {
-          root: 'dist-1',
-          js: 'aa/js',
-        },
-      },
-    },
-  });
-
-  await gotoPage(page, rsbuild);
-
-  expect(rsbuild.port).toBe(3000);
-
-  expect(
-    fse.existsSync(join(fixtures, 'basic/dist-1/index.html')),
-  ).toBeTruthy();
-
-  expect(fse.existsSync(join(fixtures, 'basic/dist-1/aa/js'))).toBeTruthy();
-
-  const locator = page.locator('#test');
-  await expect(locator).toHaveText('Hello Rsbuild!');
-
-  await rsbuild.close();
-
-  expect(errors).toEqual([]);
-
-  await fse.remove(join(fixtures, 'basic/dist-1'));
-});
-
 rspackOnlyTest(
   'hmr should work when setting dev.port & client',
   async ({ page }) => {

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test';
 import { dev, getRandomPort, gotoPage } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should allow to set port via server.port', async ({ page }) => {
   const errors: string[] = [];
@@ -9,11 +8,7 @@ test('should allow to set port via server.port', async ({ page }) => {
   const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
-    plugins: [pluginReact()],
     rsbuildConfig: {
-      dev: {
-        writeToDisk: true,
-      },
       server: {
         port,
       },

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+import { dev, getRandomPort, gotoPage } from '@e2e/helper';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+test('should allow to set port via server.port', async ({ page }) => {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+
+  const port = await getRandomPort();
+  const rsbuild = await dev({
+    cwd: __dirname,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      dev: {
+        writeToDisk: true,
+      },
+      server: {
+        port,
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  expect(rsbuild.port).toBe(port);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+
+  expect(errors).toEqual([]);
+});

--- a/e2e/cases/server/port/src/index.js
+++ b/e2e/cases/server/port/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);


### PR DESCRIPTION
## Summary

Fix the unstable server.port case:

<img width="894" alt="Screenshot 2024-04-10 at 12 01 39" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/0c54deb4-aa05-4f5f-854a-605bee503f57">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
