### PR TITLE
chore: reduce exports of the shared package

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -25,6 +25,7 @@ export default {
     '/^caniuse-lite(/.*)/': 'caniuse-lite$1',
     webpack: 'webpack',
     postcss: 'postcss',
+    typescript: 'typescript',
   },
   dependencies: [
     'open',

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -91,13 +91,6 @@ export default {
       externals: {
         'postcss-value-parser': '../postcss-value-parser',
         semver: '@rsbuild/shared/semver',
-        'postcss-modules-local-by-default':
-          '@rsbuild/shared/postcss-modules-local-by-default',
-        'postcss-modules-extract-imports':
-          '@rsbuild/shared/postcss-modules-extract-imports',
-        'postcss-modules-scope': '@rsbuild/shared/postcss-modules-scope',
-        'postcss-modules-values': '@rsbuild/shared/postcss-modules-values',
-        'icss-utils': '@rsbuild/shared/icss-utils',
       },
     },
     {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -68,26 +68,6 @@
       "types": "./compiled/webpack-bundle-analyzer/index.d.ts",
       "default": "./compiled/webpack-bundle-analyzer/index.js"
     },
-    "./icss-utils": {
-      "types": "./compiled/icss-utils/index.d.ts",
-      "default": "./compiled/icss-utils/index.js"
-    },
-    "./postcss-modules-extract-imports": {
-      "types": "./compiled/postcss-modules-extract-imports/index.d.ts",
-      "default": "./compiled/postcss-modules-extract-imports/index.js"
-    },
-    "./postcss-modules-local-by-default": {
-      "types": "./compiled/postcss-modules-local-by-default/index.d.ts",
-      "default": "./compiled/postcss-modules-local-by-default/index.js"
-    },
-    "./postcss-modules-scope": {
-      "types": "./compiled/postcss-modules-scope/index.d.ts",
-      "default": "./compiled/postcss-modules-scope/index.js"
-    },
-    "./postcss-modules-values": {
-      "types": "./compiled/postcss-modules-values/index.d.ts",
-      "default": "./compiled/postcss-modules-values/index.js"
-    },
     "./semver": {
       "types": "./compiled/semver/index.d.ts",
       "default": "./compiled/semver/index.js"
@@ -136,7 +116,6 @@
     "fs-extra": "^11.2.0",
     "gzip-size": "^6.0.0",
     "http-proxy-middleware": "^2.0.6",
-    "icss-utils": "5.1.0",
     "jiti": "^1.21.0",
     "json5": "^2.2.3",
     "less": "4.2.0",
@@ -144,11 +123,6 @@
     "mime-types": "^2.1.35",
     "mini-css-extract-plugin": "2.8.1",
     "picocolors": "1.0.0",
-    "postcss-modules-extract-imports": "3.1.0",
-    "postcss-modules-local-by-default": "4.0.5",
-    "postcss-modules-scope": "3.2.0",
-    "postcss-modules-values": "4.0.0",
-    "postcss-value-parser": "4.2.0",
     "prebundle": "1.1.0",
     "rslog": "^1.2.2",
     "sass": "^1.77.1",

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -60,37 +60,6 @@ export default {
       ignoreDts: true,
     },
     {
-      name: 'icss-utils',
-      ignoreDts: true,
-    },
-    {
-      name: 'postcss-value-parser',
-      ignoreDts: true,
-    },
-    {
-      name: 'postcss-modules-local-by-default',
-      ignoreDts: true,
-      externals: {
-        'icss-utils': '../icss-utils',
-        'postcss-value-parser': '../postcss-value-parser',
-      },
-    },
-    {
-      name: 'postcss-modules-extract-imports',
-      ignoreDts: true,
-    },
-    {
-      name: 'postcss-modules-scope',
-      ignoreDts: true,
-    },
-    {
-      name: 'postcss-modules-values',
-      ignoreDts: true,
-      externals: {
-        'icss-utils': '../icss-utils',
-      },
-    },
-    {
       name: 'loader-utils2',
       ignoreDts: true,
       externals: {
@@ -137,7 +106,8 @@ export default {
       externals: {
         picocolors: '../picocolors',
         browserslist: '../browserslist',
-        'postcss-value-parser': '../postcss-value-parser',
+        // Can be enabled after moving to core
+        // 'postcss-value-parser': '../postcss-value-parser',
       },
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1682,21 +1682,6 @@ importers:
       picocolors:
         specifier: 1.0.0
         version: 1.0.0
-      postcss-modules-extract-imports:
-        specifier: 3.1.0
-        version: 3.1.0(postcss@8.4.38)
-      postcss-modules-local-by-default:
-        specifier: 4.0.5
-        version: 4.0.5(postcss@8.4.38)
-      postcss-modules-scope:
-        specifier: 3.2.0
-        version: 3.2.0(postcss@8.4.38)
-      postcss-modules-values:
-        specifier: 4.0.0
-        version: 4.0.0(postcss@8.4.38)
-      postcss-value-parser:
-        specifier: 4.2.0
-        version: 4.2.0
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.4.5)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,9 +1658,6 @@ importers:
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.6
-      icss-utils:
-        specifier: 5.1.0
-        version: 5.1.0(postcss@8.4.38)
       jiti:
         specifier: ^1.21.0
         version: 1.21.0


### PR DESCRIPTION
## Summary

Reduce exports of the shared package. Some exports are only used by `@rsbuild/core` and can be removed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
