### PR TITLE
feat: support tools.cssExtract config

### DIFF
--- a/e2e/cases/css/configure-css-extract/index.test.ts
+++ b/e2e/cases/css/configure-css-extract/index.test.ts
@@ -1,0 +1,13 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to configure options of CSSExtractPlugin', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('my-css.css'))!];
+
+  expect(content).toEqual('body{color:red}');
+});

--- a/e2e/cases/css/configure-css-extract/rsbuild.config.ts
+++ b/e2e/cases/css/configure-css-extract/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  tools: {
+    cssExtract: {
+      pluginOptions: {
+        filename: 'my-css.css',
+      },
+    },
+  },
+});

--- a/e2e/cases/css/configure-css-extract/src/index.css
+++ b/e2e/cases/css/configure-css-extract/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/css/configure-css-extract/src/index.js
+++ b/e2e/cases/css/configure-css-extract/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -95,7 +95,9 @@ const getDefaultSecurityConfig = (): NormalizedSecurityConfig => ({
 const getDefaultToolsConfig = (): NormalizedToolsConfig => ({
   cssExtract: {
     loaderOptions: {},
-    pluginOptions: {},
+    pluginOptions: {
+      ignoreOrder: true,
+    },
   },
 });
 

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import {
   type BundlerChainRule,
-  type CSSExtractOptions,
   type CSSLoaderOptions,
   type ModifyChainUtils,
   type PostCSSLoaderOptions,
@@ -272,22 +271,14 @@ export async function applyCSSRule({
   });
 
   // 3. Create Rspack rule
-  // Order: style-loader/mini-css-extract -> css-loader -> postcss-loader
+  // Order: style-loader/CssExtractRspackPlugin -> css-loader -> postcss-loader
   if (target === 'web') {
-    // use mini-css-extract-plugin loader
+    // use CssExtractRspackPlugin loader
     if (enableExtractCSS) {
-      const extraCSSOptions: Required<CSSExtractOptions> =
-        typeof config.tools.cssExtract === 'object'
-          ? config.tools.cssExtract
-          : {
-              loaderOptions: {},
-              pluginOptions: {},
-            };
-
       rule
         .use(CHAIN_ID.USE.MINI_CSS_EXTRACT)
         .loader(getCssExtractPlugin().loader)
-        .options(extraCSSOptions.loaderOptions)
+        .options(config.tools.cssExtract.loaderOptions)
         .end();
     }
     // use style-loader

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -7,7 +7,6 @@ import {
   type RsbuildContext,
   getDistPath,
   getFilename,
-  mergeChainedOptions,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import { formatPublicPath } from '../helpers';
@@ -116,10 +115,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
 
         // css output
         if (isUseCssExtract(config, target)) {
-          const extractPluginOptions = mergeChainedOptions({
-            defaults: {},
-            options: config.tools.cssExtract?.pluginOptions,
-          });
+          const extractPluginOptions = config.tools.cssExtract.pluginOptions;
 
           const cssPath = getDistPath(config, 'css');
           const cssFilename = getFilename(config, 'css', isProd);
@@ -131,7 +127,6 @@ export const pluginOutput = (): RsbuildPlugin => ({
               {
                 filename: posix.join(cssPath, cssFilename),
                 chunkFilename: posix.join(cssAsyncPath, cssFilename),
-                ignoreOrder: true,
                 ...extractPluginOptions,
               },
             ]);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -122,7 +122,6 @@
     "less": "4.2.0",
     "loader-utils2": "npm:loader-utils@2.0.4",
     "mime-types": "^2.1.35",
-    "mini-css-extract-plugin": "2.8.1",
     "picocolors": "1.0.0",
     "prebundle": "1.1.0",
     "rslog": "^1.2.2",

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -143,7 +143,7 @@ export const CHAIN_ID = {
     IGNORE_CSS: 'ignore-css',
     /** css-modules-typescript-loader */
     CSS_MODULES_TS: 'css-modules-typescript',
-    /** mini-css-extract-plugin.loader */
+    /** CssExtractRspackPlugin.loader */
     MINI_CSS_EXTRACT: 'mini-css-extract',
     /** resolve-url-loader */
     RESOLVE_URL: 'resolve-url-loader',
@@ -186,7 +186,7 @@ export const CHAIN_ID = {
     HTML_PREFETCH: 'html-prefetch-plugin',
     /** htmlPreloadPlugin */
     HTML_PRELOAD: 'html-preload-plugin',
-    /** MiniCssExtractPlugin */
+    /** CssExtractRspackPlugin */
     MINI_CSS_EXTRACT: 'mini-css-extract',
     /** VueLoaderPlugin */
     VUE_LOADER_PLUGIN: 'vue-loader-plugin',

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -130,15 +130,14 @@ export interface ToolsConfig {
    */
   swc?: ToolsSwcConfig;
   /**
+   * Modify the options of [CssExtractRspackPlugin](https://rspack.dev/plugins/rspack/css-extract-rspack-plugin).
+   */
+  cssExtract?: CSSExtractOptions;
+  /**
    * Configure Rspack.
    * @requires rspack
    */
   rspack?: ToolsRspackConfig;
-  /**
-   * Modify the options of [mini-css-extract-plugin](https://github.com/webpack-contrib/mini-css-extract-plugin).
-   * @requires webpack
-   */
-  cssExtract?: CSSExtractOptions;
   /**
    * Configure [webpack](https://webpack.js.org/).
    * @requires webpack

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -1,8 +1,8 @@
-import type { LoaderContext } from '@rspack/core';
 import type {
-  LoaderOptions as MiniCSSExtractLoaderOptions,
-  PluginOptions as MiniCSSExtractPluginOptions,
-} from 'mini-css-extract-plugin';
+  CssExtractRspackLoaderOptions,
+  CssExtractRspackPluginOptions,
+  LoaderContext,
+} from '@rspack/core';
 import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 import type { MinifyOptions } from 'terser';
 import type { Configuration as WebpackConfig } from 'webpack';
@@ -17,8 +17,8 @@ import type {
 type AutoprefixerOptions = Autoprefixer.Options;
 
 export interface CSSExtractOptions {
-  pluginOptions?: MiniCSSExtractPluginOptions;
-  loaderOptions?: MiniCSSExtractLoaderOptions;
+  pluginOptions?: CssExtractRspackPluginOptions;
+  loaderOptions?: CssExtractRspackLoaderOptions;
 }
 
 export type { WebpackConfig, AutoprefixerOptions };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1635,9 +1635,6 @@ importers:
       mime-types:
         specifier: ^2.1.35
         version: 2.1.35
-      mini-css-extract-plugin:
-        specifier: 2.8.1
-        version: 2.8.1(webpack@5.91.0)
       picocolors:
         specifier: 1.0.0
         version: 1.0.0

--- a/website/docs/en/config/tools/css-extract.mdx
+++ b/website/docs/en/config/tools/css-extract.mdx
@@ -1,0 +1,71 @@
+# tools.cssExtract
+
+- **Type:**
+
+```ts
+import type {
+  CssExtractRspackPluginOptions,
+  CssExtractRspackLoaderOptions,
+} from '@rspack/core';
+
+type CSSExtractOptions = {
+  pluginOptions?: CssExtractRspackPluginOptions;
+  loaderOptions?: CssExtractRspackLoaderOptions;
+};
+```
+
+- **Default:**
+
+```js
+const defaultOptions = {
+  pluginOptions: {
+    ignoreOrder: true,
+    // The default value is determined by the output.distPath and output.filename options of Rsbuild
+    filename: 'static/css/[name].css',
+    chunkFilename: 'static/css/async/[name].css',
+  },
+  loaderOptions: {},
+};
+```
+
+- **Version:** `>= 0.7.0`
+
+Rsbuild uses the CssExtractRspackPlugin plugin by default to extract CSS into separate files.
+
+The options for [CssExtractRspackPlugin](https://rspack.dev/zh/plugins/rspack/css-extract-rspack-plugin) can be changed through `tools.cssExtract`.
+
+## pluginOptions
+
+- **Type:** `CssExtractRspackPluginOptions`
+- **Example:**
+
+```js
+export default {
+  tools: {
+    cssExtract: {
+      pluginOptions: {
+        ignoreOrder: false,
+      },
+    },
+  },
+};
+```
+
+## loaderOptions
+
+- **Type:** `CssExtractRspackLoaderOptions`
+- **Example:**
+
+```js
+export default {
+  tools: {
+    cssExtract: {
+      loaderOptions: {
+        esModule: false,
+      },
+    },
+  },
+};
+```
+
+> Please refer to the [CssExtractRspackPlugin](https://rspack.dev/zh/plugins/rspack/css-extract-rspack-plugin) plugin documentation to learn about all available options.

--- a/website/docs/zh/config/tools/css-extract.mdx
+++ b/website/docs/zh/config/tools/css-extract.mdx
@@ -1,0 +1,71 @@
+# tools.cssExtract
+
+- **类型：**
+
+```ts
+import type {
+  CssExtractRspackPluginOptions,
+  CssExtractRspackLoaderOptions,
+} from '@rspack/core';
+
+type CSSExtractOptions = {
+  pluginOptions?: CssExtractRspackPluginOptions;
+  loaderOptions?: CssExtractRspackLoaderOptions;
+};
+```
+
+- **默认值：**
+
+```js
+const defaultOptions = {
+  pluginOptions: {
+    ignoreOrder: true,
+    // 默认值由 Rsbuild 的 output.distPath 和 output.filename 选项决定
+    filename: 'static/css/[name].css',
+    chunkFilename: 'static/css/async/[name].css',
+  },
+  loaderOptions: {},
+};
+```
+
+- **版本：** `>= 0.7.0`
+
+Rsbuild 默认使用 CssExtractRspackPlugin 插件将 CSS 提取为独立的文件。
+
+通过 `tools.cssExtract` 可以更改 [CssExtractRspackPlugin](https://rspack.dev/zh/plugins/rspack/css-extract-rspack-plugin) 的选项。
+
+## pluginOptions
+
+- **类型：** `CssExtractRspackPluginOptions`
+- **示例：**
+
+```js
+export default {
+  tools: {
+    cssExtract: {
+      pluginOptions: {
+        ignoreOrder: false,
+      },
+    },
+  },
+};
+```
+
+## loaderOptions
+
+- **类型：** `CssExtractRspackLoaderOptions`
+- **示例：**
+
+```js
+export default {
+  tools: {
+    cssExtract: {
+      loaderOptions: {
+        esModule: false,
+      },
+    },
+  },
+};
+```
+
+> 请参考 [CssExtractRspackPlugin](https://rspack.dev/zh/plugins/rspack/css-extract-rspack-plugin) 插件文档来了解所有可用的选项。


### PR DESCRIPTION
## Summary

Add a new `tools.cssExtract` config to configure the options of CssExtractRspackPlugin.

## Related Links

https://www.rspack.dev/plugins/rspack/css-extract-rspack-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
