### PR TITLE
feat: support `output.manifest` config

### DIFF
--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -1,0 +1,49 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+const fixtures = __dirname;
+
+test('output.manifest', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    rsbuildConfig: {
+      output: {
+        manifest: true,
+        legalComments: 'none',
+        filenameHash: false,
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const manifestContent =
+    files[
+      Object.keys(files).find((file) => file.endsWith('asset-manifest.json'))!
+    ];
+
+  expect(manifestContent).toBeDefined();
+
+  const manifest = JSON.parse(manifestContent);
+
+  // main.js、index.html
+  expect(Object.keys(manifest.allFiles).length).toBe(2);
+
+  expect(manifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/static/js/index.js'],
+      css: [],
+    },
+    async: {
+      js: [],
+      css: [],
+    },
+    assets: [],
+    html: '/index.html',
+  });
+});

--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -23,9 +23,7 @@ test('output.manifest', async () => {
   const files = await rsbuild.unwrapOutputJSON();
 
   const manifestContent =
-    files[
-      Object.keys(files).find((file) => file.endsWith('asset-manifest.json'))!
-    ];
+    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
 
   expect(manifestContent).toBeDefined();
 

--- a/e2e/cases/output/manifest/src/index.ts
+++ b/e2e/cases/output/manifest/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -76,6 +76,7 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
         plugins.resourceHints(),
         plugins.server(),
         plugins.moduleFederation(),
+        plugins.manifest(),
       ]);
 
       pluginManager.addPlugins(allPlugins);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -66,6 +66,7 @@
     "@types/ws": "^8.5.10",
     "commander": "^12.0.0",
     "connect-history-api-fallback": "^2.0.0",
+    "rspack-manifest-plugin": "5.0.0",
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "http-compression": "1.0.19",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -18,6 +18,7 @@ export default {
     'dotenv-expand',
     'ws',
     'on-finished',
+    'rspack-manifest-plugin',
     {
       name: 'launch-editor-middleware',
       ignoreDts: true,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -139,6 +139,7 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   legalComments: 'linked',
   injectStyles: false,
   minify: true,
+  manifest: false,
   sourceMap: {
     js: undefined,
     css: false,

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -27,4 +27,5 @@ export const plugins = {
   server: () => import('./server').then((m) => m.pluginServer()),
   moduleFederation: () =>
     import('./moduleFederation').then((m) => m.pluginModuleFederation()),
+  manifest: () => import('./manifest').then((m) => m.pluginManifest()),
 };

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -1,0 +1,154 @@
+import type { Chunk } from 'webpack';
+import { recursiveChunkEntryNames } from '../rspack/preload/helpers';
+import type { RsbuildPlugin } from '../types';
+
+type FilePath = string;
+
+type ManifestByEntry = {
+  initial: {
+    js: FilePath[];
+    css: FilePath[];
+  };
+  async: {
+    js: FilePath[];
+    css: FilePath[];
+  };
+  /** other assets (e.g. png、svg、source map) related to the current entry */
+  assets: FilePath[];
+  html?: FilePath;
+};
+
+type ManifestList = {
+  entries: {
+    /** relate to rsbuild source.entry */
+    [entryName: string]: ManifestByEntry;
+  };
+  /** Flatten all assets */
+  allFiles: FilePath[];
+};
+
+type FileDescriptor = {
+  chunk?: Chunk;
+  isAsset: boolean;
+  isChunk: boolean;
+  isInitial: boolean;
+  isModuleAsset: boolean;
+  name: string;
+  path: string;
+};
+
+export const generateManifest =
+  (htmlPaths: Record<string, string>) =>
+  (_seed: Record<string, any>, files: FileDescriptor[]) => {
+    const chunkEntries = new Map<string, FileDescriptor[]>();
+
+    const licenseMap = new Map<string, string>();
+
+    const allFiles = files.map((file) => {
+      if (file.chunk) {
+        const names = recursiveChunkEntryNames(file.chunk);
+
+        for (const name of names) {
+          chunkEntries.set(name, [file, ...(chunkEntries.get(name) || [])]);
+        }
+      }
+
+      if (file.path.endsWith('.LICENSE.txt')) {
+        const sourceFilePath = file.path.split('.LICENSE.txt')[0];
+        licenseMap.set(sourceFilePath, file.path);
+      }
+      return file.path;
+    });
+
+    const entries: ManifestList['entries'] = {};
+
+    for (const [name, chunkFiles] of chunkEntries) {
+      const assets = new Set<string>();
+      const initialJS: string[] = [];
+      const asyncJS: string[] = [];
+      const initialCSS: string[] = [];
+      const asyncCSS: string[] = [];
+
+      for (const file of chunkFiles) {
+        if (file.isInitial) {
+          if (file.path.endsWith('.css')) {
+            initialCSS.push(file.path);
+          } else {
+            initialJS.push(file.path);
+          }
+        } else {
+          if (file.path.endsWith('.css')) {
+            asyncCSS.push(file.path);
+          } else {
+            asyncJS.push(file.path);
+          }
+        }
+
+        const relatedLICENSE = licenseMap.get(file.path);
+
+        if (relatedLICENSE) {
+          assets.add(relatedLICENSE);
+        }
+
+        for (const auxiliaryFile of file.chunk!.auxiliaryFiles) {
+          assets.add(auxiliaryFile);
+        }
+      }
+
+      entries[name] = {
+        initial: {
+          js: initialJS,
+          css: initialCSS,
+        },
+        async: {
+          js: asyncJS,
+          css: asyncCSS,
+        },
+        assets: Array.from(assets),
+        html: files.find((f) => f.name === htmlPaths[name])?.path,
+      };
+    }
+
+    return {
+      allFiles,
+      entries,
+    };
+  };
+
+export const pluginManifest = (): RsbuildPlugin => ({
+  name: 'rsbuild:manifest',
+
+  setup(api) {
+    api.modifyBundlerChain(async (chain, { target, CHAIN_ID }) => {
+      const htmlPaths = api.getHTMLPaths();
+
+      const {
+        output: { manifest },
+      } = api.getNormalizedConfig();
+
+      if (manifest === false) {
+        return;
+      }
+
+      const fileName =
+        typeof manifest === 'string'
+          ? manifest
+          : target === 'web'
+            ? 'asset-manifest.json'
+            : `asset-manifest-${target}.json`;
+
+      const { RspackManifestPlugin } = await import(
+        '../../compiled/rspack-manifest-plugin'
+      );
+      const publicPath = chain.output.get('publicPath');
+
+      chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(RspackManifestPlugin, [
+        {
+          fileName,
+          publicPath,
+          generate: generateManifest(htmlPaths),
+        },
+      ]);
+    });
+  },
+});

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -1,4 +1,4 @@
-import type { Chunk } from 'webpack';
+import type { Chunk } from '@rspack/core';
 import { recursiveChunkEntryNames } from '../rspack/preload/helpers';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -119,7 +119,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
   name: 'rsbuild:manifest',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { target, CHAIN_ID }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
       const htmlPaths = api.getHTMLPaths();
 
       const {
@@ -131,11 +131,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
       }
 
       const fileName =
-        typeof manifest === 'string'
-          ? manifest
-          : target === 'web'
-            ? 'asset-manifest.json'
-            : `asset-manifest-${target}.json`;
+        typeof manifest === 'string' ? manifest : 'manifest.json';
 
       const { RspackManifestPlugin } = await import(
         '../../compiled/rspack-manifest-plugin'

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -37,7 +37,7 @@ type FileDescriptor = {
   path: string;
 };
 
-export const generateManifest =
+const generateManifest =
   (htmlPaths: Record<string, string>) =>
   (_seed: Record<string, any>, files: FileDescriptor[]) => {
     const chunkEntries = new Map<string, FileDescriptor[]>();

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -29,10 +29,7 @@ type ManifestList = {
 
 type FileDescriptor = {
   chunk?: Chunk;
-  isAsset: boolean;
-  isChunk: boolean;
   isInitial: boolean;
-  isModuleAsset: boolean;
   name: string;
   path: string;
 };
@@ -136,12 +133,10 @@ export const pluginManifest = (): RsbuildPlugin => ({
       const { RspackManifestPlugin } = await import(
         '../../compiled/rspack-manifest-plugin'
       );
-      const publicPath = chain.output.get('publicPath');
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(RspackManifestPlugin, [
         {
           fileName,
-          publicPath,
           generate: generateManifest(htmlPaths),
         },
       ]);

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -80,6 +80,7 @@ export const rspackProvider: RsbuildProvider = async ({
         plugins.performance(),
         plugins.server(),
         plugins.moduleFederation(),
+        plugins.manifest(),
         import('./plugins/rspackProfile').then((m) => m.pluginRspackProfile()),
       ]);
 

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -67,7 +67,6 @@ function generateLinks(
 ): HtmlWebpackPlugin.HtmlTagObject[] {
   // get all chunks
   const extractedChunks = extractChunks({
-    // @ts-expect-error compilation type mismatch
     compilation,
     includeType: options.type,
   });

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -16,9 +16,7 @@
  */
 
 import type { PreloadOrPreFetchOption } from '@rsbuild/shared';
-import type { Compilation } from '@rspack/core';
-import type { Chunk } from 'webpack';
-import type { ChunkGroup } from './extractChunks';
+import type { Chunk, ChunkGroup, Compilation } from '@rspack/core';
 import type { BeforeAssetTagGenerationHtmlPluginData } from './type';
 
 interface DoesChunkBelongToHtmlOptions {

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -39,7 +39,7 @@ function recursiveChunkGroup(
   return parents.flatMap((chunkParent) => recursiveChunkGroup(chunkParent));
 }
 
-function recursiveChunkEntryNames(chunk: Chunk): string[] {
+export function recursiveChunkEntryNames(chunk: Chunk): string[] {
   const isChunkName = (name: string | undefined): name is string =>
     Boolean(name);
 

--- a/packages/core/src/rspack/preload/helpers/extractChunks.ts
+++ b/packages/core/src/rspack/preload/helpers/extractChunks.ts
@@ -16,9 +16,7 @@
  */
 
 import type { PreloadIncludeType } from '@rsbuild/shared';
-import type { Chunk, Compilation } from 'webpack';
-
-export type ChunkGroup = Compilation['chunkGroups'][0];
+import type { Chunk, ChunkGroup, Compilation } from '@rspack/core';
 
 interface ExtractChunks {
   compilation: Compilation;
@@ -30,6 +28,8 @@ function isAsync(chunk: Chunk | ChunkGroup): boolean {
     return !chunk.canBeInitial();
   }
   if ('isInitial' in chunk) {
+    // compat webpack
+    // @ts-expect-error
     return !chunk.isInitial();
   }
   // compat rspack
@@ -64,7 +64,8 @@ export function extractChunks({
     // Every asset, regardless of which chunk it's in.
     // Wrap it in a single, "pseudo-chunk" return value.
     // Note: webpack5 will extract license default, we do not need to preload them
-    const licenseAssets = [...compilation.assetsInfo.values()]
+    // @ts-expect-error
+    const licenseAssets = [...(compilation.assetsInfo?.values() || [])]
       .map((info) => {
         if (info.related?.license) {
           return info.related.license;
@@ -72,13 +73,13 @@ export function extractChunks({
         return false;
       })
       .filter(Boolean);
+
     return [
       {
-        // @ts-expect-error ignore ts check for files
         files: Object.keys(compilation.assets).filter(
           (t) => !licenseAssets.includes(t),
         ),
-      },
+      } as Chunk,
     ];
   }
 

--- a/packages/core/tests/__snapshots__/inspect.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inspect.test.ts.snap
@@ -32,6 +32,7 @@ exports[`inspectConfig > should print plugin names when inspect config 1`] = `
   "rsbuild:performance",
   "rsbuild:server",
   "rsbuild:module-federation",
+  "rsbuild:manifest",
   "rsbuild:rspack-profile",
 ]
 `;

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -249,6 +249,10 @@ export interface OutputConfig {
    */
   minify?: Minify;
   /**
+   * Whether to generate manifest file.
+   */
+  manifest?: string | boolean;
+  /**
    * Whether to generate source map files, and which format of source map to generate
    */
   sourceMap?: SourceMap;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -734,6 +734,9 @@ importers:
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.4.5)
+      rspack-manifest-plugin:
+        specifier: 5.0.0
+        version: 5.0.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -7651,6 +7654,15 @@ packages:
     resolution: {integrity: sha512-tZP8KjrI1nz6qOYCrFxAV7cfmfS2GV94jotU2zOmF/6ByO1zNvGR6/+0inylpjqyBjAdnnutTUW0m4th06bSTw==}
     engines: {node: '>=14.17.6'}
 
+  rspack-manifest-plugin@5.0.0:
+    resolution: {integrity: sha512-Rtpn6GI4mpTASPmLOGiHzv3KqVWuWhGJG9CKO7aioPrAhukML4jtgYUvbQdBze/mZcDrvqf6sxEGRGx5fKQ+ag==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
   rspack-plugin-virtual-module@0.1.12:
     resolution: {integrity: sha512-qyBM9XsP7oxBQSms2cr715XOeoDi6p5hUYXtlNDfst0jha8vfWVPNeC7j5+j5dG+yt//1OCmLaOY2rWqPSVXDg==}
 
@@ -7860,6 +7872,9 @@ packages:
   sorcery@0.11.0:
     resolution: {integrity: sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==}
     hasBin: true
+
+  source-list-map@2.0.1:
+    resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
@@ -8610,6 +8625,10 @@ packages:
   webpack-merge@5.10.0:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
     engines: {node: '>=10.0.0'}
+
+  webpack-sources@2.3.1:
+    resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
+    engines: {node: '>=10.13.0'}
 
   webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -15744,6 +15763,13 @@ snapshots:
 
   rslog@1.2.2: {}
 
+  rspack-manifest-plugin@5.0.0(@rspack/core@0.6.3(@swc/helpers@0.5.3)):
+    dependencies:
+      tapable: 2.2.1
+      webpack-sources: 2.3.1
+    optionalDependencies:
+      '@rspack/core': 0.6.3(@swc/helpers@0.5.3)
+
   rspack-plugin-virtual-module@0.1.12:
     dependencies:
       fs-extra: 11.2.0
@@ -15959,6 +15985,8 @@ snapshots:
       buffer-crc32: 0.2.13
       minimist: 1.2.8
       sander: 0.5.1
+
+  source-list-map@2.0.1: {}
 
   source-map-js@1.2.0: {}
 
@@ -16822,6 +16850,11 @@ snapshots:
       clone-deep: 4.0.1
       flat: 5.0.2
       wildcard: 2.0.1
+
+  webpack-sources@2.3.1:
+    dependencies:
+      source-list-map: 2.0.1
+      source-map: 0.6.1
 
   webpack-sources@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,7 +736,7 @@ importers:
         version: 1.1.0(typescript@5.4.5)
       rspack-manifest-plugin:
         specifier: 5.0.0
-        version: 5.0.0(@rspack/core@0.6.3(@swc/helpers@0.5.3))
+        version: 5.0.0(@rspack/core@0.6.4(@swc/helpers@0.5.3))
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -15763,12 +15763,12 @@ snapshots:
 
   rslog@1.2.2: {}
 
-  rspack-manifest-plugin@5.0.0(@rspack/core@0.6.3(@swc/helpers@0.5.3)):
+  rspack-manifest-plugin@5.0.0(@rspack/core@0.6.4(@swc/helpers@0.5.3)):
     dependencies:
       tapable: 2.2.1
       webpack-sources: 2.3.1
     optionalDependencies:
-      '@rspack/core': 0.6.3(@swc/helpers@0.5.3)
+      '@rspack/core': 0.6.4(@swc/helpers@0.5.3)
 
   rspack-plugin-virtual-module@0.1.12:
     dependencies:

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -5,7 +5,7 @@
 
 Whether to generate a manifest file that contains information of all assets, and the mapping relationship between [entry module](/config/source/entry) and assets.
 
-When set to `true`, Rsbuild will generate a `manifest.json` file. When the value is a `string`, it will be used as the manifest file name.
+When set to `true`, Rsbuild will generate a `manifest.json` file after building. When the value is a string, it will be used as the manifest file name.
 
 ### Example
 

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -1,0 +1,47 @@
+# output.manifest
+
+- **Type:** `string | boolean`
+- **Default:** `false`
+
+Whether to generate a manifest file that contains information of all assets, and the mapping relationship between [entry module](/config/source/entry) and assets.
+
+When set to `true`, Rsbuild will generate a `manifest.json` file. When the value is a `string`, it will be used as the manifest file name.
+
+### Example
+
+Enable asset manifest:
+
+```js
+export default {
+  output: {
+    manifest: true,
+  },
+};
+```
+
+After compiler, there will be a `dist/manifest.json` file:
+
+```json
+{
+  "allFiles": [
+    "/static/css/index.a11cfb11.css",
+    "/static/js/index.c586cd5e.js",
+    "/index.html",
+    "/static/js/index.c586cd5e.js.LICENSE.txt"
+  ],
+  "entries": {
+    "index": {
+      "initial": {
+        "js": ["/static/js/index.c586cd5e.js"],
+        "css": ["/static/css/index.a11cfb11.css"]
+      },
+      "async": {
+        "js": [],
+        "css": []
+      },
+      "assets": ["/static/js/index.c586cd5e.js.LICENSE.txt"],
+      "html": "/index.html"
+    }
+  }
+}
+```

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -19,7 +19,7 @@ export default {
 };
 ```
 
-After compiler, there will be a `dist/manifest.json` file:
+After building, there will be a `dist/manifest.json` file:
 
 ```json
 {

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -5,7 +5,7 @@
 
 Whether to generate a manifest file that contains information of all assets, and the mapping relationship between [entry module](/config/source/entry) and assets.
 
-When set to `true`, Rsbuild will generate a `manifest.json` file after building. When the value is a string, it will be used as the manifest file name.
+When set to `true`, Rsbuild will generate a `manifest.json` file after building. When the value is a string, it will be used as the manifest file name or path.
 
 ### Example
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -5,7 +5,7 @@
 
 是否生成 manifest 文件，该文件包含所有构建产物的信息、以及[入口模块](/config/source/entry)与构建产物间的映射关系。
 
-当设置为 true，构建后将会生成 `manifest.json` 文件。当该值为一个字符串时，它将作为 manifest 文件的名字。
+当设置为 true 时，Rsbuild 构建后将会生成 `manifest.json` 文件。当该值为一个字符串时，它将作为 manifest 文件的名称。
 
 ### 示例
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -19,7 +19,7 @@ export default {
 };
 ```
 
-开启后，当编译完成时，会自动生成 `dist/asset-manifest.json` 文件：
+当构建完成后，会自动生成 `dist/manifest.json` 文件：
 
 ```json
 {

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -5,7 +5,7 @@
 
 是否生成 manifest 文件，该文件包含所有构建产物的信息、以及[入口模块](/config/source/entry)与构建产物间的映射关系。
 
-当设置为 true 时，Rsbuild 构建后将会生成 `manifest.json` 文件。当该值为一个字符串时，它将作为 manifest 文件的名称。
+当设置为 true 时，Rsbuild 构建后将会生成 `manifest.json` 文件。当该值为一个字符串时，它将作为 manifest 文件的名称或路径。
 
 ### 示例
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -1,0 +1,47 @@
+# output.manifest
+
+- **类型：** `string | boolean`
+- **默认值：** `false`
+
+是否生成 manifest 文件，该文件包含所有构建产物的信息、以及[入口模块](/config/source/entry)与构建产物间的映射关系。
+
+当设置为 true，构建后将会生成 `manifest.json` 文件。当该值为一个字符串时，它将作为 manifest 文件的名字。
+
+### 示例
+
+添加以下配置来开启：
+
+```js
+export default {
+  output: {
+    manifest: true,
+  },
+};
+```
+
+开启后，当编译完成时，会自动生成 `dist/asset-manifest.json` 文件：
+
+```json
+{
+  "allFiles": [
+    "/static/css/index.a11cfb11.css",
+    "/static/js/index.c586cd5e.js",
+    "/index.html",
+    "/static/js/index.c586cd5e.js.LICENSE.txt"
+  ],
+  "entries": {
+    "index": {
+      "initial": {
+        "js": ["/static/js/index.c586cd5e.js"],
+        "css": ["/static/css/index.a11cfb11.css"]
+      },
+      "async": {
+        "js": [],
+        "css": []
+      },
+      "assets": ["/static/js/index.c586cd5e.js.LICENSE.txt"],
+      "html": "/index.html"
+    }
+  }
+}
+```


### PR DESCRIPTION
## Summary

support generator manifest file

usage:
```js
export default {
  output: {
    manifest: true,
  },
};
```

output:

```
{
  "allFiles": [
    "/static/css/index.a11cfb11.css",
    "/static/js/index.c586cd5e.js",
    "/index.html",
    "/static/js/index.c586cd5e.js.LICENSE.txt"
  ],
  "entries": {
    "index": {
      "initial": {
        "js": ["/static/js/index.c586cd5e.js"],
        "css": ["/static/css/index.a11cfb11.css"]
      },
      "async": {
        "js": [],
        "css": []
      },
      "assets": ["/static/js/index.c586cd5e.js.LICENSE.txt"],
      "html": "/index.html"
    }
  }
}
```
## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/989

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
