### PR TITLE
fix(plugin/assets-retry): repeated retrying of async css chunk

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -168,7 +168,6 @@ test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', asyn
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
-  await expect(compTestElement).toHaveCSS('background', 'rgb(0, 0, 139)');
   const blockedResponseCount = count404Response(
     logs,
     '/static/js/async/src_AsyncCompTest_tsx.js',
@@ -193,6 +192,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking async css chunk`', 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
+  await expect(compTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
   const blockedResponseCount = count404Response(
     logs,
     '/static/css/async/src_AsyncCompTest_tsx.css',

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -168,6 +168,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', asyn
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
+  await expect(compTestElement).toHaveCSS('background', 'rgb(0, 0, 139)');
   const blockedResponseCount = count404Response(
     logs,
     '/static/js/async/src_AsyncCompTest_tsx.js',

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -178,6 +178,30 @@ test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', asyn
   logger.level = 'log';
 });
 
+test('@rsbuild/plugin-assets-retry should work when blocking async css chunk`', async ({
+  page,
+}) => {
+  logger.level = 'verbose';
+  const { logs, restore } = proxyConsole();
+  const blockedMiddleware = createBlockMiddleware({
+    blockNum: 3,
+    urlPrefix: '/static/css/async/src_AsyncCompTest_tsx.css',
+  });
+  const rsbuild = await createRsbuildWithMiddleware(blockedMiddleware, {});
+
+  await gotoPage(page, rsbuild);
+  const compTestElement = page.locator('#async-comp-test');
+  await expect(compTestElement).toHaveText('Hello AsyncCompTest');
+  const blockedResponseCount = count404Response(
+    logs,
+    '/static/css/async/src_AsyncCompTest_tsx.css',
+  );
+  expect(blockedResponseCount).toBe(3);
+  await rsbuild.close();
+  restore();
+  logger.level = 'log';
+});
+
 test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking async chunk', async ({
   page,
 }) => {

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -78,6 +78,14 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
         '__RUNTIME_GLOBALS_GET_CHUNK_SCRIPT_FILENAME__',
         RuntimeGlobals.getChunkScriptFilename,
       )
+      .replaceAll(
+        '__RUNTIME_GLOBALS_GET_CSS_FILENAME__',
+        RuntimeGlobals.getChunkCssFilename,
+      )
+      .replaceAll(
+        '__RUNTIME_GLOBALS_GET_MINI_CSS_EXTRACT_FILENAME__',
+        '__webpack_require__.miniCssF'
+      )
       .replaceAll('__RUNTIME_GLOBALS_PUBLIC_PATH__', RuntimeGlobals.publicPath)
       .replaceAll('__RUNTIME_GLOBALS_LOAD_SCRIPT__', RuntimeGlobals.loadScript)
       .replaceAll('__RETRY_OPTIONS__', serialize(this.runtimeOptions));

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -98,9 +98,12 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
         const constructorName = isRspack
           ? module.constructorName
           : module.constructor?.name;
+
         const isPublicPathModule =
           module.name === 'publicPath' ||
-          constructorName === 'PublicPathRuntimeModule';
+          constructorName === 'PublicPathRuntimeModule' ||
+          constructorName === 'AutoPublicPathRuntimeModule';
+
         if (!isPublicPathModule) {
           return;
         }
@@ -108,7 +111,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
         const runtimeCode = this.getRawRuntimeRetryCode();
 
         // Rspack currently does not have module.addRuntimeModule on the js side,
-        // so we insert our runtime code after PublicPathRuntimeModule.
+        // so we insert our runtime code after PublicPathRuntimeModule or AutoPublicPathRuntimeModule.
         if (isRspack) {
           appendRspackScript(module, runtimeCode);
         } else {

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -184,7 +184,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
   const originalScriptFilename = originalGetChunkScriptFilename(chunkId);
   const originalCssFilename = originalGetCssFilename(chunkId);
 
-  // mark the async chunk name in the global variables and share it with initial chunk retry
+  // mark the async chunk name in the global variables and share it with initial chunk retry to avoid duplicate retrying
   if (typeof window !== 'undefined') {
     if (
       originalScriptFilename &&
@@ -204,6 +204,9 @@ function ensureChunk(chunkId: string): Promise<unknown> {
     const { existRetryTimes, originalSrcUrl, nextRetryUrl, nextDomain } =
       nextRetry(chunkId);
 
+    // At present, we don't consider the switching domain and addQuery of async css chunk
+    // 1. Async js chunk will be requested first. It is rare for async css chunk to fail alone.
+    // 2. the code of loading css in webpack runtime is complex and it may be modified by cssExtractPlugin, increase the complexity of this plugin.
     const isCssAsyncChunkLoadFailed =
       error?.message?.includes('CSS chunk') ?? false;
 
@@ -211,7 +214,7 @@ function ensureChunk(chunkId: string): Promise<unknown> {
       times,
       domain: nextDomain,
       url: nextRetryUrl,
-      tagName: isCssAsyncChunkLoadFailed ? 'script' : 'link',
+      tagName: isCssAsyncChunkLoadFailed ? 'link' : 'script',
       isAsyncChunk: true,
     });
 

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -186,16 +186,10 @@ function ensureChunk(chunkId: string): Promise<unknown> {
 
   // mark the async chunk name in the global variables and share it with initial chunk retry to avoid duplicate retrying
   if (typeof window !== 'undefined') {
-    if (
-      originalScriptFilename &&
-      !window.__RB_ASYNC_CHUNKS__[originalScriptFilename]
-    ) {
+    if (originalScriptFilename) {
       window.__RB_ASYNC_CHUNKS__[originalScriptFilename] = true;
     }
-    if (
-      originalCssFilename &&
-      !window.__RB_ASYNC_CHUNKS__[originalCssFilename]
-    ) {
+    if (originalCssFilename) {
       window.__RB_ASYNC_CHUNKS__[originalCssFilename] = true;
     }
   }
@@ -207,8 +201,9 @@ function ensureChunk(chunkId: string): Promise<unknown> {
     // At present, we don't consider the switching domain and addQuery of async css chunk
     // 1. Async js chunk will be requested first. It is rare for async css chunk to fail alone.
     // 2. the code of loading css in webpack runtime is complex and it may be modified by cssExtractPlugin, increase the complexity of this plugin.
-    const isCssAsyncChunkLoadFailed =
-      error?.message?.includes('CSS chunk') ?? false;
+    const isCssAsyncChunkLoadFailed = Boolean(
+      error?.message?.includes('CSS chunk'),
+    );
 
     const createContext = (times: number): AssetsRetryHookContext => ({
       times,

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -202,11 +202,15 @@ function ensureChunk(chunkId: string): Promise<unknown> {
     const { existRetryTimes, originalSrcUrl, nextRetryUrl, nextDomain } =
       nextRetry(chunkId);
 
+    const isCssAsyncChunkLoadFailed =
+      error?.message?.includes('CSS chunk') ?? false;
+
     const createContext = (times: number): AssetsRetryHookContext => ({
       times,
       domain: nextDomain,
       url: nextRetryUrl,
-      tagName: 'script',
+      tagName: isCssAsyncChunkLoadFailed ? 'script' : 'link',
+      isAsyncChunk: true,
     });
 
     const context = createContext(existRetryTimes - 1);

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -25,11 +25,13 @@ declare global {
     chunkId: ChunkId,
   ) => string;
   // RuntimeGlobals.getChunkCssFilename
-  var __RUNTIME_GLOBALS_GET_CSS_FILENAME__: (chunkId: ChunkId) => string;
+  var __RUNTIME_GLOBALS_GET_CSS_FILENAME__:
+    | ((chunkId: ChunkId) => string)
+    | undefined;
   // RuntimeGlobals.getChunkCssFilename when using Rspack.CssExtractPlugin
-  var __RUNTIME_GLOBALS_GET_MINI_CSS_EXTRACT_FILENAME__: (
-    chunkId: ChunkId,
-  ) => string | undefined;
+  var __RUNTIME_GLOBALS_GET_MINI_CSS_EXTRACT_FILENAME__:
+    | ((chunkId: ChunkId) => string)
+    | undefined;
   // RuntimeGlobals.loadScript
   var __RUNTIME_GLOBALS_LOAD_SCRIPT__: (
     url: ChunkSrcUrl,

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -233,6 +233,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
         domain,
         url,
         tagName,
+        isAsyncChunk: false,
       };
       config.onFail(context);
     }
@@ -280,6 +281,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
       domain,
       url,
       tagName,
+      isAsyncChunk: false,
     };
     config.onRetry(context);
   }
@@ -304,6 +306,7 @@ function load(config: RuntimeRetryOptions, e: Event) {
       domain,
       url,
       tagName,
+      isAsyncChunk: false,
     };
     config.onSuccess(context);
   }

--- a/packages/plugin-assets-retry/src/types.ts
+++ b/packages/plugin-assets-retry/src/types.ts
@@ -68,4 +68,5 @@ export type AssetsRetryHookContext = {
   times: number;
   domain: string;
   tagName: string;
+  isAsyncChunk: boolean;
 };

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -40,6 +40,7 @@ type AssetsRetryHookContext = {
   domain: string;
   url: string;
   tagName: string;
+  isAsyncChunk: boolean;
 };
 
 type AssetsRetryOptions = {
@@ -153,9 +154,9 @@ The callback function when the asset is being retried. For example:
 
 ```js
 pluginAssetsRetry({
-  onRetry: ({ times, domain, url, tagName }) => {
+  onRetry: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });
@@ -169,9 +170,9 @@ The callback function when the asset is successfully retried. For example:
 
 ```js
 pluginAssetsRetry({
-  onSuccess: ({ times, domain, url, tagName }) => {
+  onSuccess: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });
@@ -185,9 +186,9 @@ The callback function when the asset is failed to be retried. For example:
 
 ```js
 pluginAssetsRetry({
-  onFail: ({ times, domain, url, tagName }) => {
+  onFail: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -40,6 +40,7 @@ type AssetsRetryHookContext = {
   domain: string;
   url: string;
   tagName: string;
+  isAsyncChunk: boolean;
 };
 
 type AssetsRetryOptions = {
@@ -153,9 +154,9 @@ pluginAssetsRetry({
 
 ```js
 pluginAssetsRetry({
-  onRetry: ({ times, domain, url, tagName }) => {
+  onRetry: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });
@@ -169,9 +170,9 @@ pluginAssetsRetry({
 
 ```js
 pluginAssetsRetry({
-  onSuccess: ({ times, domain, url, tagName }) => {
+  onSuccess: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });
@@ -185,9 +186,9 @@ pluginAssetsRetry({
 
 ```js
 pluginAssetsRetry({
-  onFail: ({ times, domain, url, tagName }) => {
+  onFail: ({ times, domain, url, tagName, isAsyncChunk }) => {
     console.log(
-      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}`,
+      `Retry ${times} times, domain: ${domain}, url: ${url}, tagName: ${tagName}, isAsyncChunk: ${isAsyncChunk}`,
     );
   },
 });


### PR DESCRIPTION
## Summary

1. async css chunk file will be repeatedly retried by both initialChunkRetry and asyncChunkRetry

<img width="400" src="https://github.com/web-infra-dev/rsbuild/assets/79413249/4804da06-0831-43be-9150-3136c5139b32" />

2. fix it doesn't append script when using `publicPath: "auto"`

<img width="400" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/79413249/6bd58a60-3e58-47d9-9f5b-f5170e7be83d">


3. add `isAsyncChunk: boolean` to context

## Related Links

none
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
