### PR TITLE
docs: add plugin-basic-ssl document

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -222,7 +222,7 @@ try {
 
 After successfully starting Dev Server, you can see the following logs:
 
-```bash
+```
   > Local:    http://localhost:3000
   > Network:  http://192.168.0.1:3000
 ```

--- a/website/docs/en/api/start/index.mdx
+++ b/website/docs/en/api/start/index.mdx
@@ -38,7 +38,7 @@ await rsbuild.startDevServer();
 
 After successfully starting Dev Server, you can see the following logs:
 
-```bash
+```
   > Local:    http://localhost:3000
   > Network:  http://192.168.0.1:3000
 ```

--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -7,14 +7,14 @@ After configuring this option, you can enable HTTPS Server, and disabling the HT
 
 HTTP:
 
-```bash
+```
   > Local: http://localhost:3000/
   > Network: http://192.168.0.1:3000/
 ```
 
 HTTPS:
 
-```bash
+```
   > Local: https://localhost:3000/
   > Network: https://192.168.0.1:3000/
 ```
@@ -38,15 +38,18 @@ export default {
 };
 ```
 
-For basic usage configuration needs, you can add @rsbuild/plugin-basic-ssl to your project plugins, and it will automatically create and cache a self-signed certificate while also enabling HTTPS configuration by default.
+:::tip
+The certificates used for local development are typically generated using [mkcert](https://github.com/FiloSottile/mkcert). Please read ["How to use HTTPS for local development"](https://web.dev/articles/how-to-use-local-https?hl=en) to learn how to use it.
+:::
+
+## Self-signed Certificate
+
+For basic configuration requirements, you can add the [@rsbuild/plugin-basic-ssl](/plugins/list/plugin-basic-ssl) plugin, which will automatically create a self-signed certificate and set `server.https` option by default.
 
 ```ts
-import fs from 'node:fs';
 import { pluginBasicSsl } from '@rsbuild/plugin-basic-ssl';
 
 export default {
   plugins: [pluginBasicSsl()],
 };
 ```
-
-The certificates used for local development are typically generated using [mkcert](https://github.com/FiloSottile/mkcert). Please read ["How to use HTTPS for local development"](https://web.dev/articles/how-to-use-local-https?hl=en) to learn how to use it.

--- a/website/docs/en/guide/start/npm-packages.mdx
+++ b/website/docs/en/guide/start/npm-packages.mdx
@@ -202,6 +202,16 @@ Used to automatically resend requests when static assets fail to load.
 - [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-assets-retry)
 - [Documentation](/plugins/list/plugin-assets-retry)
 
+## @rsbuild/plugin-basic-ssl
+
+![](https://img.shields.io/npm/v/@rsbuild/plugin-basic-ssl?style=flat-square&colorA=564341&colorB=EDED91)
+
+Generate an untrusted, self-signed certificate for the HTTPS server.
+
+- [npm](https://npmjs.com/package/@rsbuild/plugin-basic-ssl)
+- [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl)
+- [Documentation](/plugins/list/plugin-basic-ssl)
+
 ## @rsbuild/shared
 
 ![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)

--- a/website/docs/en/plugins/list/_meta.json
+++ b/website/docs/en/plugins/list/_meta.json
@@ -11,6 +11,7 @@
   "plugin-solid",
   "plugin-assets-retry",
   "plugin-babel",
+  "plugin-basic-ssl",
   "plugin-eslint",
   "plugin-type-check",
   "plugin-image-compress",

--- a/website/docs/en/plugins/list/index.md
+++ b/website/docs/en/plugins/list/index.md
@@ -55,6 +55,7 @@ The following are common framework-agnostic plugins:
 
 - [Assets Retry Plugin](/plugins/list/plugin-assets-retry): Used to automatically resend requests when static assets fail to load.
 - [Babel Plugin](/plugins/list/plugin-babel): Provides support for Babel transpilation capabilities.
+- [Basic SSL Plugin](/plugins/list/plugin-basic-ssl): Generate an untrusted, self-signed certificate for the HTTPS server.
 - [ESLint Plugin](/plugins/list/plugin-eslint): Used to run ESLint checks during the compilation.
 - [Type Check Plugin](/plugins/list/plugin-type-check): Used to run TypeScript type checker on a separate process.
 - [Image Compress Plugin](/plugins/list/plugin-image-compress): Compress the image resources used in the project.

--- a/website/docs/en/plugins/list/plugin-basic-ssl.mdx
+++ b/website/docs/en/plugins/list/plugin-basic-ssl.mdx
@@ -1,0 +1,33 @@
+# Basic SSL Plugin
+
+import { SourceCode } from 'rspress/theme';
+
+<SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl" />
+
+Generate an untrusted, self-signed certificate for the HTTPS server.
+
+The Basic SSL plugin will automatically generate a self-signed certificate and set the [server.https](/config/server/https) option. When you visit the page, your browser will indicate that the certificate is not trusted. You can access the HTTPS page after manually confirming this.
+
+## Quick Start
+
+### Install Plugin
+
+You can install the plugin using the following command:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsbuild/plugin-basic-ssl -D" />
+
+### Register Plugin
+
+You can register the plugin in the `rsbuild.config.ts` file:
+
+```ts title="rsbuild.config.ts"
+import { pluginBasicSsl } from '@rsbuild/plugin-basic-ssl';
+
+export default {
+  plugins: [pluginBasicSsl()],
+};
+```
+
+Then visit the https URL of the page, and confirm in your browser.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -222,7 +222,7 @@ try {
 
 成功启动 Dev Server 后，可以看到以下日志信息：
 
-```bash
+```
   > Local:    http://localhost:3000
   > Network:  http://192.168.0.1:3000
 ```

--- a/website/docs/zh/api/start/index.mdx
+++ b/website/docs/zh/api/start/index.mdx
@@ -38,7 +38,7 @@ await rsbuild.startDevServer();
 
 成功启动 Dev Server 后，可以看到以下日志信息：
 
-```bash
+```
   > Local:    http://localhost:3000
   > Network:  http://192.168.0.1:3000
 ```

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -7,14 +7,14 @@
 
 开启前：
 
-```bash
+```
   > Local:    http://localhost:3000/
   > Network:  http://192.168.0.1:3000/
 ```
 
 开启后：
 
-```bash
+```
   > Local:    https://localhost:3000/
   > Network:  https://192.168.0.1:3000/
 ```
@@ -38,17 +38,18 @@ export default {
 };
 ```
 
-对基本使用的配置需求来说，你可以添加 @rsbuild/plugin-basic-ssl 到项目插件中，它会自动创建和缓存一个自签名的证书，并默认开启 https 配置。
+:::tip
+本地开发所使用的证书通常使用 [mkcert](https://github.com/FiloSottile/mkcert) 生成，请阅读 ["如何使用 HTTPS 进行本地开发"](https://web.dev/articles/how-to-use-local-https?hl=zh-cn) 来了解如何使用。
+:::
+
+## 自签名证书
+
+对基本的配置需求，你可以添加 [@rsbuild/plugin-basic-ssl](/plugins/list/plugin-basic-ssl) 插件，它会自动创建一个自签名的证书，并默认设置 `server.https` 选项。
 
 ```ts
-import fs from 'node:fs';
 import { pluginBasicSsl } from '@rsbuild/plugin-basic-ssl';
 
 export default {
   plugins: [pluginBasicSsl()],
 };
 ```
-
-:::tip
-本地开发所使用的证书通常使用 [mkcert](https://github.com/FiloSottile/mkcert) 生成，请阅读 ["如何使用 HTTPS 进行本地开发"](https://web.dev/articles/how-to-use-local-https?hl=zh-cn) 来了解如何使用。
-:::

--- a/website/docs/zh/guide/start/npm-packages.mdx
+++ b/website/docs/zh/guide/start/npm-packages.mdx
@@ -202,6 +202,16 @@ Check Syntax 插件，用于分析产物的语法兼容性，判断是否存在�
 - [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-assets-retry)
 - [文档](/plugins/list/plugin-assets-retry)
 
+## @rsbuild/plugin-basic-ssl
+
+![](https://img.shields.io/npm/v/@rsbuild/plugin-basic-ssl?style=flat-square&colorA=564341&colorB=EDED91)
+
+为 HTTPS server 生成不受信任的自签名证书。
+
+- [npm](https://npmjs.com/package/@rsbuild/plugin-basic-ssl)
+- [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl)
+- [文档](/plugins/list/plugin-basic-ssl)
+
 ## @rsbuild/shared
 
 ![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)
@@ -216,15 +226,6 @@ Rsbuild 内部使用的公共模块和 helpers。
 
 如果你需要使用 `@rsbuild/shared` 里的方法，可以直接拷贝相关代码到项目中，也可以通过 issues 反馈，我们会评估是否需要提供对外的 API。
 :::
-
-## @rsbuild/document
-
-![](https://img.shields.io/npm/v/@rsbuild/document?style=flat-square&colorA=564341&colorB=EDED91)
-
-Rsbuild 文档站。
-
-- [npm](https://npmjs.com/package/@rsbuild/document)
-- [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/website)
 
 ## create-rsbuild
 

--- a/website/docs/zh/plugins/list/_meta.json
+++ b/website/docs/zh/plugins/list/_meta.json
@@ -11,6 +11,7 @@
   "plugin-solid",
   "plugin-assets-retry",
   "plugin-babel",
+  "plugin-basic-ssl",
   "plugin-eslint",
   "plugin-type-check",
   "plugin-image-compress",

--- a/website/docs/zh/plugins/list/index.md
+++ b/website/docs/zh/plugins/list/index.md
@@ -55,6 +55,7 @@
 
 - [Assets Retry 插件](/plugins/list/plugin-assets-retry)：用于在静态资源加载失败时自动发起重试请求。
 - [Babel 插件](/plugins/list/plugin-babel)：提供对 Babel 转译能力的支持。
+- [Basic SSL 插件](/plugins/list/plugin-basic-ssl): 为 HTTPS server 生成不受信任的自签名证书。
 - [ESLint 插件](/plugins/list/plugin-eslint)：用于在编译过程中运行 ESLint 检查。
 - [Type Check 插件](/plugins/list/plugin-type-check)：用于在单独的进程中运行 TypeScript 类型检查。
 - [Image Compress 插件](/plugins/list/plugin-image-compress)：将项目中用到的图片资源进行压缩处理。

--- a/website/docs/zh/plugins/list/plugin-basic-ssl.mdx
+++ b/website/docs/zh/plugins/list/plugin-basic-ssl.mdx
@@ -1,0 +1,33 @@
+# Basic SSL 插件
+
+import { SourceCode } from 'rspress/theme';
+
+<SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl" />
+
+为 HTTPS server 生成不受信任的自签名证书。
+
+Basic SSL 插件会自动生成 self-signed 证书，并设置 [server.https](/config/server/https) 选项。当你访问页面时，浏览器会提示该证书是不受信任的，你可以在手动确认后访问 HTTPS 页面。
+
+## 快速开始
+
+### 安装插件
+
+你可以通过如下的命令安装插件:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add @rsbuild/plugin-basic-ssl -D" />
+
+### 注册插件
+
+你可以在 `rsbuild.config.ts` 文件中注册插件：
+
+```ts title="rsbuild.config.ts"
+import { pluginBasicSsl } from '@rsbuild/plugin-basic-ssl';
+
+export default {
+  plugins: [pluginBasicSsl()],
+};
+```
+
+然后访问页面的 https URL，并在浏览器中确认即可。


### PR DESCRIPTION
## Summary

Add plugin-basic-ssl document.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2176

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
