### PR TITLE
test(e2e/plugin-assets-retry): fix windows unstable test caused by log parse

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -5,13 +5,23 @@ import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';
 
+const pattern = [
+  '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+  '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
+].join('|');
+
+const ansiRegex = new RegExp(pattern, 'g');
+
+function stripAnsi(content: string) {
+  return content.replace(ansiRegex, '');
+}
+
 function count404Response(logs: string[], urlPrefix: string): number {
   let count = 0;
   for (const log of logs) {
-    //  use a space to match
+    const rawLog = stripAnsi(log);
     // e.g: 18:09:23 404 GET /static/js/index.js 4.443 ms
-    if (log.includes('404') && log.includes(urlPrefix)) {
-      process.stdout.write(`${log}1111111111\n`);
+    if (rawLog.includes('404 GET') && rawLog.includes(urlPrefix)) {
       count++;
     }
   }

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -5,10 +5,13 @@ import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';
 
-function count404Response(logs: string[], urlPrefix: string): number {
+function count404Response(logs: string[], url: string): number {
   let count = 0;
   for (const log of logs) {
-    if (log.includes('404') && log.includes(urlPrefix)) {
+    //  use a space to match
+    // e.g: 18:09:23 404 GET /static/js/index.js 4.443 ms
+    if (log.includes('404') && log.includes(url.concat(' '))) {
+      process.stdout.write(`${log}1111111111\n`);
       count++;
     }
   }
@@ -59,6 +62,12 @@ async function createRsbuildWithMiddleware(
             middlewares.unshift(middleware);
           },
         ],
+      },
+      output: {
+        sourceMap: {
+          css: false,
+          js: false,
+        },
       },
     },
   });

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -5,12 +5,12 @@ import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';
 
-function count404Response(logs: string[], url: string): number {
+function count404Response(logs: string[], urlPrefix: string): number {
   let count = 0;
   for (const log of logs) {
     //  use a space to match
     // e.g: 18:09:23 404 GET /static/js/index.js 4.443 ms
-    if (log.includes('404') && log.includes(url.concat(' '))) {
+    if (log.includes('404') && log.includes(urlPrefix)) {
       process.stdout.write(`${log}1111111111\n`);
       count++;
     }

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -4,17 +4,7 @@ import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
 import type { RequestHandler } from '@rsbuild/shared';
-
-const pattern = [
-  '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
-  '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))',
-].join('|');
-
-const ansiRegex = new RegExp(pattern, 'g');
-
-function stripAnsi(content: string) {
-  return content.replace(ansiRegex, '');
-}
+import stripAnsi from 'strip-ansi';
 
 function count404Response(logs: string[], urlPrefix: string): number {
   let count = 0;

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -19,6 +19,7 @@
     "vue-router": "^4.3.2"
   },
   "devDependencies": {
+    "strip-ansi": "6.0.1",
     "@e2e/helper": "workspace:*",
     "@playwright/test": "1.43.1",
     "@rsbuild/babel-preset": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       playwright:
         specifier: 1.43.1
         version: 1.43.1
+      strip-ansi:
+        specifier: 6.0.1
+        version: 6.0.1
       tailwindcss:
         specifier: ^3.4.3
         version: 3.4.3


### PR DESCRIPTION
## Summary

case 1. `18:09:23 404 GET /static/js/index.js.map 4.443 ms`
case 2. `18:09:23 404 GET /static/js/index.js 1.440 ms`

<img width="703" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/79413249/c612ca83-ddc5-49fa-9641-bbe97b88c3dd">



## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
