### PR TITLE
fix: update css-loader modules typing

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {
   type BundlerChainRule,
+  type CSSLoaderModulesMode,
   type CSSLoaderOptions,
   type ModifyChainUtils,
   type PostCSSLoaderOptions,
@@ -51,7 +52,10 @@ export const normalizeCssLoaderOptions = (
     if (modules === true) {
       modules = { exportOnlyLocals: true };
     } else if (typeof modules === 'string') {
-      modules = { mode: modules, exportOnlyLocals: true };
+      modules = {
+        mode: modules as CSSLoaderModulesMode,
+        exportOnlyLocals: true,
+      };
     } else {
       // create a new object to avoid modifying the original options
       modules = {

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -6,6 +6,7 @@ import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 import type { MinifyOptions } from 'terser';
 import type { Configuration as WebpackConfig } from 'webpack';
 import type Autoprefixer from '../../compiled/autoprefixer/index.js';
+import type { Rspack } from './rspack';
 
 type AutoprefixerOptions = Autoprefixer.Options;
 
@@ -45,9 +46,29 @@ export type PostCSSLoaderOptions = {
 
 export type { AcceptedPlugin as PostCSSPlugin } from 'postcss';
 
-export interface CSSModulesOptions {
-  compileType?: string;
-  mode?: string;
+export type CSSLoaderModulesMode =
+  | 'local'
+  | 'global'
+  | 'pure'
+  | 'icss'
+  | ((resourcePath: string) => 'local' | 'global' | 'pure' | 'icss');
+
+export type CSSLoaderExportLocalsConvention =
+  | 'asIs'
+  | 'as-is'
+  | 'camelCase'
+  | 'camel-case'
+  | 'camelCaseOnly'
+  | 'camel-case-only'
+  | 'dashes'
+  | 'dashesOnly'
+  | 'dashes-only'
+  | ((name: string) => string);
+
+export interface CSSLoaderModulesOptions {
+  /**
+   * Allows auto enable CSS modules/ICSS based on the filename, query or fragment.
+   */
   auto?:
     | boolean
     | RegExp
@@ -56,13 +77,55 @@ export interface CSSModulesOptions {
         resourceQuery: string,
         resourceFragment: string,
       ) => boolean);
+  /**
+   * Allow `css-loader` to export names from global class or id, so you can use that as local name.
+   */
   exportGlobals?: boolean;
-  localIdentName?: string;
-  localIdentContext?: string;
-  localIdentHashPrefix?: string;
-  namedExport?: boolean;
-  exportLocalsConvention?: string;
+  /**
+   * Style of exported class names.
+   */
+  exportLocalsConvention?: CSSLoaderExportLocalsConvention;
+  /**
+   * Export only locals.
+   */
   exportOnlyLocals?: boolean;
+  /**
+   * Allows to specify a function to generate the classname.
+   */
+  getLocalIdent?: (
+    context: Rspack.LoaderContext,
+    localIdentName: string,
+    localName: string,
+  ) => string;
+  /**
+   * Allows to configure the generated local ident name.
+   */
+  localIdentName?: string;
+  /**
+   * Allows to redefine basic loader context for local ident name.
+   */
+  localIdentContext?: string;
+  /**
+   * Allows to add custom hash to generate more unique classes.
+   */
+  localIdentHashSalt?: string;
+  /**
+   * Allows to specify hash function to generate classes.
+   */
+  localIdentHashFunction?: string;
+  /**
+   * Allows to specify hash digest to generate classes.
+   */
+  localIdentHashDigest?: string;
+  localIdentRegExp?: string | RegExp;
+  /**
+   * Controls the level of compilation applied to the input styles.
+   */
+  mode?: CSSLoaderModulesMode;
+  /**
+   * Enables/disables ES modules named export for locals.
+   */
+  namedExport?: boolean;
 }
 
 export interface CSSLoaderOptions {
@@ -84,7 +147,7 @@ export interface CSSLoaderOptions {
   /**
    * Allows to enable/disable CSS Modules or ICSS and setup configuration:
    */
-  modules?: boolean | string | CSSModulesOptions;
+  modules?: boolean | string | CSSLoaderModulesOptions;
   /**
    * By default generation of source maps depends on the devtool option.
    */

--- a/packages/shared/src/types/thirdParty.ts
+++ b/packages/shared/src/types/thirdParty.ts
@@ -117,6 +117,9 @@ export interface CSSLoaderModulesOptions {
    * Allows to specify hash digest to generate classes.
    */
   localIdentHashDigest?: string;
+  /**
+   * Allows to specify custom RegExp for local ident name.
+   */
   localIdentRegExp?: string | RegExp;
   /**
    * Controls the level of compilation applied to the input styles.


### PR DESCRIPTION
## Summary

Update css-loader modules typing to match the current implementation.

## Related Links

https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#modules

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
