### PR TITLE
fix: remove unused lazy compilation wrapper

### DIFF
--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
-import { isRegExp } from '../helpers';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 export const pluginLazyCompilation = (): RsbuildPlugin => ({
   name: 'rsbuild:lazy-compilation',
@@ -18,58 +17,9 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         return;
       }
 
-      const cssRegExp = /\.(?:css|less|sass|scss|styl|stylus)$/;
-
-      const isExcludedModule = (name: string) => {
-        return (
-          // exclude CSS files because Rspack does not support it yet
-          // TODO: remove this after Rspack supporting it
-          cssRegExp.test(name)
-        );
-      };
-
-      const defaultTest = (module: Rspack.Module) => {
-        const name = module.nameForCondition();
-        if (!name) {
-          return false;
-        }
-        return !isExcludedModule(name);
-      };
-
-      const mergeOptions = (): Rspack.LazyCompilationOptions => {
-        if (options === true) {
-          return { test: defaultTest };
-        }
-
-        const { test } = options;
-        if (!test) {
-          return {
-            ...options,
-            test: defaultTest,
-          };
-        }
-
-        return {
-          ...options,
-          test(module) {
-            const name = module.nameForCondition();
-
-            if (!name || isExcludedModule(name)) {
-              return false;
-            }
-
-            if (isRegExp(test)) {
-              return name ? test.test(name) : false;
-            }
-
-            return test(module);
-          },
-        };
-      };
-
       chain.experiments({
         ...chain.get('experiments'),
-        lazyCompilation: mergeOptions(),
+        lazyCompilation: options,
       });
     });
   },


### PR DESCRIPTION
## Summary

Remove unused lazy compilation wrapper, Rspack now supports lazy compilation + CSS.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
