### PR TITLE
fix: preview command print invalid URL

### DIFF
--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -195,7 +195,7 @@ export async function startProdServer(
         });
 
         const protocol = https ? 'https' : 'http';
-        const urls = getAddressUrls({ protocol, port });
+        const urls = getAddressUrls({ protocol, port, host });
 
         printServerURLs({
           urls,


### PR DESCRIPTION
## Summary

The `rsbuild preview` command should not print network URLs when `host: 'localhost'` is set.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
