### PR TITLE
fix: failed access globalThis in legacy browsers

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -1,4 +1,4 @@
-import { registerOverlay } from './hmr'
+import { registerOverlay } from './hmr';
 
 function stripAnsi(content: string) {
   const pattern = [
@@ -163,7 +163,7 @@ const overlayTemplate = `
 const {
   HTMLElement = class {} as typeof globalThis.HTMLElement,
   customElements,
-} = globalThis;
+} = typeof window === 'object' ? window : globalThis;
 
 class ErrorOverlay extends HTMLElement {
   constructor(message: string[]) {

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -163,7 +163,7 @@ const overlayTemplate = `
 const {
   HTMLElement = class {} as typeof globalThis.HTMLElement,
   customElements,
-} = typeof window === 'object' ? window : globalThis;
+} = typeof window !== 'undefined' ? window : globalThis;
 
 class ErrorOverlay extends HTMLElement {
   constructor(message: string[]) {


### PR DESCRIPTION
## Summary

Fix failed access globalThis in legacy browsers, use window instead.

## Related Links

https://caniuse.com/?search=globalThis

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
