### PR TITLE
test(e2e): improve styled-components case

### DIFF
--- a/e2e/cases/styled-component/index.test.ts
+++ b/e2e/cases/styled-component/index.test.ts
@@ -1,29 +1,21 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import type { CreateRsbuildOptions } from '@rsbuild/core';
 import { pluginStyledComponents } from '@rsbuild/plugin-styled-components';
-import type { CreateRsbuildOptions } from '@rsbuild/shared';
 
 const commonConfig: CreateRsbuildOptions = {
   cwd: __dirname,
   rsbuildConfig: {
-    tools: {
-      bundlerChain: (chain: any) => {
-        chain.externals(['styled-components']);
-      },
-    },
     output: {
       minify: false,
     },
   },
 };
 
-test('should not compiled styled-components by default', async () => {
+test('should not transform styled-components by default', async () => {
   const rsbuild = await build(commonConfig);
-  const files = await rsbuild.unwrapOutputJSON();
-
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.js'))!];
-  expect(content).toContain('div`');
+  const { content } = await rsbuild.getIndexFile();
+  expect(content).not.toContain('div.withConfig');
 });
 
 rspackOnlyTest(
@@ -33,11 +25,7 @@ rspackOnlyTest(
       ...commonConfig,
       plugins: [pluginStyledComponents()],
     });
-    const files = await rsbuild.unwrapOutputJSON();
-
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.js'))!];
-
+    const { content } = await rsbuild.getIndexFile();
     expect(content).toContain('div.withConfig');
   },
 );


### PR DESCRIPTION
## Summary

Improve styled-components case and fix Rspack ecosystem CI.

- input:

```js
import styled from 'styled-components';

const div = styled.div`
  color: red;
`;
```

- Rspack 0.7.1 output:

```js
const div = styled_components__WEBPACK_IMPORTED_MODULE_0___default().div`
  color: red;
`;
```

- Rspack 0.7.2 output:

```js
const div = (styled_components__WEBPACK_IMPORTED_MODULE_0___default().div)`
  color: red;
`;
```

## Related Links

see https://github.com/web-infra-dev/rspack-ecosystem-ci/actions/runs/9461493494/job/26062533760#step:6:2905

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
