### PR TITLE
feat: increase overlay width to display more informations

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -56,7 +56,7 @@ const overlayTemplate = `
 .container {
   font-family: Menlo, Consolas, monospace;
   line-height: 1.6;
-  width: 800px;
+  width: 960px;
   max-width: 85%;
   color: #d8d8d8;
   margin: 32px auto;


### PR DESCRIPTION
## Summary

increase overlay width from 800px to 960px to display more informations

- before:

<img width="1661" alt="Screenshot 2024-06-13 at 14 00 51" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/c805227b-a3ac-4d51-8205-b137166ba284">

- after:

<img width="1710" alt="Screenshot 2024-06-13 at 14 04 04" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/067e7c69-9fa0-4686-b65e-67094d0e5ad8">


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
