### PR TITLE
fix: failed to display overlay when use MF

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -244,4 +244,4 @@ function clearOverlay() {
   document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());
 }
 
-registerOverlay({ createOverlay, clearOverlay });
+registerOverlay(createOverlay, clearOverlay);


### PR DESCRIPTION
## Summary

Fix failed to display overlay when use MF. Rsbuild should only close overlay when the compilation hash changed.

Reproduction: https://github.com/rspack-contrib/rspack-examples/pull/58

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
