### PR TITLE
chore: set package type to module

### DIFF
--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-assets-retry"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-babel"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/plugin-basic-ssl/modern.config.ts
+++ b/packages/plugin-basic-ssl/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-basic-ssl"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-check-syntax"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-css-minimizer"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-eslint/modern.config.ts
+++ b/packages/plugin-eslint/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-eslint"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-image-compress"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-lightningcss/modern.config.ts
+++ b/packages/plugin-lightningcss/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-lightningcss"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -101,7 +101,7 @@ const applyLightningCSSLoader = ({
     const rule = chain.module.rule(ruleId);
     const use = rule.use(CHAIN_ID.USE.LIGHTNINGCSS);
 
-    use.loader(path.resolve(__dirname, './loader')).options(mergedOptions);
+    use.loader(path.resolve(__dirname, './loader.cjs')).options(mergedOptions);
 
     switch (ruleId) {
       case CHAIN_ID.RULE.SASS:

--- a/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
@@ -28,7 +28,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "cssModules": {
             "dashedIdents": true,
@@ -76,7 +76,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "cssModules": {
             "dashedIdents": true,
@@ -137,7 +137,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "cssModules": {
             "dashedIdents": true,
@@ -246,7 +246,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,
@@ -282,7 +282,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,
@@ -331,7 +331,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,
@@ -422,7 +422,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should replace postcss-loade
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,
@@ -458,7 +458,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should replace postcss-loade
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,
@@ -507,7 +507,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should replace postcss-loade
         },
       },
       {
-        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader",
+        "loader": "<ROOT>/packages/plugin-lightningcss/src/loader.cjs",
         "options": {
           "targets": {
             "chrome": 5701632,

--- a/packages/plugin-mdx/modern.config.ts
+++ b/packages/plugin-mdx/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-mdx"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-node-polyfill"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-preact"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-pug/modern.config.ts
+++ b/packages/plugin-pug/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-pug"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-react"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-rem/modern.config.ts
+++ b/packages/plugin-rem/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-rem"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-solid"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-source-build"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-styled-components"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-stylus/modern.config.ts
+++ b/packages/plugin-stylus/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-stylus"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-svelte"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-svgr/modern.config.ts
+++ b/packages/plugin-svgr/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -8,15 +8,15 @@
     "directory": "packages/plugin-svgr"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -117,7 +117,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         .type('javascript/auto')
         .resourceQuery(options.query || /react/)
         .use(CHAIN_ID.USE.SVGR)
-        .loader(path.resolve(__dirname, './loader'))
+        .loader(path.resolve(__dirname, './loader.cjs'))
         .options({
           ...svgrOptions,
           exportType: 'default',
@@ -145,7 +145,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
           // The issuer option ensures that SVGR will only apply if the SVG is imported from a JS file.
           .set('issuer', issuer)
           .use(CHAIN_ID.USE.SVGR)
-          .loader(path.resolve(__dirname, './loader'))
+          .loader(path.resolve(__dirname, './loader.cjs'))
           .options({
             ...svgrOptions,
             exportType,
@@ -159,7 +159,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
         if (mixedImport && exportType === 'named') {
           svgRule
             .use(CHAIN_ID.USE.URL)
-            .loader(path.join(__dirname, '../compiled', 'url-loader'))
+            .loader(path.join(__dirname, '../compiled', 'url-loader/index.js'))
             .options({
               limit: maxSize,
               name: outputName,

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -55,7 +55,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -148,7 +148,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -213,7 +213,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -305,7 +305,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -370,7 +370,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -462,7 +462,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -527,7 +527,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "named",
             "svgo": true,
@@ -619,7 +619,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "default",
             "svgo": true,
@@ -684,7 +684,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/src/loader",
+          "loader": "<ROOT>/packages/plugin-svgr/src/loader.cjs",
           "options": {
             "exportType": "named",
             "svgo": true,
@@ -704,7 +704,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           },
         },
         {
-          "loader": "<ROOT>/packages/plugin-svgr/compiled/url-loader",
+          "loader": "<ROOT>/packages/plugin-svgr/compiled/url-loader/index.js",
           "options": {
             "limit": 10000,
             "name": "static/svg/[name].[contenthash:8].svg",

--- a/packages/plugin-toml/modern.config.ts
+++ b/packages/plugin-toml/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-toml"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-type-check"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-umd/modern.config.ts
+++ b/packages/plugin-umd/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-umd"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-vue-jsx"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-vue"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-vue2-jsx"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-vue2"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/plugin-yaml/modern.config.ts
+++ b/packages/plugin-yaml/modern.config.ts
@@ -1,4 +1,4 @@
-import moduleTools from '@modern-js/module-tools';
+import { moduleTools } from '@modern-js/module-tools';
 import { buildConfigWithMjs } from '../../scripts/modern.base.config';
 
 export default {

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -9,15 +9,15 @@
     "directory": "packages/plugin-yaml"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,12 +9,12 @@
     "directory": "packages/shared"
   },
   "license": "MIT",
-  "type": "commonjs",
+  "type": "module",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "default": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     },
     "./autoprefixer": {
       "types": "./compiled/autoprefixer/index.d.ts",
@@ -105,7 +105,7 @@
       "default": "./compiled/http-proxy-middleware/index.js"
     }
   },
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
## Summary

Most Rsbuild packages currently support both ESModule and CommonJS. We can change the `package.json#type` of these packages to `module` to comply with the community direction.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/99

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
