### PR TITLE
chore: extract getCommonParentPath helper

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -20,7 +20,7 @@ import type {
   MultiCompiler as WebpackMultiCompiler,
 } from 'webpack';
 import { formatStatsMessages } from './client/format';
-import { COMPILED_PATH, DEFAULT_ASSET_PREFIX } from './constants';
+import { DEFAULT_ASSET_PREFIX } from './constants';
 import { logger } from './logger';
 
 export const rspackMinVersion = '0.7.0';
@@ -78,9 +78,6 @@ export const isSatisfyRspackVersion = async (originalVersion: string) => {
   // ignore other unstable versions
   return true;
 };
-
-export const getCompiledPath = (packageName: string) =>
-  path.join(COMPILED_PATH, packageName);
 
 /**
  * Add node polyfill tip when failed to resolve node built-in modules.
@@ -293,15 +290,6 @@ export const getPublicPathFromCompiler = (compiler: Rspack.Compiler) => {
   // publicPath function is not supported yet, fallback to default value
   return DEFAULT_ASSET_PREFIX;
 };
-
-/**
- * ensure absolute file path.
- * @param base - Base path to resolve relative from.
- * @param filePath - Absolute or relative file path.
- * @returns Resolved absolute file path.
- */
-export const ensureAbsolutePath = (base: string, filePath: string): string =>
-  path.isAbsolute(filePath) ? filePath : path.resolve(base, filePath);
 
 export const isFileSync = (filePath: string) => {
   try {

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -5,7 +5,7 @@ export function getCommonParentPath(paths: string[]) {
   const uniquePaths = [...new Set(paths)];
 
   if (uniquePaths.length === 1) {
-    return paths[0];
+    return uniquePaths[0];
   }
 
   const [first, ...rest] = uniquePaths.map((p) => p.split(sep));

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -7,7 +7,7 @@ export function getCommonParentPath(paths: string[]) {
   }
 
   const [first, ...rest] = [...new Set(paths)].map((p) => p.split(sep));
-  const common = [];
+  const common: string[] = [];
 
   for (let i = 0; i < first.length; i++) {
     const segment = first[i];

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -1,0 +1,33 @@
+import { isAbsolute, join, resolve, sep } from 'node:path';
+import { COMPILED_PATH } from '../constants';
+
+export function getCommonParentPath(paths: string[]) {
+  if (paths.length === 1) {
+    return paths[0];
+  }
+
+  const [first, ...rest] = paths.map((item) => item.split(sep));
+  const common = [];
+
+  for (let i = 0; i < first.length; i++) {
+    const segment = first[i];
+    if (rest.every((p) => p[i] === segment)) {
+      common.push(segment);
+    } else {
+      break;
+    }
+  }
+  return common.join(sep);
+}
+
+export const getCompiledPath = (packageName: string) =>
+  join(COMPILED_PATH, packageName);
+
+/**
+ * ensure absolute file path.
+ * @param base - Base path to resolve relative from.
+ * @param filePath - Absolute or relative file path.
+ * @returns Resolved absolute file path.
+ */
+export const ensureAbsolutePath = (base: string, filePath: string): string =>
+  isAbsolute(filePath) ? filePath : resolve(base, filePath);

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -6,7 +6,7 @@ export function getCommonParentPath(paths: string[]) {
     return paths[0];
   }
 
-  const [first, ...rest] = paths.map((item) => item.split(sep));
+  const [first, ...rest] = [...new Set(paths)].map((p) => p.split(sep));
   const common = [];
 
   for (let i = 0; i < first.length; i++) {

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -2,11 +2,13 @@ import { isAbsolute, join, resolve, sep } from 'node:path';
 import { COMPILED_PATH } from '../constants';
 
 export function getCommonParentPath(paths: string[]) {
-  if (paths.length === 1) {
+  const uniquePaths = [...new Set(paths)];
+
+  if (uniquePaths.length === 1) {
     return paths[0];
   }
 
-  const [first, ...rest] = [...new Set(paths)].map((p) => p.split(sep));
+  const [first, ...rest] = uniquePaths.map((p) => p.split(sep));
   const common: string[] = [];
 
   for (let i = 0; i < first.length; i++) {

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -13,7 +13,8 @@ import {
 } from '@rsbuild/shared';
 import type { AcceptedPlugin } from 'postcss';
 import { CSS_REGEX, LOADER_PATH } from '../constants';
-import { getCompiledPath, isFunction, isPlainObject } from '../helpers';
+import { isFunction, isPlainObject } from '../helpers';
+import { getCompiledPath } from '../helpers/path';
 import { getCssExtractPlugin } from '../pluginHelper';
 import { reduceConfigs, reduceConfigsWithContext } from '../reduceConfigs';
 import type { NormalizedEnvironmentConfig, RsbuildPlugin } from '../types';

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -4,7 +4,7 @@ import {
   type RspackChain,
   castArray,
 } from '@rsbuild/shared';
-import { ensureAbsolutePath } from '../helpers';
+import { ensureAbsolutePath } from '../helpers/path';
 import { reduceConfigs } from '../reduceConfigs';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -1,4 +1,5 @@
 import { ensureAssetPrefix, pick, prettyTime } from '../src/helpers';
+import { getCommonParentPath } from '../src/helpers/path';
 import { normalizeUrl } from '../src/server/helper';
 
 test('should pretty time correctly', () => {
@@ -72,5 +73,33 @@ describe('ensureAssetPrefix', () => {
     );
     expect(ensureAssetPrefix('//foo.com/bar.js', '/')).toBe('//foo.com/bar.js');
     expect(ensureAssetPrefix('/bar.js', '//foo.com')).toBe('//foo.com/bar.js');
+  });
+});
+
+describe('getCommonParentPath', () => {
+  it('should return the common parent path for given paths', () => {
+    const paths = [
+      '/home/user/project/dist',
+      '/home/user/project/dist/sub1',
+      '/home/user/project/dist/sub2',
+    ];
+    const result = getCommonParentPath(paths);
+    expect(result).toBe('/home/user/project/dist');
+
+    const paths2 = ['/home/user/project/dist1', '/home/user/project/dist2'];
+    const result2 = getCommonParentPath(paths2);
+    expect(result2).toBe('/home/user/project');
+  });
+
+  it('should return empty string if there is no common parent path', () => {
+    const paths = ['/home/user/project/dist', '/home2/user/project/dist'];
+    const result = getCommonParentPath(paths);
+    expect(result).toBe('');
+  });
+
+  it('should handle single path input', () => {
+    const paths = ['/home/user/project/dist1'];
+    const result = getCommonParentPath(paths);
+    expect(result).toBe('/home/user/project/dist1');
   });
 });

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -1,3 +1,4 @@
+import { sep } from 'node:path';
 import { ensureAssetPrefix, pick, prettyTime } from '../src/helpers';
 import { getCommonParentPath } from '../src/helpers/path';
 import { normalizeUrl } from '../src/server/helper';
@@ -77,29 +78,37 @@ describe('ensureAssetPrefix', () => {
 });
 
 describe('getCommonParentPath', () => {
+  const normalize = (p: string) => p.replaceAll('/', sep);
+
   it('should return the common parent path for given paths', () => {
     const paths = [
-      '/home/user/project/dist',
-      '/home/user/project/dist/sub1',
-      '/home/user/project/dist/sub2',
+      normalize('/home/user/project/dist'),
+      normalize('/home/user/project/dist/sub1'),
+      normalize('/home/user/project/dist/sub2'),
     ];
     const result = getCommonParentPath(paths);
-    expect(result).toBe('/home/user/project/dist');
+    expect(result).toBe(normalize('/home/user/project/dist'));
 
-    const paths2 = ['/home/user/project/dist1', '/home/user/project/dist2'];
+    const paths2 = [
+      normalize('/home/user/project/dist1'),
+      normalize('/home/user/project/dist2'),
+    ];
     const result2 = getCommonParentPath(paths2);
-    expect(result2).toBe('/home/user/project');
+    expect(result2).toBe(normalize('/home/user/project'));
   });
 
   it('should return empty string if there is no common parent path', () => {
-    const paths = ['/home/user/project/dist', '/home2/user/project/dist'];
+    const paths = [
+      normalize('/home/user/project/dist'),
+      normalize('/home2/user/project/dist'),
+    ];
     const result = getCommonParentPath(paths);
     expect(result).toBe('');
   });
 
   it('should handle single path input', () => {
-    const paths = ['/home/user/project/dist1'];
+    const paths = [normalize('/home/user/project/dist1')];
     const result = getCommonParentPath(paths);
-    expect(result).toBe('/home/user/project/dist1');
+    expect(result).toBe(normalize('/home/user/project/dist1'));
   });
 });


### PR DESCRIPTION
## Summary

Extract the getCommonParentPath helper.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2680

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
