### PR TITLE
fix: avoid printing undefined file path

### DIFF
--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -16,7 +16,7 @@ function resolveFileName(stats: StatsError) {
   }
 
   // fallback to moduleName if moduleIdentifier parse failed
-  return `File: ${stats.moduleName}\n`;
+  return stats.moduleName ? `File: ${stats.moduleName}\n` : '';
 }
 
 function hintUnknownFiles(message: string): string {


### PR DESCRIPTION
## Summary

Avoid printing undefined file path when using the `plugin-type-check`:

<img width="813" alt="Screenshot 2024-05-29 at 14 11 17" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/4ea15f2d-6a4b-4552-ac8a-613e47454a05">

TODO: should get `stats.moduleName` when using Rspack + fork-ts-checker.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
