### PR TITLE
feat: allow output.filename.js to be a function

### DIFF
--- a/e2e/cases/filename-function/index.test.ts
+++ b/e2e/cases/filename-function/index.test.ts
@@ -1,0 +1,23 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to custom filename by function', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  // JS
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/js/my-index.js'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/js/async/some-path/foo.js'),
+    ),
+  ).toBeTruthy();
+});

--- a/e2e/cases/filename-function/rsbuild.config.ts
+++ b/e2e/cases/filename-function/rsbuild.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filename: {
+      js: (pathData) => {
+        if (pathData.chunk?.name === 'index') {
+          return 'my-index.js';
+        }
+
+        return '/some-path/[name].js';
+      },
+    },
+  },
+});

--- a/e2e/cases/filename-function/src/async.css
+++ b/e2e/cases/filename-function/src/async.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/filename-function/src/async.js
+++ b/e2e/cases/filename-function/src/async.js
@@ -1,0 +1,3 @@
+import './async.css';
+
+console.log('async');

--- a/e2e/cases/filename-function/src/index.css
+++ b/e2e/cases/filename-function/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: blue;
+}

--- a/e2e/cases/filename-function/src/index.js
+++ b/e2e/cases/filename-function/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+import(/* webpackChunkName: "foo" */ './async');

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -72,11 +72,26 @@ export const pluginOutput = (): RsbuildPlugin => ({
         const jsPath = getDistPath(config, 'js');
         const jsAsyncPath = getDistPath(config, 'jsAsync');
         const jsFilename = getFilename(config, 'js', isProd);
+        const isJsFilenameFn = typeof jsFilename === 'function';
 
         chain.output
           .path(api.context.distPath)
-          .filename(posix.join(jsPath, jsFilename))
-          .chunkFilename(posix.join(jsAsyncPath, jsFilename))
+          .filename(
+            isJsFilenameFn
+              ? (...args) => {
+                  const name = jsFilename(...args);
+                  return posix.join(jsPath, name);
+                }
+              : posix.join(jsPath, jsFilename),
+          )
+          .chunkFilename(
+            isJsFilenameFn
+              ? (...args) => {
+                  const name = jsFilename(...args);
+                  return posix.join(jsAsyncPath, name);
+                }
+              : posix.join(jsAsyncPath, jsFilename),
+          )
           .publicPath(publicPath)
           // disable pathinfo to improve compile performance
           // the path info is useless in most cases

--- a/packages/shared/src/fs.ts
+++ b/packages/shared/src/fs.ts
@@ -31,11 +31,21 @@ export const getDistPath = (
   return ret;
 };
 
-export const getFilename = (
+export function getFilename(
+  config: NormalizedConfig,
+  type: 'js',
+  isProd: boolean,
+): NonNullable<FilenameConfig['js']>;
+export function getFilename(
+  config: NormalizedConfig,
+  type: Exclude<keyof FilenameConfig, 'js'>,
+  isProd: boolean,
+): string;
+export function getFilename(
   config: NormalizedConfig,
   type: keyof FilenameConfig,
   isProd: boolean,
-) => {
+) {
   const { filename, filenameHash } = config.output;
 
   const getHash = () => {
@@ -63,4 +73,4 @@ export const getFilename = (
     default:
       throw new Error(`unknown key ${type} in "output.filename"`);
   }
-};
+}

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -5,7 +5,7 @@ import type {
 } from '@rspack/core';
 import type { CSSLoaderModulesOptions, HTMLPluginOptions } from '../../types';
 import type { RsbuildTarget } from '../rsbuild';
-import type { RspackConfig } from '../rspack';
+import type { Rspack, RspackConfig } from '../rspack';
 
 export type DistPathConfig = {
   /**
@@ -82,7 +82,7 @@ export type FilenameConfig = {
    * - dev: '[name].js'
    * - prod: '[name].[contenthash:8].js'
    */
-  js?: string;
+  js?: NonNullable<Rspack.Configuration['output']>['filename'];
   /**
    * The name of the CSS files.
    * @default

--- a/website/docs/en/config/output/filename.mdx
+++ b/website/docs/en/config/output/filename.mdx
@@ -96,7 +96,7 @@ const { add } = await import(
 
 After specifying the module name as above, the generated file will be `dist/static/js/async/my-chunk-name.js`.
 
-## Using Functions
+## Using Function
 
 You can pass a function to `output.filename.js`, allowing you to dynamically generate filenames based on file information:
 

--- a/website/docs/en/config/output/filename.mdx
+++ b/website/docs/en/config/output/filename.mdx
@@ -4,7 +4,9 @@
 
 ```ts
 type FilenameConfig = {
-  js?: string;
+  js?:
+    | string
+    | ((pathData: Rspack.PathData, assetInfo: Rspack.JsAssetInfo) => string);
   css?: string;
   svg?: string;
   font?: string;
@@ -93,6 +95,33 @@ const { add } = await import(
 ```
 
 After specifying the module name as above, the generated file will be `dist/static/js/async/my-chunk-name.js`.
+
+## Using Functions
+
+You can pass a function to `output.filename.js`, allowing you to dynamically generate filenames based on file information:
+
+```js
+export default {
+  output: {
+    filename: {
+      js: (pathData, assetInfo) => {
+        console.log(pathData); // You can check the contents of pathData here
+
+        if (pathData.chunk?.name === 'index') {
+          const isProd = process.env.NODE_ENV === 'production';
+          return isProd ? '[name].[contenthash:8].js' : '[name].js';
+        }
+
+        return '/some-path/[name].js';
+      },
+    },
+  },
+};
+```
+
+:::tip
+Except for `output.filename.js`, other types of files currently do not support using functions.
+:::
 
 ## Query Hash
 

--- a/website/docs/zh/config/output/filename.mdx
+++ b/website/docs/zh/config/output/filename.mdx
@@ -4,7 +4,9 @@
 
 ```ts
 type FilenameConfig = {
-  js?: string;
+  js?:
+    | string
+    | ((pathData: Rspack.PathData, assetInfo: Rspack.JsAssetInfo) => string);
   css?: string;
   svg?: string;
   font?: string;
@@ -93,6 +95,33 @@ const { add } = await import(
 ```
 
 通过以上写法指定模块名称后，生成的文件会是 `dist/static/js/async/my-chunk-name.js`。
+
+## 使用函数
+
+`output.filename.js` 可以传入一个函数，这允许你根据文件信息动态生成文件名：
+
+```js
+export default {
+  output: {
+    filename: {
+      js: (pathData, assetInfo) => {
+        console.log(pathData); // 你可以在这里查看 pathData 的内容
+
+        if (pathData.chunk?.name === 'index') {
+          const isProd = process.env.NODE_ENV === 'production';
+          return isProd ? '[name].[contenthash:8].js' : '[name].js';
+        }
+
+        return '/some-path/[name].js';
+      },
+    },
+  },
+};
+```
+
+:::tip
+除了 `output.filename.js` 以外，其他类型的文件目前暂不支持使用函数。
+:::
 
 ## Query Hash
 


### PR DESCRIPTION
## Summary

Allow `output.filename.js` to be a function.

Except for `output.filename.js`, other types of files currently do not support using functions.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2526

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
