### PR TITLE
test(e2e): fix regexp for matching rem script name

### DIFF
--- a/e2e/cases/rem/basic/index.test.ts
+++ b/e2e/cases/rem/basic/index.test.ts
@@ -89,7 +89,7 @@ test('should apply crossorigin to rem runtime script', async ({ page }) => {
 
   expect(htmlFile).toBeTruthy();
   expect(files[htmlFile!]).toMatch(
-    /<script src="\/static\/js\/convert-rem.\w+.\w+.\w+.js" defer="" crossorigin="use-credentials">/,
+    /<script src="\/static\/js\/convert-rem.\d+\.\d+\.\d+(?:-(beta|alpha|rc)\.\d+)?.js" defer="" crossorigin="use-credentials">/,
   );
   expect(files[htmlFile!].includes('function setRootPixel')).toBeFalsy();
 
@@ -126,7 +126,7 @@ test('should apply html.scriptLoading to rem runtime script', async ({
 
   expect(htmlFile).toBeTruthy();
   expect(files[htmlFile!]).toMatch(
-    /<script type="module" src="\/static\/js\/convert-rem.\w+.\w+.\w+.js">/,
+    /<script type="module" src="\/static\/js\/convert-rem.\d+\.\d+\.\d+(?:-(beta|alpha|rc)\.\d+)?.js">/,
   );
   expect(files[htmlFile!].includes('function setRootPixel')).toBeFalsy();
 


### PR DESCRIPTION
## Summary

Fix regexp for matching rem script name:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f2a94fca-f0b8-45d1-9c76-9f38ca552f18)

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/9082225121/job/24958031046

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
