### PR TITLE
chore: simplify tag interface for modifyHTMLTags

### DIFF
--- a/e2e/cases/plugin-api/plugin-modify-tags/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/myPlugin.ts
@@ -5,17 +5,13 @@ export const myPlugin: RsbuildPlugin = {
   setup(api) {
     api.modifyHTMLTags(({ headTags, bodyTags }) => {
       headTags.push({
-        tagName: 'script',
-        voidTag: false,
-        meta: {},
-        attributes: { id: 'foo', src: 'https://example.com/foo.js' },
+        tag: 'script',
+        attrs: { id: 'foo', src: 'https://example.com/foo.js' },
       });
 
       bodyTags.push({
-        tagName: 'script',
-        voidTag: false,
-        meta: {},
-        attributes: { id: 'bar', src: 'https://example.com/bar.js' },
+        tag: 'script',
+        attrs: { id: 'bar', src: 'https://example.com/bar.js' },
       });
 
       return { headTags, bodyTags };

--- a/packages/shared/src/types/config/html.ts
+++ b/packages/shared/src/types/config/html.ts
@@ -26,10 +26,13 @@ export type MetaOptions = {
   [name: string]: string | false | MetaAttrs;
 };
 
-export type HtmlTag = {
+export type HtmlBasicTag = {
   tag: string;
   attrs?: Record<string, string | boolean | null | undefined>;
   children?: string;
+};
+
+export type HtmlTag = HtmlBasicTag & {
   hash?: boolean | string | ((url: string, hash: string) => string);
   publicPath?: boolean | string | ((url: string, publicPath: string) => string);
   append?: boolean;

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -4,9 +4,8 @@ import type { NodeEnv, MaybePromise } from './utils';
 import type { RsbuildTarget } from './rsbuild';
 import type { BundlerChain } from './bundlerConfig';
 import type { Rspack, RspackConfig } from './rspack';
-import type { RsbuildConfig } from './config';
+import type { HtmlBasicTag, RsbuildConfig } from './config';
 import type { WebpackConfig } from './thirdParty';
-import type { HtmlTagObject } from 'html-webpack-plugin';
 
 export type OnBeforeBuildFn<B = 'rspack'> = (params: {
   bundlerConfigs?: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
@@ -54,8 +53,8 @@ export type OnAfterCreateCompilerFn<
 export type OnExitFn = () => void;
 
 type HTMLTags = {
-  headTags: HtmlTagObject[];
-  bodyTags: HtmlTagObject[];
+  headTags: HtmlBasicTag[];
+  bodyTags: HtmlBasicTag[];
 };
 
 export type ModifyHTMLTagsFn = (tags: HTMLTags) => MaybePromise<HTMLTags>;


### PR DESCRIPTION
## Summary

Simplify tag interface for modifyHTMLTags, align typing with `html.tags` config.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/64f80923-0818-4511-8ac3-db8afdcddd3d)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
