### PR TITLE
fix: apply default dev config

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -8,11 +8,6 @@ import type { StatsError } from '@rsbuild/shared';
 import type { ClientConfig } from '@rsbuild/shared';
 import { formatStatsMessages } from './format';
 
-/**
- * hmr socket connect path
- */
-export const HMR_SOCK_PATH = '/rsbuild-hmr';
-
 function formatURL({
   port,
   protocol,
@@ -46,7 +41,7 @@ function getSocketUrl(urlParts: ClientConfig) {
     protocol: protocol || (location.protocol === 'https:' ? 'wss' : 'ws'),
     hostname: host || location.hostname,
     port: port || location.port,
-    pathname: path || HMR_SOCK_PATH,
+    pathname: path || '/rsbuild-hmr',
   });
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -29,6 +29,7 @@ import {
   DEFAULT_MOUNT_ID,
   DEFAULT_PORT,
   FONT_DIST_DIR,
+  HMR_SOCKET_PATH,
   HTML_DIST_DIR,
   IMAGE_DIST_DIR,
   JS_DIST_DIR,
@@ -56,7 +57,13 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
   liveReload: true,
   assetPrefix: DEFAULT_ASSET_PREFIX,
   startUrl: false,
+  writeToDisk: false,
   client: {
+    path: HMR_SOCKET_PATH,
+    // By default it is set to "location.port"
+    port: '',
+    // By default it is set to "location.hostname"
+    host: '',
     overlay: true,
   },
 });

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -18,6 +18,7 @@ export const LOADER_PATH = join(__dirname);
 export const STATIC_PATH = join(__dirname, '../static');
 export const COMPILED_PATH = join(__dirname, '../compiled');
 export const TS_CONFIG_FILE = 'tsconfig.json';
+export const HMR_SOCKET_PATH = '/rsbuild-hmr';
 
 // Defaults
 export const DEFAULT_PORT = 3000;

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -20,7 +20,6 @@ import {
   type UpgradeEvent,
   formatRoutes,
   getAddressUrls,
-  getDevConfig,
   getServerConfig,
   printServerURLs,
 } from './helper';
@@ -96,13 +95,9 @@ export async function createDevServer<
 
   logger.debug('create dev server');
 
-  const serverConfig = config.server;
   const { port, host, https } = await getServerConfig({
     config,
     getPortSilently,
-  });
-  const devConfig = getDevConfig({
-    config,
   });
 
   const routes = formatRoutes(
@@ -134,8 +129,8 @@ export async function createDevServer<
 
     // create dev middleware instance
     const compilerDevMiddleware = new CompilerDevMiddleware({
-      dev: devConfig,
-      server: serverConfig,
+      dev: config.dev,
+      server: config.server,
       publicPaths: publicPaths,
       devMiddleware,
     });
@@ -168,7 +163,7 @@ export async function createDevServer<
         port,
         routes,
         protocol,
-        printUrls: serverConfig.printUrls,
+        printUrls: config.server.printUrls,
       });
     });
   } else {
@@ -177,23 +172,23 @@ export async function createDevServer<
       port,
       routes,
       protocol,
-      printUrls: serverConfig.printUrls,
+      printUrls: config.server.printUrls,
     });
   }
 
   const compileMiddlewareAPI = runCompile ? await startCompile() : undefined;
 
   const fileWatcher = await setupWatchFiles({
-    dev: devConfig,
-    server: serverConfig,
+    dev: config.dev,
+    server: config.server,
     compileMiddlewareAPI,
   });
 
   const devMiddlewares = await getMiddlewares({
     pwd: options.context.rootPath,
     compileMiddlewareAPI,
-    dev: devConfig,
-    server: serverConfig,
+    dev: config.dev,
+    server: config.server,
     output: {
       distPath: config.output.distPath.root || ROOT_DIST_DIR,
     },
@@ -217,7 +212,7 @@ export async function createDevServer<
     outputFileSystem,
     listen: async () => {
       const httpServer = await createHttpServer({
-        serverConfig,
+        serverConfig: config.server,
         middlewares,
       });
       logger.debug('listen dev server');

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -2,9 +2,8 @@ import type { IncomingMessage } from 'node:http';
 import net from 'node:net';
 import type { Socket } from 'node:net';
 import os from 'node:os';
-import { color, deepmerge, isFunction } from '@rsbuild/shared';
+import { color, isFunction } from '@rsbuild/shared';
 import type {
-  DevConfig,
   NormalizedConfig,
   OutputStructure,
   PrintUrls,
@@ -160,11 +159,6 @@ export function printServerURLs({
 }
 
 /**
- * hmr socket connect path
- */
-export const HMR_SOCK_PATH = '/rsbuild-hmr';
-
-/**
  * Get available free port.
  * @param port - Current port want to use.
  * @param tryLimits - Maximum number of retries.
@@ -248,32 +242,6 @@ export const getServerConfig = async ({
   });
   const https = Boolean(config.server.https) || false;
   return { port, host, https };
-};
-
-export const getDevConfig = ({
-  config,
-}: {
-  config: NormalizedConfig;
-}): DevConfig => {
-  const defaultDevConfig: DevConfig = {
-    client: {
-      path: HMR_SOCK_PATH,
-      // By default it is set to "location.port"
-      port: '',
-      // By default it is set to "location.hostname"
-      host: '',
-      // By default it is set to "location.protocol === 'https:' ? 'wss' : 'ws'""
-      protocol: undefined,
-    },
-    writeToDisk: false,
-    liveReload: true,
-  };
-
-  const devConfig = config.dev
-    ? deepmerge(defaultDevConfig, config.dev)
-    : defaultDevConfig;
-
-  return devConfig;
 };
 
 const getIpv4Interfaces = () => {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -5,11 +5,15 @@ exports[`environment config > should normalize environment config correctly 1`] 
   "dev": {
     "assetPrefix": "/",
     "client": {
+      "host": "",
       "overlay": true,
+      "path": "/rsbuild-hmr",
+      "port": "",
     },
     "hmr": true,
     "liveReload": true,
     "startUrl": false,
+    "writeToDisk": false,
   },
   "html": {
     "crossorigin": false,
@@ -127,11 +131,15 @@ exports[`environment config > should print environment config when inspect confi
     "dev": {
       "assetPrefix": "/",
       "client": {
+        "host": "",
         "overlay": true,
+        "path": "/rsbuild-hmr",
+        "port": "",
       },
       "hmr": true,
       "liveReload": true,
       "startUrl": false,
+      "writeToDisk": false,
     },
     "html": {
       "crossorigin": false,
@@ -245,11 +253,15 @@ exports[`environment config > should print environment config when inspect confi
     "dev": {
       "assetPrefix": "/",
       "client": {
+        "host": "",
         "overlay": true,
+        "path": "/rsbuild-hmr",
+        "port": "",
       },
       "hmr": true,
       "liveReload": true,
       "startUrl": false,
+      "writeToDisk": false,
     },
     "html": {
       "crossorigin": false,
@@ -368,11 +380,15 @@ exports[`environment config > should support modify environment config by api.mo
     "dev": {
       "assetPrefix": "/",
       "client": {
+        "host": "",
         "overlay": true,
+        "path": "/rsbuild-hmr",
+        "port": "",
       },
       "hmr": true,
       "liveReload": true,
       "startUrl": false,
+      "writeToDisk": false,
     },
     "html": {
       "crossorigin": false,
@@ -486,11 +502,15 @@ exports[`environment config > should support modify environment config by api.mo
     "dev": {
       "assetPrefix": "/",
       "client": {
+        "host": "",
         "overlay": true,
+        "path": "/rsbuild-hmr",
+        "port": "",
       },
       "hmr": true,
       "liveReload": true,
       "startUrl": false,
+      "writeToDisk": false,
     },
     "html": {
       "crossorigin": false,
@@ -605,11 +625,15 @@ exports[`environment config > should support modify environment config by api.mo
     "dev": {
       "assetPrefix": "/",
       "client": {
+        "host": "",
         "overlay": true,
+        "path": "/rsbuild-hmr",
+        "port": "",
       },
       "hmr": true,
       "liveReload": true,
       "startUrl": false,
+      "writeToDisk": false,
     },
     "html": {
       "crossorigin": false,

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,14 +1,9 @@
-import type { NormalizedConfig } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import {
   isClientCompiler,
   setupServerHooks,
 } from '../src/server/devMiddleware';
-import {
-  formatRoutes,
-  getDevConfig,
-  printServerURLs,
-} from '../src/server/helper';
+import { formatRoutes, printServerURLs } from '../src/server/helper';
 
 test('formatRoutes', () => {
   expect(
@@ -306,50 +301,5 @@ describe('test dev server', () => {
         }),
       ),
     ).toBeFalsy();
-  });
-
-  test('getDevServerOptions', async () => {
-    expect(
-      getDevConfig({
-        config: {} as NormalizedConfig,
-      }),
-    ).toMatchInlineSnapshot(`
-      {
-        "client": {
-          "host": "",
-          "path": "/rsbuild-hmr",
-          "port": "",
-          "protocol": undefined,
-        },
-        "liveReload": true,
-        "writeToDisk": false,
-      }
-    `);
-
-    expect(
-      getDevConfig({
-        config: {
-          dev: {
-            hmr: false,
-            client: {
-              host: '',
-              path: '',
-            },
-          },
-        } as NormalizedConfig,
-      }),
-    ).toMatchInlineSnapshot(`
-      {
-        "client": {
-          "host": "",
-          "path": "",
-          "port": "",
-          "protocol": undefined,
-        },
-        "hmr": false,
-        "liveReload": true,
-        "writeToDisk": false,
-      }
-    `);
   });
 });

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -95,4 +95,14 @@ export interface DevConfig {
 }
 
 export type NormalizedDevConfig = DevConfig &
-  Required<Pick<DevConfig, 'hmr' | 'liveReload' | 'startUrl' | 'assetPrefix'>>;
+  Required<
+    Pick<
+      DevConfig,
+      | 'hmr'
+      | 'client'
+      | 'startUrl'
+      | 'liveReload'
+      | 'assetPrefix'
+      | 'writeToDisk'
+    >
+  >;

--- a/website/docs/en/guide/advanced/hmr.mdx
+++ b/website/docs/en/guide/advanced/hmr.mdx
@@ -33,33 +33,11 @@ export default {
 
 ## Specify HMR URL
 
-By default, Rsbuild uses the host and port number of the current page to splice the WebSocket URL of HMR.
+By default, Rsbuild uses the host and port number of the current page to splice the WebSocket URL for HMR.
 
-When the HMR connection fails, you can specify the WebSocket URL by customizing `dev.client` configuration.
+When the HMR connection fails, you can specify the WebSocket URL by customizing [dev.client](/config/dev/client) config.
 
-### Default Config
-
-The default config are as follows, Rsbuild will automatically deduce the URL of the WebSocket request according to the current location:
-
-```ts
-export default {
-  dev: {
-    client: {
-      path: '/rsbuild-hmr',
-      // Equivalent to port of the dev server
-      port: '',
-      host: location.hostname,
-      protocol: location.protocol === 'https:' ? 'wss' : 'ws',
-    },
-  },
-};
-```
-
-### Proxy
-
-WHen you proxy an online site for local development, WebSocket requests will fail to connect. You can try configuring `dev.client` to the following values so that HMR requests can reach the local Dev Server.
-
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     client: {

--- a/website/docs/zh/guide/advanced/hmr.mdx
+++ b/website/docs/zh/guide/advanced/hmr.mdx
@@ -35,31 +35,9 @@ export default {
 
 在默认情况下，Rsbuild 使用当前页面的 host 和端口号来拼接 HMR 对应的 WebSocket URL。
 
-当出现 HMR 连接失败的情况时，你可以通过自定义 `dev.client` 配置的方式来指定 WebSocket URL。
+当出现 HMR 连接失败的情况时，你可以自定义 [dev.client](/config/dev/client) 配置来指定 WebSocket URL。
 
-### 默认配置
-
-默认配置如下，Rsbuild 会根据当前页面的 location 自动推导 WebSocket 请求的 URL：
-
-```ts
-export default {
-  dev: {
-    client: {
-      path: '/rsbuild-hmr',
-      // 默认设置为 dev server 的端口号
-      port: '',
-      host: location.hostname,
-      protocol: location.protocol === 'https:' ? 'wss' : 'ws',
-    },
-  },
-};
-```
-
-### 线上代理
-
-如果你将一个线上页面代理到本地进行开发，WebSocket 请求将会连接失败。此时你可以尝试将 `dev.client` 配置成如下值，使 HMR 请求能打到本地的 Dev Server。
-
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     client: {


### PR DESCRIPTION
## Summary

Apply the default dev config in the `getDefaultDevConfig` method, this can ensure that plugins can get the correct default config via `api.getNormalizedConfig()`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
