### PR TITLE
feat(core): export the rspack object

### DIFF
--- a/.changeset/few-lobsters-yell.md
+++ b/.changeset/few-lobsters-yell.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+0.6.7

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,13 +2,20 @@
  * The methods and types exported from this file are considered as
  * the public API of @rsbuild/core.
  */
+import { rspack } from '@rspack/core';
+import type * as Rspack from '@rspack/core';
 
-// Core Methods
+// Core methods
 export { loadEnv } from './loadEnv';
 export { createRsbuild } from './createRsbuild';
 export { loadConfig, defineConfig } from './config';
 
+// Rsbuild version
 export const version = RSBUILD_VERSION;
+
+// Rspack instance
+export { rspack };
+export type { Rspack };
 
 // Helpers
 export { logger } from '@rsbuild/shared';
@@ -24,7 +31,6 @@ export {
 } from './constants';
 
 // Types
-export type { Rspack } from '@rsbuild/shared';
 export type {
   // Config Types
   RsbuildConfig,

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_ASSET_PREFIX,
   type RspackCompiler,
 } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import type { RspackPluginInstance } from '@rspack/core';
 import type { RsbuildPlugin } from '../types';
 
@@ -120,7 +121,6 @@ export function pluginModuleFederation(): RsbuildPlugin {
         }
 
         const { options } = config.moduleFederation;
-        const { rspack } = await import('@rspack/core');
 
         chain
           .plugin(CHAIN_ID.PLUGIN.MODULE_FEDERATION)

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -7,6 +7,7 @@ import type {
   RspackMultiCompiler,
   Stats,
 } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import { createCompiler } from './createCompiler';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 
@@ -45,13 +46,11 @@ export const build = async (
     await p;
   };
 
-  const { MultiStats: MultiStatsStor } = await import('@rspack/core');
-
   onCompileDone(
     compiler,
     onDone,
     // @ts-expect-error type mismatch
-    MultiStatsStor,
+    rspack.MultiStats,
   );
 
   if (watch) {

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -14,6 +14,7 @@ import {
   onCompileDone,
   prettyTime,
 } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import type { StatsCompilation } from '@rspack/core';
 import type { InternalContext } from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
@@ -35,8 +36,6 @@ export async function createCompiler({
   await context.hooks.onBeforeCreateCompiler.call({
     bundlerConfigs: rspackConfigs,
   });
-
-  const { rspack } = await import('@rspack/core');
 
   if (!(await isSatisfyRspackVersion(rspack.rspackVersion))) {
     throw new Error(
@@ -119,13 +118,11 @@ export async function createCompiler({
     isFirstCompile = false;
   };
 
-  const { MultiStats: MultiStatsStor } = await import('@rspack/core');
-
   onCompileDone(
     compiler,
     done,
     // @ts-expect-error type mismatch
-    MultiStatsStor,
+    rspack.MultiStats,
   );
 
   await context.hooks.onAfterCreateCompiler.call({ compiler });

--- a/packages/core/src/provider/plugins/minimize.ts
+++ b/packages/core/src/provider/plugins/minimize.ts
@@ -3,6 +3,7 @@ import {
   getSwcMinimizerOptions,
   parseMinifyOptions,
 } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import type { RsbuildPlugin } from '../../types';
 
 export const pluginMinimize = (): RsbuildPlugin => ({
@@ -18,7 +19,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
       }
 
       const { SwcJsMinimizerRspackPlugin, SwcCssMinimizerRspackPlugin } =
-        await import('@rspack/core');
+        rspack;
 
       const { minifyJs, minifyCss } = parseMinifyOptions(config);
 

--- a/packages/core/src/provider/plugins/output.ts
+++ b/packages/core/src/provider/plugins/output.ts
@@ -1,5 +1,6 @@
 import { posix } from 'node:path';
 import { applyOutputPlugin, getDistPath, getFilename } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import type { RsbuildPlugin } from '../../types';
 
 export const pluginOutput = (): RsbuildPlugin => ({
@@ -12,11 +13,12 @@ export const pluginOutput = (): RsbuildPlugin => ({
       const config = api.getNormalizedConfig();
 
       if (config.output.copy) {
-        const { CopyRspackPlugin } = await import('@rspack/core');
         const { copy } = config.output;
         const options = Array.isArray(copy) ? { patterns: copy } : copy;
 
-        chain.plugin(CHAIN_ID.PLUGIN.COPY).use(CopyRspackPlugin, [options]);
+        chain
+          .plugin(CHAIN_ID.PLUGIN.COPY)
+          .use(rspack.CopyRspackPlugin, [options]);
       }
     });
 

--- a/packages/core/src/provider/plugins/progress.ts
+++ b/packages/core/src/provider/plugins/progress.ts
@@ -1,4 +1,5 @@
 import { TARGET_ID_MAP, isProd } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import type { RsbuildPlugin } from '../../types';
 
 export const pluginProgress = (): RsbuildPlugin => ({
@@ -20,8 +21,7 @@ export const pluginProgress = (): RsbuildPlugin => ({
           ? options.id
           : TARGET_ID_MAP[target];
 
-      const { ProgressPlugin } = await import('@rspack/core');
-      chain.plugin(CHAIN_ID.PLUGIN.PROGRESS).use(ProgressPlugin, [
+      chain.plugin(CHAIN_ID.PLUGIN.PROGRESS).use(rspack.ProgressPlugin, [
         {
           prefix,
           ...(options === true ? {} : options),

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -11,6 +11,7 @@ import {
   mergeChainedOptions,
   modifyBundlerChain,
 } from '@rsbuild/shared';
+import { rspack } from '@rspack/core';
 import { getHTMLPlugin } from '../htmlUtils';
 import type { InternalContext } from '../types';
 import { getCompiledPath } from './shared';
@@ -44,7 +45,6 @@ async function getConfigUtils(
   chainUtils: ModifyChainUtils,
 ): Promise<ModifyRspackConfigUtils> {
   const { merge } = await import('@rsbuild/shared/webpack-merge');
-  const rspack = await import('@rspack/core');
 
   return {
     ...chainUtils,
@@ -121,7 +121,7 @@ export async function generateRspackConfig({
     IgnorePlugin,
     ProvidePlugin,
     HotModuleReplacementPlugin,
-  } = await import('@rspack/core');
+  } = rspack;
 
   const chain = await modifyBundlerChain(context, {
     ...chainUtils,

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -1,10 +1,8 @@
 import path from 'node:path';
+import { type Rspack, rspack } from '@rsbuild/core';
 import { fse, pick } from '@rsbuild/shared';
-import { Rspack } from '@rsbuild/shared/rspack';
 import serialize from 'serialize-javascript';
 import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
-
-const { RuntimeGlobals } = Rspack;
 
 // https://github.com/web-infra-dev/rspack/pull/5370
 function appendWebpackScript(module: any, appendSource: string) {
@@ -48,6 +46,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
   }
 
   getRawRuntimeRetryCode() {
+    const { RuntimeGlobals } = rspack;
     const filename = 'asyncChunkRetry';
     const minify =
       this.options?.minify ?? process.env.NODE_ENV === 'production';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -15,10 +15,6 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
-    "./rspack": {
-      "types": "./dist/rspack.d.ts",
-      "default": "./dist/rspack.js"
-    },
     "./jiti": {
       "types": "./compiled/jiti/types/jiti.d.ts",
       "default": "./compiled/jiti/index.js"

--- a/packages/shared/src/rspack.ts
+++ b/packages/shared/src/rspack.ts
@@ -1,3 +1,0 @@
-import Rspack from '@rspack/core';
-
-export { Rspack };

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -1,3 +1,4 @@
+import type { rspack } from '@rspack/core';
 import type { SwcLoaderOptions } from '@rspack/core';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
 import type { BundlerChain } from '../bundlerConfig';
@@ -74,7 +75,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
   ) => void;
   removePlugin: (pluginName: string) => void;
   mergeConfig: typeof import('../../../compiled/webpack-merge').merge;
-  rspack: typeof import('@rspack/core');
+  rspack: typeof rspack;
 };
 
 export type ToolsRspackConfig = ChainedConfigWithUtils<

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -308,6 +308,24 @@ logger.override({
 logger.info('hello'); // [info] hello
 ```
 
+## rspack
+
+The `rspack` object exported from `@rspack/core`.
+
+You can import to the `rspack` object from `@rsbuild/core` without the need to install the `@rspack/core` dependency.
+
+- **Type:** `Rspack`
+- **Example:**
+
+```ts
+import { rspack } from '@rsbuild/core';
+
+console.log(rspack.rspackVersion); // 1.0.0
+console.log(rspack.util.createHash);
+```
+
+> Please refer to [Rspack - Node API](https://rspack.dev/api/node-api) for more information.
+
 ## version
 
 The version of `@rsbuild/core` currently in use.

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -165,7 +165,7 @@ await rsbuild.build({
 In some cases, you may want to use a custom compiler:
 
 ```ts
-import { rspack } from '@rspack/core';
+import { rspack } from '@rsbuild/core';
 
 const compiler = rspack({
   // ...
@@ -247,7 +247,7 @@ await server.close();
 In some cases, you may want to use a custom compiler:
 
 ```ts
-import { rspack } from '@rspack/core';
+import { rspack } from '@rsbuild/core';
 
 const compiler = rspack({
   // ...

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -165,7 +165,7 @@ export default {
 
 ### rspack
 
-- **Type:** `typeof import('@rspack/core')`
+- **Type:** `Rspack`
 
 The Rspack instance. For example:
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -208,7 +208,7 @@ type ModifyRspackConfigUtils = {
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  rspack: typeof import('@rspack/core');
+  rspack: Rspack;
 };
 
 function ModifyRspackConfig(

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -308,6 +308,24 @@ logger.override({
 logger.info('hello'); // [info] hello
 ```
 
+## rspack
+
+由 `@rspack/core` 导出的 `rspack` 对象。
+
+你可以直接从 `@rsbuild/core` 中引用 `rspack` 对象，而无须额外安装 `@rspack/core` 依赖。
+
+- **类型：** `Rspack`
+- **示例：**
+
+```ts
+import { rspack } from '@rsbuild/core';
+
+console.log(rspack.rspackVersion); // 1.0.0
+console.log(rspack.util.createHash);
+```
+
+> 请参考 [Rspack - Node API](https://rspack.dev/api/node-api) 了解更多。
+
 ## version
 
 当前使用的 `@rsbuild/core` 的版本。

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -165,7 +165,7 @@ await rsbuild.build({
 个别情况下，你可能希望使用自定义的 compiler：
 
 ```ts
-import { rspack } from '@rspack/core';
+import { rspack } from '@rsbuild/core';
 
 const compiler = rspack({
   // ...
@@ -247,7 +247,7 @@ await server.close();
 个别情况下，你可能希望使用自定义的 compiler：
 
 ```ts
-import { rspack } from '@rspack/core';
+import { rspack } from '@rsbuild/core';
 
 const compiler = rspack({
   // ...

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -165,7 +165,7 @@ export default {
 
 ### rspack
 
-- **类型：** `typeof import('@rspack/core')`
+- **类型：** `Rspack`
 
 通过这个参数你可以拿到 Rspack 实例。比如：
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -207,7 +207,7 @@ type ModifyRspackConfigUtils = {
   target: RsbuildTarget;
   isServer: boolean;
   isWebWorker: boolean;
-  rspack: typeof import('@rspack/core');
+  rspack: Rspack;
 };
 
 function ModifyRspackConfig(


### PR DESCRIPTION
## Summary

Export the rspack object from core.

So users can directly refer to this object from `@rsbuild/core` without the need to install the `@rspack/core` dependency separately.

- **Type:** `Rspack`
- **Example:**

```ts
import { rspack } from '@rsbuild/core';

console.log(rspack.rspackVersion); // 1.0.0
console.log(rspack.util.createHash);
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
