### PR TITLE
fix(create-rsbuild): should lock alpha version

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -229,13 +229,24 @@ function copyFolder(src: string, dist: string, version: string, name?: string) {
   }
 }
 
+const isStableVersion = (version: string) => {
+  return ['alpha', 'beta', 'rc', 'canary', 'nightly'].every(
+    (tag) => !version.includes(tag),
+  );
+};
+
 const updatePackageJson = (
   pkgJsonPath: string,
   version: string,
   name?: string,
 ) => {
   let content = fs.readFileSync(pkgJsonPath, 'utf-8');
-  content = content.replace(/workspace:\*/g, `^${version}`);
+
+  // Lock the version if it is not stable
+  const targetVersion = isStableVersion(version) ? `^${version}` : version;
+
+  content = content.replace(/workspace:\*/g, targetVersion);
+
   const pkg = JSON.parse(content);
 
   if (name && name !== '.') {


### PR DESCRIPTION
## Summary

Should lock the version when run `npm create rsbuild@alpha`, otherwise npm will resolve to `1.0.0` stable version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
