### PR TITLE
fix: failed to resolve fsevents when using chokidar

### DIFF
--- a/.changeset/stale-bags-double.md
+++ b/.changeset/stale-bags-double.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+release: 0.6.10

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -123,6 +123,9 @@
     "caniuse-lite": "^1.0.30001614",
     "postcss": "^8.4.38"
   },
+  "optionalDependencies": {
+    "fsevents": "~2.3.3"
+  },
   "devDependencies": {
     "@types/connect": "3.4.38",
     "@types/fs-extra": "^11.0.4",

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -24,7 +24,12 @@ export default {
     'rslog',
     'deepmerge',
     'fs-extra',
-    'chokidar',
+    {
+      name: 'chokidar',
+      externals: {
+        fsevents: 'fsevents',
+      },
+    },
     'webpack-merge',
     'mime-types',
     'connect',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1546,6 +1546,10 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
+    optionalDependencies:
+      fsevents:
+        specifier: ~2.3.3
+        version: 2.3.3
     devDependencies:
       '@types/connect':
         specifier: 3.4.38


### PR DESCRIPTION
## Summary

Fix failed to resolve fsevents when using chokidar.

The `fsevents` is an optional dependency of `chokidar`, and `chokidar` is prebundled by `@rsbuild/shared`. So we should add it add an `optionalDependencies` of `@rsbuild/shared`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
