### PR TITLE
feat!: remove deprecated `dev.startUrl`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -56,7 +56,6 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
   hmr: true,
   liveReload: true,
   assetPrefix: DEFAULT_ASSET_PREFIX,
-  startUrl: false,
   writeToDisk: false,
   client: {
     path: HMR_SOCKET_PATH,

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -14,7 +14,6 @@ const OVERRIDE_PATH = [
   'output.emitAssets',
   'server.open',
   'server.printUrls',
-  'dev.startUrl',
   'provider',
 ];
 

--- a/packages/core/src/plugins/open.ts
+++ b/packages/core/src/plugins/open.ts
@@ -104,20 +104,19 @@ const openedURLs: string[] = [];
 const normalizeOpenConfig = (
   config: NormalizedConfig,
 ): { targets?: string[]; before?: () => Promise<void> | void } => {
-  const open = config.server.open || config.dev.startUrl;
-  const { beforeStartUrl } = config.dev;
+  const { open } = config.server;
 
   if (open === false) {
     return {};
   }
   if (open === true) {
-    return { targets: [], before: beforeStartUrl };
+    return { targets: [] };
   }
   if (typeof open === 'string') {
-    return { targets: [open], before: beforeStartUrl };
+    return { targets: [open] };
   }
   if (Array.isArray(open)) {
-    return { targets: open, before: beforeStartUrl };
+    return { targets: open };
   }
 
   return {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -12,7 +12,6 @@ exports[`environment config > should normalize environment config correctly 1`] 
     },
     "hmr": true,
     "liveReload": true,
-    "startUrl": false,
     "writeToDisk": false,
   },
   "html": {
@@ -136,7 +135,6 @@ exports[`environment config > should print environment config when inspect confi
       },
       "hmr": true,
       "liveReload": true,
-      "startUrl": false,
       "writeToDisk": false,
     },
     "html": {
@@ -256,7 +254,6 @@ exports[`environment config > should print environment config when inspect confi
       },
       "hmr": true,
       "liveReload": true,
-      "startUrl": false,
       "writeToDisk": false,
     },
     "html": {
@@ -381,7 +378,6 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
-      "startUrl": false,
       "writeToDisk": false,
     },
     "html": {
@@ -501,7 +497,6 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
-      "startUrl": false,
       "writeToDisk": false,
     },
     "html": {
@@ -622,7 +617,6 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
-      "startUrl": false,
       "writeToDisk": false,
     },
     "html": {

--- a/packages/shared/src/types/config/dev.ts
+++ b/packages/shared/src/types/config/dev.ts
@@ -47,16 +47,6 @@ export interface DevConfig {
    */
   liveReload?: boolean;
   /**
-   * Set the page URL to open when the server starts.
-   * @deprecated use `server.open` instead
-   */
-  startUrl?: boolean | string | string[];
-  /**
-   * Execute a callback function before opening the `startUrl`.
-   * @deprecated use `server.open.before` instead.
-   */
-  beforeStartUrl?: () => Promise<void> | void;
-  /**
    * Set the URL prefix of static assets during development,
    * similar to the [output.publicPath](https://rspack.dev/config/output#outputpublicpath) config of webpack.
    */
@@ -98,11 +88,6 @@ export type NormalizedDevConfig = DevConfig &
   Required<
     Pick<
       DevConfig,
-      | 'hmr'
-      | 'client'
-      | 'startUrl'
-      | 'liveReload'
-      | 'assetPrefix'
-      | 'writeToDisk'
+      'hmr' | 'client' | 'liveReload' | 'assetPrefix' | 'writeToDisk'
     >
   >;


### PR DESCRIPTION
## Summary

Remove the deprecated `dev.startUrl` config, use `server.open` instead.

## Reference

https://github.com/web-infra-dev/rsbuild/discussions/2508

Changes:

- Rename `dev.startUrl` to `server.open`.
- Rename `dev.beforeStartUrl` to `server.open.before`.

Motivation:

- Align with Rspack dev server's [open](https://www.rspack.dev/config/dev-server#devserveropen) config.
- Allow to use in the preview server.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
