### PR TITLE
fix: failed to empty dir in some cases

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -322,8 +322,17 @@ export async function emptyDir(dir: string) {
   if (!(await pathExists(dir))) {
     return;
   }
-  for (const file of fs.readdirSync(dir)) {
-    fs.rmSync(path.resolve(dir, file), { recursive: true, force: true });
+
+  try {
+    for (const file of await fs.promises.readdir(dir)) {
+      await fs.promises.rm(path.resolve(dir, file), {
+        recursive: true,
+        force: true,
+      });
+    }
+  } catch (err) {
+    logger.debug(`Failed to empty dir: ${dir}`);
+    logger.debug(err);
   }
 }
 


### PR DESCRIPTION
## Summary

Fix failed to empty dir in some cases.

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/a27263a4-4f2d-4190-9502-0b5a5e5198e1)

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/9610642439/job/26507536558

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
