### PR TITLE
Release v1.0.0-alpha.0

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -42,7 +42,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -41,7 +41,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-css-minimizer/package.json
+++ b/packages/plugin-css-minimizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-css-minimizer",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "CSS minimizer for Rsbuild",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-eslint/package.json
+++ b/packages/plugin-eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-eslint",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "ESLint plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9",
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0",
     "eslint": "^8.0.0 || ^9.0.0"
   },
   "publishConfig": {

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -41,7 +41,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-node-polyfill/package.json
+++ b/packages/plugin-node-polyfill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-node-polyfill",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Node polyfill plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -56,7 +56,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-pug/package.json
+++ b/packages/plugin-pug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-pug",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Pug plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -35,7 +35,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -44,7 +44,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-umd/package.json
+++ b/packages/plugin-umd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-umd",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "UMD plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -31,7 +31,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^0.7.9"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/shared",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "description": "The internal shared modules and dependencies of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "0.7.9",
+  "version": "1.0.0-alpha.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(deps)!: bump Rspack 1.0 alpha by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2722
* feat!: enable LightningCSS minimizer as default CSS minimizer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2716
* feat(server): support load SSR module by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2528
* feat: support environment config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2633
* feat: expose `reduceConfigs` helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2631
* feat!: replace output.targets with output.target by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2636
* feat!: remove deprecated `dev.startUrl` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2642
* feat: allow to use port placeholder in `client.port` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2641
* feat: support read environments source.entry config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2643
* feat!: add browserslist to context.environments by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2646
* feat!: output.emitAssets changed to boolean type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2649
* feat!: remove `target` param for `source.alias` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2650
* feat: support apply environment html-related config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2647
* feat: support apply more environment configs by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2652
* feat: use environment name as progress id by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2670
* feat: handle more cases in ensureAssetPrefix helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2671
* feat(deps): bump core-js v3.37 and @swc/helpers by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2673
* feat!: decorators version defaults to `2022-03` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2677
* feat(styled-components): use SWC Wasm plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2679
* feat: support apply environment bundleAnalyze config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2682
* feat(type-check): allow to check multiple tsconfig files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2684
* feat: print file size grouped by environment by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2683
* feat: support apply environment nonce config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2685
* feat(source-build): support for flat conditional exports by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2688
* types: allow to configure dev in environments by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2695
* feat: support for merging environments config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2700
* feat: add modifyEnvironmentConfig hook by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2707
* feat: support apply environment moduleFederation config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2692
* feat(create-rsbuild): enable allowImportingTsExtensions by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2710
* feat: add basic server environment api by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2714
* feat: allow to configure progress bar by environment by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2730
* feat: support output environment config when inspect config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2738
### Performance 🚀
* perf(core): remove fs-extra dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2637
### Bug Fixes 🐞
* fix: preload util type assertion by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2638
* fix: HMR not work on online IDEs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2639
* fix: apply default dev config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2640
* fix: failed to empty dir in some cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2658
* fix: should not print empty urls if target is node by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2659
* fix: bundle analyze with environment name by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2681
* fix!: remove context.tsconfigPath by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2690
* fix: remove unused lazy compilation wrapper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2691
* fix: rspack profile outputPath unexpected by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2693
* fix!: remove `output.distPath.server` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2696
* fix!: remove function usage of `source.entry` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2697
* fix(plugin-sass): additionalData function type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2708
* fix: replace Rspack's tsConfig path config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2711
* fix: bump Rspack 1.0 canary, fix types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2712
* fix: print and serve multiple environments html route correctly by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2713
* fix(typed-css-modules): missing auto function params by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2715
* fix!(plugin-lightningcss): remove minify option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2717
* fix: no longer filter rsbuild config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2718
* fix(ci): use canary specific version instead of npm tag by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/2720
* fix(config): no need to disable experiments.css by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2728
* fix(image-compress): prefer using Rspack types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2740
* fix: error message in decorator by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/2748
* fix(plugin-svelte): failed to HMR with style tag by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2749
* fix(create-rsbuild): enable verbatimModuleSyntax for svelte by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2750
* fix(plugin-vue2): apply js resolve config to vue2 sfc template by @xc2 in https://github.com/web-infra-dev/rsbuild/pull/2753
### Document 📖
* docs: add conventional commits link to contributing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2644
* docs: override browserslist by environment by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2648
* docs: support htmlPlugin param in tools.rspack utils by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2651
* docs: add basic environment config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2654
* docs: update releases page for 1.0 release by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2666
* docs: update relay example to use SWC plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2678
* docs: add guide for Preact by @fi3ework in https://github.com/web-infra-dev/rsbuild/pull/2694
* docs: update document for `output.target` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2698
* docs: update badge links in README by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2701
* docs: update dev command in webpack.mdx by @mwarger in https://github.com/web-infra-dev/rsbuild/pull/2699
* docs: update assets URLs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2719
* docs(plugin-babel): compile jsx in node_modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2729
* docs: fix typo in exportsPresence example by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2755
### Other Changes
* chore: move node env helpers to core by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2634
* chore: prefer using Node builtin fs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2635
* chore(deps): bump typescript v5.5 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2653
* chore: enable html plugins if has html paths by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2655
* refactor!: remove service-worker target by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2657
* chore(deps): update dependency launch-editor-middleware to ^2.8.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2663
* chore(deps): update dependency @modern-js/module-tools to ^2.54.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2661
* chore(config): remove allowJs true by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2667
* chore(build): emit bundleless declaration files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2668
* chore: add formatter config to VS Code setting by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2669
* chore(deps): update dependency globals to ^15.6.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2662
* chore(deps): update dependency nx to ^19.3.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2664
* chore: merge shared modules by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2672
* chore(deps): update dependency typescript-eslint to ^7.13.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2674
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2675
* refactor!: update api.context, remove `entry`, `targets` properties by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2680
* chore: extract getCommonParentPath helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2686
* chore(deps): update dependency vue-router to ^4.4.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2676
* chore(deps): update dependency svelte-preprocess to v6 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2605
* chore(deps): update dependency eslint-plugin-svelte to ^2.41.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2702
* chore: update renovate config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2704
* chore(deps): update copy-webpack-plugin to v11 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2705
* refactor: enable TypeScript isolatedDeclarations by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2709
* refactor: use environment param instead of context.environment by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2721
* chore(deps): update dependency react-router-dom to ^6.24.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2723
* chore: remove script condition helper from shared by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2731
* test(ut): prefer using matchRules helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2732
* chore: move toml plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2733
* chore: move yaml plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2734
* chore(deps): update eslint by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2724
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2735
* chore: move mdx plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2739
* chore: move basic-ssl plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2746

## New Contributors
* @mwarger made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2699

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v0.7.10...v1.0.0-alpha.0