### PR TITLE
chore: use normalized config to create server

### DIFF
--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -98,17 +98,18 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
 
     async createDevServer(options) {
       const { createDevMiddleware } = await import('./createCompiler');
-      await initRsbuildConfig({ context, pluginManager });
+      const config = await initRsbuildConfig({ context, pluginManager });
       return createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
         options,
+        config,
       );
     },
 
     async startDevServer(options) {
       const { createDevMiddleware } = await import('./createCompiler');
-      await initRsbuildConfig({
+      const config = await initRsbuildConfig({
         context,
         pluginManager,
       });
@@ -120,17 +121,18 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
         },
         createDevMiddleware,
         options,
+        config,
       );
 
       return server.listen();
     },
 
     async preview(options?: PreviewServerOptions) {
-      await initRsbuildConfig({
+      const config = await initRsbuildConfig({
         context,
         pluginManager,
       });
-      return startProdServer(context, context.config, options);
+      return startProdServer(context, config, options);
     },
 
     async build(options) {

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -102,8 +102,8 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
       return createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
-        options,
         config,
+        options,
       );
     },
 
@@ -120,8 +120,8 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
           rsbuildOptions,
         },
         createDevMiddleware,
-        options,
         config,
+        options,
       );
 
       return server.listen();

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -93,8 +93,8 @@ export const rspackProvider: RsbuildProvider = async ({
       return createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
-        options,
         config,
+        options,
       );
     },
 
@@ -106,8 +106,8 @@ export const rspackProvider: RsbuildProvider = async ({
       const server = await createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
-        options,
         config,
+        options,
       );
 
       return server.listen();

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -89,23 +89,25 @@ export const rspackProvider: RsbuildProvider = async ({
     async createDevServer(options) {
       const { createDevServer } = await import('../server/devServer');
       const { createDevMiddleware } = await import('./createCompiler');
-      await initRsbuildConfig({ context, pluginManager });
+      const config = await initRsbuildConfig({ context, pluginManager });
       return createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
         options,
+        config,
       );
     },
 
     async startDevServer(options) {
       const { createDevServer } = await import('../server/devServer');
       const { createDevMiddleware } = await import('./createCompiler');
-      await initRsbuildConfig({ context, pluginManager });
+      const config = await initRsbuildConfig({ context, pluginManager });
 
       const server = await createDevServer(
         { context, pluginManager, rsbuildOptions },
         createDevMiddleware,
         options,
+        config,
       );
 
       return server.listen();
@@ -113,8 +115,8 @@ export const rspackProvider: RsbuildProvider = async ({
 
     async preview(options?: PreviewServerOptions) {
       const { startProdServer } = await import('../server/prodServer');
-      await initRsbuildConfig({ context, pluginManager });
-      return startProdServer(context, context.config, options);
+      const config = await initRsbuildConfig({ context, pluginManager });
+      return startProdServer(context, config, options);
     },
 
     async build(options) {

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -14,7 +14,7 @@ import {
 } from '@rsbuild/shared';
 import connect from '@rsbuild/shared/connect';
 import type { CreateDevMiddlewareReturns } from '../provider/createCompiler';
-import type { InternalContext } from '../types';
+import type { InternalContext, NormalizedConfig } from '../types';
 import {
   type RsbuildDevMiddlewareOptions,
   getMiddlewares,
@@ -22,7 +22,8 @@ import {
 import {
   formatRoutes,
   getAddressUrls,
-  getDevOptions,
+  getDevConfig,
+  getServerConfig,
   printServerURLs,
 } from './helper';
 import { createHttpServer } from './httpServer';
@@ -45,6 +46,7 @@ export async function createDevServer<
     getPortSilently,
     runCompile = true,
   }: CreateDevServerOptions = {},
+  config: NormalizedConfig,
 ): Promise<RsbuildDevServer> {
   if (!getNodeEnv()) {
     setNodeEnv('development');
@@ -52,17 +54,20 @@ export async function createDevServer<
 
   debug('create dev server');
 
-  const rsbuildConfig = options.context.config;
-
-  const { devConfig, serverConfig, port, host, https } = await getDevOptions({
-    rsbuildConfig,
+  const serverConfig = config.server;
+  const { port, host, https } = await getServerConfig({
+    config,
     getPortSilently,
+  });
+  const devConfig = getDevConfig({
+    config,
+    port,
   });
 
   const routes = formatRoutes(
     options.context.entry,
-    rsbuildConfig.output?.distPath?.html,
-    rsbuildConfig.html?.outputStructure,
+    config.output.distPath.html,
+    config.html.outputStructure,
   );
 
   options.context.devServer = {
@@ -149,7 +154,7 @@ export async function createDevServer<
     dev: devConfig,
     server: serverConfig,
     output: {
-      distPath: rsbuildConfig.output?.distPath?.root || ROOT_DIST_DIR,
+      distPath: config.output.distPath.root || ROOT_DIST_DIR,
     },
     outputFileSystem,
   });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -41,12 +41,12 @@ export async function createDevServer<
     options: Options,
     compiler: StartDevServerOptions['compiler'],
   ) => Promise<CreateDevMiddlewareReturns>,
+  config: NormalizedConfig,
   {
     compiler: customCompiler,
     getPortSilently,
     runCompile = true,
   }: CreateDevServerOptions = {},
-  config: NormalizedConfig,
 ): Promise<RsbuildDevServer> {
   if (!getNodeEnv()) {
     setNodeEnv('development');

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,9 +1,9 @@
-import { isClientCompiler } from '@rsbuild/shared';
+import { type NormalizedConfig, isClientCompiler } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import { setupServerHooks } from '../src/server/devMiddleware';
 import {
   formatRoutes,
-  mergeDevOptions,
+  getDevConfig,
   printServerURLs,
 } from '../src/server/helper';
 
@@ -307,8 +307,8 @@ describe('test dev server', () => {
 
   test('getDevServerOptions', async () => {
     expect(
-      mergeDevOptions({
-        rsbuildConfig: {},
+      getDevConfig({
+        config: {} as NormalizedConfig,
         port: 3000,
       }),
     ).toMatchInlineSnapshot(`
@@ -325,8 +325,8 @@ describe('test dev server', () => {
     `);
 
     expect(
-      mergeDevOptions({
-        rsbuildConfig: {
+      getDevConfig({
+        config: {
           dev: {
             hmr: false,
             client: {
@@ -334,7 +334,7 @@ describe('test dev server', () => {
               path: '',
             },
           },
-        },
+        } as NormalizedConfig,
         port: 3001,
       }),
     ).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Summary

Use the normalized Rsbuild config to create dev server or prod server, which is more type-friendly.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
