### PR TITLE
docs: improve CSS modules type declaration

### DIFF
--- a/website/docs/en/guide/basic/css-modules.mdx
+++ b/website/docs/en/guide/basic/css-modules.mdx
@@ -131,6 +131,17 @@ declare module '*.module.stylus' {
 }
 ```
 
+- Method 3: If you need to use **named imports** to reference class names, you can use a looser type declaration:
+
+```ts title="src/env.d.ts"
+declare module '*.module.css';
+declare module '*.module.scss';
+declare module '*.module.sass';
+declare module '*.module.less';
+declare module '*.module.styl';
+declare module '*.module.stylus';
+```
+
 After adding the type declaration, if the type error still exists, you can try to restart the current IDE, or adjust the directory where `env.d.ts` is located, making sure the TypeScript can correctly identify the type definition.
 
 ### Related configuration

--- a/website/docs/zh/guide/basic/css-modules.mdx
+++ b/website/docs/zh/guide/basic/css-modules.mdx
@@ -131,7 +131,18 @@ declare module '*.module.stylus' {
 }
 ```
 
-添加类型声明后，如果依然存在上述错误提示，请尝试重启当前 IDE，或者调整 `env.d.ts` 所在的目录，使 TypeScript 能够正确识别类型定义。
+- 方法三：如果你需要使用**具名导入**来引用类名，可以更松散的类型定义：
+
+```ts title="src/env.d.ts"
+declare module '*.module.css';
+declare module '*.module.scss';
+declare module '*.module.sass';
+declare module '*.module.less';
+declare module '*.module.styl';
+declare module '*.module.stylus';
+```
+
+添加类型声明后，如果依然存在类型错误，请尝试重启当前 IDE，或者调整 `env.d.ts` 所在的目录，使 TypeScript 能够正确识别类型定义。
 
 ### 相关配置
 


### PR DESCRIPTION
## Summary

Improve CSS modules type declaration.

When using named imports, it is hard to define a complete type declaration for CSS modules, so we can use a looser declaration.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
