### PR TITLE
test(ut): prefer using matchRules helper

### DIFF
--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -1,5 +1,4 @@
-import { SCRIPT_REGEX } from '@rsbuild/shared';
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createStubRsbuild, matchRules } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
 import { pluginBabel } from '../src';
 
@@ -20,12 +19,7 @@ describe('plugins/babel', () => {
     rsbuild.addPlugins([pluginBabel()]);
 
     const config = await rsbuild.unwrapConfig();
-
-    expect(
-      config.module.rules.find(
-        (r) => r.test.toString() === SCRIPT_REGEX.toString(),
-      ),
-    ).toMatchSnapshot();
+    expect(matchRules(config, 'a.tsx')[0]).toMatchSnapshot();
   });
 
   it('should apply environment config correctly', async () => {
@@ -66,12 +60,7 @@ describe('plugins/babel', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
 
     for (const bundlerConfig of bundlerConfigs) {
-      const rules = bundlerConfig.module?.rules?.find(
-        (r) =>
-          (typeof r === 'object' ? r?.test?.toString() : '') ===
-          SCRIPT_REGEX.toString(),
-      );
-      expect(rules).toMatchSnapshot();
+      expect(matchRules(bundlerConfig, 'a.tsx')[0]).toMatchSnapshot();
     }
   });
 

--- a/packages/plugin-styled-components/tests/index.test.ts
+++ b/packages/plugin-styled-components/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { createRsbuild } from '@rsbuild/core';
-import { SCRIPT_REGEX } from '@rsbuild/shared';
+import { matchRules } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
 import { pluginStyledComponents } from '../src';
 
@@ -11,16 +11,8 @@ describe('plugins/styled-components', () => {
       },
     });
 
-    rsbuild.addPlugins([pluginStyledComponents()]);
     const configs = await rsbuild.initConfigs();
-
-    expect(
-      configs[0].module?.rules?.find(
-        (rule) =>
-          (rule as { test: RegExp }).test.toString() ===
-          SCRIPT_REGEX.toString(),
-      ),
-    ).toMatchSnapshot();
+    expect(matchRules(configs[0], 'a.tsx')[0]).toMatchSnapshot();
   });
 
   it('should enable ssr option when target contains node', async () => {
@@ -45,13 +37,7 @@ describe('plugins/styled-components', () => {
     const configs = await rsbuild.initConfigs();
 
     for (const config of configs) {
-      expect(
-        config.module?.rules?.find(
-          (rule) =>
-            (rule as { test: RegExp }).test.toString() ===
-            SCRIPT_REGEX.toString(),
-        ),
-      ).toMatchSnapshot();
+      expect(matchRules(config, 'a.tsx')[0]).toMatchSnapshot();
     }
   });
 });

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -6,7 +6,7 @@ import type { Config } from '@svgr/core';
 
 export type SvgDefaultExport = 'component' | 'url';
 
-export const SVG_REGEX: RegExp = /\.svg$/;
+const SVG_REGEX = /\.svg$/;
 
 export type PluginSvgrOptions = {
   /**

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { pluginReact } from '@rsbuild/plugin-react';
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createStubRsbuild, matchRules } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
-import { type PluginSvgrOptions, SVG_REGEX, pluginSvgr } from '../src';
+import { type PluginSvgrOptions, pluginSvgr } from '../src';
 
 describe('svgr', () => {
   const cases: Array<{ name: string; pluginConfig: PluginSvgrOptions }> = [
@@ -61,9 +61,6 @@ describe('svgr', () => {
     rsbuild.addPlugins([pluginSvgr(item.pluginConfig), pluginReact()]);
 
     const config = await rsbuild.unwrapConfig();
-
-    expect(
-      config.module.rules.find((r) => r.test === SVG_REGEX),
-    ).toMatchSnapshot();
+    expect(matchRules(config, 'a.svg')[0]).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

- Prefer using matchRules helper instead of get the script test RegExp.
- Remove unused `matchLoader` helper.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
