### PR TITLE
chore: replace webpack-chain with rspack-chain

### DIFF
--- a/packages/compat/webpack/src/index.ts
+++ b/packages/compat/webpack/src/index.ts
@@ -2,6 +2,5 @@ export { webpackProvider } from './provider';
 export type {
   // Third Party Types
   webpack,
-  WebpackChain,
   WebpackConfig,
 } from './types';

--- a/packages/compat/webpack/src/types.ts
+++ b/packages/compat/webpack/src/types.ts
@@ -1,5 +1,4 @@
-import type { WebpackChain } from '@rsbuild/shared';
 import type webpack from 'webpack';
 import type { Configuration as WebpackConfig } from 'webpack';
 
-export type { webpack, WebpackChain, WebpackConfig };
+export type { webpack, WebpackConfig };

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -4,7 +4,7 @@ import {
   type ModifyWebpackChainUtils,
   type ModifyWebpackConfigUtils,
   type RsbuildTarget,
-  type WebpackChain,
+  type RspackChain,
   castArray,
   chainToConfig,
   debug,
@@ -21,8 +21,8 @@ import type { WebpackConfig } from './types';
 async function modifyWebpackChain(
   context: InternalContext,
   utils: ModifyWebpackChainUtils,
-  chain: WebpackChain,
-): Promise<WebpackChain> {
+  chain: RspackChain,
+): Promise<RspackChain> {
   debug('modify webpack chain');
 
   const [modifiedChain] = await context.hooks.modifyWebpackChain.call(
@@ -160,13 +160,7 @@ export async function generateWebpackConfig({
     },
   });
 
-  const chain = await modifyWebpackChain(
-    context,
-    chainUtils,
-    // module rules not support merge
-    // need a special rule merge or use bundlerChain as WebpackChain
-    bundlerChain as unknown as WebpackChain,
-  );
+  const chain = await modifyWebpackChain(context, chainUtils, bundlerChain);
 
   let webpackConfig = chainToConfig(
     chain as unknown as BundlerChain,

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,9 +1,9 @@
 import path from 'node:path';
 import {
   AUDIO_EXTENSIONS,
-  type BundlerChainRule,
   FONT_EXTENSIONS,
   IMAGE_EXTENSIONS,
+  type RspackChain,
   VIDEO_EXTENSIONS,
   getDistPath,
   getFilename,
@@ -19,7 +19,7 @@ const chainStaticAssetRule = ({
   assetType,
 }: {
   emit: boolean;
-  rule: BundlerChainRule;
+  rule: RspackChain.Rule;
   maxSize: number;
   filename: string;
   assetType: string;

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import {
   type AutoprefixerOptions,
-  type BundlerChainRule,
   type CSSLoaderModulesMode,
   type CSSLoaderOptions,
   type ModifyChainUtils,
@@ -9,6 +8,7 @@ import {
   type PostCSSOptions,
   type RsbuildContext,
   type RsbuildTarget,
+  type RspackChain,
   deepmerge,
   getBrowserslistWithDefault,
   isFunction,
@@ -246,7 +246,7 @@ async function applyCSSRule({
   utils: { target, isProd, CHAIN_ID },
   importLoaders = 1,
 }: {
-  rule: BundlerChainRule;
+  rule: RspackChain.Rule;
   config: NormalizedConfig;
   context: RsbuildContext;
   utils: ModifyChainUtils;

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -144,8 +144,6 @@ export const pluginManifest = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
-      const htmlPaths = api.getHTMLPaths();
-
       const {
         output: { manifest },
       } = api.getNormalizedConfig();
@@ -158,6 +156,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
         typeof manifest === 'string' ? manifest : 'manifest.json';
 
       const { RspackManifestPlugin } = await import('rspack-manifest-plugin');
+      const htmlPaths = api.getHTMLPaths();
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(RspackManifestPlugin, [
         {

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -281,10 +281,7 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
           polyfill: config.output.polyfill,
         });
 
-        chain.optimization.splitChunks(
-          // @ts-expect-error splitChunks type mismatch
-          splitChunksOptions,
-        );
+        chain.optimization.splitChunks(splitChunksOptions);
       },
     );
   },

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -239,9 +239,12 @@ export class HtmlBasicPlugin {
 
   readonly options: HtmlBasicPluginOptions;
 
-  readonly modifyTagsFn: ModifyHTMLTagsFn;
+  readonly modifyTagsFn?: ModifyHTMLTagsFn;
 
-  constructor(options: HtmlBasicPluginOptions, modifyTagsFn: ModifyHTMLTagsFn) {
+  constructor(
+    options: HtmlBasicPluginOptions,
+    modifyTagsFn?: ModifyHTMLTagsFn,
+  ) {
     this.name = 'HtmlBasicPlugin';
     this.options = options;
     this.modifyTagsFn = modifyTagsFn;
@@ -268,20 +271,22 @@ export class HtmlBasicPlugin {
 
           addFavicon(headTags, favicon);
 
-          const result = await this.modifyTagsFn(
-            {
-              headTags: headTags.map(formatBasicTag),
-              bodyTags: bodyTags.map(formatBasicTag),
-            },
-            {
-              compilation,
-              assetPrefix: data.publicPath,
-              filename: data.outputName,
-            },
-          );
+          const tags = {
+            headTags: headTags.map(formatBasicTag),
+            bodyTags: bodyTags.map(formatBasicTag),
+          };
+
+          const modified = this.modifyTagsFn
+            ? await this.modifyTagsFn(tags, {
+                compilation,
+                assetPrefix: data.publicPath,
+                filename: data.outputName,
+              })
+            : tags;
+
           Object.assign(data, {
-            headTags: result.headTags.map(fromBasicTag),
-            bodyTags: result.bodyTags.map(fromBasicTag),
+            headTags: modified.headTags.map(fromBasicTag),
+            bodyTags: modified.bodyTags.map(fromBasicTag),
           });
 
           if (tagConfig) {

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -51,10 +51,7 @@ export function applyCSSMinimizer(
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.CSS)
-    .use(CssMinimizerWebpackPlugin, [
-      // @ts-expect-error type mismatch
-      mergedOptions,
-    ])
+    .use(CssMinimizerWebpackPlugin, [mergedOptions])
     .end();
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -107,13 +107,13 @@
     "mime-types": "^2.1.35",
     "picocolors": "1.0.1",
     "prebundle": "1.1.0",
+    "rspack-chain": "0.7.1",
     "rslog": "^1.2.2",
     "semver": "^7.6.2",
     "terser": "5.31.0",
     "typescript": "^5.4.2",
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-chain": "npm:webpack-5-chain@8.0.2",
     "webpack-merge": "5.10.0"
   },
   "optionalDependencies": {

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -50,7 +50,7 @@ export default {
       ignoreDts: true,
     },
     {
-      name: 'webpack-chain',
+      name: 'rspack-chain',
       externals: {
         deepmerge: '../deepmerge',
       },

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -3,7 +3,6 @@ import { NODE_MODULES_REGEX, TS_AND_JSX_REGEX } from './constants';
 import { debug } from './logger';
 import type {
   BundlerChain,
-  BundlerChainRule,
   CreateAsyncHook,
   ModifyBundlerChainFn,
   ModifyBundlerChainUtils,
@@ -11,6 +10,7 @@ import type {
   RsbuildConfig,
   RsbuildContext,
   RsbuildEntry,
+  RspackChain,
   RspackConfig,
 } from './types';
 import { isPlainObject } from './utils';
@@ -235,7 +235,7 @@ export function applyScriptCondition({
   includes,
   excludes,
 }: {
-  rule: BundlerChainRule;
+  rule: RspackChain.Rule;
   chain: BundlerChain;
   config: NormalizedConfig;
   context: RsbuildContext;

--- a/packages/shared/src/chain.ts
+++ b/packages/shared/src/chain.ts
@@ -17,11 +17,11 @@ import { isPlainObject } from './utils';
 import { castArray } from './utils';
 
 export async function getBundlerChain() {
-  const { default: WebpackChain } = await import(
-    '../compiled/webpack-chain/index.js'
+  const { default: RspackChain } = await import(
+    '../compiled/rspack-chain/index.js'
   );
 
-  const bundlerChain = new WebpackChain();
+  const bundlerChain = new RspackChain();
 
   return bundlerChain as unknown as BundlerChain;
 }
@@ -280,7 +280,7 @@ export function chainToConfig(chain: BundlerChain): RspackConfig {
   const formattedEntry: RsbuildEntry = {};
 
   /**
-   * webpack-chain can not handle entry description object correctly,
+   * rspack-chain can not handle entry description object correctly,
    * so we need to format the entry object and correct the entry description object.
    */
   for (const [entryName, entryValue] of Object.entries(entry)) {

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -66,12 +66,12 @@ export async function outputInspectConfigFiles({
 }
 
 export async function stringifyConfig(config: unknown, verbose?: boolean) {
-  const { default: WebpackChain } = await import(
-    '../compiled/webpack-chain/index.js'
+  const { default: RspackChain } = await import(
+    '../compiled/rspack-chain/index.js'
   );
 
   // webpackChain.toString can be used as a common stringify method
-  const stringify = WebpackChain.toString as (
+  const stringify = RspackChain.toString as (
     config: unknown,
     options: { verbose?: boolean },
   ) => string;

--- a/packages/shared/src/types/bundlerConfig.ts
+++ b/packages/shared/src/types/bundlerConfig.ts
@@ -9,5 +9,3 @@ export interface BundlerPluginInstance {
 export interface BundlerChain extends Omit<RspackChain, 'toConfig'> {
   toConfig: () => Configuration;
 }
-
-export type BundlerChainRule = RspackChain.Rule;

--- a/packages/shared/src/types/bundlerConfig.ts
+++ b/packages/shared/src/types/bundlerConfig.ts
@@ -1,13 +1,13 @@
 import type { Configuration } from '@rspack/core';
-import type { WebpackChain } from './utils';
+import type { RspackChain } from './utils';
 
 export interface BundlerPluginInstance {
   [index: string]: any;
   apply: (compiler: any) => void;
 }
 
-export interface BundlerChain extends Omit<WebpackChain, 'toConfig'> {
+export interface BundlerChain extends Omit<RspackChain, 'toConfig'> {
   toConfig: () => Configuration;
 }
 
-export type BundlerChainRule = WebpackChain.Rule;
+export type BundlerChainRule = RspackChain.Rule;

--- a/packages/shared/src/types/config/tools.ts
+++ b/packages/shared/src/types/config/tools.ts
@@ -23,7 +23,7 @@ import type {
   StyleLoaderOptions,
   WebpackConfig,
 } from '../thirdParty';
-import type { MaybePromise, OneOrMany, WebpackChain } from '../utils';
+import type { MaybePromise, OneOrMany, RspackChain } from '../utils';
 
 export type { HTMLPluginOptions };
 
@@ -76,7 +76,7 @@ export type ToolsWebpackConfig = ConfigChainWithContext<
 >;
 
 export type ToolsWebpackChainConfig = OneOrMany<
-  (chain: WebpackChain, utils: ModifyWebpackChainUtils) => void
+  (chain: RspackChain, utils: ModifyWebpackChainUtils) => void
 >;
 
 export interface ToolsConfig {

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -117,7 +117,6 @@ export type ModifyBundlerChainUtils = ModifyChainUtils & {
   };
 };
 
-/** The intersection of webpack-chain and rspack-chain */
 export type ModifyBundlerChainFn = (
   chain: BundlerChain,
   utils: ModifyBundlerChainUtils,

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -31,7 +31,7 @@ import type {
 } from './hooks';
 import type { RsbuildTarget } from './rsbuild';
 import type { RspackConfig, RspackSourceMap } from './rspack';
-import type { Falsy, WebpackChain } from './utils';
+import type { Falsy, RspackChain } from './utils';
 import type { MaybePromise } from './utils';
 
 type HookOrder = 'pre' | 'post' | 'default';
@@ -77,7 +77,7 @@ export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {
 };
 
 export type ModifyWebpackChainFn = (
-  chain: WebpackChain,
+  chain: RspackChain,
   utils: ModifyWebpackChainUtils,
 ) => Promise<void> | void;
 

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -1,6 +1,6 @@
-import type WebpackChain from '../../compiled/webpack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain/index.js';
 
-export type { WebpackChain };
+export type { RspackChain };
 
 export type Falsy = false | null | undefined;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1729,6 +1729,9 @@ importers:
       rslog:
         specifier: ^1.2.2
         version: 1.2.2
+      rspack-chain:
+        specifier: 0.7.1
+        version: 0.7.1
       semver:
         specifier: ^7.6.2
         version: 7.6.2
@@ -1744,9 +1747,6 @@ importers:
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
-      webpack-chain:
-        specifier: npm:webpack-5-chain@8.0.2
-        version: webpack-5-chain@8.0.2
       webpack-merge:
         specifier: 5.10.0
         version: 5.10.0
@@ -7799,6 +7799,10 @@ packages:
     resolution: {integrity: sha512-tZP8KjrI1nz6qOYCrFxAV7cfmfS2GV94jotU2zOmF/6ByO1zNvGR6/+0inylpjqyBjAdnnutTUW0m4th06bSTw==}
     engines: {node: '>=14.17.6'}
 
+  rspack-chain@0.7.1:
+    resolution: {integrity: sha512-oReT8FgE5elL1w8H/GfdYAwV/2QYkJF6hAw6e0zxOjbJIcyQvCWmEf+QHeKUn5aVVBHu6U6qxzMmmEXIGxBevQ==}
+    engines: {node: '>=16'}
+
   rspack-manifest-plugin@5.0.0:
     resolution: {integrity: sha512-Rtpn6GI4mpTASPmLOGiHzv3KqVWuWhGJG9CKO7aioPrAhukML4jtgYUvbQdBze/mZcDrvqf6sxEGRGx5fKQ+ag==}
     engines: {node: '>=14'}
@@ -8892,10 +8896,6 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
-
-  webpack-5-chain@8.0.2:
-    resolution: {integrity: sha512-gpzlChffrVUu5YwIw9i240/wdcglw53mSEV/7WoK7L/ddfb6Al8/sRjztyPYV8VgJAmkapH5T1AOUfMFryQ/VA==}
-    engines: {node: '>=10'}
 
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
@@ -16084,6 +16084,11 @@ snapshots:
 
   rslog@1.2.2: {}
 
+  rspack-chain@0.7.1:
+    dependencies:
+      deepmerge: 1.5.2
+      javascript-stringify: 2.1.0
+
   rspack-manifest-plugin@5.0.0(@rspack/core@0.7.1(@swc/helpers@0.5.3)):
     dependencies:
       tapable: 2.2.1
@@ -17235,11 +17240,6 @@ snapshots:
   web-namespaces@2.0.1: {}
 
   web-streams-polyfill@3.3.3: {}
-
-  webpack-5-chain@8.0.2:
-    dependencies:
-      deepmerge: 1.5.2
-      javascript-stringify: 2.1.0
 
   webpack-bundle-analyzer@4.10.2:
     dependencies:


### PR DESCRIPTION
## Summary

webpack-chain is no longer maintained and the types are outdated.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/01445e34-9088-412d-b495-382b6c054899)

So we forked `webpack-chain` as `rspack-chain` and import types from `@rspack/core`.

Currently, the API of rspack-chain are exactly the same as webpack-chain. Some Rspack-specific APIs will be added in the future.

## Related Links

https://github.com/rspack-contrib/rspack-chain
https://github.com/neutrinojs/webpack-chain/issues/358

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
