### PR TITLE
docs: add basic deploy static site guide

### DIFF
--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -12,5 +12,6 @@
   "css-modules",
   "typescript",
   "tailwindcss",
-  "unocss"
+  "unocss",
+  "static-deploy"
 ]

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -79,9 +79,7 @@ Options:
 
 ## rsbuild preview
 
-The `rsbuild preview` command is used to preview the production build outputs locally. Note that you need to execute the `rsbuild build` command beforehand to generate the corresponding outputs.
-
-Do not use this as a production server as it's not designed for it.
+The `rsbuild preview` command is used to preview the production build outputs locally. Note that you need to execute the `rsbuild build` command beforehand to generate the build outputs.
 
 ```bash
 Usage: rsbuild preview [options]
@@ -94,6 +92,10 @@ Options:
   --env-mode <mode>     specify the env mode to load the `.env.[mode]` file
   -h, --help            display help for command
 ```
+
+:::tip
+The preview command is only used for local preview. Do not use it for production servers, as it is not designed for that.
+:::
 
 ## rsbuild inspect
 

--- a/website/docs/en/guide/basic/static-deploy.mdx
+++ b/website/docs/en/guide/basic/static-deploy.mdx
@@ -1,0 +1,115 @@
+# Deploy Static Site
+
+This section introduces how to deploy the build outputs of Rsbuild as a static site.
+
+## Background Information
+
+Before start deploying, you need to understand the following background knowledge:
+
+- You need to call Rsbuild's [build command](/guide/basic/cli#rsbuild-build) to generate the build outputs for production deployment.
+- Rsbuild's build outputs typically includes HTML, JS, CSS, and other assets, and is output to the `dist` directory by default. The name and structure of the dist directory can be changed using some configuration options. See the [Output Files](/guide/basic/output-files) section for more information.
+
+```bash
+dist
+├── static
+│   ├── image
+│   ├── css
+│   └── js
+└── [name].html
+```
+
+## Local Preview
+
+Rsbuild also provides a [preview command](/guide/basic/cli#rsbuild-preview) to preview the production build outputs locally. Note that you need to execute the `rsbuild build` command beforehand to generate the build outputs.
+
+```bash
+# Production build
+npx rsbuild build
+# Local preview
+npx rsbuild preview
+```
+
+:::tip
+The preview command is only used for local preview. Do not use it for production servers, as it is not designed for that.
+:::
+
+## GitHub Pages
+
+The following are step-by-step examples on how to deploy on GitHub Pages.
+
+1. Set the URL prefix for static assets through [output.assetPrefix](/config/output/asset-prefix).
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    // Please replace <USERNAME> with the GitHub user or organization name where
+    // the repository is located, and replace <REPO_NAME> with the repository name.
+    // For example, https://jack.github.io/my-project/
+    assetPrefix: 'https://<USERNAME>.github.io/<REPO_NAME>/',
+  },
+});
+```
+
+2. Open the "Settings" page of GitHub repository, click "Pages" from the left menu to access the configuration page of GitHub Pages.
+3. Select "Source" -> "GitHub Actions" and click "create your own" to create a GitHub Action config file.
+4. Paste the following content into the input box and name the file `github-pages.yml` (you can adjust the content and name of the file as needed).
+
+```yaml title="github-pages.yml"
+# Sample workflow for building and deploying a Rsbuild site to GitHub Pages
+name: Rsbuild Deployment
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ['main']
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      # If you use other package managers like yarn or pnpm,
+      # you will need to install them first
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+5. Commit and wait for GitHub Actions to execute. Once it's done, you can visit `https://<USERNAME>.github.io/<REPO_NAME>/` to view the deployed page.

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -12,5 +12,6 @@
   "css-modules",
   "typescript",
   "tailwindcss",
-  "unocss"
+  "unocss",
+  "static-deploy"
 ]

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -81,8 +81,6 @@ Options:
 
 `rsbuild preview` 命令用于在本地预览生产环境构建的产物, 注意你需要提前执行 `rsbuild build` 命令构建出对应产物。
 
-请勿将 preview 命令用作生产服务，因为它不是为此而设计的。
-
 ```bash
 Usage: rsbuild preview [options]
 
@@ -94,6 +92,10 @@ Options:
   --env-mode <mode>     指定 env 模式来加载 `.env.[mode]` 文件
   -h, --help            显示命令帮助
 ```
+
+:::tip
+preview 命令仅用于本地预览，请勿将它用于生产服务器，因为它不是为此而设计的。
+:::
 
 ## rsbuild inspect
 

--- a/website/docs/zh/guide/basic/static-deploy.mdx
+++ b/website/docs/zh/guide/basic/static-deploy.mdx
@@ -1,0 +1,115 @@
+# 部署静态站点
+
+本章节介绍如何将 Rsbuild 的构建产物部署为静态站点。
+
+## 背景知识
+
+在开始进行部署前，你需要了解以下背景知识：
+
+- 你需要调用 Rsbuild 的 [build 命令](/guide/basic/cli#rsbuild-build) 来生成用于部署到生产环境的构建产物。
+- Rsbuild 的构建产物通常包含 HTML、JS、CSS 等文件，默认输出到 `dist` 目录下，dist 目录的名称和结构可以通过一些配置项来修改，请参考 [构建产物目录](/guide/basic/output-files) 章节来了解更多。
+
+```bash
+dist
+├── static
+│   ├── image
+│   ├── css
+│   └── js
+└── [name].html
+```
+
+## 本地预览
+
+Rsbuild 还提供了 [preview 命令](/guide/basic/cli#rsbuild-preview)，用于在本地预览生产环境构建的产物, 注意你需要提前执行 `rsbuild build` 命令构建出对应产物。
+
+```bash
+# 生产构建
+npx rsbuild build
+# 本地预览
+npx rsbuild preview
+```
+
+:::tip
+preview 命令仅用于本地预览，请勿将它用于生产服务器，因为它不是为此而设计的。
+:::
+
+## GitHub Pages
+
+下面是部署到 GitHub Pages 的步骤示例。
+
+1. 通过 [output.assetPrefix](/config/output/asset-prefix) 设置静态资源的 URL 前缀。
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    // 请将 <USERNAME> 替换为仓库所在的 GitHub 用户或组织名称，
+    // 并将 <REPO_NAME> 替换为仓库的名称。
+    // 比如 https://jack.github.io/my-project/
+    assetPrefix: 'https://<USERNAME>.github.io/<REPO_NAME>/',
+  },
+});
+```
+
+2. 打开 GitHub 仓库的 "Settings" 页面，点击左侧菜单的 "Pages" 选项，进入 GitHub Pages 的配置页面。
+3. 选择 "Source" -> "GitHub Actions"，点击 "create your own" 来创建 GitHub Action 配置文件。
+4. 将以下内容粘贴到输入框，将文件命名为 `github-pages.yml`（你可以根据需要来调整文件的内容和名称）。
+
+```yaml title="github-pages.yml"
+# 用于构建和部署 Rsbuild 站点到 GitHub Pages 的示例工作流
+name: Rsbuild Deployment
+
+on:
+  # 在推送到默认分支时触发
+  push:
+    branches: ['main']
+  # 允许你从 Actions Tabs 手动运行这个工作流
+  workflow_dispatch:
+
+# 设置 GITHUB_TOKEN 的权限以允许部署到 GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同时只允许一个部署执行
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      # 如果你使用其他的包管理器，如 yarn 或 pnpm，
+      # 你需要先安装它们
+      - name: Install dependencies
+        run: npm i
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+5. 提交，等待 GitHub Actions 执行，执行完成后，你可以访问 `https://<USERNAME>.github.io/<REPO_NAME>/` 来查看部署后的页面。


### PR DESCRIPTION
## Summary

Add basic deploy static site guide and GitHub Pages deployment example

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/780

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
