### PR TITLE
fix: should not log compile warning when warning is ignored

### DIFF
--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -216,7 +216,7 @@ export function formatStats(
     const title = color.bold(color.yellow('Compile Warning: \n'));
 
     return {
-      message: `${title}${`${warnings.join('\n\n')}\n`}`,
+      message: `${title}${warnings.join('\n\n')}\n`,
       level: 'warning',
     };
   }

--- a/packages/core/src/provider/shared.ts
+++ b/packages/core/src/provider/shared.ts
@@ -212,11 +212,11 @@ export function formatStats(
     };
   }
 
-  if (stats.hasWarnings()) {
+  if (warnings.length) {
     const title = color.bold(color.yellow('Compile Warning: \n'));
 
     return {
-      message: `${title}${`${warnings.join('\n\n') || color.yellow("For more details, please setting 'stats.warnings: true'")}\n`}`,
+      message: `${title}${`${warnings.join('\n\n')}\n`}`,
       level: 'warning',
     };
   }


### PR DESCRIPTION
## Summary

should not log compile warning when warning length is 0 (use ignoreWarning)
fix: https://github.com/web-infra-dev/rsbuild/issues/2165
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
