### PR TITLE
Release v0.7.7

### DIFF
--- a/.changeset/beige-bags-refuse.md
+++ b/.changeset/beige-bags-refuse.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/core': patch
----
-
-chore(deps): bump rspack to 0.7.3

--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -40,7 +40,7 @@
     "webpack": "^5.92.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -41,7 +41,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-basic-ssl",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "SSL plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
   },
   "peerDependencies": {
     "eslint": "^8.0.0 || ^9.0.0",
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -41,7 +41,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-mdx",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Mdx plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -56,7 +56,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-toml",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "TOML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -34,7 +34,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -31,7 +31,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.92.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.4.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.92.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-yaml",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "YAML plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "yaml-loader": "^0.8.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.6"
+    "@rsbuild/core": "workspace:^0.7.7"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.7.6",
+  "version": "0.7.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at v0.7.7 -->

## What's Changed
### New Features 🎉
* feat: support for multiple public dirs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2578
* feat(create-rsbuild): add eslint-plugin-react-hooks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2580
* feat: support for `import.meta.env` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2583
* feat: type declaration for `import.meta.env` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2584
* feat: export plugin name const by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2588
* feat: increase overlay width to display more informations by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2589
* feat: only display verbose msgs in prod build or debug mode by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2590
* feat(deps): bump rspack to 0.7.3 by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2592
* feat: reference Rspack client module types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2593
### Document 📖
* docs: fix discord badge by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2579
* docs: improve output.copy examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2581
* docs: add 404 page redirect to document by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/2585
### Other Changes
* chore(deps): update dependency webpack to ^5.92.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2574
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2490
* chore(create-rsbuild): allow renovate to update more templates by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2587


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.7.6...v0.7.7