### PR TITLE
chore(config): remove exports field

### DIFF
--- a/e2e/cases/babel/decorator/tsconfig.json
+++ b/e2e/cases/babel/decorator/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cache/tsconfig.json
+++ b/e2e/cases/cache/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cli/basic/tsconfig.json
+++ b/e2e/cases/cli/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cli/build-watch/tsconfig.json
+++ b/e2e/cases/cli/build-watch/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cli/falsy-plugins/tsconfig.json
+++ b/e2e/cases/cli/falsy-plugins/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cli/reload-config/tsconfig.json
+++ b/e2e/cases/cli/reload-config/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/cli/reload-env/tsconfig.json
+++ b/e2e/cases/cli/reload-env/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/css/css-modules-dom/tsconfig.json
+++ b/e2e/cases/css/css-modules-dom/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/css/resolve-ts-paths/tsconfig.json
+++ b/e2e/cases/css/resolve-ts-paths/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/css/style-loader/tsconfig.json
+++ b/e2e/cases/css/style-loader/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/html/combined/tsconfig.json
+++ b/e2e/cases/html/combined/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/html/minify/tsconfig.json
+++ b/e2e/cases/html/minify/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/ignore-css/tsconfig.json
+++ b/e2e/cases/ignore-css/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/performance/resource-hints/tsconfig.json
+++ b/e2e/cases/performance/resource-hints/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/rem/basic/tsconfig.json
+++ b/e2e/cases/rem/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/server/hmr/tsconfig.json
+++ b/e2e/cases/server/hmr/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/solid/ts/tsconfig.json
+++ b/e2e/cases/solid/ts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "module": "ESNext",
     "jsx": "preserve",

--- a/e2e/cases/source-build/app/tsconfig.json
+++ b/e2e/cases/source-build/app/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "declaration": false,
     "jsx": "react-jsx",

--- a/e2e/cases/source-build/components/tsconfig.json
+++ b/e2e/cases/source-build/components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "composite": true,
     "declaration": true,

--- a/e2e/cases/source-build/utils/tsconfig.json
+++ b/e2e/cases/source-build/utils/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "composite": true,
     "declaration": true,

--- a/e2e/cases/source/alias-by-target/tsconfig.json
+++ b/e2e/cases/source/alias-by-target/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/source/custom-tsconfig/tsconfig.custom.json
+++ b/e2e/cases/source/custom-tsconfig/tsconfig.custom.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/source/custom-tsconfig/tsconfig.json
+++ b/e2e/cases/source/custom-tsconfig/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/source/global-vars/tsconfig.json
+++ b/e2e/cases/source/global-vars/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/source/jsconfig-paths/jsconfig.json
+++ b/e2e/cases/source/jsconfig-paths/jsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/source/tsconfig-paths/tsconfig.json
+++ b/e2e/cases/source/tsconfig-paths/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/svelte/ts/tsconfig.json
+++ b/e2e/cases/svelte/ts/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "module": "ESNext"
   },

--- a/e2e/cases/top-level-await/tsconfig.json
+++ b/e2e/cases/top-level-await/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/type-check/basic/tsconfig.json
+++ b/e2e/cases/type-check/basic/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/type-check/exclude-node-modules/tsconfig.json
+++ b/e2e/cases/type-check/exclude-node-modules/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/typescript/tsconfig.json
+++ b/e2e/cases/typescript/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/cases/wasm/tsconfig.json
+++ b/e2e/cases/wasm/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "./",

--- a/packages/compat/babel-preset/modern.config.ts
+++ b/packages/compat/babel-preset/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/compat/babel-preset/tests/tsconfig.json
+++ b/packages/compat/babel-preset/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/babel-preset/tsconfig.json
+++ b/packages/compat/babel-preset/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/compat/plugin-swc/modern.config.ts
+++ b/packages/compat/plugin-swc/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/compat/plugin-swc/tests/tsconfig.json
+++ b/packages/compat/plugin-swc/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/plugin-swc/tsconfig.json
+++ b/packages/compat/plugin-swc/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/compat/webpack/modern.config.ts
+++ b/packages/compat/webpack/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/compat/webpack/tests/tsconfig.json
+++ b/packages/compat/webpack/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/core/modern.config.ts
+++ b/packages/core/modern.config.ts
@@ -9,7 +9,7 @@ import {
   commonExternals,
   emitTypePkgJsonPlugin,
   esmBuildConfig,
-} from '@rsbuild/config/modern';
+} from '@rsbuild/config/modern.config.ts';
 
 const externals = [
   ...commonExternals,

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/create-rsbuild/modern.config.ts
+++ b/packages/create-rsbuild/modern.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, moduleTools } from '@modern-js/module-tools';
-import { esmBuildConfig } from '@rsbuild/config/modern';
+import { esmBuildConfig } from '@rsbuild/config/modern.config.ts';
 
 export default defineConfig({
   plugins: [moduleTools()],

--- a/packages/create-rsbuild/tsconfig.json
+++ b/packages/create-rsbuild/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./"

--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-assets-retry/tests/tsconfig.json
+++ b/packages/plugin-assets-retry/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-assets-retry/tsconfig.json
+++ b/packages/plugin-assets-retry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-babel/modern.config.ts
+++ b/packages/plugin-babel/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-basic-ssl/modern.config.ts
+++ b/packages/plugin-basic-ssl/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-basic-ssl/tsconfig.json
+++ b/packages/plugin-basic-ssl/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-check-syntax/modern.config.ts
+++ b/packages/plugin-check-syntax/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-check-syntax/tests/tsconfig.json
+++ b/packages/plugin-check-syntax/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-check-syntax/tsconfig.json
+++ b/packages/plugin-check-syntax/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-css-minimizer/modern.config.ts
+++ b/packages/plugin-css-minimizer/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-css-minimizer/tsconfig.json
+++ b/packages/plugin-css-minimizer/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-eslint/modern.config.ts
+++ b/packages/plugin-eslint/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-eslint/tests/tsconfig.json
+++ b/packages/plugin-eslint/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-eslint/tsconfig.json
+++ b/packages/plugin-eslint/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-image-compress/modern.config.ts
+++ b/packages/plugin-image-compress/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-image-compress/tests/tsconfig.json
+++ b/packages/plugin-image-compress/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-image-compress/tsconfig.json
+++ b/packages/plugin-image-compress/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-less/modern.config.ts
+++ b/packages/plugin-less/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-less/tests/tsconfig.json
+++ b/packages/plugin-less/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-less/tsconfig.json
+++ b/packages/plugin-less/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-lightningcss/modern.config.ts
+++ b/packages/plugin-lightningcss/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-lightningcss/tsconfig.json
+++ b/packages/plugin-lightningcss/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-mdx/modern.config.ts
+++ b/packages/plugin-mdx/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-mdx/tests/tsconfig.json
+++ b/packages/plugin-mdx/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-mdx/tsconfig.json
+++ b/packages/plugin-mdx/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-node-polyfill/modern.config.ts
+++ b/packages/plugin-node-polyfill/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-node-polyfill/tests/tsconfig.json
+++ b/packages/plugin-node-polyfill/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-node-polyfill/tsconfig.json
+++ b/packages/plugin-node-polyfill/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-preact/modern.config.ts
+++ b/packages/plugin-preact/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-preact/tsconfig.json
+++ b/packages/plugin-preact/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-pug/modern.config.ts
+++ b/packages/plugin-pug/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-pug/tsconfig.json
+++ b/packages/plugin-pug/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-react/modern.config.ts
+++ b/packages/plugin-react/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-rem/modern.config.ts
+++ b/packages/plugin-rem/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-rem/tests/tsconfig.json
+++ b/packages/plugin-rem/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-rem/tsconfig.json
+++ b/packages/plugin-rem/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-sass/modern.config.ts
+++ b/packages/plugin-sass/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-sass/tests/tsconfig.json
+++ b/packages/plugin-sass/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-solid/modern.config.ts
+++ b/packages/plugin-solid/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-solid/tests/tsconfig.json
+++ b/packages/plugin-solid/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-source-build/modern.config.ts
+++ b/packages/plugin-source-build/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-source-build/tests/tsconfig.json
+++ b/packages/plugin-source-build/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-source-build/tsconfig.json
+++ b/packages/plugin-source-build/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-styled-components/modern.config.ts
+++ b/packages/plugin-styled-components/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-styled-components/tsconfig.json
+++ b/packages/plugin-styled-components/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-stylus/modern.config.ts
+++ b/packages/plugin-stylus/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-stylus/tests/tsconfig.json
+++ b/packages/plugin-stylus/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-svelte/modern.config.ts
+++ b/packages/plugin-svelte/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-svelte/tests/tsconfig.json
+++ b/packages/plugin-svelte/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-svgr/modern.config.ts
+++ b/packages/plugin-svgr/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-toml/modern.config.ts
+++ b/packages/plugin-toml/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-toml/tsconfig.json
+++ b/packages/plugin-toml/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-type-check/modern.config.ts
+++ b/packages/plugin-type-check/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-type-check/tests/tsconfig.json
+++ b/packages/plugin-type-check/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-type-check/tsconfig.json
+++ b/packages/plugin-type-check/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-typed-css-modules/modern.config.ts
+++ b/packages/plugin-typed-css-modules/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-typed-css-modules/tests/tsconfig.json
+++ b/packages/plugin-typed-css-modules/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-typed-css-modules/tsconfig.json
+++ b/packages/plugin-typed-css-modules/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-umd/modern.config.ts
+++ b/packages/plugin-umd/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-umd/tsconfig.json
+++ b/packages/plugin-umd/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-vue-jsx/modern.config.ts
+++ b/packages/plugin-vue-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-vue-jsx/tests/tsconfig.json
+++ b/packages/plugin-vue-jsx/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue-jsx/tsconfig.json
+++ b/packages/plugin-vue-jsx/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-vue/modern.config.ts
+++ b/packages/plugin-vue/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-vue/tests/tsconfig.json
+++ b/packages/plugin-vue/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-vue2-jsx/modern.config.ts
+++ b/packages/plugin-vue2-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-vue2-jsx/tests/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue2-jsx/tsconfig.json
+++ b/packages/plugin-vue2-jsx/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-vue2/modern.config.ts
+++ b/packages/plugin-vue2/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/packages/plugin-vue2/tests/tsconfig.json
+++ b/packages/plugin-vue2/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/plugin-vue2/tsconfig.json
+++ b/packages/plugin-vue2/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/plugin-yaml/modern.config.ts
+++ b/packages/plugin-yaml/modern.config.ts
@@ -1,5 +1,5 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern';
+import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
 
 export default {
   plugins: [moduleTools()],

--- a/packages/plugin-yaml/tests/tsconfig.json
+++ b/packages/plugin-yaml/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"],

--- a/packages/plugin-yaml/tsconfig.json
+++ b/packages/plugin-yaml/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/packages/shared/modern.config.ts
+++ b/packages/shared/modern.config.ts
@@ -4,7 +4,7 @@ import {
   commonExternals,
   emitTypePkgJsonPlugin,
   esmBuildConfig,
-} from '@rsbuild/config/modern';
+} from '@rsbuild/config/modern.config.ts';
 
 export default defineConfig({
   plugins: [moduleTools(), emitTypePkgJsonPlugin],

--- a/packages/shared/tests/tsconfig.json
+++ b/packages/shared/tests/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "baseUrl": "./",
     "types": ["vitest/globals"]

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "declarationDir": "./dist-types",

--- a/scripts/check-changeset/tsconfig.json
+++ b/scripts/check-changeset/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./"

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -2,10 +2,6 @@
   "name": "@rsbuild/config",
   "version": "0.7.2",
   "private": true,
-  "exports": {
-    "./ts": "./tsconfig.json",
-    "./modern": "./modern.config.ts"
-  },
   "devDependencies": {
     "@types/node": "18.x",
     "typescript": "^5.4.2"

--- a/scripts/test-helper/modern.config.ts
+++ b/scripts/test-helper/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
 export default configForDualPackage;

--- a/scripts/test-helper/tsconfig.json
+++ b/scripts/test-helper/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/ts",
+  "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

Remove exports field of the internal `@rsbuild/config` package, I found some tools does not support it, such as `tsc-alias`.

## Related Links

https://github.com/justkey007/tsc-alias/issues/127

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
