### PR TITLE
chore(CI): remove release with comment feature

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,47 +24,6 @@ permissions:
   id-token: write
 
 jobs:
-  issue_comment:
-    name: Release with comment
-    if: github.repository == 'web-infra-dev/rsbuild' && (github.event.issue.pull_request && contains(github.event.comment.body, '!canary'))
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          ref: refs/pull/${{ github.event.issue.number }}/head
-
-      - name: Install Pnpm
-        run: corepack enable
-
-      - name: Setup Node.js 18
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-          cache: 'pnpm'
-
-      - name: Install npm v9
-        run: npm install -g npm@9
-
-      - name: Install Dependencies
-        run: pnpm install
-
-      - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          version: 'next'
-          type: 'release'
-          branch: ''
-          tools: 'changeset'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
-          COMMENT: ${{ toJson(github.event.comment) }}
-
   release:
     name: Release
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

release with comment is not security, and we can release canary through [actions - release workflow]

## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/1866
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
