### PR TITLE
feat: add environments param into rsbuild api

### DIFF
--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -21,6 +21,7 @@ export async function createCompiler({
   logger.debug('create compiler');
   await context.hooks.onBeforeCreateCompiler.call({
     bundlerConfigs: webpackConfigs as RspackConfig[],
+    environments: context.environments,
   });
 
   const { default: webpack } = await import('webpack');
@@ -48,6 +49,7 @@ export async function createCompiler({
       await context.hooks.onDevCompileDone.call({
         isFirstCompile,
         stats: stats as Stats,
+        environments: context.environments,
       });
     }
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -32,6 +32,7 @@ export async function createCompiler({
   logger.debug('create compiler');
   await context.hooks.onBeforeCreateCompiler.call({
     bundlerConfigs: rspackConfigs,
+    environments: context.environments,
   });
 
   if (!(await isSatisfyRspackVersion(rspack.rspackVersion))) {
@@ -108,6 +109,7 @@ export async function createCompiler({
       await context.hooks.onDevCompileDone.call({
         isFirstCompile,
         stats: stats,
+        environments: context.environments,
       });
     }
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -345,6 +345,7 @@ export async function createDevServer<
       await options.context.hooks.onAfterStartDevServer.call({
         port,
         routes,
+        environments: options.context.environments,
       });
     },
     onHTTPUpgrade: devMiddlewares.onUpgrade,

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -29,6 +29,7 @@ export type OnCloseDevServerFn = () => MaybePromise<void>;
 export type OnDevCompileDoneFn = (params: {
   isFirstCompile: boolean;
   stats: Stats | MultiStats;
+  environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnBeforeStartDevServerFn = (params: {
@@ -45,6 +46,7 @@ export type Routes = Array<{
 export type OnAfterStartDevServerFn = (params: {
   port: number;
   routes: Routes;
+  environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnAfterStartProdServerFn = (params: {
@@ -54,6 +56,7 @@ export type OnAfterStartProdServerFn = (params: {
 
 export type OnBeforeCreateCompilerFn<B = 'rspack'> = (params: {
   bundlerConfigs: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
+  environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnAfterCreateCompilerFn<

--- a/website/docs/en/shared/onAfterBuild.mdx
+++ b/website/docs/en/shared/onAfterBuild.mdx
@@ -9,6 +9,7 @@ function OnAfterBuild(
   callback: (params: {
     isFirstCompile: boolean;
     stats?: Stats | MultiStats;
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/en/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/en/shared/onAfterCreateCompiler.mdx
@@ -7,5 +7,6 @@ You can access the [Compiler instance](https://webpack.js.org/api/node/#compiler
 ```ts
 function OnAfterCreateCompiler(callback: (params: {
   compiler: Compiler | MultiCompiler;
+  environments: Record<string, EnvironmentContext>;
 }) => Promise<void> | void;): void;
 ```

--- a/website/docs/en/shared/onAfterStartDevServer.mdx
+++ b/website/docs/en/shared/onAfterStartDevServer.mdx
@@ -9,6 +9,10 @@ type Routes = Array<{
 }>;
 
 function OnAfterStartDevServer(
-  callback: (params: { port: number; routes: Routes }) => Promise<void> | void,
+  callback: (params: {
+    port: number;
+    routes: Routes;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/en/shared/onBeforeBuild.mdx
+++ b/website/docs/en/shared/onBeforeBuild.mdx
@@ -8,6 +8,7 @@ You can access the Rspack configuration array through the `bundlerConfigs` param
 function OnBeforeBuild(
   callback: (params: {
     bundlerConfigs?: WebpackConfig[] | RspackConfig[];
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/en/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/en/shared/onBeforeCreateCompiler.mdx
@@ -8,6 +8,7 @@ You can access the Rspack configuration array through the `bundlerConfigs` param
 function OnBeforeCreateCompiler(
   callback: (params: {
     bundlerConfigs: WebpackConfig[] | RspackConfig[];
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/en/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/en/shared/onBeforeStartDevServer.mdx
@@ -3,5 +3,9 @@ Called before starting the dev server.
 - **Type:**
 
 ```ts
-function OnBeforeStartDevServer(callback: () => Promise<void> | void): void;
+function OnBeforeStartDevServer(
+  callback: (params: {
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
+): void;
 ```

--- a/website/docs/en/shared/onDevCompileDone.mdx
+++ b/website/docs/en/shared/onDevCompileDone.mdx
@@ -7,6 +7,7 @@ function OnDevCompileDone(
   callback: (params: {
     isFirstCompile: boolean;
     stats: Stats | MultiStats;
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onAfterBuild.mdx
+++ b/website/docs/zh/shared/onAfterBuild.mdx
@@ -9,6 +9,7 @@ function OnAfterBuild(
   callback: (params: {
     isFirstCompile: boolean;
     stats?: Stats | MultiStats;
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onAfterCreateCompiler.mdx
+++ b/website/docs/zh/shared/onAfterCreateCompiler.mdx
@@ -7,5 +7,6 @@
 ```ts
 function OnAfterCreateCompiler(callback: (params: {
   compiler: Compiler | MultiCompiler;
+  environments: Record<string, EnvironmentContext>;
 }) => Promise<void> | void;): void;
 ```

--- a/website/docs/zh/shared/onAfterStartDevServer.mdx
+++ b/website/docs/zh/shared/onAfterStartDevServer.mdx
@@ -9,6 +9,10 @@ type Routes = Array<{
 }>;
 
 function OnAfterStartDevServer(
-  callback: (params: { port: number; routes: Routes }) => Promise<void> | void,
+  callback: (params: {
+    port: number;
+    routes: Routes;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onBeforeBuild.mdx
+++ b/website/docs/zh/shared/onBeforeBuild.mdx
@@ -8,6 +8,7 @@
 function OnBeforeBuild(
   callback: (params: {
     bundlerConfigs?: WebpackConfig[] | RspackConfig[];
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/zh/shared/onBeforeCreateCompiler.mdx
@@ -8,6 +8,7 @@
 function OnBeforeCreateCompiler(
   callback: (params: {
     bundlerConfigs: WebpackConfig[] | RspackConfig[];
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/zh/shared/onBeforeStartDevServer.mdx
@@ -3,5 +3,9 @@
 - **类型：**
 
 ```ts
-function OnBeforeStartDevServer(callback: () => Promise<void> | void): void;
+function OnBeforeStartDevServer(
+  callback: (params: {
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
+): void;
 ```

--- a/website/docs/zh/shared/onDevCompileDone.mdx
+++ b/website/docs/zh/shared/onDevCompileDone.mdx
@@ -7,6 +7,7 @@ function OnDevCompileDone(
   callback: (params: {
     isFirstCompile: boolean;
     stats: Stats | MultiStats;
+    environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;
 ```


### PR DESCRIPTION
## Summary

Users can use `environment` info like follows:

```ts
api.onDevCompileDone(async ({ isFirstCompile, stats, environments }) => {
  const entries = Object.keys(environments).map(e => e.entry)
})
```
## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2680

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
