### PR TITLE
feat: add cssModules.mode option

### DIFF
--- a/e2e/cases/css/css-modules-mode/index.test.ts
+++ b/e2e/cases/css/css-modules-mode/index.test.ts
@@ -1,0 +1,23 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should compile CSS Modules global mode correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        cssModules: {
+          mode: 'global',
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+  expect(content).toEqual(
+    '.foo{position:relative}.foo .bar,.foo .baz{height:100%;overflow:hidden}.foo .lol{width:80%}',
+  );
+});

--- a/e2e/cases/css/css-modules-mode/src/a.module.css
+++ b/e2e/cases/css/css-modules-mode/src/a.module.css
@@ -1,0 +1,13 @@
+.foo {
+  position: relative;
+}
+
+.foo .bar,
+.foo .baz {
+  height: 100%;
+  overflow: hidden;
+}
+
+.foo .lol {
+  width: 80%;
+}

--- a/e2e/cases/css/css-modules-mode/src/index.js
+++ b/e2e/cases/css/css-modules-mode/src/index.js
@@ -1,0 +1,1 @@
+import './a.module.css';

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -219,11 +219,9 @@ const getCSSLoaderOptions = ({
   const defaultOptions: CSSLoaderOptions = {
     importLoaders,
     modules: {
-      auto: cssModules.auto,
-      namedExport: false,
-      exportGlobals: cssModules.exportGlobals,
-      exportLocalsConvention: cssModules.exportLocalsConvention,
+      ...cssModules,
       localIdentName,
+      namedExport: false,
     },
     sourceMap: config.output.sourceMap.css,
   };

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -3,7 +3,7 @@ import type {
   Externals,
   SwcJsMinimizerRspackPluginOptions,
 } from '@rspack/core';
-import type { HTMLPluginOptions } from '../../types';
+import type { CSSLoaderModulesOptions, HTMLPluginOptions } from '../../types';
 import type { RsbuildTarget } from '../rsbuild';
 import type { RspackConfig } from '../rspack';
 
@@ -147,26 +147,23 @@ export type CSSModules = {
   /**
    * Allows CSS Modules to be automatically enabled based on their filenames.
    */
-  auto?:
-    | boolean
-    | RegExp
-    | ((
-        resourcePath: string,
-        resourceQuery: string,
-        resourceFragment: string,
-      ) => boolean);
+  auto?: CSSLoaderModulesOptions['auto'];
   /**
    * Allows exporting names from global class names, so you can use them via import.
    */
   exportGlobals?: boolean;
   /**
+   * Style of exported class names.
+   */
+  exportLocalsConvention?: CSSModulesLocalsConvention;
+  /**
    * Set the local ident name of CSS Modules.
    */
   localIdentName?: string;
   /**
-   * Style of exported class names.
+   * Controls the level of compilation applied to the input styles.
    */
-  exportLocalsConvention?: CSSModulesLocalsConvention;
+  mode?: CSSLoaderModulesOptions['mode'];
 };
 
 export type Minify =
@@ -329,9 +326,10 @@ export interface NormalizedOutputConfig extends OutputConfig {
   injectStyles: boolean;
   cssModules: {
     auto: CSSModules['auto'];
-    localIdentName?: string;
     exportGlobals: boolean;
     exportLocalsConvention: CSSModulesLocalsConvention;
+    localIdentName?: string;
+    mode?: CSSModules['mode'];
   };
   emitAssets: EmitAssets;
 }

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -1,21 +1,6 @@
 # output.cssModules
 
-- **Type:**
-
-```ts
-type CSSModules = {
-  auto?:
-    | boolean
-    | RegExp
-    | ((
-        resourcePath: string,
-        resourceQuery: string,
-        resourceFragment: string,
-      ) => boolean);
-  localIdentName?: string;
-  exportLocalsConvention?: CSSModulesLocalsConvention;
-};
-```
+- **Type:** `CSSModules`
 
 For custom CSS Modules configuration.
 
@@ -94,6 +79,48 @@ export default {
 };
 ```
 
+## cssModules.exportGlobals
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Allows exporting names from global class names, so you can use them via import.
+
+### Example
+
+Set the `exportGlobals` to `true`:
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      exportGlobals: true,
+    },
+  },
+};
+```
+
+Use `:global()` in CSS Modules:
+
+```css title="style.module.css"
+:global(.blue) {
+  color: blue;
+}
+
+.red {
+  color: red;
+}
+```
+
+Then you can import the class name wrapped with `:global()`:
+
+```tsx title="Button.tsx"
+import styles from './style.module.css';
+
+console.log(styles.blue); // 'blue'
+console.log(styles.red); // 'red-[hash]'
+```
+
 ## cssModules.localIdentName
 
 - **Type:** `string`
@@ -149,44 +176,59 @@ export default {
 };
 ```
 
-## cssModules.exportGlobals
+## cssModules.mode
 
-- **Type:** `boolean`
-- **Default:** `false`
+- **Type:**
 
-Allows exporting names from global class names, so you can use them via import.
+```ts
+type Mode =
+  | 'local'
+  | 'global'
+  | 'pure'
+  | 'icss'
+  | ((resourcePath: string) => 'local' | 'global' | 'pure' | 'icss');
+```
 
-### Example
+- **Default:** `'local'`
 
-Set the `exportGlobals` to `true`:
+Controls the mode of compilation applied to the CSS Modules.
+
+### Optional values
+
+`cssModules.mode` can take one of the following values:
+
+1. `'local'` (default): This enables the CSS Modules specification for scoping CSS locally. Class and ID selectors are rewritten to be module-scoped, and `@value` bindings are injected.
+2. `'global'`: This opts-out of the CSS Modules behavior, disabling both local scoping and injecting `@value` bindings. Global selectors are preserved as-is.
+3. `'pure'`: This enables dead-code elimination by removing any unused local classnames and values from the final CSS. It still performs local scoping and `@value` injection.
+4. `'icss'`: This compiles to the low-level Interoperable CSS format, which provides a syntax for declaring `:import` and `:export` dependencies between CSS and other languages. It does not perform any scoping or `@value` injection.
+
+The `'local'` mode is the most common use case for CSS Modules, enabling modular and locally-scoped styles within components. The other modes may be used in specific scenarios.
+
+For example:
 
 ```ts
 export default {
   output: {
     cssModules: {
-      exportGlobals: true,
+      mode: 'global',
     },
   },
 };
 ```
 
-Use `:global()` in CSS Modules:
+### Function
 
-```css title="style.module.css"
-:global(.blue) {
-  color: blue;
+You can also pass a function to `modules.mode` that determines the mode based on the resource path, query, or fragment. This allows you to use different modes for different files.
+
+For example, to use local scoping for `.module.css` files and global styles for other files:
+
+```js
+modules: {
+  mode: (resourcePath) => {
+    if (/\.module\.\css$/.test(resourcePath)) {
+      return 'local';
+    }
+    return 'global';
+  };
 }
-
-.red {
-  color: red;
-}
-```
-
-Then you can import the class name wrapped with `:global()`:
-
-```tsx title="Button.tsx"
-import styles from './style.module.css';
-
-console.log(styles.blue); // 'blue'
-console.log(styles.red); // 'red-[hash]'
 ```

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -1,21 +1,6 @@
 # output.cssModules
 
-- **类型：**
-
-```ts
-type CSSModules = {
-  auto?:
-    | boolean
-    | RegExp
-    | ((
-        resourcePath: string,
-        resourceQuery: string,
-        resourceFragment: string,
-      ) => boolean);
-  localIdentName?: string;
-  exportLocalsConvention?: CSSModulesLocalsConvention;
-};
-```
+- **类型：** `CSSModules`
 
 用于自定义 CSS Modules 配置。
 
@@ -23,7 +8,7 @@ Rsbuild 的 CSS Modules 功能是基于 css-loader 的 `modules` 选项实现的
 
 ## cssModules.auto
 
-auto 配置项允许基于文件名自动启用 CSS 模块。
+auto 配置项允许基于文件名自动启用 CSS Modules。
 
 - **类型：**
 
@@ -42,10 +27,10 @@ type Auto =
 
 类型说明：
 
-- `true`: 为所有匹配 `/\.module\.\w+$/i.test(filename)` 正则表达式的文件启用 CSS 模块。
-- `false`: 禁用 CSS 模块。
-- `RegExp`: 为所有匹配 `/RegExp/i.test(filename)` 正则表达式的文件启用 CSS 模块。
-- `function`: 为所有通过基于文件名的过滤函数校验的文件启用 CSS 模块。
+- `true`: 为所有匹配 `/\.module\.\w+$/i.test(filename)` 正则表达式的文件启用 CSS Modules。
+- `false`: 禁用 CSS Modules。
+- `RegExp`: 为所有匹配 `/RegExp/i.test(filename)` 正则表达式的文件启用 CSS Modules。
+- `function`: 为所有通过基于文件名的过滤函数校验的文件启用 CSS Modules。
 
 ```ts
 export default {
@@ -92,6 +77,48 @@ export default {
     },
   },
 };
+```
+
+## cssModules.exportGlobals
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+允许从 global class names 导出名称，以便你可以通过 import 使用它们。
+
+### 示例
+
+将 `exportGlobals` 设置为 `true`：
+
+```ts
+export default {
+  output: {
+    cssModules: {
+      exportGlobals: true,
+    },
+  },
+};
+```
+
+在 CSS Modules 中使用 `:global()`：
+
+```css title="style.module.css"
+:global(.blue) {
+  color: blue;
+}
+
+.red {
+  color: red;
+}
+```
+
+然后你可以导入 `:global()` 包裹的类名：
+
+```tsx title="Button.tsx"
+import styles from './style.module.css';
+
+console.log(styles.blue); // 'blue'
+console.log(styles.red); // 'red-[hash]'
 ```
 
 ## cssModules.localIdentName
@@ -149,44 +176,63 @@ export default {
 };
 ```
 
-## cssModules.exportGlobals
+## cssModules.mode
 
-- **类型：** `boolean`
-- **默认值：** `false`
+- **类型：**
 
-允许从 global class names 导出名称，以便你可以通过 import 使用它们。
+```ts
+type Mode =
+  | 'local'
+  | 'global'
+  | 'pure'
+  | 'icss'
+  | ((resourcePath: string) => 'local' | 'global' | 'pure' | 'icss');
+```
 
-### 示例
+- **默认值：** `'local'`
 
-将 `exportGlobals` 设置为 `true`：
+控制 CSS Modules 的编译模式。
+
+### 可选值
+
+`cssModules.mode` 可以取以下值之一：
+
+1. `'local'` (默认值)：启用 CSS Modules 规范和局部作用域。类名和 ID 选择器会被重写为模块作用域，并注入 `@value` 绑定。
+2. `'global'`：不启用 CSS Modules 的行为，禁用局部作用域和 `@value` 绑定注入。全局选择器将按照原样保留。
+3. `'pure'`：通过删除最终 CSS 中未使用的本地类名和值来实现死代码消除。仍然执行局部作用域和 `@value` 注入。
+4. `'icss'`：编译成 low-level 可互操作的 CSS 格式，该格式提供在 CSS 和其他语言之间声明 `:import` 和 `:export` 依赖项的语法。它不执行任何作用域或 `@value` 注入。
+
+`'local'` 模式是 CSS Modules 最常见的用法，在组件内启用模块化和局部作用域样式。其他模式可能在特定场景下被使用。
+
+例如：
 
 ```ts
 export default {
   output: {
     cssModules: {
-      exportGlobals: true,
+      mode: 'global',
     },
   },
 };
 ```
 
-在 CSS Modules 中使用 `:global()`：
+### 函数
 
-```css title="style.module.css"
-:global(.blue) {
-  color: blue;
-}
+你还可以传递一个函数给 `cssModules.mode`，并根据资源路径、query 或 fragment 确定 mode。这允许你为不同的文件使用不同的 mode。
 
-.red {
-  color: red;
-}
-```
+例如，对 `.module.css` 文件使用局部作用域，对其他文件使用全局样式：
 
-然后你可以导入 `:global()` 包裹的类名：
-
-```tsx title="Button.tsx"
-import styles from './style.module.css';
-
-console.log(styles.blue); // 'blue'
-console.log(styles.red); // 'red-[hash]'
+```js
+export default {
+  output: {
+    cssModules: {
+      mode: (resourcePath) => {
+        if (/\.module\.css$/.test(resourcePath)) {
+          return 'local';
+        }
+        return 'global';
+      },
+    },
+  },
+};
 ```


### PR DESCRIPTION
## Summary

Add cssModules.mode option, which is the same as the `modules.mode` option of css-loader.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
