### PR TITLE
fix(client): Array.prototype.at not exist on legacy browsers

### DIFF
--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -3,13 +3,20 @@ import type { StatsCompilation, StatsError } from '@rspack/core';
 function resolveFileName(stats: StatsError) {
   // Get the real source file path with stats.moduleIdentifier.
   // e.g. moduleIdentifier is "builtin:react-refresh-loader!/Users/x/src/App.jsx"
-  const regex = /(?:\!|^)([^!]+)$/;
-  const fileName = stats.moduleIdentifier?.match(regex)?.at(-1) ?? '';
-  return fileName
-    ? // add default column add lines for linking
-      `File: ${fileName}:1:1\n`
-    : // fallback to moduleName if moduleIdentifier parse failed
-      `File: ${stats.moduleName}\n`;
+  if (stats.moduleIdentifier) {
+    const regex = /(?:\!|^)([^!]+)$/;
+    const matched = stats.moduleIdentifier.match(regex);
+    if (matched) {
+      const fileName = matched.pop();
+      if (fileName) {
+        // add default column add lines for linking
+        return `File: ${fileName}:1:1\n`;
+      }
+    }
+  }
+
+  // fallback to moduleName if moduleIdentifier parse failed
+  return `File: ${stats.moduleName}\n`;
 }
 
 // Cleans up Rspack error messages.


### PR DESCRIPTION
## Summary

`Array.prototype.at` not exist on legacy browsers, we should avoid using it.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/a60b51d2-3309-456a-9f22-9198d4dec6b8)

## Related Links

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at#browser_compatibility

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
