### PR TITLE
feat(plugin-umd): allow to configure chunk split strategy

### DIFF
--- a/e2e/cases/umd/split-chunks/index.test.ts
+++ b/e2e/cases/umd/split-chunks/index.test.ts
@@ -1,0 +1,25 @@
+import { build, gotoPage } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to configure split chunks with UMD plugin', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const indexBundle =
+    files[Object.keys(files).find((file) => file.endsWith('index.js'))!];
+  const reactBundle =
+    files[Object.keys(files).find((file) => file.endsWith('lib-react.js'))!];
+  expect(indexBundle).toBeTruthy();
+  expect(reactBundle).toBeTruthy();
+
+  await gotoPage(page, rsbuild);
+  const test = page.locator('#test');
+  await expect(test).toHaveText('2');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/umd/split-chunks/rsbuild.config.ts
+++ b/e2e/cases/umd/split-chunks/rsbuild.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginUmd } from '@rsbuild/plugin-umd';
+
+export default defineConfig({
+  plugins: [
+    pluginUmd({
+      name: 'myLib',
+    }),
+    pluginReact(),
+  ],
+  html: {
+    template: './src/index.html',
+  },
+  tools: {
+    htmlPlugin: true,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'split-by-experience',
+    },
+  },
+});

--- a/e2e/cases/umd/split-chunks/src/index.html
+++ b/e2e/cases/umd/split-chunks/src/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head></head>
+  <body>
+    <div id="test"></div>
+    <script>
+      document.getElementById('test').innerText = window.myLib.double(1);
+    </script>
+  </body>
+</html>

--- a/e2e/cases/umd/split-chunks/src/index.js
+++ b/e2e/cases/umd/split-chunks/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export { React, ReactDOM };
+
+export function double(a) {
+  return a * 2;
+}

--- a/packages/plugin-umd/src/index.ts
+++ b/packages/plugin-umd/src/index.ts
@@ -28,12 +28,20 @@ export const pluginUmd = (options: PluginUmdOptions): RsbuildPlugin => ({
           filenameHash: userConfig.output?.filenameHash ?? false,
         },
         html: {
-          // allows to test the umd bundle in the browser
+          // allows to test the UMD bundle in the browser
           scriptLoading: userConfig.html?.scriptLoading ?? 'blocking',
         },
         tools: {
           htmlPlugin:
             userConfig.tools?.htmlPlugin ?? (isProd() ? false : undefined),
+        },
+        performance: {
+          chunkSplit: {
+            // UMD outputs are usually distributed via a single <script> tag,
+            // so we use `all-in-one` as the default chunk splitting strategy.
+            strategy:
+              userConfig.performance?.chunkSplit?.strategy ?? 'all-in-one',
+          },
         },
       });
     });
@@ -49,9 +57,6 @@ export const pluginUmd = (options: PluginUmdOptions): RsbuildPlugin => ({
 
       // To make UMD build available on both browsers and Node.js
       chain.output.globalObject('this');
-
-      // disable split chunks to output a single chunk
-      chain.optimization.splitChunks(false);
     });
   },
 });

--- a/website/docs/en/plugins/list/plugin-umd.mdx
+++ b/website/docs/en/plugins/list/plugin-umd.mdx
@@ -168,3 +168,33 @@ export default {
   },
 };
 ```
+
+## Code Splitting
+
+The UMD plugin overrides Rsbuild's default chunk splitting rules by setting `performance.chunkSplit.strategy` to `all-in-one` to output a single bundle. This is because UMD outputs are often distributed via CDN and allow direct referencing via `<script>` tags.
+
+If you need to split the UMD outputs, you can actively configure [performance.chunkSplit](/config/performance/chunk-split), for example:
+
+```js
+export default {
+  performance: {
+    chunkSplit: {
+      strategy: 'split-by-experience',
+    },
+  },
+};
+```
+
+Note that the UMD plugin does not disable splits caused by dynamic imports. If you need to disable this, you can set the Rspack's [output.asyncChunks](https://rspack.dev/config/output#outputasyncchunks) option to `false`:
+
+```js
+export default {
+  tools: {
+    rspack: {
+      output: {
+        asyncChunks: false,
+      },
+    },
+  },
+};
+```

--- a/website/docs/zh/plugins/list/plugin-umd.mdx
+++ b/website/docs/zh/plugins/list/plugin-umd.mdx
@@ -168,3 +168,33 @@ export default {
   },
 };
 ```
+
+## 代码拆分
+
+UMD 插件覆盖了 Rsbuild 默认的 chunk 拆包规则，它会将 `performance.chunkSplit.strategy` 设置为 `all-in-one`，以输出单个 bundle 产物。这是因为 UMD 产物经常会通过 CDN 来分发，并允许通过 `<script>` 标签直接引用。
+
+如果你需要对 UMD 产物进行拆包，可以主动配置 [performance.chunkSplit](/config/performance/chunk-split)，比如：
+
+```js
+export default {
+  performance: {
+    chunkSplit: {
+      strategy: 'split-by-experience',
+    },
+  },
+};
+```
+
+注意 UMD 插件不会禁用 dynamic import 引起的拆包。如果你需要禁用它，可以将 Rspack 的 [output.asyncChunks](https://rspack.dev/config/output#outputasyncchunks) 选项设置为 `false`：
+
+```js
+export default {
+  tools: {
+    rspack: {
+      output: {
+        asyncChunks: false,
+      },
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

Allow to configure chunk split strategy when using the UMD plugin. This can be used by Garfish (a micro frontend framework) users.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
