### PR TITLE
feat: support override library type config when target is node

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -1033,7 +1033,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "chunkFilename": "[name].js",
     "filename": "[name].js",
     "hashFunction": "xxhash64",
-    "libraryTarget": "commonjs2",
+    "library": {
+      "type": "commonjs2",
+    },
     "path": "<ROOT>/packages/compat/webpack/tests/dist/server",
     "pathinfo": false,
     "publicPath": "/",

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -94,7 +94,10 @@ export const pluginOutput = (): RsbuildPlugin => ({
             .path(posix.join(api.context.distPath, serverPath))
             .filename('[name].js')
             .chunkFilename('[name].js')
-            .libraryTarget('commonjs2');
+            .library({
+              ...(chain.output.get('library') || {}),
+              type: 'commonjs2',
+            });
         }
 
         if (isServiceWorker) {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1218,7 +1218,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "chunkFilename": "[name].js",
     "filename": "[name].js",
     "hashFunction": "xxhash64",
-    "libraryTarget": "commonjs2",
+    "library": {
+      "type": "commonjs2",
+    },
     "path": "<ROOT>/packages/core/tests/dist/server",
     "pathinfo": false,
     "publicPath": "/",

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -6,7 +6,9 @@ exports[`plugin-output > should allow to custom server directory with distPath.s
     "chunkFilename": "[name].js",
     "filename": "[name].js",
     "hashFunction": "xxhash64",
-    "libraryTarget": "commonjs2",
+    "library": {
+      "type": "commonjs2",
+    },
     "path": "<ROOT>/packages/core/tests/dist/server",
     "pathinfo": false,
     "publicPath": "/",


### PR DESCRIPTION
## Summary

Use [output.library.type](https://www.rspack.dev/config/output#outputlibrarytype)  instead of  [output.libraryTarget](https://www.rspack.dev/config/output#outputlibrarytarget) , both `output.library.type` and `output.libraryTarget` can configure how the library is exposed, but `output.libraryTarget` is not recommended, and `output.libraryTarget` configuration priority is higher than `output.library.type`. 

If rsbuild uses `output.libraryTarget`, it means that the `output.library.type` set by the user will not take effect.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
