### PR TITLE
docs: link more content to Rspack website

### DIFF
--- a/packages/core/src/client/hmr/index.ts
+++ b/packages/core/src/client/hmr/index.ts
@@ -177,7 +177,7 @@ function tryApplyUpdates() {
     }
   }
 
-  // https://webpack.js.org/concepts/hot-module-replacement
+  // https://rspack.dev/api/modules#importmetawebpackhot-webpack-specific
   import.meta.webpackHot.check(true).then(
     (updatedModules) => {
       handleApplyUpdates(null, updatedModules);

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -50,7 +50,7 @@ export interface DevConfig {
   beforeStartUrl?: ArrayOrNot<() => Promise<void> | void>;
   /**
    * Set the URL prefix of static assets during development,
-   * similar to the [output.publicPath](https://webpack.js.org/guides/public-path/) config of webpack.
+   * similar to the [output.publicPath](https://rspack.dev/config/output#outputpublicpath) config of webpack.
    */
   assetPrefix?: string | boolean;
   /**

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -195,7 +195,7 @@ export interface OutputConfig {
   targets?: RsbuildTarget[];
   /**
    * At build time, prevent some `import` dependencies from being packed into bundles in your code, and instead fetch them externally at runtime.
-   * For more information, please see: [webpack Externals](https://webpack.js.org/configuration/externals/)
+   * For more information, please see: [Rspack Externals](https://rspack.dev/config/externals)
    */
   externals?: Externals;
   /**

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -25,7 +25,7 @@ export type Decorators = {
 export interface SourceConfig {
   /**
    * Create aliases to import or require certain modules,
-   * same as the [resolve.alias](https://webpack.js.org/configuration/resolve/#resolvealias) config of webpack.
+   * same as the [resolve.alias](https://rspack.dev/config/resolve) config of Rspack.
    */
   alias?: ChainedConfigWithUtils<Alias, { target: RsbuildTarget }>;
   /**

--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -78,7 +78,7 @@ It's not recommended to set assetPrefix as a relative path, such as `'./assets/'
 
 ## Compare with `publicPath`
 
-The functionality of `dev.assetPrefix` is basically the same as the [output.publicPath](https://rspack.dev/zh/config/output#outputpublicpath) config in Rspack.
+The functionality of `dev.assetPrefix` is basically the same as the [output.publicPath](https://rspack.dev/config/output#outputpublicpath) config in Rspack.
 
 The differences from the native configuration are as follows:
 

--- a/website/docs/en/config/output/asset-prefix.mdx
+++ b/website/docs/en/config/output/asset-prefix.mdx
@@ -43,7 +43,7 @@ It's not recommended to set assetPrefix as a relative path, such as `'./assets/'
 
 ## Compare with `publicPath`
 
-The functionality of `output.assetPrefix` is basically the same as the [output.publicPath](https://rspack.dev/zh/config/output#outputpublicpath) config in Rspack.
+The functionality of `output.assetPrefix` is basically the same as the [output.publicPath](https://rspack.dev/config/output#outputpublicpath) config in Rspack.
 
 The differences from the native configuration are as follows:
 

--- a/website/docs/en/config/output/externals.mdx
+++ b/website/docs/en/config/output/externals.mdx
@@ -5,7 +5,7 @@
 
 At build time, prevent some `import` dependencies from being packed into bundles in your code, and instead fetch them externally at runtime.
 
-For more information, please see: [webpack Externals](https://webpack.js.org/configuration/externals/)
+For more information, please see: [Rspack Externals](https://rspack.dev/config/externals)
 
 ### Example
 

--- a/website/docs/en/config/output/filename.mdx
+++ b/website/docs/en/config/output/filename.mdx
@@ -84,7 +84,7 @@ When you import a module via dynamic import, the module will be bundled into a s
 const { add } = await import('./add.ts');
 ```
 
-If you want to specify a fixed name for the async module, you can use the [magic comments](https://webpack.js.org/api/module-methods/#magic-comments) provided by the bundler to achieve this, using `webpackChunkName ` to specify the module name:
+If you want to specify a fixed name for the async module, you can use the [magic comments](https://rspack.dev/api/modules#magic-comments) provided by the bundler to achieve this, using `webpackChunkName ` to specify the module name:
 
 ```js title="src/index.ts"
 const { add } = await import(

--- a/website/docs/en/guide/debug/debug-mode.md
+++ b/website/docs/en/guide/debug/debug-mode.md
@@ -58,7 +58,7 @@ For a complete introduction to Rsbuild config, please see the [Configure Rsbuild
 
 ## Rspack Config File
 
-If the current project is built using Rspack, then in debug mode, Rsbuild will also automatically generate `dist/rspack.config.web.mjs` file, which contains the final generated Rspack config. In this file, you can see what is included in the config that Rsbuild finally passes to Rspack.
+Rsbuild will also automatically generate `dist/rspack.config.web.mjs` file, which contains the final generated Rspack config. In this file, you can see what is included in the config that Rsbuild finally passes to Rspack.
 
 The structure of the file is as follows:
 
@@ -78,28 +78,3 @@ export default {
 ```
 
 For a complete introduction to Rspack configs, please see [Rspack official documentation](https://rspack.dev/config/).
-
-## Webpack Config File
-
-If the current project is built using webpack, then in debug mode, Rsbuild will also automatically generate `dist/webpack.config.web.mjs` file, which contains the final generated webpack config. In this file, you can see what is included in the config that Rsbuild finally passes to webpack.
-
-The structure of the file is as follows:
-
-```js title="webpack.config.web.mjs"
-export default {
-  resolve: {
-    // some resolve configs...
-  },
-  module: {
-    // some webpack loaders...
-  },
-  plugins: [
-    // some webpack plugins...
-  ],
-  // other configs...
-};
-```
-
-In addition, if the project configures additional build targets, such as enabling the SSR capability of the framework (corresponding to additional Node.js build target), an additional `webpack.config.node.mjs` file will be generated in the `dist` directory, corresponding to the webpack config for SSR bundles.
-
-For a complete introduction to webpack configs, please see [webpack official documentation](https://webpack.js.org/concepts/config/).

--- a/website/docs/en/guide/faq/features.md
+++ b/website/docs/en/guide/faq/features.md
@@ -86,4 +86,4 @@ export default {
 };
 ```
 
-For details, please refer to: [ignoreWarnings](https://webpack.js.org/configuration/other-options/#ignorewarnings).
+For details, please refer to: [ignoreWarnings](https://rspack.dev/config/other-options#ignorewarnings).

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -68,7 +68,7 @@ export default {
 };
 ```
 
-> For detailed differences between different Source Map formats, see [webpack - devtool](https://webpack.js.org/configuration/devtool/).
+> For detailed differences between different Source Map formats, see [Rspack - devtool](https://rspack.dev/config/devtool).
 
 ### Adjust Browserslist for development
 

--- a/website/docs/en/guide/optimization/split-chunk.md
+++ b/website/docs/en/guide/optimization/split-chunk.md
@@ -211,7 +211,7 @@ export default {
 };
 ```
 
-The config in `override` will be merged with the bundler config. For specific config details, please refer to [webpack - splitChunks](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks) or [Rspack - splitChunks](https://rspack.dev/config/optimization#optimization-splitchunks).
+The config in `override` will be merged with the bundler config. For specific config details, please refer to [Rspack - splitChunks](https://rspack.dev/config/optimization#optimization-splitchunks).
 
 ## Using Dynamic Import for Code Splitting
 

--- a/website/docs/en/guide/start/glossary.mdx
+++ b/website/docs/en/guide/start/glossary.mdx
@@ -35,7 +35,7 @@ This allows for the creation of micro-frontend-style applications, where multipl
 
 Rsbuild provides an example project for Module Federation. Please refer to [examples - module-federation](https://github.com/web-infra-dev/rsbuild/tree/main/examples/module-federation).
 
-You can also read the [webpack Module Federation documentation](https://webpack.js.org/concepts/module-federation/) to learn more concepts.
+You can also read the [Module Federation documentation](https://module-federation.io/) to learn more concepts.
 
 ## Rspack
 

--- a/website/docs/en/plugins/dev/index.md
+++ b/website/docs/en/plugins/dev/index.md
@@ -230,7 +230,7 @@ The Rsbuild plugin can modify the configuration of Rspack in various ways.
 
 ### Modifying Loader
 
-Loaders can read and process different types of file modules, refer to [concepts](https://webpack.js.org/concepts/loaders) and [loaders](https://webpack.js.org/loaders/).
+Loaders can read and process different types of file modules, refer to [loaders](https://rspack.dev/api/loader-api).
 
 ```ts
 import type { RsbuildPlugin } from '@rsbuild/core';

--- a/website/docs/en/plugins/list/plugin-styled-components.mdx
+++ b/website/docs/en/plugins/list/plugin-styled-components.mdx
@@ -10,7 +10,7 @@ import { SourceCode } from 'rspress/theme';
 
 Rsbuild provides compile-time support for styled-components, improve the debugging experience and add server-side rendering support to styled-components.
 
-For details, please refer to [Rspack#styledComponents](https://www.rspack.dev/guide/builtin-swc-loader.html#optionsrspackexperimentsstyledcomponents).
+For details, please refer to [Rspack#styledComponents](https://rspack.dev/guide/builtin-swc-loader#optionsrspackexperimentsstyledcomponents).
 
 ## Quick Start
 

--- a/website/docs/zh/config/output/externals.mdx
+++ b/website/docs/zh/config/output/externals.mdx
@@ -5,7 +5,7 @@
 
 在构建时，防止将代码中某些 `import` 的依赖包打包到 bundle 中，而是在运行时再去从外部获取这些依赖。
 
-详情请见: [webpack 外部扩展 (Externals)](https://webpack.docschina.org/configuration/externals/)
+详情请见: [Rspack Externals](https://rspack.dev/zh/config/externals)
 
 ### 示例
 

--- a/website/docs/zh/config/output/filename.mdx
+++ b/website/docs/zh/config/output/filename.mdx
@@ -84,7 +84,7 @@ export default {
 const { add } = await import('./add.ts');
 ```
 
-如果你希望为异步模块指定一个固定的名称，可以通过打包工具提供的 [magic comments](https://webpack.js.org/api/module-methods/#magic-comments) 来实现，通过 `webpackChunkName` 指定模块名称：
+如果你希望为异步模块指定一个固定的名称，可以通过打包工具提供的 [magic comments](https://rspack.dev/api/modules#magic-comments) 来实现，通过 `webpackChunkName` 指定模块名称：
 
 ```js title="src/index.ts"
 const { add } = await import(

--- a/website/docs/zh/guide/debug/debug-mode.md
+++ b/website/docs/zh/guide/debug/debug-mode.md
@@ -58,7 +58,7 @@ export default {
 
 ## Rspack 配置文件
 
-如果当前项目是使用 Rspack 进行构建的，那么在调试模式下，Rsbuild 还会自动生成 `dist/rspack.config.web.mjs` 文件，这里面包含了最终生成的 Rspack 配置。在这个文件里，你可以了解到 Rsbuild 最终传递给 Rspack 的配置里包含了哪些内容。
+在调试模式下，Rsbuild 还会自动生成 `dist/rspack.config.web.mjs` 文件，这里面包含了最终生成的 Rspack 配置。在这个文件里，你可以了解到 Rsbuild 最终传递给 Rspack 的配置里包含了哪些内容。
 
 该文件的大致结构如下：
 
@@ -78,28 +78,3 @@ export default {
 ```
 
 关于 Rspack 配置项的完整介绍，请查看 [Rspack 官方文档](https://rspack.dev/zh/config)。
-
-## Webpack 配置文件
-
-如果当前项目是使用 webpack 进行构建的，那么在调试模式下，Rsbuild 还会自动生成 `dist/webpack.config.web.mjs` 文件，这里面包含了最终生成的 webpack 配置。在这个文件里，你可以了解到 Rsbuild 最终传递给 webpack 的配置里包含了哪些内容。
-
-该文件的大致结构如下：
-
-```js title="webpack.config.web.mjs"
-export default {
-  resolve: {
-    // some resolve configs...
-  },
-  module: {
-    // some webpack loaders...
-  },
-  plugins: [
-    // some webpack plugins...
-  ],
-  // other configs...
-};
-```
-
-此外，如果项目配置了额外的构建产物类型，比如开启了框架的 SSR 能力（对应额外的 Node.js 构建产物），在 `dist` 目录会另外生成一份 `webpack.config.node.mjs` 文件，对应 SSR 构建时的 webpack 配置。
-
-关于 webpack 配置项的完整介绍，请查看 [webpack 官方文档](https://webpack.js.org/concepts/configuration/)。

--- a/website/docs/zh/guide/faq/features.md
+++ b/website/docs/zh/guide/faq/features.md
@@ -86,4 +86,4 @@ export default {
 };
 ```
 
-详细信息可参考: [ignoreWarnings](https://webpack.js.org/configuration/other-options/#ignorewarnings)。
+详细信息可参考: [ignoreWarnings](https://rspack.dev/zh/config/other-options#ignorewarnings)。

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -68,7 +68,7 @@ export default {
 };
 ```
 
-> 关于不同 Source Map 格式之间的详细差异，请查看 [webpack - devtool](https://webpack.js.org/configuration/devtool/)。
+> 关于不同 Source Map 格式之间的详细差异，请查看 [Rspack - devtool](https://rspack.dev/zh/config/devtool)。
 
 ### 调整 Browserslist 范围
 

--- a/website/docs/zh/guide/optimization/split-chunk.md
+++ b/website/docs/zh/guide/optimization/split-chunk.md
@@ -94,7 +94,7 @@ export default {
 - 这个配置会将构建生成的 JS 代码全部打包到一个文件里（除了 dynamic import 拆分的 chunk）。
 - 单个 JS 文件的体积可能会非常大，使页面加载性能下降。
 
-如果你需要将 dynamic import 拆分的 chunk 也打包到单个文件中，可以将 Rspack 的 [output.asyncChunks](https://www.rspack.dev/config/output#outputasyncchunks) 选项设置为 `false`：
+如果你需要将 dynamic import 拆分的 chunk 也打包到单个文件中，可以将 Rspack 的 [output.asyncChunks](https://rspack.dev/config/output#outputasyncchunks) 选项设置为 `false`：
 
 ```js
 export default defineConfig({
@@ -207,7 +207,7 @@ export default {
 };
 ```
 
-其中 `override` 中的配置会和 bundler 的配置进行合并，具体配置项请参考 [webpack - splitChunks](https://webpack.js.org/plugins/split-chunks-plugin/#splitchunkschunks) 或 [Rspack - splitChunks](https://rspack.dev/zh/config/optimization#optimization-splitchunks)。
+其中 `override` 中的配置会和 bundler 的配置进行合并，具体配置项请参考 [Rspack - splitChunks](https://rspack.dev/zh/config/optimization#optimization-splitchunks)。
 
 ## 使用 Dynamic Import 拆包
 

--- a/website/docs/zh/guide/start/glossary.mdx
+++ b/website/docs/zh/guide/start/glossary.mdx
@@ -35,7 +35,7 @@ Modern.js 是字节跳动 Web 工程体系的开源版本，它提供多个解�
 
 Rsbuild 提供了一个 Module Federation 的示例项目，请参考 [examples - module-federation](https://github.com/web-infra-dev/rsbuild/tree/main/examples/module-federation)。
 
-你也可以阅读 [webpack Module Federation 文档](https://webpack.docschina.org/concepts/module-federation/) 来了解更多概念。
+你也可以阅读 [Module Federation 文档](https://module-federation.io/) 来了解更多概念。
 
 ## Rspack
 

--- a/website/docs/zh/plugins/dev/index.md
+++ b/website/docs/zh/plugins/dev/index.md
@@ -229,7 +229,7 @@ Rsbuild 插件可以通过多种方式修改 Rspack 的配置项。
 
 ### 修改 Loader
 
-Loader 可以读取和处理不同类型的文件模块，具体参考 [concepts](https://webpack.js.org/concepts/loaders) 和 [loaders](https://webpack.js.org/loaders/)。
+Loader 可以读取和处理不同类型的文件模块，具体参考 [loaders](https://rspack.dev/zh/api/loader-api)。
 
 ```ts
 import type { RsbuildPlugin } from '@rsbuild/core';

--- a/website/docs/zh/plugins/list/plugin-styled-components.mdx
+++ b/website/docs/zh/plugins/list/plugin-styled-components.mdx
@@ -10,7 +10,7 @@ import { SourceCode } from 'rspress/theme';
 
 Rsbuild 提供对 styled-components 的编译时支持，优化调试体验并对 styled-components 添加服务器端渲染支持。
 
-详情可参考 [Rspack#styledComponents](https://www.rspack.dev/zh/guide/builtin-swc-loader.html#optionsrspackexperimentsstyledcomponents)。
+详情可参考 [Rspack#styledComponents](https://rspack.dev/zh/guide/builtin-swc-loader#optionsrspackexperimentsstyledcomponents)。
 
 ## 快速开始
 


### PR DESCRIPTION
## Summary

Link more content to Rspack website instead of the webpack website.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
