### PR TITLE
feat(create-rsbuild): allow to add ESLint as linter

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -134,16 +134,13 @@ export async function main() {
     const toolFolder = path.join(packageRoot, `template-${tool}`);
 
     if (tool === 'eslint') {
-      const fromFolder = path.join(toolFolder, `${framework}-${language}`);
-      if (fs.existsSync(fromFolder)) {
-        copyFolder(fromFolder, distFolder, version);
-      } else {
-        copyFolder(
-          path.join(toolFolder, `common-${language}`),
-          distFolder,
-          version,
-        );
+      let subFolder = path.join(toolFolder, `${framework}-${language}`);
+
+      if (!fs.existsSync(subFolder)) {
+        subFolder = path.join(toolFolder, `common-${language}`);
       }
+
+      copyFolder(subFolder, distFolder, version);
     } else {
       copyFolder(toolFolder, distFolder, version);
     }

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -118,6 +118,7 @@ export async function main() {
       message: 'Select additional tools (use arrow keys / space bar)',
       options: [
         { value: 'biome', label: 'Add Biome for code linting and formatting' },
+        { value: 'eslint', label: 'Add ESLint for code linting' },
         { value: 'prettier', label: 'Add Prettier for code formatting' },
       ],
     }),

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -132,7 +132,21 @@ export async function main() {
 
   for (const tool of tools) {
     const toolFolder = path.join(packageRoot, `template-${tool}`);
-    copyFolder(toolFolder, distFolder, version);
+
+    if (tool === 'eslint') {
+      const fromFolder = path.join(toolFolder, `${framework}-${language}`);
+      if (fs.existsSync(fromFolder)) {
+        copyFolder(fromFolder, distFolder, version);
+      } else {
+        copyFolder(
+          path.join(toolFolder, `common-${language}`),
+          distFolder,
+          version,
+        );
+      }
+    } else {
+      copyFolder(toolFolder, distFolder, version);
+    }
   }
 
   const nextSteps = [

--- a/packages/create-rsbuild/template-eslint/common-js/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/common-js/eslint.config.mjs
@@ -1,0 +1,8 @@
+import js from '@eslint/js';
+import globals from 'globals';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/common-js/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/common-js/extra-package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "globals": "^15.4.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/common-ts/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/common-ts/eslint.config.mjs
@@ -1,0 +1,10 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/common-ts/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/common-ts/extra-package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "globals": "^15.4.0",
+    "typescript-eslint": "^7.12.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/react-js/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/react-js/eslint.config.mjs
@@ -1,0 +1,11 @@
+import { fixupConfigRules } from '@eslint/compat';
+import js from '@eslint/js';
+import react from 'eslint-plugin-react/configs/recommended.js';
+import globals from 'globals';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  ...fixupConfigRules(react),
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/react-js/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/react-js/extra-package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/compat": "^1.0.3",
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-react": "^7.34.2",
+    "globals": "^15.4.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/react-ts/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/react-ts/eslint.config.mjs
@@ -1,0 +1,13 @@
+import { fixupConfigRules } from '@eslint/compat';
+import js from '@eslint/js';
+import react from 'eslint-plugin-react/configs/recommended.js';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...fixupConfigRules(react),
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/react-ts/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/react-ts/extra-package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/compat": "^1.0.3",
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-react": "^7.34.2",
+    "globals": "^15.4.0",
+    "typescript-eslint": "^7.12.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/svelte-js/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/svelte-js/eslint.config.mjs
@@ -1,0 +1,20 @@
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+  js.configs.recommended,
+  ...svelte.configs['flat/recommended'],
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  {
+    ignores: ['dist/'],
+  },
+];

--- a/packages/create-rsbuild/template-eslint/svelte-js/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/svelte-js/extra-package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-svelte": "^2.36.0",
+    "globals": "^15.4.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/svelte-ts/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/svelte-ts/eslint.config.mjs
@@ -1,0 +1,28 @@
+import js from '@eslint/js';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+/** @type {import('eslint').Linter.FlatConfig[]} */
+export default [
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...svelte.configs['flat/recommended'],
+  {
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+    },
+  },
+  {
+    files: ['**/*.svelte'],
+    languageOptions: {
+      parserOptions: {
+        parser: ts.parser,
+      },
+    },
+  },
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/svelte-ts/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/svelte-ts/extra-package.json
@@ -1,0 +1,13 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-svelte": "^2.36.0",
+    "globals": "^15.4.0",
+    "typescript-eslint": "^8.0.0-alpha.20"
+  },
+  "type": "module"
+}

--- a/packages/create-rsbuild/template-eslint/vue-js/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/vue-js/eslint.config.mjs
@@ -1,0 +1,10 @@
+import js from '@eslint/js';
+import vue from 'eslint-plugin-vue';
+import globals from 'globals';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  ...vue.configs['flat/essential'],
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/vue-js/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/vue-js/extra-package.json
@@ -1,0 +1,11 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-vue": "^9.26.0",
+    "globals": "^15.4.0"
+  }
+}

--- a/packages/create-rsbuild/template-eslint/vue-ts/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/vue-ts/eslint.config.mjs
@@ -1,0 +1,12 @@
+import js from '@eslint/js';
+import vue from 'eslint-plugin-vue';
+import globals from 'globals';
+import ts from 'typescript-eslint';
+
+export default [
+  { languageOptions: { globals: globals.browser } },
+  js.configs.recommended,
+  ...ts.configs.recommended,
+  ...vue.configs['flat/essential'],
+  { ignores: ['dist/'] },
+];

--- a/packages/create-rsbuild/template-eslint/vue-ts/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/vue-ts/extra-package.json
@@ -1,0 +1,12 @@
+{
+  "scripts": {
+    "lint": "eslint ."
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.4.0",
+    "eslint": "9.x",
+    "eslint-plugin-vue": "^9.26.0",
+    "globals": "^15.4.0",
+    "typescript-eslint": "^7.12.0"
+  }
+}


### PR DESCRIPTION
## Summary

Allow to add ESLint as linter.

Provide default lint configs for React / Vue / Svelte / common.

## Related Links

https://eslint.org/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
