### PR TITLE
test(e2e): enable CSS Modules import loaders case

### DIFF
--- a/e2e/cases/css/import-loaders/index.test.ts
+++ b/e2e/cases/css/import-loaders/index.test.ts
@@ -1,20 +1,16 @@
 import { build } from '@e2e/helper';
-import { webpackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
-webpackOnlyTest(
-  'should compile CSS Modules which depends on importLoaders correctly',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
-    });
-    const files = await rsbuild.unwrapOutputJSON();
+test('should compile CSS Modules which depends on importLoaders correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+  const files = await rsbuild.unwrapOutputJSON();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 
-    expect(content).toEqual(
-      '.class-foo-yQ8Tl7+.hello-class-foo{background-color:red}.class-bar-TVH2T6 .hello-class-bar{background-color:blue}',
-    );
-  },
-);
+  expect(content).toEqual(
+    '.class-foo-yQ8Tl7+.hello-class-foo{background-color:red}.class-bar-TVH2T6 .hello-class-bar{background-color:blue}',
+  );
+});


### PR DESCRIPTION
## Summary

We can now enable CSS Modules import loaders case because Rsbuild has switched to `css-loader` + `CssExtractRspackPlugin`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/1577

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
