### PR TITLE
fix(create-rsbuild): let prettier ignore lock files

### DIFF
--- a/packages/create-rsbuild/template-prettier/.prettierignore
+++ b/packages/create-rsbuild/template-prettier/.prettierignore
@@ -1,0 +1,4 @@
+# Lock files
+package-lock.json
+pnpm-lock.yaml
+yarn.lock

--- a/packages/create-rsbuild/template-prettier/.prettierrc
+++ b/packages/create-rsbuild/template-prettier/.prettierrc
@@ -1,3 +1,3 @@
 {
-	"singleQuote": true
+  "singleQuote": true
 }


### PR DESCRIPTION
## Summary

Let prettier ignore lock files.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
