### PR TITLE
fix(shared): broken types due to type module

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,7 +20,7 @@
       "cache": true,
       "dependsOn": ["^build", "prebundle"],
       "inputs": ["build", "^build"],
-      "outputs": ["{projectRoot}/dist"]
+      "outputs": ["{projectRoot}/dist", "{projectRoot}/dist-types"]
     },
     "prebundle": {
       "cache": true,

--- a/packages/compat/babel-preset/modern.config.ts
+++ b/packages/compat/babel-preset/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     config.input = [
       'src/index.ts',
       'src/web.ts',

--- a/packages/compat/plugin-swc/modern.config.ts
+++ b/packages/compat/plugin-swc/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     if (config.format === 'cjs') {
       // add loader to entry
       config.input = ['src/index.ts', 'src/loader.ts'];

--- a/packages/compat/webpack/modern.config.ts
+++ b/packages/compat/webpack/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../../scripts/modern.base.config';
+import { configForDualPackage } from '../../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/create-rsbuild/modern.config.ts
+++ b/packages/create-rsbuild/modern.config.ts
@@ -1,3 +1,7 @@
-import { bundleMjsOnlyConfig } from '../../scripts/modern.base.config';
+import { defineConfig, moduleTools } from '@modern-js/module-tools';
+import { esmBuildConfig } from '../../scripts/modern.base.config';
 
-export default bundleMjsOnlyConfig;
+export default defineConfig({
+  plugins: [moduleTools()],
+  buildConfig: [esmBuildConfig],
+});

--- a/packages/monorepo-utils/modern.config.ts
+++ b/packages/monorepo-utils/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-babel/modern.config.ts
+++ b/packages/plugin-babel/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-basic-ssl/modern.config.ts
+++ b/packages/plugin-basic-ssl/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-check-syntax/modern.config.ts
+++ b/packages/plugin-check-syntax/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-css-minimizer/modern.config.ts
+++ b/packages/plugin-css-minimizer/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-eslint/modern.config.ts
+++ b/packages/plugin-eslint/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-image-compress/modern.config.ts
+++ b/packages/plugin-image-compress/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-lightningcss/modern.config.ts
+++ b/packages/plugin-lightningcss/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     if (config.format === 'cjs') {
       // add loader to entry
       config.input = ['src/index.ts', 'src/loader.ts'];

--- a/packages/plugin-mdx/modern.config.ts
+++ b/packages/plugin-mdx/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-node-polyfill/modern.config.ts
+++ b/packages/plugin-node-polyfill/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-preact/modern.config.ts
+++ b/packages/plugin-preact/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-pug/modern.config.ts
+++ b/packages/plugin-pug/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-react/modern.config.ts
+++ b/packages/plugin-react/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-rem/modern.config.ts
+++ b/packages/plugin-rem/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-solid/modern.config.ts
+++ b/packages/plugin-solid/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-source-build/modern.config.ts
+++ b/packages/plugin-source-build/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-styled-components/modern.config.ts
+++ b/packages/plugin-styled-components/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-stylus/modern.config.ts
+++ b/packages/plugin-stylus/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     return {
       ...config,
       externals: ['@rsbuild/webpack/plugin-css'],

--- a/packages/plugin-svelte/modern.config.ts
+++ b/packages/plugin-svelte/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     config.externals = [
       ...(config.externals || []),
       'svelte/compiler',

--- a/packages/plugin-svgr/modern.config.ts
+++ b/packages/plugin-svgr/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     if (config.format === 'cjs') {
       // add loader to entry
       config.input = ['src/index.ts', 'src/loader.ts'];

--- a/packages/plugin-toml/modern.config.ts
+++ b/packages/plugin-toml/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-type-check/modern.config.ts
+++ b/packages/plugin-type-check/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-typed-css-modules/modern.config.ts
+++ b/packages/plugin-typed-css-modules/modern.config.ts
@@ -1,9 +1,9 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
+  buildConfig: dualBuildConfigs.map((config) => {
     if (config.format === 'cjs') {
       // add loader to entry
       config.input = ['src/index.ts', 'src/loader.ts'];

--- a/packages/plugin-umd/modern.config.ts
+++ b/packages/plugin-umd/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/plugin-vue-jsx/modern.config.ts
+++ b/packages/plugin-vue-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-vue/modern.config.ts
+++ b/packages/plugin-vue/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-vue2-jsx/modern.config.ts
+++ b/packages/plugin-vue2-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-vue2/modern.config.ts
+++ b/packages/plugin-vue2/modern.config.ts
@@ -1,3 +1,3 @@
-import { configWithMjs } from '../../scripts/modern.base.config';
+import { configForDualPackage } from '../../scripts/modern.base.config';
 
-export default configWithMjs;
+export default configForDualPackage;

--- a/packages/plugin-yaml/modern.config.ts
+++ b/packages/plugin-yaml/modern.config.ts
@@ -1,7 +1,7 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { dualBuildConfigs } from '../../scripts/modern.base.config';
 
 export default {
   plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs,
+  buildConfig: dualBuildConfigs,
 };

--- a/packages/shared/modern.config.ts
+++ b/packages/shared/modern.config.ts
@@ -1,10 +1,26 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { buildConfigWithMjs } from '../../scripts/modern.base.config';
+import { defineConfig, moduleTools } from '@modern-js/module-tools';
+import {
+  cjsBuildConfig,
+  commonExternals,
+  emitTypePkgJsonPlugin,
+  esmBuildConfig,
+} from '../../scripts/modern.base.config';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: buildConfigWithMjs.map((config) => {
-    config.externals = [...(config.externals || []), 'mini-css-extract-plugin'];
-    return config;
-  }),
-};
+export default defineConfig({
+  plugins: [moduleTools(), emitTypePkgJsonPlugin],
+  buildConfig: [
+    {
+      ...esmBuildConfig,
+      dts: false,
+    },
+    cjsBuildConfig,
+    {
+      externals: commonExternals,
+      buildType: 'bundleless',
+      dts: {
+        distPath: '../dist-types',
+        only: true,
+      },
+    },
+  ],
+});

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,7 +12,7 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
@@ -82,9 +82,10 @@
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "dist",
+    "dist-types",
     "compiled"
   ],
   "scripts": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,5 @@ packages:
   - 'packages/**'
   - 'examples/**'
   - '!**/compiled/**'
+  - '!**/dist-types/**'
   - '!**/create-rsbuild/template-*'


### PR DESCRIPTION
## Summary

Fix broken types due to `"type": "module" in package.json and `"moduleResolution": "Node16"` in user's tsconfig.json.

In https://github.com/web-infra-dev/rsbuild/pull/2347, I tried to bundle types to fix this problem, but it turns out that the types of prebundled packages still do not work as expected.

This PR introduces a workaround to fix this, by adding an empty package.json to the `dist-types` folder.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
