### PR TITLE
fix(html): should inject chunks for entry.dependOn

### DIFF
--- a/e2e/cases/source/entry-depend-on/index.test.ts
+++ b/e2e/cases/source/entry-depend-on/index.test.ts
@@ -1,0 +1,22 @@
+import { build, gotoPage } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to set entry description object with dependOn', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+  });
+
+  await gotoPage(page, rsbuild, 'foo');
+  expect(await page.evaluate('window.test')).toBe('foo');
+
+  await gotoPage(page, rsbuild, 'bar');
+  expect(await page.evaluate('window.test')).toBe('foo-bar');
+
+  await gotoPage(page, rsbuild, 'baz');
+  expect(await page.evaluate('window.test')).toBe('foo-bar-baz');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/source/entry-depend-on/rsbuild.config.ts
+++ b/e2e/cases/source/entry-depend-on/rsbuild.config.ts
@@ -1,0 +1,15 @@
+export default {
+  source: {
+    entry: {
+      foo: './src/foo.js',
+      bar: {
+        dependOn: 'foo',
+        import: './src/bar.js',
+      },
+      baz: {
+        dependOn: ['foo', 'bar'],
+        import: './src/baz.js',
+      },
+    },
+  },
+};

--- a/e2e/cases/source/entry-depend-on/src/bar.js
+++ b/e2e/cases/source/entry-depend-on/src/bar.js
@@ -1,0 +1,1 @@
+window.test = (window.test || '') + '-bar';

--- a/e2e/cases/source/entry-depend-on/src/bar.js
+++ b/e2e/cases/source/entry-depend-on/src/bar.js
@@ -1,1 +1,1 @@
-window.test = (window.test || '') + '-bar';
+window.test = `${window.test || ''}-bar`;

--- a/e2e/cases/source/entry-depend-on/src/baz.js
+++ b/e2e/cases/source/entry-depend-on/src/baz.js
@@ -1,1 +1,1 @@
-window.test = (window.test || '') + '-baz';
+window.test = `${window.test || ''}-baz`;

--- a/e2e/cases/source/entry-depend-on/src/baz.js
+++ b/e2e/cases/source/entry-depend-on/src/baz.js
@@ -1,0 +1,1 @@
+window.test = (window.test || '') + '-baz';

--- a/e2e/cases/source/entry-depend-on/src/foo.js
+++ b/e2e/cases/source/entry-depend-on/src/foo.js
@@ -1,1 +1,1 @@
-window.test = (window.test || '') + 'foo';
+window.test = `${window.test || ''}foo`;

--- a/e2e/cases/source/entry-depend-on/src/foo.js
+++ b/e2e/cases/source/entry-depend-on/src/foo.js
@@ -1,0 +1,1 @@
+window.test = (window.test || '') + 'foo';

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -165,14 +165,14 @@ function getChunks(
 ): string[] {
   const chunks = [entryName];
 
-  entryValue.forEach((item) => {
+  for (const item of entryValue) {
     if (!isPlainObject(item)) {
-      return;
+      continue;
     }
 
     const { dependOn } = item as EntryDescription;
     if (!dependOn) {
-      return;
+      continue;
     }
 
     if (typeof dependOn === 'string') {
@@ -180,7 +180,7 @@ function getChunks(
     } else {
       chunks.unshift(...dependOn);
     }
-  });
+  }
 
   return chunks;
 }

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -257,7 +257,7 @@ export const pluginHtml = (modifyTagsFn: ModifyHTMLTagsFn): RsbuildPlugin => ({
               scriptLoading: config.html.scriptLoading,
             };
 
-            if (Array.isArray(chunks) && chunks.length > 1) {
+            if (chunks.length > 1) {
               // load entires by the order of `chunks`
               pluginOptions.chunksSortMode = 'manual';
             }

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -161,16 +161,28 @@ function getTemplateParameters(
 
 function getChunks(
   entryName: string,
-  entryValue: string | string[] | EntryDescription,
+  entryValue: Array<string | string[] | EntryDescription>,
 ): string[] {
-  if (isPlainObject(entryValue)) {
-    const { dependOn } = entryValue as EntryDescription;
-    if (Array.isArray(dependOn)) {
-      return [...dependOn, entryName];
-    }
-  }
+  const chunks = [entryName];
 
-  return [entryName];
+  entryValue.forEach((item) => {
+    if (!isPlainObject(item)) {
+      return;
+    }
+
+    const { dependOn } = item as EntryDescription;
+    if (!dependOn) {
+      return;
+    }
+
+    if (typeof dependOn === 'string') {
+      chunks.unshift(dependOn);
+    } else {
+      chunks.unshift(...dependOn);
+    }
+  });
+
+  return chunks;
 }
 
 const getTagConfig = (api: RsbuildPluginAPI): TagConfig | undefined => {
@@ -215,8 +227,8 @@ export const pluginHtml = (modifyTagsFn: ModifyHTMLTagsFn): RsbuildPlugin => ({
             const entryValue = entries[entryName].values();
             const chunks = getChunks(
               entryName,
-              // @ts-expect-error EntryDescription type mismatch
-              entryValue,
+              // EntryDescription type is different between webpack and Rspack
+              entryValue as (string | string[] | EntryDescription)[],
             );
             const inject = getInject(entryName, config);
             const filename = htmlPaths[entryName];
@@ -244,6 +256,11 @@ export const pluginHtml = (modifyTagsFn: ModifyHTMLTagsFn): RsbuildPlugin => ({
               templateParameters,
               scriptLoading: config.html.scriptLoading,
             };
+
+            if (Array.isArray(chunks) && chunks.length > 1) {
+              // load entires by the order of `chunks`
+              pluginOptions.chunksSortMode = 'manual';
+            }
 
             const htmlInfo: HtmlInfo = {};
             htmlInfoMap[entryName] = htmlInfo;


### PR DESCRIPTION
## Summary

Should inject chunks to HTML when using  `entry.dependOn`.

```js
export default {
  source: {
    entry: {
      foo: './src/foo.js',
      bar: {
        dependOn: 'foo',
        import: './src/bar.js',
      },
      baz: {
        dependOn: ['foo', 'bar'],
        import: './src/baz.js',
      },
    },
  },
};
```

Expected `baz.html`:

```html
<!doctype html>
<html>
  <head>
    <title>Rsbuild App</title>
    <meta charset="UTF-8" />
    <meta name="viewport" content="width=device-width,initial-scale=1" />
    <script defer="defer" src="/static/js/foo.js"></script>
    <script defer="defer" src="/static/js/bar.js"></script>
    <script defer="defer" src="/static/js/baz.js"></script>
  </head>
  <body>
    <div id="root"></div>
  </body>
</html>
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2290

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
