### PR TITLE
feat: allow to access compilation in modifyHTMLTags hook

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -63,8 +63,8 @@ async function applyDefaultPlugins(
     // cleanOutput plugin should before the html plugin
     pluginCleanOutput(),
     pluginAsset(),
-    pluginHtml(async (tags) => {
-      const result = await context.hooks.modifyHTMLTags.call(tags);
+    pluginHtml(async (...args) => {
+      const result = await context.hooks.modifyHTMLTags.call(...args);
       return result[0];
     }),
     pluginWasm(),

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -268,10 +268,13 @@ export class HtmlBasicPlugin {
 
           addFavicon(headTags, favicon);
 
-          const result = await this.modifyTagsFn({
-            headTags: headTags.map(formatBasicTag),
-            bodyTags: bodyTags.map(formatBasicTag),
-          });
+          const result = await this.modifyTagsFn(
+            {
+              headTags: headTags.map(formatBasicTag),
+              bodyTags: bodyTags.map(formatBasicTag),
+            },
+            { compilation },
+          );
           Object.assign(data, {
             headTags: result.headTags.map(fromBasicTag),
             bodyTags: result.bodyTags.map(fromBasicTag),

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -58,7 +58,10 @@ type HTMLTags = {
   bodyTags: HtmlBasicTag[];
 };
 
-export type ModifyHTMLTagsFn = (tags: HTMLTags) => MaybePromise<HTMLTags>;
+export type ModifyHTMLTagsFn = (
+  tags: HTMLTags,
+  context: { compilation: Rspack.Compilation },
+) => MaybePromise<HTMLTags>;
 
 export type ModifyRsbuildConfigUtils = {
   /** Merge multiple Rsbuild config objects into one. */

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -311,8 +311,12 @@ type HTMLTags = {
   bodyTags: HtmlBasicTag[];
 };
 
+type Context = {
+  compilation: import('@rspack/core').Compilation;
+};
+
 function ModifyHTMLTags(
-  callback: (tags: HTMLTags) => MaybePromise<HTMLTags>,
+  callback: (tags: HTMLTags, context: Context) => MaybePromise<HTMLTags>,
 ): void;
 ```
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -313,8 +313,12 @@ type HTMLTags = {
   bodyTags: HtmlBasicTag[];
 };
 
+type Context = {
+  compilation: import('@rspack/core').Compilation;
+};
+
 function ModifyHTMLTags(
-  callback: (tags: HTMLTags) => MaybePromise<HTMLTags>,
+  callback: (tags: HTMLTags, context: Context) => MaybePromise<HTMLTags>,
 ): void;
 ```
 


### PR DESCRIPTION
## Summary

Allow to access compilation in modifyHTMLTags hook.

This can be used to get assets and calc SRI hash.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
