### PR TITLE
feat: make it easier to access distPath config

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -3,10 +3,10 @@ import {
   type BundlerType,
   type RsbuildContext,
   type RsbuildTarget,
-  getDistPath,
   logger,
 } from '@rsbuild/shared';
 import { withDefaultConfig } from './config';
+import { ROOT_DIST_DIR } from './constants';
 import { initHooks } from './initHooks';
 import { getEntryObject } from './plugins/entry';
 import type {
@@ -24,7 +24,7 @@ function getAbsoluteDistPath(
   cwd: string,
   config: RsbuildConfig | NormalizedConfig,
 ) {
-  const dirRoot = getDistPath(config, 'root');
+  const dirRoot = config.output?.distPath?.root ?? ROOT_DIST_DIR;
   return getAbsolutePath(cwd, dirRoot);
 }
 

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -6,7 +6,6 @@ import {
   type RspackChain,
   type TransformFn,
   type TransformHandler,
-  getDistPath,
   removeLeadingSlash,
 } from '@rsbuild/shared';
 import type { Compiler } from '@rspack/core';
@@ -18,13 +17,12 @@ export function getHTMLPathByEntry(
   entryName: string,
   config: NormalizedConfig,
 ) {
-  const htmlPath = getDistPath(config, 'html');
   const filename =
     config.html.outputStructure === 'flat'
       ? `${entryName}.html`
       : `${entryName}/index.html`;
 
-  return removeLeadingSlash(`${htmlPath}/${filename}`);
+  return removeLeadingSlash(`${config.output.distPath.html}/${filename}`);
 }
 
 function applyTransformPlugin(

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { type RspackChain, getDistPath, getFilename } from '@rsbuild/shared';
+import { type RspackChain, getFilename } from '@rsbuild/shared';
 import type { GeneratorOptionsByModuleType } from '@rspack/core';
 import {
   AUDIO_EXTENSIONS,
@@ -82,7 +82,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
         emit: boolean,
       ) => {
         const regExp = getRegExpForExts(exts);
-        const distDir = getDistPath(config, assetType);
+        const distDir = config.output.distPath[assetType];
         const filename = getFilename(config, assetType, isProd);
         const { dataUriLimit } = config.output;
         const maxSize =

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -5,7 +5,6 @@ import {
   color,
   deepmerge,
   fse,
-  getDistPath,
   isHtmlDisabled,
   isPlainObject,
   isURL,
@@ -395,7 +394,7 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
               '../rspack/HtmlAppIconPlugin'
             );
 
-            const distDir = getDistPath(config, 'image');
+            const distDir = config.output.distPath.image;
             const iconPath = path.isAbsolute(appIcon)
               ? appIcon
               : path.join(api.context.rootPath, appIcon);

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_ASSET_PREFIX,
   type NormalizedConfig,
   type RsbuildContext,
-  getDistPath,
   getFilename,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
@@ -69,8 +68,10 @@ export const pluginOutput = (): RsbuildPlugin => ({
         });
 
         // js output
-        const jsPath = getDistPath(config, 'js');
-        const jsAsyncPath = getDistPath(config, 'jsAsync');
+        const jsPath = config.output.distPath.js;
+        const jsAsyncPath =
+          config.output.distPath.jsAsync ??
+          (jsPath ? `${jsPath}/async` : 'async');
         const jsFilename = getFilename(config, 'js', isProd);
         const isJsFilenameFn = typeof jsFilename === 'function';
 
@@ -102,7 +103,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
           .hashFunction('xxhash64');
 
         if (isServer) {
-          const serverPath = getDistPath(config, 'server');
+          const serverPath = config.output.distPath.server;
 
           chain.output
             .path(posix.join(api.context.distPath, serverPath))
@@ -115,7 +116,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
         }
 
         if (isServiceWorker) {
-          const workerPath = getDistPath(config, 'worker');
+          const workerPath = config.output.distPath.worker;
           const filename = posix.join(workerPath, '[name].js');
 
           chain.output.filename(filename).chunkFilename(filename);
@@ -134,9 +135,11 @@ export const pluginOutput = (): RsbuildPlugin => ({
         if (isUseCssExtract(config, target)) {
           const extractPluginOptions = config.tools.cssExtract.pluginOptions;
 
-          const cssPath = getDistPath(config, 'css');
+          const cssPath = config.output.distPath.css;
           const cssFilename = getFilename(config, 'css', isProd);
-          const cssAsyncPath = getDistPath(config, 'cssAsync');
+          const cssAsyncPath =
+            config.output.distPath.cssAsync ??
+            (cssPath ? `${cssPath}/async` : 'async');
 
           chain
             .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -1,5 +1,4 @@
 import { posix } from 'node:path';
-import { getDistPath } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginWasm = (): RsbuildPlugin => ({
@@ -8,7 +7,7 @@ export const pluginWasm = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
       const config = api.getNormalizedConfig();
-      const distPath = getDistPath(config, 'wasm');
+      const distPath = config.output.distPath.wasm;
 
       chain.experiments({
         ...chain.get('experiments'),

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,5 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { getDistPath, isHtmlDisabled } from '@rsbuild/shared';
+import { isHtmlDisabled } from '@rsbuild/shared';
 import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
@@ -23,7 +23,7 @@ export const pluginAssetsRetry = (
         const { AsyncChunkRetryPlugin } = await import(
           './AsyncChunkRetryPlugin'
         );
-        const distDir = getDistPath(config, 'js');
+        const distDir = config.output.distPath.js;
 
         // options.crossOrigin should be same as html.crossorigin by default
         if (options.crossOrigin === undefined) {

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -1,5 +1,4 @@
 import type { PostCSSPlugin, RsbuildPlugin } from '@rsbuild/core';
-import { getDistPath } from '@rsbuild/shared';
 import { cloneDeep } from '@rsbuild/shared';
 import type { PluginRemOptions, PxToRemOptions } from './types';
 
@@ -58,7 +57,7 @@ export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
 
       const entries = Object.keys(chain.entryPoints.entries() || {});
       const config = api.getNormalizedConfig();
-      const distDir = getDistPath(config, 'js');
+      const distDir = config.output.distPath.js;
 
       chain
         .plugin(CHAIN_ID.PLUGIN.AUTO_SET_ROOT_SIZE)

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -1,12 +1,7 @@
 import path from 'node:path';
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
-import {
-  SCRIPT_REGEX,
-  deepmerge,
-  getDistPath,
-  getFilename,
-} from '@rsbuild/shared';
+import { SCRIPT_REGEX, deepmerge, getFilename } from '@rsbuild/shared';
 import type { Config } from '@svgr/core';
 
 export type SvgDefaultExport = 'component' | 'url';
@@ -71,7 +66,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain(async (chain, { isProd, CHAIN_ID }) => {
       const config = api.getNormalizedConfig();
-      const distDir = getDistPath(config, 'svg');
+      const distDir = config.output.distPath.svg;
       const filename = getFilename(config, 'svg', isProd);
       const outputName = path.posix.join(distDir, filename);
       const { dataUriLimit } = config.output;

--- a/packages/shared/src/fs.ts
+++ b/packages/shared/src/fs.ts
@@ -1,35 +1,7 @@
 import fse from '../compiled/fs-extra/index.js';
-import type {
-  DistPathConfig,
-  FilenameConfig,
-  NormalizedConfig,
-  RsbuildConfig,
-} from './types';
+import type { FilenameConfig, NormalizedConfig } from './types';
 
 export { fse };
-
-export const getDistPath = (
-  config: RsbuildConfig | NormalizedConfig,
-  type: keyof DistPathConfig,
-): string => {
-  const { distPath } = config.output || {};
-  const ret = distPath?.[type];
-
-  if (typeof ret !== 'string') {
-    if (type === 'jsAsync') {
-      const jsPath = getDistPath(config, 'js');
-      return jsPath ? `${jsPath}/async` : 'async';
-    }
-    if (type === 'cssAsync') {
-      const cssPath = getDistPath(config, 'css');
-      return cssPath ? `${cssPath}/async` : 'async';
-    }
-
-    throw new Error(`unknown key ${type} in "output.distPath"`);
-  }
-
-  return ret;
-};
 
 export function getFilename(
   config: NormalizedConfig,

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -315,7 +315,10 @@ export type OverrideBrowserslist =
 export interface NormalizedOutputConfig extends OutputConfig {
   targets: RsbuildTarget[];
   filename: FilenameConfig;
-  distPath: DistPathConfig;
+  distPath: Omit<Required<DistPathConfig>, 'jsAsync' | 'cssAsync'> & {
+    jsAsync?: string;
+    cssAsync?: string;
+  };
   polyfill: Polyfill;
   sourceMap: {
     js?: RspackConfig['devtool'];


### PR DESCRIPTION
## Summary

Make it easier to access `output.distPath.[name]` config, the `getDistPath()` helper is no longer required.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
