### PR TITLE
types(plugin-sass): export PluginSassOptions type

### DIFF
--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -12,6 +12,8 @@ import type { PluginSassOptions, SassLoaderOptions } from './types';
 
 export const PLUGIN_SASS_NAME = 'rsbuild:sass';
 
+export type { PluginSassOptions };
+
 const getSassLoaderOptions = (
   userOptions: PluginSassOptions['sassLoaderOptions'],
   isUseCssSourceMap: boolean,


### PR DESCRIPTION
## Summary

export PluginSassOptions type, so other pkgs can used.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
