### PR TITLE
refactor: ship less client code

### DIFF
--- a/.changeset/happy-fishes-cover.md
+++ b/.changeset/happy-fishes-cover.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.6.8

--- a/packages/core/src/client/formatStats.ts
+++ b/packages/core/src/client/formatStats.ts
@@ -30,7 +30,6 @@ function resolveFileName(stats: webpack.StatsError) {
 // Cleans up webpack error messages.
 function formatMessage(stats: webpack.StatsError | string) {
   let lines: string[] = [];
-
   let message: string;
 
   // webpack 5 stats error object
@@ -98,18 +97,17 @@ function formatMessage(stats: webpack.StatsError | string) {
 }
 
 export function formatStatsMessages(
-  json?: Pick<StatsCompilation, 'errors' | 'warnings'>,
+  stats: Pick<StatsCompilation, 'errors' | 'warnings'>,
 ): {
   errors: string[];
   warnings: string[];
 } {
-  const formattedErrors = json?.errors?.map(formatMessage);
-  const formattedWarnings = json?.warnings?.map(formatMessage);
+  const formattedErrors = stats.errors?.map(formatMessage);
+  const formattedWarnings = stats.warnings?.map(formatMessage);
 
   const result = {
     errors: formattedErrors || [],
     warnings: formattedWarnings || [],
-    errorTips: [],
   };
 
   if (result.errors?.some(isLikelyASyntaxError)) {

--- a/packages/core/src/client/hmr/url.ts
+++ b/packages/core/src/client/hmr/url.ts
@@ -5,13 +5,7 @@ import type { ClientConfig } from '@rsbuild/shared';
  */
 export const HMR_SOCK_PATH = '/rsbuild-hmr';
 
-export function createSocketUrl(options: ClientConfig = {}) {
-  const currentLocation = self.location;
-
-  return getSocketUrl(options, currentLocation);
-}
-
-export function formatURL({
+function formatURL({
   port,
   protocol,
   hostname,
@@ -36,7 +30,8 @@ export function formatURL({
   return `${protocol}${colon}//${hostname}:${port}${pathname}`;
 }
 
-function getSocketUrl(urlParts: ClientConfig, location: Location) {
+export function getSocketUrl(urlParts: ClientConfig) {
+  const { location } = self;
   const { host, port, path, protocol } = urlParts;
 
   return formatURL({

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -220,28 +220,21 @@ if (customElements && !customElements.get(overlayId)) {
   customElements.define(overlayId, ErrorOverlay);
 }
 
-const documentAvailable = typeof document !== 'undefined';
-
 function createOverlay(err: string[]) {
-  if (!documentAvailable) {
-    console.info(
-      '[Rsbuild] Failed to display error overlay as document is not available, you can disable the `dev.client.overlay` option.',
-    );
-    return;
-  }
-
   clearOverlay();
   document.body.appendChild(new ErrorOverlay(err));
 }
 
 function clearOverlay() {
-  if (!documentAvailable) {
-    return;
-  }
-
   // use NodeList's forEach api instead of dom.iterable
   // biome-ignore lint/complexity/noForEach: <explanation>
   document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());
 }
 
-registerOverlay(createOverlay, clearOverlay);
+if (typeof document !== 'undefined') {
+  registerOverlay(createOverlay, clearOverlay);
+} else {
+  console.info(
+    '[Rsbuild] Failed to display error overlay as document is not available, you can disable the `dev.client.overlay` option.',
+  );
+}


### PR DESCRIPTION
## Summary

Ship less client code by refactoring the client code and remove some outdated code.

For example, remove `typeof console` because we do not need to compatible with IE9:  https://github.com/facebook/create-react-app/pull/2301

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
