### PR TITLE
fix: skip open in codesandbox

### DIFF
--- a/packages/core/src/plugins/startUrl.ts
+++ b/packages/core/src/plugins/startUrl.ts
@@ -96,7 +96,12 @@ export function pluginStartUrl(): RsbuildPlugin {
         const config = api.getNormalizedConfig();
         const { startUrl, beforeStartUrl } = config.dev;
         const { https } = api.context.devServer || {};
-        const shouldOpen = Boolean(startUrl);
+
+        // Skip open in codesandbox. After being bundled, the `open` package will
+        // try to call system xdg-open, which will cause an error on codesandbox.
+        // https://github.com/codesandbox/codesandbox-client/issues/6642
+        const isCodesandbox = process.env.CSB === 'true';
+        const shouldOpen = Boolean(startUrl) && !isCodesandbox;
 
         if (!shouldOpen) {
           return;


### PR DESCRIPTION
## Summary

Skip open in codesandbox.

After being bundled, the `open` package will try to call system xdg-open, which will cause an error on codesandbox.

https://github.com/sindresorhus/open/blob/2ea66da8e8b20880d235447cf4c94ba275da6a5a/index.js#L214-L227

<img width="603" alt="截屏2024-04-20 20 18 18" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/b31d6e90-5bae-47f9-9ef4-e0d82e9af423">

## Related Links

https://github.com/codesandbox/codesandbox-client/issues/6642

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
