### PR TITLE
chore: remove unused ignoreWarnings config

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -25,9 +25,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -565,9 +562,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   "experiments": {
     "asyncWebAssembly": true,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1139,9 +1133,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1498,9 +1489,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -29,9 +29,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
           },
         });
 
-        // ignore the CSS conflicting order warning
-        chain.ignoreWarnings([/Conflicting order/]);
-
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);
 

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -4,9 +4,6 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -40,9 +37,6 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -13,9 +13,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -13,9 +13,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -596,9 +593,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1244,9 +1238,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },
@@ -1641,9 +1632,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -30,9 +30,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "asyncWebAssembly": true,
     "css": false,
   },
-  "ignoreWarnings": [
-    /Conflicting order/,
-  ],
   "infrastructureLogging": {
     "level": "error",
   },


### PR DESCRIPTION
## Summary

Remove unused ignoreWarnings config, because Rsbuild have enabled the `ignoreOrder` option of  CssExtractRspackPlugin.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
