### PR TITLE
chore(deps): bump Rspack 0.7.0-beta.2

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/core": "0.7.0-beta.1",
+    "@rspack/core": "0.7.0-beta.2",
     "@swc/helpers": "0.5.3",
     "core-js": "~3.36.0",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
-    "@rspack/plugin-react-refresh": "0.7.0-beta.1",
+    "@rspack/plugin-react-refresh": "0.7.0-beta.2",
     "react-refresh": "^0.14.2"
   },
   "devDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -93,7 +93,7 @@
     "test:watch": "vitest dev --no-coverage"
   },
   "dependencies": {
-    "@rspack/core": "0.7.0-beta.1",
+    "@rspack/core": "0.7.0-beta.2",
     "caniuse-lite": "^1.0.30001617",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss": "^8.4.38"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -696,8 +696,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.7.0-beta.1
-        version: 0.7.0-beta.1(@swc/helpers@0.5.3)
+        specifier: 0.7.0-beta.2
+        version: 0.7.0-beta.2(@swc/helpers@0.5.3)
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -706,7 +706,7 @@ importers:
         version: 3.36.1
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -731,7 +731,7 @@ importers:
         version: 2.0.0
       css-loader:
         specifier: 7.1.1
-        version: 7.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(webpack@5.91.0)
+        version: 7.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(webpack@5.91.0)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -758,7 +758,7 @@ importers:
         version: 5.1.0(jiti@1.21.0)(postcss@8.4.38)(tsx@4.10.1)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0)
+        version: 8.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0)
       postcss-value-parser:
         specifier: 4.2.0
         version: 4.2.0
@@ -767,7 +767,7 @@ importers:
         version: 1.1.0(typescript@5.4.5)
       rspack-manifest-plugin:
         specifier: 5.0.0
-        version: 5.0.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))
+        version: 5.0.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -831,7 +831,7 @@ importers:
         version: 5.0.4
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))
       terser:
         specifier: 5.31.0
         version: 5.31.0
@@ -1015,7 +1015,7 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^12.2.0
-        version: 12.2.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.91.0)
+        version: 12.2.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.91.0)
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.4.5)
@@ -1184,8 +1184,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/plugin-react-refresh':
-        specifier: 0.7.0-beta.1
-        version: 0.7.0-beta.1(react-refresh@0.14.2)
+        specifier: 0.7.0-beta.2
+        version: 0.7.0-beta.2(react-refresh@0.14.2)
       react-refresh:
         specifier: ^0.14.2
         version: 0.14.2
@@ -1226,7 +1226,7 @@ importers:
         version: link:../../scripts/test-helper
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.38)
@@ -1266,7 +1266,7 @@ importers:
         version: 5.0.0
       sass-loader:
         specifier: ^14.2.1
-        version: 14.2.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(sass-embedded@1.77.2)(sass@1.77.1)(webpack@5.91.0)
+        version: 14.2.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(sass-embedded@1.77.2)(sass@1.77.1)(webpack@5.91.0)
       typescript:
         specifier: ^5.4.2
         version: 5.4.5
@@ -1350,7 +1350,7 @@ importers:
         version: 0.63.0
       stylus-loader:
         specifier: 8.1.0
-        version: 8.1.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.91.0)
+        version: 8.1.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.91.0)
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -1563,7 +1563,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(webpack@5.91.0))(lodash@4.17.21)(prettier@3.2.5)(pug@3.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.91.0)
+        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(webpack@5.91.0))(lodash@4.17.21)(prettier@3.2.5)(pug@3.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.91.0)
       webpack:
         specifier: ^5.91.0
         version: 5.91.0
@@ -1624,14 +1624,14 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/core':
-        specifier: 0.7.0-beta.1
-        version: 0.7.0-beta.1(@swc/helpers@0.5.3)
+        specifier: 0.7.0-beta.2
+        version: 0.7.0-beta.2(@swc/helpers@0.5.3)
       caniuse-lite:
         specifier: ^1.0.30001617
         version: 1.0.30001617
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -3405,56 +3405,56 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-darwin-arm64@0.7.0-beta.1':
-    resolution: {integrity: sha512-3lAatFbgPyiAzri1owo6QUAGKXp7YeBpuBh+vyYi2kSemZq2/wpchjN8eUAZRRU8aXC3U1skPu8RSfbewUoiSw==}
+  '@rspack/binding-darwin-arm64@0.7.0-beta.2':
+    resolution: {integrity: sha512-i7ir5NbTngdMFeCdOyr2+90MJcT1YSi1HHSmGq2ENTVPw5rwtLAPub2Jr1C7ef3E9FHp7FExVsfbHWItPYQbLw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.0-beta.1':
-    resolution: {integrity: sha512-gdpUI7h6CyYpTxlVwYsYQlZLM8Dvjj4VgMuLiSI13A5SfQVBlwIMSktHRCo7aNNTYIAR4+C37RwDQAeRfJg3Bw==}
+  '@rspack/binding-darwin-x64@0.7.0-beta.2':
+    resolution: {integrity: sha512-rNRYU3OQ+5N+Oy/BoLaHTmbFjKG1ZR5ZwyMkKQ2QRKWQYQMnWEVU8pMAbzw5J+3Rk/JZJDHFqknlSwNYAlP3Fw==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.0-beta.1':
-    resolution: {integrity: sha512-gkapNI/h4orb1d+ONael8ct2V7GQjVM4IYs7u3XSvSp9Kw7/m5GuT2IfMVyGwIxSIzMyMfiN8iVTF3wawWGwJA==}
+  '@rspack/binding-linux-arm64-gnu@0.7.0-beta.2':
+    resolution: {integrity: sha512-yRE0wu83IvYshmunCYDmQ1FllJRJISySFuSZgSOwAGvQYCBqMPd8yu6zLpbjf9c+P+J/kfIj2l5qLbx1NmjEvw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@0.7.0-beta.1':
-    resolution: {integrity: sha512-0KgNBmCpltBp79EWU146f00tBpJpLdQ7+oOCXVcmnyFvvXLQRZJ72PTLy0zH+Pu8cNQDWaWDWx4vwUHVAkaTfA==}
+  '@rspack/binding-linux-arm64-musl@0.7.0-beta.2':
+    resolution: {integrity: sha512-tnbCJo781U/epaikXwwjbUUV89/GoQZWv7Frh6H2hZLmb3WXSAPrvye/Q4d/ridGHUPRlf+yA56w11DxOq6UpA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@0.7.0-beta.1':
-    resolution: {integrity: sha512-JSr1rPrOi5vWJKoP80OMBO0kYPATL+wh9DAwtz4VE7D7bOnijbzBHvCWi8iPDEuZDQ9XEVvkB3rQhFomoE0BcA==}
+  '@rspack/binding-linux-x64-gnu@0.7.0-beta.2':
+    resolution: {integrity: sha512-3ghwa1LC8cvIycqzvDVWQdSHUzl+1jBdPxAUxUhJByZqusTDNVaDiqfO9Xb4cIoCCttiu5hjCsLRVaQ5zAAL0A==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@0.7.0-beta.1':
-    resolution: {integrity: sha512-2/vPaYE/CnjC2Fahr6wiPo7AI02KcMqBTlNxZaBLRnRulVLzmEGGRs8CM3bElSczPejLdHHm4Aw0WA61t2nlMw==}
+  '@rspack/binding-linux-x64-musl@0.7.0-beta.2':
+    resolution: {integrity: sha512-ce/xYvCf5STbQ2+/N8R7VYZRSyPaO94meAvxhSsWgNILtep1bzvtWJwcBVD6Pd1i6zs2Ewt7mOyz+JM+sAZRBw==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.0-beta.1':
-    resolution: {integrity: sha512-kh7G+vxBubqyj0bpScBatNv+HOgDPSAOeZZYjmf7HDoRR3AEyDFdgWTMPExE/XWd/FZbMkl5zwLjYjpqe9RDCQ==}
+  '@rspack/binding-win32-arm64-msvc@0.7.0-beta.2':
+    resolution: {integrity: sha512-gX0P8aawfnf1AZUsMjIRh9lEkARa1dH52irbwwPGlR8l5hj3qqLzKvXBrm3nBHVvl4WN9WUEI70ntxHLpoTBaw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.0-beta.1':
-    resolution: {integrity: sha512-ha3o1DZR/B5ct8Fd8pDNUqK33Q00zQ86jN4Dah+CbjqAve6hMUDY8j659nnDVQmDqk+/e8bx8YV5De51VPomzw==}
+  '@rspack/binding-win32-ia32-msvc@0.7.0-beta.2':
+    resolution: {integrity: sha512-DtfWXCmoRJUCz1Q2a1MehCR2267cOQx+E/AMuJaTnftAYZiM7gsG3zME5qLSybgef2l6sh8WbTv7K7wg319jag==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.0-beta.1':
-    resolution: {integrity: sha512-uRhcN16wFYphM/+w/28kLQsnnjij4t6jDWiWsOW2X0b3gG6qGMcTbfrdNxtdFim+iyJPwVsoQW+1v4KPcEeUqw==}
+  '@rspack/binding-win32-x64-msvc@0.7.0-beta.2':
+    resolution: {integrity: sha512-BW7K8ONJAi2KXoynyDfUJIU2hgdulFi4kxSk55jtZk3ZkundMq/Y8Im+EQzLmeoJumwTvcG26BRZpZwQx1XDhg==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@0.7.0-beta.1':
-    resolution: {integrity: sha512-gWoyGgs0Lgd5VoJasKDrc3WgQY4xHtzhqIzxf6iBOuyaWsgUCROsbDh6oXzLnscb+tWZl1ZepPeS0/QzwcWesw==}
+  '@rspack/binding@0.7.0-beta.2':
+    resolution: {integrity: sha512-lmKtv7ggg6TBtI7lvkzSjj0n9/BNbrM5mlsu7ArZP7eb9k3SngVkFm/nUUabNn1ZcWIfmXEFIoXhWMYkbyfBTQ==}
 
-  '@rspack/core@0.7.0-beta.1':
-    resolution: {integrity: sha512-pOS9nZMGh0zN2AZvgxD76wYuuNRCm/+BMt26bIYpOQHjDzSs0Yh9q88xK4OdgyhELHDbcBVGwqkD8lTgwBNBiw==}
+  '@rspack/core@0.7.0-beta.2':
+    resolution: {integrity: sha512-+td3y9BnKeYEYTOg3jM/50azwirJss7moYFRQb4ZsGFfyf7DFdZAoMF9cbfE/vQFEutoh42fs6hI0KMGDcA+7Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -3462,8 +3462,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/plugin-react-refresh@0.7.0-beta.1':
-    resolution: {integrity: sha512-V0bsrmhvaefE6PfeCyqdO5uP+ASpl/YZl64JNH0TCRT3GSUfvspnU4cJt0gTj+eSqtXlYNu2bBahGmbxEVsoeA==}
+  '@rspack/plugin-react-refresh@0.7.0-beta.2':
+    resolution: {integrity: sha512-2SOKA0nUiBpLVhb2xLtrK8rMP81cI3JpR/Bv8ZoKHfPzwLbp9t61dlHCscGsOvPQLkFNBJ7T1KWWtQ1kkBeZCg==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -10732,57 +10732,56 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.1':
     optional: true
 
-  '@rspack/binding-darwin-arm64@0.7.0-beta.1':
+  '@rspack/binding-darwin-arm64@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-darwin-x64@0.7.0-beta.1':
+  '@rspack/binding-darwin-x64@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@0.7.0-beta.1':
+  '@rspack/binding-linux-arm64-gnu@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-linux-arm64-musl@0.7.0-beta.1':
+  '@rspack/binding-linux-arm64-musl@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@0.7.0-beta.1':
+  '@rspack/binding-linux-x64-gnu@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@0.7.0-beta.1':
+  '@rspack/binding-linux-x64-musl@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@0.7.0-beta.1':
+  '@rspack/binding-win32-arm64-msvc@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@0.7.0-beta.1':
+  '@rspack/binding-win32-ia32-msvc@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@0.7.0-beta.1':
+  '@rspack/binding-win32-x64-msvc@0.7.0-beta.2':
     optional: true
 
-  '@rspack/binding@0.7.0-beta.1':
+  '@rspack/binding@0.7.0-beta.2':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.0-beta.1
-      '@rspack/binding-darwin-x64': 0.7.0-beta.1
-      '@rspack/binding-linux-arm64-gnu': 0.7.0-beta.1
-      '@rspack/binding-linux-arm64-musl': 0.7.0-beta.1
-      '@rspack/binding-linux-x64-gnu': 0.7.0-beta.1
-      '@rspack/binding-linux-x64-musl': 0.7.0-beta.1
-      '@rspack/binding-win32-arm64-msvc': 0.7.0-beta.1
-      '@rspack/binding-win32-ia32-msvc': 0.7.0-beta.1
-      '@rspack/binding-win32-x64-msvc': 0.7.0-beta.1
+      '@rspack/binding-darwin-arm64': 0.7.0-beta.2
+      '@rspack/binding-darwin-x64': 0.7.0-beta.2
+      '@rspack/binding-linux-arm64-gnu': 0.7.0-beta.2
+      '@rspack/binding-linux-arm64-musl': 0.7.0-beta.2
+      '@rspack/binding-linux-x64-gnu': 0.7.0-beta.2
+      '@rspack/binding-linux-x64-musl': 0.7.0-beta.2
+      '@rspack/binding-win32-arm64-msvc': 0.7.0-beta.2
+      '@rspack/binding-win32-ia32-msvc': 0.7.0-beta.2
+      '@rspack/binding-win32-x64-msvc': 0.7.0-beta.2
 
-  '@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3)':
+  '@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3)':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.0-beta.1
+      '@rspack/binding': 0.7.0-beta.2
       caniuse-lite: 1.0.30001617
-      enhanced-resolve: 5.12.0
       tapable: 2.2.1
       webpack-sources: 3.2.3
     optionalDependencies:
       '@swc/helpers': 0.5.3
 
-  '@rspack/plugin-react-refresh@0.7.0-beta.1(react-refresh@0.14.2)':
+  '@rspack/plugin-react-refresh@0.7.0-beta.2(react-refresh@0.14.2)':
     optionalDependencies:
       react-refresh: 0.14.2
 
@@ -12254,7 +12253,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@7.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(webpack@5.91.0):
+  css-loader@7.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(webpack@5.91.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -12265,7 +12264,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
       webpack: 5.91.0
 
   css-minimizer-webpack-plugin@5.0.1(lightningcss@1.25.0)(webpack@5.91.0):
@@ -13331,9 +13330,9 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3)):
+  html-rspack-plugin@5.7.2(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3)):
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
 
   html-tags@2.0.0: {}
 
@@ -13700,11 +13699,11 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@12.2.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.91.0):
+  less-loader@12.2.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.91.0):
     dependencies:
       less: 4.2.0
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
       webpack: 5.91.0
 
   less@4.2.0:
@@ -15202,14 +15201,14 @@ snapshots:
       postcss: 8.4.38
       tsx: 4.10.1
 
-  postcss-loader@8.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0):
+  postcss-loader@8.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.91.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.4.5)
       jiti: 1.21.0
       postcss: 8.4.38
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
       webpack: 5.91.0
     transitivePeerDependencies:
       - typescript
@@ -15890,12 +15889,12 @@ snapshots:
 
   rslog@1.2.2: {}
 
-  rspack-manifest-plugin@5.0.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3)):
+  rspack-manifest-plugin@5.0.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3)):
     dependencies:
       tapable: 2.2.1
       webpack-sources: 2.3.1
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
 
   rspack-plugin-virtual-module@0.1.12:
     dependencies:
@@ -16020,11 +16019,11 @@ snapshots:
       sass-embedded-win32-ia32: 1.77.2
       sass-embedded-win32-x64: 1.77.2
 
-  sass-loader@14.2.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(sass-embedded@1.77.2)(sass@1.77.1)(webpack@5.91.0):
+  sass-loader@14.2.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(sass-embedded@1.77.2)(sass@1.77.1)(webpack@5.91.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
       sass: 1.77.1
       sass-embedded: 1.77.2
       webpack: 5.91.0
@@ -16359,13 +16358,13 @@ snapshots:
 
   stylis@4.3.2: {}
 
-  stylus-loader@8.1.0(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.91.0):
+  stylus-loader@8.1.0(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.91.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.63.0
     optionalDependencies:
-      '@rspack/core': 0.7.0-beta.1(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.0-beta.2(@swc/helpers@0.5.3)
       webpack: 5.91.0
 
   stylus@0.63.0:
@@ -16913,10 +16912,10 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(webpack@5.91.0))(lodash@4.17.21)(prettier@3.2.5)(pug@3.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.91.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(webpack@5.91.0))(lodash@4.17.21)(prettier@3.2.5)(pug@3.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.91.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      css-loader: 7.1.1(@rspack/core@0.7.0-beta.1(@swc/helpers@0.5.3))(webpack@5.91.0)
+      css-loader: 7.1.1(@rspack/core@0.7.0-beta.2(@swc/helpers@0.5.3))(webpack@5.91.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4


### PR DESCRIPTION
## Summary

bump Rspack 0.7.0-beta.2

## Related Links

https://github.com/web-infra-dev/rspack/releases/tag/v0.7.0-beta.2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
