### PR TITLE
feat(plugin-react): support for configuring react refresh plugin

### DIFF
--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -1,8 +1,8 @@
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { getNodeEnv } from '@rsbuild/shared';
+import type { PluginOptions as ReactRefreshOptions } from '@rspack/plugin-react-refresh';
 import { applyBasicReactSupport, applyReactProfiler } from './react';
 import { applySplitChunksRule } from './splitChunks';
-import type { PluginOptions as ReactRefreshOptions } from '@rspack/plugin-react-refresh';
 
 export type SplitReactChunkOptions = {
   /**

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -2,6 +2,7 @@ import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { getNodeEnv } from '@rsbuild/shared';
 import { applyBasicReactSupport, applyReactProfiler } from './react';
 import { applySplitChunksRule } from './splitChunks';
+import type { PluginOptions as ReactRefreshOptions } from '@rspack/plugin-react-refresh';
 
 export type SplitReactChunkOptions = {
   /**
@@ -28,7 +29,16 @@ export type PluginReactOptions = {
    * Configuration for chunk splitting of React-related dependencies.
    */
   splitChunks?: SplitReactChunkOptions;
+  /**
+   * When set to `true`, enables the React Profiler for performance analysis in production builds.
+   * @default false
+   */
   enableProfiler?: boolean;
+  /**
+   * Options passed to `@rspack/plugin-react-refresh`
+   * @see https://rspack.dev/guide/tech/react#rspackplugin-react-refresh
+   */
+  reactRefreshOptions?: ReactRefreshOptions;
 };
 
 export const PLUGIN_REACT_NAME = 'rsbuild:react';
@@ -40,12 +50,11 @@ export const pluginReact = ({
   name: PLUGIN_REACT_NAME,
 
   setup(api) {
-    const isEnvProductionProfile =
-      enableProfiler && getNodeEnv() === 'production';
     if (api.context.bundlerType === 'rspack') {
       applyBasicReactSupport(api, options);
 
-      if (isEnvProductionProfile) {
+      const isProdProfile = enableProfiler && getNodeEnv() === 'production';
+      if (isProdProfile) {
         applyReactProfiler(api);
       }
     }

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -48,7 +48,12 @@ export const applyBasicReactSupport = (
 
     chain
       .plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)
-      .use(ReactRefreshRspackPlugin, [{ include: [SCRIPT_REGEX] }]);
+      .use(ReactRefreshRspackPlugin, [
+        {
+          include: [SCRIPT_REGEX],
+          ...options.reactRefreshOptions,
+        },
+      ]);
   });
 };
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -168,3 +168,36 @@ REACT_PROFILER=true npx rsbuild build
 ```
 
 > See the [React docs](https://legacy.reactjs.org/docs/optimizing-performance.html#profiling-components-with-the-devtools-profiler) for details about profiling using the React DevTools.
+
+### reactRefreshOptions
+
+- **Type:**
+
+```ts
+type ReactRefreshOptions = {
+  include?: string | RegExp | (string | RegExp)[] | null;
+  exclude?: string | RegExp | (string | RegExp)[] | null;
+  library?: string;
+  forceEnable?: boolean;
+};
+```
+
+- **Default:**
+
+```js
+const defaultOptions = {
+  include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+};
+```
+
+Set the options for [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh).
+
+- **Example:**
+
+```js
+pluginReact({
+  reactRefreshOptions: {
+    exclude: [/some-module-to-exclude/],
+  },
+});
+```

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -190,7 +190,7 @@ const defaultOptions = {
 };
 ```
 
-Set the options for [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh).
+Set the options for [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh). The passed value will be shallowly merged with the default value.
 
 - **Example:**
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -170,3 +170,36 @@ REACT_PROFILER=true npx rsbuild build
 ```
 
 > 关于使用 React DevTools 进行性能分析的详细信息，请参见 [React 文档](https://legacy.reactjs.org/docs/optimizing-performance.html#profiling-components-with-the-devtools-profiler)。
+
+### reactRefreshOptions
+
+- **类型：**
+
+```ts
+type ReactRefreshOptions = {
+  include?: string | RegExp | (string | RegExp)[] | null;
+  exclude?: string | RegExp | (string | RegExp)[] | null;
+  library?: string;
+  forceEnable?: boolean;
+};
+```
+
+- **默认值：**
+
+```js
+const defaultOptions = {
+  include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+};
+```
+
+设置 [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh) 的选项。
+
+- **示例：**
+
+```js
+pluginReact({
+  reactRefreshOptions: {
+    exclude: [/some-module-to-exclude/],
+  },
+});
+```

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -192,7 +192,7 @@ const defaultOptions = {
 };
 ```
 
-设置 [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh) 的选项。
+设置 [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/tech/react#rspackplugin-react-refresh) 的选项，传入的值会与默认值进行浅合并。
 
 - **示例：**
 


### PR DESCRIPTION
## Summary

Support for configuring react refresh plugin.

```js
pluginReact({
  reactRefreshOptions: {
    exclude: [/some-module-to-exclude/],
  },
});
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2185

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
