### PR TITLE
fix: replace Rspack's tsConfig path config

### DIFF
--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -105,13 +105,14 @@ export const pluginResolve = (): RsbuildPlugin => ({
 
     api.modifyRspackConfig(async (rspackConfig, { environment }) => {
       const { tsconfigPath } = api.context.environments[environment];
-      const isTsProject = Boolean(tsconfigPath);
       const config = api.getNormalizedConfig({ environment });
 
-      rspackConfig.resolve ||= {};
-
-      if (isTsProject && config.source.aliasStrategy === 'prefer-tsconfig') {
-        rspackConfig.resolve.tsConfigPath = tsconfigPath;
+      if (tsconfigPath && config.source.aliasStrategy === 'prefer-tsconfig') {
+        rspackConfig.resolve ||= {};
+        rspackConfig.resolve.tsConfig = {
+          configFile: tsconfigPath,
+          ...rspackConfig.resolve.tsConfig,
+        };
       }
     });
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -436,7 +436,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       ".mjs",
       ".json",
     ],
-    "tsConfigPath": "<ROOT>/packages/core/tests/tsconfig.json",
+    "tsConfig": {
+      "configFile": "<ROOT>/packages/core/tests/tsconfig.json",
+    },
   },
   "target": [
     "web",
@@ -949,7 +951,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       ".mjs",
       ".json",
     ],
-    "tsConfigPath": "<ROOT>/packages/core/tests/tsconfig.json",
+    "tsConfig": {
+      "configFile": "<ROOT>/packages/core/tests/tsconfig.json",
+    },
   },
   "target": [
     "web",
@@ -1265,7 +1269,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       ".mjs",
       ".json",
     ],
-    "tsConfigPath": "<ROOT>/packages/core/tests/tsconfig.json",
+    "tsConfig": {
+      "configFile": "<ROOT>/packages/core/tests/tsconfig.json",
+    },
   },
   "target": "node",
 }
@@ -1718,7 +1724,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
       ".mjs",
       ".json",
     ],
-    "tsConfigPath": "<ROOT>/packages/core/tests/tsconfig.json",
+    "tsConfig": {
+      "configFile": "<ROOT>/packages/core/tests/tsconfig.json",
+    },
   },
   "target": [
     "web",

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -17,7 +17,7 @@ describe('plugin-resolve', () => {
       '.mjs',
       '.json',
     ]);
-    expect(bundlerConfigs[0].resolve?.tsConfigPath).toBeDefined();
+    expect(bundlerConfigs[0].resolve?.tsConfig?.configFile).toBeDefined();
   });
 
   it('should not apply tsConfigPath when aliasStrategy is "prefer-alias"', async () => {


### PR DESCRIPTION
## Summary

Replace `resolve.tsConfigPath` with `resolve.tsConfig.configPath`, as `resolve.tsConfigPath` will be removed in Rspack 1.0.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6872

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
