### PR TITLE
feat: allow tools.rspack to be async function

### DIFF
--- a/.changeset/empty-flies-own.md
+++ b/.changeset/empty-flies-own.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.7.3

--- a/e2e/cases/configure-rspack/index.test.ts
+++ b/e2e/cases/configure-rspack/index.test.ts
@@ -1,5 +1,6 @@
 import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import type { RspackConfig } from '@rsbuild/shared';
 
 rspackOnlyTest(
   'should allow to use tools.rspack to configure Rspack',
@@ -15,6 +16,39 @@ rspackOnlyTest(
                 ENABLE_TEST: JSON.stringify(true),
               }),
             );
+          },
+        },
+      },
+    });
+
+    await gotoPage(page, rsbuild);
+
+    const testEl = page.locator('#test-el');
+    await expect(testEl).toHaveText('aaaaa');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should allow to use async tools.rspack to configure Rspack',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      runServer: true,
+      rsbuildConfig: {
+        tools: {
+          rspack: async (config, { rspack }) => {
+            return new Promise<void>((resolve) => {
+              setTimeout(() => {
+                config.plugins?.push(
+                  new rspack.DefinePlugin({
+                    ENABLE_TEST: JSON.stringify(true),
+                  }),
+                );
+                resolve();
+              }, 0);
+            });
           },
         },
       },

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -9,7 +9,7 @@ import {
   debug,
   getNodeEnv,
   modifyBundlerChain,
-  reduceConfigsWithContext,
+  reduceConfigsAsyncWithContext,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import { getHTMLPlugin } from '../pluginHelper';
@@ -27,7 +27,7 @@ async function modifyRspackConfig(
   );
 
   if (context.config.tools?.rspack) {
-    modifiedConfig = reduceConfigsWithContext({
+    modifiedConfig = await reduceConfigsAsyncWithContext({
       initial: modifiedConfig,
       config: context.config.tools.rspack,
       ctx: utils,

--- a/packages/shared/src/reduceConfigs.ts
+++ b/packages/shared/src/reduceConfigs.ts
@@ -16,7 +16,7 @@ export type ConfigChainMergeContext<T, Ctx> = OneOrMany<
 >;
 
 /**
- * Merge one or many configs into a final config,
+ * Merge one or more configs into a final config,
  * and allow to modify the config object via a function.
  */
 export function reduceConfigs<T>({
@@ -46,6 +46,10 @@ export function reduceConfigs<T>({
   return config ?? initial;
 }
 
+/**
+ * Merge one or more configs into a final config,
+ * and allow to modify the config object via a function, the function accepts a context object.
+ */
 export function reduceConfigsWithContext<T, Ctx>({
   initial,
   config,
@@ -76,6 +80,10 @@ export function reduceConfigsWithContext<T, Ctx>({
   return config ?? initial;
 }
 
+/**
+ * Merge one or more configs into a final config,
+ * and allow to modify the config object via an async function, the function accepts a context object.
+ */
 export async function reduceConfigsAsyncWithContext<T, Ctx>({
   initial,
   config,
@@ -106,6 +114,10 @@ export async function reduceConfigsAsyncWithContext<T, Ctx>({
   return config ?? initial;
 }
 
+/**
+ * Merge one or more configs into a final config,
+ * and allow to modify the config object via an async function, the function accepts a merged object.
+ */
 export function reduceConfigsMergeContext<T, Ctx>({
   initial,
   config,

--- a/packages/shared/src/reduceConfigs.ts
+++ b/packages/shared/src/reduceConfigs.ts
@@ -1,4 +1,4 @@
-import type { OneOrMany } from './types';
+import type { MaybePromise, OneOrMany } from './types';
 import { isFunction, isNil, isPlainObject } from './utils';
 
 export type ConfigChain<T> = OneOrMany<T | ((config: T) => T | void)>;
@@ -7,10 +7,18 @@ export type ConfigChainWithContext<T, Ctx> = OneOrMany<
   T | ((config: T, ctx: Ctx) => T | void)
 >;
 
+export type ConfigChainAsyncWithContext<T, Ctx> = OneOrMany<
+  T | ((config: T, ctx: Ctx) => MaybePromise<T | void>)
+>;
+
 export type ConfigChainMergeContext<T, Ctx> = OneOrMany<
   T | ((merged: { value: T } & Ctx) => T | void)
 >;
 
+/**
+ * Merge one or many configs into a final config,
+ * and allow to modify the config object via a function.
+ */
 export function reduceConfigs<T>({
   initial,
   config,
@@ -57,6 +65,36 @@ export function reduceConfigsWithContext<T, Ctx>({
   }
   if (isFunction(config)) {
     return config(initial, ctx) ?? initial;
+  }
+  if (Array.isArray(config)) {
+    return config.reduce(
+      (initial, config) =>
+        reduceConfigsWithContext({ initial, config, ctx, mergeFn }),
+      initial,
+    );
+  }
+  return config ?? initial;
+}
+
+export async function reduceConfigsAsyncWithContext<T, Ctx>({
+  initial,
+  config,
+  ctx,
+  mergeFn = Object.assign,
+}: {
+  initial: T;
+  config?: ConfigChainAsyncWithContext<T, Ctx> | undefined;
+  ctx?: Ctx;
+  mergeFn?: typeof Object.assign;
+}): Promise<T> {
+  if (isNil(config)) {
+    return initial;
+  }
+  if (isPlainObject(config)) {
+    return isPlainObject(initial) ? mergeFn(initial, config) : (config as T);
+  }
+  if (isFunction(config)) {
+    return (await config(initial, ctx)) ?? initial;
   }
   if (Array.isArray(config)) {
     return config.reduce(

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -1,7 +1,11 @@
 import type { rspack } from '@rspack/core';
 import type { SwcLoaderOptions } from '@rspack/core';
 import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
-import type { ConfigChain, ConfigChainWithContext } from '../../reduceConfigs';
+import type {
+  ConfigChain,
+  ConfigChainAsyncWithContext,
+  ConfigChainWithContext,
+} from '../../reduceConfigs';
 import type { BundlerChain } from '../bundlerConfig';
 import type { BundlerPluginInstance } from '../bundlerConfig';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
@@ -61,7 +65,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
   rspack: typeof rspack;
 };
 
-export type ToolsRspackConfig = ConfigChainWithContext<
+export type ToolsRspackConfig = ConfigChainAsyncWithContext<
   RspackConfig,
   ModifyRspackConfigUtils
 >;

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -46,9 +46,23 @@ export default {
 The object returned by the `tools.rspack` function is used directly as the final Rspack configuration and is not merged with the built-in Rspack configuration.
 :::
 
-The second parameter of this function is an object, which contains some utility functions and properties, as follows:
+`tools.rspack` can also be an async function:
+
+```js
+export default {
+  tools: {
+    rspack: async (config) => {
+      const { default: ESLintPlugin } = await import('eslint-webpack-plugin');
+      config.plugins?.push(new ESLintPlugin());
+      return config;
+    },
+  },
+};
+```
 
 ## Utils
+
+The second parameter of this function is an object, which contains some utility functions and properties, as follows:
 
 ### env
 

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -46,6 +46,20 @@ export default {
 `tools.rspack` 函数返回的对象会直接作为最终使用的 Rspack 配置，不会再与内置的 Rspack 配置进行合并。
 :::
 
+`tools.rspack` 还可以是一个异步函数：
+
+```js
+export default {
+  tools: {
+    rspack: async (config) => {
+      const { default: ESLintPlugin } = await import('eslint-webpack-plugin');
+      config.plugins?.push(new ESLintPlugin());
+      return config;
+    },
+  },
+};
+```
+
 ## 工具集合
 
 这个函数的第二个参数是一个对象，包含了一些工具函数和属性，详情如下：


### PR DESCRIPTION
## Summary

Allow `tools.rspack` to be async function.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2503

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
