### PR TITLE
chore(deps): ignore pnpm in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,6 +49,7 @@
 	],
 	"ignoreDeps": [
 		// manually update some packages
+		"pnpm",
 		"core-js",
 		"esbuild",
 		"typescript",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "packageManager": "pnpm@9.0.6",
   "engines": {
     "node": ">=18.0.0",
-    "pnpm": ">=9.0.6"
+    "pnpm": ">=9.0.0"
   },
   "pnpm": {
     "overrides": {
@@ -69,14 +69,6 @@
     "allowedDeprecatedVersions": {
       "vue": "2.x",
       "consolidate": "0.15.1"
-    },
-    "packageExtensions": {
-      "dts-packer": {
-        "//": "`resolve >= 1.21.0` breaks dts-packer",
-        "dependencies": {
-          "resolve": "1.20.0"
-        }
-      }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,6 @@ overrides:
   '@rsbuild/core': link:packages/core
   '@rsbuild/plugin-react': link:packages/plugin-react
 
-packageExtensionsChecksum: 18212998c4ac9d0b24113807ba3e5d6f
-
 importers:
 
   .:


### PR DESCRIPTION
## Summary

- Ignore pnpm in renovate config, so we can upgrade pnpm manually.
- Remove unused dts-packer config.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
