### PR TITLE
fix: lodash is not defined error

### DIFF
--- a/.changeset/swift-experts-taste.md
+++ b/.changeset/swift-experts-taste.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.6.9

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "@rspack/core": "0.6.3",
     "@swc/helpers": "0.5.3",
     "core-js": "~3.36.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss": "^8.4.38"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "terser": "5.30.4",
     "typescript": "^5.4.2"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.4.2"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -138,7 +138,7 @@
     "deepmerge": "^4.3.1",
     "fs-extra": "^11.2.0",
     "gzip-size": "^6.0.0",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.0",
+    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "http-proxy-middleware": "^2.0.6",
     "icss-utils": "5.1.0",
     "jiti": "^1.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,8 +692,8 @@ importers:
         specifier: ~3.36.0
         version: 3.36.1
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.0
-        version: html-rspack-plugin@5.7.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
+        specifier: npm:html-rspack-plugin@5.7.2
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.6.3(@swc/helpers@0.5.3))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -809,8 +809,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.0
-        version: html-rspack-plugin@5.7.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
+        specifier: npm:html-rspack-plugin@5.7.2
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.6.3(@swc/helpers@0.5.3))
       terser:
         specifier: 5.30.4
         version: 5.30.4
@@ -1182,8 +1182,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.0
-        version: html-rspack-plugin@5.7.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
+        specifier: npm:html-rspack-plugin@5.7.2
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.6.3(@swc/helpers@0.5.3))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.38)
@@ -1590,8 +1590,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.0
-        version: html-rspack-plugin@5.7.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
+        specifier: npm:html-rspack-plugin@5.7.2
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.6.3(@swc/helpers@0.5.3))
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.6
@@ -5610,8 +5610,8 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-rspack-plugin@5.7.0:
-    resolution: {integrity: sha512-8qCnfnluqMHnw+Jo+NM1lLok8SxPBY09oRLcA2cjGZb7vlin+6g1oFLEWM7JCnQHKDjEnANPzbiXV/ysNuAGTg==}
+  html-rspack-plugin@5.7.2:
+    resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -13125,7 +13125,7 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@5.7.0(@rspack/core@0.6.3(@swc/helpers@0.5.3)):
+  html-rspack-plugin@5.7.2(@rspack/core@0.6.3(@swc/helpers@0.5.3)):
     optionalDependencies:
       '@rspack/core': 0.6.3(@swc/helpers@0.5.3)
 


### PR DESCRIPTION
## Summary

`lodash.template` will generate `_.escape()` and can not work as expected:

![image](https://github.com/rspack-contrib/html-rspack-plugin/assets/7237365/8c830330-bbb8-40a9-a759-0e1817d4bcaf)

Revert to lodash.

## Related Links

See: https://github.com/rspack-contrib/html-rspack-plugin/pull/8

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
