### PR TITLE
fix: HMR not work on online IDEs

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -103,7 +103,6 @@ export async function createDevServer<
   });
   const devConfig = getDevConfig({
     config,
-    port,
   });
 
   const routes = formatRoutes(

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -252,15 +252,14 @@ export const getServerConfig = async ({
 
 export const getDevConfig = ({
   config,
-  port,
 }: {
   config: NormalizedConfig;
-  port: number;
 }): DevConfig => {
   const defaultDevConfig: DevConfig = {
     client: {
       path: HMR_SOCK_PATH,
-      port: port.toString(),
+      // By default it is set to "location.port"
+      port: '',
       // By default it is set to "location.hostname"
       host: '',
       // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -312,14 +312,13 @@ describe('test dev server', () => {
     expect(
       getDevConfig({
         config: {} as NormalizedConfig,
-        port: 3000,
       }),
     ).toMatchInlineSnapshot(`
       {
         "client": {
           "host": "",
           "path": "/rsbuild-hmr",
-          "port": "3000",
+          "port": "",
           "protocol": undefined,
         },
         "liveReload": true,
@@ -338,14 +337,13 @@ describe('test dev server', () => {
             },
           },
         } as NormalizedConfig,
-        port: 3001,
       }),
     ).toMatchInlineSnapshot(`
       {
         "client": {
           "host": "",
           "path": "",
-          "port": "3001",
+          "port": "",
           "protocol": undefined,
         },
         "hmr": false,

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -27,10 +27,12 @@ type Client = {
 ```js
 const defaultConfig = {
   path: '/rsbuild-hmr',
-  // Defaults to the port number of the dev server
+  // By default it is set to "location.port"
   port: '',
-  host: location.hostname,
-  protocol: location.protocol === 'https:' ? 'wss' : 'ws',
+  // By default it is set to "location.hostname"
+  host: '',
+  // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
+  protocol: undefined,
   overlay: true,
 };
 ```

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -27,10 +27,12 @@ type Client = {
 ```js
 const defaultConfig = {
   path: '/rsbuild-hmr',
-  // 默认为开发服务器的端口号
+  // 默认为 "location.port"
   port: '',
-  host: location.hostname,
-  protocol: location.protocol === 'https:' ? 'wss' : 'ws',
+  // 默认为 "location.hostname"
+  host: '',
+  // 默认为 "location.protocol === 'https:' ? 'wss' : 'ws'""
+  protocol: undefined,
   overlay: true,
 };
 ```


### PR DESCRIPTION
## Summary

Fix HMR not work on online IDEs (such as [MarsCode](https://marscode.com/)).

The default  value of`client.port` should be `window.location.port` instead of `server.port`, this allows online IDEs to proxy the ws requests to dev server correctly.

## Related Links

- MarsCode React template https://www.marscode.com/dashboard/templates

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
