### PR TITLE
perf(core): lazy load http-proxy-middleware

### DIFF
--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -111,9 +111,8 @@ const applyDefaultMiddlewares = async ({
   // dev proxy handler, each proxy has own handler
   if (server.proxy) {
     const { createProxyMiddleware } = await import('./proxy');
-    const { middlewares: proxyMiddlewares, upgrade } = createProxyMiddleware(
-      server.proxy,
-    );
+    const { middlewares: proxyMiddlewares, upgrade } =
+      await createProxyMiddleware(server.proxy);
     upgradeEvents.push(upgrade);
 
     for (const middleware of proxyMiddlewares) {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -79,7 +79,7 @@ export class RsbuildProdServer {
 
     if (proxy) {
       const { createProxyMiddleware } = await import('./proxy');
-      const { middlewares, upgrade } = createProxyMiddleware(proxy);
+      const { middlewares, upgrade } = await createProxyMiddleware(proxy);
 
       for (const middleware of middlewares) {
         this.middlewares.use(middleware);

--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -3,10 +3,7 @@ import type {
   ProxyDetail,
   ProxyOptions,
 } from '@rsbuild/shared';
-import {
-  type RequestHandler,
-  createProxyMiddleware as baseCreateProxyMiddleware,
-} from '@rsbuild/shared/http-proxy-middleware';
+import type { RequestHandler } from '@rsbuild/shared/http-proxy-middleware';
 import { logger } from '../logger';
 import type { UpgradeEvent } from './helper';
 
@@ -42,17 +39,21 @@ function formatProxyOptions(proxyOptions: ProxyOptions) {
   return ret;
 }
 
-export const createProxyMiddleware = (
+export const createProxyMiddleware = async (
   proxyOptions: ProxyOptions,
-): {
+): Promise<{
   middlewares: Middleware[];
   upgrade: UpgradeEvent;
-} => {
+}> => {
   // If it is not an array, it may be an object that uses the context attribute
   // or an object in the form of { source: ProxyDetail }
   const formattedOptionsList = formatProxyOptions(proxyOptions);
   const proxyMiddlewares: RequestHandler[] = [];
   const middlewares: Middleware[] = [];
+
+  const { createProxyMiddleware: baseCreateProxyMiddleware } = await import(
+    '@rsbuild/shared/http-proxy-middleware'
+  );
 
   for (const opts of formattedOptionsList) {
     const proxyMiddleware = baseCreateProxyMiddleware(opts.context!, opts);


### PR DESCRIPTION
## Summary

Should lazy load `http-proxy-middleware`:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/a1e6c099-8d0c-40ed-a04f-4e27e511b537)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
