### PR TITLE
docs: make performance.profile more clear

### DIFF
--- a/packages/core/src/plugins/performance.ts
+++ b/packages/core/src/plugins/performance.ts
@@ -1,20 +1,4 @@
-import type { BundlerChain, NormalizedConfig } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
-
-function applyProfile({
-  chain,
-  config,
-}: {
-  chain: BundlerChain;
-  config: NormalizedConfig;
-}) {
-  const { profile } = config.performance;
-  if (!profile) {
-    return;
-  }
-
-  chain.profile(profile);
-}
 
 /**
  * Apply some configs of Rsbuild performance
@@ -40,10 +24,15 @@ export const pluginPerformance = (): RsbuildPlugin => ({
         }
       }
     });
+
     api.modifyBundlerChain((chain) => {
       const config = api.getNormalizedConfig();
+      const { profile } = config.performance;
+      if (!profile) {
+        return;
+      }
 
-      applyProfile({ chain, config });
+      chain.profile(profile);
     });
   },
 });

--- a/website/docs/en/config/performance/profile.mdx
+++ b/website/docs/en/config/performance/profile.mdx
@@ -5,6 +5,11 @@
 
 Whether capture timing information for each module, same as the [profile](https://webpack.js.org/configuration/other-options/#profile) config of Rspack.
 
+After enabled:
+
+- Rsbuild will auto-generate `dist/stats.json` file through [bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer).
+- Rspack will include the build time information when generating stats.json or other statistics files.
+
 ### Example
 
 ```js
@@ -17,6 +22,6 @@ export default {
 
 When enabled, Rspack generates a JSON file with some statistics about the module that includes information about timing information for each module.
 
-### Node.js Profiling
+### Guide
 
-You can also analyze the overhead on the Node.js side, see [Node.js Profiling](/guide/optimization/build-performance#nodejs-profiling).
+Please refer to the [Build Profiling](/guide/optimization/build-performance#nodejs-profiling) section for more methods to analyze build performance.

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -51,4 +51,4 @@ This command will generate a `rspack-profile-${timestamp}` folder in the dist fo
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/).
 - `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development environment yet)
 
-For more information about Rspack build performance analysis usage, please refer to [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling).
+> For more information about Rspack build performance analysis usage, please refer to [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling).

--- a/website/docs/zh/config/performance/profile.mdx
+++ b/website/docs/zh/config/performance/profile.mdx
@@ -5,6 +5,11 @@
 
 是否捕获每个模块的耗时信息，对应 Rspack 的 [profile](https://webpack.js.org/configuration/other-options/#profile) 配置。
 
+开启后：
+
+- Rsbuild 会通过 [bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) 自动生成 `dist/stats.json` 文件。
+- Rspack 在生成 stats.json 等统计文件时，会将构建的耗时信息也包含进去。
+
 ### 示例
 
 ```js
@@ -15,8 +20,6 @@ export default {
 };
 ```
 
-开启后，Rspack 在生成一些关于模块统计数据的 JSON 文件时，会将模块构建的耗时信息也包含进去。
+### 指南
 
-### Node.js Profiling
-
-你也可以分析 Node.js 侧的开销，参考 [Node.js Profiling](/guide/optimization/build-performance#nodejs-profiling)。
+请参考 [构建性能分析](/guide/optimization/build-performance#nodejs-profiling) 章节来了解更多分析构建性能方法。

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -53,4 +53,4 @@ RSPACK_PROFILE=ALL rsbuild build
 - `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。
 - `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时 (开发环境下暂不支持)。
 
-更多 Rspack 构建性能分析用法可参考 [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling)
+> 更多 Rspack 构建性能分析用法，可参考 [Rspack - Profiling](https://web-infra-dev.github.io/rspack-dev-guide/profiling/intro.html#profiling)。


### PR DESCRIPTION
## Summary

Make the document of `performance.profile` more clear, sometimes we are confused about the difference between it and RSPACK_PROFILE.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
