### PR TITLE
docs: fix typo in exportsPresence example

### DIFF
--- a/website/docs/en/guide/faq/exceptions.mdx
+++ b/website/docs/en/guide/faq/exceptions.mdx
@@ -97,7 +97,7 @@ export default {
       module: {
         parser: {
           javascript: {
-            exportsPresence: 'error',
+            exportsPresence: 'warn',
           },
         },
       },
@@ -108,7 +108,7 @@ export default {
 
 However, it is important to contact the developer of the third-party dependency immediately to fix the issue.
 
-> You can refer to the webpack documentation for more details on [module.parser.javascript.exportsPresence](https://www.rspack.dev/config/module#moduleparserjavascriptexportspresence).
+> You can refer to the Rspack documentation for more details on [module.parser.javascript.exportsPresence](https://rspack.dev/config/module#moduleparserjavascriptexportspresence).
 
 ---
 

--- a/website/docs/zh/guide/faq/exceptions.mdx
+++ b/website/docs/zh/guide/faq/exceptions.mdx
@@ -97,7 +97,7 @@ export default {
       module: {
         parser: {
           javascript: {
-            exportsPresence: 'error',
+            exportsPresence: 'warn',
           },
         },
       },
@@ -108,7 +108,7 @@ export default {
 
 同时，你需要尽快联系第三方依赖的开发者来修复相应的问题。
 
-> 你可以查看 webpack 的文档来了解 [module.parser.javascript.exportsPresence](https://www.rspack.dev/config/module#moduleparserjavascriptexportspresence) 的更多细节。
+> 你可以查看 Rspack 的文档来了解 [module.parser.javascript.exportsPresence](https://rspack.dev/config/module#moduleparserjavascriptexportspresence) 的更多细节。
 
 ---
 


### PR DESCRIPTION
## Summary

Fix typo in the exportsPresence example.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
