### PR TITLE
chore: prefer using Node builtin fs

### DIFF
--- a/e2e/cases/cache/index.test.ts
+++ b/e2e/cases/cache/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build, webpackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
@@ -33,7 +34,7 @@ webpackOnlyTest(
 
     const configFile = path.resolve(cacheDirectory, 'buildDependencies.json');
 
-    fse.emptyDirSync(cacheDirectory);
+    fs.rmSync(cacheDirectory, { recursive: true, force: true });
 
     // first build no cache
     let rsbuild = await build(buildConfig);
@@ -85,7 +86,7 @@ webpackOnlyTest('cacheDigest should work', async () => {
 
   const configFile = path.resolve(cacheDirectory, 'buildDependencies.json');
 
-  fse.emptyDirSync(cacheDirectory);
+  fs.rmSync(cacheDirectory, { recursive: true, force: true });
 
   // first build no cache
   let rsbuild = await build(getBuildConfig());

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -8,8 +8,8 @@ import { fse } from '@rsbuild/shared';
 test('should support watch mode for build command', async () => {
   const indexFile = path.join(__dirname, 'src/index.js');
   const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  await fse.remove(indexFile);
-  await fse.remove(distIndexFile);
+  fs.rmSync(indexFile, { force: true });
+  fs.rmSync(distIndexFile, { force: true });
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
@@ -19,7 +19,7 @@ test('should support watch mode for build command', async () => {
 
   await awaitFileExists(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-  await fse.remove(distIndexFile);
+  fs.rmSync(distIndexFile, { force: true });
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await awaitFileExists(distIndexFile);

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,4 +1,5 @@
 import { exec } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { awaitFileExists } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -17,12 +18,12 @@ test('should support watch mode for build command', async () => {
   });
 
   await awaitFileExists(distIndexFile);
-  expect(fse.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
+  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
   await fse.remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await awaitFileExists(distIndexFile);
-  expect(fse.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
+  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
   process.kill();
 });

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -1,13 +1,13 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should allow to custom env prefix via loadEnv method', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  const content = fse.readFileSync(
+  const content = fs.readFileSync(
     path.join(__dirname, 'dist/static/js/index.js'),
     'utf-8',
   );

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,12 +1,13 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { globContentJSON } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should allow to export function in config file', async () => {
   const targetDir = path.join(__dirname, 'dist-production-build');
-  fse.removeSync(targetDir);
+
+  fs.rmSync(targetDir, { recursive: true, force: true });
 
   delete process.env.NODE_ENV;
   execSync('npx rsbuild build', {

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -8,8 +8,8 @@ const localFile = path.join(__dirname, '.env.local');
 const prodLocalFile = path.join(__dirname, '.env.production.local');
 
 test.beforeEach(() => {
-  fse.removeSync(localFile);
-  fse.removeSync(prodLocalFile);
+  fs.rmSync(localFile, { force: true });
+  fs.rmSync(prodLocalFile, { force: true });
 });
 
 test('should load .env config and allow rsbuild.config.ts to read env vars', async () => {

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
@@ -15,7 +16,7 @@ test('should load .env config and allow rsbuild.config.ts to read env vars', asy
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
 });
 
 test('should load .env.local with higher priority', async () => {
@@ -24,7 +25,7 @@ test('should load .env.local with higher priority', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
 });
 
 test('should load .env.production.local with higher priority', async () => {
@@ -34,7 +35,7 @@ test('should load .env.production.local with higher priority', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
 });
 
 test('should allow to specify env mode via --env-mode', async () => {
@@ -42,5 +43,5 @@ test('should allow to specify env mode via --env-mode', async () => {
     cwd: __dirname,
   });
 
-  expect(fse.existsSync(path.join(__dirname, 'dist/5'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/5'))).toBeTruthy();
 });

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -8,8 +8,8 @@ const localFile = path.join(__dirname, '.env.local');
 const prodLocalFile = path.join(__dirname, '.env.production.local');
 
 test.beforeEach(() => {
-  fse.removeSync(localFile);
-  fse.removeSync(prodLocalFile);
+  fs.rmSync(localFile, { force: true });
+  fs.rmSync(prodLocalFile, { force: true });
 });
 
 test('should load .env config and allow rsbuild.config.ts to read env vars', async () => {

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 import { fse } from '@rsbuild/shared';
@@ -15,7 +16,7 @@ test('should load .env config and allow rsbuild.config.ts to read env vars', asy
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
 });
 
 test('should load .env.local with higher priority', async () => {
@@ -24,7 +25,7 @@ test('should load .env.local with higher priority', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
 });
 
 test('should load .env.production.local with higher priority', async () => {
@@ -34,7 +35,7 @@ test('should load .env.production.local with higher priority', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });
-  expect(fse.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
 });
 
 test('should allow to specify env mode via --env-mode', async () => {
@@ -42,5 +43,5 @@ test('should allow to specify env mode via --env-mode', async () => {
     cwd: __dirname,
   });
 
-  expect(fse.existsSync(path.join(__dirname, 'dist/5'))).toBeTruthy();
+  expect(fs.existsSync(path.join(__dirname, 'dist/5'))).toBeTruthy();
 });

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -1,7 +1,7 @@
 import { execSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should inject public env vars to client', async () => {
   const { NODE_ENV } = process.env;
@@ -11,7 +11,7 @@ test('should inject public env vars to client', async () => {
     cwd: __dirname,
   });
 
-  const content = fse.readFileSync(
+  const content = fs.readFileSync(
     path.join(__dirname, 'dist/static/js/index.js'),
     'utf-8',
   );

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -3,15 +3,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { awaitFileExists, getRandomPort } from '@e2e/helper';
 import { test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should restart dev server and reload config when config file changed', async () => {
   const dist1 = path.join(__dirname, 'dist');
   const dist2 = path.join(__dirname, 'dist-2');
   const configFile = path.join(__dirname, 'rsbuild.config.mjs');
-  await fse.remove(dist1);
-  await fse.remove(dist2);
-  await fse.remove(configFile);
+
+  fs.rmSync(dist1, { force: true, recursive: true });
+  fs.rmSync(dist2, { force: true, recursive: true });
+  fs.rmSync(configFile, { force: true });
 
   fs.writeFileSync(
     configFile,

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,4 +1,5 @@
 import { exec } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { awaitFileExists, getRandomPort } from '@e2e/helper';
 import { test } from '@playwright/test';
@@ -12,7 +13,7 @@ test('should restart dev server and reload config when config file changed', asy
   await fse.remove(dist2);
   await fse.remove(configFile);
 
-  fse.writeFileSync(
+  fs.writeFileSync(
     configFile,
     `export default {
       dev: {
@@ -33,7 +34,7 @@ test('should restart dev server and reload config when config file changed', asy
 
   await awaitFileExists(dist1);
 
-  fse.writeFileSync(
+  fs.writeFileSync(
     configFile,
     `export default {
       dev: {

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { awaitFileExists, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 // Skipped as it occasionally failed in CI
 test.skip('should restart dev server when .env file is changed', async () => {
@@ -11,9 +10,10 @@ test.skip('should restart dev server when .env file is changed', async () => {
   const configFile = path.join(__dirname, 'rsbuild.config.mjs');
   const envLocalFile = path.join(__dirname, '.env.local');
   const distIndex = path.join(dist, 'static/js/index.js');
-  fse.removeSync(dist);
-  fse.removeSync(configFile);
-  fse.removeSync(envLocalFile);
+
+  fs.rmSync(dist, { recursive: true, force: true });
+  fs.rmSync(configFile, { force: true });
+  fs.rmSync(envLocalFile, { force: true });
 
   fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
   fs.writeFileSync(
@@ -37,7 +37,8 @@ test.skip('should restart dev server when .env file is changed', async () => {
   await awaitFileExists(distIndex);
   expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
 
-  fse.removeSync(distIndex);
+  fs.rmSync(distIndex, { force: true });
+
   fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
   await awaitFileExists(distIndex);
   expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,4 +1,5 @@
 import { exec } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { awaitFileExists, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -14,8 +15,8 @@ test.skip('should restart dev server when .env file is changed', async () => {
   fse.removeSync(configFile);
   fse.removeSync(envLocalFile);
 
-  fse.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
-  fse.writeFileSync(
+  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
+  fs.writeFileSync(
     configFile,
     `export default {
       dev: {
@@ -34,12 +35,12 @@ test.skip('should restart dev server when .env file is changed', async () => {
   });
 
   await awaitFileExists(distIndex);
-  expect(fse.readFileSync(distIndex, 'utf-8')).toContain('jack');
+  expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
 
   fse.removeSync(distIndex);
-  fse.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
+  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
   await awaitFileExists(distIndex);
-  expect(fse.readFileSync(distIndex, 'utf-8')).toContain('rose');
+  expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');
 
   devProcess.kill();
 });

--- a/e2e/cases/css/less-npm-import/index.test.ts
+++ b/e2e/cases/css/less-npm-import/index.test.ts
@@ -1,12 +1,13 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should compile less npm import correctly', async () => {
-  fse.copySync(
+  fs.cpSync(
     path.resolve(__dirname, '_node_modules'),
     path.resolve(__dirname, 'node_modules'),
+    { recursive: true },
   );
 
   const rsbuild = await build({

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,14 +1,15 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should compile nested npm import correctly', async () => {
   const { restore, logs } = proxyConsole();
 
-  fse.copySync(
+  fs.cpSync(
     path.resolve(__dirname, '_node_modules'),
     path.resolve(__dirname, 'node_modules'),
+    { recursive: true },
   );
 
   const rsbuild = await build({

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -74,9 +75,9 @@ rspackOnlyTest(
 
     const filePath = join(fixtures, 'test-temp-src/App.module.less');
 
-    await fse.writeFile(
+    await fs.promises.writeFile(
       filePath,
-      fse.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
+      fs.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
     );
 
     // css hmr works well

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 const fixtures = __dirname;
 
@@ -47,7 +46,11 @@ rspackOnlyTest(
       test.skip();
     }
 
-    await fse.copy(join(fixtures, 'src'), join(fixtures, 'test-temp-src'));
+    await fs.promises.cp(
+      join(fixtures, 'src'),
+      join(fixtures, 'test-temp-src'),
+      { recursive: true },
+    );
 
     const rsbuild = await dev({
       cwd: fixtures,

--- a/e2e/cases/html/combined/html.test.ts
+++ b/e2e/cases/html/combined/html.test.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test.describe('should combine multiple html config correctly', () => {
   let rsbuild: Awaited<ReturnType<typeof build>>;
@@ -30,11 +30,11 @@ test.describe('should combine multiple html config correctly', () => {
       },
     });
 
-    mainContent = await fse.readFile(
+    mainContent = await fs.promises.readFile(
       join(rsbuild.distPath, 'main.html'),
       'utf-8',
     );
-    fooContent = await fse.readFile(
+    fooContent = await fs.promises.readFile(
       join(rsbuild.distPath, 'foo.html'),
       'utf-8',
     );
@@ -51,7 +51,7 @@ test.describe('should combine multiple html config correctly', () => {
     expect(iconRelativePath).toBeDefined();
 
     const iconPath = join(rsbuild.distPath, iconRelativePath);
-    expect(fse.existsSync(iconPath)).toBeTruthy();
+    expect(fs.existsSync(iconPath)).toBeTruthy();
 
     // should work on all page
     expect(
@@ -66,7 +66,7 @@ test.describe('should combine multiple html config correctly', () => {
     expect(iconRelativePath).toBeDefined();
 
     const iconPath = join(rsbuild.distPath, iconRelativePath);
-    expect(fse.existsSync(iconPath)).toBeTruthy();
+    expect(fs.existsSync(iconPath)).toBeTruthy();
 
     // should work on all page
     expect(/<link.*rel="icon".*href="(.*?)">/.test(fooContent)).toBeTruthy();

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('tools.htmlPlugin', async ({ page }) => {
   const rsbuild = await build({
@@ -21,7 +21,7 @@ test('tools.htmlPlugin', async ({ page }) => {
   await gotoPage(page, rsbuild);
 
   const pagePath = join(rsbuild.distPath, 'index.html');
-  const content = await fse.readFile(pagePath, 'utf-8');
+  const content = await fs.promises.readFile(pagePath, 'utf-8');
 
   const allScripts = /(<script [\s\S]*?>)/g.exec(content);
 

--- a/e2e/cases/html/mount-id/index.test.ts
+++ b/e2e/cases/html/mount-id/index.test.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test.describe('should render mountId correctly', () => {
   let rsbuild: Awaited<ReturnType<typeof build>>;
@@ -36,7 +36,7 @@ test.describe('should render mountId correctly', () => {
 
   test('inject default (head)', async () => {
     const pagePath = join(rsbuild.distPath, 'index.html');
-    const content = await fse.readFile(pagePath, 'utf-8');
+    const content = await fs.promises.readFile(pagePath, 'utf-8');
 
     expect(
       /<head>[\s\S]*<script[\s\S]*>[\s\S]*<\/head>/.test(content),

--- a/e2e/cases/inspect-config/debug.test.ts
+++ b/e2e/cases/inspect-config/debug.test.ts
@@ -1,8 +1,8 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build, dev, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { logger } from '@rsbuild/core';
-import { fse } from '@rsbuild/shared';
 
 const getRsbuildConfig = (dist: string) =>
   path.resolve(__dirname, `./${dist}/rsbuild.config.mjs`);
@@ -30,8 +30,8 @@ test('should generate config files when build (with DEBUG)', async () => {
     },
   });
 
-  expect(fse.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
-  expect(fse.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   delete process.env.DEBUG;
   logger.level = 'log';
@@ -59,8 +59,8 @@ test('should generate config files when dev (with DEBUG)', async ({ page }) => {
 
   expect(res?.status()).toBe(200);
 
-  expect(fse.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
-  expect(fse.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
+  expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   delete process.env.DEBUG;
   logger.level = 'log';

--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -26,8 +26,8 @@ test('should generate config files when writeToDisk is true', async () => {
   expect(fs.existsSync(bundlerConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
-  fse.removeSync(rsbuildConfig);
-  fse.removeSync(bundlerConfig);
+  fs.rmSync(rsbuildConfig, { force: true });
+  fs.rmSync(bundlerConfig, { force: true });
 });
 
 test('should generate bundler config for node when target contains node', async () => {
@@ -47,9 +47,9 @@ test('should generate bundler config for node when target contains node', async 
   expect(fs.existsSync(bundlerConfig)).toBeTruthy();
   expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
 
-  fse.removeSync(rsbuildConfig);
-  fse.removeSync(bundlerConfig);
-  fse.removeSync(bundlerNodeConfig);
+  fs.rmSync(rsbuildConfig, { force: true });
+  fs.rmSync(bundlerConfig, { force: true });
+  fs.rmSync(bundlerNodeConfig, { force: true });
 });
 
 test('should not generate config files when writeToDisk is false', async () => {

--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { createRsbuild } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -22,8 +23,8 @@ test('should generate config files when writeToDisk is true', async () => {
     writeToDisk: true,
   });
 
-  expect(fse.existsSync(bundlerConfig)).toBeTruthy();
-  expect(fse.existsSync(rsbuildConfig)).toBeTruthy();
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
   fse.removeSync(rsbuildConfig);
   fse.removeSync(bundlerConfig);
@@ -42,9 +43,9 @@ test('should generate bundler config for node when target contains node', async 
     writeToDisk: true,
   });
 
-  expect(fse.existsSync(rsbuildConfig)).toBeTruthy();
-  expect(fse.existsSync(bundlerConfig)).toBeTruthy();
-  expect(fse.existsSync(bundlerNodeConfig)).toBeTruthy();
+  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
 
   fse.removeSync(rsbuildConfig);
   fse.removeSync(bundlerConfig);
@@ -60,6 +61,6 @@ test('should not generate config files when writeToDisk is false', async () => {
     writeToDisk: false,
   });
 
-  expect(fse.existsSync(rsbuildConfig)).toBeFalsy();
-  expect(fse.existsSync(bundlerConfig)).toBeFalsy();
+  expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
+  expect(fs.existsSync(bundlerConfig)).toBeFalsy();
 });

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -29,7 +29,8 @@ test('should compile Node addons correctly', async () => {
 test('should compile Node addons in the node_modules correctly', async () => {
   const pkgDir = join(__dirname, 'node_modules', 'node-addon-pkg');
 
-  fse.removeSync(pkgDir);
+  fs.rmSync(pkgDir, { recursive: true, force: true });
+
   fse.outputJSONSync(join(pkgDir, 'package.json'), {
     name: 'node-addon-pkg',
     main: 'src/index.js',

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -40,7 +40,7 @@ test('should compile Node addons in the node_modules correctly', async () => {
     `import addon from './other.node'; export default addon;`,
   );
   fse.ensureDirSync(join(pkgDir, 'src'));
-  fse.copyFileSync(
+  fs.copyFileSync(
     join(__dirname, 'src', 'test.darwin.node'),
     join(pkgDir, 'src', 'other.node'),
   );

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -22,7 +22,7 @@ test('should compile Node addons correctly', async () => {
   // the `test.darwin.node` is only compatible with darwin
   if (process.platform === 'darwin') {
     const content = await import('./dist/server/index.js');
-    expect(typeof content.default.readLength).toEqual('function');
+    expect(typeof (content.default as any).readLength).toEqual('function');
   }
 });
 
@@ -69,6 +69,6 @@ test('should compile Node addons in the node_modules correctly', async () => {
 
   if (process.platform === 'darwin') {
     const content = await import('./dist/server/index.js');
-    expect(typeof content.default.readLength).toEqual('function');
+    expect(typeof (content.default as any).readLength).toEqual('function');
   }
 });

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -15,7 +16,7 @@ test('should compile Node addons correctly', async () => {
   expect(addonFile?.includes('server/test.darwin.node')).toBeTruthy();
 
   expect(
-    fse.existsSync(join(__dirname, 'dist', 'server', 'test.darwin.node')),
+    fs.existsSync(join(__dirname, 'dist', 'server', 'test.darwin.node')),
   ).toBeTruthy();
 
   // the `test.darwin.node` is only compatible with darwin
@@ -62,7 +63,7 @@ test('should compile Node addons in the node_modules correctly', async () => {
   expect(addonFile?.includes('server/other.node')).toBeTruthy();
 
   expect(
-    fse.existsSync(join(__dirname, 'dist', 'server', 'other.node')),
+    fs.existsSync(join(__dirname, 'dist', 'server', 'other.node')),
   ).toBeTruthy();
 
   if (process.platform === 'darwin') {

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -15,7 +15,7 @@ test('should clean dist path by default', async () => {
   });
 
   expect(fs.existsSync(testDistFile)).toBeFalsy();
-  fse.removeSync(testDistFile);
+  fs.rmSync(testDistFile, { force: true });
 });
 
 test('should not clean dist path if it is outside root', async () => {
@@ -40,7 +40,7 @@ test('should not clean dist path if it is outside root', async () => {
 
   expect(fs.existsSync(testOutsideFile)).toBeTruthy();
 
-  fse.removeSync(testOutsideFile);
+  fs.rmSync(testOutsideFile, { force: true });
   restore();
 });
 
@@ -58,5 +58,5 @@ test('should allow to disable cleanDistPath', async () => {
 
   expect(fs.existsSync(testDistFile)).toBeTruthy();
 
-  fse.removeSync(testDistFile);
+  fs.rmSync(testDistFile, { force: true });
 });

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -13,7 +14,7 @@ test('should clean dist path by default', async () => {
     cwd,
   });
 
-  expect(fse.existsSync(testDistFile)).toBeFalsy();
+  expect(fs.existsSync(testDistFile)).toBeFalsy();
   fse.removeSync(testDistFile);
 });
 
@@ -37,7 +38,7 @@ test('should not clean dist path if it is outside root', async () => {
     logs.find((log) => log.includes('dist path is not a subdir of root path')),
   ).toBeTruthy();
 
-  expect(fse.existsSync(testOutsideFile)).toBeTruthy();
+  expect(fs.existsSync(testOutsideFile)).toBeTruthy();
 
   fse.removeSync(testOutsideFile);
   restore();
@@ -55,7 +56,7 @@ test('should allow to disable cleanDistPath', async () => {
     },
   });
 
-  expect(fse.existsSync(testDistFile)).toBeTruthy();
+  expect(fs.existsSync(testDistFile)).toBeTruthy();
 
   fse.removeSync(testDistFile);
 });

--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -1,7 +1,7 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 test('should copy asset to dist folder correctly', async () => {
   await build({
@@ -16,7 +16,7 @@ test('should copy asset to dist folder correctly', async () => {
     },
   });
 
-  expect(fse.existsSync(join(__dirname, 'dist-1/icon.png'))).toBeTruthy();
+  expect(fs.existsSync(join(__dirname, 'dist-1/icon.png'))).toBeTruthy();
 });
 
 test('should copy asset to dist sub-folder correctly', async () => {
@@ -32,5 +32,5 @@ test('should copy asset to dist sub-folder correctly', async () => {
     },
   });
 
-  expect(fse.existsSync(join(__dirname, 'dist-1/foo/icon.png'))).toBeTruthy();
+  expect(fs.existsSync(join(__dirname, 'dist-1/foo/icon.png'))).toBeTruthy();
 });

--- a/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
@@ -8,8 +9,8 @@ const distFile = path.join(__dirname, 'node_modules/hooksTempFile');
 
 const write = (str: string) => {
   let content: string;
-  if (fse.existsSync(distFile)) {
-    content = `${fse.readFileSync(distFile, 'utf-8')},${str}`;
+  if (fs.existsSync(distFile)) {
+    content = `${fs.readFileSync(distFile, 'utf-8')},${str}`;
   } else {
     content = str;
   }
@@ -48,6 +49,6 @@ rspackOnlyTest(
     await rsbuild.build();
     write('2');
 
-    expect(fse.readFileSync(distFile, 'utf-8').split(',')).toEqual(['1', '2']);
+    expect(fs.readFileSync(distFile, 'utf-8').split(',')).toEqual(['1', '2']);
   },
 );

--- a/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
@@ -34,7 +34,7 @@ const plugin: RsbuildPlugin = {
 rspackOnlyTest(
   'should run onAfterBuild hooks correctly when have multiple targets',
   async () => {
-    fse.removeSync(distFile);
+    fs.rmSync(distFile, { force: true });
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,

--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 const packagePath = path.join(
   __dirname,
@@ -14,7 +13,7 @@ rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
   async () => {
     fs.rmSync(packagePath, { recursive: true, force: true });
-    fse.copySync(path.join(__dirname, 'mock'), packagePath);
+    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
 
     const { logs, restore } = proxyConsole();
     process.env.RSDOCTOR = 'true';
@@ -37,7 +36,7 @@ rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
   async () => {
     fs.rmSync(packagePath, { recursive: true, force: true });
-    fse.copySync(path.join(__dirname, 'mock'), packagePath);
+    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
 
     process.env.RSDOCTOR = 'false';
 

--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
@@ -22,7 +23,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    expect(fse.existsSync(testFile)).toBe(true);
+    expect(fs.existsSync(testFile)).toBe(true);
     expect(
       logs.some((log) => log.includes('@rsdoctor') && log.includes('enabled')),
     ).toBe(true);
@@ -44,7 +45,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    expect(fse.existsSync(testFile)).toBe(false);
+    expect(fs.existsSync(testFile)).toBe(false);
     process.env.RSDOCTOR = '';
   },
 );

--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -13,7 +13,7 @@ const testFile = path.join(packagePath, 'test.txt');
 rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
   async () => {
-    fse.removeSync(packagePath);
+    fs.rmSync(packagePath, { recursive: true, force: true });
     fse.copySync(path.join(__dirname, 'mock'), packagePath);
 
     const { logs, restore } = proxyConsole();
@@ -36,7 +36,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
   async () => {
-    fse.removeSync(packagePath);
+    fs.rmSync(packagePath, { recursive: true, force: true });
     fse.copySync(path.join(__dirname, 'mock'), packagePath);
 
     process.env.RSDOCTOR = 'false';

--- a/e2e/cases/server/hmr/index.test.ts
+++ b/e2e/cases/server/hmr/index.test.ts
@@ -3,7 +3,6 @@ import { join } from 'node:path';
 import { dev, getRandomPort, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { fse } from '@rsbuild/shared';
 
 const cwd = __dirname;
 
@@ -14,7 +13,9 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
     test.skip();
   }
 
-  await fse.copy(join(cwd, 'src'), join(cwd, 'test-temp-src'));
+  await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+    recursive: true,
+  });
 
   const rsbuild = await dev({
     cwd,
@@ -95,7 +96,9 @@ rspackOnlyTest(
       test.skip();
     }
 
-    await fse.copy(join(cwd, 'src'), join(cwd, 'test-temp-src-1'));
+    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src-1'), {
+      recursive: true,
+    });
 
     const port = await getRandomPort();
     const rsbuild = await dev({

--- a/e2e/cases/server/hmr/index.test.ts
+++ b/e2e/cases/server/hmr/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, getRandomPort, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -49,9 +50,9 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
 
   const appPath = join(cwd, 'test-temp-src/App.tsx');
 
-  await fse.writeFile(
+  await fs.promises.writeFile(
     appPath,
-    fse.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
   );
 
   await expect(locator).toHaveText('Hello Test!');
@@ -61,7 +62,7 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
 
   const cssPath = join(cwd, 'test-temp-src/App.css');
 
-  await fse.writeFile(
+  await fs.promises.writeFile(
     cssPath,
     `#test {
   color: rgb(0, 0, 255);
@@ -71,12 +72,12 @@ rspackOnlyTest('default & hmr (default true)', async ({ page }) => {
   await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
 
   // restore
-  await fse.writeFile(
+  await fs.promises.writeFile(
     appPath,
-    fse.readFileSync(appPath, 'utf-8').replace('Hello Test', 'Hello Rsbuild'),
+    fs.readFileSync(appPath, 'utf-8').replace('Hello Test', 'Hello Rsbuild'),
   );
 
-  await fse.writeFile(
+  await fs.promises.writeFile(
     cssPath,
     `#test {
   color: rgb(255, 0, 0);
@@ -130,17 +131,17 @@ rspackOnlyTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await fse.writeFile(
+    await fs.promises.writeFile(
       appPath,
-      fse.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
     );
 
     await expect(locator).toHaveText('Hello Test!');
 
     // restore
-    await fse.writeFile(
+    await fs.promises.writeFile(
       appPath,
-      fse.readFileSync(appPath, 'utf-8').replace('Hello Test', 'Hello Rsbuild'),
+      fs.readFileSync(appPath, 'utf-8').replace('Hello Test', 'Hello Rsbuild'),
     );
 
     await rsbuild.close();

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -2,7 +2,6 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 const cwd = __dirname;
 
@@ -14,7 +13,9 @@ test('should show overlay correctly', async ({ page }) => {
 
   const { restore } = proxyConsole();
 
-  await fse.copy(join(cwd, 'src'), join(cwd, 'test-temp-src'));
+  await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+    recursive: true,
+  });
 
   const rsbuild = await dev({
     cwd,

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -34,9 +35,9 @@ test('should show overlay correctly', async ({ page }) => {
 
   const appPath = join(cwd, 'test-temp-src/App.tsx');
 
-  await fse.writeFile(
+  await fs.promises.writeFile(
     appPath,
-    fse.readFileSync(appPath, 'utf-8').replace('</div>', '</aaaaa>'),
+    fs.readFileSync(appPath, 'utf-8').replace('</div>', '</aaaaa>'),
   );
 
   await expect(errorOverlay.locator('.title')).toHaveText('Compilation failed');

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { fse } from '@rsbuild/shared';
 
 rspackOnlyTest('should work with string and path to file', async ({ page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
@@ -24,7 +23,7 @@ rspackOnlyTest('should work with string and path to file', async ({ page }) => {
   });
 
   // reset file
-  fse.truncateSync(file);
+  fs.truncateSync(file);
   await rsbuild.close();
 });
 
@@ -51,7 +50,7 @@ rspackOnlyTest(
     });
 
     // reset file
-    fse.truncateSync(file);
+    fs.truncateSync(file);
     await rsbuild.close();
   },
 );
@@ -80,7 +79,7 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
     page.waitForURL(page.url()).then(resolve);
   });
   // reset file
-  fse.truncateSync(file);
+  fs.truncateSync(file);
 
   await fs.promises.writeFile(other, 'test');
   // check the page is reloaded
@@ -88,7 +87,7 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
     page.waitForURL(page.url()).then(resolve);
   });
   // reset file
-  fse.truncateSync(other);
+  fs.truncateSync(other);
 
   await rsbuild.close();
 });
@@ -115,7 +114,7 @@ rspackOnlyTest('should work with string and glob', async ({ page }) => {
   });
 
   // reset file
-  fse.truncateSync(file);
+  fs.truncateSync(file);
   await rsbuild.close();
 });
 
@@ -143,6 +142,6 @@ rspackOnlyTest('should work with options', async ({ page }) => {
   });
 
   // reset file
-  fse.truncateSync(file);
+  fs.truncateSync(file);
   await rsbuild.close();
 });

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { fse } from '@rsbuild/shared';
@@ -16,7 +17,7 @@ rspackOnlyTest('should work with string and path to file', async ({ page }) => {
   });
   await gotoPage(page, rsbuild);
 
-  await fse.writeFile(file, 'test');
+  await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
   await new Promise((resolve) => {
     page.waitForURL(page.url()).then(resolve);
@@ -43,7 +44,7 @@ rspackOnlyTest(
     });
     await gotoPage(page, rsbuild);
 
-    await fse.writeFile(file, 'test');
+    await fs.promises.writeFile(file, 'test');
 
     await new Promise((resolve) => {
       page.waitForURL(page.url()).then(resolve);
@@ -73,7 +74,7 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
   });
   await gotoPage(page, rsbuild);
 
-  await fse.writeFile(file, 'test');
+  await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
   await new Promise((resolve) => {
     page.waitForURL(page.url()).then(resolve);
@@ -81,7 +82,7 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
   // reset file
   fse.truncateSync(file);
 
-  await fse.writeFile(other, 'test');
+  await fs.promises.writeFile(other, 'test');
   // check the page is reloaded
   await new Promise((resolve) => {
     page.waitForURL(page.url()).then(resolve);
@@ -107,7 +108,7 @@ rspackOnlyTest('should work with string and glob', async ({ page }) => {
   });
   await gotoPage(page, rsbuild);
 
-  await fse.writeFile(file, 'test');
+  await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
   await new Promise((resolve) => {
     page.waitForURL(page.url()).then(resolve);
@@ -135,7 +136,7 @@ rspackOnlyTest('should work with options', async ({ page }) => {
   });
   await gotoPage(page, rsbuild);
 
-  await fse.writeFile(file, 'test');
+  await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
   await new Promise((resolve) => {
     page.waitForURL(page.url()).then(resolve);

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -53,10 +54,9 @@ export function copyPkgToNodeModules() {
   const nodeModules = path.resolve(__dirname, 'node_modules');
 
   fse.ensureDirSync(nodeModules);
-  fse.copySync(
-    path.resolve(__dirname, 'foo'),
-    path.resolve(nodeModules, 'foo'),
-  );
+  fs.cpSync(path.resolve(__dirname, 'foo'), path.resolve(nodeModules, 'foo'), {
+    recursive: true,
+  });
 }
 
 export function shareTest(

--- a/e2e/cases/stylus/index.test.ts
+++ b/e2e/cases/stylus/index.test.ts
@@ -12,7 +12,7 @@ const generatorTempDir = async (testDir: string) => {
   await fse.emptyDir(testDir);
   await fse.copy(join(fixtures, 'src'), testDir);
 
-  return () => fse.remove(testDir);
+  return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };
 
 test('should compile stylus correctly with ts declaration', async () => {

--- a/e2e/cases/stylus/index.test.ts
+++ b/e2e/cases/stylus/index.test.ts
@@ -4,13 +4,12 @@ import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginStylus } from '@rsbuild/plugin-stylus';
 import { pluginTypedCSSModules } from '@rsbuild/plugin-typed-css-modules';
-import { fse } from '@rsbuild/shared';
 
 const fixtures = __dirname;
 
 const generatorTempDir = async (testDir: string) => {
-  await fse.emptyDir(testDir);
-  await fse.copy(join(fixtures, 'src'), testDir);
+  fs.rmSync(testDir, { recursive: true, force: true });
+  await fs.promises.cp(join(fixtures, 'src'), testDir, { recursive: true });
 
   return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };

--- a/e2e/cases/stylus/index.test.ts
+++ b/e2e/cases/stylus/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -36,7 +37,7 @@ test('should compile stylus correctly with ts declaration', async () => {
     /body{color:#f00;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,
   );
 
-  expect(fse.existsSync(join(testDir, './b.module.styl.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './b.module.styl.d.ts'))).toBeTruthy();
 
   await clear();
 });

--- a/e2e/cases/typed-css-modules/basic/index.test.ts
+++ b/e2e/cases/typed-css-modules/basic/index.test.ts
@@ -10,7 +10,7 @@ const generatorTempDir = async (testDir: string) => {
   await fse.emptyDir(testDir);
   await fse.copy(join(fixtures, 'src'), testDir);
 
-  return () => fse.remove(testDir);
+  return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };
 
 test('generator TS declaration for cssModules.auto true', async () => {

--- a/e2e/cases/typed-css-modules/basic/index.test.ts
+++ b/e2e/cases/typed-css-modules/basic/index.test.ts
@@ -2,13 +2,12 @@ import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 const fixtures = __dirname;
 
 const generatorTempDir = async (testDir: string) => {
-  await fse.emptyDir(testDir);
-  await fse.copy(join(fixtures, 'src'), testDir);
+  fs.rmSync(testDir, { recursive: true, force: true });
+  await fs.promises.cp(join(fixtures, 'src'), testDir, { recursive: true });
 
   return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };

--- a/e2e/cases/typed-css-modules/basic/index.test.ts
+++ b/e2e/cases/typed-css-modules/basic/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -25,12 +26,12 @@ test('generator TS declaration for cssModules.auto true', async () => {
     },
   });
 
-  expect(fse.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
 
-  const bContent = fse.readFileSync(join(testDir, './b.module.scss.d.ts'), {
+  const bContent = fs.readFileSync(join(testDir, './b.module.scss.d.ts'), {
     encoding: 'utf-8',
   });
 
@@ -49,7 +50,7 @@ declare const cssExports: CssExports;
 export default cssExports;
 `);
 
-  const cContent = fse.readFileSync(join(testDir, './c.module.less.d.ts'), {
+  const cContent = fs.readFileSync(join(testDir, './c.module.less.d.ts'), {
     encoding: 'utf-8',
   });
 
@@ -86,10 +87,10 @@ test('generator TS declaration for cssModules.auto function', async () => {
     },
   });
 
-  expect(fse.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeFalsy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './d.global.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeTruthy();
 
   await clear();
 });
@@ -112,10 +113,10 @@ test('generator TS declaration for cssModules.auto Regexp', async () => {
     },
   });
 
-  expect(fse.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
 
   await clear();
 });
@@ -138,13 +139,13 @@ test('generator TS declaration for `asIs` convention', async () => {
     },
   });
 
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
 
-  const bContent = fse.readFileSync(join(testDir, './b.module.scss.d.ts'), {
+  const bContent = fs.readFileSync(join(testDir, './b.module.scss.d.ts'), {
     encoding: 'utf-8',
   });
-  const cContent = fse.readFileSync(join(testDir, './c.module.less.d.ts'), {
+  const cContent = fs.readFileSync(join(testDir, './c.module.less.d.ts'), {
     encoding: 'utf-8',
   });
 

--- a/e2e/cases/typed-css-modules/named-export/index.test.ts
+++ b/e2e/cases/typed-css-modules/named-export/index.test.ts
@@ -2,13 +2,12 @@ import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { fse } from '@rsbuild/shared';
 
 const fixtures = __dirname;
 
 const generatorTempDir = async (testDir: string) => {
-  await fse.emptyDir(testDir);
-  await fse.copy(join(fixtures, 'src'), testDir);
+  fs.rmSync(testDir, { recursive: true, force: true });
+  await fs.promises.cp(join(fixtures, 'src'), testDir, { recursive: true });
 
   return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };

--- a/e2e/cases/typed-css-modules/named-export/index.test.ts
+++ b/e2e/cases/typed-css-modules/named-export/index.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { join, resolve } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
@@ -25,12 +26,12 @@ test('generator TS declaration for namedExport true', async () => {
     },
   });
 
-  expect(fse.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './a.css.d.ts'))).toBeFalsy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './d.global.less.d.ts'))).toBeFalsy();
 
-  const bContent = fse.readFileSync(join(testDir, './b.module.scss.d.ts'), {
+  const bContent = fs.readFileSync(join(testDir, './b.module.scss.d.ts'), {
     encoding: 'utf-8',
   });
 
@@ -44,7 +45,7 @@ export const theBClass: string;
 export const underline: string;
 `);
 
-  const cContent = fse.readFileSync(join(testDir, './c.module.less.d.ts'), {
+  const cContent = fs.readFileSync(join(testDir, './c.module.less.d.ts'), {
     encoding: 'utf-8',
   });
 
@@ -74,13 +75,13 @@ test('generator TS declaration for namedExport true and `asIs` convention', asyn
     },
   });
 
-  expect(fse.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
-  expect(fse.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './b.module.scss.d.ts'))).toBeTruthy();
+  expect(fs.existsSync(join(testDir, './c.module.less.d.ts'))).toBeTruthy();
 
-  const bContent = fse.readFileSync(join(testDir, './b.module.scss.d.ts'), {
+  const bContent = fs.readFileSync(join(testDir, './b.module.scss.d.ts'), {
     encoding: 'utf-8',
   });
-  const cContent = fse.readFileSync(join(testDir, './c.module.less.d.ts'), {
+  const cContent = fs.readFileSync(join(testDir, './c.module.less.d.ts'), {
     encoding: 'utf-8',
   });
 

--- a/e2e/cases/typed-css-modules/named-export/index.test.ts
+++ b/e2e/cases/typed-css-modules/named-export/index.test.ts
@@ -10,7 +10,7 @@ const generatorTempDir = async (testDir: string) => {
   await fse.emptyDir(testDir);
   await fse.copy(join(fixtures, 'src'), testDir);
 
-  return () => fse.remove(testDir);
+  return () => fs.promises.rm(testDir, { force: true, recursive: true });
 };
 
 test('generator TS declaration for namedExport true', async () => {

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,7 +1,8 @@
+import fs from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
-import { type ConsoleType, castArray, fse } from '@rsbuild/shared';
+import { type ConsoleType, castArray } from '@rsbuild/shared';
 import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
@@ -49,7 +50,7 @@ export const globContentJSON = async (path: string, options?: GlobOptions) => {
 
   await Promise.all(
     files.map((file) =>
-      fse.readFile(file, 'utf-8').then((content) => {
+      fs.promises.readFile(file, 'utf-8').then((content) => {
         ret[file] = content;
       }),
     ),
@@ -64,7 +65,7 @@ export const awaitFileExists = async (dir: string) => {
   let checks = 0;
 
   while (checks < maxChecks) {
-    if (fse.existsSync(dir)) {
+    if (fs.existsSync(dir)) {
       return;
     }
     checks++;

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import fs from 'node:fs';
 import net from 'node:net';
 import { join } from 'node:path';
 import { URL } from 'node:url';
@@ -9,7 +10,6 @@ import type {
   RsbuildPlugins,
 } from '@rsbuild/core';
 import { pluginSwc } from '@rsbuild/plugin-swc';
-import { fse } from '@rsbuild/shared';
 import type { Page } from 'playwright';
 import { globContentJSON } from './helper';
 
@@ -204,7 +204,8 @@ export async function build({
     ? await rsbuild.preview()
     : { port: 0, server: { close: noop } };
 
-  const clean = async () => await fse.remove(distPath);
+  const clean = async () =>
+    fs.promises.rm(distPath, { force: true, recursive: true });
 
   const unwrapOutputJSON = async (ignoreMap = true) => {
     return globContentJSON(distPath, {

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,6 +1,7 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { type Rspack, ensureAssetPrefix } from '@rsbuild/core';
-import { fse, getPublicPathFromCompiler } from '@rsbuild/shared';
+import { getPublicPathFromCompiler } from '@rsbuild/shared';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { PluginAssetsRetryOptions } from './types';
 
@@ -49,7 +50,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
       'runtime',
       this.minify ? `${filename}.min.js` : `${filename}.js`,
     );
-    const runtimeCode = await fse.readFile(runtimeFilePath, 'utf-8');
+    const runtimeCode = await fs.promises.readFile(runtimeFilePath, 'utf-8');
     return `(function(){${runtimeCode};init(${serialize(
       this.#retryOptions,
     )});})()`;

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -1,6 +1,6 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { type Rspack, rspack } from '@rsbuild/core';
-import { fse } from '@rsbuild/shared';
 import serialize from 'serialize-javascript';
 import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
 
@@ -66,7 +66,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
       'runtime',
       this.options.minify ? `${filename}.min.js` : `${filename}.js`,
     );
-    const rawText = fse.readFileSync(runtimeFilePath, 'utf-8');
+    const rawText = fs.readFileSync(runtimeFilePath, 'utf-8');
 
     return rawText
       .replaceAll('__RUNTIME_GLOBALS_REQUIRE__', RuntimeGlobals.require)

--- a/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
+++ b/packages/plugin-check-syntax/src/CheckSyntaxPlugin.ts
@@ -1,6 +1,7 @@
+import fs from 'node:fs';
 import { resolve } from 'node:path';
 import type { Rspack } from '@rsbuild/core';
-import { JS_REGEX, browserslistToESVersion, fse } from '@rsbuild/shared';
+import { JS_REGEX, browserslistToESVersion } from '@rsbuild/shared';
 import { parse } from 'acorn';
 import {
   checkIsExcludeSource,
@@ -88,7 +89,7 @@ export class CheckSyntaxPlugin {
     }
 
     if (JS_REGEX.test(filepath)) {
-      const jsScript = await fse.readFile(filepath, 'utf-8');
+      const jsScript = await fs.promises.readFile(filepath, 'utf-8');
       await this.tryParse(filepath, jsScript);
     }
   }

--- a/packages/plugin-check-syntax/src/helpers/generateError.ts
+++ b/packages/plugin-check-syntax/src/helpers/generateError.ts
@@ -1,4 +1,5 @@
-import { color, fse } from '@rsbuild/shared';
+import fs from 'node:fs';
+import { color } from '@rsbuild/shared';
 import { SourceMapConsumer } from 'source-map';
 import {
   type AcornParseError,
@@ -82,12 +83,12 @@ async function tryGenerateErrorFromSourceMap({
   rootPath: string;
 }): Promise<ECMASyntaxError | null> {
   const sourceMapPath = `${filepath}.map`;
-  if (!fse.existsSync(sourceMapPath)) {
+  if (!fs.existsSync(sourceMapPath)) {
     return null;
   }
 
   try {
-    const sourcemap = await fse.readFile(sourceMapPath, 'utf-8');
+    const sourcemap = await fs.promises.readFile(sourceMapPath, 'utf-8');
     const consumer = await new SourceMapConsumer(sourcemap);
     const sm = consumer.originalPositionFor({
       line: err.loc.line,

--- a/packages/plugin-check-syntax/src/helpers/generateHtmlScripts.ts
+++ b/packages/plugin-check-syntax/src/helpers/generateHtmlScripts.ts
@@ -1,8 +1,8 @@
-import { fse } from '@rsbuild/shared';
+import fs from 'node:fs';
 import { Parser } from 'htmlparser2';
 
 export async function generateHtmlScripts(filepath: string) {
-  const html = await fse.readFile(filepath, 'utf-8');
+  const html = await fs.promises.readFile(filepath, 'utf-8');
   return getHtmlScripts(html);
 }
 

--- a/packages/plugin-source-build/src/common/pnpm.ts
+++ b/packages/plugin-source-build/src/common/pnpm.ts
@@ -1,5 +1,5 @@
+import fs from 'node:fs';
 import path from 'node:path';
-import { fse } from '@rsbuild/shared';
 import glob, { type Options as GlobOptions } from 'fast-glob';
 import { PACKAGE_JSON, PNPM_WORKSPACE_FILE } from '../constants';
 import { Project } from '../project/project';
@@ -9,7 +9,7 @@ import { readPackageJson } from '../utils';
 export const getPatternsFromYaml = async (monorepoRoot: string) => {
   const { parse } = await import('yaml');
   const workspaceYamlFilePath = path.join(monorepoRoot, PNPM_WORKSPACE_FILE);
-  const yamlContent = await fse.readFile(workspaceYamlFilePath, 'utf8');
+  const yamlContent = await fs.promises.readFile(workspaceYamlFilePath, 'utf8');
   const pnpmWorkspace = parse(yamlContent) as IPnpmWorkSpace;
   return pnpmWorkspace.packages || [];
 };

--- a/packages/plugin-source-build/src/utils.ts
+++ b/packages/plugin-source-build/src/utils.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import { fse } from '@rsbuild/shared';
 import json5 from 'json5';
@@ -22,7 +23,7 @@ export const readJson = async <T>(jsonFileAbsPath: string) => {
     return {} as T;
   }
 
-  const content = await fse.readFile(jsonFileAbsPath, 'utf-8');
+  const content = await fs.promises.readFile(jsonFileAbsPath, 'utf-8');
   const json: T = json5.parse(content);
   return json;
 };

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -1,10 +1,11 @@
+import fs from 'node:fs';
 import {
   type ConfigChain,
   type RsbuildPlugin,
   logger,
   reduceConfigs,
 } from '@rsbuild/core';
-import { CHAIN_ID, NODE_MODULES_REGEX, deepmerge, fse } from '@rsbuild/shared';
+import { CHAIN_ID, NODE_MODULES_REGEX, deepmerge } from '@rsbuild/shared';
 import type ForkTSCheckerPlugin from 'fork-ts-checker-webpack-plugin';
 
 type ForkTsCheckerOptions = NonNullable<
@@ -65,7 +66,7 @@ export const pluginTypeCheck = (
 
         const { default: json5 } = await import('json5');
         const { references } = json5.parse(
-          fse.readFileSync(api.context.tsconfigPath, 'utf-8'),
+          fs.readFileSync(api.context.tsconfigPath, 'utf-8'),
         );
         const useReference = Array.isArray(references) && references.length > 0;
 


### PR DESCRIPTION
## Summary

Prefer using Node builtin fs instead of `fs-extra`.

Only use `fs-extra` when we need to use it.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
