### PR TITLE
feat: add server.open config, deprecate dev.startUrl

### DIFF
--- a/.changeset/red-numbers-sell.md
+++ b/.changeset/red-numbers-sell.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+release: 0.7.4

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -52,9 +52,9 @@ export async function init({
       ...config.source.define,
     };
 
-    if (commonOpts.open && !config.dev?.startUrl) {
-      config.dev ||= {};
-      config.dev.startUrl = commonOpts.open;
+    if (commonOpts.open && !config.server?.open) {
+      config.server ||= {};
+      config.server.open = commonOpts.open;
     }
 
     if (commonOpts.host) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -60,6 +60,7 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
 const getDefaultServerConfig = (): NormalizedServerConfig => ({
   port: DEFAULT_PORT,
   host: DEFAULT_DEV_HOST,
+  open: false,
   htmlFallback: 'index',
   compress: true,
   printUrls: true,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -40,7 +40,7 @@ async function applyDefaultPlugins(
   const { pluginSwc } = await import('./plugins/swc');
   const { pluginExternals } = await import('./plugins/externals');
   const { pluginSplitChunks } = await import('./plugins/splitChunks');
-  const { pluginStartUrl } = await import('./plugins/startUrl');
+  const { pluginOpen } = await import('./plugins/open');
   const { pluginInlineChunk } = await import('./plugins/inlineChunk');
   const { pluginBundleAnalyzer } = await import('./plugins/bundleAnalyzer');
   const { pluginRsdoctor } = await import('./plugins/rsdoctor');
@@ -79,7 +79,7 @@ async function applyDefaultPlugins(
     pluginSwc(),
     pluginExternals(),
     pluginSplitChunks(),
-    pluginStartUrl(),
+    pluginOpen(),
     pluginInlineChunk(),
     pluginBundleAnalyzer(),
     pluginRsdoctor(),

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -12,6 +12,7 @@ const OVERRIDE_PATH = [
   'output.cssModules.auto',
   'output.targets',
   'output.emitAssets',
+  'server.open',
   'server.printUrls',
   'dev.startUrl',
   'provider',

--- a/packages/core/src/plugins/open.ts
+++ b/packages/core/src/plugins/open.ts
@@ -98,16 +98,16 @@ export function resolveUrl(str: string, base: string) {
     return url.href;
   } catch (e) {
     throw new Error(
-      '[rsbuild:start-url]: Invalid input: not a valid URL or pathname',
+      '[rsbuild:open]: Invalid input: not a valid URL or pathname',
     );
   }
 }
 
 const openedURLs: string[] = [];
 
-export function pluginStartUrl(): RsbuildPlugin {
+export function pluginOpen(): RsbuildPlugin {
   return {
-    name: 'rsbuild:start-url',
+    name: 'rsbuild:open',
     setup(api) {
       const onStartServer = async (params: {
         port: number;
@@ -115,14 +115,15 @@ export function pluginStartUrl(): RsbuildPlugin {
       }) => {
         const { port, routes } = params;
         const config = api.getNormalizedConfig();
-        const { startUrl, beforeStartUrl } = config.dev;
+        const { beforeStartUrl } = config.dev;
+        const open = config.server.open || config.dev.startUrl;
         const { https } = api.context.devServer || {};
 
         // Skip open in codesandbox. After being bundled, the `open` package will
         // try to call system xdg-open, which will cause an error on codesandbox.
         // https://github.com/codesandbox/codesandbox-client/issues/6642
         const isCodesandbox = process.env.CSB === 'true';
-        const shouldOpen = Boolean(startUrl) && !isCodesandbox;
+        const shouldOpen = Boolean(open) && !isCodesandbox;
 
         if (!shouldOpen) {
           return;
@@ -132,14 +133,14 @@ export function pluginStartUrl(): RsbuildPlugin {
         const protocol = https ? 'https' : 'http';
         const baseUrl = `${protocol}://localhost:${port}`;
 
-        if (startUrl === true || !startUrl) {
+        if (open === true || !open) {
           if (routes.length) {
             // auto open the first one
             urls.push(`${baseUrl}${routes[0].pathname}`);
           }
         } else {
           urls.push(
-            ...castArray(startUrl).map((item) =>
+            ...castArray(open).map((item) =>
               resolveUrl(replacePlaceholder(item, port), baseUrl),
             ),
           );

--- a/packages/core/tests/__snapshots__/inspect.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inspect.test.ts.snap
@@ -22,7 +22,7 @@ exports[`inspectConfig > should print plugin names when inspect config 1`] = `
   "rsbuild:swc",
   "rsbuild:externals",
   "rsbuild:split-chunks",
-  "rsbuild:start-url",
+  "rsbuild:open",
   "rsbuild:inline-chunk",
   "rsbuild:bundle-analyzer",
   "rsbuild:rsdoctor",

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -160,23 +160,23 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
-  test('should merge dev.startUrl correctly', async () => {
+  test('should merge server.open correctly', async () => {
     expect(
       mergeRsbuildConfig(
         {
-          dev: {
-            startUrl: ['http://localhost:3000'],
+          server: {
+            open: ['http://localhost:3000'],
           },
         },
         {
-          dev: {
-            startUrl: false,
+          server: {
+            open: false,
           },
         },
       ),
     ).toEqual({
-      dev: {
-        startUrl: false,
+      server: {
+        open: false,
       },
     });
   });

--- a/packages/core/tests/open.test.ts
+++ b/packages/core/tests/open.test.ts
@@ -1,6 +1,6 @@
-import { replacePlaceholder, resolveUrl } from '../src/plugins/startUrl';
+import { replacePlaceholder, resolveUrl } from '../src/plugins/open';
 
-describe('plugin-start-url', () => {
+describe('plugin-open', () => {
   it('#replacePlaceholder - should replace port number correctly', () => {
     expect(replacePlaceholder('http://localhost:8080', 3000)).toEqual(
       'http://localhost:8080',

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -48,8 +48,8 @@ export interface DevConfig {
    */
   liveReload?: boolean;
   /**
-   * Used to set the page URL to open automatically when the Dev Server starts.
-   * By default, no page will be opened.
+   * Set the page URL to open when the server starts.
+   * @deprecated use `server.open` instead
    */
   startUrl?: boolean | string | string[];
   /**

--- a/packages/shared/src/types/config/server.ts
+++ b/packages/shared/src/types/config/server.ts
@@ -106,6 +106,10 @@ export interface ServerConfig {
    */
   historyApiFallback?: boolean | HistoryApiFallbackOptions;
   /**
+   * Set the page URL to open when the server starts.
+   */
+  open?: boolean | string | string[];
+  /**
    * Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
    */
   proxy?: ProxyOptions;
@@ -130,5 +134,6 @@ export type NormalizedServerConfig = ServerConfig &
       | 'publicDir'
       | 'strictPort'
       | 'printUrls'
+      | 'open'
     >
   >;

--- a/website/docs/en/config/dev/before-start-url.mdx
+++ b/website/docs/en/config/dev/before-start-url.mdx
@@ -3,12 +3,14 @@
 - **Type:** `() => Promise<void> | void`
 - **Default:** `undefined`
 
-`dev.beforeStartUrl` is used to execute a callback function before opening the `startUrl`, this config needs to be used together with [dev.startUrl](/config/dev/start-url).
+`dev.beforeStartUrl` is used to execute a callback function before opening the `startUrl`, this config needs to be used together with [server.open](/config/server/open).
 
 ```js
 export default {
+  server: {
+    open: true,
+  },
   dev: {
-    startUrl: true,
     beforeStartUrl: async () => {
       await doSomeThing();
     },

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -1,22 +1,22 @@
-# dev.startUrl
+# server.open
 
 - **Type:** `boolean | string | string[] | undefined`
 - **Default:** `undefined`
 
-`dev.startUrl` is used to configure a set of page URLs that Rsbuild will automatically open in the browser after starting the server.
+`server.open` is used to configure a set of page URLs that Rsbuild will automatically open in the browser after starting the server.
 
 > You can also use the [--open](/guide/basic/cli#opening-page) option of Rsbuild CLI to open the pages.
 
 ### Example
 
-`dev.startUrl` can be set to the following values.
+`server.open` can be set to the following values.
 
 - Open the project's default preview page, equivalent to `http://localhost:<port>`:
 
 ```js
 export default {
-  dev: {
-    startUrl: true,
+  server: {
+    open: true,
   },
 };
 ```
@@ -25,8 +25,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://localhost:3000',
+  server: {
+    open: 'http://localhost:3000',
   },
 };
 ```
@@ -35,8 +35,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: '/home',
+  server: {
+    open: '/home',
   },
 };
 ```
@@ -45,8 +45,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: ['/', '/about'],
+  server: {
+    open: ['/', '/about'],
   },
 };
 ```
@@ -55,8 +55,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://www.example.com',
+  server: {
+    open: 'http://www.example.com',
   },
 };
 ```
@@ -67,8 +67,8 @@ Since the port number may change, you can use the `<port>` placeholder to refer 
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://localhost:<port>/home',
+  server: {
+    open: 'http://localhost:<port>/home',
   },
 };
 ```

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -2,6 +2,7 @@
 
 - **Type:** `boolean | string | string[] | undefined`
 - **Default:** `undefined`
+- **Version:** `>= 0.7.4`
 
 `server.open` is used to configure a set of page URLs that Rsbuild will automatically open in the browser after starting the server.
 

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -45,7 +45,7 @@ Options:
 
 ### Opening Page
 
-The `--open` option allows you to automatically open a page when starting the dev server, which is equivalent to setting [dev.startUrl](/config/dev/start-url) to `true`.
+The `--open` option allows you to automatically open a page when starting the dev server, which is equivalent to setting [server.open](/config/server/open) to `true`.
 
 ```bash
 rsbuild dev --open

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -111,7 +111,7 @@ Below are the Rsbuild configs that correspond to the Rspack CLI's `devServer` co
 | [devServer.host](https://rspack.dev/config/dev-server#devserverhost)                             | [server.host](/config/server/host)                               |
 | [devServer.hot](https://rspack.dev/config/dev-server#devserverhot)                               | [dev.hmr](/config/dev/hmr)                                       |
 | [devServer.liveReload](https://rspack.dev/config/dev-server#devserverlivereload)                 | [dev.liveReload](/config/dev/live-reload)                        |
-| [devServer.open](https://rspack.dev/config/dev-server#devserveropen)                             | [dev.startUrl](/config/dev/start-url)                            |
+| [devServer.open](https://rspack.dev/config/dev-server#devserveropen)                             | [server.open](/config/server/open)                               |
 | [devServer.port](https://rspack.dev/config/dev-server#devserverport)                             | [server.port](/config/server/port)                               |
 | [devServer.proxy](https://rspack.dev/config/dev-server#devserverproxy)                           | [server.proxy](/config/server/proxy)                             |
 | [devServer.setupMiddlewares](https://rspack.dev/config/dev-server#devserversetupmiddlewares)     | [dev.setupMiddlewares](/config/dev/setup-middlewares)            |

--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -58,7 +58,7 @@ Here are all the main features supported by Rsbuild.
 | ---------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
 | Public Dir | Use the public directory as the directory for serving public assets by default | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul> |
 | Proxy      | Optional feature, proxy requests to the specified service                      | <ul><li>[dev.proxy](/config/dev/proxy)</li></ul>                |
-| Open page  | Optional feature, automatically open page in browser when starting server      | <ul><li>[dev.startUrl](/config/dev/start-url) </li></ul>        |
+| Open page  | Optional feature, automatically open page in browser when starting server      | <ul><li>[server.open](/config/server/open)</li></ul>            |
 | HTTPS      | Optional feature, enable HTTPS server                                          | <ul><li>[server.https](/config/server/https)</li></ul>          |
 
 ## Frontend Framework

--- a/website/docs/zh/config/dev/before-start-url.mdx
+++ b/website/docs/zh/config/dev/before-start-url.mdx
@@ -3,12 +3,14 @@
 - **类型：** `() => Promise<void> | void`
 - **默认值：** `undefined`
 
-`dev.beforeStartUrl` 用于在打开 `startUrl` 前执行一段回调函数，该配置项需要与 [dev.startUrl](/config/dev/start-url) 一同使用。
+`dev.beforeStartUrl` 用于在打开 `startUrl` 前执行一段回调函数，该配置项需要与 [server.open](/config/server.open) 一同使用。
 
 ```js
 export default {
+  server: {
+    open: true,
+  },
   dev: {
-    startUrl: true,
     beforeStartUrl: async () => {
       await doSomeThing();
     },

--- a/website/docs/zh/config/dev/before-start-url.mdx
+++ b/website/docs/zh/config/dev/before-start-url.mdx
@@ -3,7 +3,7 @@
 - **类型：** `() => Promise<void> | void`
 - **默认值：** `undefined`
 
-`dev.beforeStartUrl` 用于在打开 `startUrl` 前执行一段回调函数，该配置项需要与 [server.open](/config/server.open) 一同使用。
+`dev.beforeStartUrl` 用于在打开 `startUrl` 前执行一段回调函数，该配置项需要与 [server.open](/config/server/open) 一同使用。
 
 ```js
 export default {

--- a/website/docs/zh/config/server/open.mdx
+++ b/website/docs/zh/config/server/open.mdx
@@ -1,22 +1,22 @@
-# dev.startUrl
+# server.open
 
 - **类型：** `boolean | string | string[] | undefined`
 - **默认值：** `undefined`
 
-`dev.startUrl` 用于配置一组页面 URL，Rsbuild 会在启动 server 后自动在浏览器中打开这些页面。
+`server.open` 用于配置一组页面 URL，Rsbuild 会在启动 server 后自动在浏览器中打开这些页面。
 
 > 你也可以使用 Rsbuild CLI 的 [--open](/guide/basic/cli#打开页面) 选项来打开页面。
 
 ### 示例
 
-`dev.startUrl` 可以设置为如下的值。
+`server.open` 可以设置为如下的值。
 
 - 打开项目的默认页面，等价于 `http://localhost:<port>`：
 
 ```js
 export default {
-  dev: {
-    startUrl: true,
+  server: {
+    open: true,
   },
 };
 ```
@@ -25,8 +25,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://localhost:3000',
+  server: {
+    open: 'http://localhost:3000',
   },
 };
 ```
@@ -35,8 +35,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: '/home',
+  server: {
+    open: '/home',
   },
 };
 ```
@@ -45,8 +45,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: ['/', '/about'],
+  server: {
+    open: ['/', '/about'],
   },
 };
 ```
@@ -55,8 +55,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://www.example.com',
+  server: {
+    open: 'http://www.example.com',
   },
 };
 ```
@@ -67,8 +67,8 @@ export default {
 
 ```js
 export default {
-  dev: {
-    startUrl: 'http://localhost:<port>/home',
+  server: {
+    open: 'http://localhost:<port>/home',
   },
 };
 ```

--- a/website/docs/zh/config/server/open.mdx
+++ b/website/docs/zh/config/server/open.mdx
@@ -2,6 +2,7 @@
 
 - **类型：** `boolean | string | string[] | undefined`
 - **默认值：** `undefined`
+- **版本：** `>= 0.7.4`
 
 `server.open` 用于配置一组页面 URL，Rsbuild 会在启动 server 后自动在浏览器中打开这些页面。
 

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -45,7 +45,7 @@ Options:
 
 ### 打开页面
 
-通过 `--open` 选项可以在启动 dev server 时自动打开页面，等同于将 [dev.startUrl](/config/dev/start-url) 设置为 `true`。
+通过 `--open` 选项可以在启动 dev server 时自动打开页面，等同于将 [server.open](/config/server/open) 设置为 `true`。
 
 ```bash
 rsbuild dev --open

--- a/website/docs/zh/guide/basic/server.mdx
+++ b/website/docs/zh/guide/basic/server.mdx
@@ -111,7 +111,7 @@ Rsbuild 不支持使用 Rspack 的 [devServer](https://rspack.dev/config/dev-ser
 | [devServer.host](https://rspack.dev/config/dev-server#devserverhost)                             | [server.host](/config/server/host)                               |
 | [devServer.hot](https://rspack.dev/config/dev-server#devserverhot)                               | [dev.hmr](/config/dev/hmr)                                       |
 | [devServer.liveReload](https://rspack.dev/config/dev-server#devserverlivereload)                 | [dev.liveReload](/config/dev/live-reload)                        |
-| [devServer.open](https://rspack.dev/config/dev-server#devserveropen)                             | [dev.startUrl](/config/dev/start-url)                            |
+| [devServer.open](https://rspack.dev/config/dev-server#devserveropen)                             | [server.open](/config/server/open)                               |
 | [devServer.port](https://rspack.dev/config/dev-server#devserverport)                             | [server.port](/config/server/port)                               |
 | [devServer.proxy](https://rspack.dev/config/dev-server#devserverproxy)                           | [server.proxy](/config/server/proxy)                             |
 | [devServer.setupMiddlewares](https://rspack.dev/config/dev-server#devserversetupmiddlewares)     | [dev.setupMiddlewares](/config/dev/setup-middlewares)            |

--- a/website/docs/zh/guide/start/features.mdx
+++ b/website/docs/zh/guide/start/features.mdx
@@ -58,7 +58,7 @@
 | ----------- | ------------------------------------------------ | --------------------------------------------------------------- |
 | Public 目录 | 默认将 public 目录作为静态资源服务的文件夹       | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul> |
 | 请求代理    | 可选功能，将请求代理到指定的服务上               | <ul><li>[dev.proxy](/config/dev/proxy)</li></ul>                |
-| 打开页面    | 可选功能，在启动 server 时自动在浏览器中打开页面 | <ul><li>[dev.startUrl](/config/dev/start-url)</li></ul>         |
+| 打开页面    | 可选功能，在启动 server 时自动在浏览器中打开页面 | <ul><li>[server.open](/config/server/open)</li></ul>            |
 | HTTPS       | 可选功能，开启 server 对 HTTPS 的支持            | <ul><li>[server.https](/config/server/https)</li></ul>          |
 
 ## 框架支持

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -142,8 +142,8 @@ export default defineConfig({
         '@zh': path.join(__dirname, 'docs/zh'),
       },
     },
-    dev: {
-      startUrl: 'http://localhost:<port>/',
+    server: {
+      open: 'http://localhost:<port>/',
     },
   },
 });


### PR DESCRIPTION
## Summary

Add `server.open` config and deprecate `dev.startUrl`:

- Align with Rspack dev server's [open](https://www.rspack.dev/config/dev-server#devserveropen) config.
- Allow to use in the preview server

`dev.startUrl` will be removed in 1.0.0-alpha.0.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2508#discussioncomment-9684336

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
