### PR TITLE
chore(plugin-lightningcss): remove @rspack/core devDependencies

### DIFF
--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -30,7 +30,6 @@
     "lightningcss": "^1.24.1"
   },
   "devDependencies": {
-    "@rspack/core": "0.6.0",
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "16.x",

--- a/packages/plugin-lightningcss/src/loader.ts
+++ b/packages/plugin-lightningcss/src/loader.ts
@@ -3,7 +3,7 @@
  * MIT License https://github.com/fz6m/lightningcss-loader/blob/main/LICENSE
  * Author @fz6m
  */
-import type { LoaderContext } from '@rspack/core';
+import type { Rspack } from '@rsbuild/shared';
 import { transform as _transform } from 'lightningcss';
 import { Buffer } from 'node:buffer';
 import type { LightningCSSLoaderOptions } from './types';
@@ -11,7 +11,7 @@ import type { LightningCSSLoaderOptions } from './types';
 const LOADER_NAME = 'lightningcss-loader';
 
 async function LightningCSSLoader(
-  this: LoaderContext<LightningCSSLoaderOptions>,
+  this: Rspack.LoaderContext<LightningCSSLoaderOptions>,
   source: string,
   prevMap?: Record<string, any>,
 ): Promise<void> {

--- a/packages/plugin-lightningcss/src/minimizer.ts
+++ b/packages/plugin-lightningcss/src/minimizer.ts
@@ -6,7 +6,7 @@
 import { transform as _transform } from 'lightningcss';
 import { Buffer } from 'node:buffer';
 import { CSS_REGEX } from '@rsbuild/shared';
-import type { Compilation, Compiler } from '@rspack/core';
+import type { Rspack } from '@rsbuild/shared';
 import type { LightningCSSMinifyPluginOptions } from './types';
 
 const PLUGIN_NAME = 'lightningcss-minify-plugin';
@@ -32,7 +32,7 @@ export class LightningCSSMinifyPlugin {
     this.options = opts;
   }
 
-  apply(compiler: Compiler) {
+  apply(compiler: Rspack.Compiler) {
     compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
       compilation.hooks.processAssets.tapPromise(
         {
@@ -54,7 +54,9 @@ export class LightningCSSMinifyPlugin {
     });
   }
 
-  private async transformAssets(compilation: Compilation): Promise<void> {
+  private async transformAssets(
+    compilation: Rspack.Compilation,
+  ): Promise<void> {
     const {
       options: { devtool },
       webpack: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1008,9 +1008,6 @@ importers:
       '@rsbuild/core':
         specifier: link:../core
         version: link:../core
-      '@rspack/core':
-        specifier: 0.6.0
-        version: 0.6.0(@swc/helpers@0.5.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper


### PR DESCRIPTION
## Summary

replace `@rspack/core` devDependencies with `type Rspack` from `@rsbuild/shared` in `@rsbuild/plugin-lightningcss`

## Related Links

none

## Checklist

<!--- Check and mark with an "x" -->

- [x] Documentation updated (or not required).
