### PR TITLE
test(e2e): enable exports presence case

### DIFF
--- a/e2e/cases/exports-presence/index.test.ts
+++ b/e2e/cases/exports-presence/index.test.ts
@@ -1,27 +1,20 @@
-import { build, proxyConsole, webpackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { build, proxyConsole } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
 
-// TODO: needs rspack exportsPresence error
-// https://github.com/web-infra-dev/rspack/issues/4323
-webpackOnlyTest(
-  'should throw error by default (exportsPresence error)',
-  async () => {
-    const { logs, restore } = proxyConsole();
+test('should throw error by default (exportsPresence error)', async () => {
+  const { logs, restore } = proxyConsole();
 
-    await expect(
-      build({
-        cwd: __dirname,
-      }),
-    ).rejects.toThrowError();
+  await expect(
+    build({
+      cwd: __dirname,
+    }),
+  ).rejects.toThrowError();
 
-    restore();
+  restore();
 
-    expect(
-      logs.find((log) =>
-        log.includes(
-          `export 'aa' (imported as 'aa') was not found in './test'`,
-        ),
-      ),
-    ).toBeTruthy();
-  },
-);
+  expect(
+    logs.find((log) =>
+      log.includes(`export 'aa' (imported as 'aa') was not found in './test'`),
+    ),
+  ).toBeTruthy();
+});

--- a/website/docs/en/guide/faq/exceptions.mdx
+++ b/website/docs/en/guide/faq/exceptions.mdx
@@ -90,15 +90,17 @@ export type { Foo } from './utils'; // Correct
 
 In some cases, the error may be caused by a third-party dependency that you cannot modify directly. In this situation, if you are sure that the issue does not affect your application, you can add the following configuration to change the log level from `error` to `warn`:
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain(chain) {
-      chain.module.parser.merge({
-        javascript: {
-          exportsPresence: 'warn',
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            exportsPresence: 'error',
+          },
         },
-      });
+      },
     },
   },
 };
@@ -106,7 +108,7 @@ export default {
 
 However, it is important to contact the developer of the third-party dependency immediately to fix the issue.
 
-> You can refer to the webpack documentation for more details on [module.parser.javascript.exportsPresence](https://webpack.js.org/configuration/module/#moduleparserjavascriptexportspresence).
+> You can refer to the webpack documentation for more details on [module.parser.javascript.exportsPresence](https://www.rspack.dev/config/module#moduleparserjavascriptexportspresence).
 
 ---
 

--- a/website/docs/zh/guide/faq/exceptions.mdx
+++ b/website/docs/zh/guide/faq/exceptions.mdx
@@ -90,15 +90,17 @@ export type { Foo } from './utils'; // 正确写法
 
 在个别情况下，以上报错是由第三方依赖引入的，你无法直接修改它。此时，如果你确定该问题不影响你的应用，那么可以添加以下配置，将 `error` 日志修改为 `warn` 级别：
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   tools: {
-    bundlerChain(chain) {
-      chain.module.parser.merge({
-        javascript: {
-          exportsPresence: 'warn',
+    rspack: {
+      module: {
+        parser: {
+          javascript: {
+            exportsPresence: 'error',
+          },
         },
-      });
+      },
     },
   },
 };
@@ -106,7 +108,7 @@ export default {
 
 同时，你需要尽快联系第三方依赖的开发者来修复相应的问题。
 
-> 你可以查看 webpack 的文档来了解 [module.parser.javascript.exportsPresence](https://webpack.js.org/configuration/module/#moduleparserjavascriptexportspresence) 的更多细节。
+> 你可以查看 webpack 的文档来了解 [module.parser.javascript.exportsPresence](https://www.rspack.dev/config/module#moduleparserjavascriptexportspresence) 的更多细节。
 
 ---
 


### PR DESCRIPTION
## Summary

Enable the exports presence E2E case as Rspack 0.7.1 supports it.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6660

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
