### PR TITLE
fix: chain type when using webpack plugin

### DIFF
--- a/.changeset/pretty-toes-invent.md
+++ b/.changeset/pretty-toes-invent.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/shared': patch
+---
+
+0.7.8

--- a/packages/plugin-css-minimizer/src/index.ts
+++ b/packages/plugin-css-minimizer/src/index.ts
@@ -2,6 +2,7 @@ import type {
   ChainIdentifier,
   ConfigChain,
   RsbuildPlugin,
+  Rspack,
   RspackChain,
 } from '@rsbuild/core';
 import { reduceConfigs } from '@rsbuild/shared';
@@ -51,7 +52,9 @@ export function applyCSSMinimizer(
 
   chain.optimization
     .minimizer(CHAIN_ID.MINIMIZER.CSS)
-    .use(CssMinimizerWebpackPlugin, [mergedOptions])
+    .use(CssMinimizerWebpackPlugin as Rspack.RspackPluginInstance, [
+      mergedOptions,
+    ])
     .end();
 }
 

--- a/packages/plugin-source-build/src/plugin.ts
+++ b/packages/plugin-source-build/src/plugin.ts
@@ -89,12 +89,9 @@ export function pluginSourceBuild(
                 : ['...', sourceField],
             );
 
-            // rspack-chain do not support resolve.conditionNames yet
-            rule.resolve.merge({
-              // `conditionNames` is not affected by `resolvePriority`.
-              // The priority is controlled by the order of fields declared in `exports`.
-              conditionNames: ['...', sourceField],
-            });
+            // `conditionNames` is not affected by `resolvePriority`.
+            // The priority is controlled by the order of fields declared in `exports`.
+            rule.resolve.conditionNames.add('...').add(sourceField);
           }
         }
       });

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -69,7 +69,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
         chain.resolve.alias.set('svelte', path.join(sveltePath, 'src/runtime'));
         chain.resolve.extensions.add('.svelte');
         chain.resolve.mainFields.add('svelte').add('...');
-        chain.resolve.set('conditionNames', ['svelte', '...']);
+        chain.resolve.conditionNames.add('svelte').add('...');
 
         const loaderPath = require.resolve('svelte-loader');
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,7 +83,7 @@
     "http-proxy-middleware": "^2.0.6",
     "picocolors": "1.0.1",
     "prebundle": "1.1.0",
-    "rspack-chain": "0.7.2",
+    "rspack-chain": "^0.7.3",
     "rslog": "^1.2.2",
     "terser": "5.31.1",
     "typescript": "^5.4.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,7 +83,7 @@
     "http-proxy-middleware": "^2.0.6",
     "picocolors": "1.0.1",
     "prebundle": "1.1.0",
-    "rspack-chain": "0.7.1",
+    "rspack-chain": "0.7.2",
     "rslog": "^1.2.2",
     "terser": "5.31.1",
     "typescript": "^5.4.2",

--- a/packages/shared/tests/rspackChain.test.ts
+++ b/packages/shared/tests/rspackChain.test.ts
@@ -1,0 +1,19 @@
+import RspackChain from '../compiled/rspack-chain';
+
+test('should generate resolve config as expected', () => {
+  const chain = new RspackChain();
+
+  chain.resolve.conditionNames.add('foo').add('bar');
+  chain.resolve.merge({
+    unsupportedKey: 'hello',
+  });
+
+  expect(chain.resolve.get('conditionNames')).toEqual(['foo', 'bar']);
+
+  expect(chain.toConfig()).toEqual({
+    resolve: {
+      conditionNames: ['foo', 'bar'],
+      unsupportedKey: 'hello',
+    },
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1714,8 +1714,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       rspack-chain:
-        specifier: 0.7.1
-        version: 0.7.1
+        specifier: 0.7.2
+        version: 0.7.2
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -7871,8 +7871,8 @@ packages:
     resolution: {integrity: sha512-tZP8KjrI1nz6qOYCrFxAV7cfmfS2GV94jotU2zOmF/6ByO1zNvGR6/+0inylpjqyBjAdnnutTUW0m4th06bSTw==}
     engines: {node: '>=14.17.6'}
 
-  rspack-chain@0.7.1:
-    resolution: {integrity: sha512-oReT8FgE5elL1w8H/GfdYAwV/2QYkJF6hAw6e0zxOjbJIcyQvCWmEf+QHeKUn5aVVBHu6U6qxzMmmEXIGxBevQ==}
+  rspack-chain@0.7.2:
+    resolution: {integrity: sha512-zRMAHH3EeeL4/lOwXAXMLeuHqHeN6al4Q9W6v5hQW9i5PMu6Qblgq450oAUWTfc+YSNTTM6Gyq7WuqBgt/Ishw==}
     engines: {node: '>=16'}
 
   rspack-manifest-plugin@5.0.0:
@@ -16364,7 +16364,7 @@ snapshots:
 
   rslog@1.2.2: {}
 
-  rspack-chain@0.7.1:
+  rspack-chain@0.7.2:
     dependencies:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1714,8 +1714,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       rspack-chain:
-        specifier: 0.7.2
-        version: 0.7.2
+        specifier: ^0.7.3
+        version: 0.7.3
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -7871,8 +7871,8 @@ packages:
     resolution: {integrity: sha512-tZP8KjrI1nz6qOYCrFxAV7cfmfS2GV94jotU2zOmF/6ByO1zNvGR6/+0inylpjqyBjAdnnutTUW0m4th06bSTw==}
     engines: {node: '>=14.17.6'}
 
-  rspack-chain@0.7.2:
-    resolution: {integrity: sha512-zRMAHH3EeeL4/lOwXAXMLeuHqHeN6al4Q9W6v5hQW9i5PMu6Qblgq450oAUWTfc+YSNTTM6Gyq7WuqBgt/Ishw==}
+  rspack-chain@0.7.3:
+    resolution: {integrity: sha512-Me8ifKWw9sr+IPYnVOtRueNiqIdh3q3PrH7MJRZheXcQMQTTeUkGVtNuv7u+YbjVhbmUtgLwSTskdcTGejWV2A==}
     engines: {node: '>=16'}
 
   rspack-manifest-plugin@5.0.0:
@@ -16364,7 +16364,7 @@ snapshots:
 
   rslog@1.2.2: {}
 
-  rspack-chain@0.7.2:
+  rspack-chain@0.7.3:
     dependencies:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

see: https://github.com/rspack-contrib/rspack-chain/pull/3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling of condition names in CSS Minimizer, Source Build, and Svelte plugins for better performance and readability.

- **Chores**
  - Updated `rspack-chain` dependency version in the shared package.

- **Tests**
  - Added a new test case for generating resolve configuration using `RspackChain`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->