### PR TITLE
chore: bump @types/node to v18

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -55,7 +55,7 @@
     "@rsbuild/webpack": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/lodash": "^4.17.0",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "@types/react": "^18.2.75",
     "@types/react-dom": "^18.2.24",
     "fast-glob": "^3.3.2",

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   }
 }

--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@rsbuild/plugin-babel": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "publishConfig": {

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "publishConfig": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,7 +60,7 @@
     "postcss": "^8.4.38"
   },
   "devDependencies": {
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2",
     "webpack": "^5.91.0"
   },

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@clack/prompts": "^0.7.0",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "rslog": "^1.2.1",
     "typescript": "^5.4.2"
   },

--- a/packages/monorepo-utils/package.json
+++ b/packages/monorepo-utils/package.json
@@ -30,7 +30,7 @@
     "fast-glob": "^3.3.2"
   },
   "devDependencies": {
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "publishConfig": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/lodash": "^4.17.0",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2",
     "webpack": "^5.91.0"
   },

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "svelte": "^4.2.12",
     "typescript": "^5.4.2"
   },

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -127,7 +127,7 @@
     "postcss": "^8.4.38"
   },
   "devDependencies": {
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
     "mini-css-extract-plugin": "2.8.1",
     "terser": "5.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,7 +54,7 @@ importers:
         version: 2.11.1
       vitest:
         specifier: ^1.4.0
-        version: 1.5.0(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
+        version: 1.5.0(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
 
   e2e:
     dependencies:
@@ -195,8 +195,8 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       '@types/react':
         specifier: ^18.2.75
         version: 18.2.79
@@ -412,8 +412,8 @@ importers:
         specifier: link:../../packages/core
         version: link:../../packages/core
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -594,8 +594,8 @@ importers:
         specifier: workspace:*
         version: link:../../plugin-babel
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -671,8 +671,8 @@ importers:
         specifier: workspace:*
         version: link:../../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -699,8 +699,8 @@ importers:
         version: 8.4.38
     devDependencies:
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -714,8 +714,8 @@ importers:
         specifier: ^0.7.0
         version: 0.7.0
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       rslog:
         specifier: ^1.2.1
         version: 1.2.1
@@ -733,8 +733,8 @@ importers:
         version: 3.3.2
     devDependencies:
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -807,8 +807,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -873,8 +873,8 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -926,8 +926,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -951,8 +951,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1068,8 +1068,8 @@ importers:
         specifier: link:../core
         version: link:../core
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1112,8 +1112,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1203,8 +1203,8 @@ importers:
         specifier: link:../core
         version: link:../core
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1256,8 +1256,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       svelte:
         specifier: ^4.2.12
         version: 4.2.15
@@ -1290,8 +1290,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1479,8 +1479,8 @@ importers:
         version: 8.4.38
     devDependencies:
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.6.2
         version: html-rspack-plugin@5.6.2(@rspack/core@0.6.2(@swc/helpers@0.5.3))
@@ -1507,8 +1507,8 @@ importers:
         version: 1.1.3
     devDependencies:
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       tsx:
         specifier: ^4.7.2
         version: 4.7.2
@@ -1519,8 +1519,8 @@ importers:
         specifier: ^7.24.4
         version: 7.24.4
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.10
@@ -1724,8 +1724,8 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1747,8 +1747,8 @@ importers:
         specifier: ^1.18.3
         version: 1.18.3(react@18.2.0)(rspress@1.18.3(webpack@5.91.0))
       '@types/node':
-        specifier: 16.x
-        version: 16.18.96
+        specifier: 18.x
+        version: 18.19.31
       '@types/react':
         specifier: ^18.2.75
         version: 18.2.79
@@ -3687,8 +3687,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@16.18.96':
-    resolution: {integrity: sha512-84iSqGXoO+Ha16j8pRZ/L90vDMKX04QTYMTfYeE1WrjWaZXuchBehGUZEpNgx7JnmlrIHdnABmpjrQjhCnNldQ==}
+  '@types/node@18.19.31':
+    resolution: {integrity: sha512-ArgCD39YpyyrtFKIqMDvjz79jto5fcI/SVUs2HwB+f0dAzq68yqOdyaSivLiLugSziTpNXLQrVb7RZFmdZzbhA==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -8327,6 +8327,9 @@ packages:
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -10013,7 +10016,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       '@types/yargs': 17.0.32
       chalk: 4.1.2
 
@@ -10858,12 +10861,12 @@ snapshots:
     dependencies:
       '@types/http-cache-semantics': 4.0.4
       '@types/keyv': 3.1.4
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       '@types/responselike': 1.0.3
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/debug@4.1.12':
     dependencies:
@@ -10888,7 +10891,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/hast@2.3.10':
     dependencies:
@@ -10902,7 +10905,7 @@ snapshots:
 
   '@types/http-proxy@1.17.14':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -10920,11 +10923,11 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/less@3.0.6': {}
 
@@ -10946,21 +10949,23 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/node-sass@4.11.7':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/node@12.20.55': {}
 
-  '@types/node@16.18.96': {}
+  '@types/node@18.19.31':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/on-finished@2.3.4':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/parse5@6.0.3': {}
 
@@ -10979,11 +10984,11 @@ snapshots:
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/sass-loader@8.0.8':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       '@types/node-sass': 4.11.7
       '@types/webpack': 4.41.38
       sass: 1.75.0
@@ -11010,7 +11015,7 @@ snapshots:
 
   '@types/webpack-bundle-analyzer@4.7.0':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       tapable: 2.2.1
       webpack: 5.91.0
     transitivePeerDependencies:
@@ -11021,13 +11026,13 @@ snapshots:
 
   '@types/webpack-sources@3.2.3':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       '@types/source-list-map': 0.1.6
       source-map: 0.7.4
 
   '@types/webpack@4.41.38':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       '@types/tapable': 1.0.12
       '@types/uglify-js': 3.17.5
       '@types/webpack-sources': 3.2.3
@@ -11036,7 +11041,7 @@ snapshots:
 
   '@types/ws@8.5.10':
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -13451,7 +13456,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -13459,13 +13464,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -16405,6 +16410,8 @@ snapshots:
 
   ufo@1.5.3: {}
 
+  undici-types@5.26.5: {}
+
   unicode-canonical-property-names-ecmascript@2.0.0: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -16592,13 +16599,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@1.5.0(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
+  vite-node@1.5.0(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
     dependencies:
       cac: 6.7.14
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.2.9(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
+      vite: 5.2.9(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -16609,13 +16616,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.2.9(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
+  vite@5.2.9(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
     dependencies:
       esbuild: 0.19.12
       postcss: 8.4.38
       rollup: 4.14.3
     optionalDependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
       fsevents: 2.3.3
       less: 4.2.0
       lightningcss: 1.24.1
@@ -16623,7 +16630,7 @@ snapshots:
       stylus: 0.63.0
       terser: 5.30.3
 
-  vitest@1.5.0(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
+  vitest@1.5.0(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3):
     dependencies:
       '@vitest/expect': 1.5.0
       '@vitest/runner': 1.5.0
@@ -16642,11 +16649,11 @@ snapshots:
       strip-literal: 2.1.0
       tinybench: 2.7.0
       tinypool: 0.8.4
-      vite: 5.2.9(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
-      vite-node: 1.5.0(@types/node@16.18.96)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
+      vite: 5.2.9(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
+      vite-node: 1.5.0(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.24.1)(sass@1.75.0)(stylus@0.63.0)(terser@5.30.3)
       why-is-node-running: 2.2.2
     optionalDependencies:
-      '@types/node': 16.18.96
+      '@types/node': 18.19.31
     transitivePeerDependencies:
       - less
       - lightningcss

--- a/scripts/check-changeset/package.json
+++ b/scripts/check-changeset/package.json
@@ -11,7 +11,7 @@
     "@manypkg/get-packages": "^1.1.3"
   },
   "devDependencies": {
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "tsx": "^4.7.2"
   }
 }

--- a/scripts/prebundle/package.json
+++ b/scripts/prebundle/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.24.4",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "@types/ws": "^8.5.10",
     "@vercel/ncc": "0.38.1",
     "dts-packer": "0.0.3",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -27,7 +27,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/shared": "workspace:*",
     "@types/lodash": "^4.17.0",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "lodash": "^4.17.21",
     "typescript": "^5.4.2",
     "upath": "2.0.1"

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rspress/plugin-rss": "^1.18.3",
-    "@types/node": "16.x",
+    "@types/node": "18.x",
     "@types/react": "^18.2.75",
     "@types/react-dom": "^18.2.24",
     "fast-glob": "^3.3.2",


### PR DESCRIPTION
## Summary

bump @types/node to v18 to fix: 

<img width="741" alt="Screenshot 2024-04-23 at 17 56 17" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/b861b330-2576-4eaa-bee4-2ae916eb485c">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
