### PR TITLE
fix: remove rslog from prebundle config

### DIFF
--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -8,7 +8,7 @@ async function main() {
     const { runCli } = require('../dist/cli/commands');
     runCli();
   } catch (err) {
-    const { logger } = require('@rsbuild/shared/rslog');
+    const { logger } = require('@rsbuild/shared');
     logger.error(err);
   }
 }

--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -1,4 +1,4 @@
-import { logger } from '@rsbuild/shared/rslog';
+import { logger } from '@rsbuild/shared';
 
 function initNodeEnv() {
   if (!process.env.NODE_ENV) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,10 +28,6 @@
       "types": "./compiled/less/index.d.ts",
       "default": "./compiled/less/index.js"
     },
-    "./rslog": {
-      "types": "./compiled/rslog/dist/index.d.ts",
-      "default": "./compiled/rslog/index.js"
-    },
     "./yaml": {
       "types": "./compiled/yaml/index.d.ts",
       "default": "./compiled/yaml/index.js"

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -21,7 +21,6 @@ export default {
     typescript: 'typescript',
   },
   dependencies: [
-    'rslog',
     'deepmerge',
     'fs-extra',
     {

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -1,8 +1,5 @@
-import * as rslog from '../compiled/rslog/index.js';
-import type { Logger } from '../compiled/rslog/index.js';
+import { type Logger, logger } from 'rslog';
 import { color } from './utils';
-
-const { logger } = rslog;
 
 // setup the logger level
 if (process.env.DEBUG) {


### PR DESCRIPTION
## Summary

Remove rslog from the prebundle config to fix the ESM / CJS interop problem.

rslog is written in ESM and compiled to ESM + CJS, if we use `prebundle` to bundle it into CJS and then import the compiled rslog in an ESM file, it turns out to be a mess and we cannot get the correct exports.

So we just remove rslog from the prebundle config and it works fine.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
