### PR TITLE
feat(server): support for HTTP/2

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -175,7 +175,7 @@ export async function createDevServer<
     outputFileSystem,
     listen: async () => {
       const httpServer = await createHttpServer({
-        https: serverConfig.https,
+        serverConfig,
         middlewares,
       });
       debug('listen dev server');

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,4 +1,5 @@
 import type { Server } from 'node:http';
+import type { Http2SecureServer } from 'node:http2';
 import { join } from 'node:path';
 import {
   type PreviewServerOptions,
@@ -35,7 +36,7 @@ type RsbuildProdServerOptions = {
 };
 
 export class RsbuildProdServer {
-  private app!: Server;
+  private app!: Server | Http2SecureServer;
   private options: RsbuildProdServerOptions;
   public middlewares = connect();
 
@@ -44,7 +45,7 @@ export class RsbuildProdServer {
   }
 
   // Complete the preparation of services
-  public async onInit(app: Server) {
+  public async onInit(app: Server | Http2SecureServer) {
     this.app = app;
 
     await this.applyDefaultMiddlewares();
@@ -170,7 +171,7 @@ export async function startProdServer(
   await context.hooks.onBeforeStartProdServer.call();
 
   const httpServer = await createHttpServer({
-    https: serverConfig.https,
+    serverConfig,
     middlewares: server.middlewares,
   });
 

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SecureServerSessionOptions } from 'node:http2';
 import type { ServerOptions as HttpsServerOptions } from 'node:https';
 import type {
   Options as BaseProxyOptions,
@@ -86,7 +87,7 @@ export interface ServerConfig {
   /**
    * After configuring this option, you can enable HTTPS Server, and disabling the HTTP Server.
    */
-  https?: HttpsServerOptions;
+  https?: HttpsServerOptions | SecureServerSessionOptions;
   /**
    * Used to set the host of Rsbuild Server.
    */

--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -1,6 +1,14 @@
 # server.https
 
-- **Type:** `import('https').ServerOptions`
+- **Type:**
+
+```ts
+import type { ServerOptions } from 'node:https';
+import type { SecureServerSessionOptions } from 'node:http2';
+
+type Https = ServerOptions | SecureServerSessionOptions;
+```
+
 - **Default:** `undefined`
 
 After configuring this option, you can enable HTTPS Server, and disabling the HTTP Server.
@@ -18,6 +26,10 @@ HTTPS:
   > Local: https://localhost:3000/
   > Network: https://192.168.0.1:3000/
 ```
+
+:::tip
+Rsbuild enables HTTP/2 server by default. However, when you use [server.proxy](/config/server/proxy), the server will downgrade to HTTP/1, because the underlying `http-proxy` does not support HTTP/2.
+:::
 
 ## Set Certificate
 

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -1,6 +1,14 @@
 # server.https
 
-- **类型：** `import('https').ServerOptions`
+- **类型：**
+
+```ts
+import type { ServerOptions } from 'node:https';
+import type { SecureServerSessionOptions } from 'node:http2';
+
+type Https = ServerOptions | SecureServerSessionOptions;
+```
+
 - **默认值：** `undefined`
 
 配置该选项后，可以开启 Rsbuild Server 对 HTTPS 的支持，同时会禁用 HTTP 服务器。
@@ -18,6 +26,10 @@
   > Local:    https://localhost:3000/
   > Network:  https://192.168.0.1:3000/
 ```
+
+:::tip
+Rsbuild 默认会启用 HTTP/2 server。但当你使用 [server.proxy](/config/server/proxy) 时，server 会降级到 HTTP/1，这是因为底层使用的 `http-proxy` 不支持 HTTP/2。
+:::
 
 ## 设置证书
 


### PR DESCRIPTION
## Summary

Support for HTTP/2 server, it will be enabled by default when configuring `server.https` or using the `@rsbuild/plugin-basic-ssl`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
