### PR TITLE
feat: reference Rspack client module types

### DIFF
--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,7 +6,7 @@
     "rootDir": "src",
     "declarationDir": "./dist-types",
     "composite": true,
-    "types": ["webpack/module"],
+    "types": ["@rspack/core/module"],
     "paths": {
       "ws": ["./compiled/ws"],
       "open": ["./compiled/open"],

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="@rspack/core/module" />
+
 /**
  * import.meta
  */


### PR DESCRIPTION
## Summary

Reference Rspack client module types:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/3fc0ac34-cba9-467f-8ec8-886158e0cb1a)

## Related Links

https://github.com/web-infra-dev/rspack/pull/6787

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
