### PR TITLE
docs: correct the type of html.tags config

### DIFF
--- a/packages/plugin-image-compress/src/types/index.ts
+++ b/packages/plugin-image-compress/src/types/index.ts
@@ -6,7 +6,7 @@ import type {
 } from '@napi-rs/image';
 import type { Config as SvgoConfig } from 'svgo';
 
-export type ArrayOrNot<T> = T | T[];
+export type OneOrMany<T> = T | T[];
 
 export interface WebpTransformOptions {
   quality?: number;
@@ -22,9 +22,9 @@ export interface CodecBaseOptions {
 
 export interface BaseCompressOptions<T extends Codecs> {
   use: T;
-  test?: ArrayOrNot<RegExp>;
-  include?: ArrayOrNot<RegExp>;
-  exclude?: ArrayOrNot<RegExp>;
+  test?: OneOrMany<RegExp>;
+  include?: OneOrMany<RegExp>;
+  exclude?: OneOrMany<RegExp>;
 }
 
 export type FinalOptionCollection = {

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { WatchOptions } from '../../../compiled/chokidar/index.js';
 import type { Rspack } from '../rspack';
-import type { ArrayOrNot } from '../utils';
+import type { OneOrMany } from '../utils';
 
 export type ProgressBarConfig = {
   id?: string;
@@ -56,7 +56,7 @@ export interface DevConfig {
    * Used to execute a callback function before opening the `startUrl`.
    * This config needs to be used together with `dev.startUrl`.
    */
-  beforeStartUrl?: ArrayOrNot<() => Promise<void> | void>;
+  beforeStartUrl?: OneOrMany<() => Promise<void> | void>;
   /**
    * Set the URL prefix of static assets during development,
    * similar to the [output.publicPath](https://rspack.dev/config/output#outputpublicpath) config of webpack.

--- a/packages/shared/src/types/config/html.ts
+++ b/packages/shared/src/types/config/html.ts
@@ -1,7 +1,7 @@
 import type {
-  ArrayOrNot,
   ChainedConfigCombineUtils,
   ChainedConfigWithUtils,
+  OneOrMany,
 } from '../utils';
 
 export type CrossOrigin = 'anonymous' | 'use-credentials';
@@ -71,7 +71,7 @@ export interface HtmlConfig {
   /**
    * Inject custom html tags into the output html files.
    */
-  tags?: ArrayOrNot<HtmlTagDescriptor>;
+  tags?: OneOrMany<HtmlTagDescriptor>;
   /**
    * Set the favicon icon for all pages.
    */

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -19,9 +19,9 @@ import type {
   WebpackConfig,
 } from '../thirdParty';
 import type {
-  ArrayOrNot,
   ChainedConfig,
   ChainedConfigWithUtils,
+  OneOrMany,
   WebpackChain,
 } from '../utils';
 
@@ -31,7 +31,7 @@ export type ToolsSwcConfig = ChainedConfig<SwcLoaderOptions>;
 
 export type ToolsAutoprefixerConfig = ChainedConfig<AutoprefixerOptions>;
 
-export type ToolsBundlerChainConfig = ArrayOrNot<
+export type ToolsBundlerChainConfig = OneOrMany<
   (chain: BundlerChain, utils: ModifyBundlerChainUtils) => void
 >;
 
@@ -75,7 +75,7 @@ export type ToolsWebpackConfig = ChainedConfigWithUtils<
   ModifyWebpackConfigUtils
 >;
 
-export type ToolsWebpackChainConfig = ArrayOrNot<
+export type ToolsWebpackChainConfig = OneOrMany<
   (chain: WebpackChain, utils: ModifyWebpackChainUtils) => void
 >;
 

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -4,21 +4,21 @@ export type { WebpackChain };
 
 export type Falsy = false | null | undefined;
 
-export type ArrayOrNot<T> = T | T[];
+export type OneOrMany<T> = T | T[];
 
 export type MaybePromise<T> = T | Promise<T>;
 
 export type NodeEnv = 'development' | 'production' | 'test';
 
-export type ChainedConfig<Config> = ArrayOrNot<
+export type ChainedConfig<Config> = OneOrMany<
   Config | ((config: Config) => Config | void)
 >;
 
-export type ChainedConfigWithUtils<Config, Utils> = ArrayOrNot<
+export type ChainedConfigWithUtils<Config, Utils> = OneOrMany<
   Config | ((config: Config, utils: Utils) => Config | void)
 >;
 
-export type ChainedConfigCombineUtils<Config, Utils> = ArrayOrNot<
+export type ChainedConfigCombineUtils<Config, Utils> = OneOrMany<
   Config | ((params: { value: Config } & Utils) => Config | void)
 >;
 
@@ -26,7 +26,7 @@ export type DeepReadonly<T> = keyof T extends never
   ? T
   : { readonly [k in keyof T]: DeepReadonly<T[k]> };
 
-export type FileFilterUtil = (items: ArrayOrNot<string | RegExp>) => void;
+export type FileFilterUtil = (items: OneOrMany<string | RegExp>) => void;
 
 export type CompilerTapFn<
   CallBack extends (...args: any[]) => void = () => void,

--- a/website/docs/en/config/html/meta.mdx
+++ b/website/docs/en/config/html/meta.mdx
@@ -20,7 +20,7 @@ Configure the `<meta>` tag of the HTML.
 If the HTML template used in the current project already contains the charset or viewport meta tags, then the tags in the HTML template take precedence.
 :::
 
-### String Type
+## String Type
 
 - **Type:**
 
@@ -50,7 +50,7 @@ The generated `meta` tag in HTML is:
 <meta name="description" content="a description of the page" />
 ```
 
-### Object Type
+## Object Type
 
 - **Type:**
 
@@ -89,7 +89,7 @@ The `meta` tag in HTML is:
 <meta charset="UTF-8" />
 ```
 
-### Function Usage
+## Function Usage
 
 - **Type:**
 
@@ -145,7 +145,7 @@ export default {
 };
 ```
 
-### Remove Default Value
+## Remove Default Value
 
 Setting the `value` of the `meta` object to `false` and the meta tag will not be generated.
 

--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -1,6 +1,11 @@
 # html.tags
 
-- **Type:** `ArrayOrNot<HtmlTag | HtmlTagHandler>`
+- **Type:**
+
+```ts
+type TagsConfig = HtmlTag | HtmlTagHandler | Array<HtmlTag | HtmlTagHandler>;
+```
+
 - **Default:** `undefined`
 
 Modifies the tags that are injected into the HTML page.

--- a/website/docs/en/config/html/template.mdx
+++ b/website/docs/en/config/html/template.mdx
@@ -17,7 +17,7 @@ If `template` is not specified, the built-in HTML template of Rsbuild will be us
 </html>
 ```
 
-### String Usage
+## String Usage
 
 For example, to replace the default HTML template with the `static/index.html` file, you can add the following configuration:
 
@@ -29,7 +29,7 @@ export default {
 };
 ```
 
-### Function Usage
+## Function Usage
 
 - **Type:**
 

--- a/website/docs/en/config/html/title.mdx
+++ b/website/docs/en/config/html/title.mdx
@@ -9,7 +9,7 @@ Set the title tag of the HTML page.
 If the HTML template used in the current project already includes the `<title>` tag, the `html.title` will not take effect.
 :::
 
-### String Usage
+## String Usage
 
 `html.title` can be directly set as a string:
 
@@ -27,7 +27,7 @@ The `title` tag generated in HTML will be:
 <title>Example</title>
 ```
 
-### Function Usage
+## Function Usage
 
 - **Type:**
 

--- a/website/docs/zh/config/html/meta.mdx
+++ b/website/docs/zh/config/html/meta.mdx
@@ -20,7 +20,7 @@ const defaultMeta = {
 如果当前项目使用的 HTML 模板中已经包含了 `charset` 或 `viewport` meta 标签，那么 HTML 模板中的标签优先级更高。
 :::
 
-### String 类型
+## String 类型
 
 - **类型：**
 
@@ -50,7 +50,7 @@ export default {
 <meta name="description" content="a description of the page" />
 ```
 
-### Object 类型
+## Object 类型
 
 - **类型：**
 
@@ -87,7 +87,7 @@ export default {
 <meta charset="UTF-8" />
 ```
 
-### 函数用法
+## 函数用法
 
 - **类型：**
 
@@ -143,7 +143,7 @@ export default {
 };
 ```
 
-### 移除默认值
+## 移除默认值
 
 将 `meta` 对象的 `value` 设置为 `false`，则表示不生成对应的 meta 标签。
 

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -1,6 +1,11 @@
 # html.tags
 
-- **类型：** `ArrayOrNot<HtmlTag | HtmlTagHandler>`
+- **类型：**
+
+```ts
+type TagsConfig = HtmlTag | HtmlTagHandler | Array<HtmlTag | HtmlTagHandler>;
+```
+
 - **默认值：** `undefined`
 
 添加和修改最终注入到 HTML 页面的标签。


### PR DESCRIPTION
## Summary

- correct the type of html.tags config
- rename `ArrayOrNot` type to `OneOrMany`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
