### PR TITLE
chore: external rspack when prebundle rspack-chain

### DIFF
--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -52,6 +52,7 @@ export default {
     {
       name: 'rspack-chain',
       externals: {
+        '@rspack/core': '@rspack/core',
         deepmerge: '../deepmerge',
       },
     },


### PR DESCRIPTION
## Summary

Should external `@rspack/core` when prebundle rspack-chain.

## Related Links

Fix ecosystem CI: https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/9459134648/job/26059002470

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
