### PR TITLE
fix: print dist folder correctly if it's not a subdir of root

### DIFF
--- a/e2e/cases/performance/print-file-size/index.test.ts
+++ b/e2e/cases/performance/print-file-size/index.test.ts
@@ -134,4 +134,24 @@ test.describe('should print file size correctly', async () => {
     expect(logs.some((log) => log.includes('Total size:'))).toBeFalsy();
     expect(logs.some((log) => log.includes('Gzipped size:'))).toBeFalsy();
   });
+
+  test('should print dist folder correctly if it is not a subdir of root', async () => {
+    await build({
+      cwd,
+      rsbuildConfig: {
+        performance: {
+          printFileSize: true,
+        },
+        output: {
+          distPath: {
+            root: '../test-temp-folder/dist',
+          },
+        },
+      },
+    });
+
+    expect(
+      logs.some((log) => log.includes('../test-temp-folder/dist')),
+    ).toBeTruthy();
+  });
 });

--- a/e2e/cases/performance/print-file-size/index.test.ts
+++ b/e2e/cases/performance/print-file-size/index.test.ts
@@ -151,7 +151,9 @@ test.describe('should print file size correctly', async () => {
     });
 
     expect(
-      logs.some((log) => log.includes('../test-temp-folder/dist')),
+      logs.some((log) =>
+        log.includes(`..${path.sep}test-temp-folder${path.sep}dist`),
+      ),
     ).toBeTruthy();
   });
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,4 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  output: {
+    distPath: {
+      root: '../test/dist',
+    },
+  },
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,9 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  output: {
-    distPath: {
-      root: '../test/dist',
-    },
-  },
 });

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -94,6 +94,13 @@ async function printFileSizes(
     };
   };
 
+  const getDistFolderName = (distPath: string, rootPath: string) => {
+    if (distPath.includes(rootPath)) {
+      return distPath.replace(rootPath + path.sep, '');
+    }
+    return path.relative(rootPath, distPath);
+  };
+
   const multiStats = 'stats' in stats ? stats.stats : [stats];
   const assets = multiStats
     .map((stats) => {
@@ -119,7 +126,8 @@ async function printFileSizes(
       const filteredAssets = origin.assets!.filter((asset) =>
         filterAsset(asset.name),
       );
-      const distFolder = distPath.replace(rootPath + path.sep, '');
+
+      const distFolder = getDistFolderName(distPath, rootPath);
 
       return filteredAssets.map((asset) =>
         formatAsset(asset, distPath, distFolder),

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -94,13 +94,6 @@ async function printFileSizes(
     };
   };
 
-  const getDistFolderName = (distPath: string, rootPath: string) => {
-    if (distPath.includes(rootPath)) {
-      return distPath.replace(rootPath + path.sep, '');
-    }
-    return path.relative(rootPath, distPath);
-  };
-
   const multiStats = 'stats' in stats ? stats.stats : [stats];
   const assets = multiStats
     .map((stats) => {
@@ -127,7 +120,7 @@ async function printFileSizes(
         filterAsset(asset.name),
       );
 
-      const distFolder = getDistFolderName(distPath, rootPath);
+      const distFolder = path.relative(rootPath, distPath);
 
       return filteredAssets.map((asset) =>
         formatAsset(asset, distPath, distFolder),


### PR DESCRIPTION
## Summary

Should print dist folder correctly if it's not a subdir of root.

- before:

<img width="1069" alt="截屏2024-05-02 21 12 31" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/453368a4-3c94-4cb2-b570-87cf57d85477">

- after:

<img width="682" alt="截屏2024-05-02 21 05 09" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/6421b3dc-7e33-410f-8843-0ca3305a59e8">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
