### PR TITLE
fix(create-rsbuild): enable verbatimModuleSyntax for svelte

### DIFF
--- a/e2e/cases/svelte/ts/tsconfig.json
+++ b/e2e/cases/svelte/ts/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "module": "ESNext"
+    "module": "ESNext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src"]
 }

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -6,6 +6,9 @@
     "noEmit": true,
     "strict": true,
     "skipLibCheck": true,
+    // svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
+    // to enforce using `import type` instead of `import` for Types.
+    "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

Enable verbatimModuleSyntax for svelte to fix the compiler warning:

<img width="1178" alt="Screenshot 2024-07-02 at 11 35 35" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/06243984-4525-4d74-a95b-0ea0bd78451d">

## Related Links

https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
