### PR TITLE
docs: add basic environment config

### DIFF
--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -73,23 +73,9 @@ The type of Rsbuild environment configuration after normalization, corresponding
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';
 
-const config: NormalizedEnvironmentConfig = api.getNormalizedConfig({ environment });
-```
-
-You can also import the type definitions of each field in the normalized config:
-
-```ts
-import type {
-  NormalizedDevConfig,
-  NormalizedHtmlConfig,
-  NormalizedToolsConfig,
-  NormalizedSourceConfig,
-  NormalizedServerConfig,
-  NormalizedOutputConfig,
-  NormalizedSecurityConfig,
-  NormalizedPerformanceConfig,
-  NormalizedModuleFederationConfig,
-} from '@rsbuild/core';
+const config: NormalizedEnvironmentConfig = api.getNormalizedConfig({
+  environment,
+});
 ```
 
 ## RsbuildContext

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -71,7 +71,7 @@ import type {
 The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method.
 
 ```ts
-import type { NormalizedConfig } from '@rsbuild/core';
+import type { NormalizedEnvironmentConfig } from '@rsbuild/core';
 
 const config: NormalizedConfig = api.getNormalizedConfig({ environment });
 ```

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -66,6 +66,32 @@ import type {
 } from '@rsbuild/core';
 ```
 
+## NormalizedEnvironmentConfig
+
+The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method.
+
+```ts
+import type { NormalizedConfig } from '@rsbuild/core';
+
+const config: NormalizedConfig = api.getNormalizedConfig({ environment });
+```
+
+You can also import the type definitions of each field in the normalized config:
+
+```ts
+import type {
+  NormalizedDevConfig,
+  NormalizedHtmlConfig,
+  NormalizedToolsConfig,
+  NormalizedSourceConfig,
+  NormalizedServerConfig,
+  NormalizedOutputConfig,
+  NormalizedSecurityConfig,
+  NormalizedPerformanceConfig,
+  NormalizedModuleFederationConfig,
+} from '@rsbuild/core';
+```
+
 ## RsbuildContext
 
 The type of the [context property](/api/javascript-api/instance#rsbuildcontext) in the Rsbuild instance.

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -73,7 +73,7 @@ The type of Rsbuild environment configuration after normalization, corresponding
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';
 
-const config: NormalizedConfig = api.getNormalizedConfig({ environment });
+const config: NormalizedEnvironmentConfig = api.getNormalizedConfig({ environment });
 ```
 
 You can also import the type definitions of each field in the normalized config:

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -68,7 +68,7 @@ import type {
 
 ## NormalizedEnvironmentConfig
 
-The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method.
+The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [getNormalizedConfig({ environment })](/plugins/dev/core#apigetnormalizedconfig) method.
 
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';

--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -4,6 +4,7 @@
     "name": "index",
     "label": "Overview"
   },
+  "environments",
   "plugins",
   {
     "type": "dir",

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -2,7 +2,7 @@
 
 Rsbuild supports building outputs for multiple environments. You can use `environments` to define different Rsbuild configurations for each environment.
 
-The configuration in `environments` can override the outer Rsbuild basic configuration.
+The configuration in `environments` overrides the outer Rsbuild base configuration.
 
 - **Type:**
 

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -72,7 +72,7 @@ export default {
         target: 'web',
       },
     },
-    // configuration for ssr
+    // configuration for SSR
     node: {
       source: {
         alias: {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -90,7 +90,7 @@ export default {
 };
 ```
 
-The final rsbuild configuration that takes effect in the client environment is:
+For the `web` environment, the merged Rsbuild configuration is:
 
 ```
 const webConfig = {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -1,6 +1,6 @@
 # environments
 
-Rsbuild supports building multiple environment products. You can define multiple environments through `environments` and define different Rsbuild configurations for different environments.
+Rsbuild supports building outputs for multiple environments. You can use `environments` to define different Rsbuild configurations for each environment.
 
 The configuration in `environments` can override the outer Rsbuild basic configuration.
 

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -2,9 +2,7 @@
 
 Rsbuild supports building multiple environment products. You can define multiple environments through `environments` and define different Rsbuild configurations for different environments.
 
-Configure exclusive Rsbuild configurations for different environments.
-
-The configuration in environments can override the outer Rsbuild basic configuration.
+The configuration in `environments` can override the outer Rsbuild basic configuration.
 
 - **Type:**
 

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -92,7 +92,7 @@ export default {
 
 For the `web` environment, the merged Rsbuild configuration is:
 
-```
+```js
 const webConfig = {
   source: {
     alias: {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -73,7 +73,7 @@ export default {
       },
     },
     // configuration for ssr
-    ssr: {
+    node: {
       source: {
         alias: {
           '@common1': './src/ssr/common1',

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -47,7 +47,7 @@ type Environments = {
 
 ## Example
 
-Configure rsbuild configuration for client and ssr environment:
+Configure Rsbuild configuration for `web` (client) and `node` (SSR) environments:
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -112,7 +112,7 @@ const webConfig = {
 For the `node` environment, the merged Rsbuild configuration is:
 
 ```js
-{
+const nodeConfig = {
   source: {
     alias: {
       "@common": "./src/common",

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -111,7 +111,7 @@ const webConfig = {
 
 The final rsbuild configuration that takes effect in the ssr environment is:
 
-```
+```js
 {
   source: {
     alias: {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -1,0 +1,131 @@
+# environments
+
+Rsbuild supports building multiple environment products. You can define multiple environments through `environments` and define different Rsbuild configurations for different environments.
+
+Configure exclusive Rsbuild configurations for different environments.
+
+The configuration in environments can override the outer Rsbuild basic configuration.
+
+- **Type:**
+
+```ts
+export interface EnvironmentConfig {
+  /**
+   * Options for HTML generation.
+   */
+  html?: HtmlConfig;
+  /**
+   * Options for the low-level tools.
+   */
+  tools?: ToolsConfig;
+  /**
+   * Options for source code parsing and compilation.
+   */
+  source?: SourceConfig;
+  /**
+   * Options for build outputs.
+   */
+  output?: OutputConfig;
+  /**
+   * Options for Web security.
+   */
+  security?: SecurityConfig;
+  /**
+   * Options for build performance and runtime performance.
+   */
+  performance?: PerformanceConfig;
+  /**
+   * Options for module federation.
+   */
+  moduleFederation?: ModuleFederationConfig;
+}
+
+type Environments = {
+  [name: string]: EnvironmentConfig;
+};
+```
+
+- **Default:** `undefined`
+
+## Example
+
+Configure rsbuild configuration for client and ssr environment:
+
+```ts title="rsbuild.config.ts"
+export default {
+  // Shared configuration for all environments
+  source: {
+    alias: {
+      '@common': './src/common',
+    },
+  },
+  environments: {
+    // configuration for client
+    client: {
+      source: {
+        alias: {
+          '@common1': './src/web/common1',
+        },
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
+      output: {
+        target: 'web',
+      },
+    },
+    // configuration for ssr
+    ssr: {
+      source: {
+        alias: {
+          '@common1': './src/ssr/common1',
+        },
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
+  },
+};
+```
+
+The final rsbuild configuration that takes effect in the client environment is:
+
+```
+{
+  source: {
+    alias: {
+      "@common": "./src/common",
+      "@common1": "./src/web/common1",
+    },
+    entry: {
+      index: "./src/index.client.js",
+    },
+  },
+  output: {
+    target: "web",
+  },
+};
+```
+
+The final rsbuild configuration that takes effect in the ssr environment is:
+
+```
+{
+  source: {
+    alias: {
+      "@common": "./src/common",
+      "@common1": "./src/ssr/common1",
+    },
+    entry: {
+      index: "./src/index.server.js",
+    },
+  },
+  output: {
+    target: "node",
+  },
+};
+```

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -109,7 +109,7 @@ const webConfig = {
 };
 ```
 
-The final rsbuild configuration that takes effect in the ssr environment is:
+For the `node` environment, the merged Rsbuild configuration is:
 
 ```js
 {

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -7,7 +7,7 @@ The configuration in `environments` overrides the outer Rsbuild base configurati
 - **Type:**
 
 ```ts
-export interface EnvironmentConfig {
+interface EnvironmentConfig {
   /**
    * Options for HTML generation.
    */

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -93,7 +93,7 @@ export default {
 The final rsbuild configuration that takes effect in the client environment is:
 
 ```
-{
+const webConfig = {
   source: {
     alias: {
       "@common": "./src/common",

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -59,7 +59,7 @@ export default {
   },
   environments: {
     // configuration for client
-    client: {
+    web: {
       source: {
         alias: {
           '@common1': './src/web/common1',

--- a/website/docs/en/shared/getNormalizedConfig.mdx
+++ b/website/docs/en/shared/getNormalizedConfig.mdx
@@ -1,4 +1,4 @@
-Get the normalized Rsbuild config, this method must be called after the `modifyRsbuildConfig` hook is executed.
+Get the all normalized Rsbuild config or the Rsbuild config of a specified environment, this method must be called after the `modifyRsbuildConfig` hook is executed.
 
 Compared with the `api.getRsbuildConfig` method, the config returned by this method has been normalized, and the type definition of the config will be narrowed. For example, the `undefined` type of `config.html` will be removed.
 
@@ -7,5 +7,11 @@ It is recommended to use this method to get the Rsbuild config.
 - **Type:**
 
 ```ts
+/** Get the Rsbuild configuration of the specified environment */
+function GetNormalizedConfig(options: {
+  environment: string;
+}): Readonly<NormalizedEnvironmentConfig>;
+
+/** Get all Rsbuild configurations */
 function GetNormalizedConfig(): Readonly<NormalizedConfig>;
 ```

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -66,6 +66,34 @@ import type {
 } from '@rsbuild/core';
 ```
 
+## NormalizedEnvironmentConfig
+
+指定环境下的 Rsbuild 归一化配置类型，对应 [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
+
+```ts
+import type { NormalizedEnvironmentConfig } from '@rsbuild/core';
+
+const config: NormalizedEnvironmentConfig = api.getNormalizedConfig({
+  environment,
+});
+```
+
+你也可以引用归一化后的 Rsbuild 配置中各个字段的类型定义：
+
+```ts
+import type {
+  NormalizedDevConfig,
+  NormalizedHtmlConfig,
+  NormalizedToolsConfig,
+  NormalizedSourceConfig,
+  NormalizedServerConfig,
+  NormalizedOutputConfig,
+  NormalizedSecurityConfig,
+  NormalizedPerformanceConfig,
+  NormalizedModuleFederationConfig,
+} from '@rsbuild/core';
+```
+
 ## RsbuildContext
 
 Rsbuild 实例中 [context 属性](/api/javascript-api/instance#rsbuildcontext)的类型定义。

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -78,22 +78,6 @@ const config: NormalizedEnvironmentConfig = api.getNormalizedConfig({
 });
 ```
 
-你也可以引用归一化后的 Rsbuild 配置中各个字段的类型定义：
-
-```ts
-import type {
-  NormalizedDevConfig,
-  NormalizedHtmlConfig,
-  NormalizedToolsConfig,
-  NormalizedSourceConfig,
-  NormalizedServerConfig,
-  NormalizedOutputConfig,
-  NormalizedSecurityConfig,
-  NormalizedPerformanceConfig,
-  NormalizedModuleFederationConfig,
-} from '@rsbuild/core';
-```
-
 ## RsbuildContext
 
 Rsbuild 实例中 [context 属性](/api/javascript-api/instance#rsbuildcontext)的类型定义。

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -68,7 +68,7 @@ import type {
 
 ## NormalizedEnvironmentConfig
 
-指定环境下的 Rsbuild 归一化配置类型，对应 [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
+指定环境下的 Rsbuild 归一化配置类型，对应 [getNormalizedConfig({ environment })](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
 
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';

--- a/website/docs/zh/config/_meta.json
+++ b/website/docs/zh/config/_meta.json
@@ -4,6 +4,7 @@
     "name": "index",
     "label": "Overview"
   },
+  "environments",
   "plugins",
   {
     "type": "dir",

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -109,7 +109,7 @@ export default {
 }
 ```
 
-最终 ssr 环境下生效的 rsbuild 配置为：
+对于 `node` 环境，合并后的 Rsbuild 配置为：
 
 ```
 {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -2,7 +2,7 @@
 
 Rsbuild 支持同时为多个环境构建产物。你可以使用  `environments`  为每个环境定义不同的 Rsbuild 配置。
 
-用户在 environments 中的配置可以覆盖外层的 Rsbuild 基础配置。
+定义在 `environments` 中的配置会覆盖外部的 Rsbuild 基础配置。
 
 - **类型：**
 

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -59,7 +59,7 @@ export default {
   },
   environments: {
     // client 环境配置
-    client: {
+    web: {
       source: {
         alias: {
           '@common1': './src/web/common1',

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -1,0 +1,129 @@
+# environments
+
+Rsbuild 支持构建多个环境产物，可通过 `environments` 定义多个环境，并为不同环境定义不同的 Rsbuild 配置。
+
+用户在 environments 中的配置可以覆盖外层的 Rsbuild 基础配置。
+
+- **类型：**
+
+```ts
+export interface EnvironmentConfig {
+  /**
+   * Options for HTML generation.
+   */
+  html?: HtmlConfig;
+  /**
+   * Options for the low-level tools.
+   */
+  tools?: ToolsConfig;
+  /**
+   * Options for source code parsing and compilation.
+   */
+  source?: SourceConfig;
+  /**
+   * Options for build outputs.
+   */
+  output?: OutputConfig;
+  /**
+   * Options for Web security.
+   */
+  security?: SecurityConfig;
+  /**
+   * Options for build performance and runtime performance.
+   */
+  performance?: PerformanceConfig;
+  /**
+   * Options for module federation.
+   */
+  moduleFederation?: ModuleFederationConfig;
+}
+
+type Environments = {
+  [name: string]: EnvironmentConfig;
+};
+```
+
+- **默认值：** `undefined`
+
+## 示例
+
+分别对 client 和 ssr 场景进行配置：
+
+```ts title="rsbuild.config.ts"
+export default {
+  // 所有环境共享配置
+  source: {
+    alias: {
+      '@common': './src/common',
+    },
+  },
+  environments: {
+    // client 环境配置
+    client: {
+      source: {
+        alias: {
+          '@common1': './src/web/common1',
+        },
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
+      output: {
+        target: 'web',
+      },
+    },
+    // ssr 环境配置
+    ssr: {
+      source: {
+        alias: {
+          '@common1': './src/ssr/common1',
+        },
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
+  },
+};
+```
+
+最终 client 环境下生效的 rsbuild 配置为：
+
+```
+{
+  source: {
+    alias: {
+      "@common": "./src/common",
+      "@common1": "./src/web/common1",
+    },
+    entry: {
+      index: "./src/index.client.js",
+    },
+  },
+  output: {
+    target: "web",
+  },
+}
+```
+
+最终 ssr 环境下生效的 rsbuild 配置为：
+
+```
+{
+  source: {
+    alias: {
+      "@common": "./src/common",
+      "@common1": "./src/ssr/common1",
+    },
+    entry: {
+      index: "./src/index.server.js",
+    },
+  },
+  output: {
+    target: "node",
+  },
+}
+```

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -111,7 +111,7 @@ const webConfig = {
 
 对于 `node` 环境，合并后的 Rsbuild 配置为：
 
-```
+```js
 {
   source: {
     alias: {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -1,6 +1,6 @@
 # environments
 
-Rsbuild 支持构建多个环境产物，可通过 `environments` 定义多个环境，并为不同环境定义不同的 Rsbuild 配置。
+Rsbuild 支持同时为多个环境构建产物。你可以使用  `environments`  为每个环境定义不同的 Rsbuild 配置。
 
 用户在 environments 中的配置可以覆盖外层的 Rsbuild 基础配置。
 

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -7,7 +7,7 @@ Rsbuild 支持同时为多个环境构建产物。你可以使用  `environments
 - **类型：**
 
 ```ts
-export interface EnvironmentConfig {
+interface EnvironmentConfig {
   /**
    * Options for HTML generation.
    */

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -72,7 +72,7 @@ export default {
         target: 'web',
       },
     },
-    // ssr 环境配置
+    // SSR 环境配置
     node: {
       source: {
         alias: {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -73,7 +73,7 @@ export default {
       },
     },
     // ssr 环境配置
-    ssr: {
+    node: {
       source: {
         alias: {
           '@common1': './src/ssr/common1',

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -47,7 +47,7 @@ type Environments = {
 
 ## 示例
 
-分别对 client 和 ssr 场景进行配置：
+分别为 `web` (client) 和 `node` (SSR) 环境配置 Rsbuild：
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -112,7 +112,7 @@ const webConfig = {
 对于 `node` 环境，合并后的 Rsbuild 配置为：
 
 ```js
-{
+const nodeConfig = {
   source: {
     alias: {
       "@common": "./src/common",

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -93,7 +93,7 @@ export default {
 最终 client 环境下生效的 rsbuild 配置为：
 
 ```
-{
+const webConfig = {
   source: {
     alias: {
       "@common": "./src/common",

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -92,7 +92,7 @@ export default {
 
 最终 client 环境下生效的 rsbuild 配置为：
 
-```
+```js
 const webConfig = {
   source: {
     alias: {

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -90,7 +90,7 @@ export default {
 };
 ```
 
-最终 client 环境下生效的 rsbuild 配置为：
+对于 `web` 环境，合并后的 Rsbuild 配置为：
 
 ```js
 const webConfig = {

--- a/website/docs/zh/shared/getNormalizedConfig.mdx
+++ b/website/docs/zh/shared/getNormalizedConfig.mdx
@@ -1,4 +1,4 @@
-获取归一化后的 Rsbuild 配置，该方法必须在 `modifyRsbuildConfig` 钩子执行完成后才能被调用。
+获取归一化后的全部 Rsbuild 配置或指定环境的 Rsbuild 配置，该方法必须在 `modifyRsbuildConfig` 钩子执行完成后才能被调用。
 
 相较于 `getRsbuildConfig` 方法，该方法返回的配置经过了归一化处理，配置的类型定义会得到收敛，比如 `config.html` 的 `undefined` 类型将被移除。
 
@@ -7,5 +7,11 @@
 - **类型：**
 
 ```ts
+/** 获取指定环境的 Rsbuild 配置 */
+function GetNormalizedConfig(options: {
+  environment: string;
+}): Readonly<NormalizedEnvironmentConfig>;
+
+/** 获取全部的 Rsbuild 配置 */
 function GetNormalizedConfig(): Readonly<NormalizedConfig>;
 ```


### PR DESCRIPTION
## Summary

User can define multiple environments configuration through `environments`.

```ts title="rsbuild.config.ts"
export default {
  environments: {
    client: {
      source: {
        alias: {
          '@common1': './src/web/common1',
        },
        entry: {
          index: './src/index.client.js',
        },
      },
      output: {
        target: 'web',
      },
    },
    ssr: {
      source: {
        alias: {
          '@common1': './src/ssr/common1',
        },
        entry: {
          index: './src/index.server.js',
        },
      },
      output: {
        target: 'node',
      },
    },
  },
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2623

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
