### PR TITLE
fix: bump Rspack 1.0 canary, fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,16 @@
     },
     "overrides": {
       "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@1.0.28",
-      "esbuild": "~0.19.0"
+      "esbuild": "~0.19.0",
+      "@rspack/binding": "npm:@rspack/binding-canary@canary",
+      "@rspack/core": "npm:@rspack/core-canary@canary",
+      "@rspack/plugin-preact-refresh": "npm:@rspack/plugin-preact-refresh-canary@canary",
+      "@rspack/plugin-react-refresh": "npm:@rspack/plugin-react-refresh-canary@canary"
+    },
+    "peerDependencyRules": {
+      "allowAny": [
+        "@rspack/*"
+      ]
     }
   }
 }

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -109,6 +109,11 @@ export const pluginResolve = (): RsbuildPlugin => ({
 
       if (tsconfigPath && config.source.aliasStrategy === 'prefer-tsconfig') {
         rspackConfig.resolve ||= {};
+
+        if (typeof rspackConfig.resolve.tsConfig === 'string') {
+          return;
+        }
+
         rspackConfig.resolve.tsConfig = {
           configFile: tsconfigPath,
           ...rspackConfig.resolve.tsConfig,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -38,7 +38,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -78,7 +78,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -38,7 +38,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -485,7 +485,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -1323,7 +1323,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ exports[`plugin-less > should add less-loader 1`] = `
     "test": /\\\\\\.less\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -163,7 +163,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
     "test": /\\\\\\.less\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -238,7 +238,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     "test": /\\\\\\.less\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
@@ -12,7 +12,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -108,7 +108,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -186,7 +186,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should replace postcss-loade
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -55,7 +55,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
         "test": /\\\\\\.css\\$/,
         "use": [
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
           },
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -78,7 +78,7 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -146,7 +146,7 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -214,7 +214,7 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -297,7 +297,7 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
     "test": /\\\\\\.less\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -167,7 +167,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
@@ -78,7 +78,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/packages/plugin-typed-css-modules/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-typed-css-modules/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,7 @@ exports[`plugin-typed-css-modules > should apply css-modules-typescript-loader 1
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/plugin-typed-css-modules/src/loader.cjs",
@@ -84,7 +84,7 @@ exports[`plugin-typed-css-modules > should not apply css-modules-typescript-load
     "test": /\\\\\\.css\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core-canary/dist/builtin-plugin/css-extract/loader.js",
       },
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  esbuild: ~0.19.0
   array.prototype.flat: npm:@nolyfill/array.prototype.flat@1.0.28
+  esbuild: ~0.19.0
+  '@rspack/binding': npm:@rspack/binding-canary@canary
+  '@rspack/core': npm:@rspack/core-canary@canary
+  '@rspack/plugin-preact-refresh': npm:@rspack/plugin-preact-refresh-canary@canary
+  '@rspack/plugin-react-refresh': npm:@rspack/plugin-react-refresh-canary@canary
 
 importers:
 
@@ -729,8 +733,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/core':
-        specifier: 0.7.4
-        version: 0.7.4(@swc/helpers@0.5.11)
+        specifier: npm:@rspack/core-canary@canary
+        version: '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
       '@swc/helpers':
         specifier: 0.5.11
         version: 0.5.11
@@ -739,7 +743,7 @@ importers:
         version: 3.37.1
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
+        version: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -770,7 +774,7 @@ importers:
         version: 2.0.0
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.1)
+        version: 7.1.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))(webpack@5.92.1)
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -800,7 +804,7 @@ importers:
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.38)(tsx@4.14.0)(yaml@2.4.5)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.1)
+        version: 8.1.1(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.1)
       postcss-value-parser:
         specifier: 4.2.0
         version: 4.2.0
@@ -812,7 +816,7 @@ importers:
         version: 1.2.2
       rspack-manifest-plugin:
         specifier: 5.0.0
-        version: 5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.11))
+        version: 5.0.0(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))
       semver:
         specifier: ^7.6.2
         version: 7.6.2
@@ -882,7 +886,7 @@ importers:
         version: 5.0.4
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1054,7 +1058,7 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^12.2.0
-        version: 12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.92.1)
+        version: 12.2.0(less@4.2.0)(webpack@5.92.1)
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
@@ -1210,8 +1214,8 @@ importers:
         specifier: workspace:*
         version: link:../shared
       '@rspack/plugin-react-refresh':
-        specifier: 0.7.4
-        version: 0.7.4(react-refresh@0.14.2)
+        specifier: npm:@rspack/plugin-react-refresh-canary@canary
+        version: '@rspack/plugin-react-refresh-canary@0.7.5-canary-6253334-20240626035254(react-refresh@0.14.2)'
       react-refresh:
         specifier: ^0.14.2
         version: 0.14.2
@@ -1252,7 +1256,7 @@ importers:
         version: link:../../scripts/test-helper
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))
+        version: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.38)
@@ -1295,7 +1299,7 @@ importers:
         version: 5.0.0
       sass-loader:
         specifier: ^14.2.1
-        version: 14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1)
+        version: 14.2.1(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1382,7 +1386,7 @@ importers:
         version: 0.63.0
       stylus-loader:
         specifier: 8.1.0
-        version: 8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.92.1)
+        version: 8.1.0(stylus@0.63.0)(webpack@5.92.1)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1591,7 +1595,7 @@ importers:
         version: link:../shared
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.1)
+        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.1)
       webpack:
         specifier: ^5.92.1
         version: 5.92.1
@@ -1649,14 +1653,14 @@ importers:
   packages/shared:
     dependencies:
       '@rspack/core':
-        specifier: 0.7.4
-        version: 0.7.4(@swc/helpers@0.5.11)
+        specifier: npm:@rspack/core-canary@canary
+        version: '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
       caniuse-lite:
         specifier: ^1.0.30001636
         version: 1.0.30001636
       html-webpack-plugin:
         specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))
+        version: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
@@ -3489,104 +3493,56 @@ packages:
   '@rsbuild/shared@0.7.8':
     resolution: {integrity: sha512-HyX294wfBVj63BFjuR4M3wYh/xQHPlzlObLHpfrX/FFfrNo+elDdnYb0SVKfuv0V8eTpaYuaWjjYq+kk+M+mIw==}
 
-  '@rspack/binding-darwin-arm64@0.7.3':
-    resolution: {integrity: sha512-3Gg5yosndYYV0NpYiQ/+Z5UErKv5R7yijE59qVnXBRI80BbkSKUFA8Ulb4btc39l3Rx35ud4EBOALXHlLNA9CQ==}
+  '@rspack/binding-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-PzPxkB4nWe+y2EVkjJXv9ZW2Q6ukliuz6ukPFbqIRPrtu35z16m2H4eMPFNSjDp+/Pm0GV3IdCai2CNm5qCmiQ==}
+
+  '@rspack/binding-darwin-arm64-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-ev+Wo6TFLivzHJX//H48kXe4HrFpdzM9mt9rQYd3OxCF5OANV0SsFNtu1l11U0/Lp3BYvpCNfQCxORGgI2+/5Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@0.7.4':
-    resolution: {integrity: sha512-K78fUe9OhFTV61kHYCuahNkBXCFJMmqSGyIgNtLR9Psk82IVCHkvxY5565An1Quvo1UmgVh5R2YmylKE81mwiw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@0.7.3':
-    resolution: {integrity: sha512-VMOyiIGHOrwkPvvd3V8NKb0UW91hUnqJoQXdttoqbn+FNz9is/3GxPSiEyc+BISuoH1e9J9FATAq6diLqdJAAw==}
+  '@rspack/binding-darwin-x64-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-8/b5vEvNv8KeZECBrMJgWAN41rmemHJMK9fLnZ30Mfa2Ch4/D8CpUda/TxkIkIAC5Ftg8kIEqfb8SnLmsfM9yQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-darwin-x64@0.7.4':
-    resolution: {integrity: sha512-EQriu7oE+tZv25g5VJH6Ael74U42fmpb4zGs7wLmWyKfCtO6SegL3tJ8Jc6mMmp+vg949dVvkw7uB6TJjOqx2g==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-linux-arm64-gnu@0.7.3':
-    resolution: {integrity: sha512-Y1jArNhYSugH/BScvLGyodrjD0j3do1lNozSIOMXfmq0st/S5G+AmWWrxX06Ov6DudHW0EXEqC5oF9d9AbPKTg==}
+  '@rspack/binding-linux-arm64-gnu-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-6wLfMNocUy77KeZPZ4v9raAMFus50QXQpMw/SK6se5yEyFF8wabbYZMnDf8/WVrBB6IJsLOKqLVdd1v1Ly3HyA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@0.7.4':
-    resolution: {integrity: sha512-yhJLkU1zEXMyHNWhh8pBEaK6cRAjFzRK2hqejhhZ0K+lqC0Af9bKvZyXXGrMfmmHlsh1VJ9VVmi21qcXr/kdzg==}
+  '@rspack/binding-linux-arm64-musl-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-AFhO0c84Qveo6/6qUBYrfU/Ug9dG2qW9Q1cFNLOFyBDZr24/Ll+RL1Zr33cOQoQonQyYfuDjOR+moAIz2SHIsw==}
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-musl@0.7.3':
-    resolution: {integrity: sha512-R5PhdHBRUsVVtKdQNbRZyKEd7MsML3yuzXzM/3KhyYLyBUqkyMcVxgjDyFGtZsRZXmGv+N0xYKGpJVvhbukzrg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@0.7.4':
-    resolution: {integrity: sha512-6GV3Ztl6Q1zdJmNo+dwHiJd2Y/IEH9qWOh4YHiyzYGbQQYpfhhLYwKexalWaAAhdMm6KKoeqzklgHImCINImEg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-gnu@0.7.3':
-    resolution: {integrity: sha512-XX60MwIilJ4Pbvy4FVWf5CkROOa7ywnL/k8aVo6OMip62L2jiTpYfd85v/G2IQbeVDcE4967Pm782bpDFRCYfw==}
+  '@rspack/binding-linux-x64-gnu-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-F+tf01yv4Kdr7W6Zvct4Z6x/kXIzAShdSHi+GrVbOpzJ8s7Jg/hXWOAoNEux91E66EpwBYTH44R67CJVttnIXQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@0.7.4':
-    resolution: {integrity: sha512-KFdAEIZ7mPnT0y198xVOa8vIT9tgpEFVidCSIlxdk65UGC59g6UxEQq1EVAbcBi1Ou6Zza/UtxIlzk6Ev6KDkQ==}
+  '@rspack/binding-linux-x64-musl-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-cn9nkUz4Uojv6l/XKukA932Djg3imbpcupJV7cmUEk9sbxLdcm03lC1w6XFRh8X0D40vzWxkE0BI1USulBokeg==}
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-musl@0.7.3':
-    resolution: {integrity: sha512-oIRXO2NoXnWj/oIXJuNUbCIRnumfLndqR8rXui1vni91TZ+yUFkE9S7mGPrbrBAUXovOaSaHxB0YYi5hZ8fy4A==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@0.7.4':
-    resolution: {integrity: sha512-qekcXkv12oWRztZHXGzNAI92/O/+abU35/nGDycZmMtr+Qt2XS5hE1T9oBQ54yecIzUVDGNcYwhIMWBX6E2dmQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-win32-arm64-msvc@0.7.3':
-    resolution: {integrity: sha512-XeQ6z6Oc8wkkLJCAkG8TyLkciui6PB7reJLOes3yy0AXUJnd6l7gfiDcjzeHJGATVRzuuJojP/FXurBMCQ76uA==}
+  '@rspack/binding-win32-arm64-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-iRADzcOYsiPRd8fGT7zBPE53lQQ9+HtcPubSCuCcUJQCiknPO0DVUeQVIpLqF/QTHmqqculLEEnoURbCwUIMRg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@0.7.4':
-    resolution: {integrity: sha512-D1BccimBVeA/k2ty/28ER/j3s/c0n0MtN4kpyjYwgRILVLRSr+rfbC75i8wYh8r8AXjhNWNG88LmrFN9e9i7Ug==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@0.7.3':
-    resolution: {integrity: sha512-MWwswm5+v1Wd3DDJxFbCenOHOy8x+gGp0oBdLj0jlC5UntaaSvzfdb0H85AeVMYWPp584fOpAZfx0QPg3cg8yw==}
+  '@rspack/binding-win32-ia32-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-A2mxNhDI/4Dpc/43LIyovDCxK7bxRhh16H/fQEER5QQiHdsYDsfV4xIejLOLsiWlm8Wy8t9ArJfIwnHOBvmKDQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-ia32-msvc@0.7.4':
-    resolution: {integrity: sha512-5//TZH0Y4fRuTQ/ZmNOVaIfPIQXtgNAI78QxvF8Amygk4Uqklpo3ceHGP+yZfZgjh3mzjoUK+22fWbq/cUmW0w==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-x64-msvc@0.7.3':
-    resolution: {integrity: sha512-GzOTQxuJedTghyoUbW/RGbzbGRW+R1dRuZxer8Gtlv4558wxbCUj1d621nC2eZmELFc4RWbN9NFTwaecavttvQ==}
+  '@rspack/binding-win32-x64-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-w9W23pol36+k4AatC2CxfYBraU7pGs+EU14WutmS2XqJBFsXJmL/oGhfTz9wp3SpSNPsZqv4z3xS1C0WPv2i8A==}
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@0.7.4':
-    resolution: {integrity: sha512-C3ZxIEYKvnjQbV19FfQE6CGO6vcGp2JcvSQCc6SHwU/KNxLDrI1pA7XUG5TKoGSsqVEDZN6H8fJxLUYPQBjJcg==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rspack/binding@0.7.3':
-    resolution: {integrity: sha512-VYPOtaCb1lphNrHozZXy9L5ODGU76kp7ozCpYbF/CTFq8xaSkvkhNHwWMGXE2TIOvWZImMBRBuYX8/kjz/HiSA==}
-
-  '@rspack/binding@0.7.4':
-    resolution: {integrity: sha512-H1rTtYxbxe40miV2gYLPwIxEn2yMY6+bq+fjfiRu61kTvllexPMBYgFpKqSAc5Qyyto9j9uCkR4MJEYj2R/SQQ==}
-
-  '@rspack/core@0.7.3':
-    resolution: {integrity: sha512-SUvt4P1nMML3Int2YE1Z2+noDIxjT/hzNtcKMXXqeFp4yFys37s7vC+BnCyzonvIbpxUg2gH+bCMCgav7+xR4A==}
+  '@rspack/core-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-dEJ2DuNLGyqFf+DLugghwu441geGKCv0YrB8FjFDtCNQNSMx7zhL+XieYok2LBVu/uzpuwGOmmx4vGsOduv/Sg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -3594,25 +3550,8 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@rspack/core@0.7.4':
-    resolution: {integrity: sha512-HECQ0WL8iVS1Mwq2W2hfrStZZbtTPl/GjDdAZDMToPqWtSVGww99UDGIYTHW8G6kawQ3GY6wa86WTQNfXEpSCA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/plugin-react-refresh@0.7.3':
-    resolution: {integrity: sha512-fuXXqb6Lhlt1Ynz35E3OAmb1po9EGWYtDJgDqzXVfA9DPcnCPIZpbx6hOLLTYQRYLic74w11J0H2FCUXMHVg1g==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-
-  '@rspack/plugin-react-refresh@0.7.4':
-    resolution: {integrity: sha512-9tAJdG/xZ6hUtD5K5OVpwAl2yV2HFnNl5fU5aOR5VJ5Pk0rCsYwbEZRbRnmSZwzMWIKDnowhoTi+4Ha3JV3aeQ==}
+  '@rspack/plugin-react-refresh-canary@0.7.5-canary-6253334-20240626035254':
+    resolution: {integrity: sha512-YVhXTfnn9vU24JYyESndRsSV5SEexsSVfHgaY1ADTpEGpWueINiKtppjL0tMGQ6O2ivjJGFsbQtf5iKS8dM75g==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -4953,7 +4892,7 @@ packages:
     resolution: {integrity: sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
       webpack: ^5.27.0
     peerDependenciesMeta:
       '@rspack/core':
@@ -5819,7 +5758,7 @@ packages:
     resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -6241,7 +6180,7 @@ packages:
     resolution: {integrity: sha512-MYUxjSQSBUQmowc0l5nPieOYwMzGPUaTzB6inNW/bdPEG9zOL3eAAD1Qw5ZxSPk7we5dMojHwNODYMV1hq4EVg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
       less: ^3.5.0 || ^4.0.0
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -7306,7 +7245,7 @@ packages:
     resolution: {integrity: sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
       postcss: ^7.0.0 || ^8.0.1
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -7889,7 +7828,7 @@ packages:
     resolution: {integrity: sha512-Rtpn6GI4mpTASPmLOGiHzv3KqVWuWhGJG9CKO7aioPrAhukML4jtgYUvbQdBze/mZcDrvqf6sxEGRGx5fKQ+ag==}
     engines: {node: '>=14'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -8049,7 +7988,7 @@ packages:
     resolution: {integrity: sha512-G0VcnMYU18a4N7VoNDegg2OuMjYtxnqzQWARVWCIVSZwJeiL9kg8QMsuIZOplsJgTzZLF6jGxI3AClj8I9nRdQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: ^1.3.0
       sass-embedded: '*'
@@ -8386,7 +8325,7 @@ packages:
     resolution: {integrity: sha512-+Xcn5fd0azjzSXxclT31wVviXlXbBfcBamFgAQimN2qug9ZQf0OmRlK+/MJwLs1V8DJWhTFGuFwmOTkfV4KnYQ==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
-      '@rspack/core': 0.x || 1.x
+      '@rspack/core': npm:@rspack/core-canary@canary
       stylus: '>=0.52.4'
       webpack: ^5.0.0
     peerDependenciesMeta:
@@ -11087,10 +11026,10 @@ snapshots:
   '@rsbuild/core@0.7.8':
     dependencies:
       '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3)'
       '@swc/helpers': 0.5.3
       core-js: 3.36.1
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3))
       postcss: 8.4.38
 
   '@rsbuild/plugin-less@0.7.8(@rsbuild/core@0.7.8)(@swc/helpers@0.5.3)':
@@ -11104,7 +11043,7 @@ snapshots:
     dependencies:
       '@rsbuild/core': 0.7.8
       '@rsbuild/shared': 0.7.8(@swc/helpers@0.5.3)
-      '@rspack/plugin-react-refresh': 0.7.3(react-refresh@0.14.2)
+      '@rspack/plugin-react-refresh': '@rspack/plugin-react-refresh-canary@0.7.5-canary-6253334-20240626035254(react-refresh@0.14.2)'
       react-refresh: 0.14.2
     transitivePeerDependencies:
       - '@swc/helpers'
@@ -11121,129 +11060,75 @@ snapshots:
 
   '@rsbuild/shared@0.7.8(@swc/helpers@0.5.3)':
     dependencies:
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3)'
       caniuse-lite: 1.0.30001636
-      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3))
+      html-webpack-plugin: html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3))
       postcss: 8.4.38
     optionalDependencies:
       fsevents: 2.3.3
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@rspack/binding-darwin-arm64@0.7.3':
-    optional: true
-
-  '@rspack/binding-darwin-arm64@0.7.4':
-    optional: true
-
-  '@rspack/binding-darwin-x64@0.7.3':
-    optional: true
-
-  '@rspack/binding-darwin-x64@0.7.4':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-gnu@0.7.4':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@0.7.4':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-gnu@0.7.4':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@0.7.3':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@0.7.4':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-arm64-msvc@0.7.4':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@0.7.4':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@0.7.3':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@0.7.4':
-    optional: true
-
-  '@rspack/binding@0.7.3':
+  '@rspack/binding-canary@0.7.5-canary-6253334-20240626035254':
     optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.3
-      '@rspack/binding-darwin-x64': 0.7.3
-      '@rspack/binding-linux-arm64-gnu': 0.7.3
-      '@rspack/binding-linux-arm64-musl': 0.7.3
-      '@rspack/binding-linux-x64-gnu': 0.7.3
-      '@rspack/binding-linux-x64-musl': 0.7.3
-      '@rspack/binding-win32-arm64-msvc': 0.7.3
-      '@rspack/binding-win32-ia32-msvc': 0.7.3
-      '@rspack/binding-win32-x64-msvc': 0.7.3
+      '@rspack/binding-darwin-arm64': '@rspack/binding-darwin-arm64-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-darwin-x64': '@rspack/binding-darwin-x64-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-linux-arm64-gnu': '@rspack/binding-linux-arm64-gnu-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-linux-arm64-musl': '@rspack/binding-linux-arm64-musl-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-linux-x64-gnu': '@rspack/binding-linux-x64-gnu-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-linux-x64-musl': '@rspack/binding-linux-x64-musl-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-win32-arm64-msvc': '@rspack/binding-win32-arm64-msvc-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-win32-ia32-msvc': '@rspack/binding-win32-ia32-msvc-canary@0.7.5-canary-6253334-20240626035254'
+      '@rspack/binding-win32-x64-msvc': '@rspack/binding-win32-x64-msvc-canary@0.7.5-canary-6253334-20240626035254'
 
-  '@rspack/binding@0.7.4':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 0.7.4
-      '@rspack/binding-darwin-x64': 0.7.4
-      '@rspack/binding-linux-arm64-gnu': 0.7.4
-      '@rspack/binding-linux-arm64-musl': 0.7.4
-      '@rspack/binding-linux-x64-gnu': 0.7.4
-      '@rspack/binding-linux-x64-musl': 0.7.4
-      '@rspack/binding-win32-arm64-msvc': 0.7.4
-      '@rspack/binding-win32-ia32-msvc': 0.7.4
-      '@rspack/binding-win32-x64-msvc': 0.7.4
+  '@rspack/binding-darwin-arm64-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
 
-  '@rspack/core@0.7.3(@swc/helpers@0.5.3)':
+  '@rspack/binding-darwin-x64-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc-canary@0.7.5-canary-6253334-20240626035254':
+    optional: true
+
+  '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.3
-      caniuse-lite: 1.0.30001636
-      tapable: 2.2.1
-      webpack-sources: 3.2.3
-    optionalDependencies:
-      '@swc/helpers': 0.5.3
-
-  '@rspack/core@0.7.4(@swc/helpers@0.5.11)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.4
+      '@rspack/binding': '@rspack/binding-canary@0.7.5-canary-6253334-20240626035254'
       caniuse-lite: 1.0.30001636
       tapable: 2.2.1
       webpack-sources: 3.2.3
     optionalDependencies:
       '@swc/helpers': 0.5.11
 
-  '@rspack/core@0.7.4(@swc/helpers@0.5.3)':
+  '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3)':
     dependencies:
       '@module-federation/runtime-tools': 0.1.6
-      '@rspack/binding': 0.7.4
+      '@rspack/binding': '@rspack/binding-canary@0.7.5-canary-6253334-20240626035254'
       caniuse-lite: 1.0.30001636
       tapable: 2.2.1
       webpack-sources: 3.2.3
     optionalDependencies:
       '@swc/helpers': 0.5.3
-    optional: true
 
-  '@rspack/plugin-react-refresh@0.7.3(react-refresh@0.14.2)':
-    optionalDependencies:
-      react-refresh: 0.14.2
-
-  '@rspack/plugin-react-refresh@0.7.4(react-refresh@0.14.2)':
+  '@rspack/plugin-react-refresh-canary@0.7.5-canary-6253334-20240626035254(react-refresh@0.14.2)':
     optionalDependencies:
       react-refresh: 0.14.2
 
@@ -12749,7 +12634,7 @@ snapshots:
     dependencies:
       postcss: 8.4.38
 
-  css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.11))(webpack@5.92.1):
+  css-loader@7.1.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))(webpack@5.92.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.38)
       postcss: 8.4.38
@@ -12760,21 +12645,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
-      webpack: 5.92.1
-
-  css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.1):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.38)
-      postcss: 8.4.38
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.38)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.38)
-      postcss-modules-scope: 3.2.0(postcss@8.4.38)
-      postcss-modules-values: 4.0.0(postcss@8.4.38)
-      postcss-value-parser: 4.2.0
-      semver: 7.6.2
-    optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
       webpack: 5.92.1
 
   css-minimizer-webpack-plugin@5.0.1(lightningcss@1.25.1)(webpack@5.92.1):
@@ -13837,17 +13708,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.3(@swc/helpers@0.5.3)):
+  html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)):
     optionalDependencies:
-      '@rspack/core': 0.7.3(@swc/helpers@0.5.3)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
 
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.11)):
+  html-rspack-plugin@5.7.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3)):
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
-
-  html-rspack-plugin@5.7.2(@rspack/core@0.7.4(@swc/helpers@0.5.3)):
-    optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.3)'
 
   html-tags@2.0.0: {}
 
@@ -14214,11 +14081,10 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@12.2.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(less@4.2.0)(webpack@5.92.1):
+  less-loader@12.2.0(less@4.2.0)(webpack@5.92.1):
     dependencies:
       less: 4.2.0
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
       webpack: 5.92.1
 
   less@4.2.0:
@@ -15716,14 +15582,14 @@ snapshots:
       tsx: 4.14.0
       yaml: 2.4.5
 
-  postcss-loader@8.1.1(@rspack/core@0.7.4(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.1):
+  postcss-loader@8.1.1(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))(postcss@8.4.38)(typescript@5.5.2)(webpack@5.92.1):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.2)
       jiti: 1.21.6
       postcss: 8.4.38
       semver: 7.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
       webpack: 5.92.1
     transitivePeerDependencies:
       - typescript
@@ -16418,12 +16284,12 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.0.0(@rspack/core@0.7.4(@swc/helpers@0.5.11)):
+  rspack-manifest-plugin@5.0.0(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)):
     dependencies:
       tapable: 2.2.1
       webpack-sources: 2.3.1
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.11)
+      '@rspack/core': '@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11)'
 
   rspack-plugin-virtual-module@0.1.12:
     dependencies:
@@ -16542,11 +16408,10 @@ snapshots:
       sass-embedded-win32-ia32: 1.77.5
       sass-embedded-win32-x64: 1.77.5
 
-  sass-loader@14.2.1(@rspack/core@0.7.4(@swc/helpers@0.5.3))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1):
+  sass-loader@14.2.1(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
       sass: 1.77.6
       sass-embedded: 1.77.5
       webpack: 5.92.1
@@ -16874,13 +16739,12 @@ snapshots:
 
   stylis@4.3.2: {}
 
-  stylus-loader@8.1.0(@rspack/core@0.7.4(@swc/helpers@0.5.3))(stylus@0.63.0)(webpack@5.92.1):
+  stylus-loader@8.1.0(stylus@0.63.0)(webpack@5.92.1):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.63.0
     optionalDependencies:
-      '@rspack/core': 0.7.4(@swc/helpers@0.5.3)
       webpack: 5.92.1
 
   stylus@0.63.0:
@@ -17435,10 +17299,10 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.1):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(webpack@5.92.1):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)
-      css-loader: 7.1.2(@rspack/core@0.7.4(@swc/helpers@0.5.3))(webpack@5.92.1)
+      css-loader: 7.1.2(@rspack/core-canary@0.7.5-canary-6253334-20240626035254(@swc/helpers@0.5.11))(webpack@5.92.1)
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4


### PR DESCRIPTION
## Summary

bump Rspack 1.0 canary, fix `resolve.tsConfig` types.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6872

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
