### PR TITLE
fix(server): should match resource correctly with full url assetPrefix

### DIFF
--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build } from '@e2e/helper';
+import { build, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
@@ -246,6 +246,68 @@ test('should access /html/main success when entry is main and outputPath is /htm
   const res = await page.goto(url1.href);
 
   expect(res?.status()).toBe(404);
+
+  await rsbuild.close();
+});
+
+test('should match resource correctly with specify assetPrefix', async ({
+  page,
+}) => {
+  const port = await getRandomPort();
+
+  const rsbuild = await build({
+    cwd: fixtures,
+    runServer: true,
+    rsbuildConfig: {
+      server: {
+        port,
+      },
+      output: {
+        assetPrefix: '/subpath/',
+        distPath: {
+          root: 'dist-8',
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});
+
+test('should match resource correctly with full url assetPrefix', async ({
+  page,
+}) => {
+  const port = await getRandomPort();
+
+  const rsbuild = await build({
+    cwd: fixtures,
+    runServer: true,
+    rsbuildConfig: {
+      server: {
+        port,
+      },
+      output: {
+        assetPrefix: `http://localhost:${port}/subpath/`,
+        distPath: {
+          root: 'dist-8',
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}/`);
+
+  await page.goto(url.href);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
 
   await rsbuild.close();
 });

--- a/e2e/cases/server/assetPrefix/index.test.ts
+++ b/e2e/cases/server/assetPrefix/index.test.ts
@@ -1,0 +1,54 @@
+import { dev, getRandomPort, gotoPage } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should match resource correctly with specify assetPrefix', async ({
+  page,
+}) => {
+  const port = await getRandomPort();
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        assetPrefix: '/subpath/',
+      },
+      server: {
+        port,
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  expect(rsbuild.port).toBe(port);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});
+
+test('should match resource correctly with full url assetPrefix', async ({
+  page,
+}) => {
+  const port = await getRandomPort();
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        assetPrefix: `http://localhost:${port}/subpath/`,
+      },
+      server: {
+        port,
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  expect(rsbuild.port).toBe(port);
+
+  const locator = page.locator('#test');
+  await expect(locator).toHaveText('Hello Rsbuild!');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/server/assetPrefix/src/index.js
+++ b/e2e/cases/server/assetPrefix/src/index.js
@@ -1,0 +1,5 @@
+const testEl = document.createElement('div');
+testEl.id = 'test';
+testEl.innerHTML = 'Hello Rsbuild!';
+
+document.body.appendChild(testEl);

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -33,3 +33,11 @@ export const getCompiledPath = (packageName: string): string =>
  */
 export const ensureAbsolutePath = (base: string, filePath: string): string =>
   isAbsolute(filePath) ? filePath : resolve(base, filePath);
+
+export const pathnameParse = (publicPath: string): string => {
+  try {
+    return publicPath ? new URL(publicPath).pathname : publicPath;
+  } catch (err) {
+    return publicPath;
+  }
+};

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -6,6 +6,7 @@ import type {
   DevMiddlewareAPI,
 } from './devMiddleware';
 import { SocketServer } from './socketServer';
+import { pathParse } from './helper';
 
 type Options = {
   publicPaths: string[];
@@ -122,6 +123,8 @@ export class CompilerDevMiddleware {
       etag: 'weak',
     });
 
+    const assetPrefixes = publicPaths.map(pathParse);
+
     const warp = async (
       req: IncomingMessage,
       res: ServerResponse,
@@ -129,7 +132,7 @@ export class CompilerDevMiddleware {
     ) => {
       const { url } = req;
       const assetPrefix =
-        url && publicPaths.find((prefix) => url.startsWith(prefix));
+        url && assetPrefixes.find((prefix) => url.startsWith(prefix));
 
       // slice publicPath, static asset have publicPath but html does not.
       if (assetPrefix && assetPrefix !== '/') {

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -1,11 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Socket } from 'node:net';
 import type { DevConfig, NextFunction, ServerConfig } from '@rsbuild/shared';
+import { pathnameParse } from '../helpers/path';
 import type {
   DevMiddleware as CustomDevMiddleware,
   DevMiddlewareAPI,
 } from './devMiddleware';
-import { pathParse } from './helper';
 import { SocketServer } from './socketServer';
 
 type Options = {
@@ -123,7 +123,7 @@ export class CompilerDevMiddleware {
       etag: 'weak',
     });
 
-    const assetPrefixes = publicPaths.map(pathParse);
+    const assetPrefixes = publicPaths.map(pathnameParse);
 
     const warp = async (
       req: IncomingMessage,

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -5,8 +5,8 @@ import type {
   DevMiddleware as CustomDevMiddleware,
   DevMiddlewareAPI,
 } from './devMiddleware';
-import { SocketServer } from './socketServer';
 import { pathParse } from './helper';
+import { SocketServer } from './socketServer';
 
 type Options = {
   publicPaths: string[];

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -50,14 +50,6 @@ const formatPrefix = (prefix: string | undefined) => {
   return `${hasLeadingSlash ? '' : '/'}${prefix}${hasTailSlash ? '' : '/'}`;
 };
 
-export const pathParse = (publicPath: string): string => {
-  try {
-    return publicPath ? new URL(publicPath).pathname : publicPath;
-  } catch (err) {
-    return publicPath;
-  }
-};
-
 export const getRoutes = (context: InternalContext): Routes => {
   return Object.entries(context.environments).reduce<Routes>(
     (prev, [name, environmentContext]) => {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -50,6 +50,14 @@ const formatPrefix = (prefix: string | undefined) => {
   return `${hasLeadingSlash ? '' : '/'}${prefix}${hasTailSlash ? '' : '/'}`;
 };
 
+export const pathParse = (publicPath: string): string => {
+  try {
+    return publicPath ? new URL(publicPath).pathname : publicPath;
+  } catch (err) {
+    return publicPath;
+  }
+};
+
 export const getRoutes = (context: InternalContext): Routes => {
   return Object.entries(context.environments).reduce<Routes>(
     (prev, [name, environmentContext]) => {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -16,12 +16,12 @@ import {
   getServerConfig,
   printServerURLs,
 } from './helper';
+import { pathParse } from './helper';
 import { createHttpServer } from './httpServer';
 import {
   faviconFallbackMiddleware,
   getRequestLoggerMiddleware,
 } from './middlewares';
-import { pathParse } from './helper';
 
 type RsbuildProdServerOptions = {
   pwd: string;

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,13 +1,11 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
-import { join } from 'node:path';
 import type {
   PreviewServerOptions,
   RequestHandler,
   ServerConfig,
 } from '@rsbuild/shared';
 import type Connect from 'connect';
-import { ROOT_DIST_DIR } from '../constants';
 import { getNodeEnv, setNodeEnv } from '../helpers';
 import { logger } from '../logger';
 import type { InternalContext, NormalizedConfig } from '../types';
@@ -23,12 +21,13 @@ import {
   faviconFallbackMiddleware,
   getRequestLoggerMiddleware,
 } from './middlewares';
+import { pathParse } from './helper';
 
 type RsbuildProdServerOptions = {
   pwd: string;
   output: {
     path: string;
-    assetPrefix?: string;
+    assetPrefixes: string[];
   };
   serverConfig: ServerConfig;
 };
@@ -110,14 +109,13 @@ export class RsbuildProdServer {
 
   private async applyStaticAssetMiddleware() {
     const {
-      output: { path, assetPrefix },
+      output: { path, assetPrefixes },
       serverConfig: { htmlFallback },
-      pwd,
     } = this.options;
 
     const { default: sirv } = await import('sirv');
 
-    const assetMiddleware = sirv(join(pwd, path), {
+    const assetMiddleware = sirv(path, {
       etag: true,
       dev: true,
       ignores: ['favicon.ico'],
@@ -126,6 +124,8 @@ export class RsbuildProdServer {
 
     this.middlewares.use((req, res, next) => {
       const url = req.url;
+      const assetPrefix =
+        url && assetPrefixes.find((prefix) => url.startsWith(prefix));
 
       // handler assetPrefix
       if (assetPrefix && url?.startsWith(assetPrefix)) {
@@ -165,8 +165,10 @@ export async function startProdServer(
     {
       pwd: context.rootPath,
       output: {
-        path: config.output.distPath.root || ROOT_DIST_DIR,
-        assetPrefix: config.output.assetPrefix,
+        path: context.distPath,
+        assetPrefixes: Object.values(
+          context.normalizedConfig?.environments || [],
+        ).map((e) => pathParse(e.output.assetPrefix)),
       },
       serverConfig,
     },

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -166,9 +166,9 @@ export async function startProdServer(
       pwd: context.rootPath,
       output: {
         path: context.distPath,
-        assetPrefixes: Object.values(
-          context.normalizedConfig?.environments || {},
-        ).map((e) => pathnameParse(e.output.assetPrefix)),
+        assetPrefixes: Object.values(context.environments).map((e) =>
+          pathnameParse(e.config.output.assetPrefix),
+        ),
       },
       serverConfig,
     },

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -7,6 +7,7 @@ import type {
 } from '@rsbuild/shared';
 import type Connect from 'connect';
 import { getNodeEnv, setNodeEnv } from '../helpers';
+import { pathnameParse } from '../helpers/path';
 import { logger } from '../logger';
 import type { InternalContext, NormalizedConfig } from '../types';
 import {
@@ -16,7 +17,6 @@ import {
   getServerConfig,
   printServerURLs,
 } from './helper';
-import { pathParse } from './helper';
 import { createHttpServer } from './httpServer';
 import {
   faviconFallbackMiddleware,
@@ -167,8 +167,8 @@ export async function startProdServer(
       output: {
         path: context.distPath,
         assetPrefixes: Object.values(
-          context.normalizedConfig?.environments || [],
-        ).map((e) => pathParse(e.output.assetPrefix)),
+          context.normalizedConfig?.environments || {},
+        ).map((e) => pathnameParse(e.output.assetPrefix)),
       },
       serverConfig,
     },


### PR DESCRIPTION
## Summary

should match resource correctly with full url assetPrefix, like below:
```ts
export default defineConfig({
  dev: {
    assetPrefix: 'http://localhost:3000/subpath/,
  },
});
```

## Related Links

fix: #2747

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
