### PR TITLE
fix(plugin-assets-retry): execute onSuccess onFail once in async-chunk-retry

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -279,6 +279,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   });
 
   const rsbuild = await createRsbuildWithMiddleware(blockedMiddleware, {
+    minify: true,
     onRetry(context) {
       console.info('onRetry', context);
     },

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -61,7 +61,7 @@ async function createRsbuildWithMiddleware(
   return rsbuild;
 }
 
-test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index.js`', async ({
+test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index.js', async ({
   page,
 }) => {
   process.env.DEBUG = 'rsbuild';
@@ -82,7 +82,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index
   delete process.env.DEBUG;
 });
 
-test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking initial chunk index.js`', async ({
+test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking initial chunk index.js', async ({
   page,
 }) => {
   process.env.DEBUG = 'rsbuild';
@@ -129,7 +129,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', asyn
   delete process.env.DEBUG;
 });
 
-test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking async chunk`', async ({
+test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking async chunk', async ({
   page,
 }) => {
   process.env.DEBUG = 'rsbuild';
@@ -155,7 +155,7 @@ test('@rsbuild/plugin-assets-retry should work with minified runtime code when b
   delete process.env.DEBUG;
 });
 
-test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary when all retries failed`', async ({
+test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary when all retries failed', async ({
   page,
 }) => {
   process.env.DEBUG = 'rsbuild';
@@ -183,7 +183,7 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
   delete process.env.DEBUG;
 });
 
-test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying async chunk`', async ({
+test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying async chunk', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -266,7 +266,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await rsbuild.close();
 });
 
-test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying async chunk`', async ({
+test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying async chunk', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -1,10 +1,7 @@
 import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
-import type {
-  AssetsRetryHookContext,
-  PluginAssetsRetryOptions,
-} from '@rsbuild/plugin-assets-retry';
+import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';
 
@@ -17,6 +14,13 @@ function count404Response(logs: string[], urlPrefix: string): number {
   }
   return count;
 }
+
+type AssetsRetryHookContext = {
+  url: string;
+  times: number;
+  domain: string;
+  tagName: string;
+};
 
 function createBlockMiddleware({
   urlPrefix,

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -168,8 +168,8 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
-  expect(await compTestElement.textContent()).toContain(
-    'ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from /static/js/async/src_AsyncCompTest_tsx.js failed after 3 retries. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed',
+  await expect(compTestElement).toHaveText(
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries\. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   const blockedResponseCount = count404Response(
     logs,
@@ -293,8 +293,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
     if (msg.type() !== 'info') {
       return;
     }
-    const typeValue = await msg.args()[0].jsonValue();
-    const contextValue = await msg.args()[1].jsonValue();
+    const typeValue = await msg.args()?.[0].jsonValue();
+    const contextValue = await msg.args()?.[1].jsonValue();
 
     if (typeValue === 'onRetry') {
       onRetryContextList.push(contextValue);
@@ -307,8 +307,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
-  expect(await compTestElement.textContent()).toContain(
-    'ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from /static/js/async/src_AsyncCompTest_tsx.js failed after 3 retries. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed',
+  await expect(compTestElement).toHaveText(
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries\. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   expect({
     onRetryContextList,

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -165,8 +165,8 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
-  await expect(compTestElement).toHaveText(
-    'ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from /static/js/async/src_AsyncCompTest_tsx.js failed after 3 retries.',
+  expect(await compTestElement.textContent()).toContain(
+    'ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from /static/js/async/src_AsyncCompTest_tsx.js failed after 3 retries. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed',
   );
   const blockedResponseCount = count404Response(logs, '/static/js/async');
   // 1 first request failed

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -173,7 +173,7 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
   await expect(compTestElement).toHaveText(
-    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries\. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed.*/,
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   const blockedResponseCount = count404Response(
     logs,
@@ -312,7 +312,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
   await expect(compTestElement).toHaveText(
-    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries\. The error message of the last retry is "Loading chunk src_AsyncCompTest_tsx failed.*/,
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   expect({
     onRetryContextList,

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -187,6 +187,14 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
   delete process.env.DEBUG;
 });
 
+function delay(ms: number = 300) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve;
+    }, ms);
+  });
+}
+
 test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying async chunk', async ({
   page,
 }) => {
@@ -231,7 +239,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
-  await rsbuild.close();
+  await delay();
 
   expect({
     onRetryContextList,
@@ -268,6 +276,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
       },
     ],
   });
+  await rsbuild.close();
 });
 
 test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying async chunk', async ({
@@ -315,7 +324,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await expect(compTestElement).toHaveText(
     /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
-  await rsbuild.close();
+  await delay();
 
   expect({
     onRetryContextList,
@@ -352,4 +361,5 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
     ],
     onSuccessContextList: [],
   });
+  await rsbuild.close();
 });

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -2,8 +2,8 @@ import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type {
-  PluginAssetsRetryOptions,
   AssetsRetryHookContext,
+  PluginAssetsRetryOptions,
 } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -231,6 +231,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
+
+  await rsbuild.close();
   expect({
     onRetryContextList,
     onFailContextList,
@@ -266,8 +268,6 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
       },
     ],
   });
-
-  await rsbuild.close();
 });
 
 test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying async chunk', async ({
@@ -315,6 +315,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await expect(compTestElement).toHaveText(
     /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
+
+  await rsbuild.close();
   expect({
     onRetryContextList,
     onFailContextList,
@@ -350,6 +352,4 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
     ],
     onSuccessContextList: [],
   });
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -231,8 +231,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
-
   await rsbuild.close();
+
   expect({
     onRetryContextList,
     onFailContextList,
@@ -315,8 +315,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await expect(compTestElement).toHaveText(
     /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
-
   await rsbuild.close();
+
   expect({
     onRetryContextList,
     onFailContextList,

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -187,10 +187,10 @@ test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary whe
   delete process.env.DEBUG;
 });
 
-function delay(ms: number = 300) {
+function delay(ms = 300) {
   return new Promise((resolve) => {
     setTimeout(() => {
-      resolve;
+      resolve(1);
     }, ms);
   });
 }

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,9 +1,9 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
-import type { PluginAssetsRetryOptions } from './types';
+import type { PluginAssetsRetryOptions, AssetsRetryHookContext } from './types';
 
-export type { PluginAssetsRetryOptions };
+export type { PluginAssetsRetryOptions, AssetsRetryHookContext };
 
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,9 +1,9 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
-import type { AssetsRetryHookContext, PluginAssetsRetryOptions } from './types';
+import type { PluginAssetsRetryOptions } from './types';
 
-export type { AssetsRetryHookContext, PluginAssetsRetryOptions };
+export type { PluginAssetsRetryOptions };
 
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -3,7 +3,7 @@ import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
 import type { AssetsRetryHookContext, PluginAssetsRetryOptions } from './types';
 
-export type { PluginAssetsRetryOptions, AssetsRetryHookContext };
+export type { AssetsRetryHookContext, PluginAssetsRetryOptions };
 
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
-import type { PluginAssetsRetryOptions, AssetsRetryHookContext } from './types';
+import type { AssetsRetryHookContext, PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions, AssetsRetryHookContext };
 

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -153,7 +153,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
         url: nextRetryUrl,
         tagName: 'script',
       };
-      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries. The error message of the last retry is "${error.message}"`;
+      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
       if (typeof config.onFail === 'function') {
         config.onFail(context);
       }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -181,6 +181,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
       throw error;
     }
 
+    // Start retry
     if (config.onRetry && typeof config.onRetry === 'function') {
       const context: AssetsRetryHookContext = {
         times: existRetryTimes - 1,

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -153,7 +153,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
         url: nextRetryUrl,
         tagName: 'script',
       };
-      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries.`;
+      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries. The error message of the last retry is "${error.message}"`;
       if (typeof config.onFail === 'function') {
         config.onFail(context);
       }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -68,6 +68,20 @@ function findNextDomain(url: string) {
 //   return `?retry-attempt=${existRetryTimes}`;
 // }
 
+function createAssetsRetryContext(
+  times: number,
+  domain: string,
+  url: string,
+  tagName: string,
+): AssetsRetryHookContext {
+  return {
+    times,
+    domain,
+    url,
+    tagName,
+  };
+}
+
 function getCurrentRetry(chunkId: string): Retry | undefined {
   return retryCollector[chunkId];
 }
@@ -146,17 +160,17 @@ function ensureChunk(chunkId: string): Promise<unknown> {
     const { existRetryTimes, originalSrcUrl, nextRetryUrl, nextDomain } =
       nextRetry(chunkId);
 
-    const currContext: AssetsRetryHookContext = {
-      times: existRetryTimes - 1,
-      domain: nextDomain,
-      url: nextRetryUrl,
-      tagName: 'script',
-    };
+    const context = createAssetsRetryContext(
+      existRetryTimes - 1,
+      nextDomain,
+      nextRetryUrl,
+      'script',
+    );
 
     if (existRetryTimes > maxRetries) {
       error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
       if (typeof config.onFail === 'function') {
-        config.onFail(currContext);
+        config.onFail(context);
       }
       throw error;
     }
@@ -184,16 +198,18 @@ function ensureChunk(chunkId: string): Promise<unknown> {
 
     // Start retry
     if (config.onRetry && typeof config.onRetry === 'function') {
-      config.onRetry(currContext);
+      config.onRetry(context);
     }
 
     // biome-ignore lint/complexity/useArrowFunction: use function instead of () => {}
     return ensureChunk(chunkId).then((result) => {
       if (typeof config.onSuccess === 'function') {
-        const context = {
-          ...currContext,
-          times: existRetryTimes,
-        };
+        const context = createAssetsRetryContext(
+          existRetryTimes,
+          nextDomain,
+          nextRetryUrl,
+          'script',
+        );
         const { existRetryTimes: currRetryTimes } =
           getCurrentRetry(chunkId) ?? {};
 

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -324,7 +324,10 @@ function init(options: RuntimeRetryOptions) {
   }
 
   // init global variables shared with async chunk
-  if (typeof window !== 'undefined' && !window.__ASYNC_CHUNK_FILENAME_LIST__) {
+  if (
+    typeof window !== 'undefined' &&
+    !window.__ASYNC_CHUNK_FILENAME_LIST__
+  ) {
     window.__ASYNC_CHUNK_FILENAME_LIST__ = {};
   }
   // Bind event in window


### PR DESCRIPTION
## Summary
some fixes
1. `onFail` or `onSuccess` would be triggered every time when retry succeed or failed, after merge this pull request, they will be trigged only once
2. pass the original error message, by https://github.com/web-infra-dev/rsbuild/pull/2200#issuecomment-2076897250
3. add more e2e cases

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2200
https://github.com/web-infra-dev/rsbuild/pull/2086#issuecomment-2076555980

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
