### PR TITLE
docs: use the default 404 page

### DIFF
--- a/website/docs/404.mdx
+++ b/website/docs/404.mdx
@@ -1,7 +1,0 @@
----
-pageType: 404
----
-
-import { NotFoundLayout } from "@theme"
-
-<NotFoundLayout />


### PR DESCRIPTION
## Summary

Use the default 404 page and fix the build warning:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/c5e75b33-69dd-429c-b0d8-2105ef2a55e1)

## Related Links

https://github.com/web-infra-dev/rspress/pull/1179

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
