### PR TITLE
feat(server): support watch publicDir in dev

### DIFF
--- a/examples/vue2/rsbuild.config.ts
+++ b/examples/vue2/rsbuild.config.ts
@@ -3,10 +3,4 @@ import { pluginVue2 } from '@rsbuild/plugin-vue2';
 
 export default defineConfig({
   plugins: [pluginVue2()],
-  server: {
-    publicDir: {
-      name: 'public1',
-      watch: true,
-    },
-  },
 });

--- a/examples/vue2/rsbuild.config.ts
+++ b/examples/vue2/rsbuild.config.ts
@@ -3,4 +3,10 @@ import { pluginVue2 } from '@rsbuild/plugin-vue2';
 
 export default defineConfig({
   plugins: [pluginVue2()],
+  server: {
+    publicDir: {
+      name: 'public1',
+      watch: true,
+    },
+  },
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -62,6 +62,7 @@ const getDefaultServerConfig = (): NormalizedServerConfig => ({
   publicDir: {
     name: 'public',
     copyOnBuild: true,
+    watch: false,
   },
 });
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -124,7 +124,11 @@ export async function createDevServer<
 
   const compileMiddlewareAPI = runCompile ? await startCompile() : undefined;
 
-  const fileWatcher = await setupWatchFiles(devConfig, compileMiddlewareAPI);
+  const fileWatcher = await setupWatchFiles({
+    dev: devConfig,
+    server: serverConfig,
+    compileMiddlewareAPI,
+  });
 
   const devMiddlewares = await getMiddlewares({
     pwd: options.context.rootPath,

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -1,24 +1,83 @@
-import type { DevConfig, FSWatcher } from '@rsbuild/shared';
-import type { RsbuildDevMiddlewareOptions } from './getDevMiddlewares';
+import type {
+  ChokidarWatchOptions,
+  CompileMiddlewareAPI,
+  DevConfig,
+  ServerConfig,
+  WatchFiles,
+} from '@rsbuild/shared';
 
-export async function setupWatchFiles(
-  dev: DevConfig,
-  compileMiddlewareAPI: RsbuildDevMiddlewareOptions['compileMiddlewareAPI'],
-): Promise<FSWatcher | undefined> {
-  const { watchFiles, hmr, liveReload } = dev;
-  if (!watchFiles || (!hmr && !liveReload)) {
-    return;
-  }
+type WatchFilesOptions = {
+  dev: DevConfig;
+  server: ServerConfig;
+  compileMiddlewareAPI?: CompileMiddlewareAPI;
+};
 
+export async function setupWatchFiles(options: WatchFilesOptions) {
+  const { dev, server, compileMiddlewareAPI } = options;
+
+  const { hmr, liveReload } = dev;
+  if (!hmr && !liveReload) return;
+
+  const devFilesWatcher = await watchDevFiles(dev, compileMiddlewareAPI);
+  const serverFilesWatcher = await watchServerFiles(
+    server,
+    compileMiddlewareAPI,
+  );
+
+  return {
+    async close() {
+      await Promise.all([
+        devFilesWatcher?.close(),
+        serverFilesWatcher?.close(),
+      ]);
+    },
+  };
+}
+
+async function watchDevFiles(
+  devConfig: DevConfig,
+  compileMiddlewareAPI?: CompileMiddlewareAPI,
+) {
+  const { watchFiles } = devConfig;
+  if (!watchFiles) return;
+
+  const watchOptions = prepareWatchOptions(
+    watchFiles.paths,
+    watchFiles.options,
+  );
+  return startWatchFiles(watchOptions, compileMiddlewareAPI);
+}
+
+function watchServerFiles(
+  serverConfig: ServerConfig,
+  compileMiddlewareAPI?: CompileMiddlewareAPI,
+) {
+  const { publicDir } = serverConfig;
+  if (!publicDir || !publicDir.watch || !publicDir.name) return;
+
+  const watchOptions = prepareWatchOptions(publicDir.name);
+  return startWatchFiles(watchOptions, compileMiddlewareAPI);
+}
+
+function prepareWatchOptions(
+  paths: string | string[],
+  options?: ChokidarWatchOptions,
+) {
+  return {
+    paths: typeof paths === 'string' ? [paths] : paths,
+    options: options ?? {},
+  };
+}
+
+async function startWatchFiles(
+  { paths, options }: WatchFiles,
+  compileMiddlewareAPI?: CompileMiddlewareAPI,
+) {
   const chokidar = await import('@rsbuild/shared/chokidar');
-
-  const { paths, options } = watchFiles;
   const watcher = chokidar.watch(paths, options);
 
   watcher.on('change', () => {
-    if (compileMiddlewareAPI) {
-      compileMiddlewareAPI.sockWrite('static-changed');
-    }
+    compileMiddlewareAPI?.sockWrite('static-changed');
   });
 
   return watcher;

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -30,6 +30,13 @@ export type ClientConfig = {
   overlay?: boolean;
 };
 
+export type ChokidarWatchOptions = WatchOptions;
+
+export type WatchFiles = {
+  paths: string | string[];
+  options?: WatchOptions;
+};
+
 export interface DevConfig {
   /**
    * Whether to enable Hot Module Replacement.
@@ -80,10 +87,7 @@ export interface DevConfig {
   /**
    * This option allows you to configure a list of globs/directories/files to watch for file changes.
    */
-  watchFiles?: {
-    paths: string | string[];
-    options?: WatchOptions;
-  };
+  watchFiles?: WatchFiles;
 }
 
 export type NormalizedDevConfig = DevConfig &

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -64,7 +64,7 @@ export type PublicDir =
        */
       copyOnBuild?: boolean;
       /**
-       * whether to watch the publicDir files and reload the server when the files change
+       * whether to watch the public directory and reload the page when the files change
        * @default false
        */
       watch?: boolean;

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -63,6 +63,11 @@ export type PublicDir =
        * @default true
        */
       copyOnBuild?: boolean;
+      /**
+       * whether to watch the publicDir files and reload the server when the files change
+       * @default false
+       */
+      watch?: boolean;
     };
 
 export interface ServerConfig {

--- a/website/docs/en/config/server/public-dir.mdx
+++ b/website/docs/en/config/server/public-dir.mdx
@@ -81,7 +81,7 @@ export default {
 };
 ```
 
-Note that the `watch` option is only valid in a development environment. If `dev.hmr` and `dev.liveReload` are both set to false, `watch` will be ignored.
+Note that the `watch` option is only valid in the development build. If `dev.hmr` and `dev.liveReload` are both set to false, `watch` will be ignored.
 
 ### Path Types
 

--- a/website/docs/en/config/server/public-dir.mdx
+++ b/website/docs/en/config/server/public-dir.mdx
@@ -16,6 +16,11 @@ type PublicDir =
        * @default true
        */
       copyOnBuild?: boolean;
+      /**
+       * whether to watch the public directory and reload the page when the files change
+       * @default false
+       */
+      watch?: boolean;
     };
 ```
 
@@ -62,6 +67,21 @@ export default {
 ```
 
 Note that setting the value of `copyOnBuild` to false means that when you run `rsbuild preview` for a production preview, you will not be able to access the corresponding static resources.
+
+Setting `watch` to `true` allows the development environment to watch changes to files in the specified public directory and reload the page when the files are changed:
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      name: 'static',
+      watch: true,
+    },
+  },
+};
+```
+
+Note that the `watch` option is only valid in a development environment. If `dev.hmr` and `dev.liveReload` are both set to false, `watch` will be ignored.
 
 ### Path Types
 

--- a/website/docs/zh/config/server/public-dir.mdx
+++ b/website/docs/zh/config/server/public-dir.mdx
@@ -17,7 +17,7 @@ type PublicDir =
        */
       copyOnBuild?: boolean;
       /**
-       * 是否监控 public 目录 ，并在文件发生变化时重新加载页面
+       * 是否监听 public 目录，并在文件发生变化时重新加载页面
        * @default false
        */
       watch?: boolean;

--- a/website/docs/zh/config/server/public-dir.mdx
+++ b/website/docs/zh/config/server/public-dir.mdx
@@ -16,6 +16,11 @@ type PublicDir =
        * @default true
        */
       copyOnBuild?: boolean;
+      /**
+       * 是否监控 public 目录 ，并在文件发生变化时重新加载页面
+       * @default false
+       */
+      watch?: boolean;
     };
 ```
 
@@ -25,6 +30,7 @@ type PublicDir =
 const defaultValue = {
   name: 'public',
   copyOnBuild: true,
+  watch: false,
 };
 ```
 
@@ -62,6 +68,21 @@ export default {
 ```
 
 需要注意的是，将 `copyOnBuild` 的值为 false 后，如果执行 `rsbuild preview` 进行生产环境预览，将无法访问对应的静态资源文件。
+
+设置 `watch` 为 `true` 后，开发环境下会监控指定公共目录下的文件变化，并在文件发生变化时重新加载页面：
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      name: 'static',
+      watch: true,
+    },
+  },
+};
+```
+
+需要注意的是，`watch` 选项只有在开发环境下有效。如果 `dev.hmr` 和 `dev.liveReload` 都设置为 false，则 `watch` 将被忽略。
 
 ### 路径类型
 


### PR DESCRIPTION
## Summary
support watch publicDir in dev
set `watch: true`, page will reload when watch file content changed.
```
    server: {
        publicDir: {
          watch: true,
        },
      },
``` 
## Related Links
#1903 

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
