### PR TITLE
fix(overlay): fallback to moduleName if moduleIdentifier parse failed

### DIFF
--- a/packages/core/src/client/formatStats.ts
+++ b/packages/core/src/client/formatStats.ts
@@ -20,14 +20,11 @@ function resolveFileName(stats: webpack.StatsError) {
   // e.g. moduleIdentifier is "builtin:react-refresh-loader!/Users/x/src/App.jsx"
   const regex = /(?:\!|^)([^!]+)$/;
   const fileName = stats.moduleIdentifier?.match(regex)?.at(-1) ?? '';
-
-  // add default column add lines
-  if (fileName) {
-    return `File: ${fileName}:1:1\n`;
-  }
-
-  // fallback to moduleName if moduleIdentifier parse failed
-  return `File: ${stats.moduleName}\n`;
+  return fileName
+    ? // add default column add lines for linking
+      `File: ${fileName}:1:1\n`
+    : // fallback to moduleName if moduleIdentifier parse failed
+      `File: ${stats.moduleName}\n`;
 }
 
 // Cleans up webpack error messages.

--- a/packages/core/src/client/formatStats.ts
+++ b/packages/core/src/client/formatStats.ts
@@ -16,16 +16,18 @@ function isLikelyASyntaxError(message: string) {
 }
 
 function resolveFileName(stats: webpack.StatsError) {
-  const regex = /(?:\!|^)([^!]+)$/;
-
   // Get the real source file path with stats.moduleIdentifier.
-  // e.g. moduleIdentifier is builtin:react-refresh-loader!/Users/x/src/App.jsx"
-  let fileName = stats.moduleIdentifier?.match(regex)?.at(-1) ?? '';
+  // e.g. moduleIdentifier is "builtin:react-refresh-loader!/Users/x/src/App.jsx"
+  const regex = /(?:\!|^)([^!]+)$/;
+  const fileName = stats.moduleIdentifier?.match(regex)?.at(-1) ?? '';
 
   // add default column add lines
-  if (fileName) fileName = `File: ${fileName}:1:1\n`;
+  if (fileName) {
+    return `File: ${fileName}:1:1\n`;
+  }
 
-  return fileName;
+  // fallback to moduleName if moduleIdentifier parse failed
+  return `File: ${stats.moduleName}\n`;
 }
 
 // Cleans up webpack error messages.


### PR DESCRIPTION
## Summary

Fallback to `stats.moduleName` if `stats.moduleIdentifier` parse failed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
