### PR TITLE
perf: reduce fs calls caused by getCompiledPath

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -3,12 +3,10 @@ import {
   type BundlerChain,
   DEFAULT_ASSET_PREFIX,
   type MultiStats,
-  type SharedCompiledPkgNames,
   type Stats,
   type StatsError,
   addTrailingSlash,
   color,
-  getSharedPkgCompiledPath,
   isMultiCompiler,
   removeTailingSlash,
 } from '@rsbuild/shared';
@@ -55,13 +53,8 @@ export const isSatisfyRspackVersion = async (originalVersion: string) => {
   return true;
 };
 
-export const getCompiledPath = (packageName: string) => {
-  const providerCompilerPath = path.join(COMPILED_PATH, packageName);
-  if (fse.existsSync(providerCompilerPath)) {
-    return providerCompilerPath;
-  }
-  return getSharedPkgCompiledPath(packageName as SharedCompiledPkgNames);
-};
+export const getCompiledPath = (packageName: string) =>
+  path.join(COMPILED_PATH, packageName);
 
 /**
  * Add node polyfill tip when failed to resolve node built-in modules.

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -12,7 +12,6 @@ import {
   modifyBundlerChain,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
-import { getCompiledPath } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
 import type { InternalContext } from '../types';
 
@@ -101,7 +100,6 @@ export function getChainUtils(target: RsbuildTarget): ModifyChainUtils {
     isServer: target === 'node',
     isWebWorker: target === 'web-worker',
     isServiceWorker: target === 'service-worker',
-    getCompiledPath,
     CHAIN_ID,
     HtmlPlugin: getHTMLPlugin(),
   };

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -80,10 +80,6 @@ export type ModifyChainUtils = {
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
   HtmlPlugin: typeof HtmlWebpackPlugin;
-  /**
-   * @private internal API
-   */
-  getCompiledPath: (name: string) => string;
 };
 
 interface PluginInstance {


### PR DESCRIPTION
## Summary

- Reduce fs calls caused by getCompiledPath.
- Remove `getCompiledPath` from chain utils, as it is an internal API.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
