### PR TITLE
feat(plugin-react): enable support for profiling React in prod env

### DIFF
--- a/e2e/cases/react/enable-profiler/index.test.ts
+++ b/e2e/cases/react/enable-profiler/index.test.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { build, gotoPage } from '@e2e/helper';
+
+const fixtures = __dirname;
+
+test('should render element with enabled profiler correctly', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    runServer: true,
+  });
+
+  await gotoPage(page, rsbuild);
+
+  const testEl = page.locator('#test');
+  await expect(testEl).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/react/enable-profiler/rsbuild.config.ts
+++ b/e2e/cases/react/enable-profiler/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      enableProfiler: true,
+    }),
+  ],
+});

--- a/e2e/cases/react/enable-profiler/src/App.jsx
+++ b/e2e/cases/react/enable-profiler/src/App.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const App = () => <div id="test">Hello Rsbuild!</div>;
+
+export default App;

--- a/e2e/cases/react/enable-profiler/src/index.js
+++ b/e2e/cases/react/enable-profiler/src/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import type { SwcReactConfig } from '@rsbuild/shared';
 import { applySplitChunksRule } from './splitChunks';
-import { applyBasicReactSupport } from './react';
+import { applyBasicReactSupport, applyReactProfiler } from './react';
 
 export type SplitReactChunkOptions = {
   /**
@@ -28,18 +28,24 @@ export type PluginReactOptions = {
    * Configuration for chunk splitting of React-related dependencies.
    */
   splitChunks?: SplitReactChunkOptions;
+  enableReactProfiler?: boolean;
 };
 
 export const PLUGIN_REACT_NAME = 'rsbuild:react';
 
-export const pluginReact = (
-  options: PluginReactOptions = {},
-): RsbuildPlugin => ({
+export const pluginReact = ({
+  enableReactProfiler = false,
+  ...options
+}: PluginReactOptions = {}): RsbuildPlugin => ({
   name: PLUGIN_REACT_NAME,
 
   setup(api) {
     if (api.context.bundlerType === 'rspack') {
       applyBasicReactSupport(api, options);
+
+      if (enableReactProfiler) {
+        applyReactProfiler(api);
+      }
     }
 
     applySplitChunksRule(api, options?.splitChunks);

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -2,6 +2,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 import type { SwcReactConfig } from '@rsbuild/shared';
 import { applySplitChunksRule } from './splitChunks';
 import { applyBasicReactSupport, applyReactProfiler } from './react';
+import { getNodeEnv } from '@rsbuild/shared';
 
 export type SplitReactChunkOptions = {
   /**
@@ -40,10 +41,12 @@ export const pluginReact = ({
   name: PLUGIN_REACT_NAME,
 
   setup(api) {
+    const isEnvProductionProfile =
+      enableReactProfiler && getNodeEnv() === 'production';
     if (api.context.bundlerType === 'rspack') {
       applyBasicReactSupport(api, options);
 
-      if (enableReactProfiler) {
+      if (isEnvProductionProfile) {
         applyReactProfiler(api);
       }
     }

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -29,20 +29,20 @@ export type PluginReactOptions = {
    * Configuration for chunk splitting of React-related dependencies.
    */
   splitChunks?: SplitReactChunkOptions;
-  enableReactProfiler?: boolean;
+  enableProfiler?: boolean;
 };
 
 export const PLUGIN_REACT_NAME = 'rsbuild:react';
 
 export const pluginReact = ({
-  enableReactProfiler = false,
+  enableProfiler = false,
   ...options
 }: PluginReactOptions = {}): RsbuildPlugin => ({
   name: PLUGIN_REACT_NAME,
 
   setup(api) {
     const isEnvProductionProfile =
-      enableReactProfiler && getNodeEnv() === 'production';
+      enableProfiler && getNodeEnv() === 'production';
     if (api.context.bundlerType === 'rspack') {
       applyBasicReactSupport(api, options);
 

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -75,5 +75,6 @@ export const applyReactProfiler = (api: RsbuildPluginAPI) => {
     // Replace react-dom with the profiling version.
     // Reference: https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977
     chain.resolve.alias.set('react-dom$', 'react-dom/profiling');
+    chain.resolve.alias.set('scheduler/tracing', 'scheduler/tracing-profiling');
   });
 };

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -71,8 +71,7 @@ export const applyReactProfiler = (api: RsbuildPluginAPI) => {
     return mergeRsbuildConfig(config, enableReactProfilerConfig);
   });
 
-  api.modifyBundlerChain((chain, { isProd }) => {
-    if (!isProd) return;
+  api.modifyBundlerChain((chain) => {
     // Replace react-dom with the profiling version.
     // Reference: https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977
     chain.resolve.alias.set('react-dom$', 'react-dom/profiling');

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -5,7 +5,7 @@ import {
   modifySwcLoaderOptions,
   type SwcReactConfig,
 } from '@rsbuild/shared';
-import type { RsbuildPluginAPI } from '@rsbuild/core';
+import type { RsbuildConfig, RsbuildPluginAPI } from '@rsbuild/core';
 import type { PluginReactOptions } from '.';
 
 export const applyBasicReactSupport = (
@@ -50,5 +50,31 @@ export const applyBasicReactSupport = (
     chain
       .plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)
       .use(ReactRefreshRspackPlugin, [{ include: [SCRIPT_REGEX] }]);
+  });
+};
+
+export const applyReactProfiler = (api: RsbuildPluginAPI) => {
+  api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+    const enableReactProfilerConfig: RsbuildConfig = {
+      output: {
+        minify: {
+          jsOptions: {
+            // Need to keep classnames and function names like Components for debugging purposes.
+            mangle: {
+              keep_classnames: true,
+              keep_fnames: true,
+            },
+          },
+        },
+      },
+    };
+    return mergeRsbuildConfig(config, enableReactProfilerConfig);
+  });
+
+  api.modifyBundlerChain((chain, { isProd }) => {
+    if (!isProd) return;
+    // Replace react-dom with the profiling version.
+    // Reference: https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977
+    chain.resolve.alias.set('react-dom$', 'react-dom/profiling');
   });
 };

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -55,7 +55,7 @@ export const applyBasicReactSupport = (
 
 export const applyReactProfiler = (api: RsbuildPluginAPI) => {
   api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
-    const enableReactProfilerConfig: RsbuildConfig = {
+    const enableProfilerConfig: RsbuildConfig = {
       output: {
         minify: {
           jsOptions: {
@@ -68,7 +68,7 @@ export const applyReactProfiler = (api: RsbuildPluginAPI) => {
         },
       },
     };
-    return mergeRsbuildConfig(config, enableReactProfilerConfig);
+    return mergeRsbuildConfig(config, enableProfilerConfig);
   });
 
   api.modifyBundlerChain((chain) => {

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -145,3 +145,20 @@ pluginReact({
   },
 });
 ```
+
+### enableReactProfiler
+
+When set to true, enables the React Profiler for performance analysis in production builds. Use the React DevTools to examine profiling results and identify potential performance optimizations. Profiling adds a slight overhead, so it's disabled by default in production environments.
+
+```ts title="rsbuild.config.ts"
+pluginReact({
+  // Only enable the profiler when REACT_PROFILER is true, as the option will increase the build time and adds some small additional overhead.
+  enableReactProfiler: process.env.REACT_PROFILER === 'true',
+});
+```
+
+In your env file, define `REACT_PROFILER`.
+
+```env title=".env"
+REACT_PROFILER=true
+```

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -157,8 +157,8 @@ pluginReact({
 });
 ```
 
-In your env file, define `REACT_PROFILER`. You can customize the environment variable name if desired.
+Set `REACT_PROFILER` when running build script.
 
-```env title=".env"
-REACT_PROFILER=true
+```
+REACT_PROFILER=true npx rsbuild build
 ```

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -157,7 +157,7 @@ pluginReact({
 });
 ```
 
-In your env file, define `REACT_PROFILER`.
+In your env file, define `REACT_PROFILER`. You can customize the environment variable name if desired.
 
 ```env title=".env"
 REACT_PROFILER=true

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -146,14 +146,14 @@ pluginReact({
 });
 ```
 
-### enableReactProfiler
+### enableProfiler
 
 When set to true, enables the React Profiler for performance analysis in production builds. Use the React DevTools to examine profiling results and identify potential performance optimizations. Profiling adds a slight overhead, so it's disabled by default in production environments.
 
 ```ts title="rsbuild.config.ts"
 pluginReact({
   // Only enable the profiler when REACT_PROFILER is true, as the option will increase the build time and adds some small additional overhead.
-  enableReactProfiler: process.env.REACT_PROFILER === 'true',
+  enableProfiler: process.env.REACT_PROFILER === 'true',
 });
 ```
 


### PR DESCRIPTION
## Summary
Adds support for profiling React components against a production build. This is a good use case for profiling an app when running preview in localhost.

## Related Links
- [CRA Profiling](https://create-react-app.dev/docs/production-build/#profiling)

## Checklist
- [x] Tests updated (or not required).
- [x] Documentation updated.
