### PR TITLE
refactor!: use environment.htmlPaths instead of api.getHtmlPath

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -158,7 +158,6 @@ export async function createRsbuild(
       'onCloseDevServer',
       'onDevCompileDone',
       'onExit',
-      'getHTMLPaths',
       'getRsbuildConfig',
       'getNormalizedConfig',
     ]),

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -97,16 +97,6 @@ export function getPluginAPI({
     throw new Error('`getRsbuildConfig` get an invalid type param.');
   }) as GetRsbuildConfig;
 
-  const getHTMLPaths = (options?: { environment: string }) => {
-    if (options?.environment) {
-      return context.environments[options.environment].htmlPaths;
-    }
-    return Object.values(context.environments).reduce(
-      (prev, context) => Object.assign(prev, context.htmlPaths),
-      {} as Record<string, string>,
-    );
-  };
-
   const exposed: Array<{ id: string | symbol; api: any }> = [];
 
   const expose = (id: string | symbol, api: any) => {
@@ -161,7 +151,6 @@ export function getPluginAPI({
     expose,
     transform,
     useExposed,
-    getHTMLPaths,
     getRsbuildConfig,
     getNormalizedConfig,
     isPluginExists: pluginManager.isPluginExists,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -278,9 +278,8 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain(
       async (chain, { HtmlPlugin, isProd, CHAIN_ID, environment }) => {
-        const { config } = environment;
+        const { config, htmlPaths } = environment;
 
-        const htmlPaths = api.getHTMLPaths({ environment: environment.name });
         if (Object.keys(htmlPaths).length === 0) {
           return;
         }

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -8,12 +8,11 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, isDev, environment }) => {
-      const htmlPaths = api.getHTMLPaths({ environment: environment.name });
+      const { htmlPaths, config } = environment;
       if (Object.keys(htmlPaths).length === 0 || isDev) {
         return;
       }
 
-      const { config } = environment;
       const { InlineChunkHtmlPlugin } = await import(
         '../rspack/InlineChunkHtmlPlugin'
       );

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -156,7 +156,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
         typeof manifest === 'string' ? manifest : 'manifest.json';
 
       const { RspackManifestPlugin } = await import('rspack-manifest-plugin');
-      const htmlPaths = api.getHTMLPaths({ environment: environment.name });
+      const { htmlPaths } = environment;
 
       chain.plugin(CHAIN_ID.PLUGIN.MANIFEST).use(RspackManifestPlugin, [
         {

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -45,13 +45,12 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
     });
 
     api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
-      const htmlPaths = api.getHTMLPaths({ environment: environment.name });
+      const { config, htmlPaths } = environment;
 
       if (Object.keys(htmlPaths).length === 0) {
         return;
       }
 
-      const { config } = environment;
       const {
         performance: { preload, prefetch },
       } = config;

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -192,7 +192,7 @@ export const pluginSri = (): RsbuildPlugin => ({
     }
 
     api.modifyBundlerChain((chain, { environment }) => {
-      const htmlPaths = api.getHTMLPaths({ environment: environment.name });
+      const { htmlPaths } = environment;
 
       if (Object.keys(htmlPaths).length === 0) {
         return;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,7 +115,6 @@ export type RsbuildInstance = {
   createDevServer: ProviderInstance['createDevServer'];
   startDevServer: ProviderInstance['startDevServer'];
 
-  getHTMLPaths: RsbuildPluginAPI['getHTMLPaths'];
   getRsbuildConfig: RsbuildPluginAPI['getRsbuildConfig'];
   getNormalizedConfig: RsbuildPluginAPI['getNormalizedConfig'];
 

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -12,9 +12,8 @@ export const pluginAssetsRetry = (
   setup(api) {
     api.modifyBundlerChain(
       async (chain, { CHAIN_ID, HtmlPlugin, isProd, environment }) => {
-        const { config } = environment;
+        const { config, htmlPaths } = environment;
 
-        const htmlPaths = api.getHTMLPaths({ environment: environment.name });
         if (!options || Object.keys(htmlPaths).length === 0) {
           return;
         }

--- a/packages/shared/src/types/plugin.ts
+++ b/packages/shared/src/types/plugin.ts
@@ -259,11 +259,6 @@ export type RsbuildPluginAPI = Readonly<{
   /** Only works when bundler is Webpack */
   modifyWebpackConfig: PluginHook<ModifyWebpackConfigFn>;
 
-  /**
-   * Get the relative paths of generated HTML files.
-   * The key is entry name and the value is path.
-   */
-  getHTMLPaths: (options?: { environment: string }) => Record<string, string>;
   getRsbuildConfig: GetRsbuildConfig;
   getNormalizedConfig: typeof getNormalizedConfig;
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -784,18 +784,3 @@ rsbuild.onBeforeBuild(() => {
   console.log(config.html.title);
 });
 ```
-
-## rsbuild.getHTMLPaths
-
-import GetHTMLPaths from '@en/shared/getHtmlPaths.mdx';
-
-<GetHTMLPaths />
-
-- **Example:**
-
-```ts
-rsbuild.onBeforeBuild(() => {
-  const htmlPaths = api.getHTMLPaths();
-  console.log(htmlPaths); // { main: 'html/main/index.html' };
-});
-```

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -161,25 +161,6 @@ export default () => ({
 });
 ```
 
-## api.getHTMLPaths
-
-import GetHTMLPaths from '@en/shared/getHtmlPaths.mdx';
-
-<GetHTMLPaths />
-
-- **Example:**
-
-```ts
-const pluginFoo = () => ({
-  setup(api) {
-    api.modifyRspackConfig(() => {
-      const htmlPaths = api.getHTMLPaths();
-      console.log(htmlPaths); // { index: 'index.html' };
-    });
-  },
-});
-```
-
 ## api.transform
 
 Used to transform the code of modules.

--- a/website/docs/en/shared/getHtmlPaths.mdx
+++ b/website/docs/en/shared/getHtmlPaths.mdx
@@ -1,9 +1,0 @@
-Gets path information for HTML assets for all or a specified environment.
-
-This method will return an object, the key is the entry name and the value is the relative path of the HTML file in the dist directory.
-
-- **Type:**
-
-```ts
-function GetHTMLPaths(options?: { environment: string }): Record<string, string>;
-```

--- a/website/docs/en/shared/getHtmlPaths.mdx
+++ b/website/docs/en/shared/getHtmlPaths.mdx
@@ -1,9 +1,9 @@
-Get path information for all HTML assets.
+Gets path information for HTML assets for all or a specified environment.
 
 This method will return an object, the key is the entry name and the value is the relative path of the HTML file in the dist directory.
 
 - **Type:**
 
 ```ts
-function GetHTMLPaths(): Record<string, string>;
+function GetHTMLPaths(options?: { environment: string }): Record<string, string>;
 ```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -776,18 +776,3 @@ rsbuild.onBeforeBuild(() => {
   console.log(config.html.title);
 });
 ```
-
-## rsbuild.getHTMLPaths
-
-import GetHTMLPaths from '@zh/shared/getHtmlPaths.mdx';
-
-<GetHTMLPaths />
-
-- **示例：**
-
-```ts
-rsbuild.onBeforeBuild(() => {
-  const htmlPaths = api.getHTMLPaths();
-  console.log(htmlPaths); // { main: 'html/main/index.html' };
-});
-```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -159,25 +159,6 @@ export default () => ({
 });
 ```
 
-## api.getHTMLPaths
-
-import GetHTMLPaths from '@zh/shared/getHtmlPaths.mdx';
-
-<GetHTMLPaths />
-
-- **示例：**
-
-```ts
-const pluginFoo = () => ({
-  setup(api) {
-    api.modifyRspackConfig(() => {
-      const htmlPaths = api.getHTMLPaths();
-      console.log(htmlPaths); // { index: 'index.html' };
-    });
-  },
-});
-```
-
 ## api.transform
 
 用于转换模块的代码。

--- a/website/docs/zh/shared/getHtmlPaths.mdx
+++ b/website/docs/zh/shared/getHtmlPaths.mdx
@@ -1,9 +1,0 @@
-获取所有 / 指定环境的 HTML 产物的路径信息。
-
-该方法会返回一个对象，对象的 key 为 entry 名称，value 为 HTML 文件在产物目录下的相对路径。
-
-- **类型：**
-
-```ts
-function GetHTMLPaths(options?: { environment: string }): Record<string, string>;
-```

--- a/website/docs/zh/shared/getHtmlPaths.mdx
+++ b/website/docs/zh/shared/getHtmlPaths.mdx
@@ -1,9 +1,9 @@
-获取所有 HTML 产物的路径信息。
+获取所有 / 指定环境的 HTML 产物的路径信息。
 
 该方法会返回一个对象，对象的 key 为 entry 名称，value 为 HTML 文件在产物目录下的相对路径。
 
 - **类型：**
 
 ```ts
-function GetHTMLPaths(): Record<string, string>;
+function GetHTMLPaths(options?: { environment: string }): Record<string, string>;
 ```


### PR DESCRIPTION
## Summary

BREAKING CHANGE: Remove `api.getHtmlPath`, use environment htmlPaths  instead.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2620

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
