### PR TITLE
fix: should not print empty urls if target is node

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -76,10 +76,6 @@ function getURLMessages(
   urls: Array<{ url: string; label: string }>,
   routes: Routes,
 ) {
-  if (!routes.length) {
-    return '';
-  }
-
   if (routes.length === 1) {
     return urls
       .map(
@@ -121,9 +117,9 @@ export function printServerURLs({
   routes: Routes;
   protocol: string;
   printUrls?: PrintUrls;
-}) {
+}): string | null {
   if (printUrls === false) {
-    return;
+    return null;
   }
 
   let urls = originalUrls;
@@ -137,7 +133,7 @@ export function printServerURLs({
     });
 
     if (!newUrls) {
-      return;
+      return null;
     }
 
     if (!Array.isArray(newUrls)) {
@@ -152,8 +148,8 @@ export function printServerURLs({
     }));
   }
 
-  if (urls.length === 0) {
-    return;
+  if (urls.length === 0 || routes.length === 0) {
+    return null;
   }
 
   const message = getURLMessages(urls, routes);

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -76,6 +76,10 @@ function getURLMessages(
   urls: Array<{ url: string; label: string }>,
   routes: Routes,
 ) {
+  if (!routes.length) {
+    return '';
+  }
+
   if (routes.length === 1) {
     return urls
       .map(
@@ -153,7 +157,9 @@ export function printServerURLs({
   }
 
   const message = getURLMessages(urls, routes);
-  logger.log(message);
+  if (message) {
+    logger.log(message);
+  }
 
   return message;
 }

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -153,9 +153,7 @@ export function printServerURLs({
   }
 
   const message = getURLMessages(urls, routes);
-  if (message) {
-    logger.log(message);
-  }
+  logger.log(message);
 
   return message;
 }

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -153,7 +153,7 @@ test('formatRoutes', () => {
 });
 
 test('printServerURLs', () => {
-  let message: string | undefined;
+  let message: string | null;
 
   message = printServerURLs({
     port: 3000,
@@ -223,6 +223,15 @@ test('printServerURLs', () => {
       - bar      http:/10.94.62.193:3000/bar
     "
   `);
+
+  message = printServerURLs({
+    port: 3000,
+    protocol: 'http',
+    urls: [],
+    routes: [],
+  });
+
+  expect(message).toEqual(undefined);
 });
 
 describe('test dev server', () => {

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -231,7 +231,7 @@ test('printServerURLs', () => {
     routes: [],
   });
 
-  expect(message).toEqual(undefined);
+  expect(message).toEqual(null);
 });
 
 describe('test dev server', () => {


### PR DESCRIPTION
## Summary

If `target` is `node`, no HTML files will be generated, and Rsbuild should not print empty urls.

<img width="344" alt="Screenshot 2024-06-21 at 17 03 20" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/1efafd6c-0f43-4064-a165-ad3e23f86f0d">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
