### PR TITLE
feat: proxy bypass support return true

### DIFF
--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -62,6 +62,8 @@ export const createProxyMiddleware = (proxyOptions: ProxyOptions) => {
       } else if (typeof bypassUrl === 'string') {
         req.url = bypassUrl;
         next();
+      } else if (bypassUrl === true) {
+        next();
       } else {
         (proxyMiddleware as Middleware)(req, res, next);
       }

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -13,7 +13,7 @@ export type ProxyDetail = BaseProxyOptions & {
     req: IncomingMessage,
     res: ServerResponse,
     proxyOptions: ProxyOptions,
-  ) => string | undefined | null | false;
+  ) => string | undefined | null | boolean;
   context?: ProxyFilter;
 };
 

--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -89,7 +89,7 @@ type ProxyDetail = HttpProxyOptions & {
     req: IncomingMessage,
     res: ServerResponse,
     proxyOptions: ProxyOptions,
-  ) => string | undefined | null | false;
+  ) => string | undefined | null | boolean;
   context?: Filter;
 };
 
@@ -107,6 +107,7 @@ In addition to the http-proxy-middleware option, Rsbuild also support the bypass
 Bypass the proxy based on the return value of a function.
 
 - Return `null` or `undefined` to continue processing the request with proxy.
+- Return `true` to continue processing the request without proxy.
 - Return `false` to produce a 404 error for the request.
 - Return a path to serve from, instead of continuing to proxy the request.
 

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -89,7 +89,7 @@ type ProxyDetail = HttpProxyOptions & {
     req: IncomingMessage,
     res: ServerResponse,
     proxyOptions: ProxyOptions,
-  ) => string | undefined | null | false;
+  ) => string | undefined | null | boolean;
   context?: Filter;
 };
 
@@ -107,6 +107,7 @@ type ProxyOptions =
 根据函数的返回值绕过代理。
 
 - 返回 `null` 或 `undefined` 会继续用代理处理请求。
+- 返回 `true` 会跳过代理继续处理请求。
 - 返回 `false` 会返回 404 错误。
 - 返回一个具体的服务路径，将会使用此路径替代原请求路径。
 


### PR DESCRIPTION
## Summary

proxy bypass support return `true` to continue processing the request without proxy.

```
export default defineConfig({
  server: {
    proxy: {
      '/api': {
        target: 'http://xxxx/',
        bypass: (req) => {
          // not proxy when request like /api/no-proxy/xxxx
          if (req.url.includes('/no-proxy')) {
            return true;
          }
        }
      }
    }
  }
});

```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
