### PR TITLE
Release: 0.7.0-beta.5

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-basic-ssl",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "SSL plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-mdx",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Mdx plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -57,7 +57,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -41,7 +41,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-toml",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "TOML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "prebundle": "1.1.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.91.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-yaml",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "YAML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "yaml-loader": "^0.8.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.0-beta.4"
+    "@rsbuild/core": "workspace:^0.7.0-beta.5"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/scripts/tsconfig/package.json
+++ b/scripts/tsconfig/package.json
@@ -1,5 +1,5 @@
 {
   "name": "@rsbuild/tsconfig",
-  "version": "0.7.0-beta.4",
+  "version": "0.7.0-beta.5",
   "private": true
 }


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: add `rsbuild.getPlugins` JavaScript API by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2369
* feat(plugin-vue): support CSS Modules in SFC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2374
* feat(plugin-vue2): support CSS Modules in SFC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2375
### Performance 🚀
* perf: reduce fs calls caused by getCompiledPath by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2372
### Bug Fixes 🐞
* fix: build target of client bundles by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2366
* fix: lazy import webpack-dev-middleware by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2367
* fix(plugin-swc): no longer depend on internal helper to parse minify by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2371
* fix: missing resourceQuery param of cssLoader.module.auto by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2373
### Document 📖
* docs: bump Rspress to match Rsbuild v0.7 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2365
* docs: add rsbuild-storybook link by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2368
### Other Changes
* test(helper): simplify createStubRsbuild by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2370


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.7.0-beta.4...v0.7.0-beta.5