### PR TITLE
docs(plugin-babel): compile jsx in node_modules

### DIFF
--- a/e2e/cases/solid/hmr/rsbuild.config.ts
+++ b/e2e/cases/solid/hmr/rsbuild.config.ts
@@ -5,7 +5,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/e2e/cases/solid/index.test.ts
+++ b/e2e/cases/solid/index.test.ts
@@ -10,7 +10,6 @@ const buildFixture = (rootDir: string): ReturnType<typeof build> => {
   const plugins = [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ];

--- a/e2e/cases/solid/ref/rsbuild.config.ts
+++ b/e2e/cases/solid/ref/rsbuild.config.ts
@@ -5,7 +5,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/e2e/cases/vue/jsx-basic/rsbuild.config.ts
+++ b/e2e/cases/vue/jsx-basic/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVueJsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/e2e/cases/vue/jsx-hmr/rsbuild.config.ts
+++ b/e2e/cases/vue/jsx-hmr/rsbuild.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     pluginVue(),
     pluginBabel({
       include: /\.(?:jsx|tsx)(\.js)?$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginVueJsx(),
   ],

--- a/e2e/cases/vue/sfc-lang-jsx/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-lang-jsx/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVueJsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/e2e/cases/vue/sfc-lang-tsx/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-lang-tsx/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVueJsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/e2e/cases/vue2/jsx-basic/rsbuild.config.ts
+++ b/e2e/cases/vue2/jsx-basic/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVue2Jsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/e2e/cases/vue2/sfc-lang-jsx/rsbuild.config.ts
+++ b/e2e/cases/vue2/sfc-lang-jsx/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVue2Jsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/e2e/cases/vue2/sfc-lang-tsx/rsbuild.config.ts
+++ b/e2e/cases/vue2/sfc-lang-tsx/rsbuild.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     pluginVue2Jsx(),
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
   ],
 });

--- a/examples/solid/rsbuild.config.ts
+++ b/examples/solid/rsbuild.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid({}),
   ],

--- a/packages/create-rsbuild/template-solid-js/rsbuild.config.mjs
+++ b/packages/create-rsbuild/template-solid-js/rsbuild.config.mjs
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/packages/create-rsbuild/template-solid-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-solid-ts/rsbuild.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -34,7 +34,6 @@ export default defineConfig({
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -32,7 +32,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/website/docs/en/plugins/list/plugin-vue-jsx.mdx
+++ b/website/docs/en/plugins/list/plugin-vue-jsx.mdx
@@ -28,7 +28,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginVueJsx(),
   ],

--- a/website/docs/en/plugins/list/plugin-vue2-jsx.mdx
+++ b/website/docs/en/plugins/list/plugin-vue2-jsx.mdx
@@ -32,7 +32,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginVue2Jsx(),
   ],

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -34,7 +34,6 @@ export default defineConfig({
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -28,7 +28,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginSolid(),
   ],

--- a/website/docs/zh/plugins/list/plugin-vue-jsx.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue-jsx.mdx
@@ -28,7 +28,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginVueJsx(),
   ],

--- a/website/docs/zh/plugins/list/plugin-vue2-jsx.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue2-jsx.mdx
@@ -28,7 +28,6 @@ export default {
   plugins: [
     pluginBabel({
       include: /\.(?:jsx|tsx)$/,
-      exclude: /[\\/]node_modules[\\/]/,
     }),
     pluginVue2Jsx(),
   ],


### PR DESCRIPTION
## Summary

Update the pluginBabel examples to allow compiling .jsx files in the node_modules.

## Related Links

close https://github.com/web-infra-dev/rsbuild/issues/2727

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
