### PR TITLE
chore(@rsbuild/shared): set logger.level in isDebug() function

### DIFF
--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -11,6 +11,7 @@ export const isDebug = () => {
     return false;
   }
 
+  logger.level = 'verbose'; // support `process.env.DEBUG` in e2e
   const values = process.env.DEBUG.toLocaleLowerCase().split(',');
   return ['rsbuild', 'builder', '*'].some((key) => values.includes(key));
 };


### PR DESCRIPTION
## Summary


<!--- Provide links of related issues or pages -->
https://github.com/web-infra-dev/rsbuild/blob/00a598f0095fd53cb309102757a58c89f416107b/packages/shared/src/logger.ts#L3-L8

logger.level is set too early to be affected by `process.env.DEBUG`

So it cannot be used like this

```ts
import { build } from '@rsbuild/core';

function main() {
	process.env.DEBUG = 'rsbuild';
	build();
	process.env.DEBUG = ''
}
main()
```

and in some cases of devServer e2e, we need some logs of the server


## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2115


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated not required.
- [x] Documentation updated not required
