### PR TITLE
fix(plugin-svelte): failed to HMR with style tag

### DIFF
--- a/e2e/cases/svelte/hmr/src/B.svelte
+++ b/e2e/cases/svelte/hmr/src/B.svelte
@@ -5,3 +5,12 @@
 <main>
   <button id="B">B: {count}</button>
 </main>
+
+<style>
+  #B {
+    color: #ff3e00;
+    text-transform: uppercase;
+    font-size: 4em;
+    font-weight: 100;
+  }
+</style>

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -61,7 +61,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
       }
 
       api.modifyBundlerChain(
-        async (chain, { CHAIN_ID, environment, isDev }) => {
+        async (chain, { CHAIN_ID, environment, isDev, isProd }) => {
           const { default: sveltePreprocess } = await import(
             'svelte-preprocess'
           );
@@ -97,7 +97,9 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
                 dev: isDev,
               },
               preprocess: sveltePreprocess(options.preprocessOptions),
-              emitCss: !environmentConfig.output.injectStyles,
+              // NOTE emitCss: true is currently not supported with HMR
+              // See https://github.com/web-infra-dev/rsbuild/issues/2744
+              emitCss: isProd && !environmentConfig.output.injectStyles,
               hotReload: isDev && environmentConfig.dev.hmr,
             },
             options.svelteLoaderOptions ?? {},

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -13,7 +13,7 @@ exports[`plugin-svelte > should add svelte loader properly 1`] = `
               "compilerOptions": {
                 "dev": false,
               },
-              "emitCss": true,
+              "emitCss": false,
               "hotReload": false,
               "preprocess": {
                 "markup": [Function],

--- a/website/docs/en/plugins/list/plugin-svelte.mdx
+++ b/website/docs/en/plugins/list/plugin-svelte.mdx
@@ -38,7 +38,7 @@ If you need to customize the compilation behavior of Svelte, you can use the fol
 
 Options passed to `svelte-loader`, please refer to the [svelte-loader documentation](https://github.com/sveltejs/svelte-loader) for detailed usage.
 
-- **Type:** `Object`
+- **Type:** `SvelteLoaderOptions`
 - **Default:**
 
 ```js
@@ -47,7 +47,7 @@ const defaultOptions = {
     dev: isDev,
   },
   preprocess: require('svelte-preprocess')(),
-  emitCss: !rsbuildConfig.output.injectStyles,
+  emitCss: isProd && !rsbuildConfig.output.injectStyles,
   hotReload: isDev && rsbuildConfig.dev.hmr,
 };
 ```

--- a/website/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/website/docs/zh/plugins/list/plugin-svelte.mdx
@@ -38,7 +38,7 @@ export default {
 
 传递给 `svelte-loader` 的选项，请查阅 [svelte-loader 文档](https://github.com/sveltejs/svelte-loader) 来了解具体用法。
 
-- **类型：** `Object`
+- **类型：** `SvelteLoaderOptions`
 - **默认值：**
 
 ```js
@@ -47,7 +47,7 @@ const defaultOptions = {
     dev: isDev,
   },
   preprocess: require('svelte-preprocess')(),
-  emitCss: !rsbuildConfig.output.injectStyles,
+  emitCss: isProd && !rsbuildConfig.output.injectStyles,
   hotReload: isDev && rsbuildConfig.dev.hmr,
 };
 ```


### PR DESCRIPTION
## Summary

Fix plugin-svelte failed to HMR with style tag.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/2744

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
