### PR TITLE
fix(create-rsbuild): should allow skipping tools selection

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -115,12 +115,13 @@ export async function main() {
 
   const tools = checkCancel<string[]>(
     await multiselect({
-      message: 'Select additional tools (use arrow keys / space bar)',
+      message: 'Select additional tools (press enter to continue)',
       options: [
         { value: 'biome', label: 'Add Biome for code linting and formatting' },
         { value: 'eslint', label: 'Add ESLint for code linting' },
         { value: 'prettier', label: 'Add Prettier for code formatting' },
       ],
+      required: false,
     }),
   );
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -64,7 +64,7 @@ When creating a project, uou can choose from the following templates provided by
 `create-rsbuild` can help you set up some commonly used tools, including [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), and [prettier](https://github.com/prettier/prettier). You can use the arrow keys and the space bar to make your selections. If you don't need these tools, you can simply press Enter to skip.
 
 ```text
-◆  Select additional tools (use arrow keys / space bar)
+◆  Select additional tools (press enter to continue)
 │  ◻ Add Biome for code linting and formatting
 │  ◻ Add ESLint for code linting
 │  ◻ Add Prettier for code formatting

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -64,7 +64,7 @@ import { PackageManagerTabs } from '@theme';
 `create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint) 和 [prettier](https://github.com/prettier/prettier)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
 
 ```text
-◆  Select additional tools (use arrow keys / space bar)
+◆  Select additional tools (press enter to continue)
 │  ◻ Add Biome for code linting and formatting
 │  ◻ Add ESLint for code linting
 │  ◻ Add Prettier for code formatting


### PR DESCRIPTION
## Summary

Should add `required: false` to allow skipping tools selection.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
