### PR TITLE
chore: simplify default plugins typing

### DIFF
--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -14,7 +14,6 @@ import { applyDefaultPlugins } from './shared';
 import { initConfigs } from './core/initConfigs';
 
 export const webpackProvider: RsbuildProvider<'webpack'> = async ({
-  plugins,
   pluginManager,
   rsbuildOptions,
 }) => {
@@ -44,7 +43,7 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
     publicContext: createPublicContext(context),
 
     async applyDefaultPlugins() {
-      pluginManager.addPlugins(await applyDefaultPlugins(plugins));
+      pluginManager.addPlugins(await applyDefaultPlugins());
     },
 
     async initConfigs() {

--- a/packages/compat/webpack/src/shared.ts
+++ b/packages/compat/webpack/src/shared.ts
@@ -3,12 +3,12 @@ import { join } from 'node:path';
 import {
   awaitableGetter,
   getSharedPkgCompiledPath,
-  type Plugins,
   type RsbuildPlugin,
   type SharedCompiledPkgNames,
 } from '@rsbuild/shared';
+import { plugins } from '@rsbuild/core/internal';
 
-export const applyDefaultPlugins = (plugins: Plugins) =>
+export const applyDefaultPlugins = () =>
   awaitableGetter<RsbuildPlugin>([
     plugins.basic?.(),
     plugins.entry?.(),

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -5,7 +5,6 @@ import {
   type RsbuildProvider,
   type CreateRsbuildOptions,
 } from '@rsbuild/shared';
-import { plugins } from './plugins';
 import { createPluginManager } from './pluginManager';
 
 const getRspackProvider = async () => {
@@ -40,7 +39,6 @@ export async function createRsbuild(
     startDevServer,
     applyDefaultPlugins,
   } = await provider({
-    plugins,
     pluginManager,
     rsbuildOptions,
   });

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,6 +1,4 @@
-import type { Plugins } from '@rsbuild/shared';
-
-export const plugins: Plugins = {
+export const plugins = {
   basic: () => import('./basic').then((m) => m.pluginBasic()),
   html: () => import('./html').then((m) => m.pluginHtml()),
   cleanOutput: () => import('./cleanOutput').then((m) => m.pluginCleanOutput()),

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -12,7 +12,6 @@ import { applyDefaultPlugins } from './shared';
 export const rspackProvider: RsbuildProvider = async ({
   pluginManager,
   rsbuildOptions,
-  plugins,
 }) => {
   const rsbuildConfig = pickRsbuildConfig(rsbuildOptions.rsbuildConfig);
 
@@ -45,7 +44,7 @@ export const rspackProvider: RsbuildProvider = async ({
     publicContext: createPublicContext(context),
 
     async applyDefaultPlugins() {
-      pluginManager.addPlugins(await applyDefaultPlugins(plugins));
+      pluginManager.addPlugins(await applyDefaultPlugins());
     },
 
     async createDevServer(options) {

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -9,12 +9,13 @@ import {
   type StatsError,
 } from '@rsbuild/shared';
 import { fse } from '@rsbuild/shared';
+import { plugins } from '../plugins';
 import type { RsbuildPlugin } from '../types';
-import { awaitableGetter, type Plugins } from '@rsbuild/shared';
+import { awaitableGetter } from '@rsbuild/shared';
 import { formatStatsMessages } from '../client/formatStats';
 import type { StatsCompilation, StatsValue } from '@rspack/core';
 
-export const applyDefaultPlugins = (plugins: Plugins) =>
+export const applyDefaultPlugins = () =>
   awaitableGetter<RsbuildPlugin>([
     import('./plugins/transition').then((m) => m.pluginTransition()),
     plugins.basic(),

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -129,36 +129,6 @@ export type RsbuildPlugins = (
   | Promise<RsbuildPlugin | Falsy>
 )[];
 
-type PluginsFn<T = undefined> = T extends undefined
-  ? () => Promise<RsbuildPlugin>
-  : (arg: T) => Promise<RsbuildPlugin>;
-
-export type Plugins = {
-  basic: PluginsFn;
-  cleanOutput: PluginsFn;
-  startUrl: PluginsFn;
-  fileSize: PluginsFn;
-  target: PluginsFn;
-  entry: PluginsFn;
-  cache: PluginsFn;
-  splitChunks: PluginsFn;
-  inlineChunk: PluginsFn;
-  bundleAnalyzer: PluginsFn;
-  rsdoctor: PluginsFn;
-  asset: PluginsFn;
-  html: PluginsFn;
-  wasm: PluginsFn;
-  moment: PluginsFn;
-  nodeAddons: PluginsFn;
-  externals: PluginsFn;
-  networkPerformance: PluginsFn;
-  preloadOrPrefetch: PluginsFn;
-  performance: PluginsFn;
-  define: PluginsFn;
-  server: PluginsFn;
-  moduleFederation: PluginsFn;
-};
-
 export type GetRsbuildConfig = {
   (): Readonly<RsbuildConfig>;
   (type: 'original' | 'current'): Readonly<RsbuildConfig>;

--- a/packages/shared/src/types/provider.ts
+++ b/packages/shared/src/types/provider.ts
@@ -1,4 +1,4 @@
-import type { PluginManager, Plugins, RsbuildPluginAPI } from './plugin';
+import type { PluginManager, RsbuildPluginAPI } from './plugin';
 import type { RsbuildContext } from './context';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildMode, CreateRsbuildOptions } from './rsbuild';
@@ -55,7 +55,6 @@ export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {
 
 export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
   (options: {
-    plugins: Plugins;
     pluginManager: PluginManager;
     rsbuildOptions: Required<CreateRsbuildOptions>;
   }) => Promise<ProviderInstance<B>>;

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -12,11 +12,6 @@ const getRspackProvider = async () => {
   return rspackProvider;
 };
 
-export const getRsbuildPlugins = async () => {
-  const { plugins } = await import('@rsbuild/core/internal');
-  return plugins;
-};
-
 export function baseMatchLoader({
   config,
   loader,
@@ -125,7 +120,6 @@ export async function createStubRsbuild({
   } = await provider({
     pluginManager,
     rsbuildOptions,
-    plugins: await getRsbuildPlugins(),
   });
 
   if (plugins) {


### PR DESCRIPTION
## Summary

Simplify default plugins typing, we do not need to passing the default plugins list to provider and do not need to maintain the  default plugins typing.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
