### PR TITLE
docs: localIdentName hashDigest has been supported in rspack mode

### DIFF
--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -37,3 +37,45 @@ test('should compile CSS Modules follow by output.cssModules', async () => {
     /.the-a-class{color:red}.the-b-class-\w{6}{color:blue}.the-c-class{color:yellow}.the-d-class{color:green}/,
   );
 });
+
+test('should compile CSS Modules follow by output.cssModules custom localIdentName', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        cssModules: {
+          localIdentName: '[hash:base64:8]',
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+  expect(content).toMatch(
+    /\.the-a-class{color:red}\.\w{8}{color:blue}\.\w{8}{color:yellow}\.the-d-class{color:green}/,
+  );
+});
+
+test('should compile CSS Modules follow by output.cssModules custom localIdentName - hashDigest', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        cssModules: {
+          localIdentName: '[hash:hex:4]',
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+  expect(content).toMatch(
+    /\.the-a-class{color:red}\.\w{4}{color:blue}\.\w{4}{color:yellow}\.the-d-class{color:green}/,
+  );
+});

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -125,25 +125,6 @@ describe('plugin-css', () => {
     );
   });
 
-  it('should ignore hashDigest when custom cssModules.localIdentName', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginCss()],
-      rsbuildConfig: {
-        output: {
-          cssModules: {
-            localIdentName: '[hash:base64:5]',
-          },
-        },
-      },
-    });
-
-    const bundlerConfigs = await rsbuild.initConfigs();
-
-    expect(JSON.stringify(bundlerConfigs[0])).toContain(
-      '"localIdentName":"[hash:base64:5]"',
-    );
-  });
-
   it('should use custom cssModules rule when using output.cssModules config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -114,10 +114,6 @@ You can use the following template strings in `localIdentName`:
 - `[ext]` - extension with leading dot.
 - `[hash:<hashDigest>:<hashDigestLength>]`: hash with hash settings.
 
-:::tip
-When using Rspack as the bundler, currently does not support custom `<hashDigest>`.
-:::
-
 ### Example
 
 Set `localIdentName` to other value:

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -114,10 +114,6 @@ console.log(styles.header);
 - `[ext]` - 文件后缀名，包含点号。
 - `[hash:<hashDigest>:<hashDigestLength>]` - 带有哈希设置的哈希。
 
-:::tip
-在使用 Rspack 作为打包工具时, 暂不支持配置 `<hashDigest>`。
-:::
-
 ### 示例
 
 将 `localIdentName` 设置为其他值：


### PR DESCRIPTION
## Summary

since we use CssExtractRspackPlugin to extract CSS, localIdentName hashDigest has been supported in rspack mode.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1577
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
