### PR TITLE
feat: output.dataUriLimit defaults to 4096

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -64,7 +64,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -91,7 +91,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -118,7 +118,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -145,7 +145,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -601,7 +601,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -628,7 +628,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -655,7 +655,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -682,7 +682,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1172,7 +1172,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1199,7 +1199,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1226,7 +1226,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1253,7 +1253,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1529,7 +1529,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1556,7 +1556,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1583,7 +1583,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1610,7 +1610,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -23,7 +23,7 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -50,7 +50,7 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -77,7 +77,7 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -104,7 +104,7 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -140,7 +140,7 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -167,7 +167,7 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -194,7 +194,7 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -221,7 +221,7 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -257,7 +257,7 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -284,7 +284,7 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -311,7 +311,7 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -338,7 +338,7 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -374,7 +374,7 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -401,7 +401,7 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -428,7 +428,7 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -455,7 +455,7 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -144,7 +144,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -171,7 +171,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -198,7 +198,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -225,7 +225,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -144,7 +144,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -171,7 +171,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -198,7 +198,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -225,7 +225,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -724,7 +724,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -751,7 +751,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -778,7 +778,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -805,7 +805,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1357,7 +1357,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1384,7 +1384,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1411,7 +1411,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1438,7 +1438,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1771,7 +1771,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1798,7 +1798,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1825,7 +1825,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -1852,7 +1852,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/plugin-image-compress/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-image-compress/tests/__snapshots__/index.test.ts.snap
@@ -23,7 +23,7 @@ exports[`plugin-image-compress > should generate correct options 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -50,7 +50,7 @@ exports[`plugin-image-compress > should generate correct options 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -77,7 +77,7 @@ exports[`plugin-image-compress > should generate correct options 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -104,7 +104,7 @@ exports[`plugin-image-compress > should generate correct options 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -171,7 +171,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -198,7 +198,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -225,7 +225,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",
@@ -252,7 +252,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             },
             "parser": {
               "dataUrlCondition": {
-                "maxSize": 10000,
+                "maxSize": 4096,
               },
             },
             "type": "asset",

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -83,7 +83,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
       },
       "parser": {
         "dataUrlCondition": {
-          "maxSize": 10000,
+          "maxSize": 4096,
         },
       },
       "type": "asset",
@@ -240,7 +240,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
       },
       "parser": {
         "dataUrlCondition": {
-          "maxSize": 10000,
+          "maxSize": 4096,
         },
       },
       "type": "asset",
@@ -397,7 +397,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
       },
       "parser": {
         "dataUrlCondition": {
-          "maxSize": 10000,
+          "maxSize": 4096,
         },
       },
       "type": "asset",
@@ -554,7 +554,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
       },
       "parser": {
         "dataUrlCondition": {
-          "maxSize": 10000,
+          "maxSize": 4096,
         },
       },
       "type": "asset",
@@ -706,7 +706,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
         {
           "loader": "<ROOT>/packages/plugin-svgr/compiled/url-loader/index.js",
           "options": {
-            "limit": 10000,
+            "limit": 4096,
             "name": "static/svg/[name].[contenthash:8].svg",
           },
         },
@@ -718,7 +718,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
       },
       "parser": {
         "dataUrlCondition": {
-          "maxSize": 10000,
+          "maxSize": 4096,
         },
       },
       "type": "asset",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -2,7 +2,7 @@ import type { RsbuildTarget } from './types';
 
 // Defaults
 export const DEFAULT_PORT = 3000;
-export const DEFAULT_DATA_URL_SIZE = 10000;
+export const DEFAULT_DATA_URL_SIZE = 4096;
 export const DEFAULT_MOUNT_ID = 'root';
 export const DEFAULT_DEV_HOST = '0.0.0.0';
 

--- a/website/docs/en/config/output/data-uri-limit.mdx
+++ b/website/docs/en/config/output/data-uri-limit.mdx
@@ -16,17 +16,18 @@ type DataUriLimitConfig =
 - **Default:**
 
 ```js
+// Since Rsbuild v0.7.0, the defaults changed from 10000 to 4096
 const defaultDatUriLimit = {
-  svg: 10000,
-  font: 10000,
-  image: 10000,
-  media: 10000,
+  svg: 4096,
+  font: 4096,
+  image: 4096,
+  media: 4096,
 };
 ```
 
 Set the size threshold to inline static assets such as images and fonts.
 
-By default, static assets will be Base64 encoded and inline into the page if the size is less than 10KB.
+By default, static assets will be Base64 encoded and inline into the page if the size is less than 4KiB.
 
 You can adjust the threshold by setting the `dataUriLimit` config.
 
@@ -39,12 +40,12 @@ Detail:
 
 ### Example
 
-- Inline all static assets less than 4kB:
+- Inline all static assets less than 10KiB:
 
 ```js
 export default {
   output: {
-    dataUriLimit: 4000,
+    dataUriLimit: 10 * 1024,
   },
 };
 ```
@@ -69,13 +70,13 @@ export default {
 };
 ```
 
-- Set the threshold for image assets to 5kB, do not inline video assets:
+- Set the threshold for image assets to 5KiB, do not inline video assets:
 
 ```js
 export default {
   output: {
     dataUriLimit: {
-      image: 5000,
+      image: 5 * 1024,
       media: 0,
     },
   },

--- a/website/docs/zh/config/output/data-uri-limit.mdx
+++ b/website/docs/zh/config/output/data-uri-limit.mdx
@@ -16,17 +16,18 @@ type DataUriLimitConfig =
 - **默认值：**
 
 ```js
+// 从 Rsbuild v0.7.0 开始，默认值从 10000 更改为 4096
 const defaultDatUriLimit = {
-  svg: 10000,
-  font: 10000,
-  image: 10000,
-  media: 10000,
+  svg: 4096,
+  font: 4096,
+  image: 4096,
+  media: 4096,
 };
 ```
 
 设置图片、字体、媒体等静态资源被自动内联为 base64 的体积阈值。
 
-默认情况下，体积小于 10KB 的图片、字体、媒体等文件，会自动经过 Base64 编码，内联到页面中，不再会发送独立的 HTTP 请求。
+默认情况下，体积小于 4KiB 的图片、字体、媒体等文件，会自动经过 Base64 编码，内联到页面中，不再会发送独立的 HTTP 请求。
 
 你可以通过修改 `dataUriLimit` 参数来调整这个阈值。
 
@@ -39,12 +40,12 @@ const defaultDatUriLimit = {
 
 ### 示例
 
-- 内联小于 4kB 的所有静态资源：
+- 内联小于 10KiB 的所有静态资源：
 
 ```js
 export default {
   output: {
-    dataUriLimit: 4000,
+    dataUriLimit: 10 * 1024,
   },
 };
 ```
@@ -69,13 +70,13 @@ export default {
 };
 ```
 
-- 设置图片资源的阈值为 5kB，不内联视频资源：
+- 设置图片资源的阈值为 5KiB，不内联视频资源：
 
 ```js
 export default {
   output: {
     dataUriLimit: {
-      image: 5000,
+      image: 5 * 1024,
       media: 0,
     },
   },


### PR DESCRIPTION
## Summary

The default value for `output.dataUriLimit` is changed from `10000 (10kB)` to `4096 (4KiB)`.

This is because more applications are currently using HTTP2.0, so splitting assets into separate files would perform better. Meanwhile, inlining assets over 4KiB can make the JS bundle to be too large and not cache-friendly.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2271

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
