### PR TITLE
chore: separate nonce plugin from html plugin

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -52,6 +52,7 @@ async function applyDefaultPlugins(
   const { pluginRspackProfile } = await import('./plugins/rspackProfile');
   const { pluginLazyCompilation } = await import('./plugins/lazyCompilation');
   const { pluginSri } = await import('./plugins/sri');
+  const { pluginNonce } = await import('./plugins/nonce');
 
   pluginManager.addPlugins([
     pluginBasic(),
@@ -90,6 +91,7 @@ async function applyDefaultPlugins(
     pluginRspackProfile(),
     pluginLazyCompilation(),
     pluginSri(),
+    pluginNonce(),
   ]);
 }
 

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,10 +1,8 @@
 import path, { isAbsolute } from 'node:path';
 import {
   type MinifyJSOptions,
-  applyToCompiler,
   castArray,
   color,
-  createVirtualModule,
   deepmerge,
   fse,
   getDistPath,
@@ -417,40 +415,12 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
       },
     );
 
-    api.onAfterCreateCompiler(({ compiler }) => {
-      const { nonce } = api.getNormalizedConfig().security;
-
-      if (!nonce) {
-        return;
-      }
-
-      applyToCompiler(compiler, (compiler) => {
-        const { plugins } = compiler.options;
-        const hasHTML = plugins.some(
-          (plugin) => plugin && plugin.constructor.name === 'HtmlBasicPlugin',
-        );
-        if (!hasHTML) {
-          return;
-        }
-
-        // apply __webpack_nonce__
-        // https://webpack.js.org/guides/csp/
-        const injectCode = createVirtualModule(
-          `__webpack_nonce__ = "${nonce}";`,
-        );
-        new compiler.webpack.EntryPlugin(compiler.context, injectCode, {
-          name: undefined,
-        }).apply(compiler);
-      });
-    });
-
     api.modifyHTMLTags({
       // ensure `crossorigin` and `nonce` can be applied to all tags
       order: 'post',
       handler: ({ headTags, bodyTags }) => {
         const config = api.getNormalizedConfig();
         const { crossorigin } = config.html;
-        const { nonce } = config.security;
         const allTags = [...headTags, ...bodyTags];
 
         if (crossorigin) {
@@ -463,15 +433,6 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
               (tag.tag === 'link' && tag.attrs?.rel === 'stylesheet')
             ) {
               tag.attrs.crossorigin ??= formattedCrossorigin;
-            }
-          }
-        }
-
-        if (nonce) {
-          for (const tag of allTags) {
-            if (tag.tag === 'script' || tag.tag === 'style') {
-              tag.attrs ??= {};
-              tag.attrs.nonce = nonce;
             }
           }
         }

--- a/packages/core/src/plugins/nonce.ts
+++ b/packages/core/src/plugins/nonce.ts
@@ -1,0 +1,56 @@
+import { applyToCompiler, createVirtualModule } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '../types';
+
+export const pluginNonce = (): RsbuildPlugin => ({
+  name: 'rsbuild:nonce',
+
+  setup(api) {
+    api.onAfterCreateCompiler(({ compiler }) => {
+      const { nonce } = api.getNormalizedConfig().security;
+
+      if (!nonce) {
+        return;
+      }
+
+      applyToCompiler(compiler, (compiler) => {
+        const { plugins } = compiler.options;
+        const hasHTML = plugins.some(
+          (plugin) => plugin && plugin.constructor.name === 'HtmlBasicPlugin',
+        );
+        if (!hasHTML) {
+          return;
+        }
+
+        // apply __webpack_nonce__
+        // https://webpack.js.org/guides/csp/
+        const injectCode = createVirtualModule(
+          `__webpack_nonce__ = "${nonce}";`,
+        );
+        new compiler.webpack.EntryPlugin(compiler.context, injectCode, {
+          name: undefined,
+        }).apply(compiler);
+      });
+    });
+
+    api.modifyHTMLTags({
+      // ensure `nonce` can be applied to all tags
+      order: 'post',
+      handler: ({ headTags, bodyTags }) => {
+        const config = api.getNormalizedConfig();
+        const { nonce } = config.security;
+        const allTags = [...headTags, ...bodyTags];
+
+        if (nonce) {
+          for (const tag of allTags) {
+            if (tag.tag === 'script' || tag.tag === 'style') {
+              tag.attrs ??= {};
+              tag.attrs.nonce = nonce;
+            }
+          }
+        }
+
+        return { headTags, bodyTags };
+      },
+    });
+  },
+});

--- a/packages/core/tests/__snapshots__/inspect.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inspect.test.ts.snap
@@ -34,5 +34,6 @@ exports[`inspectConfig > should print plugin names when inspect config 1`] = `
   "rsbuild:rspack-profile",
   "rsbuild:lazy-compilation",
   "rsbuild:sri",
+  "rsbuild:nonce",
 ]
 `;


### PR DESCRIPTION
## Summary

Separate nonce plugin from html plugin to make the html plugin easier to maintain.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
