### PR TITLE
fix(plugin-svgr): failed to resolve file-loader

### DIFF
--- a/.changeset/nine-tips-draw.md
+++ b/.changeset/nine-tips-draw.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-svgr': patch
+---
+
+release: 0.6.11

--- a/packages/plugin-svgr/prebundle.config.mjs
+++ b/packages/plugin-svgr/prebundle.config.mjs
@@ -35,7 +35,7 @@ export default {
         const filePath = join(task.distPath, 'index.js');
         const content = readFileSync(filePath, 'utf-8');
         const newContent = content.replace(
-          '"file-loader"',
+          /['"]file-loader['"]/,
           'require.resolve("../file-loader")',
         );
 


### PR DESCRIPTION
## Summary

Fix failed to resolve file-loader, because we removed the minify step of prebundle and the file-loader path replacement can not work as expected.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/1238

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
