### PR TITLE
feat(check-syntax): print the expected ECMA version

### DIFF
--- a/e2e/cases/check-syntax/basic/index.test.ts
+++ b/e2e/cases/check-syntax/basic/index.test.ts
@@ -2,6 +2,7 @@ import { build, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 import { normalizeToPosixPath } from '@scripts/test-helper';
+import stripAnsi from 'strip-ansi';
 
 test('should throw error when exist syntax errors', async () => {
   const cwd = __dirname;
@@ -15,6 +16,14 @@ test('should throw error when exist syntax errors', async () => {
   ).rejects.toThrowError('[Syntax Checker]');
 
   restore();
+
+  expect(
+    logs.find((log) =>
+      stripAnsi(log).includes(
+        'Find some syntax that does not match "ecmaVersion <= 5"',
+      ),
+    ),
+  ).toBeTruthy();
 
   expect(logs.find((log) => log.includes('ERROR 1'))).toBeTruthy();
   expect(

--- a/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
+++ b/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
@@ -70,7 +70,7 @@ export class CheckSyntaxPlugin {
           }),
         );
 
-        printErrors(this.errors);
+        printErrors(this.errors, this.ecmaVersion);
       },
     );
   }

--- a/packages/plugin-check-syntax/src/helpers/printErrors.ts
+++ b/packages/plugin-check-syntax/src/helpers/printErrors.ts
@@ -1,6 +1,6 @@
 import { logger } from '@rsbuild/core';
 import { color } from '@rsbuild/shared';
-import type { ECMASyntaxError } from '../types';
+import type { ECMASyntaxError, EcmaVersion } from '../types';
 
 type Error = {
   source: string;
@@ -9,7 +9,10 @@ type Error = {
   code: string;
 };
 
-export function printErrors(errors: ECMASyntaxError[]) {
+export function printErrors(
+  errors: ECMASyntaxError[],
+  ecmaVersion: EcmaVersion,
+) {
   if (errors.length === 0) {
     logger.success('The syntax check success.');
     return;
@@ -25,8 +28,10 @@ export function printErrors(errors: ECMASyntaxError[]) {
   }));
 
   const longest = Math.max(...Object.keys(errs[0]).map((err) => err.length));
+
+  const expectedVersion = color.yellow(`ecmaVersion <= ${ecmaVersion}`);
   logger.error(
-    '[Syntax Checker] Find some syntax errors after production build:\n',
+    `[Syntax Checker] Find some syntax that does not match "${expectedVersion}":\n`,
   );
 
   errs.forEach((err, index) => {

--- a/website/docs/en/plugins/list/plugin-check-syntax.mdx
+++ b/website/docs/en/plugins/list/plugin-check-syntax.mdx
@@ -39,7 +39,7 @@ When Rsbuild detects incompatible advanced syntax in the build artifacts, it wil
 The format of the error logs is as follows, including the source file, artifact location, error reason, and source code:
 
 ```bash
-error   [Syntax Checker] Find some syntax errors after production build:
+error   [Syntax Checker] Find some syntax that does not match "ecmaVersion <= 2015":
 
   Error 1
   source:  /node_modules/foo/index.js:1:0

--- a/website/docs/zh/plugins/list/plugin-check-syntax.mdx
+++ b/website/docs/zh/plugins/list/plugin-check-syntax.mdx
@@ -39,7 +39,7 @@ export default {
 错误日志的格式如下所示，包含代码来源文件、产物位置、错误原因、源代码等信息：
 
 ```bash
-error   [Syntax Checker] Find some syntax errors after production build:
+error   [Syntax Checker] Find some syntax that does not match "ecmaVersion <= 2015":
 
   Error 1
   source:  /node_modules/foo/index.js:1:0


### PR DESCRIPTION
## Summary

Print the expected ECMA version to make it more clear.

<img width="627" alt="截屏2024-06-16 20 29 00" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/b8ccedc3-e4a6-4d30-abab-9621c06f4e35">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
