### PR TITLE
chore: add formatter config to VS Code setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["biomejs.biome"]
+  "recommendations": [
+    "biomejs.biome",
+    "esbenp.prettier-vscode",
+    "unifiedjs.vscode-mdx"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
     "**/.DS_Store": true
   },
   "mdx.validate.validateFileLinks": "ignore",
+  // Use prettier to format all files
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  // Use project's typescript version
   "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,6 @@
     "**/.DS_Store": true
   },
   "mdx.validate.validateFileLinks": "ignore",
-  // Use prettier to format all files
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  // Use project's typescript version
   "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Summary

Add formatter config to VS Code setting.

Biome currently does not supports markdown and MDX, so we still need to use prettier as the formatter.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
