### PR TITLE
fix: increase priority split-by-module so it can differ from defaultVendors

### DIFF
--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -137,7 +137,7 @@ function splitByModule(ctx: SplitChunksContext): SplitChunks {
       ...userDefinedCacheGroups,
       // Core group
       vendors: {
-        priority: -10,
+        priority: -9,
         test: NODE_MODULES_REGEX,
         name(module) {
           return module

--- a/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
@@ -152,7 +152,7 @@ exports[`plugin-split-chunks > should set split-by-module config 1`] = `
       "cacheGroups": {
         "vendors": {
           "name": [Function],
-          "priority": -10,
+          "priority": -9,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
         },
       },


### PR DESCRIPTION
fix: increase priority split-by-module so it can differ from defaultVendors

## Summary

Webpack's defaultVendors priority is -10, so the priority of defaultVendors and vendors are the same, in some case, module will be in defaultVendors chunk, not vendor chunk

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
