### PR TITLE
fix(asset-retry): should use unminified code in dev builds

### DIFF
--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -16,7 +16,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
 
   readonly inlineScript: boolean;
 
-  readonly minify: boolean;
+  readonly minify?: boolean;
 
   readonly HtmlPlugin: typeof HtmlWebpackPlugin;
 
@@ -34,7 +34,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
       distDir,
       HtmlPlugin,
       inlineScript = true,
-      minify = process.env.NODE_ENV === 'production',
+      minify,
       ...retryOptions
     } = options;
     this.name = 'AssetsRetryPlugin';

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -48,12 +48,10 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
   getRawRuntimeRetryCode() {
     const { RuntimeGlobals } = rspack;
     const filename = 'asyncChunkRetry';
-    const minify =
-      this.options?.minify ?? process.env.NODE_ENV === 'production';
     const runtimeFilePath = path.join(
       __dirname,
       'runtime',
-      minify ? `${filename}.min.js` : `${filename}.js`,
+      this.options.minify ? `${filename}.min.js` : `${filename}.js`,
     );
     const rawText = fse.readFileSync(runtimeFilePath, 'utf-8');
 

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -59,7 +59,7 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
       "HtmlPlugin": [Function],
       "distDir": "static/js",
       "inlineScript": true,
-      "minify": true,
+      "minify": false,
       "name": "AssetsRetryPlugin",
       "scriptPath": "",
     },
@@ -68,7 +68,7 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
       "options": {
         "crossOrigin": false,
         "isRspack": false,
-        "minify": true,
+        "minify": false,
       },
       "runtimeOptions": {},
     },

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -221,7 +221,13 @@ Configure whether to enable code minification for runtime JavaScript code.
 
 By default, it will be affected by the [output.minify](/config/output/minify) configuration.
 
-### Notes
+```js
+pluginAssetsRetry({
+  minify: true,
+});
+```
+
+## Notes
 
 When you use Assets Retry plugin, the Rsbuild injects some runtime code into the HTML and serializes the Assets Retry plugin config, inserting it into the runtime code. Therefore, you need to be aware of the following:
 
@@ -245,17 +251,17 @@ pluginAssetsRetry({
 });
 ```
 
-### Limitation
+## Limitation
 
 Assets Retry plugin may not work in the following scenarios:
 
-#### Micro-frontend
+### Micro-frontend
 
 If your project is a micro-frontend application (such as a Garfish sub-application), the assets retry may not work because micro-frontend sub-applications are typically not loaded directly based on the `<script>` tag.
 
 If you need to retry assets in micro-frontend scenarios, please contact the developers of the micro-frontend framework to find a solution.
 
-#### Assets in custom templates
+### Assets in custom templates
 
 Assets Retry plugin listens to the page error event to know whether the current resource fails to load and needs to be retried. Therefore, if the resource in the custom template is executed earlier than Assets Retry plugin, then Assets Retry plugin cannot listen to the event that the resource fails to load, so it will not be retried.
 

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -221,7 +221,13 @@ pluginAssetsRetry({
 
 默认情况下，会受到 [output.minify](/config/output/minify) 配置的影响。
 
-### 注意事项
+```js
+pluginAssetsRetry({
+  minify: true,
+});
+```
+
+## 注意事项
 
 当你使用 Assets Retry 插件时，Rsbuild 会向 HTML 中注入一段运行时代码，并将 Assets Retry 插件配置的内容序列化，插入到这段代码中，因此你需要注意：
 
@@ -245,17 +251,17 @@ pluginAssetsRetry({
 });
 ```
 
-### 使用限制
+## 使用限制
 
 以下场景 Assets Retry 插件可能无法生效：
 
-#### 微前端
+### 微前端
 
 如果你的工程是微前端应用（比如 Garfish 子应用），那么 Assets Retry 插件可能无法生效，因为微前端子应用通常不是基于 `<script>` 标签直接加载的。
 
 如果你需要对微前端场景的资源加载进行重试，请联系微前端框架的开发者，以寻找相应的解决方案。
 
-#### 自定义模版中的资源
+### 自定义模版中的资源
 
 Assets Retry 插件通过监听页面 error 事件来获悉当前资源是否加载失败需要重试。因此，如果自定义模版中的资源执行早于 Assets Retry 插件，那 Assets Retry 插件无法监听到该资源加载失败的事件，retry 无法对其生效。
 


### PR DESCRIPTION
## Summary

Should use unminified assets retry code in dev builds.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1978

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
