### PR TITLE
fix: browserslist resolve is broken by prebundle

### DIFF
--- a/e2e/cases/browserslist/browserslist-config-mock/index.json
+++ b/e2e/cases/browserslist/browserslist-config-mock/index.json
@@ -1,0 +1,1 @@
+["Chrome >= 49", "Edge >= 79", "Firefox >= 49", "Safari >= 10"]

--- a/e2e/cases/browserslist/browserslist-config-mock/package.json
+++ b/e2e/cases/browserslist/browserslist-config-mock/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@e2e/browserslist-config-mock",
+  "version": "1.0.0",
+  "main": "index.json"
+}

--- a/e2e/cases/browserslist/extends-browserslist/index.test.ts
+++ b/e2e/cases/browserslist/extends-browserslist/index.test.ts
@@ -1,0 +1,16 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+// TODO Rspack does not supports extends browserslist yet
+test.fail('extends browserslist and downgrade the syntax', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const indexFile =
+    files[Object.keys(files).find((file) => file.endsWith('.js'))!];
+
+  expect(indexFile.includes('async ')).toBeFalsy();
+});

--- a/e2e/cases/browserslist/extends-browserslist/package.json
+++ b/e2e/cases/browserslist/extends-browserslist/package.json
@@ -1,0 +1,11 @@
+{
+  "private": true,
+  "name": "@e2e/extends-browserslist",
+  "version": "1.0.0",
+  "dependencies": {
+    "@e2e/browserslist-config-mock": "workspace:*"
+  },
+  "browserslist": [
+    "extends @e2e/browserslist-config-mock"
+  ]
+}

--- a/e2e/cases/browserslist/extends-browserslist/rsbuild.config.ts
+++ b/e2e/cases/browserslist/extends-browserslist/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
+
+export default defineConfig({
+  plugins: [pluginCheckSyntax()],
+});

--- a/e2e/cases/browserslist/extends-browserslist/src/index.js
+++ b/e2e/cases/browserslist/extends-browserslist/src/index.js
@@ -1,0 +1,5 @@
+async function foo() {
+  console.log('hello');
+}
+
+console.log(foo);

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -31,9 +31,20 @@ export default {
     },
     'webpack-merge',
     'mime-types',
-    'browserslist',
     'gzip-size',
     'json5',
+    {
+      name: 'browserslist',
+      // preserve the `require(require.resolve())`
+      beforeBundle(task) {
+        replaceFileContent(join(task.depPath, 'node.js'), (content) =>
+          content.replaceAll(
+            'require(require.resolve',
+            'eval("require")(require.resolve',
+          ),
+        );
+      },
+    },
     {
       name: 'jiti',
       ignoreDts: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,14 @@ importers:
         specifier: ^7.24.5
         version: 7.24.5(@babel/core@7.24.5)
 
+  e2e/cases/browserslist/browserslist-config-mock: {}
+
+  e2e/cases/browserslist/extends-browserslist:
+    dependencies:
+      '@e2e/browserslist-config-mock':
+        specifier: workspace:*
+        version: link:../browserslist-config-mock
+
   e2e/cases/eslint:
     dependencies:
       eslint:


### PR DESCRIPTION
## Summary

Fix browserslist resolve is broken by prebundle.

This PR is part of fixes to support `extends` in browserslist config, see https://github.com/web-infra-dev/rsbuild/issues/2443

We still need to support `extends` in the Rust (Rspack) side.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
