### PR TITLE
docs: remove outdated deploy guide

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -44,10 +44,6 @@ Rsbuild supports convert SVG to React components via [SVGR](https://react-svgr.c
 
 If you need to use svgr, you also need to register the [SVGR plugin](/plugins/list/plugin-svgr).
 
-import DeployApp from '@en/shared/deployApp.mdx';
-
-<DeployApp />
-
 ## React Fast Refresh
 
 Rsbuild uses React's official [Fast Refresh](https://www.npmjs.com/package/react-refresh) capability to perform component hot updates.

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -40,7 +40,3 @@ export default defineConfig({
   ],
 });
 ```
-
-import DeployApp from '@en/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/en/guide/framework/svelte.mdx
+++ b/website/docs/en/guide/framework/svelte.mdx
@@ -33,7 +33,3 @@ export default defineConfig({
   plugins: [pluginSvelte()],
 });
 ```
-
-import DeployApp from '@en/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/en/guide/framework/vue2.mdx
+++ b/website/docs/en/guide/framework/vue2.mdx
@@ -58,7 +58,3 @@ declare module '*.vue' {
   export default Vue;
 }
 ```
-
-import DeployApp from '@en/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/en/shared/deployApp.mdx
+++ b/website/docs/en/shared/deployApp.mdx
@@ -1,7 +1,0 @@
-## Deploy the Application
-
-After running `rsbuild build` to build the application, you will get a set of static assets in the `dist` directory. These assets can be deployed to any platform or server.
-
-Please note that the default output structure of Rsbuild may not be suitable for all platforms because different platforms have different requirements for the directory structure. You can refer to the [Output Files](/guide/basic/output-files) section to modify the directory structure to meet the requirements of your deployment platform.
-
-Additionally, if you need to preview the deployment artifacts locally, you can use the [rsbuild preview](/guide/basic/cli#rsbuild-preview) command provided by Rsbuild CLI.

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -44,10 +44,6 @@ Rsbuild 支持调用 [SVGR](https://react-svgr.com/)，将 SVG 图片转换为�
 
 如果你需要使用 SVGR，需要注册 Rsbuild 的 [SVGR 插件](/plugins/list/plugin-svgr)。
 
-import DeployApp from '@zh/shared/deployApp.mdx';
-
-<DeployApp />
-
 ## React Fast Refresh
 
 Rsbuild 使用 React 官方的 [Fast Refresh](https://www.npmjs.com/package/react-refresh) 能力来进行组件热更新。

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -40,7 +40,3 @@ export default defineConfig({
   ],
 });
 ```
-
-import DeployApp from '@zh/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/zh/guide/framework/svelte.mdx
+++ b/website/docs/zh/guide/framework/svelte.mdx
@@ -33,7 +33,3 @@ export default defineConfig({
   plugins: [pluginSvelte()],
 });
 ```
-
-import DeployApp from '@zh/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/zh/guide/framework/vue2.mdx
+++ b/website/docs/zh/guide/framework/vue2.mdx
@@ -58,7 +58,3 @@ declare module '*.vue' {
   export default Vue;
 }
 ```
-
-import DeployApp from '@zh/shared/deployApp.mdx';
-
-<DeployApp />

--- a/website/docs/zh/shared/deployApp.mdx
+++ b/website/docs/zh/shared/deployApp.mdx
@@ -1,7 +1,0 @@
-## 部署应用
-
-当你执行 `rsbuild build` 构建应用后，你会在 `dist` 目录下得到一份静态资源产物，这份产物可以被部署到任意平台或服务器上。
-
-请留意 Rsbuild 默认的产物结构并不适用于所有的平台，因为不同的平台对产物目录结构有不同的要求。你可以参考 [构建产物目录](/guide/basic/output-files) 章节对目录结构进行修改，以满足部署平台的要求。
-
-此外，如果你需要在本地预览待部署的产物，可以使用 Rsbuild CLI 提供的 [rsbuild preview](/guide/basic/cli#rsbuild-preview) 命令。


### PR DESCRIPTION
## Summary

Remove the outdated deploy guide, as we have provided a better guide in:  https://rsbuild.dev/guide/basic/static-deploy

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
