### PR TITLE
chore: node build target to ES2021

### DIFF
--- a/scripts/config/modern.config.ts
+++ b/scripts/config/modern.config.ts
@@ -13,7 +13,7 @@ export const define = {
 };
 
 export const BUILD_TARGET = {
-  node: 'es2020',
+  node: 'es2021',
   client: 'es2017',
 } as const;
 

--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2019",
+    "target": "ES2021",
     "lib": ["DOM", "ESNext"],
     "allowJs": true,
     "module": "ES2020",


### PR DESCRIPTION
## Summary

Change node build target to ES2021.

## Related Links

The same as https://github.com/web-infra-dev/rspack/pull/6628

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
