### PR TITLE
feat: add dev.lazyCompilation config

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,9 +1,14 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
+    // TODO fix this case in Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     const rsbuild = await dev({
       cwd: __dirname,
     });

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,0 +1,19 @@
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should render pages correctly when using lazy compilation',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+    });
+
+    await gotoPage(page, rsbuild, 'page1');
+    await expect(page.locator('#test')).toHaveText('Page 1');
+
+    await gotoPage(page, rsbuild, 'page2');
+    await expect(page.locator('#test')).toHaveText('Page 2');
+
+    rsbuild.close();
+  },
+);

--- a/e2e/cases/lazy-compilation/basic/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/basic/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  source: {
+    entry: {
+      page1: './src/page1/index.js',
+      page2: './src/page2/index.js',
+    },
+  },
+});

--- a/e2e/cases/lazy-compilation/basic/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/basic/rsbuild.config.ts
@@ -9,4 +9,7 @@ export default defineConfig({
       page2: './src/page2/index.js',
     },
   },
+  dev: {
+    lazyCompilation: true,
+  },
 });

--- a/e2e/cases/lazy-compilation/basic/src/page1/App.jsx
+++ b/e2e/cases/lazy-compilation/basic/src/page1/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div id="test">Page 1</div>;
+};
+
+export default App;

--- a/e2e/cases/lazy-compilation/basic/src/page1/index.js
+++ b/e2e/cases/lazy-compilation/basic/src/page1/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/e2e/cases/lazy-compilation/basic/src/page2/App.jsx
+++ b/e2e/cases/lazy-compilation/basic/src/page2/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div id="test">Page 2</div>;
+};
+
+export default App;

--- a/e2e/cases/lazy-compilation/basic/src/page2/index.js
+++ b/e2e/cases/lazy-compilation/basic/src/page2/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -50,6 +50,7 @@ async function applyDefaultPlugins(
   const { pluginManifest } = await import('./plugins/manifest');
   const { pluginModuleFederation } = await import('./plugins/moduleFederation');
   const { pluginRspackProfile } = await import('./plugins/rspackProfile');
+  const { pluginLazyCompilation } = await import('./plugins/lazyCompilation');
 
   pluginManager.addPlugins([
     pluginBasic(),
@@ -86,6 +87,7 @@ async function applyDefaultPlugins(
     pluginManifest(),
     pluginModuleFederation(),
     pluginRspackProfile(),
+    pluginLazyCompilation(),
   ]);
 }
 

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -17,10 +17,12 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         return;
       }
 
+      const clientRegExp = /[\\/]core[\\/]dist[\\/]client[\\/]/;
+
       const isExcludedModule = (name: string) => {
         return (
           // alway include Rsbuild client code, such as HMR
-          name.includes('/core/dist/client/') ||
+          clientRegExp.test(name) ||
           // exclude CSS files because Rspack does not support it yet
           // TODO: remove this after Rspack supporting it
           name.endsWith('.css')

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,5 +1,6 @@
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { isRegExp } from '@rsbuild/shared';
+import { CSS_REGEX } from '../constants';
 
 export const pluginLazyCompilation = (): RsbuildPlugin => ({
   name: 'rsbuild:lazy-compilation',
@@ -25,7 +26,7 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
           clientRegExp.test(name) ||
           // exclude CSS files because Rspack does not support it yet
           // TODO: remove this after Rspack supporting it
-          name.endsWith('.css')
+          CSS_REGEX.test(name)
         );
       };
 

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,0 +1,75 @@
+import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
+import { isRegExp } from '@rsbuild/shared';
+
+export const pluginLazyCompilation = (): RsbuildPlugin => ({
+  name: 'rsbuild:lazy-compilation',
+
+  setup(api) {
+    api.modifyBundlerChain((chain, { isProd, target }) => {
+      if (isProd || target !== 'web') {
+        return;
+      }
+
+      const config = api.getNormalizedConfig();
+
+      const options = config.dev?.lazyCompilation;
+      if (!options) {
+        return;
+      }
+
+      const isExcludedModule = (name: string) => {
+        return (
+          // alway include Rsbuild client code, such as HMR
+          name.includes('/core/dist/client/') ||
+          // exclude CSS files because Rspack does not support it yet
+          // TODO: remove this after Rspack supporting it
+          name.endsWith('.css')
+        );
+      };
+
+      const defaultTest = (module: Rspack.Module) => {
+        const name = module.nameForCondition();
+        if (!name) {
+          return false;
+        }
+        return !isExcludedModule(name);
+      };
+
+      const mergeOptions = (): Rspack.LazyCompilationOptions => {
+        if (options === true) {
+          return { test: defaultTest };
+        }
+
+        const { test } = options;
+        if (!test) {
+          return {
+            ...options,
+            test,
+          };
+        }
+
+        return {
+          ...options,
+          test(module) {
+            const name = module.nameForCondition();
+
+            if (!name || isExcludedModule(name)) {
+              return false;
+            }
+
+            if (isRegExp(test)) {
+              return name ? test.test(name) : false;
+            }
+
+            return test(module);
+          },
+        };
+      };
+
+      chain.experiments({
+        ...chain.get('experiments'),
+        lazyCompilation: mergeOptions(),
+      });
+    });
+  },
+});

--- a/packages/core/tests/__snapshots__/inspect.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inspect.test.ts.snap
@@ -32,5 +32,6 @@ exports[`inspectConfig > should print plugin names when inspect config 1`] = `
   "rsbuild:manifest",
   "rsbuild:module-federation",
   "rsbuild:rspack-profile",
+  "rsbuild:lazy-compilation",
 ]
 `;

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { WatchOptions } from '../../../compiled/chokidar/index.js';
+import type { Rspack } from '../rspack';
 import type { ArrayOrNot } from '../utils';
 
 export type ProgressBarConfig = {
@@ -88,6 +89,10 @@ export interface DevConfig {
    * This option allows you to configure a list of globs/directories/files to watch for file changes.
    */
   watchFiles?: WatchFiles;
+  /**
+   * Enable lazy compilation.
+   */
+  lazyCompilation?: boolean | Rspack.LazyCompilationOptions;
 }
 
 export type NormalizedDevConfig = DevConfig &


### PR DESCRIPTION
## Summary

Add `dev.lazyCompilation` config. It is a light wrapper to make Rspack's lazy compilation works in Rsbuild.

## Related Links

https://www.rspack.dev/config/experiments#experimentslazycompilation

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
