### PR TITLE
chore: enable html plugins if has html paths

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -5,8 +5,8 @@ import {
   type NormalizedEnvironmentConfig,
   type RsbuildContext,
   type RsbuildEntry,
+  type RsbuildTarget,
   getBrowserslist,
-  isHtmlDisabled,
 } from '@rsbuild/shared';
 import { withDefaultConfig } from './config';
 import { ROOT_DIST_DIR } from './constants';
@@ -83,13 +83,28 @@ export async function getBrowserslistByEnvironment(
   return DEFAULT_BROWSERSLIST[target];
 }
 
+const hasHTML = (
+  config: NormalizedEnvironmentConfig,
+  target: RsbuildTarget,
+) => {
+  const { htmlPlugin } = config.tools as {
+    htmlPlugin: boolean | Array<unknown>;
+  };
+  const pluginDisabled =
+    htmlPlugin === false ||
+    (Array.isArray(htmlPlugin) && htmlPlugin.includes(false));
+
+  return target === 'web' && !pluginDisabled;
+};
+
 const getEnvironmentHTMLPaths = (
   entry: RsbuildEntry,
   config: NormalizedEnvironmentConfig,
 ) => {
-  if (isHtmlDisabled(config, config.output.target)) {
+  if (!hasHTML(config, config.output.target)) {
     return {};
   }
+
   return Object.keys(entry).reduce<Record<string, string>>((prev, key) => {
     prev[key] = getHTMLPathByEntry(key, config);
     return prev;

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -5,7 +5,6 @@ import {
   castArray,
   color,
   deepmerge,
-  isHtmlDisabled,
   isPlainObject,
 } from '@rsbuild/shared';
 import type {
@@ -283,11 +282,11 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      async (chain, { HtmlPlugin, isProd, CHAIN_ID, target, environment }) => {
+      async (chain, { HtmlPlugin, isProd, CHAIN_ID, environment }) => {
         const config = api.getNormalizedConfig({ environment });
 
-        // if html is disabled or target is server, skip html plugin
-        if (isHtmlDisabled(config, target)) {
+        const htmlPaths = api.getHTMLPaths({ environment });
+        if (Object.keys(htmlPaths).length === 0) {
           return;
         }
 
@@ -295,7 +294,6 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
         const assetPrefix = getPublicPathFromChain(chain, false);
         const entries = chain.entryPoints.entries() || {};
         const entryNames = Object.keys(entries);
-        const htmlPaths = api.getHTMLPaths({ environment });
         const htmlInfoMap: Record<string, HtmlInfo> = {};
 
         const finalOptions = await Promise.all(

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -1,8 +1,4 @@
-import {
-  type InlineChunkTest,
-  JS_REGEX,
-  isHtmlDisabled,
-} from '@rsbuild/shared';
+import { type InlineChunkTest, JS_REGEX } from '@rsbuild/shared';
 import { CSS_REGEX } from '../constants';
 import { pick } from '../helpers';
 import type { RsbuildPlugin } from '../types';
@@ -11,13 +7,13 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
   name: 'rsbuild:inline-chunk',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { target, CHAIN_ID, isDev }) => {
-      const config = api.getNormalizedConfig();
-
-      if (isHtmlDisabled(config, target) || isDev) {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, isDev, environment }) => {
+      const htmlPaths = api.getHTMLPaths({ environment });
+      if (Object.keys(htmlPaths).length === 0 || isDev) {
         return;
       }
 
+      const config = api.getNormalizedConfig({ environment });
       const { InlineChunkHtmlPlugin } = await import(
         '../rspack/InlineChunkHtmlPlugin'
       );

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -1,8 +1,7 @@
-import {
-  type DnsPrefetchOption,
-  type HtmlBasicTag,
-  type PreconnectOption,
-  isHtmlDisabled,
+import type {
+  DnsPrefetchOption,
+  HtmlBasicTag,
+  PreconnectOption,
 } from '@rsbuild/shared';
 import type { RsbuildPlugin } from '../types';
 
@@ -45,16 +44,17 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       return { headTags, bodyTags };
     });
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
-      const config = api.getNormalizedConfig();
-      const {
-        performance: { preload, prefetch },
-      } = config;
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+      const htmlPaths = api.getHTMLPaths({ environment });
 
-      if (isHtmlDisabled(config, target)) {
+      if (Object.keys(htmlPaths).length === 0) {
         return;
       }
 
+      const config = api.getNormalizedConfig({ environment });
+      const {
+        performance: { preload, prefetch },
+      } = config;
       const HTMLCount = chain.entryPoints.values().length;
 
       const { HtmlPreloadOrPrefetchPlugin } = await import(

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -1,11 +1,6 @@
 import type { Buffer } from 'node:buffer';
 import crypto from 'node:crypto';
-import {
-  type Rspack,
-  type SriAlgorithm,
-  type SriOptions,
-  isHtmlDisabled,
-} from '@rsbuild/shared';
+import type { Rspack, SriAlgorithm, SriOptions } from '@rsbuild/shared';
 import { HTML_REGEX } from '../constants';
 import { isProd, removeLeadingSlash } from '../helpers';
 import { logger } from '../logger';
@@ -191,10 +186,10 @@ export const pluginSri = (): RsbuildPlugin => ({
       }
     }
 
-    api.modifyBundlerChain((chain, { target }) => {
-      const config = api.getNormalizedConfig();
+    api.modifyBundlerChain((chain, { environment }) => {
+      const htmlPaths = api.getHTMLPaths({ environment });
 
-      if (isHtmlDisabled(config, target)) {
+      if (Object.keys(htmlPaths).length === 0) {
         return;
       }
 

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,5 +1,4 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { isHtmlDisabled } from '@rsbuild/shared';
 import type { PluginAssetsRetryOptions } from './types';
 
 export type { PluginAssetsRetryOptions };
@@ -12,10 +11,11 @@ export const pluginAssetsRetry = (
   name: PLUGIN_ASSETS_RETRY_NAME,
   setup(api) {
     api.modifyBundlerChain(
-      async (chain, { CHAIN_ID, target, HtmlPlugin, isProd }) => {
+      async (chain, { CHAIN_ID, HtmlPlugin, isProd, environment }) => {
         const config = api.getNormalizedConfig();
 
-        if (!options || isHtmlDisabled(config, target)) {
+        const htmlPaths = api.getHTMLPaths({ environment });
+        if (!options || Object.keys(htmlPaths).length === 0) {
           return;
         }
 

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -3,11 +3,7 @@ import type { Compiler } from '@rspack/core';
 import deepmerge from '../compiled/deepmerge/index.js';
 import color from '../compiled/picocolors/index.js';
 import { DEFAULT_ASSET_PREFIX } from './constants';
-import type {
-  CacheGroups,
-  NormalizedEnvironmentConfig,
-  RsbuildTarget,
-} from './types';
+import type { CacheGroups } from './types';
 
 export { color, deepmerge };
 
@@ -98,18 +94,4 @@ export const getPublicPathFromCompiler = (compiler: Compiler) => {
 
   // publicPath function is not supported yet, fallback to default value
   return DEFAULT_ASSET_PREFIX;
-};
-
-export const isHtmlDisabled = (
-  config: NormalizedEnvironmentConfig,
-  target: RsbuildTarget,
-) => {
-  const { htmlPlugin } = config.tools as {
-    htmlPlugin: boolean | Array<unknown>;
-  };
-  return (
-    htmlPlugin === false ||
-    (Array.isArray(htmlPlugin) && htmlPlugin.includes(false)) ||
-    target !== 'web'
-  );
 };


### PR DESCRIPTION
## Summary

Enable html plugins if has html paths, so we do not need to call the `isHtmlDisabled` helper anymore.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
