### PR TITLE
docs: add rsbuild.initConfigs to document

### DIFF
--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -4,7 +4,7 @@ This section describes some of the core methods provided by Rsbuild.
 
 ## createRsbuild
 
-Create a Rsbuild instance object.
+Create an [Rsbuild instance](/api/javascript-api/instance).
 
 - **Type:**
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -105,7 +105,7 @@ The bundler type of current build.
 type bundlerType = 'rspack' | 'webpack';
 ```
 
-> Rsbuild internally supports switching to webpack for comparative testing, usually, you do not need to use this field.
+> Rsbuild internally supports switching to webpack for comparative testing, so this field is provided for differentiation. Usually, you do not need to use this field.
 
 ## rsbuild.build
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -105,6 +105,8 @@ The bundler type of current build.
 type bundlerType = 'rspack' | 'webpack';
 ```
 
+> Rsbuild internally supports switching to webpack for comparative testing, usually, you do not need to use this field.
+
 ## rsbuild.build
 
 Perform a production build.
@@ -519,27 +521,49 @@ rsbuild.addPlugins([pluginFoo()]);
 rsbuild.isPluginExists(pluginFoo().name); // true
 ```
 
+## rsbuild.initConfigs
+
+The initConfigs method is used to initialize the internal configs of Rsbuild and return the Rspack config generated internally by Rsbuild.
+
+Usually, you do not need to call the initConfigs method, because it will be automatically called when methods such as [rsbuild.build](#rsbuildbuild), [rsbuild.startDevServer](#rsbuildstartdevserver) are called.
+
+- **Type:**
+
+```ts
+function InitConfigs(): Promise<{
+  rspackConfigs: RspackConfig[];
+}>;
+```
+
+- **Example:**
+
+```ts
+const { rspackConfigs } = await rsbuild.initConfigs();
+
+console.log(rspackConfigs);
+```
+
 ## rsbuild.inspectConfig
 
-Inspect the final generated Rsbuild config and bundler config.
+The inspectConfig method is typically used for debugging the internal configuration of Rsbuild. It returns the internally generated Rsbuild config and Rspack config, serializes them into strings, and supports writing them to the disk.
 
-:::tip
-The `inspectConfig` method does not support simultaneous use with the `startDevServer` / `build` method.
-
-When you need to view the complete Rsbuild and bundler configurations during the build process, you can use the [debug mode](/guide/debug/debug-mode) or obtain them through hooks such as `onBeforeBuild` and `onBeforeCreateCompile`.
-:::
+If you need to view the Rsbuild and Rspack configurations during the build process, you can use [debug mode](/guide/debug/debug-mode), or obtain them through hooks such as [onBeforeBuild](#rsbuildonbeforebuild), [onBeforeCreateCompile](#rsbuildonbeforecreatecompiler).
 
 - **Type:**
 
 ```ts
 type InspectConfigOptions = {
-  // View the config in the specified environment, the default is "development", can be set to "production"
+  // View the config in the specified environment
+  // defaults to "development", can be set to "production"
   env?: RsbuildMode;
-  // Whether to enable verbose mode, display the complete content of the function in the config, the default is `false`
+  // Whether to enable verbose mode, display the complete content of the function in the config
+  // defaults to `false`
   verbose?: boolean;
-  // Specify the output path, defaults to the value configured by `output.distPath.root`
+  // Specify the output path
+  // defaults to the value configured by `output.distPath.root`
   outputPath?: string;
-  // Whether to write the result to disk, the default is `false`
+  // Whether to write the result to disk
+  // defaults to `false`
   writeToDisk?: boolean;
 };
 
@@ -581,7 +605,7 @@ import OnBeforeCreateCompiler from '@en/shared/onBeforeCreateCompiler.mdx';
 
 ```ts
 rsbuild.onBeforeCreateCompiler(({ bundlerConfigs }) => {
-  console.log('the bundler config is ', bundlerConfigs);
+  console.log('the Rspack config is ', bundlerConfigs);
 });
 ```
 
@@ -609,7 +633,7 @@ import OnBeforeBuild from '@en/shared/onBeforeBuild.mdx';
 
 ```ts
 rsbuild.onBeforeBuild(({ bundlerConfigs }) => {
-  console.log('the bundler config is ', bundlerConfigs);
+  console.log('the Rspack config is ', bundlerConfigs);
 });
 ```
 

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -154,3 +154,4 @@ const rspackConfig: Rspack.Configuration = {};
 - ModifyRspackConfigFn
 - TransformFn,
 - TransformHandler
+- more...

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -4,7 +4,7 @@
 
 ## createRsbuild
 
-创建一个 Rsbuild 实例对象。
+创建一个 [Rsbuild 实例对象](/api/javascript-api/instance)。
 
 - **类型：**
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -105,7 +105,7 @@ type DevServer = {
 type bundlerType = 'rspack' | 'webpack';
 ```
 
-> Rsbuild 内部支持切换到 webpack 进行对照测试，通常你不需要使用此字段。
+> Rsbuild 内部支持切换到 webpack 进行对照测试，因此提供了该字段进行区分，通常你不需要使用此字段。
 
 ## rsbuild.build
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -105,6 +105,8 @@ type DevServer = {
 type bundlerType = 'rspack' | 'webpack';
 ```
 
+> Rsbuild 内部支持切换到 webpack 进行对照测试，通常你不需要使用此字段。
+
 ## rsbuild.build
 
 调用 build 方法时，会执行一次生产环境构建。
@@ -511,27 +513,49 @@ rsbuild.addPlugins([pluginFoo()]);
 rsbuild.isPluginExists(pluginFoo().name); // true
 ```
 
+## rsbuild.initConfigs
+
+initConfigs 方法用于初始化 Rsbuild 内部的配置，并返回 Rsbuild 内部生成的 Rspack 配置。
+
+通常你不需要调用 initConfigs 方法，因为调用 [rsbuild.build](#rsbuildbuild)、[rsbuild.startDevServer](#rsbuildstartdevserver) 等方法时会自动调用 initConfigs。
+
+- **类型：**
+
+```ts
+function InitConfigs(): Promise<{
+  rspackConfigs: RspackConfig[];
+}>;
+```
+
+- **示例：**
+
+```ts
+const { rspackConfigs } = await rsbuild.initConfigs();
+
+console.log(rspackConfigs);
+```
+
 ## rsbuild.inspectConfig
 
-查看 Rsbuild 内部最终生成的 Rsbuild 配置和 bundler 配置。
+inspectConfig 方法通常用于调试 Rsbuild 内部的配置，它会返回 Rsbuild 内部生成的 Rsbuild 配置和 Rspack 配置，将它们序列化为字符串，并支持写入到磁盘上。
 
-:::tip
-`inspectConfig` 方法不支持与 `startDevServer` / `build` 方法同时使用。
-
-当你需要在构建过程中查看完整的 Rsbuild 和 bundler 配置时，可以使用 [调试模式](/guide/debug/debug-mode)，也可以通过 `onBeforeBuild`、`onBeforeCreateCompile` 等钩子函数来获取。
-:::
+如果你需要在构建过程中查看 Rsbuild 和 Rspack 配置，可以使用 [调试模式](/guide/debug/debug-mode)，也可以通过 [onBeforeBuild](#rsbuildonbeforebuild)、[onBeforeCreateCompile](#rsbuildonbeforecreatecompiler) 等 hooks 来获取。
 
 - **类型：**
 
 ```ts
 type InspectConfigOptions = {
-  // 查看指定环境下的配置，默认为 "development"，可以设置为 "production"
+  // 查看指定环境下的配置
+  // 默认为 "development"，可以设置为 "production"
   env?: RsbuildMode;
-  // 是否开启冗余模式，展示配置中函数的完整内容，默认为 `false`
+  // 是否开启冗余模式，展示配置中函数的完整内容
+  // 默认为 `false`
   verbose?: boolean;
-  // 指定输出路径，默认为 `output.distPath.root` 配置的值
+  // 指定输出路径
+  // 默认为 `output.distPath.root` 配置的值
   outputPath?: string;
-  // 是否将结果写入到磁盘中，默认为 `false`
+  // 是否将结果写入到磁盘中
+  // 默认为 `false`
   writeToDisk?: boolean;
 };
 
@@ -573,7 +597,7 @@ import OnBeforeCreateCompiler from '@zh/shared/onBeforeCreateCompiler.mdx';
 
 ```ts
 rsbuild.onBeforeCreateCompiler(({ bundlerConfigs }) => {
-  console.log('the bundler config is ', bundlerConfigs);
+  console.log('the Rspack config is ', bundlerConfigs);
 });
 ```
 
@@ -601,7 +625,7 @@ import OnBeforeBuild from '@zh/shared/onBeforeBuild.mdx';
 
 ```ts
 rsbuild.onBeforeBuild(({ bundlerConfigs }) => {
-  console.log('the bundler config is ', bundlerConfigs);
+  console.log('the Rspack config is ', bundlerConfigs);
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -154,3 +154,4 @@ const rspackConfig: Rspack.Configuration = {};
 - ModifyRspackConfigFn
 - TransformFn,
 - TransformHandler
+- more...

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,7 +4,9 @@
     "jsx": "react-jsx",
     "outDir": "./dist",
     "paths": {
-      "@theme": ["./theme"]
+      "@theme": ["./theme"],
+      "@zh/*": ["./docs/zh/*"],
+      "@en/*": ["./docs/en/*"]
     },
     "baseUrl": "./"
   },


### PR DESCRIPTION
## Summary

Add `rsbuild.initConfigs` to document and update some outdated descriptions in the API docs.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
