### PR TITLE
chore: make some plugins do not depend on shared

### DIFF
--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -1,10 +1,5 @@
-import { __internalHelper, logger } from '@rsbuild/core';
-import {
-  CSS_REGEX,
-  type NormalizedConfig,
-  color,
-  deepmerge,
-} from '@rsbuild/shared';
+import { type NormalizedConfig, __internalHelper, logger } from '@rsbuild/core';
+import { color, deepmerge } from '@rsbuild/shared';
 import type { webpack } from '@rsbuild/webpack';
 import { minify, minifyCss } from './binding';
 import { JS_REGEX } from './constants';
@@ -27,6 +22,8 @@ const normalize = <T>(
   }
   return v;
 };
+
+const CSS_REGEX = /\.css$/;
 
 export class SwcMinimizerPlugin {
   private readonly minifyOptions: NormalizedSwcMinifyOption;

--- a/packages/compat/plugin-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-swc/tests/plugin.test.ts
@@ -1,7 +1,5 @@
-import type {
-  ModifyWebpackChainUtils,
-  NormalizedConfig,
-} from '@rsbuild/shared';
+import type { NormalizedConfig } from '@rsbuild/core';
+import type { ModifyWebpackChainUtils } from '@rsbuild/shared';
 import { webpackProvider } from '@rsbuild/webpack';
 import { createStubRsbuild } from '@scripts/test-helper';
 import { pluginSwc } from '../src';

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -1,11 +1,10 @@
+import { type Rspack, logger } from '@rsbuild/core';
 import {
   type BuildOptions,
   type MultiStats,
-  type Rspack,
   type RspackConfig,
   type Stats,
   getNodeEnv,
-  logger,
   onCompileDone,
   setNodeEnv,
 } from '@rsbuild/shared';

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -1,10 +1,9 @@
+import { type Rspack, logger } from '@rsbuild/core';
 import {
-  type Rspack,
   type RspackConfig,
   type Stats,
   debug,
   isDev,
-  logger,
   onCompileDone,
 } from '@rsbuild/shared';
 // @ts-expect-error

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -16,7 +16,6 @@ import {
   SERVER_DIST_DIR,
   SERVICE_WORKER_DIST_DIR,
   SVG_DIST_DIR,
-  TS_CONFIG_FILE,
   WASM_DIST_DIR,
   color,
   debounce,
@@ -37,6 +36,7 @@ import type {
   RsbuildConfig,
   RsbuildEntry,
 } from '@rsbuild/shared';
+import { TS_CONFIG_FILE } from './constants';
 import { findExists, isFileExists } from './helpers';
 import { mergeRsbuildConfig } from './mergeConfig';
 import { restartDevServer } from './server/restart';

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -10,3 +10,8 @@ export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';
 export const LOADER_PATH = join(__dirname);
 export const STATIC_PATH = join(__dirname, '../static');
 export const COMPILED_PATH = join(__dirname, '../compiled');
+
+export const TS_CONFIG_FILE = 'tsconfig.json';
+
+export const HTML_REGEX = /\.html$/;
+export const CSS_REGEX = /\.css$/;

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -3,7 +3,6 @@ import {
   type BundlerChainRule,
   type CSSExtractOptions,
   type CSSLoaderOptions,
-  CSS_REGEX,
   type ModifyChainUtils,
   type PostCSSLoaderOptions,
   type PostCSSOptions,
@@ -16,7 +15,7 @@ import {
   mergeChainedOptions,
 } from '@rsbuild/shared';
 import type { AcceptedPlugin } from 'postcss';
-import { LOADER_PATH } from '../constants';
+import { CSS_REGEX, LOADER_PATH } from '../constants';
 import { getCompiledPath } from '../helpers';
 import { getCssExtractPlugin } from '../pluginHelper';
 import type { NormalizedConfig, RsbuildPlugin } from '../types';

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -3,7 +3,7 @@
  * license at https://github.com/facebook/create-react-app/blob/master/LICENSE
  */
 import path from 'node:path';
-import { CSS_REGEX, HTML_REGEX, JS_REGEX, fse } from '@rsbuild/shared';
+import { JS_REGEX, fse } from '@rsbuild/shared';
 import { color, logger } from '@rsbuild/shared';
 import type {
   MultiStats,
@@ -11,6 +11,7 @@ import type {
   Stats,
   StatsAsset,
 } from '@rsbuild/shared';
+import { CSS_REGEX, HTML_REGEX } from '../constants';
 import type { RsbuildPlugin } from '../types';
 
 /** Filter source map and license files */

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -1,10 +1,10 @@
 import {
-  CSS_REGEX,
   type InlineChunkTest,
   JS_REGEX,
   isHtmlDisabled,
   pick,
 } from '@rsbuild/shared';
+import { CSS_REGEX } from '../constants';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginInlineChunk = (): RsbuildPlugin => ({

--- a/packages/core/src/plugins/less.ts
+++ b/packages/core/src/plugins/less.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import {
   type FileFilterUtil,
-  LESS_REGEX,
   type LessLoaderOptions,
   type ToolsLessConfig,
   castArray,
@@ -75,7 +74,7 @@ export function pluginLess(): RsbuildPlugin {
 
         const rule = chain.module
           .rule(utils.CHAIN_ID.RULE.LESS)
-          .test(LESS_REGEX);
+          .test(/\.less$/);
 
         const { excludes, options } = getLessLoaderOptions(
           config.tools.less,

--- a/packages/core/src/plugins/sass.ts
+++ b/packages/core/src/plugins/sass.ts
@@ -3,7 +3,6 @@ import { pathToFileURL } from 'node:url';
 import {
   type CompilerTapFn,
   type FileFilterUtil,
-  SASS_REGEX,
   type SassLoaderOptions,
   type ToolsSassConfig,
   castArray,
@@ -150,7 +149,7 @@ export function pluginSass(): RsbuildPlugin {
 
         const rule = chain.module
           .rule(utils.CHAIN_ID.RULE.SASS)
-          .test(SASS_REGEX);
+          .test(/\.s(?:a|c)ss$/);
 
         for (const item of excludes) {
           rule.exclude.add(item);

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
+import type { Rspack } from '@rsbuild/core';
 import {
-  type Rspack,
   fse,
   generateScriptTag,
   getPublicPathFromCompiler,

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "selfsigned": "^2.4.1"
   },
   "devDependencies": {

--- a/packages/plugin-basic-ssl/src/util.ts
+++ b/packages/plugin-basic-ssl/src/util.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { ServerConfig } from '@rsbuild/shared';
+import type { ServerConfig } from '@rsbuild/core';
 import selfsigned from 'selfsigned';
 
 export const resolveHttpsConfig = (config: ServerConfig['https']) => {

--- a/packages/plugin-basic-ssl/tsconfig.json
+++ b/packages/plugin-basic-ssl/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
+++ b/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
@@ -1,11 +1,6 @@
 import { resolve } from 'node:path';
 import type { Rspack } from '@rsbuild/core';
-import {
-  HTML_REGEX,
-  JS_REGEX,
-  browserslistToESVersion,
-  fse,
-} from '@rsbuild/shared';
+import { JS_REGEX, browserslistToESVersion, fse } from '@rsbuild/shared';
 import { parse } from 'acorn';
 import {
   checkIsExcludeSource,
@@ -23,6 +18,8 @@ import type {
 
 type Compiler = Rspack.Compiler;
 type Compilation = Rspack.Compilation;
+
+const HTML_REGEX = /\.html$/;
 
 export class CheckSyntaxPlugin {
   errors: ECMASyntaxError[] = [];

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "eslint": "^8.57.0",
     "eslint-webpack-plugin": "^4.1.0",
     "webpack": "^5.91.0"

--- a/packages/plugin-eslint/tsconfig.json
+++ b/packages/plugin-eslint/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@napi-rs/image": "^1.9.2",
-    "@rsbuild/shared": "workspace:*",
     "svgo": "^3.3.2"
   },
   "devDependencies": {

--- a/packages/plugin-image-compress/tsconfig.json
+++ b/packages/plugin-image-compress/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-lightningcss/src/loader.ts
+++ b/packages/plugin-lightningcss/src/loader.ts
@@ -4,7 +4,7 @@ import { Buffer } from 'node:buffer';
  * MIT License https://github.com/fz6m/lightningcss-loader/blob/main/LICENSE
  * Author @fz6m
  */
-import type { Rspack } from '@rsbuild/shared';
+import type { Rspack } from '@rsbuild/core';
 import { transform as _transform } from 'lightningcss';
 import type { LightningCSSLoaderOptions } from './types';
 

--- a/packages/plugin-lightningcss/src/minimizer.ts
+++ b/packages/plugin-lightningcss/src/minimizer.ts
@@ -1,6 +1,5 @@
 import { Buffer } from 'node:buffer';
-import { CSS_REGEX } from '@rsbuild/shared';
-import type { Rspack } from '@rsbuild/shared';
+import type { Rspack } from '@rsbuild/core';
 /**
  * modified from https://github.com/fz6m/lightningcss-loader
  * MIT License https://github.com/fz6m/lightningcss-loader/blob/main/LICENSE
@@ -10,6 +9,8 @@ import { transform as _transform } from 'lightningcss';
 import type { LightningCSSMinifyPluginOptions } from './types';
 
 const PLUGIN_NAME = 'lightningcss-minify-plugin';
+
+const CSS_REGEX = /\.css$/;
 
 export class LightningCSSMinifyPlugin {
   private readonly options: LightningCSSMinifyPluginOptions;

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -1,16 +1,15 @@
 import path from 'node:path';
-import {
-  getBrowserslistWithDefault,
-  mergeChainedOptions,
-} from '@rsbuild/shared';
 import type {
-  BundlerChain,
-  ModifyBundlerChainUtils,
   NormalizedConfig,
   RsbuildContext,
   RsbuildPlugin,
   RsbuildTarget,
+} from '@rsbuild/core';
+import {
+  getBrowserslistWithDefault,
+  mergeChainedOptions,
 } from '@rsbuild/shared';
+import type { BundlerChain, ModifyBundlerChainUtils } from '@rsbuild/shared';
 import browserslist from '@rsbuild/shared/browserslist';
 import { browserslistToTargets as _browserslistToTargets } from 'lightningcss';
 import type * as LightningCSS from 'lightningcss';

--- a/packages/plugin-lightningcss/tests/index.test.ts
+++ b/packages/plugin-lightningcss/tests/index.test.ts
@@ -1,10 +1,10 @@
-import { createRsbuild } from '@rsbuild/core';
-import { type Rspack, type RspackConfig, isPlainObject } from '@rsbuild/shared';
+import { type Rspack, createRsbuild } from '@rsbuild/core';
+import { isPlainObject } from '@rsbuild/shared';
 import { createStubRsbuild } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
 import { lightningcss, pluginLightningcss } from '../src';
 
-const getCssRules = (rspackConfig: RspackConfig) => {
+const getCssRules = (rspackConfig: Rspack.Configuration) => {
   const CSS_RULES = ['css', 'scss', 'sass', 'less', 'stylus'];
 
   return (

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "assert": "^2.1.0",
     "browserify-zlib": "^0.2.0",
     "buffer": "^5.7.1",

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import type { RsbuildConfig, RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import {
   type BundlerChain,
-  CHAIN_ID,
+  type ChainIdentifier,
   SCRIPT_REGEX,
   deepmerge,
   isUsingHMR,
@@ -11,9 +11,11 @@ import type { PluginReactOptions } from '.';
 
 const modifySwcLoaderOptions = ({
   chain,
+  CHAIN_ID,
   modifier,
 }: {
   chain: BundlerChain;
+  CHAIN_ID: ChainIdentifier;
   modifier: (config: Rspack.SwcLoaderOptions) => Rspack.SwcLoaderOptions;
 }) => {
   const ruleIds = [CHAIN_ID.RULE.JS, CHAIN_ID.RULE.JS_DATA_URI];
@@ -46,6 +48,7 @@ export const applyBasicReactSupport = (
 
     modifySwcLoaderOptions({
       chain,
+      CHAIN_ID,
       modifier: (opts) => {
         const extraOptions: Rspack.SwcLoaderOptions = {
           jsc: {

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
-import { logger } from '@rsbuild/core';
+import { type Rspack, logger } from '@rsbuild/core';
 import {
-  type Rspack,
   type ScriptLoading,
   generateScriptTag,
   getPublicPathFromCompiler,

--- a/packages/plugin-source-build/src/plugin.ts
+++ b/packages/plugin-source-build/src/plugin.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { TS_CONFIG_FILE, fse } from '@rsbuild/shared';
 import type { Project } from './project';
 import {
   type ExtraMonorepoStrategies,
@@ -102,14 +101,14 @@ export function pluginSourceBuild(
 
       const getReferences = async (): Promise<string[]> => {
         const refers = projects
-          .map((project) => path.join(project.dir, TS_CONFIG_FILE))
+          .map((project) => path.join(project.dir, 'tsconfig.json'))
           .filter((filePath) => fs.existsSync(filePath));
 
         // merge with user references
         if (api.context.tsconfigPath) {
           const { default: json5 } = await import('@rsbuild/shared/json5');
           const { references } = json5.parse(
-            fse.readFileSync(api.context.tsconfigPath, 'utf-8'),
+            fs.readFileSync(api.context.tsconfigPath, 'utf-8'),
           );
 
           return Array.isArray(references)

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -3,7 +3,6 @@ import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
 import {
   SCRIPT_REGEX,
-  SVG_REGEX,
   deepmerge,
   getDistPath,
   getFilename,
@@ -11,6 +10,8 @@ import {
 import type { Config } from '@svgr/core';
 
 export type SvgDefaultExport = 'component' | 'url';
+
+export const SVG_REGEX = /\.svg$/;
 
 export type PluginSvgrOptions = {
   /**

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -1,8 +1,7 @@
 import { pluginReact } from '@rsbuild/plugin-react';
-import { SVG_REGEX } from '@rsbuild/shared';
 import { createStubRsbuild } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
-import { type PluginSvgrOptions, pluginSvgr } from '../src';
+import { type PluginSvgrOptions, SVG_REGEX, pluginSvgr } from '../src';
 
 describe('svgr', () => {
   const cases: Array<{ name: string; pluginConfig: PluginSvgrOptions }> = [

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "toml": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/plugin-toml/tsconfig.json
+++ b/packages/plugin-toml/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-typed-css-modules/src/loader.ts
+++ b/packages/plugin-typed-css-modules/src/loader.ts
@@ -12,7 +12,8 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
-import { NODE_MODULES_REGEX, type Rspack } from '@rsbuild/shared';
+import type { Rspack } from '@rsbuild/core';
+import { NODE_MODULES_REGEX } from '@rsbuild/shared';
 import LineDiff from '../compiled/line-diff/index.js';
 
 export type CssLoaderModules =

--- a/packages/plugin-typed-css-modules/tests/index.test.ts
+++ b/packages/plugin-typed-css-modules/tests/index.test.ts
@@ -1,6 +1,6 @@
 import type { RspackConfig, RspackRule } from '@rsbuild/shared';
 import { createStubRsbuild } from '@scripts/test-helper';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { pluginCss } from '../../core/src/plugins/css';
 import { pluginTypedCSSModules } from '../src';
 

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -1,7 +1,5 @@
 import type { RsbuildConfig, RsbuildPlugin } from '@rsbuild/core';
-import { deepmerge } from '@rsbuild/shared';
-import { VueLoaderPlugin } from 'vue-loader';
-import type { VueLoaderOptions } from 'vue-loader';
+import { type VueLoaderOptions, VueLoaderPlugin } from 'vue-loader';
 import { applySplitChunksRule } from './splitChunks';
 
 export type SplitVueChunkOptions = {
@@ -72,15 +70,16 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
       api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
         chain.resolve.extensions.add('.vue');
 
-        const vueLoaderOptions = deepmerge(
-          {
-            compilerOptions: {
-              preserveWhitespace: false,
-            },
-            experimentalInlineMatchResource: true,
-          },
-          options.vueLoaderOptions ?? {},
-        );
+        const userLoaderOptions = options.vueLoaderOptions ?? {};
+        const compilerOptions = {
+          preserveWhitespace: false,
+          ...userLoaderOptions.compilerOptions,
+        };
+        const vueLoaderOptions = {
+          experimentalInlineMatchResource: true,
+          ...userLoaderOptions,
+          compilerOptions,
+        };
 
         chain.module
           .rule(CHAIN_ID.RULE.VUE)

--- a/packages/plugin-vue2/src/VueLoader15PitchFixPlugin.ts
+++ b/packages/plugin-vue2/src/VueLoader15PitchFixPlugin.ts
@@ -1,4 +1,4 @@
-import type { Rspack } from '@rsbuild/shared';
+import type { Rspack } from '@rsbuild/core';
 
 /**
  * this plugin is a quick fix for issue https://github.com/web-infra-dev/rsbuild/issues/2093

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -1,7 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { deepmerge } from '@rsbuild/shared';
-import { VueLoaderPlugin } from 'vue-loader';
-import type { VueLoaderOptions } from 'vue-loader';
+import { type VueLoaderOptions, VueLoaderPlugin } from 'vue-loader';
 import { VueLoader15PitchFixPlugin } from './VueLoader15PitchFixPlugin';
 import { applySplitChunksRule } from './splitChunks';
 
@@ -65,15 +63,16 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
           chain.resolve.alias.set('vue$', 'vue/dist/vue.runtime.esm.js');
         }
 
-        const vueLoaderOptions = deepmerge(
-          {
-            compilerOptions: {
-              preserveWhitespace: false,
-            },
-            experimentalInlineMatchResource: true,
-          },
-          options.vueLoaderOptions ?? {},
-        );
+        const userLoaderOptions = options.vueLoaderOptions ?? {};
+        const compilerOptions = {
+          preserveWhitespace: false,
+          ...userLoaderOptions.compilerOptions,
+        };
+        const vueLoaderOptions = {
+          experimentalInlineMatchResource: true,
+          ...userLoaderOptions,
+          compilerOptions,
+        };
 
         chain.module
           .rule(CHAIN_ID.RULE.VUE)

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -28,9 +28,6 @@
     "dev": "modern build --watch",
     "prebundle": "prebundle"
   },
-  "dependencies": {
-    "@rsbuild/shared": "workspace:*"
-  },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",

--- a/packages/plugin-yaml/tsconfig.json
+++ b/packages/plugin-yaml/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -56,18 +56,11 @@ export const AUDIO_EXTENSIONS = ['mp3', 'wav', 'flac', 'aac', 'm4a', 'opus'];
 export const DEFAULT_ASSET_PREFIX = '/';
 
 // RegExp
-export const HTML_REGEX = /\.html$/;
 export const JS_REGEX = /\.(?:js|mjs|cjs|jsx)$/;
 export const TS_REGEX = /\.(?:ts|mts|cts|tsx)$/;
 export const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 export const TS_AND_JSX_REGEX = /\.(?:ts|tsx|jsx|mts|cts)$/;
-export const SVG_REGEX = /\.svg$/;
-export const CSS_REGEX = /\.css$/;
-export const LESS_REGEX = /\.less$/;
-export const SASS_REGEX = /\.s(?:a|c)ss$/;
 export const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
-
-export const TS_CONFIG_FILE = 'tsconfig.json';
 
 export const TARGET_ID_MAP: Record<RsbuildTarget, string> = {
   web: 'Client',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,9 +884,6 @@ importers:
 
   packages/plugin-basic-ssl:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       selfsigned:
         specifier: ^2.4.1
         version: 2.4.1
@@ -950,9 +947,6 @@ importers:
 
   packages/plugin-eslint:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -978,9 +972,6 @@ importers:
       '@napi-rs/image':
         specifier: ^1.9.2
         version: 1.9.2
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -1047,9 +1038,6 @@ importers:
 
   packages/plugin-node-polyfill:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       assert:
         specifier: ^2.1.0
         version: 2.1.0
@@ -1382,9 +1370,6 @@ importers:
 
   packages/plugin-toml:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       toml:
         specifier: ^3.0.0
         version: 3.0.0
@@ -1557,10 +1542,6 @@ importers:
         version: 5.4.5
 
   packages/plugin-yaml:
-    dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core


### PR DESCRIPTION
## Summary

Make some plugins do not depend on `@rsbuild/shared`.

In the future, we want to maintain more plugins in independent repos and no longer rely on the shared package inside the Rsbuild repo.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
