### PR TITLE
feat(plugin-vue): support CSS Modules in SFC

### DIFF
--- a/e2e/cases/vue/sfc-css-modules/index.test.ts
+++ b/e2e/cases/vue/sfc-css-modules/index.test.ts
@@ -1,0 +1,24 @@
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should build Vue sfc with CSS Modules correctly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const test1 = page.locator('#test1');
+    const test2 = page.locator('#test2');
+    const test3 = page.locator('#test3');
+
+    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue/sfc-css-modules/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-css-modules/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cases/vue/sfc-css-modules/src/A.vue
+++ b/e2e/cases/vue/sfc-css-modules/src/A.vue
@@ -1,0 +1,27 @@
+<template>
+  <p id="test1" :class="{ [$style.red]: isRed }">Red</p>
+  <p id="test2" :class="[$style.red, $style.blue]">Blue</p>
+  <p id="test3" :class="style.green">Green</p>
+</template>
+
+<script>
+import style from './style.module.css';
+
+export default {
+  setup() {
+    return {
+      style,
+      isRed: true,
+    };
+  },
+};
+</script>
+
+<style module>
+.red {
+  color: red;
+}
+.blue {
+  color: blue;
+}
+</style>

--- a/e2e/cases/vue/sfc-css-modules/src/index.js
+++ b/e2e/cases/vue/sfc-css-modules/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import A from './A.vue';
+
+createApp(A).mount('#root');

--- a/e2e/cases/vue/sfc-css-modules/src/style.module.css
+++ b/e2e/cases/vue/sfc-css-modules/src/style.module.css
@@ -1,0 +1,3 @@
+.green {
+  color: green;
+}


### PR DESCRIPTION
## Summary

Support CSS Modules in SFC:

```html
<template>
  <p id="test1" :class="{ [$style.red]: isRed }">Red</p>
</template>

<script>
export default {
  setup() {
    return {
      isRed: true,
    };
  },
};
</script>

<style module>
.red {
  color: red;
}
</style>
```

## Related Links

https://vuejs.org/api/sfc-css-features.html#css-modules
https://github.com/web-infra-dev/rsbuild/issues/1425

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
