### PR TITLE
fix: rspack profile outputPath unexpected

### DIFF
--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -43,10 +43,7 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     }
 
     const timestamp = Date.now();
-    const profileDir = path.join(
-      api.context.distPath,
-      `rspack-profile-${timestamp}`,
-    );
+    const profileDirName = `rspack-profile-${timestamp}`;
 
     let profileSession: inspector.Session | undefined;
 
@@ -59,11 +56,12 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     const enableLogging =
       RSPACK_PROFILE === 'ALL' || RSPACK_PROFILE.includes('LOGGING');
 
-    const traceFilePath = path.join(profileDir, 'trace.json');
-    const cpuProfilePath = path.join(profileDir, 'jscpuprofile.json');
-    const loggingFilePath = path.join(profileDir, 'logging.json');
-
     const onStart = () => {
+      // can't get precise api.context.distPath before config init
+      const profileDir = path.join(api.context.distPath, profileDirName);
+
+      const traceFilePath = path.join(profileDir, 'trace.json');
+
       if (!fs.existsSync(profileDir)) {
         fs.mkdirSync(profileDir, { recursive: true });
       }
@@ -88,6 +86,10 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     api.onBeforeStartDevServer(onStart);
 
     api.onAfterBuild(async ({ stats }) => {
+      const profileDir = path.join(api.context.distPath, profileDirName);
+
+      const loggingFilePath = path.join(profileDir, 'logging.json');
+
       if (enableLogging && stats) {
         const logging = stats.toJson({
           all: false,
@@ -102,6 +104,9 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
       if (enableProfileTrace) {
         rspack.experimental_cleanupGlobalTrace();
       }
+      const profileDir = path.join(api.context.distPath, profileDirName);
+
+      const cpuProfilePath = path.join(profileDir, 'jscpuprofile.json');
 
       stopProfiler(cpuProfilePath, profileSession);
 

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -86,9 +86,11 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     api.onBeforeStartDevServer(onStart);
 
     api.onAfterBuild(async ({ stats }) => {
-      const profileDir = path.join(api.context.distPath, profileDirName);
-
-      const loggingFilePath = path.join(profileDir, 'logging.json');
+      const loggingFilePath = path.join(
+        api.context.distPath,
+        profileDirName,
+        'logging.json',
+      );
 
       if (enableLogging && stats) {
         const logging = stats.toJson({


### PR DESCRIPTION
## Summary

should not get `api.context.distPath` before config init

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
