### PR TITLE
test(e2e): delete process.env.NODE_ENV to solve unstable e2e

### DIFF
--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -8,6 +8,7 @@ test('should allow to export function in config file', async () => {
   const targetDir = path.join(__dirname, 'dist-production-build');
   fse.removeSync(targetDir);
 
+  delete process.env.NODE_ENV;
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@playwright/test';
 import { globContentJSON } from '@e2e/helper';
 
 test('should run inspect command correctly', async () => {
+  delete process.env.NODE_ENV;
   execSync('npx rsbuild inspect', {
     cwd: __dirname,
   });
@@ -26,6 +27,7 @@ test('should run inspect command correctly', async () => {
 });
 
 test('should run inspect command with output option correctly', async () => {
+  delete process.env.NODE_ENV;
   execSync('npx rsbuild inspect --output foo', {
     cwd: __dirname,
   });

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@playwright/test';
 import { globContentJSON } from '@e2e/helper';
 
 test('should set NODE_ENV correctly when running build command', async () => {
+  delete process.env.NODE_ENV;
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -28,7 +28,8 @@ test.skip('should restart dev server when .env file is changed', async () => {
     };`,
   );
 
-  const process = exec('npx rsbuild dev', {
+  delete process.env.NODE_ENV;
+  const devProcess = exec('npx rsbuild dev', {
     cwd: __dirname,
   });
 
@@ -40,5 +41,5 @@ test.skip('should restart dev server when .env file is changed', async () => {
   await awaitFileExists(distIndex);
   expect(fse.readFileSync(distIndex, 'utf-8')).toContain('rose');
 
-  process.kill();
+  devProcess.kill();
 });


### PR DESCRIPTION
## Summary
`npx rsbuild build` is unstable because of shared `process.env` of parallel test runner

add `delete process.env.NODE_ENV`
<img width="801" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/79413249/c3bae978-5915-416b-9991-b4c7afa5d4c7">




## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
