### PR TITLE
fix(plugin-check-syntax): allow to match assets with query

### DIFF
--- a/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
+++ b/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
@@ -52,6 +52,8 @@ export class CheckSyntaxPlugin {
     complier.hooks.afterEmit.tapPromise(
       CheckSyntaxPlugin.name,
       async (compilation: Compilation) => {
+        const JS_WITH_QUERY_REGEX = /\.(?:js|mjs|cjs|jsx)(\?.*)?$/;
+        const QUERY_REGEX = /\?.*$/;
         const outputPath = compilation.outputOptions.path || 'dist';
         // not support compilation.emittedAssets in Rspack
         const emittedAssets = compilation
@@ -61,8 +63,8 @@ export class CheckSyntaxPlugin {
           .map((p) => resolve(outputPath, p));
 
         const files = emittedAssets.filter(
-          (assets) => HTML_REGEX.test(assets) || JS_REGEX.test(assets),
-        );
+          (assets) => HTML_REGEX.test(assets) || JS_REGEX.test(assets) || JS_WITH_QUERY_REGEX.test(assets),
+        ).map(file => file.replace(QUERY_REGEX, ''));
         await Promise.all(
           files.map(async (file) => {
             await this.check(file);


### PR DESCRIPTION
## Summary

当 output.filename 为以下配置时，CheckSyntaxPlugin 匹配不到资源文件，进而导致失效了
```
   filename: {
      js: '[name].js?v=[contenthash:8]',
      css: '[name].css?v=[contenthash:8]',
      svg: '[name].svg?=[contenthash:8]',
      font: '[name][ext]?v=[contenthash:8]',
      image: '[name][ext]?v=[contenthash:8]',
      media: '[name][ext]?v=[contenthash:8]'
    },
```
