### PR TITLE
feat: support receive raw Buffer code with transform API

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -126,10 +126,12 @@ export function getPluginAPI({
         rule.resourceQuery(descriptor.resourceQuery);
       }
 
-      rule
-        .use(id)
-        .loader(join(__dirname, './rspack/transformLoader'))
-        .options({ id });
+      const loaderName = descriptor.raw
+        ? 'transformRawLoader'
+        : 'transformLoader';
+      const loaderPath = join(__dirname, `./rspack/${loaderName}`);
+
+      rule.use(id).loader(loaderPath).options({ id });
 
       applyTransformPlugin(chain, transformer);
     });

--- a/packages/core/src/rspack/transformRawLoader.ts
+++ b/packages/core/src/rspack/transformRawLoader.ts
@@ -1,0 +1,6 @@
+import transform from './transformLoader';
+
+export default transform;
+
+// make the loader to receive raw Buffer
+export const raw = true;

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -209,6 +209,11 @@ export type TransformDescriptor = {
    * @see https://rsbuild.dev/config/output/targets
    */
   targets?: RsbuildTarget[];
+  /**
+   * If raw is `true`, the transform handler will receive the Buffer type code instead of the string type.
+   * @see https://rspack.dev/api/loader-api#raw-loader
+   */
+  raw?: boolean;
 };
 
 export type TransformFn = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -228,6 +228,7 @@ type TransformDescriptor = {
   test?: RuleSetCondition;
   targets?: RsbuildTarget[];
   resourceQuery?: RuleSetCondition;
+  raw?: boolean;
 };
 ```
 

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -257,6 +257,14 @@ api.transform({ resourceQuery: /raw/ }, ({ code }) => {
 });
 ```
 
+- `raw`: if raw is `true`, the transform handler will receive the Buffer type code instead of the string type.
+
+```js
+api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
+  // ...
+});
+```
+
 ### Handler Param
 
 The handler param is a transformation function that takes the current module code and returns the transformed code.

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -226,6 +226,7 @@ type TransformDescriptor = {
   test?: RuleSetCondition;
   targets?: RsbuildTarget[];
   resourceQuery?: RuleSetCondition;
+  raw?: boolean;
 };
 ```
 
@@ -251,6 +252,14 @@ api.transform({ test: /\.pug$/, targets: ['web'] }, ({ code }) => {
 
 ```js
 api.transform({ resourceQuery: /raw/ }, ({ code }) => {
+  // ...
+});
+```
+
+- `raw`：如果 `raw` 为 `true`，则 transform 函数将接收到 Buffer 类型的代码，而不是 string 类型。
+
+```js
+api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
   // ...
 });
 ```


### PR DESCRIPTION
## Summary

if raw is `true`, the transform handler will receive the Buffer type code instead of the string type.

```js
api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
  // ...
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
