### PR TITLE
fix: lazy import webpack-dev-middleware

### DIFF
--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -89,7 +89,7 @@ export async function createDevMiddleware(
   }
 
   return {
-    devMiddleware: getDevMiddleware(compiler),
+    devMiddleware: await getDevMiddleware(compiler),
     compiler,
   };
 }

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -148,7 +148,7 @@ export async function createDevMiddleware(
 
   const { getDevMiddleware } = await import('../server/devMiddleware');
   return {
-    devMiddleware: getDevMiddleware(compiler),
+    devMiddleware: await getDevMiddleware(compiler),
     compiler,
   };
 }

--- a/packages/core/src/server/devMiddleware.ts
+++ b/packages/core/src/server/devMiddleware.ts
@@ -7,7 +7,6 @@ import {
   isNodeCompiler,
 } from '@rsbuild/shared';
 import type { Compiler, MultiCompiler } from '@rspack/core';
-import webpackDevMiddleware from '../../compiled/webpack-dev-middleware/index.js';
 
 type ServerCallbacks = {
   onInvalid: () => void;
@@ -66,9 +65,13 @@ function applyHMREntry({
   }
 }
 
-export const getDevMiddleware =
-  (multiCompiler: Compiler | MultiCompiler): NonNullable<DevMiddleware> =>
-  (options) => {
+export const getDevMiddleware = async (
+  multiCompiler: Compiler | MultiCompiler,
+): Promise<NonNullable<DevMiddleware>> => {
+  const { default: webpackDevMiddleware } = await import(
+    '../../compiled/webpack-dev-middleware/index.js'
+  );
+  return (options) => {
     const { clientPaths, clientConfig, callbacks, liveReload, ...restOptions } =
       options;
 
@@ -89,3 +92,4 @@ export const getDevMiddleware =
 
     return webpackDevMiddleware(multiCompiler, restOptions);
   };
+};


### PR DESCRIPTION
## Summary

After merging https://github.com/web-infra-dev/rsbuild/pull/2361, an unexpected rebuild will occur when Rspress starts:

![img_v3_02au_b5b166f9-bccb-47e2-956a-ffae47a094fg](https://github.com/web-infra-dev/rsbuild/assets/7237365/76ed4f95-878a-4c2f-b47c-71e2e4d78a4d)

Then I found that lazy import webpack-dev-middleware can solve this issue, this may be some side effects of webpack-dev-middleware on fs.

This PR lazy import webpack-dev-middleware to fix this issue.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
