### PR TITLE
feat: supports use targets as a filter of the transform API

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
@@ -1,0 +1,23 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow plugin to transform code by targets', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const webJs = Object.keys(files).find(
+    (file) =>
+      file.includes('index') &&
+      !file.includes('server') &&
+      file.endsWith('.js'),
+  );
+  const nodeJs = Object.keys(files).find(
+    (file) =>
+      file.includes('index') && file.includes('server') && file.endsWith('.js'),
+  );
+
+  expect(files[webJs!].includes('target is web')).toBeTruthy();
+  expect(files[nodeJs!].includes('target is node')).toBeTruthy();
+});

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/myPlugin.ts
@@ -1,0 +1,17 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.transform({ test: /\.js$/, targets: ['web'] }, ({ code }) => {
+      return {
+        code: code.replace('hello', 'target is web'),
+      };
+    });
+    api.transform({ test: /\.js$/, targets: ['node'] }, ({ code }) => {
+      return {
+        code: code.replace('hello', 'target is node'),
+      };
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { myPlugin } from './myPlugin';
+
+export default {
+  plugins: [myPlugin],
+  output: {
+    targets: ['web', 'node'],
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/src/index.js
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -112,7 +112,11 @@ export function getPluginAPI({
 
     transformer[id] = handler;
 
-    hooks.modifyBundlerChain.tap((chain) => {
+    hooks.modifyBundlerChain.tap((chain, { target }) => {
+      if (descriptor.targets && !descriptor.targets.includes(target)) {
+        return;
+      }
+
       const rule = chain.module.rule(id);
 
       if (descriptor.test) {

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -28,6 +28,7 @@ import type {
   OnDevCompileDoneFn,
   OnExitFn,
 } from './hooks';
+import type { RsbuildTarget } from './rsbuild';
 import type { RspackConfig, RspackSourceMap } from './rspack';
 import type { Falsy, WebpackChain } from './utils';
 import type { MaybePromise } from './utils';
@@ -203,6 +204,11 @@ export type TransformDescriptor = {
    * @see https://rspack.dev/config/module#ruleresourcequery
    */
   resourceQuery?: RuleSetCondition;
+  /**
+   * Match based on the Rsbuild targets and only apply the transform to certain targets.
+   * @see https://rsbuild.dev/config/output/targets
+   */
+  targets?: RsbuildTarget[];
 };
 
 export type TransformFn = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -226,6 +226,7 @@ The descriptor param is an object describing the module's matching conditions.
 ```ts
 type TransformDescriptor = {
   test?: RuleSetCondition;
+  targets?: RsbuildTarget[];
   resourceQuery?: RuleSetCondition;
 };
 ```
@@ -236,6 +237,14 @@ The `descriptor` param supports the following matching conditions:
 
 ```js
 api.transform({ test: /\.pug$/ }, ({ code }) => {
+  // ...
+});
+```
+
+- `targets`: matches the Rsbuild [output.targets](/config/output/targets), and applies the current transform function only to the matched targets.
+
+```js
+api.transform({ test: /\.pug$/, targets: ['web'] }, ({ code }) => {
   // ...
 });
 ```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -224,6 +224,7 @@ descriptor 参数是一个对象，用于描述模块的匹配条件。
 ```ts
 type TransformDescriptor = {
   test?: RuleSetCondition;
+  targets?: RsbuildTarget[];
   resourceQuery?: RuleSetCondition;
 };
 ```
@@ -234,6 +235,14 @@ descriptor 参数支持设置以下匹配条件：
 
 ```js
 api.transform({ test: /\.pug$/ }, ({ code }) => {
+  // ...
+});
+```
+
+- `targets`：匹配 Rsbuild [output.targets](/config/output/targets)，仅对匹配的 targets 应用当前 transform 函数。
+
+```js
+api.transform({ test: /\.pug$/, targets: ['web'] }, ({ code }) => {
   // ...
 });
 ```


### PR DESCRIPTION
## Summary

Supports use targets as a filter of the transform API.

```js
api.transform({ test: /\.pug$/, targets: ['web'] }, ({ code }) => {
  // ...
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
