### PR TITLE
fix(typed-css-modules): missing auto function params

### DIFF
--- a/packages/plugin-typed-css-modules/tests/helper.test.ts
+++ b/packages/plugin-typed-css-modules/tests/helper.test.ts
@@ -1,40 +1,76 @@
-import { isCSSModules } from '../src/loader';
+import { type CssLoaderModules, isCSSModules } from '../src/loader';
 
 it('check isCSSModules', () => {
-  expect(isCSSModules('src/index.css', false)).toBeFalsy();
-  expect(isCSSModules('src/index.css', { auto: false })).toBeFalsy();
-  expect(isCSSModules('src/index.module.css', { auto: false })).toBeFalsy();
+  const testIsCSSModules = (
+    resourcePath: string,
+    modules: CssLoaderModules,
+  ) => {
+    return isCSSModules({
+      modules,
+      resourcePath,
+      resourceQuery: '',
+      resourceFragment: '',
+    });
+  };
 
-  expect(isCSSModules('src/index.css', true)).toBeTruthy();
+  expect(testIsCSSModules('/path/to/src/index.css', false)).toBeFalsy();
+  expect(
+    testIsCSSModules('/path/to/src/index.css', {
+      auto: false,
+      namedExport: false,
+    }),
+  ).toBeFalsy();
+  expect(
+    testIsCSSModules('/path/to/src/index.module.css', {
+      auto: false,
+      namedExport: false,
+    }),
+  ).toBeFalsy();
 
-  expect(isCSSModules('src/index.css', { auto: true })).toBeFalsy();
-  expect(isCSSModules('src/index.module.css', { auto: true })).toBeTruthy();
+  expect(testIsCSSModules('/path/to/src/index.css', true)).toBeTruthy();
 
   expect(
-    isCSSModules('src/index.module.css', {
-      auto: (path) => {
-        return path.includes('.module.');
-      },
+    testIsCSSModules('/path/to/src/index.css', {
+      auto: true,
+      namedExport: false,
+    }),
+  ).toBeFalsy();
+  expect(
+    testIsCSSModules('/path/to/src/index.module.css', {
+      auto: true,
+      namedExport: false,
     }),
   ).toBeTruthy();
 
   expect(
-    isCSSModules('src/index.css', {
+    testIsCSSModules('/path/to/src/index.module.css', {
       auto: (path) => {
         return path.includes('.module.');
       },
+      namedExport: false,
+    }),
+  ).toBeTruthy();
+
+  expect(
+    testIsCSSModules('/path/to/src/index.css', {
+      auto: (path) => {
+        return path.includes('.module.');
+      },
+      namedExport: false,
     }),
   ).toBeFalsy();
 
   expect(
-    isCSSModules('src/index.module.css', {
+    testIsCSSModules('/path/to/src/index.module.css', {
       auto: /\.module\./i,
+      namedExport: false,
     }),
   ).toBeTruthy();
 
   expect(
-    isCSSModules('src/index.css', {
+    testIsCSSModules('/path/to/src/index.css', {
       auto: /\.module\./i,
+      namedExport: false,
     }),
   ).toBeFalsy();
 });

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -79,8 +79,8 @@ If a large number of warning logs are generated due to the three-party package, 
 ```ts
 export default {
   tools: {
-    bundlerChain: (chain) => {
-      chain.ignoreWarnings([/Using \/ for division outside of calc()/]);
+    rspack: {
+      ignoreWarnings: [/Using \/ for division outside of calc()/],
     },
   },
 };

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -79,8 +79,8 @@ Inspect config succeed, open following files to view the content:
 ```ts
 export default {
   tools: {
-    bundlerChain: (chain) => {
-      chain.ignoreWarnings([/Using \/ for division outside of calc()/]);
+    rspack: {
+      ignoreWarnings: [/Using \/ for division outside of calc()/],
     },
   },
 };


### PR DESCRIPTION
## Summary

- Fix the missing auto function params for plugin-typed-css-modules.
- Prefer using `tools.rspack` instead of `tools.bundlerChain` in examples.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
