### PR TITLE
fix: allow to import multiple core-js versions

### DIFF
--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -131,7 +131,8 @@ export const pluginSwc = (): RsbuildPlugin => ({
          * https://webpack.js.org/api/module-methods/#import
          * @example: import x from 'data:text/javascript,export default 1;';
          */
-        dataUriRule.resolve // https://github.com/webpack/webpack/issues/11467 // compatible with legacy packages with type="module"
+        dataUriRule.resolve
+          // https://github.com/webpack/webpack/issues/11467 // compatible with legacy packages with type="module"
           .set('fullySpecified', false)
           .end()
           .use(CHAIN_ID.USE.SWC)

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -132,7 +132,8 @@ export const pluginSwc = (): RsbuildPlugin => ({
          * @example: import x from 'data:text/javascript,export default 1;';
          */
         dataUriRule.resolve
-          // https://github.com/webpack/webpack/issues/11467 // compatible with legacy packages with type="module"
+          // https://github.com/webpack/webpack/issues/11467
+          // compatible with legacy packages with type="module"
           .set('fullySpecified', false)
           .end()
           .use(CHAIN_ID.USE.SWC)

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import {
   type Polyfill,
   type RsbuildTarget,
-  type RspackChain,
   SCRIPT_REGEX,
   applyScriptCondition,
   cloneDeep,
@@ -68,6 +67,12 @@ export const pluginSwc = (): RsbuildPlugin => ({
           .test(SCRIPT_REGEX)
           .type('javascript/auto');
 
+        const dataUriRule = chain.module
+          .rule(CHAIN_ID.RULE.JS_DATA_URI)
+          .mimetype({
+            or: ['text/javascript', 'application/javascript'],
+          });
+
         applyScriptCondition({
           rule,
           chain,
@@ -101,8 +106,11 @@ export const pluginSwc = (): RsbuildPlugin => ({
             swcConfig.env!.mode = undefined;
           } else {
             swcConfig.env!.mode = polyfillMode;
-            /* Apply core-js version and path alias and exclude core-js */
-            await applyCoreJs(swcConfig, chain, polyfillMode);
+
+            const coreJsDir = await applyCoreJs(swcConfig, polyfillMode);
+            for (const item of [rule, dataUriRule]) {
+              item.resolve.alias.set('core-js', coreJsDir);
+            }
           }
         }
 
@@ -123,14 +131,8 @@ export const pluginSwc = (): RsbuildPlugin => ({
          * https://webpack.js.org/api/module-methods/#import
          * @example: import x from 'data:text/javascript,export default 1;';
          */
-        chain.module
-          .rule(CHAIN_ID.RULE.JS_DATA_URI)
-          .mimetype({
-            or: ['text/javascript', 'application/javascript'],
-          })
-          // compatible with legacy packages with type="module"
-          // https://github.com/webpack/webpack/issues/11467
-          .resolve.set('fullySpecified', false)
+        dataUriRule.resolve // https://github.com/webpack/webpack/issues/11467 // compatible with legacy packages with type="module"
+          .set('fullySpecified', false)
           .end()
           .use(CHAIN_ID.USE.SWC)
           .loader(builtinSwcLoaderName)
@@ -143,7 +145,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
 
 async function applyCoreJs(
   swcConfig: SwcLoaderOptions,
-  chain: RspackChain,
   polyfillMode: Polyfill,
 ) {
   const coreJsPath = require.resolve('core-js/package.json');
@@ -158,9 +159,7 @@ async function applyCoreJs(
     swcConfig.env!.shippedProposals = true;
   }
 
-  chain.resolve.alias.merge({
-    'core-js': coreJsDir,
-  });
+  return coreJsDir;
 }
 
 function applyTransformImport(

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -99,6 +99,11 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -143,6 +148,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -420,7 +428,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
       ".ts",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -99,6 +99,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -143,6 +148,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -420,7 +428,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
       ".ts",
@@ -538,6 +545,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -582,6 +594,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -924,7 +939,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
       ".ts",
@@ -1365,6 +1379,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -1409,6 +1428,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -1689,7 +1711,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
     "extensions": [
       ".ts",

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -21,6 +21,11 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -65,6 +70,9 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -106,7 +114,6 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
   },
 }
@@ -134,6 +141,11 @@ exports[`plugin-swc > should add browserslist 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -175,6 +187,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -213,7 +228,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -242,6 +256,11 @@ exports[`plugin-swc > should add browserslist 2`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -283,6 +302,9 @@ exports[`plugin-swc > should add browserslist 2`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -321,7 +343,6 @@ exports[`plugin-swc > should add browserslist 2`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -350,6 +371,11 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -401,6 +427,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -449,7 +478,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -470,6 +498,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
+    "resolve": {
+      "alias": {
+        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+      },
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -491,6 +524,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       ],
     },
     "resolve": {
+      "alias": {
+        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+      },
       "fullySpecified": false,
     },
     "use": [
@@ -521,6 +557,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
+    "resolve": {
+      "alias": {
+        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+      },
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -565,6 +606,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       ],
     },
     "resolve": {
+      "alias": {
+        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+      },
       "fullySpecified": false,
     },
     "use": [
@@ -625,6 +669,11 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -669,6 +718,9 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -710,7 +762,6 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
     },
   },
 }
@@ -949,6 +1000,11 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -992,6 +1048,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -1032,7 +1091,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -1061,6 +1119,11 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1105,6 +1168,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -1146,7 +1212,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -1176,6 +1241,11 @@ exports[`plugin-swc > should has correct core-js 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1219,6 +1289,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -1259,7 +1332,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },
@@ -1389,6 +1461,11 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1433,6 +1510,9 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
             ],
           },
           "resolve": {
+            "alias": {
+              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+            },
             "fullySpecified": false,
           },
           "use": [
@@ -1474,7 +1554,6 @@ exports[`plugin-swc > should'n override browserslist when target platform is not
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
   },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -17,6 +17,11 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
   ],
+  "resolve": {
+    "alias": {
+      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+    },
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -116,6 +116,11 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -165,6 +170,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           ],
         },
         "resolve": {
+          "alias": {
+            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+          },
           "fullySpecified": false,
         },
         "use": [
@@ -467,7 +475,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       "react-refresh": "<ROOT>/node_modules/<PNPM_INNER>/react-refresh",
     },
     "extensions": [

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -13,6 +13,11 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resolve": {
+    "alias": {
+      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+    },
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -125,6 +130,11 @@ exports[`plugins/styled-components > should enable ssr option when target contai
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resolve": {
+    "alias": {
+      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+    },
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [


### PR DESCRIPTION
## Summary

Allow to import multiple core-js versions, as some legacy packages are still using `core-js@2` or `babel-runtime/core-js`.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/2566

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
