### PR TITLE
docs: support htmlPlugin param in tools.rspack utils

### DIFF
--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -198,6 +198,22 @@ export default {
 };
 ```
 
+### HtmlPlugin
+
+- **Type:** `typeof import('html-webpack-plugin')`
+
+The instance of `html-webpack-plugin`:
+
+```js
+export default {
+  tools: {
+    rspack: (config, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
+    },
+  },
+};
+```
+
 ### addRules
 
 - **Type:** `(rules: RuleSetRule | RuleSetRule[]) => void`

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -198,6 +198,22 @@ export default {
 };
 ```
 
+### HtmlPlugin
+
+- **类型：** `typeof import('html-webpack-plugin')`
+
+通过这个参数你可以拿到 `html-webpack-plugin` 插件的实例。
+
+```js
+export default {
+  tools: {
+    rspack: (config, { HtmlPlugin }) => {
+      console.log(HtmlPlugin);
+    },
+  },
+};
+```
+
 ### addRules
 
 - **类型：** `(rules: RuleSetRule | RuleSetRule[]) => void`


### PR DESCRIPTION
## Summary
Improve doc, support htmlPlugin param in tools.rspack utils.

<img width="1040" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/92571fcd-ec70-4574-9ead-28a4ed075c33">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
