### PR TITLE
chore(build): emit bundleless declaration files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
   "files.exclude": {
     "**/.DS_Store": true
   },
-  "mdx.validate.validateFileLinks": "ignore"
+  "mdx.validate.validateFileLinks": "ignore",
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -68,6 +68,6 @@
     "playwright": "1.44.1",
     "strip-ansi": "6.0.1",
     "tailwindcss": "^3.4.4",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "lit": "^3.1.4",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/mdx/package.json
+++ b/examples/mdx/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-mdx": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -8,6 +8,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@rsbuild/plugin-swc": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "nx": "^19.2.3",
     "prettier": "^3.3.2",
     "simple-git-hooks": "^2.11.1",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "vitest": "^1.6.0"
   },
   "packageManager": "pnpm@9.0.6",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "nano-staged": "^0.8.0",
     "nx": "^19.2.3",
     "prettier": "^3.3.2",
+    "typescript": "^5.5.0",
     "simple-git-hooks": "^2.11.1",
     "vitest": "^1.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,22 +10,22 @@
   },
   "scripts": {
     "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @e2e/* rsbuild-* --parallel=10",
-    "prebundle": "nx run-many -t prebundle",
+    "build:doc": "cd website && pnpm run build",
     "change": "changeset",
     "changeset": "changeset",
     "check-dependency-version": "check-dependency-version-consistency . --ignore-dep vue-loader",
     "check-spell": "npx cspell",
     "dev:doc": "cd website && pnpm run dev",
-    "build:doc": "cd website && pnpm run build",
-    "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell",
-    "prepare": "pnpm run build && simple-git-hooks",
-    "sort-package-json": "npx sort-package-json \"packages/*/package.json\" \"packages/compat/*/package.json\"",
-    "test": "pnpm run ut",
-    "ut": "vitest run",
-    "ut:watch": "vitest",
     "e2e": "cd ./e2e && pnpm test",
     "e2e:rspack": "cd ./e2e && pnpm test:rspack",
-    "e2e:webpack": "cd ./e2e && pnpm test:webpack"
+    "e2e:webpack": "cd ./e2e && pnpm test:webpack",
+    "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell",
+    "prebundle": "nx run-many -t prebundle",
+    "prepare": "pnpm run build && simple-git-hooks",
+    "sort-package-json": "npx sort-package-json \"./package.json\" \"packages/*/package.json\" \"packages/compat/*/package.json\"",
+    "test": "pnpm run ut",
+    "ut": "vitest run",
+    "ut:watch": "vitest"
   },
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"
@@ -50,8 +50,8 @@
     "nano-staged": "^0.8.0",
     "nx": "^19.2.3",
     "prettier": "^3.3.2",
-    "typescript": "^5.5.0",
     "simple-git-hooks": "^2.11.1",
+    "typescript": "^5.5.0",
     "vitest": "^1.6.0"
   },
   "packageManager": "pnpm@9.0.6",
@@ -60,13 +60,13 @@
     "pnpm": ">=9.0.0"
   },
   "pnpm": {
-    "overrides": {
-      "esbuild": "~0.19.0",
-      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@1.0.28"
-    },
     "allowedDeprecatedVersions": {
-      "vue": "2.x",
-      "consolidate": "0.15.1"
+      "consolidate": "0.15.1",
+      "vue": "2.x"
+    },
+    "overrides": {
+      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@1.0.28",
+      "esbuild": "~0.19.0"
     }
   }
 }

--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -67,7 +67,7 @@
   },
   "devDependencies": {
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/webpack": "workspace:*",
     "@types/lodash": "^4.17.5",
     "@types/semver": "^7.5.8",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "webpack": "^5.92.0"
   },
   "peerDependencies": {

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -40,7 +40,7 @@
     "ansi-escapes": "4.3.2",
     "cli-truncate": "2.1.0",
     "patch-console": "1.0.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,7 @@
     "sirv": "^2.0.4",
     "style-loader": "3.3.4",
     "tsc-alias": "^1.8.10",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "webpack": "^5.92.0",
     "webpack-dev-middleware": "7.2.1",
     "ws": "^8.17.1"

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -35,7 +35,7 @@
     "@types/node": "18.x",
     "deepmerge": "^4.3.1",
     "rslog": "^1.2.2",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "engines": {
     "node": ">=16.7.0"

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "lit": "^3.1.4",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -16,6 +16,6 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -14,6 +14,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@rsbuild/plugin-solid": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "svelte-check": "^3.8.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-vue2": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -38,7 +38,7 @@
     "@types/serialize-javascript": "^5.0.4",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "terser": "5.31.1",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -42,7 +42,7 @@
     "@types/node": "18.x",
     "babel-loader": "9.1.3",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-basic-ssl/package.json
+++ b/packages/plugin-basic-ssl/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@types/lodash": "^4.17.5",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "eslint": "^9.5.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -38,7 +38,7 @@
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -33,7 +33,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-mdx/package.json
+++ b/packages/plugin-mdx/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -53,7 +53,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -34,7 +34,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -40,7 +40,7 @@
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "prebundle": "1.1.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^14.2.1",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -35,7 +35,7 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "yaml": "^2.4.5"
   },
   "peerDependencies": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -35,7 +35,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "svelte": "^4.2.18",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@types/node": "18.x",
     "file-loader": "6.2.0",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "url-loader": "4.1.1"
   },
   "peerDependencies": {

--- a/packages/plugin-toml/package.json
+++ b/packages/plugin-toml/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -36,7 +36,7 @@
     "@scripts/test-helper": "workspace:*",
     "line-diff": "2.1.1",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -35,7 +35,7 @@
     "@babel/core": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "vue": "^3.4.19",
     "webpack": "^5.92.0"
   },

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -8,7 +8,7 @@ export const applySplitChunksRule = (
     vue: true,
     router: true,
   },
-) => {
+): void => {
   api.modifyBundlerChain((chain, { environment }) => {
     const config = api.getNormalizedConfig({ environment });
     if (config.performance.chunkSplit.strategy !== 'split-by-experience') {

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "workspace:^0.7.9"

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "webpack": "^5.92.0"
   },
   "peerDependencies": {

--- a/packages/plugin-yaml/package.json
+++ b/packages/plugin-yaml/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "prebundle": "1.1.0",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "yaml-loader": "^0.8.1"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -83,7 +83,7 @@
     "prebundle": "1.1.0",
     "rspack-chain": "^0.7.3",
     "terser": "5.31.1",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "webpack": "^5.92.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-merge": "5.10.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       simple-git-hooks:
         specifier: ^2.11.1
         version: 2.11.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.5.2
       vitest:
         specifier: ^1.6.0
         version: 1.6.0(@types/node@18.19.31)(less@4.2.0)(lightningcss@1.25.1)(sass@1.77.5)(stylus@0.63.0)(terser@5.31.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         specifier: ^2.11.1
         version: 2.11.1
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       vitest:
         specifier: ^1.6.0
@@ -233,7 +233,7 @@ importers:
         specifier: ^3.4.4
         version: 3.4.4
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   e2e/cases/babel/decorator:
@@ -390,7 +390,7 @@ importers:
         specifier: ^3.1.4
         version: 3.1.4
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/mdx:
@@ -412,7 +412,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-react
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/module-federation/host:
@@ -456,7 +456,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/preact:
@@ -472,7 +472,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-preact
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/react:
@@ -497,7 +497,7 @@ importers:
         specifier: ^18.3.0
         version: 18.3.0
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/solid:
@@ -535,7 +535,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   examples/vue2:
@@ -583,7 +583,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/compat/webpack
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/compat/babel-preset:
@@ -635,7 +635,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/compat/plugin-swc:
@@ -672,7 +672,7 @@ importers:
         specifier: ^7.5.8
         version: 7.5.8
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       webpack:
         specifier: ^5.92.0
@@ -715,7 +715,7 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/core:
@@ -821,7 +821,7 @@ importers:
         specifier: ^1.8.10
         version: 1.8.10
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       webpack:
         specifier: ^5.92.0
@@ -848,7 +848,7 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-assets-retry:
@@ -882,7 +882,7 @@ importers:
         specifier: 5.31.1
         version: 5.31.1
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-babel:
@@ -925,7 +925,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-basic-ssl:
@@ -938,7 +938,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-check-syntax:
@@ -963,7 +963,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-css-minimizer:
@@ -982,7 +982,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-eslint:
@@ -1004,7 +1004,7 @@ importers:
         specifier: ^9.5.0
         version: 9.5.0
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-image-compress:
@@ -1026,7 +1026,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-less:
@@ -1054,7 +1054,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-lightningcss:
@@ -1076,7 +1076,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-mdx:
@@ -1089,7 +1089,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-node-polyfill:
@@ -1168,7 +1168,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-preact:
@@ -1180,7 +1180,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-pug:
@@ -1196,7 +1196,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-react:
@@ -1221,7 +1221,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-rem:
@@ -1255,7 +1255,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-sass:
@@ -1292,7 +1292,7 @@ importers:
         specifier: ^14.2.1
         version: 14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-solid:
@@ -1317,7 +1317,7 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-source-build:
@@ -1342,7 +1342,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       yaml:
         specifier: ^2.4.5
@@ -1361,7 +1361,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-stylus:
@@ -1383,7 +1383,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-svelte:
@@ -1411,7 +1411,7 @@ importers:
         specifier: ^4.2.18
         version: 4.2.18
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-svgr:
@@ -1451,7 +1451,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       url-loader:
         specifier: 4.1.1
@@ -1467,7 +1467,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-type-check:
@@ -1492,7 +1492,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-typed-css-modules:
@@ -1514,7 +1514,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-umd:
@@ -1523,7 +1523,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-vue:
@@ -1545,7 +1545,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       vue:
         specifier: ^3.4.19
@@ -1573,7 +1573,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-vue2:
@@ -1595,7 +1595,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-vue2-jsx:
@@ -1617,7 +1617,7 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   packages/plugin-yaml:
@@ -1632,7 +1632,7 @@ importers:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       yaml-loader:
         specifier: ^0.8.1
@@ -1694,7 +1694,7 @@ importers:
         specifier: 5.31.1
         version: 5.31.1
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       webpack:
         specifier: ^5.92.0
@@ -1712,7 +1712,7 @@ importers:
         specifier: 18.x
         version: 18.19.31
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
 
   scripts/test-helper:
@@ -1733,7 +1733,7 @@ importers:
         specifier: ^4.17.21
         version: 4.17.21
       typescript:
-        specifier: ^5.5.0
+        specifier: ^5.5.2
         version: 5.5.2
       upath:
         specifier: 2.0.1

--- a/scripts/config/modern.config.ts
+++ b/scripts/config/modern.config.ts
@@ -39,6 +39,7 @@ export const esmBuildConfig: PartialBaseBuildConfig = {
   shims: true,
   externals: commonExternals,
   banner: requireShim,
+  dts: false,
 };
 
 export const cjsBuildConfig: PartialBaseBuildConfig = {
@@ -53,6 +54,12 @@ export const cjsBuildConfig: PartialBaseBuildConfig = {
 export const dualBuildConfigs: PartialBaseBuildConfig[] = [
   cjsBuildConfig,
   esmBuildConfig,
+  {
+    buildType: 'bundleless',
+    dts: {
+      only: true,
+    },
+  },
 ];
 
 export const emitTypePkgJsonPlugin: CliPlugin<ModuleTools> = {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.2"
   }
 }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -30,7 +30,7 @@
     "@types/lodash": "^4.17.5",
     "@types/node": "18.x",
     "lodash": "^4.17.21",
-    "typescript": "^5.5.0",
+    "typescript": "^5.5.2",
     "upath": "2.0.1"
   },
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Emit bundleless declaration files, prepare for TS 5.5 "isolatedDeclarations": true.
- Use workspace version of typescript.

## Related Links

https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
