### PR TITLE
feat(source-build): support for flat conditional exports

### DIFF
--- a/e2e/cases/source-build/components/package.json
+++ b/e2e/cases/source-build/components/package.json
@@ -16,6 +16,7 @@
     }
   },
   "dependencies": {
-    "@e2e/source-build-utils": "workspace:*"
+    "@e2e/source-build-utils": "workspace:*",
+    "@e2e/source-build-utils2": "workspace:*"
   }
 }

--- a/e2e/cases/source-build/components/src/card/index.tsx
+++ b/e2e/cases/source-build/components/src/card/index.tsx
@@ -1,4 +1,5 @@
 import { strAdd } from '@e2e/source-build-utils';
+import { toLowerCase } from '@e2e/source-build-utils2';
 import './index.less';
 
 export interface CardProps {
@@ -10,7 +11,7 @@ export const Card = (props: CardProps) => {
   const { title, content = '' } = props;
   return (
     <div className="card-comp">
-      <h2>Card Comp Title: {title}</h2>
+      <h2>Card Comp Title: {toLowerCase(title)}</h2>
       <article>{strAdd('Card Comp Content:', content)}</article>
     </div>
   );

--- a/e2e/cases/source-build/index.test.ts
+++ b/e2e/cases/source-build/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest(
 
     const locator = page.locator('#root');
     await expect(locator).toHaveText(
-      'Card Comp Title: AppCARD COMP CONTENT:hello world',
+      'Card Comp Title: appCARD COMP CONTENT:hello world',
     );
 
     await rsbuild.close();

--- a/e2e/cases/source-build/utils2/package.json
+++ b/e2e/cases/source-build/utils2/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@e2e/source-build-utils2",
+  "private": true,
+  "version": "1.0.0",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "source": "./src/index.ts"
+  }
+}

--- a/e2e/cases/source-build/utils2/src/common/index.ts
+++ b/e2e/cases/source-build/utils2/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './toUpperCase';
+export * from './toLowerCase';

--- a/e2e/cases/source-build/utils2/src/common/toLowerCase.ts
+++ b/e2e/cases/source-build/utils2/src/common/toLowerCase.ts
@@ -1,0 +1,1 @@
+export const toLowerCase = (s: string) => s.toLowerCase();

--- a/e2e/cases/source-build/utils2/src/common/toUpperCase.ts
+++ b/e2e/cases/source-build/utils2/src/common/toUpperCase.ts
@@ -1,0 +1,1 @@
+export const toUpperCase = (s: string) => s.toUpperCase();

--- a/e2e/cases/source-build/utils2/src/index.ts
+++ b/e2e/cases/source-build/utils2/src/index.ts
@@ -1,0 +1,3 @@
+import { toLowerCase } from '@common/index';
+
+export { toLowerCase };

--- a/e2e/cases/source-build/utils2/tsconfig.json
+++ b/e2e/cases/source-build/utils2/tsconfig.json
@@ -4,22 +4,15 @@
     "composite": true,
     "declaration": true,
     "declarationDir": "./dist/types",
+    "declarationMap": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"],
-      "@card/*": ["./src/card/*"]
+      "@common/*": ["./src/common/*"]
     },
-    "rootDir": "src",
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
-  "references": [
-    {
-      "path": "../utils"
-    },
-    {
-      "path": "../utils2"
-    }
-  ],
   "include": ["src"]
 }

--- a/packages/plugin-source-build/src/project-utils/filter.ts
+++ b/packages/plugin-source-build/src/project-utils/filter.ts
@@ -10,14 +10,15 @@ function hasExportsSourceField(
   exportsConfig: ExportsConfig,
   sourceField: string,
 ) {
-  return Object.values(exportsConfig).some(
-    (moduleRules) =>
-      typeof moduleRules === 'object' &&
-      typeof moduleRules[sourceField] === 'string',
+  return (
+    typeof exportsConfig[sourceField] === 'string' ||
+    Object.values(exportsConfig).some(
+      (moduleRules) =>
+        typeof moduleRules === 'object' &&
+        typeof moduleRules[sourceField] === 'string',
+    )
   );
 }
-
-export const defaultFilter: FilterFunction = (projects) => projects;
 
 export const filterByField =
   (fieldName: string, checkExports?: boolean): FilterFunction =>

--- a/packages/plugin-source-build/src/project-utils/getDependentProjects.ts
+++ b/packages/plugin-source-build/src/project-utils/getDependentProjects.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { getMonorepoBaseData, getMonorepoSubProjects } from '../common';
-import type { Project } from '../project/project';
 import type { MonorepoAnalyzer } from '../types';
 import { readPackageJson } from '../utils';
-import { type Filter, defaultFilter } from './filter';
+import type { Filter } from './filter';
 
 export type ExtraMonorepoStrategies = Record<string, MonorepoAnalyzer>;
 
@@ -22,14 +21,6 @@ async function pathExists(path: string) {
     .then(() => true)
     .catch(() => false);
 }
-
-const filterProjects = async (projects: Project[], filter?: Filter) => {
-  if (!filter) {
-    return defaultFilter(projects);
-  }
-
-  return filter(projects);
-};
 
 const getDependentProjects = async (
   projectNameOrRootPath: string,
@@ -72,7 +63,9 @@ const getDependentProjects = async (
   let dependentProjects = currentProject.getDependentProjects(projects, {
     recursive,
   });
-  dependentProjects = await filterProjects(dependentProjects, filter);
+  if (filter) {
+    dependentProjects = await filter(dependentProjects);
+  }
 
   return dependentProjects;
 };

--- a/packages/plugin-source-build/src/project/project.ts
+++ b/packages/plugin-source-build/src/project/project.ts
@@ -128,6 +128,12 @@ export class Project {
   #getExportsSourceDirs(exportsConfig: ExportsConfig, sourceField: string) {
     const exportsSourceDirs: string[] = [];
 
+    if (typeof exportsConfig[sourceField] === 'string') {
+      exportsSourceDirs.push(
+        path.normalize(exportsConfig[sourceField] as string),
+      );
+    }
+
     for (const moduleRules of Object.values(exportsConfig)) {
       if (
         typeof moduleRules === 'object' &&

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,8 +302,13 @@ importers:
       '@e2e/source-build-utils':
         specifier: workspace:*
         version: link:../utils
+      '@e2e/source-build-utils2':
+        specifier: workspace:*
+        version: link:../utils2
 
   e2e/cases/source-build/utils: {}
+
+  e2e/cases/source-build/utils2: {}
 
   e2e/cases/source-map:
     dependencies:


### PR DESCRIPTION
## Summary

Support for conditional exports without subpaths.

```json
// package.json
{
  "exports": {
    "source": "./index-module.ts",
    "import": "./index-module.js",
    "require": "./index-require.cjs"
  },
  "type": "module"
}
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2687

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
