### PR TITLE
fix(example): load moduleFederation config file fail

### DIFF
--- a/examples/module-federation/host/rsbuild.config.ts
+++ b/examples/module-federation/host/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { mfConfig } from './module-federation.config';
+import { mfConfig } from './moduleFederation.config';
 
 export default defineConfig({
   plugins: [pluginReact()],

--- a/examples/module-federation/remote/rsbuild.config.ts
+++ b/examples/module-federation/remote/rsbuild.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { mfConfig } from './module-federation.config';
+import { mfConfig } from './moduleFederation.config';
 
 export default defineConfig({
   plugins: [pluginReact()],


### PR DESCRIPTION
## Summary

update `./module-federation.config` to `./moduleFederation.config`
<img width="1407" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/8fd47821-6903-4799-9b7e-ece8c1781000">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
