### PR TITLE
chore(config): remove allowJs true

### DIFF
--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-basic-ssl/modern.config.ts
+++ b/packages/plugin-basic-ssl/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-eslint/modern.config.ts
+++ b/packages/plugin-eslint/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-mdx/modern.config.ts
+++ b/packages/plugin-mdx/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-pug/modern.config.ts
+++ b/packages/plugin-pug/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-rem/modern.config.ts
+++ b/packages/plugin-rem/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-toml/modern.config.ts
+++ b/packages/plugin-toml/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-umd/modern.config.ts
+++ b/packages/plugin-umd/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/packages/plugin-yaml/modern.config.ts
+++ b/packages/plugin-yaml/modern.config.ts
@@ -1,7 +1,3 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs,
-};
+export default configForDualPackage;

--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2021",
     "lib": ["DOM", "ESNext"],
-    "allowJs": true,
     "module": "ES2020",
     "strict": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary

Remove `"allowJs": true` from tsconfig.json, as allowJs can not be used with `"isolatedDeclarations": true`.

<img width="673" alt="截屏2024-06-22 10 24 55" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/e669265d-7063-4da6-89ba-4d88bcae0452">

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
