### PR TITLE
feat: ship runtime code in es2017 by default

### DIFF
--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -58,6 +58,7 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
         } else {
           applyScriptCondition({
             rule: chain.module.rule(CHAIN_ID.RULE.JS),
+            chain,
             config: rsbuildConfig,
             context: api.context,
             includes: [],

--- a/packages/core/modern.config.ts
+++ b/packages/core/modern.config.ts
@@ -6,12 +6,12 @@ export default defineConfig({
   buildConfig: [
     {
       ...baseBuildConfig.buildConfig,
-      input: ['src', '!src/client/hmr',  '!src/client/overlay.ts'],
+      input: ['src', '!src/client/hmr', '!src/client/overlay.ts'],
     },
     {
       buildType: 'bundle',
       format: 'esm',
-      target: 'es5',
+      target: 'es2017',
       dts: false,
       input: {
         hmr: 'src/client/hmr/index.ts',
@@ -20,6 +20,13 @@ export default defineConfig({
       externals: ['./hmr'],
       outDir: './dist/client',
       autoExtension: true,
+      externalHelpers: true,
+      // Skip esbuild transform and only use SWC to transform,
+      // because esbuild will transform `import.meta`.
+      esbuildOptions: (options) => {
+        options.target = undefined;
+        return options;
+      },
     },
   ],
 });

--- a/packages/core/src/plugins/target.ts
+++ b/packages/core/src/plugins/target.ts
@@ -8,26 +8,29 @@ export const pluginTarget = (): RsbuildPlugin => ({
   name: 'rsbuild:target',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { target }) => {
-      if (target === 'node') {
-        chain.target('node');
-        return;
-      }
+    api.modifyBundlerChain({
+      order: 'pre',
+      handler: async (chain, { target }) => {
+        if (target === 'node') {
+          chain.target('node');
+          return;
+        }
 
-      const config = api.getNormalizedConfig();
-      const browserslist = await getBrowserslistWithDefault(
-        api.context.rootPath,
-        config,
-        target,
-      );
-      const esVersion = browserslistToESVersion(browserslist);
+        const config = api.getNormalizedConfig();
+        const browserslist = await getBrowserslistWithDefault(
+          api.context.rootPath,
+          config,
+          target,
+        );
+        const esVersion = browserslistToESVersion(browserslist);
 
-      if (target === 'web-worker' || target === 'service-worker') {
-        chain.target(['webworker', `es${esVersion}`]);
-        return;
-      }
+        if (target === 'web-worker' || target === 'service-worker') {
+          chain.target(['webworker', `es${esVersion}`]);
+          return;
+        }
 
-      chain.target(['web', `es${esVersion}`]);
+        chain.target(['web', `es${esVersion}`]);
+      },
     });
   },
 });

--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -65,6 +65,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
 
         applyScriptCondition({
           rule,
+          chain,
           config,
           context: api.context,
           includes: [],

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -239,12 +239,14 @@ export type ChainIdentifier = typeof CHAIN_ID;
 
 export function applyScriptCondition({
   rule,
+  chain,
   config,
   context,
   includes,
   excludes,
 }: {
   rule: BundlerChainRule;
+  chain: BundlerChain;
   config: NormalizedConfig;
   context: RsbuildContext;
   includes: (string | RegExp)[];
@@ -259,6 +261,15 @@ export function applyScriptCondition({
   // Always compile TS and JSX files.
   // Otherwise, it will lead to compilation errors and incorrect output.
   rule.include.add(TS_AND_JSX_REGEX);
+
+  const target = castArray(chain.get('target'));
+  const legacyTarget = ['es3', 'es5', 'es6', 'es2015', 'es2016'];
+  if (
+    target.includes('web') &&
+    legacyTarget.some((item) => target.includes(item))
+  ) {
+    rule.include.add(/@rsbuild\/core\/dist\/client/);
+  }
 
   for (const condition of [...includes, ...(config.source.include || [])]) {
     rule.include.add(condition);

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -262,6 +262,8 @@ export function applyScriptCondition({
   // Otherwise, it will lead to compilation errors and incorrect output.
   rule.include.add(TS_AND_JSX_REGEX);
 
+  // The Rsbuild runtime code is es2017 by default,
+  // transform the runtime code if user target < es2017
   const target = castArray(chain.get('target'));
   const legacyTarget = ['es5', 'es6', 'es2015', 'es2016'];
   if (legacyTarget.some((item) => target.includes(item))) {

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -263,7 +263,7 @@ export function applyScriptCondition({
   rule.include.add(TS_AND_JSX_REGEX);
 
   const target = castArray(chain.get('target'));
-  const legacyTarget = ['es3', 'es5', 'es6', 'es2015', 'es2016'];
+  const legacyTarget = ['es5', 'es6', 'es2015', 'es2016'];
   if (legacyTarget.some((item) => target.includes(item))) {
     rule.include.add(/[\\/]@rsbuild[\\/]core[\\/]/);
   }

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -268,7 +268,7 @@ export function applyScriptCondition({
     target.includes('web') &&
     legacyTarget.some((item) => target.includes(item))
   ) {
-    rule.include.add(/@rsbuild\/core\/dist\/client/);
+    rule.include.add(/[\\/]@rsbuild[\\/]core[\\/]/);
   }
 
   for (const condition of [...includes, ...(config.source.include || [])]) {

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -264,10 +264,7 @@ export function applyScriptCondition({
 
   const target = castArray(chain.get('target'));
   const legacyTarget = ['es3', 'es5', 'es6', 'es2015', 'es2016'];
-  if (
-    target.includes('web') &&
-    legacyTarget.some((item) => target.includes(item))
-  ) {
+  if (legacyTarget.some((item) => target.includes(item))) {
     rule.include.add(/[\\/]@rsbuild[\\/]core[\\/]/);
   }
 


### PR DESCRIPTION
## Summary

- ship runtime code in es2017 by default
- use SWC to transform the runtime code if user target < es2017

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
