### PR TITLE
fix(plugin-source-build): avoid self reference

### DIFF
--- a/packages/plugin-source-build/src/plugin.ts
+++ b/packages/plugin-source-build/src/plugin.ts
@@ -140,7 +140,10 @@ export function pluginSourceBuild(
             ...(Array.isArray(configObject.references)
               ? configObject.references
               : []),
-          ];
+          ].filter(
+            // avoid self reference, it will break the resolver
+            (item) => item !== tsconfigPath,
+          );
 
           config.resolve.tsConfig = {
             configFile: configObject?.configFile || tsconfigPath,


### PR DESCRIPTION
## Summary

Avoid generating self reference as it will break the resolver.

## Related Links

https://github.com/oxc-project/oxc-resolver/pull/211

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
