### PR TITLE
test: add css resolve-ts-paths test case

### DIFF
--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,4 +1,4 @@
-import { build, rspackOnlyTest, proxyConsole } from '@e2e/helper';
+import { build, proxyConsole, rspackOnlyTest } from 'scripts';
 import { expect } from '@playwright/test';
 
 // TODO enhance-resolve on the js side cannot get the tsConfig paths configuration on the rust side

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,5 +1,5 @@
-import { expect } from '@playwright/test';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
 // TODO enhance-resolve on the js side cannot get the tsConfig paths configuration on the rust side
 rspackOnlyTest.fail(

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,5 +1,5 @@
-import { build, proxyConsole, rspackOnlyTest } from 'scripts';
 import { expect } from '@playwright/test';
+import { build, proxyConsole, rspackOnlyTest } from 'scripts';
 
 // TODO enhance-resolve on the js side cannot get the tsConfig paths configuration on the rust side
 rspackOnlyTest.fail(

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { build, proxyConsole, rspackOnlyTest } from 'scripts';
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 
 // TODO enhance-resolve on the js side cannot get the tsConfig paths configuration on the rust side
 rspackOnlyTest.fail(

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,0 +1,24 @@
+import { build, rspackOnlyTest, proxyConsole } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+// TODO enhance-resolve on the js side cannot get the tsConfig paths configuration on the rust side
+rspackOnlyTest.fail(
+  'should resolve ts paths correctly in SCSS file',
+  async () => {
+    const { restore } = proxyConsole();
+    try {
+      const rsbuild = await build({
+        cwd: __dirname,
+      });
+
+      const files = await rsbuild.unwrapOutputJSON();
+
+      const content =
+        files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+      expect(content).toContain('background-image:url(/static/image/icon');
+    } finally {
+      restore();
+    }
+  },
+);

--- a/e2e/cases/css/resolve-ts-paths/rsbuild.config.ts
+++ b/e2e/cases/css/resolve-ts-paths/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default {
+  plugins: [pluginSass()],
+};

--- a/e2e/cases/css/resolve-ts-paths/src/a.scss
+++ b/e2e/cases/css/resolve-ts-paths/src/a.scss
@@ -1,0 +1,1 @@
+@import 'src/common/b.scss';

--- a/e2e/cases/css/resolve-ts-paths/src/common/b.scss
+++ b/e2e/cases/css/resolve-ts-paths/src/common/b.scss
@@ -1,0 +1,4 @@
+.bar {
+  color: blue;
+  background-image: url('@assets/icon.png?url');
+}

--- a/e2e/cases/css/resolve-ts-paths/src/index.ts
+++ b/e2e/cases/css/resolve-ts-paths/src/index.ts
@@ -1,0 +1,1 @@
+import 'src/a.scss';

--- a/e2e/cases/css/resolve-ts-paths/tsconfig.json
+++ b/e2e/cases/css/resolve-ts-paths/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/tsconfig/base",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "src/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -22,6 +22,9 @@ export const getProviderTest = (
 
   // @ts-expect-error
   testSkip.describe = test.describe.skip;
+
+  // @ts-expect-error
+  testSkip.fail = test.describe.skip;
   // @ts-expect-error
   return testSkip as typeof test.skip & {
     describe: typeof test.describe.skip;


### PR DESCRIPTION
## Summary

This is a failed case because the current js loader uses an enhanced resolver, which causes resolve.tsconfig to not work with the js loader.

see: https://github.com/web-infra-dev/rspack/issues/4672

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
