### PR TITLE
feat: only display verbose msgs in prod build or debug mode

### DIFF
--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -49,7 +49,7 @@ function hintUnknownFiles(message: string): string {
 }
 
 // Cleans up Rspack error messages.
-function formatMessage(stats: StatsError | string) {
+function formatMessage(stats: StatsError | string, verbose?: boolean) {
   let lines: string[] = [];
   let message: string;
 
@@ -57,8 +57,9 @@ function formatMessage(stats: StatsError | string) {
   if (typeof stats === 'object') {
     const fileName = resolveFileName(stats);
     const mainMessage = stats.message;
-    const details = stats.details ? `\nDetails: ${stats.details}\n` : '';
-    const stack = stats.stack ? `\n${stats.stack}` : '';
+    const details =
+      verbose && stats.details ? `\nDetails: ${stats.details}\n` : '';
+    const stack = verbose && stats.stack ? `\n${stats.stack}` : '';
 
     message = `${fileName}${mainMessage}${details}${stack}`;
   } else {
@@ -79,17 +80,26 @@ function formatMessage(stats: StatsError | string) {
 
   // Reassemble the message
   message = lines.join('\n');
+
+  const innerError = '-- inner error --';
+  if (!verbose && message.includes(innerError)) {
+    message = message.split(innerError)[0];
+  }
+
   return message.trim();
 }
 
 export function formatStatsMessages(
   stats: Pick<StatsCompilation, 'errors' | 'warnings'>,
+  verbose?: boolean,
 ): {
   errors: string[];
   warnings: string[];
 } {
-  const formattedErrors = stats.errors?.map(formatMessage) || [];
-  const formattedWarnings = stats.warnings?.map(formatMessage) || [];
+  const formattedErrors =
+    stats.errors?.map((error) => formatMessage(error, verbose)) || [];
+  const formattedWarnings =
+    stats.warnings?.map((warning) => formatMessage(warning, verbose)) || [];
 
   return {
     errors: formattedErrors,

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -7,7 +7,9 @@ import {
   type StatsError,
   addTrailingSlash,
   color,
+  isDebug,
   isMultiCompiler,
+  isProd,
   removeTailingSlash,
 } from '@rsbuild/shared';
 import { fse } from '@rsbuild/shared';
@@ -196,10 +198,14 @@ export function formatStats(
       : options,
   );
 
-  const { errors, warnings } = formatStatsMessages({
-    errors: getAllStatsErrors(statsData),
-    warnings: getAllStatsWarnings(statsData),
-  });
+  const { errors, warnings } = formatStatsMessages(
+    {
+      errors: getAllStatsErrors(statsData),
+      warnings: getAllStatsWarnings(statsData),
+    },
+    // display verbose messages in prod build or debug mode
+    isProd() || isDebug(),
+  );
 
   if (stats.hasErrors()) {
     return {


### PR DESCRIPTION
## Summary

Only display verbose messages in prod build or debug mode.

- input:

```css
body {
  color: #ff
}
```

- non-verbose:

<img width="1325" alt="Screenshot 2024-06-13 at 14 47 46" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/235869f2-701a-4ae4-bcbf-a30063552095">

- verbose:

<img width="1318" alt="Screenshot 2024-06-13 at 14 48 05" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/d9c95ce9-b2fd-4892-a06c-f2e80e92a46c">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
