### PR TITLE
feat(plugin/assets-retry): support addQuery option

### DIFF
--- a/e2e/cases/assets-retry/src/testQueryEntry.js
+++ b/e2e/cases/assets-retry/src/testQueryEntry.js
@@ -1,0 +1,3 @@
+const script = document.createElement('script');
+script.src = '/test-query?a=1&b=1';
+document.head.appendChild(script);

--- a/e2e/cases/assets-retry/src/testQueryEntry.js
+++ b/e2e/cases/assets-retry/src/testQueryEntry.js
@@ -1,3 +1,14 @@
-const script = document.createElement('script');
-script.src = '/test-query?a=1&b=1';
-document.head.appendChild(script);
+function case1() {
+  const script = document.createElement('script');
+  script.src = '/test-query?a=1&b=1';
+  document.head.appendChild(script);
+}
+
+function case2() {
+  const script = document.createElement('script');
+  script.src = '/test-query-hash?a=1&b=1#title';
+  document.head.appendChild(script);
+}
+
+case1();
+case2();

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -41,6 +41,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
       'onRetry',
       'onSuccess',
       'onFail',
+      'addQuery',
       'test',
     ]);
   }

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,6 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
-import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin';
 import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
@@ -19,6 +18,9 @@ export const pluginAssetsRetry = (
         }
 
         const { AssetsRetryPlugin } = await import('./AssetsRetryPlugin');
+        const { AsyncChunkRetryPlugin } = await import(
+          './AsyncChunkRetryPlugin'
+        );
         const distDir = getDistPath(config, 'js');
 
         // options.crossOrigin should be same as html.crossorigin by default

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -63,10 +63,15 @@ function findNextDomain(url: string) {
   return domainList[(index + 1) % domainList.length] || url;
 }
 
-// TODO: add option query to onRetry with initial chunk together
-// function getUrlRetryQuery(existRetryTimes: number): string {
-//   return `?retry-attempt=${existRetryTimes}`;
-// }
+function getUrlRetryQuery(existRetryTimes: number): string {
+  if (config.addQuery === true) {
+    return `?retry=${existRetryTimes}`;
+  }
+  if (typeof config.addQuery === 'function') {
+    return config.addQuery(existRetryTimes);
+  }
+  return '';
+}
 
 function getCurrentRetry(chunkId: string): Retry | undefined {
   return retryCollector[chunkId];
@@ -88,8 +93,8 @@ function initRetry(chunkId: string): Retry {
     nextRetryUrl:
       nextDomain +
       (nextDomain[nextDomain.length - 1] === '/' ? '' : '/') +
-      originalScriptFilename,
-    // + getUrlRetryQuery(existRetryTimes),
+      originalScriptFilename +
+      getUrlRetryQuery(existRetryTimes),
 
     originalScriptFilename,
     originalSrcUrl,
@@ -111,8 +116,8 @@ function nextRetry(chunkId: string): Retry {
       nextRetryUrl:
         nextDomain +
         (nextDomain[nextDomain.length - 1] === '/' ? '' : '/') +
-        currRetry.originalScriptFilename,
-      // + getUrlRetryQuery(existRetryTimes),
+        currRetry.originalScriptFilename +
+        getUrlRetryQuery(existRetryTimes),
 
       originalScriptFilename: currRetry.originalScriptFilename,
       originalSrcUrl: currRetry.originalSrcUrl,
@@ -221,7 +226,7 @@ function loadScript(
 }
 
 function registerAsyncChunkRetry() {
-  // init global variables shared with async chunk
+  // init global variables shared between initial-chunk-retry and async-chunk-retry
   if (typeof window !== 'undefined' && !window.__RB_ASYNC_CHUNKS__) {
     window.__RB_ASYNC_CHUNKS__ = {};
   }

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -241,7 +241,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   // Then, we will start to retry
   const nextDomain = findNextDomain(domain, config.domain!);
 
-  // if the initial requeset is "/static/js/async/src_Hello_tsx.js?q=1", retry url would be "/static/js/async/src_Hello_tsx.js?q=1&retry=1"
+  // if the initial request is "/static/js/async/src_Hello_tsx.js?q=1", retry url would be "/static/js/async/src_Hello_tsx.js?q=1&retry=1"
   const originalQuery =
     target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
   function getUrlRetryQuery(existRetryTimes: number): string {

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -182,7 +182,6 @@ function reloadElementResource(
   }
 }
 
-// resourceMonitor -> retry -> createElement -> reloadElementResource
 function retry(config: RuntimeRetryOptions, e: Event) {
   const targetInfo = validateTargetInfo(config, e);
   if (targetInfo === false) {

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -80,12 +80,13 @@ function validateTargetInfo(
   return { target, tagName, url };
 }
 
-const QUERY_REG = /\?.*$/;
-function removeQuery(url: string) {
-  return url.replace(QUERY_REG, '');
+const postfixRE = /[?#].*$/;
+function cleanUrl(url: string) {
+  return url.replace(postfixRE, '');
 }
 function getQueryFromUrl(url: string) {
-  return url.match(QUERY_REG)?.[0] ?? '';
+  const parts = url.split('?')[1];
+  return parts ? `?${parts.split('#')[0]}` : '';
 }
 
 function createElement(
@@ -263,7 +264,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
 
   const attributes: ScriptElementAttributes = {
     url:
-      removeQuery(url.replace(domain, nextDomain)) +
+      cleanUrl(url.replace(domain, nextDomain)) +
       getUrlRetryQuery(existRetryTimes + 1),
     times: existRetryTimes + 1,
     crossOrigin: config.crossOrigin,

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -116,7 +116,7 @@ function createElement(
     if (attributes.isAsync) {
       script.dataset.rsbuildAsync = '';
     }
-    if (attributes.originalQuery) {
+    if (attributes.originalQuery !== undefined) {
       script.dataset.rsbuildOriginalQuery = attributes.originalQuery;
     }
 
@@ -144,7 +144,7 @@ function createElement(
     if (attributes.times) {
       link.dataset.rsbuildRetryTimes = String(attributes.times);
     }
-    if (attributes.originalQuery) {
+    if (attributes.originalQuery !== undefined) {
       link.dataset.rsbuildOriginalQuery = attributes.originalQuery;
     }
     return {

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -21,6 +21,7 @@ export type PluginAssetsRetryOptions = {
   domain?: string[];
   /**
    * Set the `crossorigin` attribute for tags.
+   * @default config.html.crossorigin
    */
   crossOrigin?: boolean | CrossOrigin;
   /**
@@ -36,11 +37,20 @@ export type PluginAssetsRetryOptions = {
    */
   onSuccess?: (options: AssetsRetryHookContext) => void;
   /**
+   * The function to add query parameters to the URL of the asset being retried.
+   * @param existRetryTimes e.g: 1 -> 2 -> 3
+   * @default false
+   * @description true -> `?retry=${existRetryTimes}`
+   */
+  addQuery?: boolean | ((existRetryTimes: number) => string);
+  /**
    * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
+   * @default true
    */
   inlineScript?: boolean;
   /**
    * Whether to minify the runtime JavaScript code of Assets Retry plugin.
+   * @default process.env.NODE_ENV === 'production'
    */
   minify?: boolean;
 };

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -38,11 +38,11 @@ export type PluginAssetsRetryOptions = {
   onSuccess?: (options: AssetsRetryHookContext) => void;
   /**
    * The function to add query parameters to the URL of the asset being retried.
-   * @param existRetryTimes e.g: 1 -> 2 -> 3
+   * @param times e.g: 1 -> 2 -> 3
    * @default false
    * @description true -> `?retry=${existRetryTimes}`
    */
-  addQuery?: boolean | ((existRetryTimes: number) => string);
+  addQuery?: boolean | ((times: number) => string);
   /**
    * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
    * @default true

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -39,10 +39,11 @@ export type PluginAssetsRetryOptions = {
   /**
    * The function to add query parameters to the URL of the asset being retried.
    * @param times e.g: 1 -> 2 -> 3
+   * @param originalQuery initial request url's query
    * @default false
    * @description true -> `?retry=${existRetryTimes}`
    */
-  addQuery?: boolean | ((times: number) => string);
+  addQuery?: boolean | ((times: number, originalQuery: string) => string);
   /**
    * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
    * @default true

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -41,7 +41,7 @@ export type PluginAssetsRetryOptions = {
    * @param times e.g: 1 -> 2 -> 3
    * @param originalQuery initial request url's query
    * @default false
-   * @description true -> `?retry=${existRetryTimes}`
+   * @description true -> hasQuery(originalQuery) ? `${getQuery(originalQuery)}&retry=${existRetryTimes}` : `?retry=${existRetryTimes}`
    */
   addQuery?: boolean | ((times: number, originalQuery: string) => string);
   /**

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -39,7 +39,7 @@ export type PluginAssetsRetryOptions = {
   /**
    * The function to add query parameters to the URL of the asset being retried.
    * @param times e.g: 1 -> 2 -> 3
-   * @param originalQuery initial request url's query
+   * @param originalQuery initial request url's query e.g: <script src="https://cdn.com/a.js?version=1"></script> -> "?version=1"
    * @default false
    * @description true -> hasQuery(originalQuery) ? `${getQuery(originalQuery)}&retry=${existRetryTimes}` : `?retry=${existRetryTimes}`
    */

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -14,6 +14,7 @@ exports[`plugin-assets-retry > should accept user custom options 1`] = `
     AsyncChunkRetryPlugin {
       "name": "ASYNC_CHUNK_RETRY_PLUGIN",
       "options": {
+        "addQuery": [Function],
         "crossOrigin": true,
         "domain": [
           "/http/localhost:3003",
@@ -35,6 +36,7 @@ exports[`plugin-assets-retry > should accept user custom options 1`] = `
         ],
       },
       "runtimeOptions": {
+        "addQuery": [Function],
         "domain": [
           "/http/localhost:3003",
           "/http/localhost:3002",

--- a/packages/plugin-assets-retry/tests/assetsRetry.test.ts
+++ b/packages/plugin-assets-retry/tests/assetsRetry.test.ts
@@ -52,6 +52,9 @@ describe('plugin-assets-retry', () => {
           onFail(context) {
             console.log('Failed retry', context);
           },
+          addQuery(existRetryTimes) {
+            return `?retry-times=${existRetryTimes}`;
+          },
         }),
       ],
     });

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -172,7 +172,7 @@ When set to `true`, `retry=${times}` will be added to the query when requesting,
 
 For example:
 
-1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${ times}`
+1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${times}`
 
 2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js? version=1&retry=${times}`
 

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -161,6 +161,25 @@ pluginAssetsRetry({
 });
 ```
 
+### addQuery
+
+- **Type:* `boolean | ((times: number) => string);`
+- **Default:** `false`
+
+Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.
+
+When set to `true`, `?retry=${times}` query will be added when requesting, in order of `?retry=1`, `?retry=2`, `?retry=3`..., in ascending order.
+
+When you want to customize query, you can pass in a function, such as:
+
+```js
+pluginAssetsRetry({
+  addQuery: (times) => {
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  },
+});
+```
+
 ### onSuccess
 
 - **Type:** `undefined | (options: AssetsRetryHookContext) => void`

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -161,48 +161,6 @@ pluginAssetsRetry({
 });
 ```
 
-### addQuery
-
-- **Type:* `boolean | ((times: number, originalQuery: string) => string);`
-- **Default:** `false`
-
-Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.
-
-When set to `true`, `retry=${times}` will be added to the query when requesting, and requests will be made in sequence according to `retry=1`, `retry=2`, `retry=3` etc.
-
-For example:
-
-1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${times}`
-
-2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js? version=1&retry=${times}`
-
-When you want to customize query, you can pass a function, for example:
-
-* **Example:** All assets requested do not contain query:
-
-```js
-pluginAssetsRetry({
-  addQuery: (times) => {
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
-  },
-});
-```
-
-* **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
-
-```js
-pluginAssetsRetry({
-  addQuery: (times, originalQuery) => {
-    if (originalQuery !== '') {
-      return times === 3 
-        ? `${originalQuery}&retryCount=${times}&isLast=1`
-        : `${originalQuery}&retryCount=${times}`;
-    }
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
-  },
-});
-```
-
 ### onSuccess
 
 - **Type:** `undefined | (options: AssetsRetryHookContext) => void`
@@ -231,6 +189,46 @@ pluginAssetsRetry({
     console.log(
       `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
     );
+  },
+});
+```
+
+### addQuery
+
+- **Type:* `boolean | ((times: number, originalQuery: string) => string);`
+- **Default:** `false`
+
+Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.
+
+When set to `true`, `retry=${times}` will be added to the query when requesting, and requests will be made in sequence according to `retry=1`, `retry=2`, `retry=3` etc, for example:
+
+1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${times}`
+
+2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js? version=1&retry=${times}`
+
+When you want to customize query, you can pass a function, for example:
+
+* **Example:** All assets requested do not contain query:
+
+```js
+pluginAssetsRetry({
+  addQuery: (times) => {
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  },
+});
+```
+
+* **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
+
+```js
+pluginAssetsRetry({
+  addQuery: (times, originalQuery) => {
+    if (originalQuery !== '') {
+      return times === 3 
+        ? `${originalQuery}&retryCount=${times}&isLast=1`
+        : `${originalQuery}&retryCount=${times}`;
+    }
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
   },
 });
 ```

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -178,6 +178,18 @@ For example:
 
 When you want to customize query, you can pass a function, for example:
 
+* **Example:** All assets requested do not contain query:
+
+```js
+pluginAssetsRetry({
+  addQuery: (times) => {
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  },
+});
+```
+
+* **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
+
 ```js
 pluginAssetsRetry({
   addQuery: (times, originalQuery) => {

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -163,7 +163,7 @@ pluginAssetsRetry({
 
 ### addQuery
 
-- **Type:* `boolean | ((times: number) => string);`
+- **Type:* `boolean | ((times: number, originalQuery: string) => string);`
 - **Default:** `false`
 
 Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -204,7 +204,7 @@ When set to `true`, `retry=${times}` will be added to the query when requesting,
 
 1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${times}`
 
-2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js? version=1&retry=${times}`
+2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?version=1&retry=${times}`
 
 When you want to customize query, you can pass a function, for example:
 

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -168,13 +168,24 @@ pluginAssetsRetry({
 
 Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.
 
-When set to `true`, `?retry=${times}` query will be added when requesting, in order of `?retry=1`, `?retry=2`, `?retry=3`..., in ascending order.
+When set to `true`, `retry=${times}` will be added to the query when requesting, and requests will be made in sequence according to `retry=1`, `retry=2`, `retry=3` etc.
 
-When you want to customize query, you can pass in a function, such as:
+For example:
+
+1. Assume that the requested asset is `https://js.cdn.net/foo.js`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js?retry=${ times}`
+
+2. Assume that the requested asset is `https://js.cdn.net/foo.js?version=1`. If the request fails, it will automatically retry `https://js.cdn.net/foo.js? version=1&retry=${times}`
+
+When you want to customize query, you can pass a function, for example:
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times) => {
+  addQuery: (times, originalQuery) => {
+    if (originalQuery !== '') {
+      return times === 3 
+        ? `${originalQuery}&retryCount=${times}&isLast=1`
+        : `${originalQuery}&retryCount=${times}`;
+    }
     return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
   },
 });

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -233,7 +233,6 @@ pluginAssetsRetry({
 });
 ```
 
-
 ### inlineScript
 
 - **类型：** `boolean`

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -195,7 +195,7 @@ pluginAssetsRetry({
 
 ### addQuery
 
-- **类型：** `boolean | ((times: number) => string);`
+- **类型：** `boolean | ((times: number, originalQuery: string) => string);`
 - **默认值：** `false`
 
 是否在资源重试时添加 query，这样可以避免被浏览器、CDN 缓存影响到重试的结果。

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -200,13 +200,24 @@ pluginAssetsRetry({
 
 是否在资源重试时添加 query，这样可以避免被浏览器、CDN 缓存影响到重试的结果。
 
-当设置为 `true` 时，请求时会添加 `?retry=${times}`，按照 `?retry=1`，`?retry=2`，`?retry=3`...，依次递增。
+当设置为 `true` 时，请求时会在 query 中添加 `retry=${times}`，按照 `retry=1`，`retry=2`，`retry=3` 依次请求。
+
+比如：
+
+1. 假设请求的静态资源为 `https://js.cdn.net/foo.js`，请求失败后会自动重试 `https://js.cdn.net/foo.js?retry=${times}`
+
+2. 假设请求的静态资源为 `https://js.cdn.net/foo.js?version=1`，请求失败后会自动重试 `https://js.cdn.net/foo.js?version=1&retry=${times}`
 
 当你想要自定义 query 时，可以传入一个函数，比如：
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times) => {
+  addQuery: (times, originalQuery) => {
+    if (originalQuery !== '') {
+      return times === 3 
+        ? `${originalQuery}&retryCount=${times}&isLast=1`
+        : `${originalQuery}&retryCount=${times}`;
+    }
     return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
   },
 });

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -200,15 +200,25 @@ pluginAssetsRetry({
 
 是否在资源重试时添加 query，这样可以避免被浏览器、CDN 缓存影响到重试的结果。
 
-当设置为 `true` 时，请求时会在 query 中添加 `retry=${times}`，按照 `retry=1`，`retry=2`，`retry=3` 依次请求。
-
-比如：
+当设置为 `true` 时，请求时会在 query 中添加 `retry=${times}`，按照 `retry=1`，`retry=2`，`retry=3` 依次请求，比如：
 
 1. 假设请求的静态资源为 `https://js.cdn.net/foo.js`，请求失败后会自动重试 `https://js.cdn.net/foo.js?retry=${times}`
 
 2. 假设请求的静态资源为 `https://js.cdn.net/foo.js?version=1`，请求失败后会自动重试 `https://js.cdn.net/foo.js?version=1&retry=${times}`
 
 当你想要自定义 query 时，可以传入一个函数，比如：
+
+* **示例：** 请求的所有资源都不含 query：
+
+```js
+pluginAssetsRetry({
+  addQuery: (times) => {
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  },
+});
+```
+
+* **示例：** 请求的某些资源中含有 query 可以使用 originalQuery 区分：
 
 ```js
 pluginAssetsRetry({

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -193,6 +193,26 @@ pluginAssetsRetry({
 });
 ```
 
+### addQuery
+
+- **类型：** `boolean | ((times: number) => string);`
+- **默认值：** `false`
+
+是否在资源重试时添加 query，这样可以避免被浏览器、CDN 缓存影响到重试的结果。
+
+当设置为 `true` 时，请求时会添加 `?retry=${times}`，按照 `?retry=1`，`?retry=2`，`?retry=3`...，依次递增。
+
+当你想要自定义 query 时，可以传入一个函数，比如：
+
+```js
+pluginAssetsRetry({
+  addQuery: (times) => {
+    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  },
+});
+```
+
+
 ### inlineScript
 
 - **类型：** `boolean`


### PR DESCRIPTION
## Summary

support `addQuery` option in `@rsbuild/plugin-assets-retry`

Here are some examples: 

1. no query, `<script src="https://cdn.com/a.js"></script>`

after set `addQuery: true`, if the resource requests failed, we would retry with query like below

```
// if failed, retry the next line 
https://cdn.com/a.js?retry=1
https://cdn.com/a.js?retry=2
https://cdn.com/a.js?retry=3
```

2. with query, `<script src="https://cdn.com/a.js?version=1"></script>`

after set `addQuery: true`, if the resource request failed, we would retry with query like below

```
// if failed, retry the next line 
https://cdn.com/a.js?version=1&retry=1
https://cdn.com/a.js?version=1&retry=2
https://cdn.com/a.js?version=1&retry=3
```

3. with anchor, `<script src="https://cdn.com/a.js?version=1#title"></script>`

```
// if failed, retry the next line 
https://cdn.com/a.js?version=1&retry=1
https://cdn.com/a.js?version=1&retry=2
https://cdn.com/a.js?version=1&retry=3
```


## Related Links

closes #2116
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
