### PR TITLE
chore(deps): bump Rspress v1.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
       "esbuild": "~0.19.0",
       "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@1.0.28",
       "@rsbuild/core": "link:packages/core",
+      "@rsbuild/plugin-less": "link:packages/plugin-less",
+      "@rsbuild/plugin-sass": "link:packages/plugin-sass",
       "@rsbuild/plugin-react": "link:packages/plugin-react"
     },
     "allowedDeprecatedVersions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   esbuild: ~0.19.0
   array.prototype.flat: npm:@nolyfill/array.prototype.flat@1.0.28
   '@rsbuild/core': link:packages/core
+  '@rsbuild/plugin-less': link:packages/plugin-less
+  '@rsbuild/plugin-sass': link:packages/plugin-sass
   '@rsbuild/plugin-react': link:packages/plugin-react
 
 importers:
@@ -118,7 +120,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-image-compress
       '@rsbuild/plugin-less':
-        specifier: workspace:*
+        specifier: link:../packages/plugin-less
         version: link:../packages/plugin-less
       '@rsbuild/plugin-lightningcss':
         specifier: workspace:*
@@ -142,7 +144,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-rem
       '@rsbuild/plugin-sass':
-        specifier: workspace:*
+        specifier: link:../packages/plugin-sass
         version: link:../packages/plugin-sass
       '@rsbuild/plugin-solid':
         specifier: workspace:*
@@ -1233,10 +1235,10 @@ importers:
         specifier: link:../core
         version: link:../core
       '@rsbuild/plugin-less':
-        specifier: workspace:*
+        specifier: link:../plugin-less
         version: link:../plugin-less
       '@rsbuild/plugin-sass':
-        specifier: workspace:*
+        specifier: link:../plugin-sass
         version: link:../plugin-sass
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1780,12 +1782,9 @@ importers:
       '@rsbuild/core':
         specifier: link:../packages/core
         version: link:../packages/core
-      '@rsbuild/plugin-sass':
-        specifier: workspace:*
-        version: link:../packages/plugin-sass
       '@rspress/plugin-rss':
-        specifier: 0.0.0-next-20240516095608
-        version: 0.0.0-next-20240516095608(react@18.3.1)(rspress@0.0.0-next-20240516095608(webpack@5.91.0))
+        specifier: 1.22.0
+        version: 1.22.0(react@18.3.1)(rspress@1.22.0(webpack@5.91.0))
       '@types/node':
         specifier: 18.x
         version: 18.19.31
@@ -1814,8 +1813,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       rspress:
-        specifier: 0.0.0-next-20240516095608
-        version: 0.0.0-next-20240516095608(webpack@5.91.0)
+        specifier: 1.22.0
+        version: 1.22.0(webpack@5.91.0)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -3141,9 +3140,6 @@ packages:
   '@modern-js/types@2.50.0':
     resolution: {integrity: sha512-YE9UGfOy/Svsneb/9lo8/gog9l8FWNs+QPjrsFajjt7TEfzJox3/qHozw4RacmtiiuAkSAP6r+liEH37P4RYVQ==}
 
-  '@modern-js/utils@2.49.3':
-    resolution: {integrity: sha512-fs/sCxDjdHSf5WdH8sTsZ3yGiUC/dPQLHieiIAyWwWh1GQAcBxqLRVuebsPk/xNnbpukiKcW05a3xHznxLJvNw==}
-
   '@modern-js/utils@2.50.0':
     resolution: {integrity: sha512-Gt/NIAsbkmwXif9uIPWaEt6nWoMCtYlvwuNNJN7ktD2SOmecaVAGWHn6+IEtkz794SQQHTe1b8Wd72LilaN/zw==}
 
@@ -3488,96 +3484,96 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-f6UpYYiyxJ/qZ+vvT8yuhpKy/D+9FooSCAHpOcyX9E8Aa7MdESt1VrdoPFwp9okV1EJdDLdB0ZU+AIEdAcIrIQ==}
+  '@rspress/core@1.22.0':
+    resolution: {integrity: sha512-IkkJQ4DO8LU+FQRHGgSj5MPc5KvcCorsvBx9Fdt07BdA5o52zcngzFt3oMcsacQ0MlvxSEsiywsYLoIxruWDhA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/mdx-rs-darwin-arm64@0.5.5':
-    resolution: {integrity: sha512-XlRjqOnxkXs+jZ9TEDrt3XExeOp1CRQBawZYlAwleGFvvOxcnFjVoAGaFsCEID5snoXFyfoMheyvNcShbLSj2A==}
+  '@rspress/mdx-rs-darwin-arm64@0.5.7':
+    resolution: {integrity: sha512-8zU3nCA1ot2mKpaQsWyEUgpMqBXj/0aWFzsXdxyHojKAkRxgY9pTTKSolUx/Nt3iDeJwhfMBRmoD1d34rZemEQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspress/mdx-rs-darwin-x64@0.5.5':
-    resolution: {integrity: sha512-uyXxBuPPdQQaixf4lkwQLRduK3K1w6UdG+o+aprp6HSHbpZWjYRKSaSfpqFZQTVZF2I+/XBxGe8fbZFw27KDlg==}
+  '@rspress/mdx-rs-darwin-x64@0.5.7':
+    resolution: {integrity: sha512-nNiEKvuWWBL2OUvGGZS8v83fXHhyQKy6CTwZ9vwamVZrslvN63W/11TxX23wumvhnwgfbi3+1gy2sEF4b/F5ew==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [darwin]
 
-  '@rspress/mdx-rs-linux-arm64-gnu@0.5.5':
-    resolution: {integrity: sha512-cLRpcNCcuFm7mkzJAzcZTYrlarwruOmShZXnKDcBHTRBF3ELnKe5C+rPGB/lM2sHp4TnD5MaGyhIsZ1lULoytw==}
+  '@rspress/mdx-rs-linux-arm64-gnu@0.5.7':
+    resolution: {integrity: sha512-vaNgtx2VX5289JfobXpNekFchM9kzBkqglDeujA9LHiokvr373seHsm+TEJ2XZiY2ELyRi1PS1MX5soIasbyfg==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
 
-  '@rspress/mdx-rs-linux-arm64-musl@0.5.5':
-    resolution: {integrity: sha512-G2YvWnG7kQ2B++skU6TRQDoPP+jETpJDaSTf45+77bIFvOnNxsgWEE761hJTqXfOfSjr/WN85Bu+83k8V21wcg==}
+  '@rspress/mdx-rs-linux-arm64-musl@0.5.7':
+    resolution: {integrity: sha512-/bQilCaEK3HJ2fkCU37ioazcY0NJ6QeYLNQBnXLM3cFL7a+iCq1+AVXz6DFNQdE/bE1AzUySrLFFFQaMhrx06w==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [linux]
 
-  '@rspress/mdx-rs-linux-x64-gnu@0.5.5':
-    resolution: {integrity: sha512-GACjD8qQXEVZQd009S3E0G+81MkjMVQfoGJJDlGqwW1rbEqqXYJoh1aTqEjoJQc499OvJFmyBExALQug03e6rA==}
+  '@rspress/mdx-rs-linux-x64-gnu@0.5.7':
+    resolution: {integrity: sha512-t4Zevz9wVt2HAj7WVGS/w388yV8jE0WgYK7TE9Dv86t/L/ko+qNTfjm+t5k7r/CKPUaXrLzxsTsRzqBWoDF8bQ==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
 
-  '@rspress/mdx-rs-linux-x64-musl@0.5.5':
-    resolution: {integrity: sha512-r+CS3t3z/upiylN/bNH3rmqrPvEZCNhefGwPHHV0jfpJj6OsCPk67Ec6MQBm7zp3VWB08GBGYvj6N29T9I8dSQ==}
+  '@rspress/mdx-rs-linux-x64-musl@0.5.7':
+    resolution: {integrity: sha512-4hZhb9MN/o1QaT+eQtVxcf/RZnDw5dVFA/AQWfsmuJRNp1jkzF3DIdyIVaJpQdWt5XXnWNqXrhN43qsHy8nZMQ==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [linux]
 
-  '@rspress/mdx-rs-win32-arm64-msvc@0.5.5':
-    resolution: {integrity: sha512-k6rCbcb3BMTnP+kFTwtyZvY0KKJtgKpkgsqR9k2SnIn/NY8x3DzjH6CpHSKqdYn3taESE0am6/L2Z1lmbs1+5A==}
+  '@rspress/mdx-rs-win32-arm64-msvc@0.5.7':
+    resolution: {integrity: sha512-IIwUiJ35fnpG7Z9c0Doqaxw3XSVgahX0rHsOdFc21RPfUqHGNlTUCdDaK00oXwaxSCzNyw1zRN7qynpR0RsPvQ==}
     engines: {node: '>=14.12'}
     cpu: [arm64]
     os: [win32]
 
-  '@rspress/mdx-rs-win32-x64-msvc@0.5.5':
-    resolution: {integrity: sha512-SGCb19Cl5aeJu/4i1sALZIVs3qdvbNfmhYQZQzhYrTbMkjkymbcnaEboj1uU73yh9k/U/q4EMFrdg9+Uq/ztkQ==}
+  '@rspress/mdx-rs-win32-x64-msvc@0.5.7':
+    resolution: {integrity: sha512-W7hbIJ3Zro8/ML3mZPdhFhmDh8VXcRM8jiMdfnXPUG+vSFmj8N6kfV/FO539foUoUKI1+4VGPxYO2vKXs3iDDQ==}
     engines: {node: '>=14.12'}
     cpu: [x64]
     os: [win32]
 
-  '@rspress/mdx-rs@0.5.5':
-    resolution: {integrity: sha512-slReZPDzDmilw35Gpoxl13xPLuORppA9gdcjjkfnNZ4t45EbqLDsfBXWfF3awz2df+GMdQDTLjrM6lmj4BcUDw==}
+  '@rspress/mdx-rs@0.5.7':
+    resolution: {integrity: sha512-Ie9TqTeMF7yCBqKAOxyLD1W2cDhRZkMsIFD4UJ9nAJTuV4zMj1aXoaKL94phsnl6ImDykF/dohTeuBUrwch08g==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-9RY0+Zb4NT1wwOKUgFWV2loDn9jCxatOqFag6545j5t2ju0hml/gu+x16eYf9qTlz4QkovS092cUL0ZQkYwQWw==}
+  '@rspress/plugin-auto-nav-sidebar@1.22.0':
+    resolution: {integrity: sha512-fxl5rsDugxRO+oxG2T5zqmJLZfnVlaUEwjLk9dlZPFOPJlGG3IWBRQPwwFyKvZhpASZ6ujuJNjOOJHtt3ofstg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-LjERL+wyuQ0yahHmZEK1Lfnz0u6ZayvPiX1IRIVjhK8bhmFlt0jq6Jtva07VSH/NNVPSZh2hMHc1A833B+b69A==}
+  '@rspress/plugin-container-syntax@1.22.0':
+    resolution: {integrity: sha512-tbdLznevhyAm3mAA9T+7mplib08ZTU+8fH/FB28a8uiX9plGkCXncZ4DrrJ91121HohH7SeIE4og1lvrNkaC6A==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-lpRLTZH0rV2OlGxCL/VOwK+aIhMxMjeMV/vVLow1SDOmNgrrhSoxSJhFshgccBtr1AzzILShSIOynLOd0AzR+A==}
+  '@rspress/plugin-last-updated@1.22.0':
+    resolution: {integrity: sha512-IuT6q2M/dmF9Qe63ydPbbK9iSWx4A23m3G6yzpUy3YDM6IwmEBNtElqh+HFVIawASB505yNvmZ+GuJthi5mbwQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-QM+K0iuZJ33FHvxoNJPgsrXjiiPl9Ia5a8FhznA+kQ5nXhcKykGq++uufE0FtYAmZX5vC3QuT9Xbwd9tEf0AAQ==}
+  '@rspress/plugin-medium-zoom@1.22.0':
+    resolution: {integrity: sha512-oWQz3KdAdG0xBscnNHF334WSojEYQkIRFTjEyWCfkPPYeFcseBD11D6V0myhUqKDrbUzm7bhUzdNl8AWwm/fAg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': 0.0.0-next-20240516095608
+      '@rspress/runtime': ^1.0.2
 
-  '@rspress/plugin-rss@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-0aRLrlr60OzmhntiqH9CfQkaMpA451hO+rwxhE3esUR0TXAtV7BKnzMjTgzJbVTGkkfif+pB3Ei7Pwzv9chgBg==}
+  '@rspress/plugin-rss@1.22.0':
+    resolution: {integrity: sha512-9ByefMi0iamJpg7r2g08hoFblYVD10B143y5aX1hxyWFAOBsoKfzpOoL6pQQHnpvY0HpKXQd6qSMh2H0vzpz+w==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: 0.0.0-next-20240516095608
+      rspress: ^1.17.0
 
-  '@rspress/runtime@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-VEZ4NTtjyxTXSRgYekAyCjLQIim9bFnimwuHqxjLII+e6Zi1SXW1e1OXDt1MDb9DoANNcPMmvrnfSC1LW2F3eg==}
+  '@rspress/runtime@1.22.0':
+    resolution: {integrity: sha512-bb65ppN5scXQCIEa4UyqTuqNiK99wqO4i2+yua6N2A+c3ujFzmRBdC9RKku/5ssa+copm9/n4jr13ADjoNmSVA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-C3oS4hdNYw3/Nd2IPvHFNSyXsmOT8iHG5c7hMOaw0uAXOUvpqebOAYrHwvYyKB8MeVXm+pmIcjsZvLmkdtaycg==}
+  '@rspress/shared@1.22.0':
+    resolution: {integrity: sha512-qE699hhoVhRkwuBgla+qfPPFu5/hhtdalg8jZwcfKonTUJZqH7MTZ2TVy01kOf0TVe82421mPpoC9KwXXM5aPQ==}
 
-  '@rspress/theme-default@0.0.0-next-20240516095608':
-    resolution: {integrity: sha512-xMt6iDvlW5nLvDsJtUXKV9+XGl6X6vEn4mth3o8ZM+GvM2s08JsVIqtN9eY6SnEukKyuGu56WDEsHMAEMCpiLQ==}
+  '@rspress/theme-default@1.22.0':
+    resolution: {integrity: sha512-wbSHISH3XrDi2lG2CXOQtKyhFOQtQuEEyUqm5Q5PXxFDXEUW6Eh0bA6JQhjz7nE+ge9G2fb30ciAeTo3vij+EQ==}
     engines: {node: '>=14.17.6'}
 
   '@selderee/plugin-htmlparser2@0.11.0':
@@ -7718,8 +7714,8 @@ packages:
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
 
-  rspress@0.0.0-next-20240516095608:
-    resolution: {integrity: sha512-W/0H3CgQ+r2nuc9xQ0Bd29Ldg94rI4U0B6ijjuqOqAtqS7W6E+w8tX6YkouoB/Y4EVH63C9cTYJks6gXovQrHg==}
+  rspress@1.22.0:
+    resolution: {integrity: sha512-naxeRSSwI9yTH6Om5V6KXAqpPXaxJfSVR/FM6vCIr0wfwL1K/busSRx9s3GLrqWTad61tD60tWEvAMFp6YB2wA==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -10542,13 +10538,6 @@ snapshots:
 
   '@modern-js/types@2.50.0': {}
 
-  '@modern-js/utils@2.49.3':
-    dependencies:
-      '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001617
-      lodash: 4.17.21
-      rslog: 1.2.2
-
   '@modern-js/utils@2.50.0':
     dependencies:
       '@swc/helpers': 0.5.3
@@ -10808,23 +10797,25 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspress/core@0.0.0-next-20240516095608(webpack@5.91.0)':
+  '@rspress/core@1.22.0(webpack@5.91.0)':
     dependencies:
       '@loadable/component': 5.16.4(react@18.3.1)
       '@mdx-js/loader': 2.3.0(webpack@5.91.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@modern-js/utils': 2.49.3
+      '@modern-js/utils': 2.50.0
       '@rsbuild/core': link:packages/core
+      '@rsbuild/plugin-less': link:packages/plugin-less
       '@rsbuild/plugin-react': link:packages/plugin-react
-      '@rspress/mdx-rs': 0.5.5
-      '@rspress/plugin-auto-nav-sidebar': 0.0.0-next-20240516095608
-      '@rspress/plugin-container-syntax': 0.0.0-next-20240516095608
-      '@rspress/plugin-last-updated': 0.0.0-next-20240516095608
-      '@rspress/plugin-medium-zoom': 0.0.0-next-20240516095608(@rspress/runtime@0.0.0-next-20240516095608)
-      '@rspress/runtime': 0.0.0-next-20240516095608
-      '@rspress/shared': 0.0.0-next-20240516095608
-      '@rspress/theme-default': 0.0.0-next-20240516095608
+      '@rsbuild/plugin-sass': link:packages/plugin-sass
+      '@rspress/mdx-rs': 0.5.7
+      '@rspress/plugin-auto-nav-sidebar': 1.22.0
+      '@rspress/plugin-container-syntax': 1.22.0
+      '@rspress/plugin-last-updated': 1.22.0
+      '@rspress/plugin-medium-zoom': 1.22.0(@rspress/runtime@1.22.0)
+      '@rspress/runtime': 1.22.0
+      '@rspress/shared': 1.22.0
+      '@rspress/theme-default': 1.22.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       enhanced-resolve: 5.16.0
@@ -10862,74 +10853,74 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rspress/mdx-rs-darwin-arm64@0.5.5':
+  '@rspress/mdx-rs-darwin-arm64@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-darwin-x64@0.5.5':
+  '@rspress/mdx-rs-darwin-x64@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-linux-arm64-gnu@0.5.5':
+  '@rspress/mdx-rs-linux-arm64-gnu@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-linux-arm64-musl@0.5.5':
+  '@rspress/mdx-rs-linux-arm64-musl@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-linux-x64-gnu@0.5.5':
+  '@rspress/mdx-rs-linux-x64-gnu@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-linux-x64-musl@0.5.5':
+  '@rspress/mdx-rs-linux-x64-musl@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-win32-arm64-msvc@0.5.5':
+  '@rspress/mdx-rs-win32-arm64-msvc@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs-win32-x64-msvc@0.5.5':
+  '@rspress/mdx-rs-win32-x64-msvc@0.5.7':
     optional: true
 
-  '@rspress/mdx-rs@0.5.5':
+  '@rspress/mdx-rs@0.5.7':
     optionalDependencies:
-      '@rspress/mdx-rs-darwin-arm64': 0.5.5
-      '@rspress/mdx-rs-darwin-x64': 0.5.5
-      '@rspress/mdx-rs-linux-arm64-gnu': 0.5.5
-      '@rspress/mdx-rs-linux-arm64-musl': 0.5.5
-      '@rspress/mdx-rs-linux-x64-gnu': 0.5.5
-      '@rspress/mdx-rs-linux-x64-musl': 0.5.5
-      '@rspress/mdx-rs-win32-arm64-msvc': 0.5.5
-      '@rspress/mdx-rs-win32-x64-msvc': 0.5.5
+      '@rspress/mdx-rs-darwin-arm64': 0.5.7
+      '@rspress/mdx-rs-darwin-x64': 0.5.7
+      '@rspress/mdx-rs-linux-arm64-gnu': 0.5.7
+      '@rspress/mdx-rs-linux-arm64-musl': 0.5.7
+      '@rspress/mdx-rs-linux-x64-gnu': 0.5.7
+      '@rspress/mdx-rs-linux-x64-musl': 0.5.7
+      '@rspress/mdx-rs-win32-arm64-msvc': 0.5.7
+      '@rspress/mdx-rs-win32-x64-msvc': 0.5.7
 
-  '@rspress/plugin-auto-nav-sidebar@0.0.0-next-20240516095608':
+  '@rspress/plugin-auto-nav-sidebar@1.22.0':
     dependencies:
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/shared': 1.22.0
 
-  '@rspress/plugin-container-syntax@0.0.0-next-20240516095608':
+  '@rspress/plugin-container-syntax@1.22.0':
     dependencies:
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/shared': 1.22.0
 
-  '@rspress/plugin-last-updated@0.0.0-next-20240516095608':
+  '@rspress/plugin-last-updated@1.22.0':
     dependencies:
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/shared': 1.22.0
 
-  '@rspress/plugin-medium-zoom@0.0.0-next-20240516095608(@rspress/runtime@0.0.0-next-20240516095608)':
+  '@rspress/plugin-medium-zoom@1.22.0(@rspress/runtime@1.22.0)':
     dependencies:
-      '@rspress/runtime': 0.0.0-next-20240516095608
+      '@rspress/runtime': 1.22.0
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@0.0.0-next-20240516095608(react@18.3.1)(rspress@0.0.0-next-20240516095608(webpack@5.91.0))':
+  '@rspress/plugin-rss@1.22.0(react@18.3.1)(rspress@1.22.0(webpack@5.91.0))':
     dependencies:
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/shared': 1.22.0
       feed: 4.2.2
       react: 18.3.1
-      rspress: 0.0.0-next-20240516095608(webpack@5.91.0)
+      rspress: 1.22.0(webpack@5.91.0)
 
-  '@rspress/runtime@0.0.0-next-20240516095608':
+  '@rspress/runtime@1.22.0':
     dependencies:
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/shared': 1.22.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.23.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@rspress/shared@0.0.0-next-20240516095608':
+  '@rspress/shared@1.22.0':
     dependencies:
       '@rsbuild/core': link:packages/core
       chalk: 4.1.2
@@ -10938,11 +10929,11 @@ snapshots:
       gray-matter: 4.0.3
       unified: 10.1.2
 
-  '@rspress/theme-default@0.0.0-next-20240516095608':
+  '@rspress/theme-default@1.22.0':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 0.0.0-next-20240516095608
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/runtime': 1.22.0
+      '@rspress/shared': 1.22.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.6.32
@@ -15916,11 +15907,11 @@ snapshots:
 
   rspress-plugin-font-open-sans@1.0.0: {}
 
-  rspress@0.0.0-next-20240516095608(webpack@5.91.0):
+  rspress@1.22.0(webpack@5.91.0):
     dependencies:
       '@rsbuild/core': link:packages/core
-      '@rspress/core': 0.0.0-next-20240516095608(webpack@5.91.0)
-      '@rspress/shared': 0.0.0-next-20240516095608
+      '@rspress/core': 1.22.0(webpack@5.91.0)
+      '@rspress/shared': 1.22.0
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-sass": "workspace:*",
-    "@rspress/plugin-rss": "0.0.0-next-20240516095608",
+    "@rspress/plugin-rss": "1.22.0",
     "@types/node": "18.x",
     "@types/react": "^18.3.2",
     "@types/react-dom": "^18.3.0",
@@ -21,7 +20,7 @@
     "rsbuild-plugin-google-analytics": "1.0.0",
     "rsbuild-plugin-open-graph": "1.0.0",
     "rsfamily-nav-icon": "^1.0.2",
-    "rspress": "0.0.0-next-20240516095608",
+    "rspress": "1.22.0",
     "rspress-plugin-font-open-sans": "1.0.0"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginRss } from '@rspress/plugin-rss';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
@@ -123,8 +122,6 @@ export default defineConfig({
   builderConfig: {
     plugins: [
       rsbuildPluginOverview,
-      // TODO: remove after bumping Rspress
-      pluginSass(),
       pluginGoogleAnalytics({ id: 'G-L6BZ6TKW4R' }),
       pluginOpenGraph({
         title: 'Rsbuild',


### PR DESCRIPTION
## Summary

Bump Rspress v1.22.0.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v1.22.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
