### PR TITLE
fix: ignore the CSS conflicting order warning by default

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -25,6 +25,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -559,6 +562,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1127,6 +1133,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1476,6 +1485,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -26,7 +26,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -563,7 +563,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -1134,7 +1134,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -1486,7 +1486,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -30,7 +30,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         });
 
         // ignore the CSS conflicting order warning
-        chain.ignoreWarnings([/Conflicting order between/]);
+        chain.ignoreWarnings([/Conflicting order/]);
 
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -29,6 +29,9 @@ export const pluginBasic = (): RsbuildPlugin => ({
           },
         });
 
+        // ignore the CSS conflicting order warning
+        chain.ignoreWarnings([/Conflicting order between/]);
+
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);
 

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -4,6 +4,9 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -37,6 +40,9 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -5,7 +5,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -41,7 +41,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -12,6 +12,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -13,7 +13,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -12,6 +12,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -715,6 +718,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1483,6 +1489,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1900,6 +1909,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -13,7 +13,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -719,7 +719,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -1490,7 +1490,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",
@@ -1910,7 +1910,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -30,7 +30,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "asyncWebAssembly": true,
   },
   "ignoreWarnings": [
-    /Conflicting order between/,
+    /Conflicting order/,
   ],
   "infrastructureLogging": {
     "level": "error",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -29,6 +29,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
+  "ignoreWarnings": [
+    /Conflicting order between/,
+  ],
   "infrastructureLogging": {
     "level": "error",
   },


### PR DESCRIPTION
## Summary

Ignore the CSS conflicting order warning by default.

## Related Links

- close https://github.com/web-infra-dev/rsbuild/issues/2088
- https://www.rspack.dev/blog/announcing-0.6.html#emit-warnings-when-css-order-is-inconsistent-in-multiple-chunks

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
