### PR TITLE
fix: missing resourceQuery param of cssLoader.module.auto

### DIFF
--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -144,7 +144,14 @@ export type CssModuleLocalsConvention =
   | 'dashesOnly';
 
 export type CssModules = {
-  auto?: boolean | RegExp | ((resourcePath: string) => boolean);
+  auto?:
+    | boolean
+    | RegExp
+    | ((
+        resourcePath: string,
+        resourceQuery: string,
+        resourceFragment: string,
+      ) => boolean);
   /**
    * Set the local ident name of CSS Modules.
    */

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -80,7 +80,14 @@ export type { AcceptedPlugin as PostCSSPlugin } from 'postcss';
 export interface CSSModulesOptions {
   compileType?: string;
   mode?: string;
-  auto?: boolean | RegExp | ((resourcePath: string) => boolean);
+  auto?:
+    | boolean
+    | RegExp
+    | ((
+        resourcePath: string,
+        resourceQuery: string,
+        resourceFragment: string,
+      ) => boolean);
   exportGlobals?: boolean;
   localIdentName?: string;
   localIdentContext?: string;

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -4,7 +4,14 @@
 
 ```ts
 type CssModules = {
-  auto?: boolean | RegExp | ((resourcePath: string) => boolean);
+  auto?:
+    | boolean
+    | RegExp
+    | ((
+        resourcePath: string,
+        resourceQuery: string,
+        resourceFragment: string,
+      ) => boolean);
   localIdentName?: string;
   exportLocalsConvention?: CssModuleLocalsConvention;
 };
@@ -16,7 +23,19 @@ For custom CSS Modules configuration.
 
 The `auto` configuration option allows CSS Modules to be automatically enabled based on their filenames.
 
-- **Type:** `boolean | RegExp | ((resourcePath: string) => boolean)`
+- **Type:**
+
+```ts
+type Auto =
+  | boolean
+  | RegExp
+  | ((
+      resourcePath: string,
+      resourceQuery: string,
+      resourceFragment: string,
+    ) => boolean);
+```
+
 - **Default:** `true`
 
 Type description:

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -4,7 +4,14 @@
 
 ```ts
 type CssModules = {
-  auto?: boolean | RegExp | ((resourcePath: string) => boolean);
+  auto?:
+    | boolean
+    | RegExp
+    | ((
+        resourcePath: string,
+        resourceQuery: string,
+        resourceFragment: string,
+      ) => boolean);
   localIdentName?: string;
   exportLocalsConvention?: CssModuleLocalsConvention;
 };
@@ -16,7 +23,19 @@ type CssModules = {
 
 auto 配置项允许基于文件名自动启用 CSS 模块。
 
-- **类型：** `boolean | RegExp | ((resourcePath: string) => boolean)`
+- **类型：**
+
+```ts
+type Auto =
+  | boolean
+  | RegExp
+  | ((
+      resourcePath: string,
+      resourceQuery: string,
+      resourceFragment: string,
+    ) => boolean);
+```
+
 - **默认值：** `true`
 
 类型说明：


### PR DESCRIPTION
## Summary

Fix missing resourceQuery param of `cssLoader.module.auto`

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f2840252-2c25-4cf4-a629-5699fcf4c33c)

## Related Links

https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#auto

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
