### PR TITLE
feat: add rsbuild.getPlugins JavaScript API

### DIFF
--- a/packages/compat/webpack/src/inspectConfig.ts
+++ b/packages/compat/webpack/src/inspectConfig.ts
@@ -41,7 +41,7 @@ export async function inspectConfig({
     pluginNames: string[];
   } = {
     ...context.normalizedConfig!,
-    pluginNames: pluginManager.plugins.map((p) => p.name),
+    pluginNames: pluginManager.getPlugins().map((p) => p.name),
   };
 
   const rawRsbuildConfig = await stringifyConfig(

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -48,7 +48,12 @@ export async function createRsbuild(
   debug('add default plugins done');
 
   const rsbuild = {
-    ...pick(pluginManager, ['addPlugins', 'removePlugins', 'isPluginExists']),
+    ...pick(pluginManager, [
+      'addPlugins',
+      'getPlugins',
+      'removePlugins',
+      'isPluginExists',
+    ]),
     ...pick(pluginAPI, [
       'onBeforeBuild',
       'onBeforeCreateCompiler',

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -92,9 +92,7 @@ export function createPluginManager(): PluginManager {
     Boolean(plugins.find((plugin) => plugin.name === pluginName));
 
   return {
-    get plugins() {
-      return plugins;
-    },
+    getPlugins: () => plugins,
     addPlugins,
     removePlugins,
     isPluginExists,
@@ -177,7 +175,7 @@ export async function initPlugins({
 }) {
   debug('init plugins');
 
-  const plugins = pluginDagSort(pluginManager.plugins);
+  const plugins = pluginDagSort(pluginManager.getPlugins());
 
   const removedPlugins = plugins.reduce<string[]>((ret, plugin) => {
     if (plugin.remove) {

--- a/packages/core/src/provider/inspectConfig.ts
+++ b/packages/core/src/provider/inspectConfig.ts
@@ -41,7 +41,7 @@ export async function inspectConfig({
     pluginNames: string[];
   } = {
     ...context.normalizedConfig!,
-    pluginNames: pluginManager.plugins.map((p) => p.name),
+    pluginNames: pluginManager.getPlugins().map((p) => p.name),
   };
 
   const rawRsbuildConfig = await stringifyConfig(

--- a/packages/core/tests/createPluginManager.test.ts
+++ b/packages/core/tests/createPluginManager.test.ts
@@ -3,7 +3,7 @@ import { createPluginManager } from '../src/pluginManager';
 describe('createPluginManager', () => {
   it('addPlugins and removePlugins works', () => {
     const pluginManager = createPluginManager();
-    expect(pluginManager.plugins).toEqual([]);
+    expect(pluginManager.getPlugins()).toEqual([]);
     pluginManager.addPlugins([
       {
         name: 'foo',
@@ -18,9 +18,9 @@ describe('createPluginManager', () => {
         },
       },
     ]);
-    expect(pluginManager.plugins).toHaveLength(2);
+    expect(pluginManager.getPlugins()).toHaveLength(2);
     pluginManager.removePlugins(['foo']);
-    expect(pluginManager.plugins).toHaveLength(1);
+    expect(pluginManager.getPlugins()).toHaveLength(1);
     expect(pluginManager.isPluginExists('foo')).toBe(false);
   });
 });

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -87,7 +87,7 @@ export type ModifyWebpackConfigFn = (
 ) => Promise<WebpackConfig | void> | WebpackConfig | void;
 
 export type PluginManager = {
-  readonly plugins: RsbuildPlugin[];
+  getPlugins: () => RsbuildPlugin[];
   addPlugins: (
     plugins: Array<RsbuildPlugin | Falsy>,
     options?: { before?: string },

--- a/packages/shared/src/types/rsbuild.ts
+++ b/packages/shared/src/types/rsbuild.ts
@@ -23,6 +23,7 @@ export type RsbuildInstance<
   context: RsbuildContext;
 
   addPlugins: PluginManager['addPlugins'];
+  getPlugins: PluginManager['getPlugins'];
   removePlugins: PluginManager['removePlugins'];
   isPluginExists: PluginManager['isPluginExists'];
 

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -79,6 +79,7 @@ export async function createStubRsbuild({
     | 'startDevServer'
     | 'context'
     | 'addPlugins'
+    | 'getPlugins'
     | 'removePlugins'
     | 'isPluginExists'
     | 'initConfigs'
@@ -145,7 +146,12 @@ export async function createStubRsbuild({
     baseMatchLoader({ config: await unwrapConfig(), loader, testFile });
 
   return {
-    ...pick(pluginManager, ['addPlugins', 'removePlugins', 'isPluginExists']),
+    ...pick(pluginManager, [
+      'addPlugins',
+      'getPlugins',
+      'removePlugins',
+      'isPluginExists',
+    ]),
     build,
     createCompiler,
     inspectConfig,

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -466,6 +466,22 @@ rsbuild.addPlugins([pluginFoo()], { before: 'bar' });
 rsbuild.addPlugins([pluginFoo()], { after: 'bar' });
 ```
 
+## rsbuild.getPlugins
+
+Get all the Rsbuild plugins registered in the current Rsbuild instance.
+
+- **Type:**
+
+```ts
+function GetPlugins(): RsbuildPlugin[];
+```
+
+- **Example:**
+
+```ts
+console.log(rsbuild.getPlugins());
+```
+
 ## rsbuild.removePlugins
 
 Removes one or more Rsbuild plugins, which can be called multiple times.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -458,6 +458,22 @@ rsbuild.addPlugins([pluginFoo()], { before: 'bar' });
 rsbuild.addPlugins([pluginFoo()], { after: 'bar' });
 ```
 
+## rsbuild.getPlugins
+
+获取当前 Rsbuild 实例中注册的所有 Rsbuild 插件。
+
+- **类型：**
+
+```ts
+function GetPlugins(): RsbuildPlugin[];
+```
+
+- **示例：**
+
+```ts
+console.log(rsbuild.getPlugins());
+```
+
 ## rsbuild.removePlugins
 
 移除一个或多个 Rsbuild 插件，可以被多次调用。


### PR DESCRIPTION
## Summary

Add `rsbuild.getPlugins` JavaScript API, this API can be used for testing or some other scenarios.

For example, replace the current implementation of [createStubRsbuild](https://github.com/web-infra-dev/rsbuild/blob/1500f2e/scripts/test-helper/src/rsbuild.ts).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
