### PR TITLE
Release v0.6.0

### DIFF
--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-esbuild/package.json
+++ b/packages/compat/plugin-esbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-esbuild",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Esbuild plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/document",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Shared documentation of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/monorepo-utils",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "The monorepo utils of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-mdx",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Mdx plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -57,7 +57,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-toml",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "TOML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-yaml",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "YAML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.5.9"
+    "@rsbuild/core": "workspace:^0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsbuild/prebundle",
   "private": true,
-  "version": "0.5.9",
+  "version": "0.6.0",
   "main": "./dist/index.js",
   "scripts": {
     "dev": "tsc --watch",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.5.9",
+  "version": "0.6.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@rsbuild/tsconfig",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "private": true
 }


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.6.0 -->

## What's Changed
### Notable Changes
* feat: bump Rspack v0.6.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2049
* feat: enable error overlay by default by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2050
* feat: switch default server port to 3000 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2043

see [Breaking changes in Rsbuild v0.6.0](https://github.com/web-infra-dev/rsbuild/discussions/1970) for more details.

### New Features 🎉
* feat: support apply some stats options by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2021
* feat: compat with Rspack 0.6 CSS modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/1985
* feat: only inject overlay code when dev.client.overlay is enabled by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2016
* feat(devServer): support add etag header by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2041
* feat: support for Vue3 JSX HMR by @liyincode in https://github.com/web-infra-dev/rsbuild/pull/2018
### Bug Fixes 🐞
* fix: allow to use error overlay when hmr is disabled by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2045
### Document 📖
* docs: add rspack-examples to intro page by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2022
* docs: add reading jsconfig.json guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2038
* docs(plugin-eslint): fix incorrect description by @scout9ll in https://github.com/web-infra-dev/rsbuild/pull/2042
* docs: add the transform plugin API by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2051
* docs: update URL of some design resoureces by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2054
### Other Changes
* chore(deps): update dependency css-loader to v6.11.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2024
* chore(deps): update dependency nx to ^18.2.3 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2025
* chore: use .gitignore for biome ignore list by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2029
* chore(deps): update dependency postcss-modules-scope to v3.2.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2027
* chore(workflow): replace ls-lint with Biome rule by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2030
* test(e2e): fix confusing decorator error logs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2031
* test(e2e): add case for jsconfig#paths by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2032
* test(e2e/mjs-artifact): add pluginLightningcss and pluginUmd by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/2034
* test(e2e/plugin-babel): babel/decorator test -> rspackOnlyTest by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/2033
* chore(deps): update dependency sass to ^1.74.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2028
* chore(deps): update dependency postcss-modules-extract-imports to v3.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2026
* chore: update prebundled packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2039
* test(ut): add case for plugin dag sort by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2047
* test(e2e): add case for client.overlay by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2048
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2023
* chore(core): reduce internal exports by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2052
* test(e2e): fix unstable server.port case by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2053

## New Contributors
* @scout9ll made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2042
* @liyincode made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2018

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.5.9...v0.6.0