### PR TITLE
feat!(plugin-vue2): update Vue 2 compiler options to condense whitespace

### DIFF
--- a/packages/plugin-vue2/src/index.ts
+++ b/packages/plugin-vue2/src/index.ts
@@ -67,7 +67,8 @@ export function pluginVue2(options: PluginVueOptions = {}): RsbuildPlugin {
 
         const userLoaderOptions = options.vueLoaderOptions ?? {};
         const compilerOptions = {
-          preserveWhitespace: false,
+          // https://github.com/vuejs/vue-cli/pull/3853
+          whitespace: 'condense',
           ...userLoaderOptions.compilerOptions,
         };
         const vueLoaderOptions = {

--- a/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -11,7 +11,7 @@ exports[`plugin-vue2 > should add vue-loader and VueLoaderPlugin correctly 1`] =
             "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/lib/index.js",
             "options": {
               "compilerOptions": {
-                "preserveWhitespace": false,
+                "whitespace": "condense",
               },
               "experimentalInlineMatchResource": true,
             },
@@ -51,7 +51,7 @@ exports[`plugin-vue2 > should allow to configure vueLoader options 1`] = `
             "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/lib/index.js",
             "options": {
               "compilerOptions": {
-                "preserveWhitespace": false,
+                "whitespace": "condense",
               },
               "experimentalInlineMatchResource": true,
               "hotReload": false,
@@ -107,7 +107,7 @@ exports[`plugin-vue2 > should include polyfill resolve config 1`] = `
             "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/lib/index.js",
             "options": {
               "compilerOptions": {
-                "preserveWhitespace": false,
+                "whitespace": "condense",
               },
               "experimentalInlineMatchResource": true,
               "hotReload": false,

--- a/website/docs/en/plugins/list/plugin-vue2.mdx
+++ b/website/docs/en/plugins/list/plugin-vue2.mdx
@@ -48,7 +48,7 @@ Options passed to `vue-loader`, please refer to the [vue-loader documentation](h
 ```js
 const defaultOptions = {
   compilerOptions: {
-    preserveWhitespace: false,
+    whitespace: 'condense',
   },
   experimentalInlineMatchResource: true,
 };

--- a/website/docs/zh/plugins/list/plugin-vue2.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue2.mdx
@@ -48,7 +48,7 @@ export default {
 ```js
 const defaultOptions = {
   compilerOptions: {
-    preserveWhitespace: false,
+    whitespace: 'condense',
   },
   experimentalInlineMatchResource: true,
 };


### PR DESCRIPTION
## Summary

set whitespace: 'condense' for template compiler 

Consistent with vue cli compilation behavior

## Related Links

<!--- Provide links of related issues or pages -->

https://github.com/vuejs/vue-cli/pull/3853

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
