### PR TITLE
feat: handle more cases in ensureAssetPrefix helper

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -268,6 +268,21 @@ export const getPublicPathFromChain = (
   return formatPublicPath(DEFAULT_ASSET_PREFIX, withSlash);
 };
 
+export const getPublicPathFromCompiler = (compiler: Rspack.Compiler) => {
+  const { publicPath } = compiler.options.output;
+
+  if (typeof publicPath === 'string') {
+    // 'auto' is a magic value in Rspack and behave like `publicPath: ""`
+    if (publicPath === 'auto') {
+      return '';
+    }
+    return publicPath.endsWith('/') ? publicPath : `${publicPath}/`;
+  }
+
+  // publicPath function is not supported yet, fallback to default value
+  return DEFAULT_ASSET_PREFIX;
+};
+
 /**
  * ensure absolute file path.
  * @param base - Base path to resolve relative from.
@@ -352,7 +367,10 @@ export const canParse = (url: string) => {
   }
 };
 
-export const ensureAssetPrefix = (url: string, assetPrefix: string) => {
+export const ensureAssetPrefix = (
+  url: string,
+  assetPrefix = DEFAULT_ASSET_PREFIX,
+) => {
   // The use of an absolute URL without a protocol is technically legal,
   // however it cannot be parsed as a URL instance, just return it.
   // e.g. str is //example.com/foo.js
@@ -364,6 +382,11 @@ export const ensureAssetPrefix = (url: string, assetPrefix: string) => {
   // Only absolute url with hostname & protocol can be parsed into URL instance.
   // e.g. str is https://example.com/foo.js
   if (canParse(url)) {
+    return url;
+  }
+
+  // 'auto' is a magic value in Rspack and behave like `publicPath: ""`
+  if (assetPrefix === 'auto') {
     return url;
   }
 

--- a/packages/core/src/rspack/HtmlAppIconPlugin.ts
+++ b/packages/core/src/rspack/HtmlAppIconPlugin.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import { basename, posix } from 'node:path';
-import { getPublicPathFromCompiler } from '@rsbuild/shared';
 import type { Compilation, Compiler } from '@rspack/core';
 import { ensureAssetPrefix } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
@@ -37,15 +36,16 @@ export class HtmlAppIconPlugin {
       getHTMLPlugin()
         .getHooks(compilation)
         .alterAssetTagGroups.tap(this.name, (data) => {
-          const publicPath = getPublicPathFromCompiler(compiler);
-
           data.headTags.unshift({
             tagName: 'link',
             voidTag: true,
             attributes: {
               rel: 'apple-touch-icon',
               sizes: '180*180',
-              href: ensureAssetPrefix(iconRelativePath, publicPath),
+              href: ensureAssetPrefix(
+                iconRelativePath,
+                compilation.outputOptions.publicPath,
+              ),
             },
             meta: {},
           });

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -6,14 +6,10 @@
  * modified from https://github.com/facebook/create-react-app/blob/master/packages/react-dev-utils/InlineChunkHtmlPlugin.js
  */
 import { join } from 'node:path';
-import {
-  type InlineChunkTest,
-  getPublicPathFromCompiler,
-  isFunction,
-} from '@rsbuild/shared';
+import { type InlineChunkTest, isFunction } from '@rsbuild/shared';
 import type { Compilation, Compiler } from '@rspack/core';
 import type { HtmlTagObject } from 'html-webpack-plugin';
-import { addTrailingSlash } from '../helpers';
+import { addTrailingSlash, getPublicPathFromCompiler } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
 
 export type InlineChunkHtmlPluginOptions = {

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  type PreloadOrPreFetchOption,
-  getPublicPathFromCompiler,
-} from '@rsbuild/shared';
+import type { PreloadOrPreFetchOption } from '@rsbuild/shared';
 import type {
   Chunk,
   Compilation,
@@ -121,8 +118,7 @@ function generateLinks(
   // Sort to ensure the output is predictable.
   const sortedFilteredFiles = filteredFiles.sort();
   const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
-  const publicPath = getPublicPathFromCompiler(compilation.compiler);
-  const { crossOriginLoading } = compilation.compiler.options.output;
+  const { publicPath, crossOriginLoading } = compilation.outputOptions;
 
   for (const file of sortedFilteredFiles) {
     const href = ensureAssetPrefix(file, publicPath);

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,13 +1,17 @@
 import fs from 'node:fs';
-import {
-  type CreateDevServerOptions,
-  type Rspack,
-  type StartDevServerOptions,
-  getPublicPathFromCompiler,
+import type {
+  CreateDevServerOptions,
+  Rspack,
+  StartDevServerOptions,
 } from '@rsbuild/shared';
 import type Connect from 'connect';
 import { ROOT_DIST_DIR } from '../constants';
-import { getNodeEnv, isMultiCompiler, setNodeEnv } from '../helpers';
+import {
+  getNodeEnv,
+  getPublicPathFromCompiler,
+  isMultiCompiler,
+  setNodeEnv,
+} from '../helpers';
 import { logger } from '../logger';
 import type { CreateDevMiddlewareReturns } from '../provider/createCompiler';
 import type {

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { type Rspack, ensureAssetPrefix } from '@rsbuild/core';
-import { getPublicPathFromCompiler } from '@rsbuild/shared';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { PluginAssetsRetryOptions } from './types';
 
@@ -110,7 +109,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
               innerHTML: await this.getRetryCode(),
             });
           } else {
-            const publicPath = getPublicPathFromCompiler(compiler);
+            const { publicPath } = compilation.outputOptions;
             const url = ensureAssetPrefix(
               await this.getScriptPath(),
               publicPath,

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -5,7 +5,6 @@ import {
   ensureAssetPrefix,
   logger,
 } from '@rsbuild/core';
-import { getPublicPathFromCompiler } from '@rsbuild/shared';
 import type HtmlWebpackPlugin from 'html-webpack-plugin';
 import type { PluginRemOptions } from './types';
 
@@ -162,7 +161,7 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
               innerHTML: await getRuntimeCode(),
             });
           } else {
-            const publicPath = getPublicPathFromCompiler(compiler);
+            const { publicPath } = compilation.outputOptions;
             const url = ensureAssetPrefix(
               await this.getScriptPath(),
               publicPath,

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs';
-import type { Compiler } from '@rspack/core';
 import deepmerge from '../compiled/deepmerge/index.js';
 import color from '../compiled/picocolors/index.js';
-import { DEFAULT_ASSET_PREFIX } from './constants';
 import type { CacheGroups } from './types';
 
 export { color, deepmerge };
@@ -80,18 +78,3 @@ export function createCacheGroups(
 
   return experienceCacheGroup;
 }
-
-export const getPublicPathFromCompiler = (compiler: Compiler) => {
-  const { publicPath } = compiler.options.output;
-
-  if (typeof publicPath === 'string') {
-    // 'auto' is a magic value in Rspack and behave like `publicPath: ""`
-    if (publicPath === 'auto') {
-      return '';
-    }
-    return publicPath.endsWith('/') ? publicPath : `${publicPath}/`;
-  }
-
-  // publicPath function is not supported yet, fallback to default value
-  return DEFAULT_ASSET_PREFIX;
-};


### PR DESCRIPTION
## Summary

Handle more cases in ensureAssetPrefix helper, this allows plugins to use publicPath easily.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
