### PR TITLE
chore(assets-retry): passing addQuery params in object format

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -480,14 +480,11 @@ test('@rsbuild/plugin-assets-retry should work with addQuery function type optio
     {
       minify: true,
       addQuery: ({ times, originalQuery }) => {
-        if (originalQuery) {
-          return times === 3
-            ? `${originalQuery}&retryCount=${times}&isLast=1`
-            : `${originalQuery}&retryCount=${times}`;
-        }
-        return times === 3
-          ? `?retryCount=${times}&isLast=1`
-          : `?retryCount=${times}`;
+        const extraQuery =
+          times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
+        return originalQuery
+          ? `${originalQuery}&${extraQuery}`
+          : `?${extraQuery}`;
       },
     },
   );

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -479,8 +479,8 @@ test('@rsbuild/plugin-assets-retry should work with addQuery function type optio
     [initialChunkBlockedMiddleware, asyncChunkBlockedMiddleware],
     {
       minify: true,
-      addQuery: (times, originalQuery) => {
-        if (originalQuery !== '') {
+      addQuery: ({ times, originalQuery }) => {
+        if (originalQuery) {
           return times === 3
             ? `${originalQuery}&retryCount=${times}&isLast=1`
             : `${originalQuery}&retryCount=${times}`;

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -480,11 +480,9 @@ test('@rsbuild/plugin-assets-retry should work with addQuery function type optio
     {
       minify: true,
       addQuery: ({ times, originalQuery }) => {
-        const extraQuery =
+        const query =
           times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
-        return originalQuery
-          ? `${originalQuery}&${extraQuery}`
-          : `?${extraQuery}`;
+        return originalQuery ? `${originalQuery}&${query}` : `?${query}`;
       },
     },
   );

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -82,7 +82,7 @@ function getUrlRetryQuery(
       : `?retry=${existRetryTimes}`;
   }
   if (typeof config.addQuery === 'function') {
-    return config.addQuery(existRetryTimes, originalQuery);
+    return config.addQuery({ times: existRetryTimes, originalQuery });
   }
   return '';
 }

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -252,7 +252,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
         : `?retry=${existRetryTimes}`;
     }
     if (typeof config.addQuery === 'function') {
-      return config.addQuery(existRetryTimes, originalQuery);
+      return config.addQuery({ times: existRetryTimes, originalQuery });
     }
     return '';
   }

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -27,15 +27,15 @@ export type PluginAssetsRetryOptions = {
   /**
    * The callback function when the asset is failed to be retried.
    */
-  onFail?: (options: AssetsRetryHookContext) => void;
+  onFail?: (context: AssetsRetryHookContext) => void;
   /**
    * The callback function when the asset is being retried.
    */
-  onRetry?: (options: AssetsRetryHookContext) => void;
+  onRetry?: (context: AssetsRetryHookContext) => void;
   /**
    * The callback function when the asset is successfully retried.
    */
-  onSuccess?: (options: AssetsRetryHookContext) => void;
+  onSuccess?: (context: AssetsRetryHookContext) => void;
   /**
    * The function to add query parameters to the URL of the asset being retried.
    * @param times e.g: 1 -> 2 -> 3
@@ -45,7 +45,7 @@ export type PluginAssetsRetryOptions = {
    */
   addQuery?:
     | boolean
-    | ((params: { times: number; originalQuery: string }) => string);
+    | ((context: { times: number; originalQuery: string }) => string);
   /**
    * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
    * @default true

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -43,7 +43,9 @@ export type PluginAssetsRetryOptions = {
    * @default false
    * @description true -> hasQuery(originalQuery) ? `${getQuery(originalQuery)}&retry=${existRetryTimes}` : `?retry=${existRetryTimes}`
    */
-  addQuery?: boolean | ((times: number, originalQuery: string) => string);
+  addQuery?:
+    | boolean
+    | ((params: { times: number; originalQuery: string }) => string);
   /**
    * Whether to inline the runtime JavaScript code of Assets Retry plugin into the HTML file.
    * @default true

--- a/packages/plugin-assets-retry/tests/assetsRetry.test.ts
+++ b/packages/plugin-assets-retry/tests/assetsRetry.test.ts
@@ -52,8 +52,8 @@ describe('plugin-assets-retry', () => {
           onFail(context) {
             console.log('Failed retry', context);
           },
-          addQuery(existRetryTimes) {
-            return `?retry-times=${existRetryTimes}`;
+          addQuery({ times }) {
+            return `?retry-times=${times}`;
           },
         }),
       ],

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -232,14 +232,9 @@ pluginAssetsRetry({
 ```js
 pluginAssetsRetry({
   addQuery: ({ times, originalQuery }) => {
-    if (originalQuery) {
-      return times === 3
-        ? `${originalQuery}&retryCount=${times}&isLast=1`
-        : `${originalQuery}&retryCount=${times}`;
-    }
-    return times === 3
-      ? `?retryCount=${times}&isLast=1`
-      : `?retryCount=${times}`;
+    const extraQuery =
+      times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
+    return originalQuery ? `${originalQuery}&${extraQuery}` : `?${extraQuery}`;
   },
 });
 ```

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -195,7 +195,14 @@ pluginAssetsRetry({
 
 ### addQuery
 
-- **Type:* `boolean | ((times: number, originalQuery: string) => string);`
+- **Type:**
+
+```ts
+type AddQuery =
+  | boolean
+  | ((params: { times: number; originalQuery: string }) => string);
+```
+
 - **Default:** `false`
 
 Whether to add query when retrying resources, so as to avoid being affected by browser and CDN caches on the retry results.
@@ -208,27 +215,31 @@ When set to `true`, `retry=${times}` will be added to the query when requesting,
 
 When you want to customize query, you can pass a function, for example:
 
-* **Example:** All assets requested do not contain query:
+- **Example:** All assets requested do not contain query:
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times) => {
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  addQuery: ({ times }) => {
+    return times === 3
+      ? `?retryCount=${times}&isLast=1`
+      : `?retryCount=${times}`;
   },
 });
 ```
 
-* **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
+- **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times, originalQuery) => {
+  addQuery: ({ times, originalQuery }) => {
     if (originalQuery !== '') {
-      return times === 3 
+      return times === 3
         ? `${originalQuery}&retryCount=${times}&isLast=1`
         : `${originalQuery}&retryCount=${times}`;
     }
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+    return times === 3
+      ? `?retryCount=${times}&isLast=1`
+      : `?retryCount=${times}`;
   },
 });
 ```

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -49,9 +49,9 @@ type AssetsRetryOptions = {
   test?: string | ((url: string) => boolean);
   crossOrigin?: boolean | 'anonymous' | 'use-credentials';
   inlineScript?: boolean;
-  onRetry?: (options: AssetsRetryHookContext) => void;
-  onSuccess?: (options: AssetsRetryHookContext) => void;
-  onFail?: (options: AssetsRetryHookContext) => void;
+  onRetry?: (context: AssetsRetryHookContext) => void;
+  onSuccess?: (context: AssetsRetryHookContext) => void;
+  onFail?: (context: AssetsRetryHookContext) => void;
 };
 ```
 
@@ -147,7 +147,7 @@ pluginAssetsRetry({
 
 ### onRetry
 
-- **Type:** `undefined | (options: AssetsRetryHookContext) => void`
+- **Type:** `undefined | (context: AssetsRetryHookContext) => void`
 
 The callback function when the asset is being retried. For example:
 
@@ -163,7 +163,7 @@ pluginAssetsRetry({
 
 ### onSuccess
 
-- **Type:** `undefined | (options: AssetsRetryHookContext) => void`
+- **Type:** `undefined | (context: AssetsRetryHookContext) => void`
 
 The callback function when the asset is successfully retried. For example:
 
@@ -179,7 +179,7 @@ pluginAssetsRetry({
 
 ### onFail
 
-- **Type:** `undefined | (options: AssetsRetryHookContext) => void`
+- **Type:** `undefined | (context: AssetsRetryHookContext) => void`
 
 The callback function when the asset is failed to be retried. For example:
 
@@ -200,7 +200,7 @@ pluginAssetsRetry({
 ```ts
 type AddQuery =
   | boolean
-  | ((params: { times: number; originalQuery: string }) => string);
+  | ((context: { times: number; originalQuery: string }) => string);
 ```
 
 - **Default:** `false`

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -232,9 +232,9 @@ pluginAssetsRetry({
 ```js
 pluginAssetsRetry({
   addQuery: ({ times, originalQuery }) => {
-    const extraQuery =
+    const query =
       times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
-    return originalQuery ? `${originalQuery}&${extraQuery}` : `?${extraQuery}`;
+    return originalQuery ? `${originalQuery}&${query}` : `?${query}`;
   },
 });
 ```

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -232,7 +232,7 @@ pluginAssetsRetry({
 ```js
 pluginAssetsRetry({
   addQuery: ({ times, originalQuery }) => {
-    if (originalQuery !== '') {
+    if (originalQuery) {
       return times === 3
         ? `${originalQuery}&retryCount=${times}&isLast=1`
         : `${originalQuery}&retryCount=${times}`;

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -227,7 +227,7 @@ pluginAssetsRetry({
 });
 ```
 
-- **Example:** Some of the requested assets contain query and can be distinguished using `originalQuery`:
+- **Example:** If there is a query in some of the requested assets, you can read it with `originalQuery`:
 
 ```js
 pluginAssetsRetry({

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -49,9 +49,9 @@ type AssetsRetryOptions = {
   test?: string | ((url: string) => boolean);
   crossOrigin?: boolean | 'anonymous' | 'use-credentials';
   inlineScript?: boolean;
-  onRetry?: (options: AssetsRetryHookContext) => void;
-  onSuccess?: (options: AssetsRetryHookContext) => void;
-  onFail?: (options: AssetsRetryHookContext) => void;
+  onRetry?: (context: AssetsRetryHookContext) => void;
+  onSuccess?: (context: AssetsRetryHookContext) => void;
+  onFail?: (context: AssetsRetryHookContext) => void;
 };
 ```
 
@@ -147,7 +147,7 @@ pluginAssetsRetry({
 
 ### onRetry
 
-- **类型：** `undefined | (options: AssetsRetryHookContext) => void`
+- **类型：** `undefined | (context: AssetsRetryHookContext) => void`
 
 资源重试时的回调函数。比如：
 
@@ -163,7 +163,7 @@ pluginAssetsRetry({
 
 ### onSuccess
 
-- **类型：** `undefined | (options: AssetsRetryHookContext) => void`
+- **类型：** `undefined | (context: AssetsRetryHookContext) => void`
 
 资源重试成功时的回调函数。比如：
 
@@ -179,7 +179,7 @@ pluginAssetsRetry({
 
 ### onFail
 
-- **类型：** `undefined | (options: AssetsRetryHookContext) => void`
+- **类型：** `undefined | (context: AssetsRetryHookContext) => void`
 
 资源重试超过最大重试次数时的回调函数。比如：
 
@@ -200,7 +200,7 @@ pluginAssetsRetry({
 ```ts
 type AddQuery =
   | boolean
-  | ((params: { times: number; originalQuery: string }) => string);
+  | ((context: { times: number; originalQuery: string }) => string);
 ```
 
 - **默认值：** `false`

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -195,7 +195,14 @@ pluginAssetsRetry({
 
 ### addQuery
 
-- **类型：** `boolean | ((times: number, originalQuery: string) => string);`
+- **类型：**
+
+```ts
+type AddQuery =
+  | boolean
+  | ((params: { times: number; originalQuery: string }) => string);
+```
+
 - **默认值：** `false`
 
 是否在资源重试时添加 query，这样可以避免被浏览器、CDN 缓存影响到重试的结果。
@@ -208,27 +215,31 @@ pluginAssetsRetry({
 
 当你想要自定义 query 时，可以传入一个函数，比如：
 
-* **示例：** 请求的所有资源都不含 query：
+- **示例：** 请求的所有资源都不含 query：
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times) => {
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+  addQuery: ({ times }) => {
+    return times === 3
+      ? `?retryCount=${times}&isLast=1`
+      : `?retryCount=${times}`;
   },
 });
 ```
 
-* **示例：** 请求的某些资源中含有 query 可以使用 originalQuery 区分：
+- **示例：** 请求的某些资源中含有 query 可以使用 originalQuery 区分：
 
 ```js
 pluginAssetsRetry({
-  addQuery: (times, originalQuery) => {
-    if (originalQuery !== '') {
-      return times === 3 
+  addQuery: ({ times, originalQuery }) => {
+    if (originalQuery) {
+      return times === 3
         ? `${originalQuery}&retryCount=${times}&isLast=1`
         : `${originalQuery}&retryCount=${times}`;
     }
-    return times === 3 ? `?retryCount=${times}&isLast=1` : `?retryCount=${times}`
+    return times === 3
+      ? `?retryCount=${times}&isLast=1`
+      : `?retryCount=${times}`;
   },
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -232,14 +232,9 @@ pluginAssetsRetry({
 ```js
 pluginAssetsRetry({
   addQuery: ({ times, originalQuery }) => {
-    if (originalQuery) {
-      return times === 3
-        ? `${originalQuery}&retryCount=${times}&isLast=1`
-        : `${originalQuery}&retryCount=${times}`;
-    }
-    return times === 3
-      ? `?retryCount=${times}&isLast=1`
-      : `?retryCount=${times}`;
+    const extraQuery =
+      times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
+    return originalQuery ? `${originalQuery}&${extraQuery}` : `?${extraQuery}`;
   },
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -232,9 +232,9 @@ pluginAssetsRetry({
 ```js
 pluginAssetsRetry({
   addQuery: ({ times, originalQuery }) => {
-    const extraQuery =
+    const query =
       times === 3 ? `retryCount=${times}&isLast=1` : `retryCount=${times}`;
-    return originalQuery ? `${originalQuery}&${extraQuery}` : `?${extraQuery}`;
+    return originalQuery ? `${originalQuery}&${query}` : `?${query}`;
   },
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -227,7 +227,7 @@ pluginAssetsRetry({
 });
 ```
 
-- **示例：** 请求的某些资源中含有 query 可以使用 originalQuery 区分：
+- **示例：** 当请求的某些资源中含有 query 时，可以使用 `originalQuery` 读取：
 
 ```js
 pluginAssetsRetry({


### PR DESCRIPTION
## Summary

Passing addQuery params in object format, this makes it easier for us to add more parameters in the future.

```ts
// before
addQuery?: boolean | ((times: number, originalQuery: string) => string);

// after
addQuery?: boolean | ((context: { times: number; originalQuery: string }) => string);
```

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2277

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
