### PR TITLE
feat(plugin-asset-retry): support async chunk retry

### DIFF
--- a/e2e/cases/assets-retry/src/App.tsx
+++ b/e2e/cases/assets-retry/src/App.tsx
@@ -14,7 +14,7 @@ const App = () => {
         </ErrorBoundary>
       </div>
       <div style={{ border: '1px solid white', padding: 20 }}>
-        <ErrorBoundary elementId='"async-comp-test-error"'>
+        <ErrorBoundary elementId="async-comp-test-error">
           <AsyncCompTest />
         </ErrorBoundary>
       </div>

--- a/packages/plugin-assets-retry/scripts/postCompile.js
+++ b/packages/plugin-assets-retry/scripts/postCompile.js
@@ -4,9 +4,10 @@ const { transformAsync } = require('@babel/core');
 const { performance } = require('node:perf_hooks');
 
 /**
- *
+ * transform ../src/runtime/${filename}.ts
+ *  to ../dist/runtime/${filename}.js
+ * and ../dist/runtime/${filename}.min.js
  * @param {string} filename
- * @param {string} output
  */
 async function compileRuntimeFile(filename) {
   const sourceFilePath = path.join(__dirname, `../src/runtime/${filename}.ts`);

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -48,9 +48,11 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
 
   async getRetryCode() {
     const { default: serialize } = await import('serialize-javascript');
+    const filename = 'initialChunkRetry';
     const runtimeFilePath = path.join(
       __dirname,
-      this.minify ? 'runtime.min.js' : 'runtime.js',
+      'runtime',
+      this.minify ? `${filename}.min.js` : `${filename}.js`,
     );
     const runtimeCode = await fse.readFile(runtimeFilePath, 'utf-8');
     return `(function(){${runtimeCode};init(${serialize(

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -1,0 +1,92 @@
+import { fse, pick } from '@rsbuild/shared';
+import { Rspack } from '@rsbuild/shared/rspack';
+import path from 'node:path';
+import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
+import serialize from 'serialize-javascript';
+
+const { RuntimeGlobals } = Rspack;
+
+function appendWebpackScript(module: any, appendSource: string) {
+  try {
+    const originSource = module.getGeneratedCode();
+    module.getGeneratedCode = () => `${originSource}\n${appendSource}`;
+  } catch (err) {
+    console.error('Failed to modify Webpack RuntimeModule', err);
+    throw err;
+  }
+}
+
+function appendRspackScript(
+  module: any, // JsRuntimeModule type is not exported by rspack temporarily */
+  appendSource: string,
+) {
+  try {
+    const source = module.source.source.toString();
+    module.source.source = Buffer.from(`${source}\n${appendSource}`, 'utf-8');
+  } catch (err) {
+    console.error('Failed to modify Rspack RuntimeModule', err);
+    throw err;
+  }
+}
+
+class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
+  readonly name = 'ASYNC_CHUNK_RETRY_PLUGIN';
+  readonly options: PluginAssetsRetryOptions & { isRspack?: boolean };
+  readonly runtimeOptions: RuntimeRetryOptions;
+
+  constructor(options: PluginAssetsRetryOptions & { isRspack?: boolean }) {
+    this.options = options;
+    this.runtimeOptions = pick(options, [
+      'domain',
+      'max',
+      'onRetry',
+      'onSuccess',
+      'onFail',
+      'test',
+    ]);
+  }
+
+  getRawRuntimeRetryCode() {
+    const filename = 'asyncChunkRetry';
+    const minify =
+      this.options?.minify ?? process.env.NODE_ENV === 'production';
+    const runtimeFilePath = path.join(
+      __dirname,
+      'runtime',
+      minify ? `${filename}.min.js` : `${filename}.js`,
+    );
+    const rawText = fse.readFileSync(runtimeFilePath, 'utf-8');
+
+    return rawText
+      .replaceAll('__RUNTIME_GLOBALS_REQUIRE__', RuntimeGlobals.require)
+      .replaceAll(
+        '__RUNTIME_GLOBALS_ENSURE_CHUNK__',
+        RuntimeGlobals.ensureChunk,
+      )
+      .replaceAll(
+        '__RUNTIME_GLOBALS_GET_CHUNK_SCRIPT_FILENAME__',
+        RuntimeGlobals.getChunkScriptFilename,
+      )
+      .replaceAll('__RUNTIME_GLOBALS_PUBLIC_PATH__', RuntimeGlobals.publicPath)
+      .replaceAll('__RUNTIME_GLOBALS_LOAD_SCRIPT__', RuntimeGlobals.loadScript)
+      .replaceAll('__RETRY_OPTIONS__', serialize(this.runtimeOptions));
+  }
+
+  apply(compiler: Rspack.Compiler) {
+    compiler.hooks.thisCompilation.tap(this.name, (compilation) => {
+      compilation.hooks.runtimeModule.tap(this.name, (module, _chunk) => {
+        // Rspack currently does not have module.addRuntimeModule on the js side, so we insert our runtime code after PublicPathRuntimeModule
+        if (module.constructorName === 'PublicPathRuntimeModule') {
+          const runtimeCode = this.getRawRuntimeRetryCode();
+          if (this.options.isRspack === false) {
+            appendWebpackScript(module, runtimeCode);
+          } else {
+            appendRspackScript(module, runtimeCode);
+          }
+        }
+      });
+    });
+  }
+}
+
+export { AsyncChunkRetryPlugin };

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -1,8 +1,8 @@
+import path from 'node:path';
 import { fse, pick } from '@rsbuild/shared';
 import { Rspack } from '@rsbuild/shared/rspack';
-import path from 'node:path';
-import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
 import serialize from 'serialize-javascript';
+import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
 
 const { RuntimeGlobals } = Rspack;
 

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,6 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
 import type { PluginAssetsRetryOptions } from './types';
+import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
 
 export type { PluginAssetsRetryOptions };
 
@@ -39,6 +40,11 @@ export const pluginAssetsRetry = (
           HtmlPlugin,
         },
       ]);
+
+      const isRspack = api.context.bundlerType === 'rspack';
+      chain
+        .plugin(CHAIN_ID.PLUGIN.ASYNC_CHUNK_RETRY)
+        .use(AsyncChunkRetryPlugin, [{ ...options, isRspack }]);
     });
   },
 });

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
-import type { PluginAssetsRetryOptions } from './types';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
+import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
 

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -183,9 +183,10 @@ function ensureChunk(chunkId: string): Promise<unknown> {
 
     // biome-ignore lint/complexity/useArrowFunction: use function instead of () => {}
     return new Promise(function (resolve) {
-      setTimeout(() => {
-        resolve(ensureChunk(chunkId));
-      }, 300); // TODO: options to set retryDelay
+      // TODO: options to set retryDelay
+      // setTimeout(() => {
+      resolve(ensureChunk(chunkId));
+      // }, 300);
     })
       .then((result) => {
         if (typeof config.onSuccess === 'function') {

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -136,7 +136,10 @@ function ensureChunk(chunkId: string): Promise<unknown> {
   const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
 
   // mark the async chunk name in the global variables and share it with initial chunk retry
-  if (window && !window.__ASYNC_CHUNK_FILENAME_LIST__[originalScriptFilename]) {
+  if (
+    typeof window !== 'undefined' &&
+    !window.__ASYNC_CHUNK_FILENAME_LIST__[originalScriptFilename]
+  ) {
     window.__ASYNC_CHUNK_FILENAME_LIST__[originalScriptFilename] = true;
   }
 
@@ -219,7 +222,7 @@ function loadScript(
 
 function registerAsyncChunkRetry() {
   // init global variables shared with async chunk
-  if (window && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
+  if (typeof window !== 'undefined' && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
     window.__ASYNC_CHUNK_FILENAME_LIST__ = {};
   }
 

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -1,0 +1,238 @@
+import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types';
+
+type ChunkId = string; // e.g: src_AsyncCompTest_tsx
+type ChunkFilename = string; // e.g: static/js/async/src_AsyncCompTest_tsx.js
+type ChunkSrcUrl = string; // publicPath + ChunkFilename e.g: http://localhost:3000/static/js/async/src_AsyncCompTest_tsx.js
+
+type Retry = {
+  nextDomain: string;
+  nextRetryUrl: ChunkSrcUrl;
+  existRetryTimes: number;
+  originalScriptFilename: ChunkFilename;
+  originalSrcUrl: ChunkSrcUrl;
+};
+
+type RetryCollector = Record<ChunkId, Retry>;
+
+declare global {
+  // RuntimeGlobals.require
+  var __RUNTIME_GLOBALS_REQUIRE__: unknown;
+  // RuntimeGlobals.ensure
+  var __RUNTIME_GLOBALS_ENSURE_CHUNK__: (chunkId: ChunkId) => Promise<unknown>;
+  // RuntimeGlobals.getChunkScriptFilename
+  var __RUNTIME_GLOBALS_GET_CHUNK_SCRIPT_FILENAME__: (
+    chunkId: ChunkId,
+  ) => string;
+  // RuntimeGlobals.loadScript
+  var __RUNTIME_GLOBALS_LOAD_SCRIPT__: (
+    url: ChunkSrcUrl,
+    done: unknown,
+    key: string,
+    chunkId: ChunkId,
+  ) => void;
+  // RuntimeGlobals.publicPath
+  var __RUNTIME_GLOBALS_PUBLIC_PATH__: string;
+  // user options
+  var __RETRY_OPTIONS__: RuntimeRetryOptions;
+  // global variables shared with initial chunk retry runtime
+  var __ASYNC_CHUNK_FILENAME_LIST__: Record<ChunkFilename, boolean>;
+}
+
+// rsbuild/runtime/async-chunk-retry
+
+// init retryCollector and nextRetry function
+const config = __RETRY_OPTIONS__ || {};
+const maxRetries = config.max || 3;
+const retryCollector: RetryCollector = {};
+
+function findCurrentDomain(url: string) {
+  const domainList = config.domain ?? [];
+  let domain = '';
+  for (let i = 0; i < domainList.length; i++) {
+    if (url.indexOf(domainList[i]) !== -1) {
+      domain = domainList[i];
+      break;
+    }
+  }
+  return domain || url;
+}
+
+function findNextDomain(url: string) {
+  const domainList = config.domain ?? [];
+  const currentDomain = findCurrentDomain(url);
+  const index = domainList.indexOf(currentDomain);
+  return domainList[(index + 1) % domainList.length] || url;
+}
+
+// TODO: add option query to onRetry with initial chunk together
+// function getUrlRetryQuery(existRetryTimes: number): string {
+//   return `?retry-attempt=${existRetryTimes}`;
+// }
+
+function getCurrentRetry(chunkId: string): Retry | undefined {
+  return retryCollector[chunkId];
+}
+
+function initRetry(chunkId: string): Retry {
+  const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
+
+  const originalSrcUrl =
+    __RUNTIME_GLOBALS_PUBLIC_PATH__ + originalScriptFilename;
+
+  const nextDomain = config.domain?.[0] ?? __RUNTIME_GLOBALS_PUBLIC_PATH__;
+
+  const existRetryTimes = 1;
+
+  return {
+    existRetryTimes,
+    nextDomain,
+    nextRetryUrl:
+      nextDomain +
+      (nextDomain.endsWith('/') ? '' : '/') +
+      originalScriptFilename,
+    // + getUrlRetryQuery(existRetryTimes),
+
+    originalScriptFilename,
+    originalSrcUrl,
+  };
+}
+
+function nextRetry(chunkId: string): Retry {
+  const currRetry = getCurrentRetry(chunkId);
+
+  let nextRetry: Retry;
+  if (!currRetry) {
+    nextRetry = initRetry(chunkId);
+  } else {
+    const existRetryTimes = currRetry.existRetryTimes + 1;
+    const nextDomain = findNextDomain(currRetry.nextDomain);
+    nextRetry = {
+      existRetryTimes,
+      nextDomain,
+      nextRetryUrl:
+        nextDomain +
+        (nextDomain.endsWith('/') ? '' : '/') +
+        currRetry.originalScriptFilename,
+      // + getUrlRetryQuery(existRetryTimes),
+
+      originalScriptFilename: currRetry.originalScriptFilename,
+      originalSrcUrl: currRetry.originalSrcUrl,
+    };
+  }
+
+  retryCollector[chunkId] = nextRetry;
+  return nextRetry;
+}
+
+// rewrite webpack runtime with nextRetry()
+const originalEnsureChunk = __RUNTIME_GLOBALS_ENSURE_CHUNK__;
+const originalGetChunkScriptFilename =
+  __RUNTIME_GLOBALS_GET_CHUNK_SCRIPT_FILENAME__;
+const originalLoadScript = __RUNTIME_GLOBALS_LOAD_SCRIPT__;
+
+// if users want to support es5, add Promise polyfill first https://github.com/webpack/webpack/issues/12877
+function ensureChunk(chunkId: string): Promise<unknown> {
+  const result = originalEnsureChunk(chunkId);
+  const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
+
+  // mark the async chunk name in the global variables and share it with initial chunk retry
+  if (window && !window.__ASYNC_CHUNK_FILENAME_LIST__[originalScriptFilename]) {
+    window.__ASYNC_CHUNK_FILENAME_LIST__[originalScriptFilename] = true;
+  }
+
+  return result.catch(function (error: Error) {
+    const { existRetryTimes, originalSrcUrl, nextRetryUrl, nextDomain } =
+      nextRetry(chunkId);
+
+    if (existRetryTimes > maxRetries) {
+      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries.`;
+      throw error;
+    }
+
+    // Filter by config.test and config.domain
+    let tester = config.test;
+    if (tester) {
+      if (typeof tester === 'string') {
+        const regexp = new RegExp(tester);
+        tester = (str: string) => regexp.test(str);
+      }
+
+      if (typeof tester !== 'function' || !tester(nextRetryUrl)) {
+        throw error;
+      }
+    }
+
+    if (
+      config.domain &&
+      config.domain.length > 0 &&
+      config.domain.indexOf(nextDomain) === -1
+    ) {
+      throw error;
+    }
+
+    const context: AssetsRetryHookContext = {
+      times: existRetryTimes,
+      domain: nextDomain,
+      url: nextRetryUrl,
+      tagName: 'script',
+    };
+
+    if (config.onRetry && typeof config.onRetry === 'function') {
+      config.onRetry(context);
+    }
+
+    // biome-ignore lint/complexity/useArrowFunction: use function instead of () => {}
+    return new Promise(function (resolve) {
+      setTimeout(() => {
+        resolve(ensureChunk(chunkId));
+      }, 300); // TODO: options to set retryDelay
+    })
+      .then((result) => {
+        if (typeof config.onSuccess === 'function') {
+          config.onSuccess(context);
+        }
+        return result;
+      })
+      .catch((error) => {
+        if (typeof config.onFail === 'function') {
+          config.onFail(context);
+        }
+        throw error;
+      });
+  });
+}
+
+function loadScript(
+  originalUrl: ChunkSrcUrl,
+  done: unknown,
+  key: string,
+  chunkId: ChunkId,
+) {
+  const retry = getCurrentRetry(chunkId);
+  if (retry) {
+    return originalLoadScript(retry.nextRetryUrl, done, key, chunkId);
+  }
+
+  return originalLoadScript(originalUrl, done, key, chunkId);
+}
+
+function registerAsyncChunkRetry() {
+  // init global variables shared with async chunk
+  if (window && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
+    window.__ASYNC_CHUNK_FILENAME_LIST__ = {};
+  }
+
+  if (typeof __RUNTIME_GLOBALS_REQUIRE__ !== 'undefined') {
+    try {
+      __RUNTIME_GLOBALS_ENSURE_CHUNK__ = ensureChunk;
+      __RUNTIME_GLOBALS_LOAD_SCRIPT__ = loadScript;
+    } catch (e) {
+      console.error(
+        '[@rsbuild/plugin-assets-retry] Register async chunk retry runtime failed',
+        e,
+      );
+    }
+  }
+}
+
+registerAsyncChunkRetry();

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -1,9 +1,6 @@
 // rsbuild/runtime/initial-chunk-retry
 import type { CrossOrigin } from '@rsbuild/shared';
-import type {
-  AssetsRetryHookContext,
-  PluginAssetsRetryOptions,
-} from '../types';
+import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types';
 
 interface ScriptElementAttributes {
   url: string;
@@ -54,7 +51,7 @@ function getRequestUrl(element: HTMLElement) {
   return null;
 }
 
-const defaultConfig: PluginAssetsRetryOptions = {
+const defaultConfig: RuntimeRetryOptions = {
   max: 3,
   type: TYPES,
   domain: [],
@@ -62,7 +59,7 @@ const defaultConfig: PluginAssetsRetryOptions = {
 };
 
 function validateTargetInfo(
-  config: PluginAssetsRetryOptions,
+  config: RuntimeRetryOptions,
   e: Event,
 ): { target: HTMLElement; tagName: string; url: string } | false {
   const target: HTMLElement = e.target as HTMLElement;
@@ -163,7 +160,7 @@ function reloadElementResource(
   }
 }
 
-function retry(config: PluginAssetsRetryOptions, e: Event) {
+function retry(config: RuntimeRetryOptions, e: Event) {
   const targetInfo = validateTargetInfo(config, e);
   if (targetInfo === false) {
     return;
@@ -251,7 +248,7 @@ function retry(config: PluginAssetsRetryOptions, e: Event) {
   reloadElementResource(target, element, attributes);
 }
 
-function load(config: PluginAssetsRetryOptions, e: Event) {
+function load(config: RuntimeRetryOptions, e: Event) {
   const targetInfo = validateTargetInfo(config, e);
   if (targetInfo === false) {
     return;
@@ -301,8 +298,8 @@ function resourceMonitor(
 }
 
 // @ts-expect-error init is a global function, ignore ts(6133)
-function init(options: PluginAssetsRetryOptions) {
-  const config: PluginAssetsRetryOptions = {};
+function init(options: RuntimeRetryOptions) {
+  const config: RuntimeRetryOptions = {};
 
   for (const key in defaultConfig) {
     // @ts-ignore

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -170,7 +170,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
 
   // If the requested failed chunk is async chunk，skip it, because async chunk will be retried by asyncChunkRetry runtime
   if (
-    window &&
+    typeof window !== 'undefined' &&
     Object.keys(window.__ASYNC_CHUNK_FILENAME_LIST__ || {}).some(
       (chunkName) => {
         return url.indexOf(chunkName) !== -1;
@@ -324,7 +324,7 @@ function init(options: RuntimeRetryOptions) {
   }
 
   // init global variables shared with async chunk
-  if (window && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
+  if (typeof window !== 'undefined' && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
     window.__ASYNC_CHUNK_FILENAME_LIST__ = {};
   }
   // Bind event in window

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -45,6 +45,11 @@ export type PluginAssetsRetryOptions = {
   minify?: boolean;
 };
 
+export type RuntimeRetryOptions = Omit<
+  PluginAssetsRetryOptions,
+  'crossOrigin' | 'inlineScript' | 'minify'
+>;
+
 export type AssetsRetryHookContext = {
   url: string;
   times: number;

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -24,10 +24,6 @@ export type PluginAssetsRetryOptions = {
    */
   crossOrigin?: boolean | CrossOrigin;
   /**
-   * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
-   */
-  inlineScript?: boolean;
-  /**
    * The callback function when the asset is failed to be retried.
    */
   onFail?: (options: AssetsRetryHookContext) => void;
@@ -40,6 +36,10 @@ export type PluginAssetsRetryOptions = {
    */
   onSuccess?: (options: AssetsRetryHookContext) => void;
   /**
+   * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
+   */
+  inlineScript?: boolean;
+  /**
    * Whether to minify the runtime JavaScript code of Assets Retry plugin.
    */
   minify?: boolean;
@@ -47,7 +47,7 @@ export type PluginAssetsRetryOptions = {
 
 export type RuntimeRetryOptions = Omit<
   PluginAssetsRetryOptions,
-  'crossOrigin' | 'inlineScript' | 'minify'
+  'inlineScript' | 'minify'
 >;
 
 export type AssetsRetryHookContext = {

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -11,6 +11,15 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
       "name": "AssetsRetryPlugin",
       "scriptPath": "",
     },
+    AsyncChunkRetryPlugin {
+      "name": "ASYNC_CHUNK_RETRY_PLUGIN",
+      "options": {
+        "crossOrigin": false,
+        "isRspack": false,
+        "minify": true,
+      },
+      "runtimeOptions": {},
+    },
   ],
 }
 `;

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -1,5 +1,57 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugin-assets-retry > should accept user custom options 1`] = `
+{
+  "plugins": [
+    AssetsRetryPlugin {
+      "HtmlPlugin": [Function],
+      "distDir": "static/js",
+      "inlineScript": true,
+      "minify": true,
+      "name": "AssetsRetryPlugin",
+      "scriptPath": "",
+    },
+    AsyncChunkRetryPlugin {
+      "name": "ASYNC_CHUNK_RETRY_PLUGIN",
+      "options": {
+        "crossOrigin": true,
+        "domain": [
+          "/http/localhost:3003",
+          "/http/localhost:3002",
+          "/http/localhost:3001",
+          "/http/localhost:3000",
+        ],
+        "inlineScript": true,
+        "isRspack": false,
+        "max": 4,
+        "minify": true,
+        "onFail": [Function],
+        "onRetry": [Function],
+        "onSuccess": [Function],
+        "test": [Function],
+        "type": [
+          "script",
+          "link",
+        ],
+      },
+      "runtimeOptions": {
+        "domain": [
+          "/http/localhost:3003",
+          "/http/localhost:3002",
+          "/http/localhost:3001",
+          "/http/localhost:3000",
+        ],
+        "max": 4,
+        "onFail": [Function],
+        "onRetry": [Function],
+        "onSuccess": [Function],
+        "test": [Function],
+      },
+    },
+  ],
+}
+`;
+
 exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
 {
   "plugins": [
@@ -19,6 +71,58 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
         "minify": true,
       },
       "runtimeOptions": {},
+    },
+  ],
+}
+`;
+
+exports[`plugin-assets-retry > should set function options with user options 1`] = `
+{
+  "plugins": [
+    AssetsRetryPlugin {
+      "HtmlPlugin": [Function],
+      "distDir": "static/js",
+      "inlineScript": true,
+      "minify": true,
+      "name": "AssetsRetryPlugin",
+      "scriptPath": "",
+    },
+    AsyncChunkRetryPlugin {
+      "name": "ASYNC_CHUNK_RETRY_PLUGIN",
+      "options": {
+        "crossOrigin": true,
+        "domain": [
+          "/http/localhost:3003",
+          "/http/localhost:3002",
+          "/http/localhost:3001",
+          "/http/localhost:3000",
+        ],
+        "inlineScript": true,
+        "isRspack": false,
+        "max": 4,
+        "minify": true,
+        "onFail": [Function],
+        "onRetry": [Function],
+        "onSuccess": [Function],
+        "test": [Function],
+        "type": [
+          "script",
+          "link",
+        ],
+      },
+      "runtimeOptions": {
+        "domain": [
+          "/http/localhost:3003",
+          "/http/localhost:3002",
+          "/http/localhost:3001",
+          "/http/localhost:3000",
+        ],
+        "max": 4,
+        "onFail": [Function],
+        "onRetry": [Function],
+        "onSuccess": [Function],
+        "test": [Function],
+      },
     },
   ],
 }

--- a/packages/plugin-assets-retry/tests/assetsRetry.test.ts
+++ b/packages/plugin-assets-retry/tests/assetsRetry.test.ts
@@ -24,4 +24,39 @@ describe('plugin-assets-retry', () => {
 
     expect(config).toMatchSnapshot();
   });
+
+  it('should accept user custom options', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        pluginAssetsRetry({
+          max: 4,
+          inlineScript: true,
+          minify: true,
+          crossOrigin: true,
+          domain: [
+            'http://localhost:3003',
+            'http://localhost:3002',
+            'http://localhost:3001',
+            'http://localhost:3000',
+          ],
+          type: ['script', 'link'],
+          test(url) {
+            return url.includes('/static');
+          },
+          onRetry(context) {
+            console.log('Retry', context);
+          },
+          onSuccess(context) {
+            console.log('Successful retry', context);
+          },
+          onFail(context) {
+            console.log('Failed retry', context);
+          },
+        }),
+      ],
+    });
+    const config = await rsbuild.unwrapConfig();
+
+    expect(config).toMatchSnapshot();
+  });
 });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,6 +15,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./rspack": {
+      "types": "./dist/rspack.d.ts",
+      "default": "./dist/rspack.js"
+    },
     "./jiti": {
       "types": "./compiled/jiti/types/jiti.d.ts",
       "default": "./compiled/jiti/index.js"

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -212,7 +212,7 @@ export const CHAIN_ID = {
     SUBRESOURCE_INTEGRITY: 'subresource-integrity',
     /** AssetsRetryPlugin */
     ASSETS_RETRY: 'assets-retry',
-    /** AssetsRetryPlugin */
+    /** AsyncChunkRetryPlugin */
     ASYNC_CHUNK_RETRY: 'async-chunk-retry',
     /** AutoSetRootFontSizePlugin */
     AUTO_SET_ROOT_SIZE: 'auto-set-root-size',

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -212,6 +212,8 @@ export const CHAIN_ID = {
     SUBRESOURCE_INTEGRITY: 'subresource-integrity',
     /** AssetsRetryPlugin */
     ASSETS_RETRY: 'assets-retry',
+    /** AssetsRetryPlugin */
+    ASYNC_CHUNK_RETRY: 'async-chunk-retry',
     /** AutoSetRootFontSizePlugin */
     AUTO_SET_ROOT_SIZE: 'auto-set-root-size',
     /** VueLoader15PitchFixPlugin */

--- a/packages/shared/src/rspack.ts
+++ b/packages/shared/src/rspack.ts
@@ -1,0 +1,3 @@
+import Rspack from '@rspack/core';
+
+export { Rspack };


### PR DESCRIPTION
## Summary

1. implement asyncChunkRetry rspack plugin based on compilation.hooks.runtimeModule https://github.com/web-infra-dev/rspack/pull/5370
2. design based on https://github.com/mattlewis92/webpack-retry-chunk-load-plugin

## Design
We will rewrite `__webpack_require__.ensureChunk` and `__webpack_require.loadScript` to achieve this feature.

1. `__webpack_require__.ensureChunk` is a way how webpack loads async chunks and it returns a promise. We intercepted the error of this Promise.
2. `__webpack_require__.loadScript` is to calculate the request url and it defines the `src` of `<script>` and we intercepted the url calculation


## Related Links

close #91
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
