### PR TITLE
feat: export plugin name const

### DIFF
--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -4,10 +4,12 @@ import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
 
+export const PLUGIN_ASSETS_RETRY_NAME = 'rsbuild:assets-retry';
+
 export const pluginAssetsRetry = (
   options: PluginAssetsRetryOptions = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:assets-retry',
+  name: PLUGIN_ASSETS_RETRY_NAME,
   setup(api) {
     api.modifyBundlerChain(
       async (chain, { CHAIN_ID, target, HtmlPlugin, isProd }) => {

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -1,4 +1,8 @@
-export { pluginBabel, getDefaultBabelOptions } from './plugin';
+export {
+  pluginBabel,
+  getDefaultBabelOptions,
+  PLUGIN_BABEL_NAME,
+} from './plugin';
 export {
   getBabelUtils,
   getUseBuiltIns,

--- a/packages/plugin-check-syntax/src/index.ts
+++ b/packages/plugin-check-syntax/src/index.ts
@@ -20,11 +20,13 @@ async function getTargets(
   );
 }
 
+export const PLUGIN_CHECK_SYNTAX_NAME = 'rsbuild:check-syntax';
+
 export function pluginCheckSyntax(
   options: PluginCheckSyntaxOptions = {},
 ): RsbuildPlugin {
   return {
-    name: 'rsbuild:check-syntax',
+    name: PLUGIN_CHECK_SYNTAX_NAME,
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { isDev, target }) => {

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -55,10 +55,12 @@ export function applyCSSMinimizer(
     .end();
 }
 
+export const PLUGIN_CSS_MINIMIZER_NAME = 'rsbuild:css-minimizer';
+
 export const pluginCssMinimizer = (
   options?: PluginCssMinimizerOptions,
 ): RsbuildPlugin => ({
-  name: 'rsbuild:css-minimizer',
+  name: PLUGIN_CSS_MINIMIZER_NAME,
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd }) => {

--- a/packages/plugin-eslint/src/index.ts
+++ b/packages/plugin-eslint/src/index.ts
@@ -15,10 +15,12 @@ export type PluginEslintOptions = {
   eslintPluginOptions?: Options;
 };
 
+export const PLUGIN_ESLINT_NAME = 'rsbuild:eslint';
+
 export const pluginEslint = (
   options: PluginEslintOptions = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:eslint',
+  name: PLUGIN_ESLINT_NAME,
 
   setup(api) {
     const { enable = true, eslintPluginOptions } = options;

--- a/packages/plugin-image-compress/src/index.ts
+++ b/packages/plugin-image-compress/src/index.ts
@@ -33,11 +33,13 @@ const normalizeOptions = (options: Options[]) => {
   return normalized;
 };
 
+export const PLUGIN_IMAGE_COMPRESS_NAME = 'rsbuild:image-compress';
+
 /** Options enable by default: {@link DEFAULT_OPTIONS} */
 export const pluginImageCompress: IPluginImageCompress = (
   ...args
 ): RsbuildPlugin => ({
-  name: 'rsbuild:image-compress',
+  name: PLUGIN_IMAGE_COMPRESS_NAME,
 
   setup(api) {
     const opts = normalizeOptions(castOptions(args));

--- a/packages/plugin-mdx/src/index.ts
+++ b/packages/plugin-mdx/src/index.ts
@@ -21,8 +21,10 @@ function createRegExp(exts: string[]): RegExp {
   );
 }
 
+export const PLUGIN_MDX_NAME = 'rsbuild:mdx';
+
 export const pluginMdx = (options: PluginMdxOptions = {}): RsbuildPlugin => ({
-  name: 'rsbuild:mdx',
+  name: PLUGIN_MDX_NAME,
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/plugin-node-polyfill/src/index.ts
+++ b/packages/plugin-node-polyfill/src/index.ts
@@ -54,13 +54,15 @@ const getProvideGlobals = async (globals?: Globals) => {
   return result;
 };
 
+export const PLUGIN_NODE_POLYFILL_NAME = 'rsbuild:node-polyfill';
+
 export function pluginNodePolyfill(
   options: PluginNodePolyfillOptions = {},
 ): RsbuildPlugin {
   const { protocolImports = true } = options;
 
   return {
-    name: 'rsbuild:node-polyfill',
+    name: PLUGIN_NODE_POLYFILL_NAME,
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isServer, bundler }) => {

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -9,10 +9,12 @@ export type PluginPreactOptions = {
   reactAliasesEnabled?: boolean;
 };
 
+export const PLUGIN_PREACT_NAME = 'rsbuild:preact';
+
 export const pluginPreact = (
   options: PluginPreactOptions = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:preact',
+  name: PLUGIN_PREACT_NAME,
 
   setup(api) {
     const { reactAliasesEnabled = true } = options;

--- a/packages/plugin-pug/src/index.ts
+++ b/packages/plugin-pug/src/index.ts
@@ -10,8 +10,10 @@ export type PluginPugOptions = {
   pugOptions?: PugOptions;
 };
 
+export const PLUGIN_PUG_NAME = 'rsbuild:pug';
+
 export const pluginPug = (options: PluginPugOptions = {}): RsbuildPlugin => ({
-  name: 'rsbuild:pug',
+  name: PLUGIN_PUG_NAME,
 
   async setup(api) {
     const VUE_SFC_REGEXP = /\.vue$/;

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -10,8 +10,10 @@ const defaultOptions: PluginRemOptions = {
 
 export type { PluginRemOptions };
 
+export const PLUGIN_REM_NAME = 'rsbuild:rem';
+
 export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
-  name: 'rsbuild:rem',
+  name: PLUGIN_REM_NAME,
 
   setup(api) {
     const userOptions = {

--- a/packages/plugin-styled-components/src/index.ts
+++ b/packages/plugin-styled-components/src/index.ts
@@ -28,10 +28,12 @@ const getDefaultStyledComponentsConfig = (isProd: boolean, ssr: boolean) => {
   };
 };
 
+export const PLUGIN_STYLED_COMPONENTS_NAME = 'rsbuild:styled-components';
+
 export const pluginStyledComponents = (
   pluginOptions: ConfigChain<PluginStyledComponentsOptions> = {},
 ): RsbuildPlugin => ({
-  name: 'rsbuild:styled-components',
+  name: PLUGIN_STYLED_COMPONENTS_NAME,
 
   setup(api) {
     if (api.context.bundlerType === 'webpack') {

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -37,9 +37,11 @@ export type PluginSvelteOptions = {
   preprocessOptions?: AutoPreprocessOptions;
 };
 
+export const PLUGIN_SVELTE_NAME = 'rsbuild:svelte';
+
 export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
   return {
-    name: 'rsbuild:svelte',
+    name: PLUGIN_SVELTE_NAME,
 
     setup(api) {
       let sveltePath = '';

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -61,8 +61,10 @@ function getSvgoDefaultConfig() {
   };
 }
 
+export const PLUGIN_SVGR_NAME = 'rsbuild:svgr';
+
 export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
-  name: 'rsbuild:svgr',
+  name: PLUGIN_SVGR_NAME,
 
   pre: [PLUGIN_REACT_NAME],
 

--- a/packages/plugin-toml/src/index.ts
+++ b/packages/plugin-toml/src/index.ts
@@ -1,7 +1,9 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
 
+export const PLUGIN_TOML_NAME = 'rsbuild:toml';
+
 export const pluginToml = (): RsbuildPlugin => ({
-  name: 'rsbuild:toml',
+  name: PLUGIN_TOML_NAME,
 
   async setup(api) {
     const { parse } = await import('toml');

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -25,11 +25,13 @@ export type PluginTypeCheckerOptions = {
   forkTsCheckerOptions?: ConfigChain<ForkTsCheckerOptions>;
 };
 
+export const PLUGIN_TYPE_CHECK_NAME = 'rsbuild:type-check';
+
 export const pluginTypeCheck = (
   options: PluginTypeCheckerOptions = {},
 ): RsbuildPlugin => {
   return {
-    name: 'rsbuild:type-check',
+    name: PLUGIN_TYPE_CHECK_NAME,
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { target, isProd }) => {

--- a/packages/plugin-typed-css-modules/src/index.ts
+++ b/packages/plugin-typed-css-modules/src/index.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
 import type { CSSLoaderOptions, RsbuildPlugin } from '@rsbuild/core';
 
-const PLUGIN_NAME = 'rsbuild:typed-css-modules';
+export const PLUGIN_TYPED_CSS_MODULES_NAME = 'rsbuild:typed-css-modules';
 
 export const pluginTypedCSSModules = (): RsbuildPlugin => ({
-  name: PLUGIN_NAME,
+  name: PLUGIN_TYPED_CSS_MODULES_NAME,
 
   setup(api) {
     api.modifyBundlerChain({

--- a/packages/plugin-umd/src/index.ts
+++ b/packages/plugin-umd/src/index.ts
@@ -11,8 +11,10 @@ export type PluginUmdOptions = {
   export?: string | string[];
 };
 
+export const PLUGIN_UMD_NAME = 'rsbuild:umd';
+
 export const pluginUmd = (options: PluginUmdOptions): RsbuildPlugin => ({
-  name: 'rsbuild:umd',
+  name: PLUGIN_UMD_NAME,
 
   setup(api) {
     api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {

--- a/packages/plugin-vue-jsx/src/index.ts
+++ b/packages/plugin-vue-jsx/src/index.ts
@@ -11,9 +11,11 @@ export type PluginVueJsxOptions = {
   vueJsxOptions?: VueJSXPluginOptions;
 };
 
+export const PLUGIN_VUE_JSX_NAME = 'rsbuild:vue-jsx';
+
 export function pluginVueJsx(options: PluginVueJsxOptions = {}): RsbuildPlugin {
   return {
-    name: 'rsbuild:vue-jsx',
+    name: PLUGIN_VUE_JSX_NAME,
 
     setup(api) {
       api.modifyBundlerChain(async (chain, { CHAIN_ID, isProd, target }) => {

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -27,9 +27,11 @@ export type PluginVueOptions = {
   splitChunks?: SplitVueChunkOptions;
 };
 
+export const PLUGIN_VUE_NAME = 'rsbuild:vue';
+
 export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'rsbuild:vue',
+    name: PLUGIN_VUE_NAME,
 
     setup(api) {
       const VUE_REGEXP = /\.vue$/;

--- a/packages/plugin-vue2-jsx/src/index.ts
+++ b/packages/plugin-vue2-jsx/src/index.ts
@@ -33,9 +33,11 @@ export type PluginVueOptions = {
   vueJsxOptions?: VueJSXPresetOptions;
 };
 
+export const PLUGIN_VUE2_JSX_NAME = 'rsbuild:vue2-jsx';
+
 export function pluginVue2Jsx(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'rsbuild:vue2-jsx',
+    name: PLUGIN_VUE2_JSX_NAME,
 
     setup(api) {
       api.modifyBundlerChain((chain, { CHAIN_ID }) => {

--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -28,9 +28,11 @@ export type PluginVueOptions = {
   splitChunks?: SplitVueChunkOptions;
 };
 
+export const PLUGIN_VUE2_NAME = 'rsbuild:vue2';
+
 export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
   return {
-    name: 'rsbuild:vue2',
+    name: PLUGIN_VUE2_NAME,
 
     setup(api) {
       const VUE_REGEXP = /\.vue$/;

--- a/packages/plugin-yaml/src/index.ts
+++ b/packages/plugin-yaml/src/index.ts
@@ -1,8 +1,10 @@
 import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
+export const PLUGIN_YAML_NAME = 'rsbuild:yaml';
+
 export const pluginYaml = (): RsbuildPlugin => ({
-  name: 'rsbuild:yaml',
+  name: PLUGIN_YAML_NAME,
 
   setup(api) {
     api.modifyBundlerChain((chain, { CHAIN_ID }) => {


### PR DESCRIPTION
## Summary

export all plugins name const, so user can import plugin name via `PLUGIN_XXX_NAME`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
