### PR TITLE
fix!: remove function usage of `source.entry`

### DIFF
--- a/e2e/cases/source/multiple-entry/rsbuild.config.ts
+++ b/e2e/cases/source/multiple-entry/rsbuild.config.ts
@@ -1,30 +1,26 @@
 import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
-  source: {
-    entry({ target }) {
-      if (target === 'web') {
-        return {
-          index: './src/index.client.js',
-        };
-      }
-      if (target === 'node') {
-        return {
-          index: './src/index.server.js',
-        };
-      }
-    },
-  },
   output: {
     filenameHash: false,
   },
   environments: {
     web: {
+      source: {
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
       output: {
         target: 'web',
       },
     },
     node: {
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
       output: {
         target: 'node',
         distPath: {

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -13,7 +13,6 @@ import { getCommonParentPath } from './helpers/path';
 import { initHooks } from './initHooks';
 import { getHTMLPathByEntry } from './initPlugins';
 import { logger } from './logger';
-import { getEntryObject } from './plugins/entry';
 import type {
   CreateRsbuildOptions,
   InternalContext,
@@ -139,19 +138,19 @@ export async function updateEnvironmentContext(
     const tsconfigPath = config.source.tsconfigPath
       ? getAbsolutePath(context.rootPath, config.source.tsconfigPath)
       : undefined;
-    const entry = getEntryObject(config, config.output.target);
 
     const browserslist = await getBrowserslistByEnvironment(
       context.rootPath,
       config,
     );
 
+    const entry = config.source.entry ?? {};
     const htmlPaths = getEnvironmentHTMLPaths(entry, config);
 
     context.environments[name] = {
       target: config.output.target,
       distPath: getAbsoluteDistPath(context.rootPath, config),
-      entry: getEntryObject(config, config.output.target),
+      entry,
       browserslist,
       htmlPaths,
       tsconfigPath,

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,29 +1,7 @@
-import {
-  type NormalizedEnvironmentConfig,
-  type RsbuildEntry,
-  type RsbuildTarget,
-  castArray,
-  color,
-} from '@rsbuild/shared';
+import { castArray, color } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
 import { createVirtualModule } from '../helpers';
-import { reduceConfigsMergeContext } from '../reduceConfigs';
-import type { NormalizedConfig, RsbuildConfig, RsbuildPlugin } from '../types';
-
-export function getEntryObject(
-  config: RsbuildConfig | NormalizedConfig | NormalizedEnvironmentConfig,
-  target: RsbuildTarget,
-): RsbuildEntry {
-  if (!config.source?.entry) {
-    return {};
-  }
-
-  return reduceConfigsMergeContext({
-    initial: {},
-    config: config.source?.entry,
-    ctx: { target },
-  });
-}
+import type { RsbuildPlugin } from '../types';
 
 export const pluginEntry = (): RsbuildPlugin => ({
   name: 'rsbuild:entry',

--- a/packages/shared/src/types/config/source.ts
+++ b/packages/shared/src/types/config/source.ts
@@ -1,6 +1,6 @@
 import type { RuleSetCondition } from '@rspack/core';
-import type { RsbuildEntry, RsbuildTarget } from '../rsbuild';
-import type { ConfigChain, ConfigChainMergeContext } from '../utils';
+import type { RsbuildEntry } from '../rsbuild';
+import type { ConfigChain } from '../utils';
 
 export type Alias = Record<string, string | false | (string | false)[]>;
 
@@ -39,7 +39,7 @@ export interface SourceConfig {
   /**
    * Set the entry modules.
    */
-  entry?: ConfigChainMergeContext<RsbuildEntry, { target: RsbuildTarget }>;
+  entry?: RsbuildEntry;
   /**
    * Specifies that certain files that will be excluded from compilation.
    */

--- a/website/docs/en/config/output/override-browserslist.mdx
+++ b/website/docs/en/config/output/override-browserslist.mdx
@@ -45,7 +45,7 @@ Check out the [browserslist documentation](https://github.com/browserslist/brows
 
 ## Set by environment
 
-When you build for multiple environments, you can set different browserslist for each environment:
+When you build for multiple [environments](/config/environments), you can set different browserslist for each environment:
 
 For example, set different browserslist for `web` and `node` environments:
 
@@ -54,11 +54,13 @@ export default {
   environments: {
     web: {
       output: {
+        target: 'web',
         overrideBrowserslist: ['iOS >= 9', 'Android >= 4.4'],
       },
     },
     node: {
       output: {
+        target: 'node',
         overrideBrowserslist: ['node >= 20'],
       },
     },

--- a/website/docs/en/config/source/alias.mdx
+++ b/website/docs/en/config/source/alias.mdx
@@ -60,7 +60,7 @@ export default {
 
 ## Set by environment
 
-When you build for multiple environments, you can set different alias for each environment:
+When you build for multiple [environments](/config/environments), you can set different alias for each environment:
 
 For example, set different alias for `web` and `node` environments:
 

--- a/website/docs/en/config/source/entry.mdx
+++ b/website/docs/en/config/source/entry.mdx
@@ -3,7 +3,7 @@
 - **Type:**
 
 ```ts
-type Entry = Record<string, string | string[] | EntryDescription> | Function;
+type Entry = Record<string, string | string[] | EntryDescription>;
 ```
 
 - **Default:**
@@ -72,30 +72,35 @@ export default {
 
 For the complete usage of the description object, please refer to [Rspack - Entry Description Object](https://rspack.dev/config/entry#entry-description-object).
 
-## Function Usage
+## Set by environment
 
-`source.entry` supports setting as a function, which is commonly used to set different entry objects for different build target.
+When you build for multiple [environments](/config/environments), you can set different entry for each environment:
 
-For example, set entry for web target and node target separately:
+For example, set different entry for `web` and `node` environments:
 
-```ts title="rsbuild.config.ts"
+```js
 export default {
-  source: {
-    entry({ target }) {
-      if (target === 'web') {
-        return {
+  environments: {
+    web: {
+      source: {
+        entry: {
           index: './src/index.client.js',
-        };
-      }
-      if (target === 'node') {
-        return {
-          index: './src/index.server.js',
-        };
-      }
+        },
+      },
+      output: {
+        target: 'web',
+      },
     },
-  },
-  output: {
-    targets: ['web', 'node'],
+    node: {
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
   },
 };
 ```

--- a/website/docs/zh/config/output/override-browserslist.mdx
+++ b/website/docs/zh/config/output/override-browserslist.mdx
@@ -45,7 +45,7 @@ export default {
 
 ## 基于 environment 设置
 
-当你面向多个 environment 构建时，可以为每个 environment 设置不同的 browserslist：
+当你面向多个 [environments](/config/environments) 构建时，可以为每个 environment 设置不同的 browserslist：
 
 比如为 `web` 和 `node` 环境设置不同的 browserslist：
 
@@ -54,11 +54,13 @@ export default {
   environments: {
     web: {
       output: {
+        target: 'web',
         overrideBrowserslist: ['iOS >= 9', 'Android >= 4.4'],
       },
     },
     node: {
       output: {
+        target: 'node',
         overrideBrowserslist: ['node >= 20'],
       },
     },

--- a/website/docs/zh/config/source/alias.mdx
+++ b/website/docs/zh/config/source/alias.mdx
@@ -60,7 +60,7 @@ export default {
 
 ## 基于 environment 设置
 
-当你面向多个 environment 构建时，可以为每个 environment 设置不同的 alias：
+当你面向多个 [environments](/config/environments) 构建时，可以为每个 environment 设置不同的 alias：
 
 比如为 `web` 和 `node` 环境设置不同的 alias：
 

--- a/website/docs/zh/config/source/entry.mdx
+++ b/website/docs/zh/config/source/entry.mdx
@@ -3,7 +3,7 @@
 - **类型：**
 
 ```ts
-type Entry = Record<string, string | string[] | EntryDescription> | Function;
+type Entry = Record<string, string | string[] | EntryDescription>;
 ```
 
 - **默认值：**
@@ -96,6 +96,39 @@ export default {
   },
   output: {
     targets: ['web', 'node'],
+  },
+};
+```
+
+## 基于 environment 设置
+
+当你面向多个 [environments](/config/environments) 构建时，可以为每个 environment 设置不同的 entry：
+
+比如为 `web` 和 `node` 环境设置不同的 entry：
+
+```js
+export default {
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
+      output: {
+        target: 'web',
+      },
+    },
+    node: {
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
   },
 };
 ```


### PR DESCRIPTION
## Summary

BREAKING CHANGE: emove function usage of `source.entry`

Use `environments` config instead.

- before:

```js
export default {
  source: {
    entry({ target }) {
      if (target === 'web') {
        return {
          index: './src/index.client.js',
        };
      }
      if (target === 'node') {
        return {
          index: './src/index.server.js',
        };
      }
    },
  },
  output: {
    targets: ['web', 'node'],
  },
};
```

- after:

```js
export default {
  environments: {
    web: {
      source: {
        entry: {
          index: './src/index.client.js',
        },
      },
      output: {
        target: 'web',
      },
    },
    node: {
      source: {
        entry: {
          index: './src/index.server.js',
        },
      },
      output: {
        target: 'node',
      },
    },
  },
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
