### PR TITLE
chore(build): enable full type check and fix type issue

### DIFF
--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -23,7 +23,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "modern build && node scripts/postCompile.js",
+    "build": "modern build && node scripts/postCompile.mjs",
     "dev": "modern build --watch"
   },
   "dependencies": {

--- a/packages/plugin-assets-retry/scripts/postCompile.mjs
+++ b/packages/plugin-assets-retry/scripts/postCompile.mjs
@@ -1,7 +1,12 @@
-const path = require('node:path');
-const { readFile, writeFile, mkdir } = require('node:fs/promises');
-const { transformAsync } = require('@babel/core');
-const { performance } = require('node:perf_hooks');
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+import { transformAsync } from '@babel/core';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
  * transform ../src/runtime/${filename}.ts
@@ -48,11 +53,17 @@ async function compileRuntimeFile(filename) {
 
 async function compile() {
   const startTime = performance.now();
-  await mkdir(path.join(__dirname, '../dist/runtime'));
+
+  const runtimeDir = path.join(__dirname, '../dist/runtime');
+  if (!existsSync(runtimeDir)) {
+    await mkdir(runtimeDir);
+  }
+
   await Promise.all([
     compileRuntimeFile('initialChunkRetry'),
     compileRuntimeFile('asyncChunkRetry'),
   ]);
+
   console.log(
     `Compiled assets retry runtime code. Time cost: ${(
       performance.now() - startTime

--- a/packages/plugin-image-compress/src/types/index.ts
+++ b/packages/plugin-image-compress/src/types/index.ts
@@ -16,7 +16,7 @@ export interface CodecBaseOptions {
   jpeg: JpegCompressOptions;
   png: PngQuantOptions;
   pngLossless: PNGLosslessOptions;
-  ico: Record<string, never>;
+  ico: Record<string, unknown>;
   svg: SvgoConfig;
 }
 

--- a/scripts/modern.base.config.ts
+++ b/scripts/modern.base.config.ts
@@ -50,9 +50,7 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     define,
     autoExtension: true,
     externals,
-    dts: {
-      respectExternal: false,
-    },
+    dts: false,
   },
   {
     format: 'esm',
@@ -63,6 +61,12 @@ export const buildConfigWithMjs: PartialBaseBuildConfig[] = [
     shims: true,
     externals,
     banner: requireShim,
+  },
+  {
+    buildType: 'bundleless',
+    dts: {
+      only: true,
+    },
   },
 ];
 


### PR DESCRIPTION
## Summary

Rsbuild uses Modern.js Module to build packages, and it uses `rollup-plugin-dts` to generate dts files by default. But the `rollup-plugin-dts` can not perform a full type checking and does not have complete type generating supports (for example, cannot handle namespace).

This PR changed the build config and uses tsc for type checking and dts generation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
