### PR TITLE
fix: apply lightningcss minify to the correct stage

### DIFF
--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -35,20 +35,16 @@ export class SwcMinimizerPlugin {
     cssMinify?: boolean | CssMinifyOptions;
     rsbuildConfig: NormalizedConfig;
   }) {
-    const { minify } = options.rsbuildConfig.output;
-    const minifyJs =
-      minify === true || (typeof minify === 'object' && minify.js);
-    const minifyCss =
-      minify === true || (typeof minify === 'object' && minify.css);
-
     this.minifyOptions = {
-      jsMinify: minifyJs
+      jsMinify: options.jsMinify
         ? deepmerge(
             this.getDefaultJsMinifyOptions(options.rsbuildConfig),
             normalize(options.jsMinify, {}),
           )
         : undefined,
-      cssMinify: minifyCss ? normalize(options.cssMinify, {}) : undefined,
+      cssMinify: options.cssMinify
+        ? normalize(options.cssMinify, {})
+        : undefined,
     };
   }
 

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -785,7 +785,7 @@ exports[`plugin-swc > should set correct swc minimizer options in production 1`]
   "minimizer": [
     SwcMinimizerPlugin {
       "minifyOptions": {
-        "cssMinify": {},
+        "cssMinify": undefined,
         "jsMinify": {
           "compress": false,
           "format": {
@@ -793,6 +793,13 @@ exports[`plugin-swc > should set correct swc minimizer options in production 1`]
           },
           "mangle": false,
         },
+      },
+      "name": "swc-minimizer-plugin",
+    },
+    SwcMinimizerPlugin {
+      "minifyOptions": {
+        "cssMinify": {},
+        "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
     },
@@ -805,7 +812,7 @@ exports[`plugin-swc > should set correct swc minimizer options using raw swc con
   "minimizer": [
     SwcMinimizerPlugin {
       "minifyOptions": {
-        "cssMinify": {},
+        "cssMinify": undefined,
         "jsMinify": {
           "compress": false,
           "format": {
@@ -813,6 +820,13 @@ exports[`plugin-swc > should set correct swc minimizer options using raw swc con
           },
           "mangle": false,
         },
+      },
+      "name": "swc-minimizer-plugin",
+    },
+    SwcMinimizerPlugin {
+      "minifyOptions": {
+        "cssMinify": {},
+        "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
     },
@@ -1005,13 +1019,20 @@ exports[`plugin-swc > should set swc minimizer in production 1`] = `
   "minimizer": [
     SwcMinimizerPlugin {
       "minifyOptions": {
-        "cssMinify": {},
+        "cssMinify": undefined,
         "jsMinify": {
           "format": {
             "asciiOnly": true,
           },
           "mangle": true,
         },
+      },
+      "name": "swc-minimizer-plugin",
+    },
+    SwcMinimizerPlugin {
+      "minifyOptions": {
+        "cssMinify": {},
+        "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
     },

--- a/packages/plugin-lightningcss/src/minimizer.ts
+++ b/packages/plugin-lightningcss/src/minimizer.ts
@@ -28,9 +28,10 @@ export class LightningCSSMinifyPlugin {
       compilation.hooks.processAssets.tapPromise(
         {
           name: PLUGIN_NAME,
-          stage: (compilation as any)?.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
+          stage:
+            compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE,
         },
-        async () => await this.transformAssets(compilation),
+        async () => this.transformAssets(compilation),
       );
 
       compilation.hooks.statsPrinter.tap(PLUGIN_NAME, (statsPrinter) => {


### PR DESCRIPTION
## Summary

- apply lightningcss minify to the correct stage (`compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE` is undefined)
- change the minimizer ID of SWC minimizers in webpack mode, so it can be override as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
