### PR TITLE
chore: remove pnpm hoist pattern

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 registry = 'https://registry.npmjs.org/'
 strict-peer-dependencies=false
+hoist-pattern[]=[]

--- a/e2e/cases/babel/decorator/index.test.ts
+++ b/e2e/cases/babel/decorator/index.test.ts
@@ -51,7 +51,11 @@ rspackOnlyTest(
       runServer: true,
       plugins: [
         pluginBabel({
-          babelLoaderOptions(_, { addPresets }) {
+          babelLoaderOptions(options, { addPresets }) {
+            // CWD is set to <project>/e2e by playwright, to find @babel/preset-env
+            // correctly, manually set it to `__dirname`, better setting CWD to project root
+            // for each test file with something like `setupFiles` in Vitest, playwright lacks though.
+            options.cwd = __dirname;
             addPresets([
               [
                 '@babel/preset-env',

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -35,7 +35,8 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "typescript": "^5.4.2",
-    "webpack": "^5.91.0"
+    "webpack": "^5.91.0",
+    "vue": "^3.4.19"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.6.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1341,7 +1341,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^17.4.0
-        version: 17.4.2(webpack@5.91.0)
+        version: 17.4.2(vue@3.4.23(typescript@5.4.5))(webpack@5.91.0)
       webpack:
         specifier: ^5.91.0
         version: 5.91.0
@@ -1355,6 +1355,9 @@ importers:
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
+      vue:
+        specifier: ^3.4.19
+        version: 3.4.23(typescript@5.4.5)
 
   packages/plugin-vue-jsx:
     dependencies:
@@ -16689,12 +16692,14 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(webpack@5.91.0):
+  vue-loader@17.4.2(vue@3.4.23(typescript@5.4.5))(webpack@5.91.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
       webpack: 5.91.0
+    optionalDependencies:
+      vue: 3.4.23(typescript@5.4.5)
 
   vue-router@4.3.1(vue@3.4.23(typescript@5.4.5)):
     dependencies:


### PR DESCRIPTION
## Summary

1. add `vue` to provide peer dep for vue-loader
2. tweak babel-loader cwd to help finding `@babel/preset-env`

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
