### PR TITLE
feat: print hints for CSS preprocessors plugins

### DIFF
--- a/e2e/cases/css/less-plugin-hints/index.test.ts
+++ b/e2e/cases/css/less-plugin-hints/index.test.ts
@@ -1,0 +1,20 @@
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should print Less plugin hints as expected', async () => {
+  const { logs, restore } = proxyConsole();
+
+  await expect(
+    build({
+      cwd: __dirname,
+    }),
+  ).rejects.toThrowError('build failed');
+
+  expect(
+    logs.some((log) =>
+      log.includes('To enable support for Less, use "@rsbuild/plugin-less"'),
+    ),
+  ).toBeTruthy();
+
+  restore();
+});

--- a/e2e/cases/css/less-plugin-hints/src/a.less
+++ b/e2e/cases/css/less-plugin-hints/src/a.less
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/css/less-plugin-hints/src/index.js
+++ b/e2e/cases/css/less-plugin-hints/src/index.js
@@ -1,0 +1,1 @@
+import './a.less';

--- a/e2e/cases/css/sass-plugin-hints/index.test.ts
+++ b/e2e/cases/css/sass-plugin-hints/index.test.ts
@@ -1,0 +1,20 @@
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should print Sass plugin hints as expected', async () => {
+  const { logs, restore } = proxyConsole();
+
+  await expect(
+    build({
+      cwd: __dirname,
+    }),
+  ).rejects.toThrowError('build failed');
+
+  expect(
+    logs.some((log) =>
+      log.includes('To enable support for Sass, use "@rsbuild/plugin-sass"'),
+    ),
+  ).toBeTruthy();
+
+  restore();
+});

--- a/e2e/cases/css/sass-plugin-hints/src/a.scss
+++ b/e2e/cases/css/sass-plugin-hints/src/a.scss
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/css/sass-plugin-hints/src/index.js
+++ b/e2e/cases/css/sass-plugin-hints/src/index.js
@@ -1,0 +1,1 @@
+import './a.scss';

--- a/e2e/cases/css/stylus-plugin-hints/index.test.ts
+++ b/e2e/cases/css/stylus-plugin-hints/index.test.ts
@@ -1,0 +1,22 @@
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should print Stylus plugin hints as expected', async () => {
+  const { logs, restore } = proxyConsole();
+
+  await expect(
+    build({
+      cwd: __dirname,
+    }),
+  ).rejects.toThrowError('build failed');
+
+  expect(
+    logs.some((log) =>
+      log.includes(
+        'To enable support for Stylus, use "@rsbuild/plugin-stylus"',
+      ),
+    ),
+  ).toBeTruthy();
+
+  restore();
+});

--- a/e2e/cases/css/stylus-plugin-hints/src/a.styl
+++ b/e2e/cases/css/stylus-plugin-hints/src/a.styl
@@ -1,0 +1,2 @@
+body
+  color red

--- a/e2e/cases/css/stylus-plugin-hints/src/index.js
+++ b/e2e/cases/css/stylus-plugin-hints/src/index.js
@@ -1,0 +1,1 @@
+import './a.styl';

--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -19,6 +19,35 @@ function resolveFileName(stats: StatsError) {
   return `File: ${stats.moduleName}\n`;
 }
 
+function hintUnknownFiles(message: string): string {
+  const hint = 'You may need an appropriate loader to handle this file type.';
+
+  if (message.indexOf(hint) === -1) {
+    return message;
+  }
+
+  if (/File: .+\.s(c|a)ss/.test(message)) {
+    return message.replace(
+      hint,
+      `To enable support for Sass, use "@rsbuild/plugin-sass".`,
+    );
+  }
+  if (/File: .+\.less/.test(message)) {
+    return message.replace(
+      hint,
+      `To enable support for Less, use "@rsbuild/plugin-less".`,
+    );
+  }
+  if (/File: .+\.styl(us)?/.test(message)) {
+    return message.replace(
+      hint,
+      `To enable support for Stylus, use "@rsbuild/plugin-stylus".`,
+    );
+  }
+
+  return message;
+}
+
 // Cleans up Rspack error messages.
 function formatMessage(stats: StatsError | string) {
   let lines: string[] = [];
@@ -35,6 +64,8 @@ function formatMessage(stats: StatsError | string) {
   } else {
     message = stats;
   }
+
+  message = hintUnknownFiles(message);
 
   lines = message.split('\n');
 

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -59,7 +59,7 @@ export const getCompiledPath = (packageName: string) =>
 /**
  * Add node polyfill tip when failed to resolve node built-in modules.
  */
-const addNodePolyfillTip = (message: string): string => {
+const hintNodePolyfill = (message: string): string => {
   if (!message.includes(`Can't resolve`)) {
     return message;
   }
@@ -123,7 +123,7 @@ const addNodePolyfillTip = (message: string): string => {
 };
 
 function formatErrorMessage(errors: string[]) {
-  const messages = errors.map((error) => addNodePolyfillTip(error));
+  const messages = errors.map((error) => hintNodePolyfill(error));
 
   const text = `${messages.join('\n\n')}\n`;
   const isTerserError = text.includes('from Terser');


### PR DESCRIPTION
## Summary

Print hints for CSS preprocessors plugins, this could help users to migrate to Rsbuild v0.7.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f6fd86df-984c-44d7-b092-d42a375a8ef1)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
