### PR TITLE
fix(plugin-solid): only enable solid-refresh when target is web

### DIFF
--- a/.changeset/many-cycles-end.md
+++ b/.changeset/many-cycles-end.md
@@ -1,0 +1,5 @@
+---
+"@rsbuild/core": patch
+---
+
+release: 0.6.2

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,6 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { SolidPresetOptions } from './types';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
+import { isUsingHMR } from '@rsbuild/shared';
 
 export type PluginSolidOptions = {
   /**
@@ -17,7 +18,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
     name: PLUGIN_SOLID_NAME,
 
     setup(api) {
-      api.modifyBundlerChain(async (chain, { CHAIN_ID, isDev }) => {
+      api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {
         const rsbuildConfig = api.getNormalizedConfig();
 
         modifyBabelLoaderOptions({
@@ -30,7 +31,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
               options.solidPresetOptions || {},
             ]);
 
-            if (isDev && rsbuildConfig.dev.hmr) {
+            if (isUsingHMR(rsbuildConfig, { isProd, target })) {
               babelOptions.plugins ??= [];
               babelOptions.plugins.push([
                 require.resolve('solid-refresh/babel'),

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -21,6 +21,9 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
                   },
                 ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-class-properties/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                ],
               ],
               "presets": [
                 [
@@ -47,6 +50,11 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
       },
     ],
   },
+  "resolve": {
+    "alias": {
+      "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",
+    },
+  },
 }
 `;
 
@@ -71,6 +79,9 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
                   },
                 ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-class-properties/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                ],
               ],
               "presets": [
                 [
@@ -93,6 +104,11 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
         ],
       },
     ],
+  },
+  "resolve": {
+    "alias": {
+      "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",
+    },
   },
 }
 `;
@@ -118,6 +134,9 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
                   },
                 ],
                 "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-transform-class-properties/lib/index.js",
+                [
+                  "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/babel.cjs",
+                ],
               ],
               "presets": [
                 [
@@ -140,6 +159,11 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
         ],
       },
     ],
+  },
+  "resolve": {
+    "alias": {
+      "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",
+    },
   },
 }
 `;

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -309,13 +309,7 @@ export function isUsingHMR(
   config: NormalizedConfig,
   { isProd, target }: Pick<ModifyChainUtils, 'isProd' | 'target'>,
 ) {
-  return (
-    !isProd &&
-    target !== 'node' &&
-    target !== 'web-worker' &&
-    target !== 'service-worker' &&
-    config.dev.hmr
-  );
+  return !isProd && config.dev.hmr && target === 'web';
 }
 
 export const isClientCompiler = (compiler: {


### PR DESCRIPTION
## Summary

Only enable solid-refresh when target is web, use the `isUsingHMR` helper to detect whether is using HMR.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
