### PR TITLE
fix: only enable React JSX compilation when using React plugin

### DIFF
--- a/e2e/cases/performance/print-file-size/rsbuild.config.ts
+++ b/e2e/cases/performance/print-file-size/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default {
+  plugins: [pluginReact()],
+};

--- a/packages/core/src/provider/plugins/swc.ts
+++ b/packages/core/src/provider/plugins/swc.ts
@@ -22,7 +22,7 @@ import type {
 
 const builtinSwcLoaderName = 'builtin:swc-loader';
 
-export async function getDefaultSwcConfig(
+async function getDefaultSwcConfig(
   config: NormalizedConfig,
   rootPath: string,
   target: RsbuildTarget,
@@ -31,7 +31,7 @@ export async function getDefaultSwcConfig(
     jsc: {
       externalHelpers: true,
       parser: {
-        tsx: true,
+        tsx: false,
         syntax: 'typescript',
         decorators: true,
       },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -68,7 +68,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -112,7 +112,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -68,7 +68,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -112,7 +112,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -648,7 +648,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -692,7 +692,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -1287,7 +1287,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -1325,7 +1325,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -1695,7 +1695,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -1739,7 +1739,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -44,7 +44,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -88,7 +88,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -154,7 +154,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -195,7 +195,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -262,7 +262,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -303,7 +303,7 @@ exports[`plugin-swc > should add browserslist 2`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -373,7 +373,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -424,7 +424,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -544,7 +544,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
             "parser": {
               "decorators": true,
               "syntax": "typescript",
-              "tsx": true,
+              "tsx": false,
             },
             "preserveAllComments": true,
             "transform": {
@@ -588,7 +588,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
             "parser": {
               "decorators": true,
               "syntax": "typescript",
-              "tsx": true,
+              "tsx": false,
             },
             "preserveAllComments": true,
             "transform": {
@@ -648,7 +648,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -692,7 +692,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
                 "parser": {
                   "decorators": true,
                   "syntax": "typescript",
-                  "tsx": true,
+                  "tsx": false,
                 },
                 "preserveAllComments": true,
                 "transform": {
@@ -755,7 +755,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -793,7 +793,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -860,7 +860,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -902,7 +902,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -971,7 +971,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1014,7 +1014,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1084,7 +1084,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1128,7 +1128,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1198,7 +1198,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1241,7 +1241,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1305,7 +1305,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1343,7 +1343,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1412,7 +1412,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {
@@ -1456,7 +1456,7 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
                   "parser": {
                     "decorators": true,
                     "syntax": "typescript",
-                    "tsx": true,
+                    "tsx": false,
                   },
                   "preserveAllComments": true,
                   "transform": {

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -40,7 +40,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {

--- a/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
@@ -24,7 +24,7 @@ exports[`plugin-mdx > should allow to configure mdx loader 1`] = `
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {
@@ -69,7 +69,7 @@ exports[`plugin-mdx > should register mdx loader correctly 1`] = `
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -28,6 +28,11 @@ export const pluginPreact = (
         tools: {
           swc: {
             jsc: {
+              parser: {
+                syntax: 'typescript',
+                // enable supports for JSX/TSX compilation
+                tsx: true,
+              },
               transform: {
                 react: reactOptions,
               },

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import type { RsbuildConfig, RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import {
   SCRIPT_REGEX,
+  deepmerge,
   isUsingHMR,
   modifySwcLoaderOptions,
 } from '@rsbuild/shared';
@@ -26,13 +27,20 @@ export const applyBasicReactSupport = (
     modifySwcLoaderOptions({
       chain,
       modifier: (opts) => {
-        opts.jsc ??= {};
-        opts.jsc.transform ??= {};
-        opts.jsc.transform.react = {
-          ...opts.jsc.transform.react,
-          ...reactOptions,
+        const extraOptions: Rspack.SwcLoaderOptions = {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              // enable supports for React JSX/TSX compilation
+              tsx: true,
+            },
+            transform: {
+              react: reactOptions,
+            },
+          },
         };
-        return opts;
+
+        return deepmerge(opts, extraOptions);
       },
     });
 

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -36,7 +36,7 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {
@@ -89,7 +89,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {
@@ -148,7 +148,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
           "parser": {
             "decorators": true,
             "syntax": "typescript",
-            "tsx": true,
+            "tsx": false,
           },
           "preserveAllComments": true,
           "transform": {

--- a/website/docs/en/config/tools/swc.mdx
+++ b/website/docs/en/config/tools/swc.mdx
@@ -9,7 +9,7 @@ const defaultOptions = {
   jsc: {
     externalHelpers: true,
     parser: {
-      tsx: true,
+      tsx: false,
       syntax: 'typescript',
       decorators: true,
     },

--- a/website/docs/zh/config/tools/swc.mdx
+++ b/website/docs/zh/config/tools/swc.mdx
@@ -9,7 +9,7 @@ const defaultOptions = {
   jsc: {
     externalHelpers: true,
     parser: {
-      tsx: true,
+      tsx: false,
       syntax: 'typescript',
       decorators: true,
     },


### PR DESCRIPTION
## Summary

The `jsc.parser.tsx` option should only be enabled in React / Preact projects, otherwise SWC will transform JSX with React syntax in non-React projects, and users might get confused.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2328

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
