### PR TITLE
chore(lazy-compilation): no need to exclude global entry

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,9 +1,14 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
+    // TODO fix this case in Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     const rsbuild = await dev({
       cwd: __dirname,
     });

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,14 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
-    // TODO fix this case in Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
     });

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -17,13 +17,10 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         return;
       }
 
-      const clientRegExp = /[\\/]core[\\/]dist[\\/]client[\\/]/;
       const cssRegExp = /\.(?:css|less|sass|scss|styl|stylus)$/;
 
       const isExcludedModule = (name: string) => {
         return (
-          // alway include Rsbuild client code, such as HMR
-          clientRegExp.test(name) ||
           // exclude CSS files because Rspack does not support it yet
           // TODO: remove this after Rspack supporting it
           cssRegExp.test(name)

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist",
     "paths": {
       "@theme": ["./theme"],
+      "@components/*": ["./components/*"],
       "@zh/*": ["./docs/zh/*"],
       "@en/*": ["./docs/en/*"]
     },


### PR DESCRIPTION
## Summary

No longer need to exclude global entry when using the Rspack lazy compilation.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6674

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
