### PR TITLE
fix(create-rsbuild): fix package#name if create in current dir

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -161,7 +161,11 @@ const updatePackageJson = (
   let content = fs.readFileSync(pkgJsonPath, 'utf-8');
   content = content.replace(/workspace:\*/g, `^${version}`);
   const pkg = JSON.parse(content);
-  if (name) pkg.name = name;
+
+  if (name && name !== '.') {
+    pkg.name = name;
+  }
+
   fs.writeFileSync(pkgJsonPath, JSON.stringify(pkg, null, 2));
 };
 


### PR DESCRIPTION
## Summary

Fix package#name if create new project in the current dir, the name should be the template name instead of a `'.'`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
