### PR TITLE
feat: support for merging environments config

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -1,7 +1,7 @@
 import { type RsbuildConfig, castArray } from '@rsbuild/shared';
 import { isFunction, isPlainObject } from './helpers';
 
-const OVERRIDE_PATH = [
+const OVERRIDE_PATHS = [
   'performance.removeConsole',
   'output.inlineScripts',
   'output.inlineStyles',
@@ -15,7 +15,14 @@ const OVERRIDE_PATH = [
 /**
  * When merging configs, some properties prefer `override` over `merge to array`
  */
-const isOverridePath = (key: string) => OVERRIDE_PATH.includes(key);
+const isOverridePath = (key: string) => {
+  // ignore environments name prefix, such as `environments.web`
+  if (key.startsWith('environments.')) {
+    const realKey = key.split('.').slice(2).join('.');
+    return OVERRIDE_PATHS.includes(realKey);
+  }
+  return OVERRIDE_PATHS.includes(key);
+};
 
 const merge = (x: unknown, y: unknown, path = '') => {
   // force some keys to override

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -34,25 +34,25 @@ describe('mergeRsbuildConfig', () => {
     const config = mergeRsbuildConfig(
       { source: { alias: {} } },
       { source: { alias: undefined } },
-      { tools: { webpack: noop } },
-      { tools: { webpack: undefined } },
+      { tools: { rspack: noop } },
+      { tools: { rspack: undefined } },
     );
     expect(config).toEqual({
       source: {
         alias: {},
       },
       tools: {
-        webpack: noop,
+        rspack: noop,
       },
     });
   });
 
   test('should keep single function value', () => {
     const config = mergeRsbuildConfig(
-      { tools: { webpack: undefined } },
-      { tools: { webpack: () => ({}) } },
+      { tools: { rspack: undefined } },
+      { tools: { rspack: () => ({}) } },
     );
-    expect(typeof config.tools?.webpack).toEqual('function');
+    expect(typeof config.tools?.rspack).toEqual('function');
   });
 
   test('should merge string and string[] correctly', async () => {

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -222,4 +222,63 @@ describe('mergeRsbuildConfig', () => {
       },
     });
   });
+
+  test('should merge overrideBrowserslist in environments as expected', async () => {
+    expect(
+      mergeRsbuildConfig(
+        {
+          output: {
+            overrideBrowserslist: ['chrome 50'],
+          },
+          environments: {
+            web: {
+              output: {
+                overrideBrowserslist: ['edge 10'],
+              },
+            },
+            node: {
+              output: {
+                overrideBrowserslist: ['node 14'],
+              },
+            },
+          },
+        },
+        {
+          output: {
+            overrideBrowserslist: ['chrome 100'],
+          },
+        },
+        {
+          environments: {
+            web: {
+              output: {
+                overrideBrowserslist: ['edge 11'],
+              },
+            },
+            node: {
+              output: {
+                overrideBrowserslist: ['node 16'],
+              },
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      output: {
+        overrideBrowserslist: ['chrome 100'],
+      },
+      environments: {
+        web: {
+          output: {
+            overrideBrowserslist: ['edge 11'],
+          },
+        },
+        node: {
+          output: {
+            overrideBrowserslist: ['node 16'],
+          },
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add support for merging environments config. The `isOverridePath` helper should omit the environments name prefix.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
