### PR TITLE
fix!: remove context.tsconfigPath

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -159,22 +159,12 @@ export async function updateEnvironmentContext(
   }
 }
 
-export function updateContextByNormalizedConfig(
-  context: RsbuildContext,
-  config: NormalizedConfig,
-) {
+export function updateContextByNormalizedConfig(context: RsbuildContext) {
   // Try to get the parent dist path from all environments
   const distPaths = Object.values(context.environments).map(
     (item) => item.distPath,
   );
   context.distPath = getCommonParentPath(distPaths);
-
-  if (config.source.tsconfigPath) {
-    context.tsconfigPath = getAbsolutePath(
-      context.rootPath,
-      config.source.tsconfigPath,
-    );
-  }
 }
 
 export function createPublicContext(

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -118,8 +118,7 @@ export async function initRsbuildConfig({
   };
 
   await updateEnvironmentContext(context, environments);
-
-  updateContextByNormalizedConfig(context, context.normalizedConfig);
+  updateContextByNormalizedConfig(context);
 
   return context.normalizedConfig;
 }

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -72,16 +72,6 @@ The absolute path of the build cache files.
 type CachePath = string;
 ```
 
-### context.tsconfigPath
-
-The absolute path of the tsconfig.json file, or `undefined` if the tsconfig.json file does not exist in current project.
-
-- **Type:**
-
-```ts
-type TsconfigPath = string | undefined;
-```
-
 ### context.devServer
 
 Dev Server information, including the current Dev Server hostname and port number.
@@ -106,6 +96,18 @@ type bundlerType = 'rspack' | 'webpack';
 ```
 
 > Rsbuild internally supports switching to webpack for comparative testing, so this field is provided for differentiation. Usually, you do not need to use this field.
+
+## rsbuild.environments
+
+### tsconfigPath
+
+The absolute path of the tsconfig.json file, or `undefined` if the tsconfig.json file does not exist in current project.
+
+- **Type:**
+
+```ts
+type TsconfigPath = string | undefined;
+```
 
 ## rsbuild.build
 

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -68,7 +68,7 @@ import type {
 
 ## NormalizedEnvironmentConfig
 
-The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [getNormalizedConfig({ environment })](/plugins/dev/core#apigetnormalizedconfig) method.
+The type of Rsbuild environment configuration after normalization, corresponding to the return value of the [`getNormalizedConfig({ environment })`](/plugins/dev/core#apigetnormalizedconfig) method.
 
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -72,16 +72,6 @@ type DistPath = string;
 type CachePath = string;
 ```
 
-### context.tsconfigPath
-
-tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件，则为 `undefined`。
-
-- **类型：**
-
-```ts
-type TsconfigPath = string | undefined;
-```
-
 ### context.devServer
 
 Dev Server 相关信息，包含了当前 Dev Server 的 hostname 和端口号。
@@ -106,6 +96,18 @@ type bundlerType = 'rspack' | 'webpack';
 ```
 
 > Rsbuild 内部支持切换到 webpack 进行对照测试，因此提供了该字段进行区分，通常你不需要使用此字段。
+
+## rsbuild.environments
+
+### tsconfigPath
+
+tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件，则为 `undefined`。
+
+- **类型：**
+
+```ts
+type TsconfigPath = string | undefined;
+```
 
 ## rsbuild.build
 

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -68,7 +68,7 @@ import type {
 
 ## NormalizedEnvironmentConfig
 
-指定环境下的 Rsbuild 归一化配置类型，对应 [getNormalizedConfig({ environment })](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
+指定环境下的 Rsbuild 归一化配置类型，对应 [`getNormalizedConfig({ environment })`](/plugins/dev/core#apigetnormalizedconfig) 方法的返回值。
 
 ```ts
 import type { NormalizedEnvironmentConfig } from '@rsbuild/core';

--- a/website/env.d.ts
+++ b/website/env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.mdx' {
+  let MDXComponent: () => JSX.Element;
+  export default MDXComponent;
+}

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -14,5 +14,5 @@
   "mdx": {
     "checkMdx": true
   },
-  "include": ["docs", "rspress.config.ts", "theme", "components"]
+  "include": ["docs", "rspress.config.ts", "theme", "components", "env.d.ts"]
 }


### PR DESCRIPTION
## Summary

Remove `context.tsconfigPath`, use `environments[name].tsconfigPath` instead.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
