### PR TITLE
feat: allow tools.bundlerChain to be async function

### DIFF
--- a/e2e/cases/bundler-chain/index.test.ts
+++ b/e2e/cases/bundler-chain/index.test.ts
@@ -24,3 +24,31 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
 
   await rsbuild.close();
 });
+
+test('should allow to use async tools.bundlerChain to set alias config', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+    rsbuildConfig: {
+      tools: {
+        bundlerChain: async (chain) => {
+          return new Promise((resolve) => {
+            setTimeout(() => {
+              chain.resolve.alias.merge({
+                '@common': join(__dirname, 'src/common'),
+              });
+              resolve();
+            }, 0);
+          });
+        },
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
+
+  await rsbuild.close();
+});

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -46,7 +46,7 @@ export async function modifyBundlerChain(
 
   if (context.config.tools?.bundlerChain) {
     for (const item of castArray(context.config.tools.bundlerChain)) {
-      item(modifiedBundlerChain, utils);
+      await item(modifiedBundlerChain, utils);
     }
   }
 

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -23,7 +23,7 @@ import type {
   StyleLoaderOptions,
   WebpackConfig,
 } from '../thirdParty';
-import type { OneOrMany, WebpackChain } from '../utils';
+import type { MaybePromise, OneOrMany, WebpackChain } from '../utils';
 
 export type { HTMLPluginOptions };
 
@@ -32,7 +32,7 @@ export type ToolsSwcConfig = ConfigChain<SwcLoaderOptions>;
 export type ToolsAutoprefixerConfig = ConfigChain<AutoprefixerOptions>;
 
 export type ToolsBundlerChainConfig = OneOrMany<
-  (chain: BundlerChain, utils: ModifyBundlerChainUtils) => void
+  (chain: BundlerChain, utils: ModifyBundlerChainUtils) => MaybePromise<void>
 >;
 
 export type ToolsPostCSSLoaderConfig = ConfigChainWithContext<

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -6,22 +6,29 @@
 type BundlerChainFn = (
   chain: BundlerChain,
   utils: ModifyBundlerChainUtils,
-) => void;
+) => Promise<void> | void;
 ```
 
 - **Default:** `undefined`
 
-You can modify the Rspack and webpack configuration by configuring `tools.bundlerChain` which is type of `Function`. The function receives two parameters, the first is the original bundler chain object, and the second is an object containing some utils.
+You can modify the default Rspack config through `tools.bundlerChain`. Its value is a function that takes two arguments:
+
+- The first argument is a `bundler-chain` instance, which you can use to modify the Rspack config.
+- The second argument is an utils object, including `env`, `isProd`, `CHAIN_ID`, etc.
 
 :::tip What is BundlerChain
 
-Bundler chain is a subset of webpack chain, which contains part of the webpack chain API that you can use to modify both Rspack and webpack configuration.
+import BundlerChain from '@en/shared/bundlerChain.mdx';
 
-Configurations modified via bundler chain will work on both Rspack and webpack builds. Note that the bundler chain only supports modifying the configuration of the non-differentiated parts of Rspack and webpack. For example, modifying the devtool configuration option (Rspack and webpack have the same devtool property value type), or adding an [Rspack-compatible](https://rspack.dev/guide/compatibility/plugin) webpack plugin.
+<BundlerChain />
 
 :::
 
-> `tools.bundlerChain` is executed earlier than tools.rspack and thus will be overridden by changes in other.
+> `tools.bundlerChain` will be executed earlier than [tools.rspack](/config/tools/rspack), so it will be overridden by `tools.rspack`.
+
+## Examples
+
+Please refer to: [BundlerChain examples](/guide/basic/configure-rspack#use-bundler-chain).
 
 ## Utils
 
@@ -231,7 +238,3 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 | --------------- | ------------------------------------------- |
 | `MINIMIZER.JS`  | correspond to `SwcJsMinimizerRspackPlugin`  |
 | `MINIMIZER.CSS` | correspond to `SwcCssMinimizerRspackPlugin` |
-
-### Examples
-
-For usage examples, please refer to: [BundlerChain examples](/guide/basic/configure-rsbuild#examples).

--- a/website/docs/en/guide/basic/configure-rspack.mdx
+++ b/website/docs/en/guide/basic/configure-rspack.mdx
@@ -43,12 +43,10 @@ import BundlerChain from '@en/shared/bundlerChain.mdx';
 
 ### tools.bundlerChain
 
-Rsbuild provides the `tools.bundlerChain` configuration option to modify the bundler chain.
+Rsbuild provides the [tools.bundlerChain](/config/tools/bundler-chain) config to modify the bundler chain. Its value is a function that takes two arguments:
 
-The value of `tools.bundlerChain` is a `Function` type that accepts two parameters:
-
-- The first parameter is the `bundler-chain` instance, which can be used to modify the default bundler configuration.
-- The second parameter is [utils](/config/tools/bundler-chain#utils) that includes `env`, `isProd`, `CHAIN_ID`, and more.
+- The first argument is a `bundler-chain` instance, which you can use to modify the Rspack config.
+- The second argument is an utils object, including `env`, `isProd`, `CHAIN_ID`, etc.
 
 Here's a basic example:
 
@@ -64,11 +62,24 @@ export default {
 };
 ```
 
+`tools.bundlerChain` can also be an async function:
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain: (chain, { env }) => {
+      const value = await fetchValue();
+      chain.devtool(value);
+    },
+  },
+};
+```
+
 ### Basics
 
 Before using the bundler chain to modify the Rspack configuration, it is recommended to familiarize yourself with some basics.
 
-#### How the Bundler Chain Locates Objects Quickly
+#### About ID
 
 In short, the bundler chain requires users to set a unique ID for each rule, loader, plugin, and minimizer. With this ID, you can easily find the desired object from deeply nested objects.
 
@@ -87,7 +98,7 @@ export default {
 };
 ```
 
-#### Types of Bundler Chain IDs
+#### ID Types
 
 The `CHAIN_ID` object contains various IDs, which correspond to the following configurations:
 

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -6,27 +6,31 @@
 type BundlerChainFn = (
   chain: BundlerChain,
   utils: ModifyBundlerChainUtils,
-) => void;
+) => Promise<void> | void;
 ```
 
 - **默认值：** `undefined`
 
-你可以通过 `tools.bundlerChain` 来修改默认的 Rspack 和 webpack 配置，它的值为 `Function` 类型，接收两个参数：
+你可以通过 `tools.bundlerChain` 来修改默认的 Rspack 配置，它的值是一个函数，接收两个参数：
 
-- 第一个参数为 `bundler-chain` 对象实例，你可以通过这个实例来修改 Rspack 和 webpack 的配置。
-- 第二个参数为一个工具集合，包括`env`、`isProd`、`CHAIN_ID` 等。
+- 第一个参数为 `bundler-chain` 实例，你可以通过它来修改 Rspack 配置。
+- 第二个参数为一个工具对象，包括 `env`、`isProd`、`CHAIN_ID` 等。
 
 :::tip 什么是 BundlerChain
 
-Bundler chain 是 webpack chain 的子集，其中包含一部分 webpack chain API，你可以用它来同时修改 Rspack 和 webpack 的配置。
+import BundlerChain from '@zh/shared/bundlerChain.mdx';
 
-通过 bundler chain 修改的配置，在 Rspack 和 webpack 构建时均可生效。需要注意的是，bundler chain 只支持修改 Rspack 和 webpack 间无差异部分的配置。如，修改 devtool 配置项（Rspack 和 webpack 的 devtool 属性值类型相同），或添加一个[Rspack 兼容](https://rspack.dev/guide/compatibility/plugin)的 webpack 插件。
+<BundlerChain />
 
 :::
 
-> `tools.bundlerChain` 的执行时机早于 tools.rspack，因此会被其他配置中的修改所覆盖。
+> `tools.bundlerChain` 会早于 [tools.rspack](/config/tools/rspack) 被执行，因此会被 `tools.rspack` 覆盖。
 
-## 工具集合
+## 示例
+
+参考：[BundlerChain 示例](/guide/basic/configure-rspack#使用-bundler-chain)。
+
+## 工具对象
 
 ### env
 
@@ -234,7 +238,3 @@ Rsbuild 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 | --------------- | ---------------------------------- |
 | `MINIMIZER.JS`  | 对应 `SwcJsMinimizerRspackPlugin`  |
 | `MINIMIZER.CSS` | 对应 `SwcCssMinimizerRspackPlugin` |
-
-### 使用示例
-
-使用示例可参考：[BundlerChain 示例](/guide/basic/configure-rsbuild#示例)。

--- a/website/docs/zh/guide/basic/configure-rspack.mdx
+++ b/website/docs/zh/guide/basic/configure-rspack.mdx
@@ -45,10 +45,10 @@ import BundlerChain from '@zh/shared/bundlerChain.mdx';
 
 Rsbuild 提供了 [tools.bundlerChain](/config/tools/bundler-chain) 配置项来修改 bundler-chain。
 
-`tools.bundlerChain` 的值为 `Function` 类型，接收两个参数：
+`tools.bundlerChain` 的值是一个函数，接收两个参数：
 
-- 第一个参数为 `bundler-chain` 实例对象，你可以通过这个实例来修改默认的 bundler 配置。
-- 第二个参数为一个[工具集合](/config/tools/bundler-chain#工具集合)，包括 `env`、`isProd`、`CHAIN_ID` 等。
+- 第一个参数为 `bundler-chain` 实例对象，你可以通过 它来修改默认的 Rspack 配置。
+- 第二个参数为一个[工具对象](/config/tools/bundler-chain#工具对象)，包括 `env`、`isProd`、`CHAIN_ID` 等。
 
 下面是一个基本示例：
 
@@ -64,11 +64,24 @@ export default {
 };
 ```
 
-### 基础知识
+`tools.bundlerChain` 还可以是一个异步函数：
 
-在开始使用 bundler-chain 来修改 Rspack 配置之前，建议你先了解一些基础知识。
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain: (chain, { env }) => {
+      const value = await fetchValue();
+      chain.devtool(value);
+    },
+  },
+};
+```
 
-#### bundler-chain 是如何快速定位的
+### 背景知识
+
+在开始使用 bundler-chain 来修改 Rspack 配置之前，请先了解一些背景知识。
+
+#### 关于 ID
 
 简单来说，bundler-chain 要求使用者为每个 Rule、Loader、Plugin、Minimizer 都设置一个独一无二的 id，通过这个 id，就可以便捷地从嵌套层级很深的对象中找到所需的对象。
 
@@ -87,7 +100,7 @@ export default {
 };
 ```
 
-#### bundler-chain id 的类型
+#### ID 类型
 
 `CHAIN_ID` 对象包含了多种 id，对应的含义如下：
 


### PR DESCRIPTION
## Summary

Allow `tools.bundlerChain` to be async function.

## Related Links

same as https://github.com/web-infra-dev/rsbuild/pull/2515

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
