### PR TITLE
feat(deps): bump core-js v3.37 and @swc/helpers

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -63,7 +63,7 @@
     "@rsbuild/plugin-babel": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "babel-plugin-dynamic-import-node": "2.3.3",
-    "core-js": "~3.36.0"
+    "core-js": "~3.37.1"
   },
   "devDependencies": {
     "@types/node": "18.x",

--- a/packages/compat/babel-preset/tests/__snapshots__/web.test.ts.snap
+++ b/packages/compat/babel-preset/tests/__snapshots__/web.test.ts.snap
@@ -234,7 +234,7 @@ exports[`should support inject core-js polyfills by entry 1`] = `
         "bugfixes": true,
         "corejs": {
           "proposals": true,
-          "version": "3.36",
+          "version": "3.37",
         },
         "exclude": [
           "transform-typeof-symbol",
@@ -287,7 +287,7 @@ exports[`should support inject core-js polyfills by usage 1`] = `
         "bugfixes": true,
         "corejs": {
           "proposals": true,
-          "version": "3.36",
+          "version": "3.37",
         },
         "exclude": [
           "transform-typeof-symbol",

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -29,7 +29,7 @@
     "@modern-js/swc-plugins": "0.6.7",
     "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.3",
-    "core-js": "~3.36.0",
+    "core-js": "~3.37.1",
     "lodash": "^4.17.21",
     "semver": "^7.6.2"
   },

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@modern-js/swc-plugins": "0.6.7",
     "@rsbuild/shared": "workspace:*",
-    "@swc/helpers": "0.5.3",
+    "@swc/helpers": "0.5.11",
     "core-js": "~3.37.1",
     "lodash": "^4.17.21",
     "semver": "^7.6.2"

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -24,7 +24,7 @@ exports[`plugin-swc > should apply multiply environment configs correctly 1`] = 
               "options": {
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "targets": [
                     "chrome >= 87",
@@ -83,7 +83,7 @@ exports[`plugin-swc > should apply multiply environment configs correctly 1`] = 
               "options": {
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "targets": [
                     "chrome >= 87",
@@ -151,7 +151,7 @@ exports[`plugin-swc > should apply multiply environment configs correctly 1`] = 
               "options": {
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "targets": [
                     "node >= 16",
@@ -208,7 +208,7 @@ exports[`plugin-swc > should apply multiply environment configs correctly 1`] = 
               "options": {
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "targets": [
                     "node >= 16",
@@ -282,7 +282,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -342,7 +342,7 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -413,7 +413,7 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -473,7 +473,7 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -543,7 +543,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "node >= 16",
@@ -600,7 +600,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "node >= 16",
@@ -667,7 +667,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -727,7 +727,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -797,7 +797,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -857,7 +857,7 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
           "options": {
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "targets": [
                 "chrome >= 87",
@@ -980,7 +980,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -1032,7 +1032,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -1092,7 +1092,7 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
         "options": {
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "targets": [
               "chrome >= 87",
@@ -1188,7 +1188,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",
@@ -1248,7 +1248,7 @@ exports[`plugin-swc > should set swc-loader 1`] = `
             "options": {
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "targets": [
                   "chrome >= 87",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.7.4",
     "@swc/helpers": "0.5.3",
-    "core-js": "~3.36.0",
+    "core-js": "~3.37.1",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss": "^8.4.38"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
     "@rspack/core": "0.7.4",
-    "@swc/helpers": "0.5.3",
+    "@swc/helpers": "0.5.11",
     "core-js": "~3.37.1",
     "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
     "postcss": "^8.4.38"

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -111,7 +111,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -158,7 +158,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -111,7 +111,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -158,7 +158,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -558,7 +558,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -605,7 +605,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -1396,7 +1396,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -1443,7 +1443,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -33,7 +33,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -80,7 +80,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -153,7 +153,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -197,7 +197,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -268,7 +268,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -322,7 +322,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -454,7 +454,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -501,7 +501,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -562,7 +562,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -616,7 +616,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.36",
+            "coreJs": "3.37",
             "mode": "usage",
             "shippedProposals": true,
             "targets": [
@@ -790,7 +790,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -837,7 +837,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -1121,7 +1121,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1167,7 +1167,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1240,7 +1240,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -1287,7 +1287,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "usage",
                   "shippedProposals": true,
                   "targets": [
@@ -1362,7 +1362,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",
@@ -1408,7 +1408,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.36",
+                  "coreJs": "3.37",
                   "mode": "entry",
                   "targets": [
                     "chrome >= 87",

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [
@@ -117,7 +117,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-mdx/tests/__snapshots__/index.test.ts.snap
@@ -8,7 +8,7 @@ exports[`plugin-mdx > should allow to configure mdx loader 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [
@@ -53,7 +53,7 @@ exports[`plugin-mdx > should register mdx loader correctly 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -128,7 +128,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [
@@ -180,7 +180,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.36",
+                "coreJs": "3.37",
                 "mode": "usage",
                 "shippedProposals": true,
                 "targets": [

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -25,7 +25,7 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [
@@ -142,7 +142,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.36",
+          "coreJs": "3.37",
           "mode": "usage",
           "shippedProposals": true,
           "targets": [

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -22,7 +22,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -115,7 +115,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -180,7 +180,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -272,7 +272,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -337,7 +337,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -429,7 +429,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -494,7 +494,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -586,7 +586,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [
@@ -651,7 +651,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.36",
+              "coreJs": "3.37",
               "mode": "usage",
               "shippedProposals": true,
               "targets": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,8 +628,8 @@ importers:
         specifier: 2.3.3
         version: 2.3.3
       core-js:
-        specifier: ~3.36.0
-        version: 3.36.1
+        specifier: ~3.37.1
+        version: 3.37.1
     devDependencies:
       '@types/node':
         specifier: 18.x
@@ -650,8 +650,8 @@ importers:
         specifier: 0.5.3
         version: 0.5.3
       core-js:
-        specifier: ~3.36.0
-        version: 3.36.1
+        specifier: ~3.37.1
+        version: 3.37.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -4876,6 +4876,9 @@ packages:
 
   core-js@3.36.1:
     resolution: {integrity: sha512-BTvUrwxVBezj5SZ3f10ImnX2oRByMxql3EimVqMysepbC9EeMUOpLwdy6Eoili2x6E4kf+ZUB5k/+Jv55alPfA==}
+
+  core-js@3.37.1:
+    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -12658,6 +12661,8 @@ snapshots:
       browserslist: 4.23.1
 
   core-js@3.36.1: {}
+
+  core-js@3.37.1: {}
 
   core-util-is@1.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -642,13 +642,13 @@ importers:
     dependencies:
       '@modern-js/swc-plugins':
         specifier: 0.6.7
-        version: 0.6.7(@swc/helpers@0.5.3)
+        version: 0.6.7(@swc/helpers@0.5.11)
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../../shared
       '@swc/helpers':
-        specifier: 0.5.3
-        version: 0.5.3
+        specifier: 0.5.11
+        version: 0.5.11
       core-js:
         specifier: ~3.37.1
         version: 3.37.1
@@ -725,16 +725,16 @@ importers:
         version: link:../shared
       '@rspack/core':
         specifier: 0.7.4
-        version: 0.7.4(@swc/helpers@0.5.3)
+        version: 0.7.4(@swc/helpers@0.5.11)
       '@swc/helpers':
-        specifier: 0.5.3
-        version: 0.5.3
+        specifier: 0.5.11
+        version: 0.5.11
       core-js:
         specifier: ~3.37.1
         version: 3.37.1
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -765,7 +765,7 @@ importers:
         version: 2.0.0
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0)
+        version: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.0)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -795,7 +795,7 @@ importers:
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0)
+        version: 8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0)
       postcss-value-parser:
         specifier: 4.2.0
         version: 4.2.0
@@ -807,7 +807,7 @@ importers:
         version: 1.2.2
       rspack-manifest-plugin:
         specifier: 5.0.0
-        version: 5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: 5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))
       semver:
         specifier: ^7.6.2
         version: 7.6.2
@@ -877,7 +877,7 @@ importers:
         version: 5.0.4
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1049,7 +1049,7 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^12.2.0
-        version: 12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.92.0)
+        version: 12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.0)
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
@@ -1247,7 +1247,7 @@ importers:
         version: link:../../scripts/test-helper
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.38)
@@ -1290,7 +1290,7 @@ importers:
         version: 5.0.0
       sass-loader:
         specifier: ^14.2.1
-        version: 14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0)
+        version: 14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1374,7 +1374,7 @@ importers:
         version: 0.63.0
       stylus-loader:
         specifier: 8.1.0
-        version: 8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.92.0)
+        version: 8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.0)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1583,7 +1583,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0)
+        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0)
       webpack:
         specifier: ^5.92.0
         version: 5.92.0
@@ -1642,13 +1642,13 @@ importers:
     dependencies:
       '@rspack/core':
         specifier: 0.7.4
-        version: 0.7.4(@swc/helpers@0.5.3)
+        version: 0.7.4(@swc/helpers@0.5.11)
       caniuse-lite:
         specifier: ^1.0.30001636
         version: 1.0.30001636
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -3785,6 +3785,9 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.11':
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@swc/helpers@0.5.3':
     resolution: {integrity: sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==}
@@ -10864,9 +10867,9 @@ snapshots:
       '@modern-js/swc-plugins-win32-arm64-msvc': 0.6.6
       '@modern-js/swc-plugins-win32-x64-msvc': 0.6.6
 
-  '@modern-js/swc-plugins@0.6.7(@swc/helpers@0.5.3)':
+  '@modern-js/swc-plugins@0.6.7(@swc/helpers@0.5.11)':
     dependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.11
     optionalDependencies:
       '@modern-js/swc-plugins-darwin-arm64': 0.6.7
       '@modern-js/swc-plugins-darwin-x64': 0.6.7
@@ -11228,7 +11231,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.3
 
-  '@rspack/core@0.7.4(@swc/helpers@0.5.3)':
+  '@rspack/core@0.7.4(@swc/helpers@0.5.11)':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
       '@rspack/binding': 0.7.4
@@ -11236,7 +11239,7 @@ snapshots:
       tapable: 2.2.1
       webpack-sources: 3.2.3
     optionalDependencies:
-      '@swc/helpers': 0.5.3
+      '@swc/helpers': 0.5.11
 
   '@rspack/plugin-react-refresh@0.7.3(react-refresh@0.14.2)':
     optionalDependencies:
@@ -11489,6 +11492,10 @@ snapshots:
       - typescript
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.11':
+    dependencies:
+      tslib: 2.6.2
 
   '@swc/helpers@0.5.3':
     dependencies:
@@ -12744,7 +12751,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0):
+  css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.0):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -12755,7 +12762,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
       webpack: 5.92.0
 
   css-minimizer-webpack-plugin@5.0.1(lightningcss@1.25.1)(webpack@5.92.0):
@@ -13824,9 +13831,9 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3)):
+  html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11)):
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
 
   html-tags@2.0.0: {}
 
@@ -14193,11 +14200,11 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.92.0):
+  less-loader@12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.0):
     dependencies:
       less: 4.2.0
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
       webpack: 5.92.0
 
   less@4.2.0:
@@ -15699,14 +15706,14 @@ snapshots:
       tsx: 4.14.0
       yaml: 2.4.5
 
-  postcss-loader@8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0):
+  postcss-loader@8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.0):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.2)
       jiti: 1.21.6
       postcss: 8.4.38
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
       webpack: 5.92.0
     transitivePeerDependencies:
       - typescript
@@ -16405,12 +16412,12 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.3)):
+  rspack-manifest-plugin@5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.11)):
     dependencies:
       tapable: 2.2.1
       webpack-sources: 2.3.1
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
 
   rspack-plugin-virtual-module@0.1.12:
     dependencies:
@@ -16536,11 +16543,11 @@ snapshots:
       sass-embedded-win32-ia32: 1.77.5
       sass-embedded-win32-x64: 1.77.5
 
-  sass-loader@14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0):
+  sass-loader@14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.5)(webpack@5.92.0):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
       sass: 1.77.5
       sass-embedded: 1.77.5
       webpack: 5.92.0
@@ -16875,13 +16882,13 @@ snapshots:
 
   stylis@4.3.2: {}
 
-  stylus-loader@8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.92.0):
+  stylus-loader@8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.0):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.63.0
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
       webpack: 5.92.0
 
   stylus@0.63.0:
@@ -17439,10 +17446,10 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.0))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.0):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      css-loader: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.0)
+      css-loader: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.0)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -730,8 +730,8 @@ importers:
         specifier: 0.5.3
         version: 0.5.3
       core-js:
-        specifier: ~3.36.0
-        version: 3.36.1
+        specifier: ~3.37.1
+        version: 3.37.1
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
         version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))


### PR DESCRIPTION
## Summary

- bump core-js v3.37
- bump @swc/helpers v0.5.11

## Related Links

https://github.com/zloirock/core-js/releases/tag/v3.37.0

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
