### PR TITLE
feat(create-rsbuild): enable allowImportingTsExtensions

### DIFF
--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -3,12 +3,14 @@
     "target": "ES2020",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-preact-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-preact-ts/tsconfig.json
@@ -5,12 +5,14 @@
     "module": "ESNext",
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],
       "react-dom": ["./node_modules/preact/compat/"]

--- a/packages/create-rsbuild/template-react-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react-ts/tsconfig.json
@@ -4,12 +4,14 @@
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
     "jsx": "react-jsx",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -5,12 +5,14 @@
     "module": "ESNext",
     "jsx": "preserve",
     "jsxImportSource": "solid-js",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -3,12 +3,14 @@
     "target": "ES2020",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -3,12 +3,14 @@
     "target": "ES2020",
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vue2-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue2-ts/tsconfig.json
@@ -4,12 +4,14 @@
     "lib": ["DOM", "ES2020"],
     "module": "ESNext",
     "jsx": "preserve",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-vue3-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue3-ts/tsconfig.json
@@ -5,12 +5,14 @@
     "module": "ESNext",
     "jsx": "preserve",
     "jsxImportSource": "vue",
+    "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true
+    "useDefineForClassFields": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Enable `allowImportingTsExtensions` to allow TypeScript files to import each other with a TypeScript-specific extension like .ts, .mts, or .tsx.

## Related Links

https://www.typescriptlang.org/tsconfig/#allowImportingTsExtensions

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
