### PR TITLE
feat: support resourceQuery for transform API

### DIFF
--- a/packages/core/src/provider/initPlugins.ts
+++ b/packages/core/src/provider/initPlugins.ts
@@ -119,6 +119,9 @@ export function getPluginAPI({
       if (descriptor.test) {
         rule.test(descriptor.test);
       }
+      if (descriptor.resourceQuery) {
+        rule.resourceQuery(descriptor.resourceQuery);
+      }
 
       rule
         .use(id)

--- a/packages/document/docs/en/plugins/dev/core.mdx
+++ b/packages/document/docs/en/plugins/dev/core.mdx
@@ -217,6 +217,26 @@ const pluginPug = () => ({
 });
 ```
 
+### Matching Conditions
+
+The `descriptor` param supports the following matching conditions:
+
+- `test`: matches module's path (without query), the same as Rspack's [Rule.test](https://rspack.dev/config/module#ruletest).
+
+```js
+api.transform({ test: /\.pug$/ }, ({ code }) => {
+  // ...
+});
+```
+
+- `resourceQuery`: matches module's query, the same as Rspack's [Rule.resourceQuery](https://rspack.dev/config/module#ruleresourcequery).
+
+```js
+api.transform({ resourceQuery: /raw/ }, ({ code }) => {
+  // ...
+});
+```
+
 ### Difference with loader
 
 `api.transform` can be thought of as a lightweight implementation of Rspack loader. It provides a simple and easy to use API and automatically calls Rspack loader at the backend to transform the code.

--- a/packages/document/docs/zh/plugins/dev/core.mdx
+++ b/packages/document/docs/zh/plugins/dev/core.mdx
@@ -187,7 +187,7 @@ const pluginFoo = () => ({
 
 ```ts
 function Transform(
-  descriptor: { test?: RuleSetCondition | undefined },
+  descriptor: TransformDescriptor,
   handler: TransformHandler,
 ): void;
 ```
@@ -212,6 +212,26 @@ const pluginPug = () => ({
       return `${templateCode}; module.exports = template;`;
     });
   },
+});
+```
+
+### 匹配条件
+
+descriptor 参数支持传入以下匹配条件：
+
+- `test`：匹配模块的路径（不包含 query），等价于 Rspack 的 [Rule.test](https://rspack.dev/config/module#ruletest)。
+
+```js
+api.transform({ test: /\.pug$/ }, ({ code }) => {
+  // ...
+});
+```
+
+- `resourceQuery`：匹配模块的 query，等价于 Rspack 的 [Rule.resourceQuery](https://rspack.dev/config/module#ruleresourcequery)。
+
+```js
+api.transform({ resourceQuery: /raw/ }, ({ code }) => {
+  // ...
 });
 ```
 

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -221,14 +221,21 @@ export type TransformHandler = (
   context: TransformContext,
 ) => MaybePromise<TransformResult>;
 
+export type TransformDescriptor = {
+  /**
+   * Include modules that match the test assertion, the same as `rule.test`
+   * @see https://rspack.dev/config/module#ruletest
+   */
+  test?: RuleSetCondition;
+  /**
+   * A condition that matches the resource query.
+   * @see https://rspack.dev/config/module#ruleresourcequery
+   */
+  resourceQuery?: RuleSetCondition;
+};
+
 export type TransformFn = (
-  descriptor: {
-    /**
-     * Include modules that match the test assertion, the same as `rule.test`
-     * @see https://rspack.dev/config/module#ruletest
-     */
-    test?: RuleSetCondition;
-  },
+  descriptor: TransformDescriptor,
   handler: TransformHandler,
 ) => void;
 


### PR DESCRIPTION
## Summary


- `test`: matches module's path (without query), the same as Rspack's [Rule.test](https://rspack.dev/config/module#ruletest).

```js
api.transform({ test: /\.pug$/ }, ({ code }) => {
  // ...
});
```

- `resourceQuery`: matches module's query, the same as Rspack's [Rule.resourceQuery](https://rspack.dev/config/module#ruleresourcequery).

```js
api.transform({ resourceQuery: /raw/ }, ({ code }) => {
  // ...
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
