### PR TITLE
fix: failed to load postcss.config.ts

### DIFF
--- a/e2e/cases/css/postcss-config-ts/index.test.ts
+++ b/e2e/cases/css/postcss-config-ts/index.test.ts
@@ -1,0 +1,17 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should load postcss.config.ts correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const indexCssFile = Object.keys(files).find(
+    (file) => file.includes('index.') && file.endsWith('.css'),
+  )!;
+
+  expect(files[indexCssFile]).toEqual(
+    '.text-3xl{font-size:1.875rem;line-height:2.25rem}.font-bold{font-weight:700}.underline{text-decoration-line:underline}',
+  );
+});

--- a/e2e/cases/css/postcss-config-ts/postcss.config.ts
+++ b/e2e/cases/css/postcss-config-ts/postcss.config.ts
@@ -1,0 +1,9 @@
+const path = require('node:path');
+
+export default {
+  plugins: {
+    tailwindcss: {
+      config: path.join(__dirname, './tailwind.config.cjs'),
+    },
+  },
+};

--- a/e2e/cases/css/postcss-config-ts/rsbuild.config.ts
+++ b/e2e/cases/css/postcss-config-ts/rsbuild.config.ts
@@ -1,0 +1,5 @@
+export default {
+  html: {
+    template: './src/index.html',
+  },
+};

--- a/e2e/cases/css/postcss-config-ts/src/index.css
+++ b/e2e/cases/css/postcss-config-ts/src/index.css
@@ -1,0 +1,1 @@
+@tailwind utilities;

--- a/e2e/cases/css/postcss-config-ts/src/index.html
+++ b/e2e/cases/css/postcss-config-ts/src/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <h1 class="text-3xl font-bold underline">Hello world!</h1>
+  </body>
+</html>

--- a/e2e/cases/css/postcss-config-ts/src/index.ts
+++ b/e2e/cases/css/postcss-config-ts/src/index.ts
@@ -1,0 +1,1 @@
+import './index.css';

--- a/e2e/cases/css/postcss-config-ts/tailwind.config.cjs
+++ b/e2e/cases/css/postcss-config-ts/tailwind.config.cjs
@@ -1,0 +1,10 @@
+const path = require('node:path');
+
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [path.join(__dirname, './src/**/*.{html,js,ts,jsx,tsx}')],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -112,11 +112,11 @@ export default {
       // this is a trick to avoid ncc compiling the dynamic import syntax
       // https://github.com/vercel/ncc/issues/935
       beforeBundle(task) {
-        replaceFileContent(join(task.depPath, 'src/req.js'), (content) => {
-          content = `${content.replaceAll('await import', 'await __import')}`;
-          content = `${content.replaceAll(`import('jiti')`, `import('@rsbuild/shared/jiti')`)}`;
-          return content;
-        });
+        replaceFileContent(join(task.depPath, 'src/req.js'), (content) =>
+          content
+            .replaceAll('await import', 'await __import')
+            .replaceAll(`import('jiti')`, `import('@rsbuild/shared/jiti')`),
+        );
       },
       afterBundle(task) {
         replaceFileContent(

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -105,22 +105,24 @@ export default {
     {
       name: 'postcss-load-config',
       externals: {
-        jiti: '@rsbuild/shared/jiti',
         yaml: '@rsbuild/shared/yaml',
+        '@rsbuild/shared/jiti': '@rsbuild/shared/jiti',
       },
       ignoreDts: true,
       // this is a trick to avoid ncc compiling the dynamic import syntax
       // https://github.com/vercel/ncc/issues/935
       beforeBundle(task) {
-        replaceFileContent(
-          join(task.depPath, 'src/req.js'),
-          (content) => `${content.replace('await import', 'await __import')}`,
-        );
+        replaceFileContent(join(task.depPath, 'src/req.js'), (content) => {
+          content = `${content.replaceAll('await import', 'await __import')}`;
+          content = `${content.replaceAll(`import('jiti')`, `import('@rsbuild/shared/jiti')`)}`;
+          return content;
+        });
       },
       afterBundle(task) {
         replaceFileContent(
           join(task.distPath, 'index.js'),
-          (content) => `${content.replace('await __import', 'await import')}`,
+          (content) =>
+            `${content.replaceAll('await __import', 'await import')}`,
         );
       },
     },


### PR DESCRIPTION
## Summary

Fix failed to load postcss.config.ts.

Let the `postcss-load-config` to use the `jiti` exported by `@rsbuild/shared`, so it can transform `postcss.config.ts` as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
