### PR TITLE
docs: list plugin-typed-css-modules in npm-packages page

### DIFF
--- a/website/docs/en/guide/start/npm-packages.mdx
+++ b/website/docs/en/guide/start/npm-packages.mdx
@@ -212,6 +212,16 @@ Generate an untrusted, self-signed certificate for the HTTPS server.
 - [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl)
 - [Documentation](/plugins/list/plugin-basic-ssl)
 
+## @rsbuild/plugin-typed-css-modules
+
+![](https://img.shields.io/npm/v/@rsbuild/plugin-typed-css-modules?style=flat-square&colorA=564341&colorB=EDED91)
+
+Generate TypeScript declaration file for CSS Modules.
+
+- [npm](https://npmjs.com/package/@rsbuild/plugin-typed-css-modules)
+- [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-typed-css-modules)
+- [Documentation](/plugins/list/plugin-typed-css-modules)
+
 ## @rsbuild/shared
 
 ![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)

--- a/website/docs/zh/guide/start/npm-packages.mdx
+++ b/website/docs/zh/guide/start/npm-packages.mdx
@@ -212,6 +212,16 @@ Check Syntax 插件，用于分析产物的语法兼容性，判断是否存在�
 - [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-basic-ssl)
 - [文档](/plugins/list/plugin-basic-ssl)
 
+## @rsbuild/plugin-typed-css-modules
+
+![](https://img.shields.io/npm/v/@rsbuild/plugin-typed-css-modules?style=flat-square&colorA=564341&colorB=EDED91)
+
+为项目中的 CSS Modules 文件生成相应的类型声明文件。
+
+- [npm](https://npmjs.com/package/@rsbuild/plugin-typed-css-modules)
+- [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-typed-css-modules)
+- [文档](/plugins/list/plugin-typed-css-modules)
+
 ## @rsbuild/shared
 
 ![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)


### PR DESCRIPTION
## Summary

add `@rsbuild/plugin-typed-css-modules` to `npm-packages` page.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2342

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
