### PR TITLE
chore(server): get outputFileSystem via compiler.outputFileSystem

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import {
   type CreateDevMiddlewareReturns,
   type CreateDevServerOptions,
@@ -12,7 +13,6 @@ import {
   isMultiCompiler,
   setNodeEnv,
 } from '@rsbuild/shared';
-import fs from 'node:fs';
 import connect from '@rsbuild/shared/connect';
 import type { InternalContext } from '../types';
 import {

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -12,6 +12,7 @@ import {
   isMultiCompiler,
   setNodeEnv,
 } from '@rsbuild/shared';
+import fs from 'node:fs';
 import connect from '@rsbuild/shared/connect';
 import type { InternalContext } from '../types';
 import {
@@ -65,6 +66,8 @@ export async function createDevServer<
     https,
   };
 
+  let outputFileSystem = fs;
+
   const startCompile: () => Promise<
     RsbuildDevMiddlewareOptions['compileMiddlewareAPI']
   > = async () => {
@@ -87,6 +90,8 @@ export async function createDevServer<
     });
 
     compilerDevMiddleware.init();
+
+    outputFileSystem = isMultiCompiler(compiler) ? compiler.compilers[0].outputFileSystem : compiler.outputFileSystem; 
 
     return {
       middleware: compilerDevMiddleware.middleware,
@@ -138,6 +143,7 @@ export async function createDevServer<
     output: {
       distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
     },
+    outputFileSystem,
   });
 
   const middlewares = connect();
@@ -153,6 +159,7 @@ export async function createDevServer<
   const server = {
     port,
     middlewares,
+    outputFileSystem,
     listen: async () => {
       const httpServer = await createHttpServer({
         https: serverConfig.https,

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -63,7 +63,6 @@ const applyDefaultMiddlewares = async ({
   outputFileSystem,
 }: RsbuildDevMiddlewareOptions & {
   middlewares: Middlewares;
-  compileMiddlewareAPI?: CompileMiddlewareAPI;
 }): Promise<{
   onUpgrade: UpgradeEvent;
 }> => {
@@ -204,13 +203,8 @@ export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
   middlewares.push(...before);
 
   const { onUpgrade } = await applyDefaultMiddlewares({
+    ...options,
     middlewares,
-    dev: options.dev,
-    server: options.server,
-    compileMiddlewareAPI,
-    output: options.output,
-    pwd: options.pwd,
-    outputFileSystem: options.outputFileSystem,
   });
 
   middlewares.push(...after);

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,6 +1,6 @@
+import type fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import url from 'node:url';
-import type fs from 'node:fs';
 import type {
   CompileMiddlewareAPI,
   DevConfig,

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,5 +1,6 @@
 import { isAbsolute, join } from 'node:path';
 import url from 'node:url';
+import type fs from 'node:fs';
 import type {
   CompileMiddlewareAPI,
   DevConfig,
@@ -21,6 +22,7 @@ export type RsbuildDevMiddlewareOptions = {
   dev: DevConfig;
   server: ServerConfig;
   compileMiddlewareAPI?: CompileMiddlewareAPI;
+  outputFileSystem: typeof fs;
   output: {
     distPath: string;
   };
@@ -58,6 +60,7 @@ const applyDefaultMiddlewares = async ({
   compileMiddlewareAPI,
   output,
   pwd,
+  outputFileSystem,
 }: RsbuildDevMiddlewareOptions & {
   middlewares: Middlewares;
   compileMiddlewareAPI?: CompileMiddlewareAPI;
@@ -154,6 +157,7 @@ const applyDefaultMiddlewares = async ({
         distPath: isAbsolute(distPath) ? distPath : join(pwd, distPath),
         callback: compileMiddlewareAPI.middleware,
         htmlFallback: server.htmlFallback,
+        outputFileSystem,
       }),
     );
 
@@ -206,6 +210,7 @@ export const getMiddlewares = async (options: RsbuildDevMiddlewareOptions) => {
     compileMiddlewareAPI,
     output: options.output,
     pwd: options.pwd,
+    outputFileSystem: options.outputFileSystem,
   });
 
   middlewares.push(...after);

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import type fs from 'node:fs';
 import path from 'node:path';
 import { parse } from 'node:url';
 import {
@@ -79,7 +79,8 @@ export const getHtmlFallbackMiddleware: (params: {
   distPath: string;
   callback?: Middleware;
   htmlFallback?: HtmlFallback;
-}) => Middleware = ({ htmlFallback, distPath, callback }) => {
+  outputFileSystem: typeof fs;
+}) => Middleware = ({ htmlFallback, distPath, callback, outputFileSystem }) => {
   /**
    * support access page without suffix and support fallback in some edge cases
    */
@@ -114,17 +115,6 @@ export const getHtmlFallbackMiddleware: (params: {
         new Error(`Invalid URL: ${color.yellow(url)}`, { cause: err }),
       );
       return next();
-    }
-
-    let outputFileSystem = fs;
-
-    // support memory fs
-    // @ts-expect-error
-    if (res.locals.webpack) {
-      // reference: https://github.com/webpack/webpack-dev-middleware#server-side-rendering
-      // @ts-expect-error
-      const { devMiddleware } = res.locals.webpack;
-      outputFileSystem = devMiddleware.outputFileSystem;
     }
 
     const rewrite = (newUrl: string, isFallback = false) => {


### PR DESCRIPTION
## Summary

get outputFileSystem via compiler.outputFileSystem, no need depend on webpack-dev-middleware#res.locals.webpack
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
