### PR TITLE
fix(plugin-sass): should publish compiled folder

### DIFF
--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -20,7 +20,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "compiled"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -20,7 +20,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "compiled"
   ],
   "scripts": {
     "build": "modern build",


### PR DESCRIPTION
## Summary

Should publish the compiled folder of plugin-sass and plugin-less.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
