### PR TITLE
fix(plugin-swc): no longer depend on internal helper to parse minify

### DIFF
--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -38,9 +38,12 @@ export class SwcMinimizerPlugin {
     cssMinify?: boolean | CssMinifyOptions;
     rsbuildConfig: NormalizedConfig;
   }) {
-    const { minifyJs, minifyCss } = __internalHelper.parseMinifyOptions(
-      options.rsbuildConfig,
-    );
+    const { minify } = options.rsbuildConfig.output;
+    const minifyJs =
+      minify === true || (typeof minify === 'object' && minify.js);
+    const minifyCss =
+      minify === true || (typeof minify === 'object' && minify.css);
+
     this.minifyOptions = {
       jsMinify: minifyJs
         ? deepmerge(

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { __internalHelper } from '@rsbuild/core';
 import {
   DEFAULT_BROWSERSLIST,
   type RsbuildPlugin,
@@ -134,8 +133,11 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
           minimizersChain.delete(CHAIN_ID.MINIMIZER.CSS).end();
         }
 
-        const { minifyJs, minifyCss } =
-          __internalHelper.parseMinifyOptions(rsbuildConfig);
+        const { minify } = rsbuildConfig.output;
+        const minifyJs =
+          minify === true || (typeof minify === 'object' && minify.js);
+        const minifyCss =
+          minify === true || (typeof minify === 'object' && minify.css);
 
         minimizersChain
           .end()

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -21,7 +21,7 @@ export {
 export { formatStats, getStatsOptions } from './helpers';
 export { getChainUtils } from './provider/rspackConfig';
 export { applySwcDecoratorConfig } from './plugins/swc';
-export { getSwcMinimizerOptions, parseMinifyOptions } from './plugins/minimize';
+export { getSwcMinimizerOptions } from './plugins/minimize';
 export { getDevMiddleware } from './server/devMiddleware';
 export { createDevServer, startProdServer } from './server';
 export { plugins } from './plugins';

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -67,12 +67,11 @@ export const pluginCssMinimizer = (
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {
       const config = api.getNormalizedConfig();
       const { minify } = config.output;
-      const isMinimize =
-        isProd &&
-        minify !== false &&
-        !(typeof minify === 'object' && minify.css === false);
 
-      if (isMinimize) {
+      if (
+        isProd &&
+        (minify === true || (typeof minify === 'object' && minify.css))
+      ) {
         applyCSSMinimizer(chain, CHAIN_ID, options);
       }
     });

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -185,8 +185,7 @@ export const pluginLightningcss = (
       const { minify } = config.output;
       const isMinimize =
         isProd &&
-        minify !== false &&
-        !(typeof minify === 'object' && minify.css === false);
+        (minify === true || (typeof minify === 'object' && minify.css));
 
       if (isMinimize && options?.minify !== false) {
         await applyLightningCSSMinifyPlugin({


### PR DESCRIPTION
## Summary

No longer depend on internal helper to parse minify. We want remove all internal helper exports of `@rsbuild/core` in the long run.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
