### PR TITLE
chore: update manifest html type to array

### DIFF
--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -42,6 +42,52 @@ test('output.manifest', async () => {
       css: [],
     },
     assets: [],
-    html: '/index.html',
+    html: ['/index.html'],
+  });
+});
+
+test('output.manifest when target is node', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    rsbuildConfig: {
+      output: {
+        distPath: {
+          root: 'dist-1',
+        },
+        targets: ['node'],
+        manifest: true,
+        legalComments: 'none',
+        filenameHash: false,
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const manifestContent =
+    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+
+  expect(manifestContent).toBeDefined();
+
+  const manifest = JSON.parse(manifestContent);
+
+  // main.js、index.html
+  expect(Object.keys(manifest.allFiles).length).toBe(1);
+
+  expect(manifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/index.js'],
+      css: [],
+    },
+    async: {
+      js: [],
+      css: [],
+    },
+    assets: [],
   });
 });

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -15,7 +15,7 @@ type ManifestByEntry = {
   };
   /** other assets (e.g. png、svg、source map) related to the current entry */
   assets: FilePath[];
-  html?: FilePath;
+  html?: FilePath[];
 };
 
 type ManifestList = {
@@ -92,6 +92,8 @@ const generateManifest =
         }
       }
 
+      const htmlPath = files.find((f) => f.name === htmlPaths[name])?.path;
+
       entries[name] = {
         initial: {
           js: initialJS,
@@ -102,7 +104,7 @@ const generateManifest =
           css: asyncCSS,
         },
         assets: Array.from(assets),
-        html: files.find((f) => f.name === htmlPaths[name])?.path,
+        html: htmlPath ? [htmlPath] : undefined,
       };
     }
 

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -40,7 +40,7 @@ After building, there will be a `dist/manifest.json` file:
         "css": []
       },
       "assets": ["/static/js/index.c586cd5e.js.LICENSE.txt"],
-      "html": "/index.html"
+      "html": ["/index.html"]
     }
   }
 }

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -40,7 +40,7 @@ export default {
         "css": []
       },
       "assets": ["/static/js/index.c586cd5e.js.LICENSE.txt"],
-      "html": "/index.html"
+      "html": ["/index.html"]
     }
   }
 }


### PR DESCRIPTION
## Summary

There may be a one-to-many relationship between entry and html.

eg: 

```
{
  "entries": {
    "index": {
      "html": ["/index.html", "/index-1.html"]
    }
  }
}
```
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
