### PR TITLE
feat(create-rsbuild): add eslint-plugin-react-hooks

### DIFF
--- a/packages/create-rsbuild/template-eslint/react-js/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/react-js/eslint.config.mjs
@@ -1,11 +1,29 @@
-import { fixupConfigRules } from '@eslint/compat';
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactJsx from 'eslint-plugin-react/configs/jsx-runtime.js';
 import react from 'eslint-plugin-react/configs/recommended.js';
 import globals from 'globals';
 
 export default [
   { languageOptions: { globals: globals.browser } },
   js.configs.recommended,
-  ...fixupConfigRules(react),
+  ...fixupConfigRules([
+    {
+      ...react,
+      settings: {
+        react: { version: 'detect' },
+      },
+    },
+    reactJsx,
+  ]),
+  {
+    plugins: {
+      'react-hooks': fixupPluginRules(reactHooks),
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
   { ignores: ['dist/'] },
 ];

--- a/packages/create-rsbuild/template-eslint/react-js/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/react-js/extra-package.json
@@ -7,6 +7,7 @@
     "@eslint/js": "^9.4.0",
     "eslint": "9.x",
     "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "globals": "^15.4.0"
   }
 }

--- a/packages/create-rsbuild/template-eslint/react-ts/eslint.config.mjs
+++ b/packages/create-rsbuild/template-eslint/react-ts/eslint.config.mjs
@@ -1,5 +1,7 @@
-import { fixupConfigRules } from '@eslint/compat';
+import { fixupConfigRules, fixupPluginRules } from '@eslint/compat';
 import js from '@eslint/js';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactJsx from 'eslint-plugin-react/configs/jsx-runtime.js';
 import react from 'eslint-plugin-react/configs/recommended.js';
 import globals from 'globals';
 import ts from 'typescript-eslint';
@@ -8,6 +10,22 @@ export default [
   { languageOptions: { globals: globals.browser } },
   js.configs.recommended,
   ...ts.configs.recommended,
-  ...fixupConfigRules(react),
+  ...fixupConfigRules([
+    {
+      ...react,
+      settings: {
+        react: { version: 'detect' },
+      },
+    },
+    reactJsx,
+  ]),
+  {
+    plugins: {
+      'react-hooks': fixupPluginRules(reactHooks),
+    },
+    rules: {
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
   { ignores: ['dist/'] },
 ];

--- a/packages/create-rsbuild/template-eslint/react-ts/extra-package.json
+++ b/packages/create-rsbuild/template-eslint/react-ts/extra-package.json
@@ -7,6 +7,7 @@
     "@eslint/js": "^9.4.0",
     "eslint": "9.x",
     "eslint-plugin-react": "^7.34.2",
+    "eslint-plugin-react-hooks": "^4.6.2",
     "globals": "^15.4.0",
     "typescript-eslint": "^7.12.0"
   }


### PR DESCRIPTION
## Summary

- add eslint-plugin-react-hooks to React ESLint templates.
- add `eslint-plugin-react/configs/jsx-runtime` to fix JSX runtime errors.

## Related Links

https://github.com/jsx-eslint/eslint-plugin-react/issues/3699
https://www.npmjs.com/package/eslint-plugin-react-hooks

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
