### PR TITLE
docs: add guide for upgrading Rsbuild

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -98,6 +98,7 @@ svgr
 swcrc
 systemjs
 tailwindcss
+taze
 templating
 transpiling
 treeshaking

--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -13,5 +13,6 @@
   "typescript",
   "tailwindcss",
   "unocss",
-  "static-deploy"
+  "static-deploy",
+  "upgrade-rsbuild"
 ]

--- a/website/docs/en/guide/basic/upgrade-rsbuild.mdx
+++ b/website/docs/en/guide/basic/upgrade-rsbuild.mdx
@@ -1,0 +1,59 @@
+# Upgrade Rsbuild
+
+This section explains how to upgrade the project's Rsbuild dependencies to the latest version.
+
+> Please see [Releases](/community/releases/index) to understand the Rsbuild release strategy.
+
+## Using Taze
+
+We recommend using [Taze](https://github.com/antfu-collective/taze) to upgrade the Rsbuild version. Taze is a CLI tool for updating npm dependencies.
+
+### Usage
+
+Run the following command to upgrade all dependencies that include `rsbuild` in their names:
+
+```bash
+npx taze --include /rsbuild/ -w
+```
+
+The result will look similar to:
+
+```bash
+rsbuild - 3 patch
+
+  @rsbuild/core               dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/plugin-react       dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/plugin-type-check  dev  ~2mo  ^0.6.0  →  ^0.6.15
+
+ℹ changes written to package.json, run npm i to install updates.
+```
+
+You can also adjust the `include` pattern to match specific packages, for example, to upgrade only packages under the `@rsbuild` scope:
+
+```bash
+npx taze --include /@rsbuild/ -w
+```
+
+### Options
+
+Here are some examples of using taze options.
+
+- In a monorepo, you can add the `-r` option to upgrade recursively:
+
+```bash
+npx taze --include /rsbuild/ -w -r
+```
+
+- Add `-l` to upgrade locked versions:
+
+```bash
+npx taze --include /rsbuild/ -w -l
+```
+
+- To upgrade to a major version:
+
+```bash
+npx taze major --include /rsbuild/ -w
+```
+
+> For more options, please refer to the [taze documentation](https://github.com/antfu-collective/taze).

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -13,5 +13,6 @@
   "typescript",
   "tailwindcss",
   "unocss",
-  "static-deploy"
+  "static-deploy",
+  "upgrade-rsbuild"
 ]

--- a/website/docs/zh/guide/basic/upgrade-rsbuild.mdx
+++ b/website/docs/zh/guide/basic/upgrade-rsbuild.mdx
@@ -1,0 +1,59 @@
+# 升级 Rsbuild
+
+本章节介绍如何升级项目中的 Rsbuild 依赖到最新版本。
+
+> 请参考 [版本发布](/community/releases/index) 来了解 Rsbuild 的版本发布策略。
+
+## 使用 Taze
+
+我们推荐使用 [Taze](https://github.com/antfu-collective/taze) 来升级 Rsbuild 的版本，这是一个用于升级 npm 依赖版本的 CLI 工具。
+
+### 用法
+
+运行以下命令来升级所有名称中包含 `rsbuild` 的依赖：
+
+```bash
+npx taze --include /rsbuild/ -w
+```
+
+运行结果类似于：
+
+```bash
+rsbuild - 3 patch
+
+  @rsbuild/core               dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/plugin-react       dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/plugin-type-check  dev  ~2mo  ^0.6.0  →  ^0.6.15
+
+ℹ changes written to package.json, run npm i to install updates.
+```
+
+你也可以调整 `include` 来匹配不同的包，比如仅升级 `@rsbuild` scope 下的包：
+
+```bash
+npx taze --include /@rsbuild/ -w
+```
+
+### 选项
+
+下面是一些使用 taze 选项的示例。
+
+- 在 monorepo 中，你可以添加 `-r` 选项来递归升级：
+
+```bash
+npx taze --include /rsbuild/ -w -r
+```
+
+- 添加 `-l` 来升级被锁定的版本：
+
+```bash
+npx taze --include /rsbuild/ -w -l
+```
+
+- 升级 major 版本：
+
+```bash
+npx taze major --include /rsbuild/ -w
+```
+
+> 更多选项请参考 [taze 文档](https://github.com/antfu-collective/taze)。


### PR DESCRIPTION
## Summary

Add guide for upgrading Rsbuild, using taze.

## Related Links

https://github.com/antfu-collective/taze?tab=readme-ov-file

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
