### PR TITLE
docs: fix typo in quick-start.mdx

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -46,7 +46,7 @@ Then follow the prompts to complete the operation.
 
 ### Templates
 
-When creating a project, uou can choose from the following templates provided by `create-rsbuild`:
+When creating a project, you can choose from the following templates provided by `create-rsbuild`:
 
 | Template | Description                     | Optional Features |
 | -------- | ------------------------------- | ----------------- |


### PR DESCRIPTION
just a little spelling mistake

uou -> you