### PR TITLE
feat(plugin-vue): support for lang="postcss"

### DIFF
--- a/e2e/cases/vue/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-pcss/index.test.ts
@@ -1,0 +1,19 @@
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should build Vue sfc with lang="postcss" correctly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const button = page.locator('#button');
+    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue/sfc-lang-pcss/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-lang-pcss/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+});

--- a/e2e/cases/vue/sfc-lang-pcss/src/App.vue
+++ b/e2e/cases/vue/sfc-lang-pcss/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <button id="button" type="button">A</button>
+</template>
+
+<style lang="pcss">
+#button {
+  color: red;
+}
+</style>

--- a/e2e/cases/vue/sfc-lang-pcss/src/index.js
+++ b/e2e/cases/vue/sfc-lang-pcss/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/e2e/cases/vue/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-postcss/index.test.ts
@@ -1,0 +1,19 @@
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should build Vue sfc with lang="postcss" correctly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const button = page.locator('#button');
+    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue/sfc-lang-postcss/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-lang-postcss/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+});

--- a/e2e/cases/vue/sfc-lang-postcss/src/App.vue
+++ b/e2e/cases/vue/sfc-lang-postcss/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <button id="button" type="button">A</button>
+</template>
+
+<style lang="postcss">
+#button {
+  color: red;
+}
+</style>

--- a/e2e/cases/vue/sfc-lang-postcss/src/index.js
+++ b/e2e/cases/vue/sfc-lang-postcss/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/e2e/cases/vue2/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-pcss/index.test.ts
@@ -1,0 +1,19 @@
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should build Vue sfc with lang="postcss" correctly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const button = page.locator('#button');
+    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue2/sfc-lang-pcss/rsbuild.config.ts
+++ b/e2e/cases/vue2/sfc-lang-pcss/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue2 } from '@rsbuild/plugin-vue2';
+
+export default defineConfig({
+  plugins: [pluginVue2()],
+});

--- a/e2e/cases/vue2/sfc-lang-pcss/src/App.vue
+++ b/e2e/cases/vue2/sfc-lang-pcss/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <button id="button" type="button">A</button>
+</template>
+
+<style lang="pcss">
+#button {
+  color: red;
+}
+</style>

--- a/e2e/cases/vue2/sfc-lang-pcss/src/index.js
+++ b/e2e/cases/vue2/sfc-lang-pcss/src/index.js
@@ -1,0 +1,7 @@
+import Vue from 'vue';
+import App from './App.vue';
+
+new Vue({
+  el: '#root',
+  render: (h) => h(App),
+});

--- a/e2e/cases/vue2/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-postcss/index.test.ts
@@ -1,0 +1,19 @@
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should build Vue sfc with lang="postcss" correctly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const button = page.locator('#button');
+    await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue2/sfc-lang-postcss/rsbuild.config.ts
+++ b/e2e/cases/vue2/sfc-lang-postcss/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue2 } from '@rsbuild/plugin-vue2';
+
+export default defineConfig({
+  plugins: [pluginVue2()],
+});

--- a/e2e/cases/vue2/sfc-lang-postcss/src/App.vue
+++ b/e2e/cases/vue2/sfc-lang-postcss/src/App.vue
@@ -1,0 +1,9 @@
+<template>
+  <button id="button" type="button">A</button>
+</template>
+
+<style lang="postcss">
+#button {
+  color: red;
+}
+</style>

--- a/e2e/cases/vue2/sfc-lang-postcss/src/index.js
+++ b/e2e/cases/vue2/sfc-lang-postcss/src/index.js
@@ -1,0 +1,7 @@
+import Vue from 'vue';
+import App from './App.vue';
+
+new Vue({
+  el: '#root',
+  render: (h) => h(App),
+});

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -88,6 +88,9 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
           .loader(require.resolve('vue-loader'))
           .options(vueLoaderOptions);
 
+        // Support for lang="postcss" and lang="pcss" in SFC
+        chain.module.rule(CHAIN_ID.RULE.CSS).test(/\.(?:css|postcss|pcss)$/);
+
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
       });
 

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -18,6 +18,9 @@ exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 1`] = 
           },
         ],
       },
+      {
+        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
+      },
     ],
   },
   "plugins": [
@@ -49,6 +52,9 @@ exports[`plugin-vue > should allow to configure vueLoader options 1`] = `
             },
           },
         ],
+      },
+      {
+        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
       },
     ],
   },

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -81,6 +81,9 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
           .loader(require.resolve('vue-loader'))
           .options(vueLoaderOptions);
 
+        // Support for lang="postcss" and lang="pcss" in SFC
+        chain.module.rule(CHAIN_ID.RULE.CSS).test(/\.(?:css|postcss|pcss)$/);
+
         chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
         // we could remove this once a new vue-loader@15 is released with https://github.com/vuejs/vue-loader/pull/2071 shipped
         chain

--- a/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -18,6 +18,9 @@ exports[`plugin-vue2 > should add vue-loader and VueLoaderPlugin correctly 1`] =
           },
         ],
       },
+      {
+        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
+      },
     ],
   },
   "plugins": [
@@ -55,6 +58,9 @@ exports[`plugin-vue2 > should allow to configure vueLoader options 1`] = `
             },
           },
         ],
+      },
+      {
+        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
       },
     ],
   },

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -59,6 +59,7 @@ osascript
 outro
 pageerror
 pathinfo
+pcss
 perfetto
 picocolors
 pjpeg


### PR DESCRIPTION
## Summary

Support for lang="postcss" and lang="pcss" in Vue SFC.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/df5f6ff8-dc9d-4e15-bb45-691c2d85d3d9)

https://vue-loader-v14.vuejs.org/en/features/postcss.html

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
