### PR TITLE
perf: use Rspack native IgnorePlugin

### DIFF
--- a/packages/compat/webpack/src/core/webpackConfig.ts
+++ b/packages/compat/webpack/src/core/webpackConfig.ts
@@ -145,6 +145,7 @@ export async function generateWebpackConfig({
   const {
     BannerPlugin,
     DefinePlugin,
+    IgnorePlugin,
     ProvidePlugin,
     HotModuleReplacementPlugin,
   } = await import('webpack');
@@ -154,6 +155,7 @@ export async function generateWebpackConfig({
     bundler: {
       BannerPlugin,
       DefinePlugin,
+      IgnorePlugin,
       ProvidePlugin,
       HotModuleReplacementPlugin,
     },

--- a/packages/core/src/plugins/moment.ts
+++ b/packages/core/src/plugins/moment.ts
@@ -1,72 +1,17 @@
-import type { RspackPluginInstance, Compiler } from '@rspack/core';
 import type { RsbuildPlugin } from '../types';
-
-type IgnorePluginOptions = {
-  /**
-   * A RegExp to test the context (directory) against.
-   */
-  contextRegExp?: RegExp;
-  /**
-   * A RegExp to test the request against.
-   */
-  resourceRegExp: RegExp;
-};
-
-/**
- * modified from https://github.com/webpack/webpack/blob/main/lib/IgnorePlugin.js
- * MIT License http://www.opensource.org/licenses/mit-license.php
- * Author Tobias Koppers @sokra
- * TODO: remove this plugin after Rspack provides IgnorePlugin
- */
-class IgnorePlugin implements RspackPluginInstance {
-  options: IgnorePluginOptions;
-
-  constructor(options: IgnorePluginOptions) {
-    this.options = options;
-
-    this.checkIgnore = this.checkIgnore.bind(this);
-  }
-
-  checkIgnore(resolveData: any) {
-    if (
-      'resourceRegExp' in this.options &&
-      this.options.resourceRegExp &&
-      this.options.resourceRegExp.test(resolveData.request)
-    ) {
-      if ('contextRegExp' in this.options && this.options.contextRegExp) {
-        // if "contextRegExp" is given,
-        // both the "resourceRegExp" and "contextRegExp" have to match.
-        if (this.options.contextRegExp.test(resolveData.context)) {
-          return false;
-        }
-      } else {
-        return false;
-      }
-    }
-  }
-
-  apply(compiler: Compiler) {
-    compiler.hooks.normalModuleFactory.tap('IgnorePlugin', (nmf) => {
-      nmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
-    });
-    compiler.hooks.contextModuleFactory.tap('IgnorePlugin', (cmf) => {
-      cmf.hooks.beforeResolve.tap('IgnorePlugin', this.checkIgnore);
-    });
-  }
-}
 
 export const pluginMoment = (): RsbuildPlugin => ({
   name: 'rsbuild:moment',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain) => {
+    api.modifyBundlerChain(async (chain, { bundler }) => {
       const config = api.getNormalizedConfig();
 
       if (config.performance.removeMomentLocale) {
         // Moment.js includes a lots of locale data by default.
         // We can using IgnorePlugin to allow the user to opt into importing specific locales.
         // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-        chain.plugin('remove-moment-locale').use(IgnorePlugin, [
+        chain.plugin('remove-moment-locale').use(bundler.IgnorePlugin, [
           {
             resourceRegExp: /^\.\/locale$/,
             contextRegExp: /moment$/,

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -118,6 +118,7 @@ export async function generateRspackConfig({
   const {
     BannerPlugin,
     DefinePlugin,
+    IgnorePlugin,
     ProvidePlugin,
     HotModuleReplacementPlugin,
   } = await import('@rspack/core');
@@ -127,6 +128,7 @@ export async function generateRspackConfig({
     bundler: {
       BannerPlugin,
       DefinePlugin,
+      IgnorePlugin,
       ProvidePlugin,
       HotModuleReplacementPlugin,
     },

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -12,8 +12,8 @@ import { fse } from '@rsbuild/shared';
 import { formatStatsMessages } from '../client/formatStats';
 import type { StatsCompilation, StatsValue } from '@rspack/core';
 
-// depend on CSS modules generator config
-export const rspackMinVersion = '0.6.0';
+// depend on native IgnorePlugin
+export const rspackMinVersion = '0.6.2';
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/document/docs/en/plugins/dev/hooks.mdx
+++ b/packages/document/docs/en/plugins/dev/hooks.mdx
@@ -262,6 +262,7 @@ type ModifyBundlerChainUtils = {
   bundler: {
     BannerPlugin: rspack.BannerPlugin;
     DefinePlugin: rspack.DefinePlugin;
+    IgnorePlugin: rspack.IgnorePlugin;
     ProvidePlugin: rspack.ProvidePlugin;
     HotModuleReplacementPlugin: rspack.HotModuleReplacementPlugin;
   };

--- a/packages/document/docs/zh/plugins/dev/hooks.mdx
+++ b/packages/document/docs/zh/plugins/dev/hooks.mdx
@@ -264,6 +264,7 @@ type ModifyBundlerChainUtils = {
   bundler: {
     BannerPlugin: rspack.BannerPlugin;
     DefinePlugin: rspack.DefinePlugin;
+    IgnorePlugin: rspack.IgnorePlugin;
     ProvidePlugin: rspack.ProvidePlugin;
     HotModuleReplacementPlugin: rspack.HotModuleReplacementPlugin;
   };

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -94,6 +94,7 @@ export type ModifyBundlerChainUtils = ModifyChainUtils & {
   bundler: {
     BannerPlugin: PluginInstance;
     DefinePlugin: PluginInstance;
+    IgnorePlugin: PluginInstance;
     ProvidePlugin: PluginInstance;
     HotModuleReplacementPlugin: PluginInstance;
   };


### PR DESCRIPTION
## Summary

Use Rspack native IgnorePlugin instead of the current JS plugin.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6166

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
