### PR TITLE
test(e2e): enable skipped check assets case

### DIFF
--- a/e2e/cases/check-syntax/index.test.ts
+++ b/e2e/cases/check-syntax/index.test.ts
@@ -51,10 +51,7 @@ test('should throw error when exist syntax errors', async () => {
   ).toBeTruthy();
 });
 
-// TODO Rspack occasionally generates invalid comments
-// such as:
-// /*! ./test */se information please see index.js?v=fc0ca1e8.LICENSE.txt */
-test.skip('should check assets with query correctly', async () => {
+test('should check assets with query correctly', async () => {
   const cwd = path.join(__dirname, 'fixtures/basic');
   const { logs, restore } = proxyConsole();
 


### PR DESCRIPTION
## Summary

Enable skipped check assets case as the bug has been fixed, see https://github.com/web-infra-dev/rspack/issues/6366

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
