### PR TITLE
docs: fix broken plugin links and update MF glossary

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -30,6 +30,7 @@ flac
 flexbox
 flexbugs
 fnames
+frontends
 fullhash
 gzipped
 icss

--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -12,7 +12,7 @@ When using module federation, it is recommended that you use the `moduleFederati
 
 When you set the `moduleFederation.options` option, Rsbuild will take the following actions:
 
-- Automatically register the [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) plugin, and pass the value of `options` to the plugin.
+- Automatically register the [ModuleFederationPlugin](https://rspack.dev/plugins/webpack/module-federation-plugin) plugin, and pass the value of `options` to the plugin.
 - Set the default value of Rspack's [output.publicPath](https://rspack.dev/config/output#outputpublicpath) configuration to `'auto'`.
 - Turn off the `split-by-experience` rules in Rsbuild's [performance.chunkSplit](/config/performance/chunk-split) as it may conflict with shared modules, refer to [#3161](https://github.com/module-federation/module-federation-examples/issues/3161).
 - Turn off the splitChunks rule of remote entry.
@@ -32,7 +32,7 @@ export default defineConfig({
 });
 ```
 
-Please refer to the [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) document for all available options.
+Please refer to the [ModuleFederationPlugin](https://rspack.dev/plugins/webpack/module-federation-plugin) document for all available options.
 
 ## Example
 

--- a/website/docs/en/config/source/define.mdx
+++ b/website/docs/en/config/source/define.mdx
@@ -12,7 +12,7 @@ Each key passed into options is an identifier or multiple identifiers joined wit
 - If the value is an object all keys are defined the same way.
 - If you prefix typeof to the key, it's only defined for typeof calls.
 
-For more information please visit [Rspack - DefinePlugin](https://rspack.dev/config/plugins#defineplugin).
+For more information please visit [Rspack - DefinePlugin](https://rspack.dev/plugins/webpack/define-plugin).
 
 ### Example
 

--- a/website/docs/en/guide/start/glossary.mdx
+++ b/website/docs/en/guide/start/glossary.mdx
@@ -29,9 +29,12 @@ Modern.js is an open source web engineering system from ByteDance, which provide
 
 ## Module Federation
 
-Module Federation (MF) is a feature of Webpack. It allows a JavaScript application to dynamically load code from another application, and in the process, share dependencies. If an application consuming a federated module does not have a dependency needed by the federated code, Webpack will download the missing dependency from that federated build origin.
+Module Federation is an architectural pattern for the decentralization of JavaScript applications (similar to microservices on the server-side). It allows you to share code and resources among multiple JavaScript applications (or micro-frontends). This can help you:
 
-This allows for the creation of micro-frontend-style applications, where multiple systems can share code and be dynamically updated without having to rebuild the entire application.
+- Reduce code duplication
+- Improve code maintainability
+- Lower the overall size of your applications
+- Enhance the performance of your applications
 
 Rsbuild provides an example project for Module Federation. Please refer to [examples - module-federation](https://github.com/web-infra-dev/rsbuild/tree/main/examples/module-federation).
 

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -12,7 +12,7 @@
 
 当你设置 `moduleFederation.options` 选项后，Rsbuild 会执行以下操作：
 
-- 自动注册 [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) 插件，并将 `options` 的值透传给插件。
+- 自动注册 [ModuleFederationPlugin](https://rspack.dev/zh/plugins/webpack/module-federation-plugin) 插件，并将 `options` 的值透传给插件。
 - 将 Rspack [output.publicPath](https://rspack.dev/config/output#outputpublicpath) 配置的默认值设置为 `'auto'`。
 - 关闭 Rsbuild [performance.chunkSplit](/config/performance/chunk-split) 中 `split-by-experience` 相关的规则，因为这可能会与 shared modules 冲突，参考 [#3161](https://github.com/module-federation/module-federation-examples/issues/3161)。
 - 关闭 remote entry 的 splitChunks 规则。
@@ -32,7 +32,7 @@ export default defineConfig({
 });
 ```
 
-请参考 [ModuleFederationPlugin](https://rspack.dev/config/plugins#containermodulefederationplugin) 文档来了解所有可用的选项。
+请参考 [ModuleFederationPlugin](https://rspack.dev/zh/plugins/webpack/module-federation-plugin) 文档来了解所有可用的选项。
 
 ## 示例
 

--- a/website/docs/zh/config/source/define.mdx
+++ b/website/docs/zh/config/source/define.mdx
@@ -12,7 +12,7 @@
 - 嵌套对象的父子键名之间会用 `.` 连接作为需要替换的变量名。
 - 以 typeof 开头的键名会用来替换 typeof 调用。
 
-更多细节参考 [Rspack - DefinePlugin](https://rspack.dev/zh/config/plugins#defineplugin)。
+更多细节参考 [Rspack - DefinePlugin](https://rspack.dev/zh/plugins/webpack/define-plugin)。
 
 ### 示例
 

--- a/website/docs/zh/guide/start/glossary.mdx
+++ b/website/docs/zh/guide/start/glossary.mdx
@@ -29,9 +29,12 @@ Modern.js 是字节跳动 Web 工程体系的开源版本，它提供多个解�
 
 ## Module Federation
 
-模块联邦（Module Federation，简称 MF）是 Webpack 的一个特性。它允许 JavaScript 应用从另一个应用动态加载代码，并在此过程中共享依赖关系。如果使用联邦模块的应用缺少联邦代码所需的依赖项，Webpack 将从该联邦的构建源下载缺失的依赖项。
+Module Federation 是一种 JavaScript 应用分治的架构模式（类似于服务端的微服务），它允许你在多个 JavaScript 应用程序（或微前端）之间共享代码和资源。这可以帮助你：
 
-这使得可以创建微前端风格的应用程序，多个系统可以共享代码，并在不需要重新构建整个应用程序的情况下进行动态更新。
+- 减少代码重复
+- 提高代码可维护性
+- 降低应用程序的整体大小
+- 提高应用程序的性能
 
 Rsbuild 提供了一个 Module Federation 的示例项目，请参考 [examples - module-federation](https://github.com/web-infra-dev/rsbuild/tree/main/examples/module-federation)。
 


### PR DESCRIPTION
## Summary

Fix broken Rspack plugin links and update MF glossary.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
