### PR TITLE
fix(plugin-eslint): make ESLint as a peer dependency

### DIFF
--- a/e2e/cases/eslint/flat-config/rsbuild.config.ts
+++ b/e2e/cases/eslint/flat-config/rsbuild.config.ts
@@ -6,7 +6,6 @@ export default {
       eslintPluginOptions: {
         cwd: __dirname,
         configType: 'flat',
-        eslintPath: 'eslint/use-at-your-own-risk',
       },
     }),
   ],

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -27,16 +27,17 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "eslint": "^9.3.0",
     "eslint-webpack-plugin": "^4.2.0",
     "webpack": "^5.91.0"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
+    "eslint": "^9.3.0",
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
+    "eslint": "^8.0.0 || ^9.0.0",
     "@rsbuild/core": "workspace:^0.7.0-beta.9"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,9 +956,6 @@ importers:
 
   packages/plugin-eslint:
     dependencies:
-      eslint:
-        specifier: ^9.3.0
-        version: 9.3.0
       eslint-webpack-plugin:
         specifier: ^4.2.0
         version: 4.2.0(eslint@9.3.0)(webpack@5.91.0)
@@ -972,6 +969,9 @@ importers:
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
+      eslint:
+        specifier: ^9.3.0
+        version: 9.3.0
       typescript:
         specifier: ^5.4.2
         version: 5.4.5

--- a/website/docs/en/plugins/list/plugin-eslint.mdx
+++ b/website/docs/en/plugins/list/plugin-eslint.mdx
@@ -90,6 +90,17 @@ const defaultOptions = {
 
 The `eslintPluginOptions` object will be shallowly merged with the default configuration object.
 
+- For example, enable ESLint v9's flat config:
+
+```ts
+pluginEslint({
+  eslintPluginOptions: {
+    cwd: __dirname,
+    configType: 'flat',
+  },
+});
+```
+
 - For example, exclude some files using `exclude`:
 
 ```ts

--- a/website/docs/zh/plugins/list/plugin-eslint.mdx
+++ b/website/docs/zh/plugins/list/plugin-eslint.mdx
@@ -90,6 +90,17 @@ const defaultOptions = {
 
 `eslintPluginOptions` 对象会与默认配置对象进行浅合并。
 
+- 比如开启 ESLint v9 的 flat config：
+
+```ts
+pluginEslint({
+  eslintPluginOptions: {
+    cwd: __dirname,
+    configType: 'flat',
+  },
+});
+```
+
 - 比如通过 `exclude` 排除一些文件：
 
 ```ts


### PR DESCRIPTION
## Summary

Make ESLint as a peer dependency, this allows user to choose to use ESLint v8 or v9.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
