### PR TITLE
fix: bundle analyze with environment name

### DIFF
--- a/packages/core/src/plugins/bundleAnalyzer.ts
+++ b/packages/core/src/plugins/bundleAnalyzer.ts
@@ -24,7 +24,7 @@ export function pluginBundleAnalyzer(): RsbuildPlugin {
         return config;
       });
 
-      api.modifyBundlerChain(async (chain, { CHAIN_ID, target }) => {
+      api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
         const config = api.getNormalizedConfig();
 
         if (!isUseAnalyzer(config)) {
@@ -41,7 +41,7 @@ export function pluginBundleAnalyzer(): RsbuildPlugin {
             {
               analyzerMode: 'static',
               openAnalyzer: false,
-              reportFilename: `report-${target}.html`,
+              reportFilename: `report-${environment}.html`,
               ...(config.performance.bundleAnalyze || {}),
             },
           ]);

--- a/website/docs/en/config/performance/bundle-analyze.mdx
+++ b/website/docs/en/config/performance/bundle-analyze.mdx
@@ -10,8 +10,8 @@ By default, Rsbuild does not enable `webpack-bundle-analyzer`. When this feature
 const defaultConfig = {
   analyzerMode: 'static',
   openAnalyzer: false,
-  // target is the compilation target, such as `web`, `node`, etc.
-  reportFilename: `report-${target}.html`,
+  // Distinguish by environment names, such as `web`, `node`, etc.
+  reportFilename: `report-${environment}.html`,
 };
 ```
 

--- a/website/docs/zh/config/performance/bundle-analyze.mdx
+++ b/website/docs/zh/config/performance/bundle-analyze.mdx
@@ -10,8 +10,8 @@
 const defaultConfig = {
   analyzerMode: 'static',
   openAnalyzer: false,
-  // target 为编译目标，如 `web`、`node` 等
-  reportFilename: `report-${target}.html`,
+  // 通过 environment 名称区分，如 `web`、`node` 等
+  reportFilename: `report-${environment}.html`,
 };
 ```
 


### PR DESCRIPTION
## Summary

Generate bundle analyze HTML files with environment name.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
