### PR TITLE
docs: update assets domain

### DIFF
--- a/packages/document/docs/en/community/releases/v0-1.mdx
+++ b/packages/document/docs/en/community/releases/v0-1.mdx
@@ -6,7 +6,7 @@ published_at: 2023-11-22 08:00:00
 
 > November 22, 2023
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-1.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-1.png)
 
 We are pleased to announce **the release of** **[Rsbuild](https://github.com/web-infra-dev/rsbuild)** **v0.1!**
 

--- a/packages/document/docs/en/community/releases/v0-2.mdx
+++ b/packages/document/docs/en/community/releases/v0-2.mdx
@@ -6,7 +6,7 @@ published_at: 2023-12-11 08:00:00
 
 > December 11, 2023
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-2.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-2.png)
 
 The Rsbuild v0.2 contains some incompatible API changes. Please refer to the current documentation for upgrading.
 

--- a/packages/document/docs/en/community/releases/v0-3.mdx
+++ b/packages/document/docs/en/community/releases/v0-3.mdx
@@ -6,7 +6,7 @@ published_at: 2024-01-10 08:00:00
 
 > January 10, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-3.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-3.png)
 
 Rsbuild v0.3 version has upgraded Rspack to v0.5 and now supports Module Federation. In addition, it includes some incompatible API changes. Please refer to the current documentation for upgrading.
 

--- a/packages/document/docs/en/community/releases/v0-4.mdx
+++ b/packages/document/docs/en/community/releases/v0-4.mdx
@@ -6,7 +6,7 @@ published_at: 2024-02-06 08:00:00
 
 > February 06, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-4.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-4.png)
 
 Rsbuild v0.4 provides built-in support for module federation. It also contains some incompatible API updates. Please refer to the current document for upgrading.
 

--- a/packages/document/docs/en/community/releases/v0-5.mdx
+++ b/packages/document/docs/en/community/releases/v0-5.mdx
@@ -6,7 +6,7 @@ published_at: 2024-03-19 08:00:00
 
 > March 19, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-5.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-5.png)
 
 Rsbuild v0.5 is an important milestone. As of this release, most of the Rsbuild API has reached a stable state and we expect to release Rsbuild v1.0 in Q3 2024.
 

--- a/packages/document/docs/en/community/releases/v0-6.mdx
+++ b/packages/document/docs/en/community/releases/v0-6.mdx
@@ -6,7 +6,7 @@ published_at: 2024-04-10 18:00:00
 
 > April 10, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-6.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-6.png)
 
 Rsbuild v0.6 has been released along with Rspack v0.6!
 
@@ -32,7 +32,7 @@ In the new version, Rspack has enabled the new tree shaking algorithm by default
 
 Starting from Rsbuild v0.6, the default value of [dev.client.overlay](/config/dev/client) has been adjusted to `true`. This means that when a compilation error occurs, Rsbuild will pop up the error overlay by default to display the error information:
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/assets/rsbuild-error-overlay.png)
+![](https://assets.rspack.dev/rsbuild/assets/rsbuild-error-overlay.png)
 
 If you do not need this feature, you can set `dev.client.overlay` to `false` to disable it.
 

--- a/packages/document/docs/en/index.md
+++ b/packages/document/docs/en/index.md
@@ -17,7 +17,7 @@ hero:
       text: Quick Start
       link: /guide/start/quick-start
   image:
-    src: https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-logo.svg
+    src: https://assets.rspack.dev/rsbuild/rsbuild-logo.svg
     alt: Rsbuild Logo
 
 features:

--- a/packages/document/docs/zh/community/releases/v0-1.mdx
+++ b/packages/document/docs/zh/community/releases/v0-1.mdx
@@ -6,7 +6,7 @@ published_at: 2023-11-22 08:00:00
 
 > November 22, 2023
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-1.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-1.png)
 
 我们很高兴地宣布 **[Rsbuild](https://github.com/web-infra-dev/rsbuild)** **v0.1** 的发布！
 

--- a/packages/document/docs/zh/community/releases/v0-2.mdx
+++ b/packages/document/docs/zh/community/releases/v0-2.mdx
@@ -6,7 +6,7 @@ published_at: 2023-12-11 08:00:00
 
 > December 11, 2023
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-2.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-2.png)
 
 Rsbuild v0.2 版本包含一些 API 的不兼容更新，请参考当前文档进行升级。
 

--- a/packages/document/docs/zh/community/releases/v0-3.mdx
+++ b/packages/document/docs/zh/community/releases/v0-3.mdx
@@ -6,7 +6,7 @@ published_at: 2024-01-10 08:00:00
 
 > January 10, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-3.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-3.png)
 
 Rsbuild v0.3 版本升级 Rspack 到 v0.5 并支持了模块联邦。此外，还包含一些 API 的不兼容更新，请参考当前文档进行升级。
 

--- a/packages/document/docs/zh/community/releases/v0-4.mdx
+++ b/packages/document/docs/zh/community/releases/v0-4.mdx
@@ -6,7 +6,7 @@ published_at: 2024-02-06 08:00:00
 
 > February 06, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-4.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-4.png)
 
 Rsbuild v0.4 版本提供内置的模块联邦支持。此外，还包含一些 API 的不兼容更新，请参考当前文档进行升级。
 

--- a/packages/document/docs/zh/community/releases/v0-5.mdx
+++ b/packages/document/docs/zh/community/releases/v0-5.mdx
@@ -6,7 +6,7 @@ published_at: 2024-03-19 08:00:00
 
 > March 19, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-5.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-5.png)
 
 Rsbuild v0.5 是一个重要的里程碑，从该版本开始，Rsbuild 的绝大部分 API 已经达到稳定状态，我们预计在 2024 年 Q3 发布 Rsbuild v1.0。
 

--- a/packages/document/docs/zh/community/releases/v0-6.mdx
+++ b/packages/document/docs/zh/community/releases/v0-6.mdx
@@ -6,7 +6,7 @@ published_at: 2024-04-10 18:00:00
 
 > April 10, 2024
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-banner-v0-6.png)
+![](https://assets.rspack.dev/rsbuild/rsbuild-banner-v0-6.png)
 
 Rsbuild v0.6 已与 Rspack v0.6 同步发布！
 
@@ -32,7 +32,7 @@ Rsbuild 已将依赖的 Rspack 升级至 v0.6 版本，并适配了 Rspack v0.6 
 
 从 Rsbuild v0.6 开始，[dev.client.overlay](/config/dev/client) 的默认值调整为 `true`。这意味着当出现编译错误时，Rsbuild 将默认弹出 error overlay 来展示错误信息：
 
-![](https://rsfamily-design-resources.netlify.app/rsbuild/assets/rsbuild-error-overlay.png)
+![](https://assets.rspack.dev/rsbuild/assets/rsbuild-error-overlay.png)
 
 如果你不需要此功能，可以将 `dev.client.overlay` 设置为 `false` 来禁用：
 

--- a/packages/document/docs/zh/index.md
+++ b/packages/document/docs/zh/index.md
@@ -17,7 +17,7 @@ hero:
       text: 快速上手
       link: /zh/guide/start/quick-start
   image:
-    src: https://rsfamily-design-resources.netlify.app/rsbuild/rsbuild-logo.svg
+    src: https://assets.rspack.dev/rsbuild/rsbuild-logo.svg
     alt: Rsbuild Logo
 
 features:

--- a/packages/document/rspress.config.ts
+++ b/packages/document/rspress.config.ts
@@ -57,11 +57,10 @@ export default defineConfig({
   lang: 'en',
   base: '/',
   title: 'Rsbuild',
-  icon: 'https://rsfamily-design-resources.netlify.app/rsbuild/favicon-128x128.png',
+  icon: 'https://assets.rspack.dev/rsbuild/favicon-128x128.png',
   logo: {
-    light:
-      'https://rsfamily-design-resources.netlify.app/rsbuild/navbar-logo-light.png',
-    dark: 'https://rsfamily-design-resources.netlify.app/rsbuild/navbar-logo-dark.png',
+    light: 'https://assets.rspack.dev/rsbuild/navbar-logo-light.png',
+    dark: 'https://assets.rspack.dev/rsbuild/navbar-logo-dark.png',
   },
   markdown: {
     checkDeadLinks: true,


### PR DESCRIPTION
## Summary

Use `https://assets.rspack.dev/` to host assets. The `rsfamily-design-resources.netlify.app` is no longer used because it might be blocked in some areas.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
