### PR TITLE
docs: recommend using @swc/plugin-emotion

### DIFF
--- a/website/docs/en/config/tools/swc.mdx
+++ b/website/docs/en/config/tools/swc.mdx
@@ -86,27 +86,29 @@ Please note that SWC's wasm plugins are currently not backward compatible, and t
 
 For more information, refer to [SWC - Selecting the version](https://swc.rs/docs/plugin/selecting-swc-core).
 
-### Enable emotion support
+### Enable Emotion Support
 
-Example of enabling the emotion support using the `builtin:swc-loader`:
+Example of enabling the Emotion support using the `builtin:swc-loader`:
 
 ```js
 export default {
   tools: {
     swc: {
-      rspackExperiments: {
-        emotion: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-emotion', {}]],
+        },
       },
     },
   },
 };
 ```
 
-For more options, please refer to [Rspack - rspackExperiments.emotion](https://rspack.dev/guide/features/builtin-swc-loader#rspackexperimentsemotion).
+For more options, please refer to [@swc/plugin-emotion](https://www.npmjs.com/package/@swc/plugin-emotion).
 
-### Enable relay support
+### Enable Relay Support
 
-Example of enabling the relay support using the `builtin:swc-loader`:
+Example of enabling the Relay support using the `builtin:swc-loader`:
 
 ```js
 export default {

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -156,7 +156,7 @@ If you need to use styled-components, We recommend register the [Styled Componen
 Rsbuild supports compiling [Emotion](https://github.com/emotion-js/emotion), you can add the following configuration to use:
 
 - [swcReactOptions.importSource](/plugins/list/plugin-react#swcreactoptions)
-- [rspackExperiments.emotion](https://rspack.dev/guide/features/builtin-swc-loader#rspackexperimentsemotion)
+- [@swc/plugin-emotion](https://www.npmjs.com/package/@swc/plugin-emotion)
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';
@@ -172,8 +172,10 @@ export default defineConfig({
   ],
   tools: {
     swc: {
-      rspackExperiments: {
-        emotion: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-emotion', {}]],
+        },
       },
     },
   },

--- a/website/docs/zh/config/tools/swc.mdx
+++ b/website/docs/zh/config/tools/swc.mdx
@@ -86,27 +86,29 @@ export default {
 
 更多信息可参考 [SWC - Selecting the version](https://swc.rs/docs/plugin/selecting-swc-core)。
 
-### 启用 emotion 支持
+### 启用 Emotion 支持
 
-启用 `builtin:swc-loader` 对 emotion 支持的示例：
+启用 `builtin:swc-loader` 对 Emotion 支持的示例：
 
 ```js
 export default {
   tools: {
     swc: {
-      rspackExperiments: {
-        emotion: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-emotion', {}]],
+        },
       },
     },
   },
 };
 ```
 
-更多选项可参考 [Rspack - rspackExperiments.emotion](https://rspack.dev/zh/guide/features/builtin-swc-loader#rspackexperimentsemotion)。
+更多选项可参考 [@swc/plugin-emotion](https://www.npmjs.com/package/@swc/plugin-emotion)。
 
-### 启用 relay 支持
+### 启用 Relay 支持
 
-启用 `builtin:swc-loader` 对 relay 支持的示例：
+启用 `builtin:swc-loader` 对 Relay 支持的示例：
 
 ```js
 export default {

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -156,7 +156,7 @@ Rsbuild 支持编译 [styled-components](https://github.com/styled-components/st
 Rsbuild 支持编译 [Emotion](https://github.com/emotion-js/emotion)，你可以添加以下配置来使用：
 
 - [swcReactOptions.importSource](/plugins/list/plugin-react#swcreactoptions)
-- [rspackExperiments.emotion](https://rspack.dev/guide/features/builtin-swc-loader#rspackexperimentsemotion)
+- [@swc/plugin-emotion](https://www.npmjs.com/package/@swc/plugin-emotion)
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';
@@ -172,8 +172,10 @@ export default defineConfig({
   ],
   tools: {
     swc: {
-      rspackExperiments: {
-        emotion: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-emotion', {}]],
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Recommend using `@swc/plugin-emotion`. `rspackExperiments.emotion` will be removed in Rspack v1.0.

## Related Links

https://github.com/web-infra-dev/rspack/discussions/6626#discussioncomment-9593912

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
