### PR TITLE
fix: change rspack min version to 0.6.0

### DIFF
--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -52,8 +52,8 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     import('./plugins/rspackProfile').then((m) => m.pluginRspackProfile()),
   ]);
 
-// apply builtin:swc-loader
-export const rspackMinVersion = '0.5.0';
+// apply CSS modules generator
+export const rspackMinVersion = '0.6.0';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -52,7 +52,7 @@ export const applyDefaultPlugins = (plugins: Plugins) =>
     import('./plugins/rspackProfile').then((m) => m.pluginRspackProfile()),
   ]);
 
-// apply CSS modules generator
+// depend on CSS modules generator config
 export const rspackMinVersion = '0.6.0';
 
 const compareSemver = (version1: string, version2: string) => {


### PR DESCRIPTION
## Summary

Change rspack min version to 0.6.0 because Rsbuild now uses the new CSS modules generator config.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
