### PR TITLE
test(e2e): use concurrent instead of serial for globContentJSON

### DIFF
--- a/e2e/cases/performance/load-resource/index.test.ts
+++ b/e2e/cases/performance/load-resource/index.test.ts
@@ -26,8 +26,9 @@ test('should generate prefetch link when prefetch is defined', async () => {
 
   const files = await rsbuild.unwrapOutputJSON();
 
-  const asyncFileName = Object.keys(files).find((file) =>
-    file.includes('/static/js/async/'),
+  const asyncFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
   )!;
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),
@@ -66,8 +67,9 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
 
   const files = await rsbuild.unwrapOutputJSON();
 
-  const asyncFileName = Object.keys(files).find((file) =>
-    file.includes('/static/js/async/'),
+  const asyncFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
   )!;
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),
@@ -187,8 +189,9 @@ test('should generate preload link when preload is defined', async () => {
 
   const files = await rsbuild.unwrapOutputJSON();
 
-  const asyncFileName = Object.keys(files).find((file) =>
-    file.includes('/static/js/async/'),
+  const asyncFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
   )!;
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),
@@ -230,8 +233,9 @@ test('should generate preload link with crossOrigin', async () => {
 
   const files = await rsbuild.unwrapOutputJSON();
 
-  const asyncFileName = Object.keys(files).find((file) =>
-    file.includes('/static/js/async/'),
+  const asyncFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
   )!;
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),
@@ -270,8 +274,9 @@ test('should generate preload link without crossOrigin when same origin', async 
 
   const files = await rsbuild.unwrapOutputJSON();
 
-  const asyncFileName = Object.keys(files).find((file) =>
-    file.includes('/static/js/async/'),
+  const asyncFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
   )!;
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),

--- a/e2e/cases/source/alias-by-target/index.test.ts
+++ b/e2e/cases/source/alias-by-target/index.test.ts
@@ -9,9 +9,11 @@ test('should allow to set alias by build target', async () => {
   const files = await rsbuild.unwrapOutputJSON();
   const fileNames = Object.keys(files);
   const webIndex = fileNames.find(
-    (file) => file.includes('static/js') && file.includes('index.js'),
+    (file) => file.includes('static/js') && file.endsWith('index.js'),
   );
-  const nodeIndex = fileNames.find((file) => file.includes('server/index'));
+  const nodeIndex = fileNames.find(
+    (file) => file.includes('server/index') && file.endsWith('index.js'),
+  );
 
   expect(files[webIndex!]).toContain('for web target');
   expect(files[nodeIndex!]).toContain('for node target');

--- a/e2e/cases/source/multiple-entry/index.test.ts
+++ b/e2e/cases/source/multiple-entry/index.test.ts
@@ -9,7 +9,7 @@ test('should allow to set entry by build target', async () => {
   const files = await rsbuild.unwrapOutputJSON();
   const fileNames = Object.keys(files);
   const webIndex = fileNames.find(
-    (file) => file.includes('static/js') && file.includes('index.js'),
+    (file) => file.includes('static/js') && file.endsWith('index.js'),
   );
   const nodeIndex = fileNames.find((file) => file.includes('server/index'));
 

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -44,9 +44,13 @@ export const globContentJSON = async (path: string, options?: GlobOptions) => {
   const files = await glob(convertPath(join(path, '**/*')), options);
   const ret: Record<string, string> = {};
 
-  for await (const file of files) {
-    ret[file] = await fse.readFile(file, 'utf-8');
-  }
+  await Promise.all(
+    files.map((file) =>
+      fse.readFile(file, 'utf-8').then((content) => {
+        ret[file] = content;
+      }),
+    ),
+  );
 
   return ret;
 };


### PR DESCRIPTION
## Summary

`globContentJSON` could be written in concurrent async logic, and some test case need to be changed to prevent uncertain result in race-condition when running concurrently.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
