### PR TITLE
feat: support open with specified path

### DIFF
--- a/packages/core/tests/startUrl.test.ts
+++ b/packages/core/tests/startUrl.test.ts
@@ -1,4 +1,4 @@
-import { replacePlaceholder } from '../src/plugins/startUrl';
+import { replacePlaceholder, resolveUrl } from '../src/plugins/startUrl';
 
 describe('plugin-start-url', () => {
   it('#replacePlaceholder - should replace port number correctly', () => {
@@ -11,5 +11,23 @@ describe('plugin-start-url', () => {
     expect(replacePlaceholder('http://localhost:<port>/path/', 3000)).toEqual(
       'http://localhost:3000/path/',
     );
+  });
+
+  it('#resolveUrl - should resolve url correctly', () => {
+    const baseUrl = 'http://localhost';
+    expect(resolveUrl('https://example.com', baseUrl)).toEqual(
+      'https://example.com',
+    );
+    expect(resolveUrl('https://example.com/foo', baseUrl)).toEqual(
+      'https://example.com/foo',
+    );
+    expect(resolveUrl('https://example.com/foo.html', baseUrl)).toEqual(
+      'https://example.com/foo.html',
+    );
+    expect(resolveUrl('/path/to/resource', baseUrl)).toEqual(
+      'http://localhost/path/to/resource',
+    );
+    expect(resolveUrl('//localhost', baseUrl)).toEqual('http://localhost/');
+    expect(resolveUrl('path', baseUrl)).toEqual('http://localhost/path');
   });
 });

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -4,6 +4,16 @@ import { URL } from 'node:url';
 // remove repeat '/'
 export const normalizeUrl = (url: string) => url.replace(/([^:]\/)\/+/g, '$1');
 
+// Can be replaced with URL.canParse when we drop support for Node.js 16
+export const canParse = (url: string) => {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const urlJoin = (base: string, path: string) => {
   const fullUrl = new URL(base);
   fullUrl.pathname = posix.join(fullUrl.pathname, path);
@@ -21,10 +31,9 @@ export const withPublicPath = (str: string, base: string) => {
   // If str is an complete URL, just return it.
   // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
-  try {
-    new URL(str).toString();
+  if (canParse(str)) {
     return str;
-  } catch {}
+  }
 
   if (base.startsWith('http')) {
     return urlJoin(base, str);

--- a/website/docs/en/config/dev/start-url.mdx
+++ b/website/docs/en/config/dev/start-url.mdx
@@ -31,12 +31,32 @@ export default {
 };
 ```
 
+- Open the specified path, equivalent to `http://localhost:<port>/home`:
+
+```js
+export default {
+  dev: {
+    startUrl: '/home',
+  },
+};
+```
+
 - Open multiple pages:
 
 ```js
 export default {
   dev: {
-    startUrl: ['http://localhost:3000', 'http://localhost:3000/about'],
+    startUrl: ['/', '/about'],
+  },
+};
+```
+
+- Open a non-localhost URL (used with proxy):
+
+```js
+export default {
+  dev: {
+    startUrl: 'http://www.example.com',
   },
 };
 ```

--- a/website/docs/zh/config/dev/start-url.mdx
+++ b/website/docs/zh/config/dev/start-url.mdx
@@ -31,12 +31,32 @@ export default {
 };
 ```
 
+- 打开指定的路径，等价于 `http://localhost:<port>/home`：
+
+```js
+export default {
+  dev: {
+    startUrl: '/home',
+  },
+};
+```
+
 - 打开多个页面：
 
 ```js
 export default {
   dev: {
-    startUrl: ['http://localhost:3000', 'http://localhost:3000/about'],
+    startUrl: ['/', '/about'],
+  },
+};
+```
+
+- 打开一个非 localhost URL（配合 proxy 使用）：
+
+```js
+export default {
+  dev: {
+    startUrl: 'http://www.example.com',
   },
 };
 ```


### PR DESCRIPTION
## Summary

Support open with specified path.

- Open the specified path, equivalent to `http://localhost:<port>/home`:

```js
export default {
  dev: {
    startUrl: '/home',
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
