### PR TITLE
perf(plugin-lightningcss): only validate in setup stage

### DIFF
--- a/packages/plugin-lightningcss/src/index.ts
+++ b/packages/plugin-lightningcss/src/index.ts
@@ -1,4 +1,4 @@
-export { pluginLightningcss } from './plugin';
+export { pluginLightningcss, PLUGIN_LIGHTNINGCSS_NAME } from './plugin';
 
 import * as lightningcss from 'lightningcss';
 export { lightningcss };

--- a/packages/plugin-lightningcss/src/loader.ts
+++ b/packages/plugin-lightningcss/src/loader.ts
@@ -1,47 +1,33 @@
-import { Buffer } from 'node:buffer';
 /**
  * modified from https://github.com/fz6m/lightningcss-loader
  * MIT License https://github.com/fz6m/lightningcss-loader/blob/main/LICENSE
  * Author @fz6m
  */
+import { Buffer } from 'node:buffer';
 import type { Rspack } from '@rsbuild/core';
-import { transform as _transform } from 'lightningcss';
+import lightningcss from 'lightningcss';
 import type { LightningCSSLoaderOptions } from './types';
-
-const LOADER_NAME = 'lightningcss-loader';
 
 async function LightningCSSLoader(
   this: Rspack.LoaderContext<LightningCSSLoaderOptions>,
   source: string,
-  prevMap?: Record<string, any>,
+  prevSourceMap?: Record<string, unknown>,
 ): Promise<void> {
   const done = this.async();
   const options = this.getOptions();
   const { implementation, targets, ...opts } = options;
-
-  if (
-    implementation &&
-    typeof (implementation as any).transform !== 'function'
-  ) {
-    done(
-      new TypeError(
-        `[${LOADER_NAME}]: options.implementation.transform must be an 'lightningcss' transform function. Received ${typeof (implementation as any).transform}`,
-      ),
-    );
-    return;
-  }
-
-  const transform: typeof _transform =
-    (implementation as any)?.transform ?? _transform;
+  const transformFn = implementation?.transform ?? lightningcss.transform;
 
   try {
-    const { code, map } = transform({
+    const { code, map } = transformFn({
       filename: this.resourcePath,
       code: Buffer.from(source),
       sourceMap: this.sourceMap,
       targets,
       inputSourceMap:
-        this.sourceMap && prevMap ? JSON.stringify(prevMap) : undefined,
+        this.sourceMap && prevSourceMap
+          ? JSON.stringify(prevSourceMap)
+          : undefined,
       ...opts,
     });
     const codeAsString = code.toString();

--- a/packages/plugin-lightningcss/src/loader.ts
+++ b/packages/plugin-lightningcss/src/loader.ts
@@ -5,7 +5,7 @@
  */
 import { Buffer } from 'node:buffer';
 import type { Rspack } from '@rsbuild/core';
-import lightningcss from 'lightningcss';
+import * as lightningcss from 'lightningcss';
 import type { LightningCSSLoaderOptions } from './types';
 
 async function LightningCSSLoader(

--- a/packages/plugin-lightningcss/src/minimizer.ts
+++ b/packages/plugin-lightningcss/src/minimizer.ts
@@ -5,7 +5,7 @@
  */
 import { Buffer } from 'node:buffer';
 import type { Rspack } from '@rsbuild/core';
-import lightningcss from 'lightningcss';
+import * as lightningcss from 'lightningcss';
 import type { LightningCSSMinifyPluginOptions, Lightningcss } from './types';
 
 const PLUGIN_NAME = 'lightningcss-minify-plugin';

--- a/packages/plugin-lightningcss/src/minimizer.ts
+++ b/packages/plugin-lightningcss/src/minimizer.ts
@@ -1,12 +1,12 @@
-import { Buffer } from 'node:buffer';
-import type { Rspack } from '@rsbuild/core';
 /**
  * modified from https://github.com/fz6m/lightningcss-loader
  * MIT License https://github.com/fz6m/lightningcss-loader/blob/main/LICENSE
  * Author @fz6m
  */
-import { transform as _transform } from 'lightningcss';
-import type { LightningCSSMinifyPluginOptions } from './types';
+import { Buffer } from 'node:buffer';
+import type { Rspack } from '@rsbuild/core';
+import lightningcss from 'lightningcss';
+import type { LightningCSSMinifyPluginOptions, Lightningcss } from './types';
 
 const PLUGIN_NAME = 'lightningcss-minify-plugin';
 
@@ -15,21 +15,11 @@ const CSS_REGEX = /\.css$/;
 export class LightningCSSMinifyPlugin {
   private readonly options: LightningCSSMinifyPluginOptions;
 
-  private readonly transform: typeof _transform;
+  private readonly transform: Lightningcss['transform'];
 
   constructor(opts: LightningCSSMinifyPluginOptions = {}) {
     const { implementation } = opts;
-
-    if (
-      implementation &&
-      typeof (implementation as any).transform !== 'function'
-    ) {
-      throw new TypeError(
-        `[${PLUGIN_NAME}]: implementation.transform must be an 'lightningcss' transform function. Received ${typeof (implementation as any).transform}`,
-      );
-    }
-
-    this.transform = (implementation as any)?.transform ?? _transform;
+    this.transform = implementation?.transform ?? lightningcss.transform;
     this.options = opts;
   }
 
@@ -104,7 +94,7 @@ export class LightningCSSMinifyPlugin {
                 asset.name,
                 JSON.parse(result.map!.toString()),
                 sourceAsString,
-                map as any,
+                map,
                 true,
               )
             : new RawSource(codeString),

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -12,14 +12,15 @@ import {
   mergeChainedOptions,
 } from '@rsbuild/shared';
 import browserslist from '@rsbuild/shared/browserslist';
-import { browserslistToTargets as _browserslistToTargets } from 'lightningcss';
-import type * as LightningCSS from 'lightningcss';
+import lightningcss from 'lightningcss';
+import type { Targets } from 'lightningcss';
 import type {
   LightningCSSLoaderOptions,
+  Lightningcss,
   PluginLightningcssOptions,
 } from './types';
 
-const PLUGIN_NAME = 'rsbuild:lightningcss';
+export const PLUGIN_LIGHTNINGCSS_NAME = 'rsbuild:lightningcss';
 
 const getLightningCSSTargets = async ({
   context,
@@ -30,7 +31,7 @@ const getLightningCSSTargets = async ({
   context: RsbuildContext;
   config: NormalizedConfig;
   target: RsbuildTarget;
-  options: PluginLightningcssOptions | undefined;
+  options: PluginLightningcssOptions;
 }) => {
   const browserslistUserConfig = await getBrowserslistWithDefault(
     context.rootPath,
@@ -38,20 +39,13 @@ const getLightningCSSTargets = async ({
     target,
   );
 
-  const { implementation } = (options ?? {}) as any;
-  if (
-    implementation &&
-    typeof implementation.browserslistToTargets !== 'function'
-  ) {
-    throw new TypeError(
-      `[${PLUGIN_NAME}]: options.implementation.browserslistToTargets must be an 'lightningcss' browserslistToTargets function. Received ${typeof implementation.browserslistToTargets}`,
-    );
-  }
+  const implementation =
+    (options.implementation as Lightningcss) ?? lightningcss;
 
-  const browserslistToTargets: typeof _browserslistToTargets =
-    implementation?.browserslistToTargets ?? _browserslistToTargets;
+  const targets = implementation.browserslistToTargets(
+    browserslist(browserslistUserConfig),
+  );
 
-  const targets = browserslistToTargets(browserslist(browserslistUserConfig));
   return targets;
 };
 
@@ -63,7 +57,7 @@ const applyLightningCSSLoader = ({
 }: {
   chain: BundlerChain;
   CHAIN_ID: ChainIdentifier;
-  targets: LightningCSS.Targets;
+  targets: Targets;
   options: PluginLightningcssOptions | undefined;
 }) => {
   if (!chain.module.rules.has(CHAIN_ID.RULE.CSS)) {
@@ -107,7 +101,7 @@ const applyLightningCSSMinifyPlugin = async ({
 }: {
   chain: BundlerChain;
   CHAIN_ID: ChainIdentifier;
-  targets: LightningCSS.Targets;
+  targets: Targets;
   options: PluginLightningcssOptions | undefined;
 }) => {
   const defaultOptions = {
@@ -135,13 +129,43 @@ const applyLightningCSSMinifyPlugin = async ({
     .end();
 };
 
+const validateImplementation = (implementation: unknown) => {
+  if (!implementation) {
+    return;
+  }
+
+  const lightningcss = implementation as Lightningcss;
+
+  if (typeof implementation !== 'object') {
+    throw new TypeError(
+      `[${PLUGIN_LIGHTNINGCSS_NAME}]: implementation must be an 'lightningcss' object. Received ${typeof lightningcss}`,
+    );
+  }
+
+  if (typeof lightningcss.transform !== 'function') {
+    throw new TypeError(
+      `[${PLUGIN_LIGHTNINGCSS_NAME}]: implementation.transform must be an 'lightningcss' transform function. Received ${typeof lightningcss.transform}`,
+    );
+  }
+
+  if (typeof lightningcss.browserslistToTargets !== 'function') {
+    throw new TypeError(
+      `[${PLUGIN_LIGHTNINGCSS_NAME}]: options.implementation.browserslistToTargets must be an 'lightningcss' browserslistToTargets function. Received ${typeof lightningcss.browserslistToTargets}`,
+    );
+  }
+};
+
 export const pluginLightningcss = (
-  options?: PluginLightningcssOptions,
+  options: PluginLightningcssOptions = {},
 ): RsbuildPlugin => ({
-  name: PLUGIN_NAME,
+  name: PLUGIN_LIGHTNINGCSS_NAME,
 
   setup(api) {
-    let targets: LightningCSS.Targets;
+    let targets: Targets;
+
+    if (options.implementation) {
+      validateImplementation(options.implementation);
+    }
 
     api.modifyBundlerChain({
       // ensure lightningcss-loader can be applied to sass/less/stylus rules

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -12,7 +12,7 @@ import {
   mergeChainedOptions,
 } from '@rsbuild/shared';
 import browserslist from '@rsbuild/shared/browserslist';
-import lightningcss from 'lightningcss';
+import * as lightningcss from 'lightningcss';
 import type { Targets } from 'lightningcss';
 import type {
   LightningCSSLoaderOptions,

--- a/packages/plugin-lightningcss/src/types.ts
+++ b/packages/plugin-lightningcss/src/types.ts
@@ -1,21 +1,22 @@
+import type lightningcss from 'lightningcss';
 import type { CustomAtRules, TransformOptions } from 'lightningcss';
+
+export type Lightningcss = typeof lightningcss;
 
 export type LightningCSSTransformOptions = Omit<
   TransformOptions<CustomAtRules>,
   'filename' | 'code' | 'inputSourceMap'
 >;
 
-type Implementation = unknown; // loose type of `typeof import('lightningcss')`
-
 export type LightningCSSLoaderOptions = LightningCSSTransformOptions & {
-  implementation?: Implementation;
+  implementation?: Lightningcss;
 };
 
 export type LightningCSSMinifyPluginOptions = Omit<
   LightningCSSTransformOptions,
   'minify'
 > & {
-  implementation?: Implementation;
+  implementation?: Lightningcss;
 };
 
 export type PluginLightningcssOptions = {
@@ -40,6 +41,7 @@ export type PluginLightningcssOptions = {
    * @example
    * import { pluginLightningcss } from '@rsbuild/plugin-lightningcss';
    * import lightningcss from 'lightningcss';
+   *
    * pluginLightningcss({
    *    implementation: lightningcss,
    *    minify: {
@@ -47,5 +49,5 @@ export type PluginLightningcssOptions = {
    *    }
    * })
    */
-  implementation?: Implementation;
+  implementation?: unknown; // loose type of `typeof import('lightningcss')`
 };

--- a/packages/plugin-lightningcss/src/types.ts
+++ b/packages/plugin-lightningcss/src/types.ts
@@ -40,7 +40,7 @@ export type PluginLightningcssOptions = {
    * lightningcss instance
    * @example
    * import { pluginLightningcss } from '@rsbuild/plugin-lightningcss';
-   * import lightningcss from 'lightningcss';
+   * import * as lightningcss from 'lightningcss';
    *
    * pluginLightningcss({
    *    implementation: lightningcss,

--- a/website/docs/en/config/security/nonce.mdx
+++ b/website/docs/en/config/security/nonce.mdx
@@ -8,7 +8,7 @@ type Nonce = string;
 
 - **Default:** `undefined`
 
-Add a random attribute value --- nonce, to the scripts resources introduced for HTML. This allows the browser to determine whether the script can be executed when it parses inline scripts with matching nonce values.
+Adding a `nonce` attribute to the scripts resources introduced for HTML. This allows the browser to determine whether the script can be executed when it parses inline scripts with matching nonce values.
 
 #### Introduce nonce
 

--- a/website/docs/en/config/security/sri.mdx
+++ b/website/docs/en/config/security/sri.mdx
@@ -12,7 +12,7 @@ type SriOptions = {
 - **Default:** `undefined`
 - **Version:** `>= 0.7.3`
 
-Adding an integrity attribute (`integrity`) to `<script>` and `<link rel="stylesheet">` tags introduced by HTML allows the browser to verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
+Adding an `integrity` attribute to `<script>` and `<link rel="stylesheet">` tags introduced by HTML allows the browser to verify the integrity of the introduced resource, thus preventing tampering with the downloaded resource.
 
 ## SRI
 

--- a/website/docs/en/plugins/list/plugin-lightningcss.mdx
+++ b/website/docs/en/plugins/list/plugin-lightningcss.mdx
@@ -140,7 +140,7 @@ Used to inject lightningcss instance. This configuration can be used when a ligh
 
 ```ts
 import { pluginLightningcss } from '@rsbuild/plugin-lightningcss';
-import lightningcss from 'lightningcss';
+import * as lightningcss from 'lightningcss';
 
 pluginLightningcss({
   implementation: lightningcss,

--- a/website/docs/zh/plugins/list/plugin-lightningcss.mdx
+++ b/website/docs/zh/plugins/list/plugin-lightningcss.mdx
@@ -140,7 +140,7 @@ pluginLightningcss({
 
 ```ts
 import { pluginLightningcss } from '@rsbuild/plugin-lightningcss';
-import lightningcss from 'lightningcss';
+import * as lightningcss from 'lightningcss';
 
 pluginLightningcss({
   implementation: lightningcss,


### PR DESCRIPTION
## Summary

- Only validate in setup stage for `plugin-lightningcss`.
- Reduce `any` in code.
- Export `PLUGIN_LIGHTNINGCSS_NAME` constant.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
