### PR TITLE
fix(core): prebundle should be devDependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,8 +58,7 @@
     "@swc/helpers": "0.5.3",
     "core-js": "~3.36.0",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.6.2",
-    "postcss": "^8.4.38",
-    "prebundle": "1.0.3"
+    "postcss": "^8.4.38"
   },
   "devDependencies": {
     "@types/node": "18.x",
@@ -73,6 +72,7 @@
     "launch-editor-middleware": "^2.6.1",
     "on-finished": "2.4.1",
     "open": "^8.4.0",
+    "prebundle": "1.0.3",
     "sirv": "^2.0.4",
     "typescript": "^5.4.2",
     "webpack": "^5.91.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,9 +697,6 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
-      prebundle:
-        specifier: 1.0.3
-        version: 1.0.3
     devDependencies:
       '@types/node':
         specifier: 18.x
@@ -734,6 +731,9 @@ importers:
       open:
         specifier: ^8.4.0
         version: 8.4.2
+      prebundle:
+        specifier: 1.0.3
+        version: 1.0.3
       sirv:
         specifier: ^2.0.4
         version: 2.0.4


### PR DESCRIPTION
## Summary

The prebundle should be devDependencies of `@rsbuild/core`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
