### PR TITLE
fix(check-syntax): remove query before matching

### DIFF
--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -54,7 +54,7 @@ test('should throw error when exist syntax errors', async () => {
 // TODO Rspack occasionally generates invalid comments
 // such as:
 // /*! ./test */se information please see index.js?v=fc0ca1e8.LICENSE.txt */
-test('should check assets with query correctly', async () => {
+test.skip('should check assets with query correctly', async () => {
   const cwd = path.join(__dirname, 'fixtures/basic');
   const { logs, restore } = proxyConsole();
 

--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@playwright/test';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 import type { RsbuildConfig } from '@rsbuild/shared';
 import { normalizeToPosixPath } from '@scripts/test-helper';
+import { mergeRsbuildConfig } from '@rsbuild/core';
 
 function getCommonBuildConfig(cwd: string): RsbuildConfig {
   return {
@@ -27,6 +28,49 @@ test('should throw error when exist syntax errors', async () => {
     build({
       cwd,
       rsbuildConfig: getCommonBuildConfig(cwd),
+      plugins: [pluginCheckSyntax()],
+    }),
+  ).rejects.toThrowError('[Syntax Checker]');
+
+  restore();
+
+  expect(logs.find((log) => log.includes('ERROR 1'))).toBeTruthy();
+  expect(
+    logs.find((log) => log.includes('source:') && log.includes('src/test.js')),
+  ).toBeTruthy();
+  expect(
+    logs.find(
+      (log) =>
+        log.includes('output:') &&
+        normalizeToPosixPath(log).includes('/dist/static/js/index'),
+    ),
+  ).toBeTruthy();
+  expect(logs.find((log) => log.includes('reason:'))).toBeTruthy();
+  expect(
+    logs.find((log) => log.includes('> 1 | export const printLog = () => {')),
+  ).toBeTruthy();
+});
+
+// TODO Rspack occasionally generates invalid comments
+// such as:
+// /*! ./test */se information please see index.js?v=fc0ca1e8.LICENSE.txt */
+test('should check assets with query correctly', async () => {
+  const cwd = path.join(__dirname, 'fixtures/basic');
+  const { logs, restore } = proxyConsole();
+
+  const rsbuildConfig = mergeRsbuildConfig(getCommonBuildConfig(cwd), {
+    output: {
+      filename: {
+        js: '[name].js?v=[contenthash:8]',
+        css: '[name].css?v=[contenthash:8]',
+      },
+    },
+  });
+
+  await expect(
+    build({
+      cwd,
+      rsbuildConfig,
       plugins: [pluginCheckSyntax()],
     }),
   ).rejects.toThrowError('[Syntax Checker]');


### PR DESCRIPTION
## Summary

Remove query before matching the file extension, use a more performant way to implement it.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2187

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
