### PR TITLE
feat: print compiler close errors

### DIFF
--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -72,7 +72,11 @@ export const build = async (
       else {
         // When using run or watch, call close and wait for it to finish before calling run or watch again.
         // Concurrent compilations will corrupt the output files.
-        compiler.close(() => {
+        compiler.close((closeErr) => {
+          if (closeErr) {
+            logger.error(closeErr);
+          }
+
           // Assert type of stats must align to compiler.
           resolve({ stats });
         });


### PR DESCRIPTION
## Summary

The `compiler.close` method can accepts an error. Rsbuild should log it to notify users.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/bbcdc4e5-21b9-416a-874b-842e4d8e36d8)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
