### PR TITLE
test(e2e/plugin-assets-retry): fix the unstable request num

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -27,7 +27,7 @@ function createBlockMiddleware({
     if (req.url?.startsWith(urlPrefix)) {
       counter++;
       // if blockNum is 3, 1 2 3 would be blocked, 4 would be passed
-      if (counter % (blockNum + 1) !== 0) {
+      if (counter <= blockNum) {
         res.statusCode = 404;
       }
       res.setHeader('block-async', counter);

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -5,10 +5,10 @@ import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import type { RequestHandler } from '@rsbuild/shared';
 
-function count404Response(logs: string[]) {
+function count404Response(logs: string[], urlPrefix: string): number {
   let count = 0;
   for (const log of logs) {
-    if (log.includes('404')) {
+    if (log.includes('404') && log.includes(urlPrefix)) {
       count++;
     }
   }
@@ -72,7 +72,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#comp-test');
   await expect(compTestElement).toHaveText('Hello CompTest');
-  const blockedResponseCount = count404Response(logs);
+  const blockedResponseCount = count404Response(logs, '/static/js/index.js');
   expect(blockedResponseCount).toBe(3);
   await rsbuild.close();
   restore();
@@ -95,7 +95,7 @@ test('@rsbuild/plugin-assets-retry should work with minified runtime code when b
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#comp-test');
   await expect(compTestElement).toHaveText('Hello CompTest');
-  const blockedResponseCount = count404Response(logs);
+  const blockedResponseCount = count404Response(logs, '/static/js/index.js');
   expect(blockedResponseCount).toBe(3);
   await rsbuild.close();
   restore();


### PR DESCRIPTION
# summary

fix the unstable e2e test

Possible reasons
1. race condition in runtime code (maybe not)
2. testRunner: devServer isolation of every runner
3. testRunner: logs isolation of every runner
4. Network environment

![img_v3_02a3_a233c50e-2c8d-4b61-a945-c9fb0fe0810g](https://github.com/web-infra-dev/rsbuild/assets/79413249/cdfc55d9-9d19-4133-8fa8-7c905e3f30b1)
