### PR TITLE
fix(plugin-source-build): dedupe references

### DIFF
--- a/packages/plugin-source-build/src/types/index.ts
+++ b/packages/plugin-source-build/src/types/index.ts
@@ -12,3 +12,7 @@ export interface MonorepoAnalyzer {
 export interface IPnpmWorkSpace {
   packages: string[];
 }
+
+export type TsConfig = {
+  references?: Array<{ path?: string }>;
+};


### PR DESCRIPTION
## Summary

Dedupe the generated references and always use absolute path:

<img width="882" alt="Screenshot 2024-07-03 at 16 37 29" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/6321e392-dab3-4483-bb0f-3eaf76b16c65">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
