### PR TITLE
fix(plugin-babel): run babel loader before builtin SWC loader

### DIFF
--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -135,7 +135,10 @@ export const pluginBabel = (
         const { include, exclude } = options;
 
         if (include || exclude) {
-          const rule = chain.module.rule(BABEL_JS_RULE);
+          const rule = chain.module
+            .rule(BABEL_JS_RULE)
+            // run babel loader before the builtin SWC loader
+            .before(CHAIN_ID.RULE.JS);
 
           if (include) {
             for (const condition of castArray(include)) {
@@ -148,18 +151,8 @@ export const pluginBabel = (
             }
           }
 
-          const swcRule = chain.module.rules
-            .get(CHAIN_ID.RULE.JS)
-            .use(CHAIN_ID.USE.SWC);
-          const swcLoader = swcRule.get('loader');
-          const swcOptions = swcRule.get('options');
-
           rule
             .test(SCRIPT_REGEX)
-            .use(CHAIN_ID.USE.SWC)
-            .loader(swcLoader)
-            .options(swcOptions)
-            .end()
             .use(CHAIN_ID.USE.BABEL)
             .loader(babelLoader)
             .options(babelOptions);

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -138,7 +138,7 @@ export const pluginBabel = (
           const rule = chain.module
             .rule(BABEL_JS_RULE)
             // run babel loader before the builtin SWC loader
-            .before(CHAIN_ID.RULE.JS);
+            .after(CHAIN_ID.RULE.JS);
 
           if (include) {
             for (const condition of castArray(include)) {


### PR DESCRIPTION
## Summary

Run babel loader before builtin SWC loader, and avoid transforming JS modules with SWC twice.

## Related Links

https://github.com/rspack-contrib/rspack-examples/issues/87
https://stackoverflow.com/questions/32234329/what-is-the-loader-order-for-webpack

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
