### PR TITLE
fix: print and serve multiple environments html route correctly

### DIFF
--- a/e2e/cases/environments/outputs/index.test.ts
+++ b/e2e/cases/environments/outputs/index.test.ts
@@ -1,7 +1,7 @@
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should apply multiply dist path correctly', async () => {
+test('should apply multiple dist path correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {

--- a/e2e/cases/server/environments/index.test.ts
+++ b/e2e/cases/server/environments/index.test.ts
@@ -1,0 +1,86 @@
+import { dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+const cwd = __dirname;
+
+test('should serve multiply environments correctly', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      environments: {
+        web: {},
+        web1: {
+          dev: {
+            // When generating multiple environment web products, file search conflicts will occur if assetPrefix is ​​not added.
+            assetPrefix: 'auto',
+          },
+          source: {
+            entry: {
+              main: './src/web1.js',
+            },
+          },
+          output: {
+            distPath: {
+              root: 'dist/web1',
+              html: 'html1',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await page.goto(`http://localhost:${rsbuild.port}/web1/html1/main`);
+
+  const locator1 = page.locator('#test');
+  await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
+
+  await rsbuild.close();
+});
+
+// TODO: not support serve multiply environments when distPath different
+test.skip('serve multiply environments correctly when distPath different', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      environments: {
+        web: {},
+        web1: {
+          dev: {
+            assetPrefix: 'auto',
+          },
+          source: {
+            entry: {
+              main: './src/web1.js',
+            },
+          },
+          output: {
+            distPath: {
+              root: 'dist1',
+              html: 'html1',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}/dist`);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await page.goto(`http://localhost:${rsbuild.port}/dist1/html1/main`);
+
+  const locator1 = page.locator('#test');
+  await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/server/environments/index.test.ts
+++ b/e2e/cases/server/environments/index.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
 
-test('should serve multiply environments correctly', async ({ page }) => {
+test('should serve multiple environments correctly', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
     rsbuildConfig: {
@@ -43,8 +43,8 @@ test('should serve multiply environments correctly', async ({ page }) => {
   await rsbuild.close();
 });
 
-// TODO: not support serve multiply environments when distPath different
-test.skip('serve multiply environments correctly when distPath different', async ({
+// TODO: not support serve multiple environments when distPath different
+test.skip('serve multiple environments correctly when distPath different', async ({
   page,
 }) => {
   const rsbuild = await dev({

--- a/e2e/cases/server/environments/src/index.js
+++ b/e2e/cases/server/environments/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);

--- a/e2e/cases/server/environments/src/web1.js
+++ b/e2e/cases/server/environments/src/web1.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild (web1)!';
+
+document.body.appendChild(testEl);

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -33,6 +33,57 @@ test('should print server urls correctly when printUrls is true', async ({
   restore();
 });
 
+test('should print different environment server urls correctly', async ({
+  page,
+}) => {
+  const { logs, restore } = proxyConsole('log');
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: true,
+      },
+      environments: {
+        web: {
+          output: {
+            distPath: {
+              html: 'html',
+            },
+          },
+        },
+        web1: {
+          source: {
+            entry: {
+              main: './src/web1.tsx',
+            },
+          },
+          html: {
+            outputStructure: 'nested',
+          },
+          output: {
+            distPath: {
+              html: 'html1',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const localMainLog = logs.find(
+    (log) =>
+      log.includes('Local:') && log.includes('http://localhost/html1/main'),
+  );
+
+  expect(localMainLog).toBeTruthy();
+
+  await rsbuild.close();
+  restore();
+});
+
 test('should not print server urls when printUrls is false', async ({
   page,
 }) => {

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -48,14 +48,14 @@ test('should print different environment server urls correctly', async ({
         web: {
           output: {
             distPath: {
-              html: 'html',
+              html: 'html0',
             },
           },
         },
         web1: {
           source: {
             entry: {
-              main: './src/web1.tsx',
+              main: './src/index.js',
             },
           },
           html: {
@@ -73,9 +73,14 @@ test('should print different environment server urls correctly', async ({
 
   await page.goto(`http://localhost:${rsbuild.port}`);
 
+  const localIndexLog = logs.find(
+    (log) => log.includes('Local:') && log.includes('/html0'),
+  );
+
+  expect(localIndexLog).toBeTruthy();
+
   const localMainLog = logs.find(
-    (log) =>
-      log.includes('Local:') && log.includes('http://localhost/html1/main'),
+    (log) => log.includes('Local:') && log.includes('/html1/main'),
   );
 
   expect(localMainLog).toBeTruthy();

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugin-swc > should apply multiply environment configs correctly 1`] = `
+exports[`plugin-swc > should apply multiple environment configs correctly 1`] = `
 [
   {
     "module": {

--- a/packages/compat/plugin-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-swc/tests/plugin.test.ts
@@ -29,7 +29,7 @@ describe('plugin-swc', () => {
     expect(config).toMatchSnapshot();
   });
 
-  it('should apply multiply environment configs correctly', async () => {
+  it('should apply multiple environment configs correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
       rsbuildConfig: {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -94,6 +94,7 @@ export function runCli() {
     .action(async (options: PreviewOptions) => {
       try {
         const rsbuild = await init({ cliOptions: options });
+        await rsbuild?.initConfigs();
 
         if (rsbuild) {
           const { distPath } = rsbuild.context;

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -1,4 +1,4 @@
-import { type RsbuildConfig, castArray } from '@rsbuild/shared';
+import { type RsbuildConfig, castArray, cloneDeep } from '@rsbuild/shared';
 import { isFunction, isPlainObject } from './helpers';
 
 const OVERRIDE_PATHS = [
@@ -32,10 +32,10 @@ const merge = (x: unknown, y: unknown, path = '') => {
 
   // ignore undefined property
   if (x === undefined) {
-    return y;
+    return isPlainObject(y) ? cloneDeep(y) : y;
   }
   if (y === undefined) {
-    return x;
+    return isPlainObject(x) ? cloneDeep(x) : x;
   }
 
   const pair = [x, y];

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import type {
   CreateDevServerOptions,
-  Routes,
   Rspack,
   StartDevServerOptions,
 } from '@rsbuild/shared';
@@ -27,8 +26,8 @@ import {
 import {
   type StartServerResult,
   type UpgradeEvent,
-  formatRoutes,
   getAddressUrls,
+  getRoutes,
   getServerConfig,
   printServerURLs,
 } from './helper';
@@ -118,21 +117,7 @@ export async function createDevServer<
   });
   const devConfig = formatDevConfig(config.dev, port);
 
-  const routes = Object.entries(options.context.environments).reduce<Routes>(
-    (prev, [name, context]) => {
-      const environmentConfig =
-        options.context.pluginAPI?.getNormalizedConfig({ environment: name }) ||
-        config;
-
-      const routes = formatRoutes(
-        context.htmlPaths,
-        environmentConfig.output.distPath.html,
-        environmentConfig.html.outputStructure,
-      );
-      return prev.concat(...routes);
-    },
-    [],
-  );
+  const routes = getRoutes(options);
 
   options.context.devServer = {
     hostname: host,
@@ -218,7 +203,7 @@ export async function createDevServer<
     dev: devConfig,
     server: config.server,
     output: {
-      distPath: config.output.distPath.root || ROOT_DIST_DIR,
+      distPath: options.context.distPath || ROOT_DIST_DIR,
     },
     outputFileSystem,
   });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -117,7 +117,7 @@ export async function createDevServer<
   });
   const devConfig = formatDevConfig(config.dev, port);
 
-  const routes = getRoutes(options);
+  const routes = getRoutes(options.context);
 
   options.context.devServer = {
     hostname: host,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -49,20 +49,20 @@ const formatPrefix = (prefix: string | undefined) => {
   return `${hasLeadingSlash ? '' : '/'}${prefix}${hasTailSlash ? '' : '/'}`;
 };
 
-export const getRoutes = (options: { context: InternalContext }): Routes => {
-  return Object.entries(options.context.environments).reduce<Routes>(
-    (prev, [name, context]) => {
+export const getRoutes = (context: InternalContext): Routes => {
+  return Object.entries(context.environments).reduce<Routes>(
+    (prev, [name, environmentContext]) => {
       const distPrefix = relative(
-        options.context.distPath,
-        options.context.environments[name].distPath,
+        context.distPath,
+        environmentContext.distPath,
       );
 
-      const environmentConfig = options.context.pluginAPI!.getNormalizedConfig({
+      const environmentConfig = context.pluginAPI!.getNormalizedConfig({
         environment: name,
       });
 
       const routes = formatRoutes(
-        context.htmlPaths,
+        environmentContext.htmlPaths,
         join(distPrefix, environmentConfig.output.distPath.html),
         environmentConfig.html.outputStructure,
       );

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -49,7 +49,7 @@ const formatPrefix = (prefix: string | undefined) => {
   return `${hasLeadingSlash ? '' : '/'}${prefix}${hasTailSlash ? '' : '/'}`;
 };
 
-export const getRoutes = (options: { context: InternalContext }) => {
+export const getRoutes = (options: { context: InternalContext }): Routes => {
   return Object.entries(options.context.environments).reduce<Routes>(
     (prev, [name, context]) => {
       const distPrefix = relative(

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -13,8 +13,8 @@ import { logger } from '../logger';
 import type { InternalContext, NormalizedConfig } from '../types';
 import {
   type StartServerResult,
-  formatRoutes,
   getAddressUrls,
+  getRoutes,
   getServerConfig,
   printServerURLs,
 } from './helper';
@@ -189,14 +189,9 @@ export async function startProdServer(
         port,
       },
       async () => {
-        const routes = formatRoutes(
-          Object.values(context.environments).reduce(
-            (prev, context) => Object.assign(prev, context.htmlPaths),
-            {},
-          ),
-          config.output.distPath.html,
-          config.html.outputStructure,
-        );
+        const routes = getRoutes({
+          context,
+        });
         await context.hooks.onAfterStartProdServer.call({
           port,
           routes,

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -189,9 +189,7 @@ export async function startProdServer(
         port,
       },
       async () => {
-        const routes = getRoutes({
-          context,
-        });
+        const routes = getRoutes(context);
         await context.hooks.onAfterStartProdServer.call({
           port,
           routes,

--- a/packages/core/tests/__snapshots__/entry.test.ts.snap
+++ b/packages/core/tests/__snapshots__/entry.test.ts.snap
@@ -1,5 +1,24 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugin-entry > should apply different environments entry config correctly 1`] = `
+[
+  {
+    "entry": {
+      "index": [
+        "src/index.client",
+      ],
+    },
+  },
+  {
+    "entry": {
+      "main": [
+        "src/index.ssr",
+      ],
+    },
+  },
+]
+`;
+
 exports[`plugin-entry > should apply environments entry config correctly 1`] = `
 [
   {

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -75,7 +75,7 @@ exports[`plugin-output > should allow to use copy plugin 1`] = `
 }
 `;
 
-exports[`plugin-output > should allow to use copy plugin with multiply config 1`] = `
+exports[`plugin-output > should allow to use copy plugin with multiple config 1`] = `
 {
   "output": {
     "chunkFilename": "static/js/async/[name].js",

--- a/packages/core/tests/entry.test.ts
+++ b/packages/core/tests/entry.test.ts
@@ -87,4 +87,32 @@ describe('plugin-entry', () => {
     const configs = await rsbuild.initConfigs();
     expect(configs).toMatchSnapshot();
   });
+
+  it('should apply different environments entry config correctly', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginEntry()],
+      rsbuildConfig: {
+        environments: {
+          web: {
+            source: {
+              entry: {
+                index: './src/index.client',
+              },
+            },
+          },
+          ssr: {
+            source: {
+              entry: {
+                main: './src/index.ssr',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const configs = await rsbuild.initConfigs();
+
+    expect(configs).toMatchSnapshot();
+  });
 });

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -160,6 +160,39 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
+  it('should not modify the original objects when the merged config modified', () => {
+    const obj: RsbuildConfig = {
+      source: {
+        alias: {},
+      },
+    };
+
+    const other: RsbuildConfig = {};
+
+    const res = mergeRsbuildConfig(obj, other);
+
+    if (!res.source?.entry) {
+      res.source!.entry = {
+        index: './index',
+      };
+    }
+
+    expect(res).toEqual({
+      source: {
+        alias: {},
+        entry: {
+          index: './index',
+        },
+      },
+    });
+
+    expect(obj).toEqual({
+      source: {
+        alias: {},
+      },
+    });
+  });
+
   test('should merge server.open correctly', async () => {
     expect(
       mergeRsbuildConfig(

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -100,7 +100,7 @@ describe('plugin-output', () => {
     expect(bundlerConfigs[0]).toMatchSnapshot();
   });
 
-  it('should allow to use copy plugin with multiply config', async () => {
+  it('should allow to use copy plugin with multiple config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
       rsbuildConfig: {


### PR DESCRIPTION
## Summary

print and serve multiple environments html route correctly in basic case.

When we need to serve multiple environment products, rsbuild server can run correctly in the following case: 
```ts
export default defineConfig({
  plugins: [pluginReact()],
  environments: {
    web: {},
    web1: {
      dev: {
        // assetPrefix is necessary when generating multiple environment web products, file search conflicts will occur if assetPrefix is ​​not added.
        assetPrefix: 'auto',
      },
      source: {
        entry: {
          main: './src/web1.tsx',
        },
      },
      output: {
        distPath: {
          root: 'dist/web1',
        },
      },
    },
  },
});

```

At this point, the print url is as follows:
```bash
  - index    http://localhost:3000/
  - main     http://localhost:3000/web1/main
```

Warning: not support serve multiply environments when distPath is different (non-inclusive relationship), such as, `distPath.root: 'dist' ` in environment web and `distPath.root: 'dist1' `  in environment web1 


## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
