### PR TITLE
feat(type-check): allow to check multiple tsconfig files

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -2,11 +2,13 @@ name: Release Nightly
 
 on:
   workflow_dispatch:
+  # Nightly release disabled
   # schedule:
     # 00:00 AM Beijing Time.
     # - cron: "0 16 * * *"
 
 permissions:
+  # To publish packages with provenance
   id-token: write
 
 jobs:

--- a/e2e/cases/type-check/multiple-tsconfig/index.test.ts
+++ b/e2e/cases/type-check/multiple-tsconfig/index.test.ts
@@ -1,0 +1,30 @@
+import { build } from '@e2e/helper';
+import { proxyConsole } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should check multiple tsconfig.json as expected', async () => {
+  const { logs, restore } = proxyConsole();
+  await expect(
+    build({
+      cwd: __dirname,
+    }),
+  ).rejects.toThrowError('build failed!');
+
+  expect(
+    logs.find((log) =>
+      log.includes(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      ),
+    ),
+  ).toBeTruthy();
+
+  expect(
+    logs.find((log) =>
+      log.includes(
+        `Argument of type '{}' is not assignable to parameter of type 'number'.`,
+      ),
+    ),
+  ).toBeTruthy();
+
+  restore();
+});

--- a/e2e/cases/type-check/multiple-tsconfig/rsbuild.config.ts
+++ b/e2e/cases/type-check/multiple-tsconfig/rsbuild.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+
+export default defineConfig({
+  plugins: [pluginTypeCheck()],
+  environments: {
+    web: {
+      output: {
+        target: 'web',
+      },
+    },
+    node: {
+      source: {
+        tsconfigPath: './tsconfig.server.json',
+      },
+      output: {
+        target: 'node',
+      },
+    },
+  },
+});

--- a/e2e/cases/type-check/multiple-tsconfig/server/index.ts
+++ b/e2e/cases/type-check/multiple-tsconfig/server/index.ts
@@ -1,0 +1,4 @@
+const add = (a: number, b: number) => a + b;
+
+// this is a type error
+add(1, '2');

--- a/e2e/cases/type-check/multiple-tsconfig/src/index.ts
+++ b/e2e/cases/type-check/multiple-tsconfig/src/index.ts
@@ -1,0 +1,4 @@
+const add = (a: number, b: number) => a + b;
+
+// this is a type error
+add(1, {});

--- a/e2e/cases/type-check/multiple-tsconfig/tsconfig.json
+++ b/e2e/cases/type-check/multiple-tsconfig/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/type-check/multiple-tsconfig/tsconfig.server.json
+++ b/e2e/cases/type-check/multiple-tsconfig/tsconfig.server.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["server"]
+}


### PR DESCRIPTION
## Summary

Allow to check multiple tsconfig files, because each tsconfig.json may include different folders.

```js
export default defineConfig({
  environments: {
    web: {
      source: {
        tsconfigPath: './tsconfig.json',
      },
    },
    node: {
      source: {
        tsconfigPath: './tsconfig.node.json',
      },
    },
  },
});
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
