### PR TITLE
feat: support read environments source.entry config

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -108,6 +108,7 @@ export function createPublicContext(
     'configPath',
     'tsconfigPath',
     'bundlerType',
+    'environments',
   ];
 
   // Using Proxy to get the current value of context.

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -30,11 +30,10 @@ export const pluginEntry = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      async (chain, { target, isServer, isServiceWorker }) => {
-        const config = api.getNormalizedConfig();
+      async (chain, { environment, isServer, isServiceWorker }) => {
+        const config = api.getNormalizedConfig({ environment });
         const { preEntry } = config.source;
-        const entry =
-          target === 'web' ? api.context.entry : getEntryObject(config, target);
+        const entry = api.context.environments[environment].entry;
 
         const injectCoreJsEntry =
           config.output.polyfill === 'entry' && !isServer && !isServiceWorker;

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -33,7 +33,7 @@ export const pluginEntry = (): RsbuildPlugin => ({
       async (chain, { environment, isServer, isServiceWorker }) => {
         const config = api.getNormalizedConfig({ environment });
         const { preEntry } = config.source;
-        const entry = api.context.environments[environment].entry;
+        const { entry } = api.context.environments[environment];
 
         const injectCoreJsEntry =
           config.output.polyfill === 'entry' && !isServer && !isServiceWorker;

--- a/packages/core/tests/__snapshots__/entry.test.ts.snap
+++ b/packages/core/tests/__snapshots__/entry.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugin-entry > should apply environment entry config correctly 1`] = `
+exports[`plugin-entry > should apply environments entry config correctly 1`] = `
 [
   {
     "entry": {

--- a/packages/core/tests/__snapshots__/entry.test.ts.snap
+++ b/packages/core/tests/__snapshots__/entry.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`plugin-entry > should apply environment entry config correctly 1`] = `
+[
+  {
+    "entry": {
+      "index": [
+        "src/index.client",
+      ],
+    },
+  },
+  {
+    "entry": {
+      "index": [
+        "src/index.ssr",
+      ],
+    },
+  },
+]
+`;

--- a/packages/core/tests/entry.test.ts
+++ b/packages/core/tests/entry.test.ts
@@ -60,4 +60,31 @@ describe('plugin-entry', () => {
 
     expect(config).toEqual(item.expected);
   });
+
+  it('should apply environments entry config correctly', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginEntry()],
+      rsbuildConfig: {
+        environments: {
+          web: {
+            source: {
+              entry: {
+                index: './src/index.client',
+              },
+            },
+          },
+          ssr: {
+            source: {
+              entry: {
+                index: './src/index.ssr',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const configs = await rsbuild.initConfigs();
+    expect(configs).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

support read environments source.entry config

```js
export default defineConfig({
      environments: {
          web: {
            source: {
              entry: {
                index: './src/index.client',
              },
            },
          },
          ssr: {
            source: {
              entry: {
                index: './src/index.ssr',
              },
            },
          },
        },
      },
});
```
## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
