### PR TITLE
chore(deps): bump typescript v5.5

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -68,6 +68,6 @@
     "playwright": "1.44.1",
     "strip-ansi": "6.0.1",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "lit": "^3.1.4",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/mdx/package.json
+++ b/examples/mdx/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-mdx": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -1,16 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  environments: {
-    web: {
-      output: {
-        overrideBrowserslist: ['iOS >= 9', 'Android >= 4.4'],
-      },
-    },
-    node: {
-      output: {
-        overrideBrowserslist: ['node >= 20'],
-      },
-    },
-  },
+  plugins: [pluginReact()],
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig } from '@rsbuild/core';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  environments: {
+    web: {
+      output: {
+        overrideBrowserslist: ['iOS >= 9', 'Android >= 4.4'],
+      },
+    },
+    node: {
+      output: {
+        overrideBrowserslist: ['node >= 20'],
+      },
+    },
+  },
 });

--- a/examples/service-worker/package.json
+++ b/examples/service-worker/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@rsbuild/plugin-swc": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/webpack": "workspace:*",
     "@types/lodash": "^4.17.5",
     "@types/semver": "^7.5.8",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "webpack": "^5.92.0"
   },
   "peerDependencies": {

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -40,7 +40,7 @@
     "ansi-escapes": "4.3.2",
     "cli-truncate": "2.1.0",
     "patch-console": "1.0.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
     "sirv": "^2.0.4",
     "style-loader": "3.3.4",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "webpack": "^5.92.0",
     "webpack-dev-middleware": "7.2.1",
     "ws": "^8.17.1"

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -35,7 +35,7 @@
     "@types/node": "18.x",
     "deepmerge": "^4.3.1",
     "rslog": "^1.2.2",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "engines": {
     "node": ">=16.7.0"

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "lit": "^3.1.4",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -16,6 +16,6 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-solid": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "svelte-check": "^3.8.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-vue2": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -38,7 +38,7 @@
     "@types/serialize-javascript": "^5.0.4",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "terser": "5.31.1",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -42,7 +42,7 @@
     "@types/node": "18.x",
     "babel-loader": "9.1.3",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@types/lodash": "^4.17.5",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "eslint": "^9.5.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -38,7 +38,7 @@
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -40,7 +40,7 @@
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "prebundle": "1.1.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^14.2.1",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "yaml": "^2.4.5"
   },
   "peerDependencies": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -35,7 +35,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "svelte": "^4.2.18",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@types/node": "18.x",
     "file-loader": "6.2.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "url-loader": "4.1.1"
   },
   "peerDependencies": {

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -36,7 +36,7 @@
     "@scripts/test-helper": "workspace:*",
     "line-diff": "2.1.1",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "vue": "^3.4.19",
     "webpack": "^5.92.0"
   },

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "webpack": "^5.92.0"
   },
   "peerDependencies": {

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "prebundle": "1.1.0",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "yaml-loader": "^0.8.1"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,7 +83,7 @@
     "prebundle": "1.1.0",
     "rspack-chain": "^0.7.3",
     "terser": "5.31.1",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "webpack": "^5.92.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-merge": "5.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 2.27.5
       '@modern-js/module-tools':
         specifier: ^2.52.0
-        version: 2.52.0(eslint@9.5.0)(typescript@5.4.5)
+        version: 2.52.0(typescript@5.5.2)
       '@rsbuild/config':
         specifier: workspace:*
         version: link:scripts/config
@@ -77,10 +77,10 @@ importers:
         version: 1.8.17
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
       vue-router:
         specifier: ^4.3.3
-        version: 4.3.3(vue@3.4.23(typescript@5.4.5))
+        version: 4.3.3(vue@3.4.23(typescript@5.5.2))
     devDependencies:
       '@e2e/helper':
         specifier: workspace:*
@@ -230,8 +230,8 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   e2e/cases/babel/decorator:
     devDependencies:
@@ -263,7 +263,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
 
   e2e/cases/react/react-compiler-babel:
     dependencies:
@@ -349,13 +349,13 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
 
   e2e/cases/vue/jsx-hmr:
     dependencies:
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -387,8 +387,8 @@ importers:
         specifier: ^3.1.4
         version: 3.1.4
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/mdx:
     dependencies:
@@ -409,8 +409,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-react
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/module-federation/host:
     dependencies:
@@ -453,8 +453,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/preact:
     dependencies:
@@ -469,8 +469,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-preact
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/react:
     dependencies:
@@ -494,8 +494,8 @@ importers:
         specifier: ^18.3.0
         version: 18.3.0
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/service-worker:
     devDependencies:
@@ -503,8 +503,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/solid:
     dependencies:
@@ -541,8 +541,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   examples/vue2:
     dependencies:
@@ -561,7 +561,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -589,8 +589,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/compat/webpack
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/compat/babel-preset:
     dependencies:
@@ -641,8 +641,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/compat/plugin-swc:
     dependencies:
@@ -678,8 +678,8 @@ importers:
         specifier: ^7.5.8
         version: 7.5.8
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -721,8 +721,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/core:
     dependencies:
@@ -801,13 +801,13 @@ importers:
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.0)
+        version: 8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0)
       postcss-value-parser:
         specifier: 4.2.0
         version: 4.2.0
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       rslog:
         specifier: ^1.2.2
         version: 1.2.2
@@ -827,8 +827,8 @@ importers:
         specifier: ^1.8.10
         version: 1.8.10
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -854,8 +854,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-assets-retry:
     dependencies:
@@ -888,8 +888,8 @@ importers:
         specifier: 5.31.1
         version: 5.31.1
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-babel:
     dependencies:
@@ -929,10 +929,10 @@ importers:
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.92.0)
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-basic-ssl:
     dependencies:
@@ -944,8 +944,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-check-syntax:
     dependencies:
@@ -969,8 +969,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-css-minimizer:
     dependencies:
@@ -988,8 +988,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-eslint:
     dependencies:
@@ -1010,8 +1010,8 @@ importers:
         specifier: ^9.5.0
         version: 9.5.0
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-image-compress:
     dependencies:
@@ -1032,8 +1032,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-less:
     dependencies:
@@ -1058,10 +1058,10 @@ importers:
         version: 12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.92.0)
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-lightningcss:
     dependencies:
@@ -1082,8 +1082,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-mdx:
     dependencies:
@@ -1095,8 +1095,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-node-polyfill:
     dependencies:
@@ -1174,8 +1174,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-preact:
     devDependencies:
@@ -1186,8 +1186,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-pug:
     dependencies:
@@ -1202,8 +1202,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-react:
     dependencies:
@@ -1227,8 +1227,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-rem:
     dependencies:
@@ -1259,10 +1259,10 @@ importers:
         version: 6.1.0(postcss@8.4.38)
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-sass:
     dependencies:
@@ -1290,7 +1290,7 @@ importers:
         version: 8.0.8
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1298,8 +1298,8 @@ importers:
         specifier: ^14.2.1
         version: 14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-solid:
     dependencies:
@@ -1323,8 +1323,8 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-source-build:
     dependencies:
@@ -1348,8 +1348,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       yaml:
         specifier: ^2.4.5
         version: 2.4.5
@@ -1367,8 +1367,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-stylus:
     dependencies:
@@ -1389,8 +1389,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-svelte:
     dependencies:
@@ -1402,7 +1402,7 @@ importers:
         version: 3.2.3(svelte@4.2.18)
       svelte-preprocess:
         specifier: ^5.1.4
-        version: 5.1.4(@babel/core@7.24.7)(less@4.2.0)(postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5))(postcss@8.4.38)(pug@3.0.3)(sass@1.77.5)(stylus@0.63.0)(svelte@4.2.18)(typescript@5.4.5)
+        version: 5.1.4(@babel/core@7.24.7)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.38))(postcss@8.4.38)(pug@3.0.3)(sass@1.77.5)(stylus@0.63.0)(svelte@4.2.18)(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1417,8 +1417,8 @@ importers:
         specifier: ^4.2.18
         version: 4.2.18
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-svgr:
     dependencies:
@@ -1430,13 +1430,13 @@ importers:
         version: link:../shared
       '@svgr/core':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.4.5)
+        version: 8.1.0(typescript@5.5.2)
       '@svgr/plugin-jsx':
         specifier: 8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.5.2))
       '@svgr/plugin-svgo':
         specifier: 8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@5.4.5))(typescript@5.4.5)
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.5.2))(typescript@5.5.2)
       loader-utils:
         specifier: ^2.0.4
         version: 2.0.4
@@ -1455,10 +1455,10 @@ importers:
         version: 6.2.0(webpack@5.92.0)
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       url-loader:
         specifier: 4.1.1
         version: 4.1.1(file-loader@6.2.0(webpack@5.92.0))(webpack@5.92.0)
@@ -1473,8 +1473,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-type-check:
     dependencies:
@@ -1483,7 +1483,7 @@ importers:
         version: link:../shared
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
-        version: 9.0.2(typescript@5.4.5)(webpack@5.92.0)
+        version: 9.0.2(typescript@5.5.2)(webpack@5.92.0)
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -1498,8 +1498,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-typed-css-modules:
     dependencies:
@@ -1518,10 +1518,10 @@ importers:
         version: 2.1.1
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-umd:
     devDependencies:
@@ -1529,8 +1529,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-vue:
     dependencies:
@@ -1539,7 +1539,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^17.4.0
-        version: 17.4.2(vue@3.4.23(typescript@5.4.5))(webpack@5.92.0)
+        version: 17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.0)
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -1551,11 +1551,11 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       vue:
         specifier: ^3.4.19
-        version: 3.4.23(typescript@5.4.5)
+        version: 3.4.23(typescript@5.5.2)
 
   packages/plugin-vue-jsx:
     dependencies:
@@ -1579,8 +1579,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-vue2:
     dependencies:
@@ -1589,7 +1589,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0)
+        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.0)
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -1601,8 +1601,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-vue2-jsx:
     dependencies:
@@ -1611,7 +1611,7 @@ importers:
         version: link:../plugin-babel
       '@vue/babel-preset-jsx':
         specifier: ^1.4.0
-        version: 1.4.0(@babel/core@7.24.7)(vue@3.4.23(typescript@5.4.5))
+        version: 1.4.0(@babel/core@7.24.7)(vue@3.4.23(typescript@5.5.2))
     devDependencies:
       '@babel/core':
         specifier: ^7.24.7
@@ -1623,8 +1623,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   packages/plugin-yaml:
     devDependencies:
@@ -1636,10 +1636,10 @@ importers:
         version: link:../../scripts/test-helper
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       yaml-loader:
         specifier: ^0.8.1
         version: 0.8.1
@@ -1692,7 +1692,7 @@ importers:
         version: 1.0.1
       prebundle:
         specifier: 1.1.0
-        version: 1.1.0(typescript@5.4.5)
+        version: 1.1.0(typescript@5.5.2)
       rspack-chain:
         specifier: ^0.7.3
         version: 0.7.3
@@ -1700,8 +1700,8 @@ importers:
         specifier: 5.31.1
         version: 5.31.1
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -1718,8 +1718,8 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
 
   scripts/test-helper:
     dependencies:
@@ -1739,8 +1739,8 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       typescript:
-        specifier: ^5.4.2
-        version: 5.4.5
+        specifier: ^5.5.0
+        version: 5.5.2
       upath:
         specifier: 2.0.1
         version: 2.0.1
@@ -7919,7 +7919,7 @@ packages:
   rsbuild-plugin-google-analytics@1.0.0:
     resolution: {integrity: sha512-Z2hVetWq48QT+X/HMmtp+YTxzPw+ujt/KUrbQXn98LmUDYqJyGSCBAjit8atAoRiThUSKlkG+NU3+zkFvKoLdA==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 0.x
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -7927,7 +7927,7 @@ packages:
   rsbuild-plugin-open-graph@1.0.0:
     resolution: {integrity: sha512-SuN9w2FH2v9Mp9/jBowH/RvR74i5A1KzM8+3JrCwCpsuny2HQ3iZqVETgDJ0VIcXqLHUxPnI0aGMgbAcqmlzcg==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 0.x
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -8737,8 +8737,8 @@ packages:
     resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
     engines: {node: '>=14.16'}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.2:
+    resolution: {integrity: sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -10871,7 +10871,7 @@ snapshots:
       '@modern-js/utils': 2.52.0
       '@swc/helpers': 0.5.3
 
-  '@modern-js/module-tools@2.52.0(eslint@9.5.0)(typescript@5.4.5)':
+  '@modern-js/module-tools@2.52.0(typescript@5.5.2)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@ast-grep/napi': 0.16.0
@@ -10881,7 +10881,7 @@ snapshots:
       '@modern-js/plugin': 2.52.0
       '@modern-js/plugin-changeset': 2.52.0
       '@modern-js/plugin-i18n': 2.52.0
-      '@modern-js/plugin-lint': 2.52.0(eslint@9.5.0)
+      '@modern-js/plugin-lint': 2.52.0
       '@modern-js/swc-plugins': 0.6.6(@swc/helpers@0.5.3)
       '@modern-js/types': 2.52.0
       '@modern-js/utils': 2.52.0
@@ -10901,7 +10901,7 @@ snapshots:
       terser: 5.19.2
       tsconfig-paths-webpack-plugin: 4.1.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
     transitivePeerDependencies:
       - debug
       - eslint
@@ -10931,15 +10931,13 @@ snapshots:
       '@modern-js/utils': 2.52.0
       '@swc/helpers': 0.5.3
 
-  '@modern-js/plugin-lint@2.52.0(eslint@9.5.0)':
+  '@modern-js/plugin-lint@2.52.0':
     dependencies:
       '@modern-js/tsconfig': 2.52.0
       '@modern-js/utils': 2.52.0
       '@swc/helpers': 0.5.3
       cross-spawn: 7.0.3
       husky: 8.0.3
-    optionalDependencies:
-      eslint: 9.5.0
 
   '@modern-js/plugin@2.52.0':
     dependencies:
@@ -11596,12 +11594,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.24.7)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.24.7)
 
-  '@svgr/core@8.1.0(typescript@5.4.5)':
+  '@svgr/core@8.1.0(typescript@5.5.2)':
     dependencies:
       '@babel/core': 7.24.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.7)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      cosmiconfig: 8.3.6(typescript@5.5.2)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -11612,20 +11610,20 @@ snapshots:
       '@babel/types': 7.24.7
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.4.5))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.5.2))':
     dependencies:
       '@babel/core': 7.24.7
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.7)
-      '@svgr/core': 8.1.0(typescript@5.4.5)
+      '@svgr/core': 8.1.0(typescript@5.5.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.4.5))(typescript@5.4.5)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.5.2))(typescript@5.5.2)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.4.5)
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      '@svgr/core': 8.1.0(typescript@5.5.2)
+      cosmiconfig: 8.3.6(typescript@5.5.2)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -11931,7 +11929,7 @@ snapshots:
       lodash.kebabcase: 4.1.1
       svg-tags: 1.0.0
 
-  '@vue/babel-preset-jsx@1.4.0(@babel/core@7.24.7)(vue@3.4.23(typescript@5.4.5))':
+  '@vue/babel-preset-jsx@1.4.0(@babel/core@7.24.7)(vue@3.4.23(typescript@5.5.2))':
     dependencies:
       '@babel/core': 7.24.7
       '@vue/babel-helper-vue-jsx-merge-props': 1.4.0
@@ -11943,7 +11941,7 @@ snapshots:
       '@vue/babel-sugar-v-model': 1.4.0(@babel/core@7.24.7)
       '@vue/babel-sugar-v-on': 1.4.0(@babel/core@7.24.7)
     optionalDependencies:
-      vue: 3.4.23(typescript@5.4.5)
+      vue: 3.4.23(typescript@5.5.2)
 
   '@vue/babel-sugar-composition-api-inject-h@1.4.0(@babel/core@7.24.7)':
     dependencies:
@@ -12020,9 +12018,9 @@ snapshots:
       '@vue/compiler-dom': 3.4.23
       '@vue/shared': 3.4.23
 
-  '@vue/component-compiler-utils@3.3.0(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@vue/component-compiler-utils@3.3.0(lodash@4.17.21)(pug@3.0.3)':
     dependencies:
-      consolidate: 0.15.1(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      consolidate: 0.15.1(lodash@4.17.21)(pug@3.0.3)
       hash-sum: 1.0.2
       lru-cache: 4.1.5
       merge-source-map: 1.1.0
@@ -12104,11 +12102,11 @@ snapshots:
       '@vue/shared': 3.4.23
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.4.23(vue@3.4.23(typescript@5.4.5))':
+  '@vue/server-renderer@3.4.23(vue@3.4.23(typescript@5.5.2))':
     dependencies:
       '@vue/compiler-ssr': 3.4.23
       '@vue/shared': 3.4.23
-      vue: 3.4.23(typescript@5.4.5)
+      vue: 3.4.23(typescript@5.5.2)
 
   '@vue/shared@3.4.23': {}
 
@@ -12757,14 +12755,12 @@ snapshots:
 
   console-browserify@1.2.0: {}
 
-  consolidate@0.15.1(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  consolidate@0.15.1(lodash@4.17.21)(pug@3.0.3):
     dependencies:
       bluebird: 3.7.2
     optionalDependencies:
       lodash: 4.17.21
       pug: 3.0.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   constantinople@4.0.1:
     dependencies:
@@ -12807,23 +12803,23 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@8.3.6(typescript@5.4.5):
+  cosmiconfig@8.3.6(typescript@5.5.2):
     dependencies:
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
-  cosmiconfig@9.0.0(typescript@5.4.5):
+  cosmiconfig@9.0.0(typescript@5.5.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.0
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   create-ecdh@4.0.4:
     dependencies:
@@ -13566,12 +13562,12 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.4.5)(webpack@5.92.0):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.5.2)(webpack@5.92.0):
     dependencies:
       '@babel/code-frame': 7.24.2
       chalk: 4.1.2
       chokidar: 3.6.0
-      cosmiconfig: 8.3.6(typescript@5.4.5)
+      cosmiconfig: 8.3.6(typescript@5.5.2)
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
@@ -13580,7 +13576,7 @@ snapshots:
       schema-utils: 3.3.0
       semver: 7.6.2
       tapable: 2.2.1
-      typescript: 5.4.5
+      typescript: 5.5.2
       webpack: 5.92.0
 
   form-data@4.0.0:
@@ -15840,9 +15836,9 @@ snapshots:
       tsx: 4.14.0
       yaml: 2.4.5
 
-  postcss-loader@8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.4.5)(webpack@5.92.0):
+  postcss-loader@8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.4.5)
+      cosmiconfig: 9.0.0(typescript@5.5.2)
       jiti: 1.21.6
       postcss: 8.4.38
       semver: 7.6.2
@@ -16031,11 +16027,11 @@ snapshots:
 
   preact@10.22.0: {}
 
-  prebundle@1.1.0(typescript@5.4.5):
+  prebundle@1.1.0(typescript@5.5.2):
     dependencies:
       '@vercel/ncc': 0.38.1
       rollup: 4.17.1
-      rollup-plugin-dts: 6.1.0(rollup@4.17.1)(typescript@5.4.5)
+      rollup-plugin-dts: 6.1.0(rollup@4.17.1)(typescript@5.5.2)
     transitivePeerDependencies:
       - typescript
 
@@ -16499,11 +16495,11 @@ snapshots:
       hash-base: 3.1.0
       inherits: 2.0.4
 
-  rollup-plugin-dts@6.1.0(rollup@4.17.1)(typescript@5.4.5):
+  rollup-plugin-dts@6.1.0(rollup@4.17.1)(typescript@5.5.2):
     dependencies:
       magic-string: 0.30.10
       rollup: 4.17.1
-      typescript: 5.4.5
+      typescript: 5.5.2
     optionalDependencies:
       '@babel/code-frame': 7.24.6
 
@@ -17081,7 +17077,7 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@4.2.18)
 
-  svelte-preprocess@5.1.4(@babel/core@7.24.7)(less@4.2.0)(postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5))(postcss@8.4.38)(pug@3.0.3)(sass@1.77.5)(stylus@0.63.0)(svelte@4.2.18)(typescript@5.4.5):
+  svelte-preprocess@5.1.4(@babel/core@7.24.7)(less@4.2.0)(postcss-load-config@4.0.2(postcss@8.4.38))(postcss@8.4.38)(pug@3.0.3)(sass@1.77.5)(stylus@0.63.0)(svelte@4.2.18)(typescript@5.5.2):
     dependencies:
       '@types/pug': 2.0.10
       detect-indent: 6.1.0
@@ -17093,11 +17089,11 @@ snapshots:
       '@babel/core': 7.24.7
       less: 4.2.0
       postcss: 8.4.38
-      postcss-load-config: 6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5)
+      postcss-load-config: 4.0.2(postcss@8.4.38)
       pug: 3.0.3
       sass: 1.77.5
       stylus: 0.63.0
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   svelte@4.2.18:
     dependencies:
@@ -17315,7 +17311,7 @@ snapshots:
 
   type-fest@3.13.1: {}
 
-  typescript@5.4.5: {}
+  typescript@5.5.2: {}
 
   ufo@1.5.3: {}
 
@@ -17580,9 +17576,9 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.0):
     dependencies:
-      '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)
       css-loader: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
@@ -17647,19 +17643,19 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(vue@3.4.23(typescript@5.4.5))(webpack@5.92.0):
+  vue-loader@17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
       webpack: 5.92.0
     optionalDependencies:
-      vue: 3.4.23(typescript@5.4.5)
+      vue: 3.4.23(typescript@5.5.2)
 
-  vue-router@4.3.3(vue@3.4.23(typescript@5.4.5)):
+  vue-router@4.3.3(vue@3.4.23(typescript@5.5.2)):
     dependencies:
       '@vue/devtools-api': 6.6.1
-      vue: 3.4.23(typescript@5.4.5)
+      vue: 3.4.23(typescript@5.5.2)
 
   vue-style-loader@4.1.3:
     dependencies:
@@ -17673,15 +17669,15 @@ snapshots:
       '@vue/compiler-sfc': 2.7.16
       csstype: 3.1.3
 
-  vue@3.4.23(typescript@5.4.5):
+  vue@3.4.23(typescript@5.5.2):
     dependencies:
       '@vue/compiler-dom': 3.4.23
       '@vue/compiler-sfc': 3.4.23
       '@vue/runtime-dom': 3.4.23
-      '@vue/server-renderer': 3.4.23(vue@3.4.23(typescript@5.4.5))
+      '@vue/server-renderer': 3.4.23(vue@3.4.23(typescript@5.5.2))
       '@vue/shared': 3.4.23
     optionalDependencies:
-      typescript: 5.4.5
+      typescript: 5.5.2
 
   w-json@1.3.10: {}
 

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",
-    "typescript": "^5.4.2"
+    "typescript": "^5.5.0"
   }
 }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.17.5",
     "@types/node": "18.x",
     "lodash": "^4.17.21",
-    "typescript": "^5.4.2",
+    "typescript": "^5.5.0",
     "upath": "2.0.1"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump typescript v5.5.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
