### PR TITLE
docs: update relay example to use SWC plugin

### DIFF
--- a/website/docs/en/config/tools/swc.mdx
+++ b/website/docs/en/config/tools/swc.mdx
@@ -114,12 +114,14 @@ Example of enabling the Relay support using the `builtin:swc-loader`:
 export default {
   tools: {
     swc: {
-      rspackExperiments: {
-        relay: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-relay', {}]],
+        },
       },
     },
   },
 };
 ```
 
-For more options, please refer to [Rspack - rspackExperiments.relay](https://rspack.dev/guide/features/builtin-swc-loader#rspackexperimentsrelay).
+For more options, please refer to [@swc/plugin-relay](https://www.npmjs.com/package/@swc/plugin-relay).

--- a/website/docs/zh/config/tools/swc.mdx
+++ b/website/docs/zh/config/tools/swc.mdx
@@ -114,12 +114,14 @@ export default {
 export default {
   tools: {
     swc: {
-      rspackExperiments: {
-        relay: true,
+      jsc: {
+        experimental: {
+          plugins: [['@swc/plugin-relay', {}]],
+        },
       },
     },
   },
 };
 ```
 
-更多选项可参考 [Rspack - rspackExperiments.relay](https://rspack.dev/zh/guide/features/builtin-swc-loader#rspackexperimentsrelay)。
+更多选项可参考 [@swc/plugin-relay](https://www.npmjs.com/package/@swc/plugin-relay)。


### PR DESCRIPTION
## Summary

Update relay example to use SWC plugin, the `rspackExperiments.relay` option will be removed in Rspack v1.0.0.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6862

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
