### PR TITLE
fix(config): no need to disable experiments.css

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -337,10 +337,5 @@ export const pluginCss = (): RsbuildPlugin => ({
         });
       },
     });
-
-    api.modifyRspackConfig(async (rspackConfig) => {
-      rspackConfig.experiments ||= {};
-      rspackConfig.experiments.css = false;
-    });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,7 +11,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -2,9 +2,6 @@
 
 exports[`plugin-css > should override browserslist of autoprefixer when using output.overrideBrowserslist config 1`] = `
 {
-  "experiments": {
-    "css": false,
-  },
   "module": {
     "rules": [
       {
@@ -65,9 +62,6 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
 
 exports[`plugin-css > should use custom cssModules rule when using output.cssModules config 1`] = `
 {
-  "experiments": {
-    "css": false,
-  },
   "module": {
     "rules": [
       {
@@ -134,9 +128,6 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
 
 exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyles is true and target is node 1`] = `
 {
-  "experiments": {
-    "css": false,
-  },
   "module": {
     "rules": [
       {
@@ -173,9 +164,6 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
 
 exports[`plugin-css injectStyles > should use css-loader + style-loader when injectStyles is true 1`] = `
 {
-  "experiments": {
-    "css": false,
-  },
   "module": {
     "rules": [
       {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,7 +11,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -458,7 +457,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -985,7 +983,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1300,7 +1297,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -28,7 +28,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "css": false,
   },
   "infrastructureLogging": {
     "level": "error",


### PR DESCRIPTION
## Summary

No need to disable `experiments.css` after bump Rspack 1.0 alpha, it is disabled by default.

## Related Links

https://github.com/web-infra-dev/rspack/pull/6910

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
