### PR TITLE
fix: Acquire the real address to ensure the ability to open the edito…

### DIFF
--- a/packages/core/src/client/formatStats.ts
+++ b/packages/core/src/client/formatStats.ts
@@ -15,6 +15,19 @@ function isLikelyASyntaxError(message: string) {
   return message.includes(friendlySyntaxErrorLabel);
 }
 
+function resolveFileName(stats: webpack.StatsError) {
+  const regex = /(?:\!|^)([^!]+)$/;
+
+  // Get the real source file path with stats.moduleIdentifier.
+  // e.g. moduleIdentifier is builtin:react-refresh-loader!/Users/x/src/App.jsx"
+  let fileName = stats.moduleIdentifier?.match(regex)?.at(-1) ?? '';
+
+  // add default column add lines
+  if (fileName) fileName = `File: ${fileName}:1:1\n`;
+
+  return fileName;
+}
+
 // Cleans up webpack error messages.
 function formatMessage(stats: webpack.StatsError | string) {
   let lines: string[] = [];
@@ -23,7 +36,7 @@ function formatMessage(stats: webpack.StatsError | string) {
 
   // webpack 5 stats error object
   if (typeof stats === 'object') {
-    const fileName = stats.moduleName ? `File: ${stats.moduleName}\n` : '';
+    const fileName = resolveFileName(stats);
     // compat rspack
     const mainMessage =
       typeof stats.formatted === 'string' ? stats.formatted : stats.message;


### PR DESCRIPTION
## Summary

By `stats.moduleIdentifier`, we can obtain the file information from the error stack, ensuring the ability to open the editor in the overlay.

Within the compile error information of rspack and webpack, file information is not included as it is with `Vite`. This absence prevents direct pinpointing and opening of the editor from the overlay.

Currently, there is hope to acquire the source file through stats.moduleIdentifier. Unfortunately, it is not possible to obtain the exact line and column, as the error stack does not contain this information, thus it is defaulted to the first line and first column."

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
