### PR TITLE
fix(hmr): should not register node compiler event

### DIFF
--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -257,7 +257,7 @@ describe('test dev server', () => {
   });
   test('should not setupServerHooks when compiler is server', () => {
     const compiler = rspack({
-      name: 'server',
+      name: 'Server',
     });
     const onDoneFn = vi.fn();
     const onInvalidFn = vi.fn();

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -228,7 +228,9 @@ test('printServerURLs', () => {
 
 describe('test dev server', () => {
   test('should setupServerHooks correctly', () => {
-    const compiler = rspack({});
+    const compiler = rspack({
+      target: 'web',
+    });
     const onDoneFn = vi.fn();
     const onInvalidFn = vi.fn();
 

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -257,7 +257,7 @@ describe('test dev server', () => {
   });
   test('should not setupServerHooks when compiler is server', () => {
     const compiler = rspack({
-      name: 'Server',
+      target: 'node',
     });
     const onDoneFn = vi.fn();
     const onInvalidFn = vi.fn();

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -323,7 +323,9 @@ type ServerCallbacks = {
 
 export const setupServerHooks = (
   compiler: {
-    name?: Compiler['name'];
+    options: {
+      target?: Compiler['options']['target'];
+    };
     hooks: {
       compile: CompilerTapFn<ServerCallbacks['onInvalid']>;
       invalid: CompilerTapFn<ServerCallbacks['onInvalid']>;
@@ -332,7 +334,7 @@ export const setupServerHooks = (
   },
   hookCallbacks: ServerCallbacks,
 ) => {
-  if (compiler.name === TARGET_ID_MAP.node) {
+  if (!isClientCompiler(compiler)) {
     return;
   }
 

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -7,7 +7,7 @@ import type {
 import deepmerge from '../compiled/deepmerge';
 import fse from '../compiled/fs-extra';
 import color from '../compiled/picocolors';
-import { DEFAULT_ASSET_PREFIX } from './constants';
+import { DEFAULT_ASSET_PREFIX, TARGET_ID_MAP } from './constants';
 import type {
   CacheGroups,
   CompilerTapFn,
@@ -332,7 +332,7 @@ export const setupServerHooks = (
   },
   hookCallbacks: ServerCallbacks,
 ) => {
-  if (compiler.name === 'server') {
+  if (compiler.name === TARGET_ID_MAP.node) {
     return;
   }
 

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -7,7 +7,7 @@ import type {
 import deepmerge from '../compiled/deepmerge';
 import fse from '../compiled/fs-extra';
 import color from '../compiled/picocolors';
-import { DEFAULT_ASSET_PREFIX, TARGET_ID_MAP } from './constants';
+import { DEFAULT_ASSET_PREFIX } from './constants';
 import type {
   CacheGroups,
   CompilerTapFn,


### PR DESCRIPTION
## Summary

fix node compiler.name check error, the compiler.name is `Server` instead of `server`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
