### PR TITLE
refactor: remove helpers from the shared package

### DIFF
--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
-import { type ConsoleType, castArray } from '@rsbuild/shared';
+import type { ConsoleType } from '@rsbuild/shared';
 import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
@@ -81,7 +81,7 @@ export const proxyConsole = (
   const logs: string[] = [];
   const restores: Array<() => void> = [];
 
-  for (const type of castArray(types)) {
+  for (const type of Array.isArray(types) ? types : [types]) {
     const method = console[type];
 
     restores.push(() => {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -30,6 +30,7 @@
     "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.11",
     "core-js": "~3.37.1",
+    "deepmerge": "^4.3.1",
     "lodash": "^4.17.21",
     "picocolors": "^1.0.1",
     "semver": "^7.6.2"

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -31,6 +31,7 @@
     "@swc/helpers": "0.5.11",
     "core-js": "~3.37.1",
     "lodash": "^4.17.21",
+    "picocolors": "^1.0.1",
     "semver": "^7.6.2"
   },
   "devDependencies": {

--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -3,8 +3,9 @@ import {
   __internalHelper,
   logger,
 } from '@rsbuild/core';
-import { color, deepmerge } from '@rsbuild/shared';
+import { deepmerge } from '@rsbuild/shared';
 import type { webpack } from '@rsbuild/webpack';
+import color from 'picocolors';
 import { minify, minifyCss } from './binding';
 import { JS_REGEX } from './constants';
 import type { CssMinifyOptions, JsMinifyOptions, Output } from './types';

--- a/packages/compat/plugin-swc/src/minimizer.ts
+++ b/packages/compat/plugin-swc/src/minimizer.ts
@@ -3,8 +3,8 @@ import {
   __internalHelper,
   logger,
 } from '@rsbuild/core';
-import { deepmerge } from '@rsbuild/shared';
 import type { webpack } from '@rsbuild/webpack';
+import deepmerge from 'deepmerge';
 import color from 'picocolors';
 import { minify, minifyCss } from './binding';
 import { JS_REGEX } from './constants';
@@ -42,9 +42,9 @@ export class SwcMinimizerPlugin {
   }) {
     this.minifyOptions = {
       jsMinify: options.jsMinify
-        ? deepmerge(
+        ? deepmerge<JsMinifyOptions>(
             this.getDefaultJsMinifyOptions(options.environmentConfig),
-            normalize(options.jsMinify, {}),
+            normalize(options.jsMinify, {}) ?? {},
           )
         : undefined,
       cssMinify: options.cssMinify

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { SCRIPT_REGEX } from '@rsbuild/shared';
 import { SwcMinimizerPlugin } from './minimizer';
 import type {
   ObjPluginSwcOptions,
@@ -63,7 +62,7 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
 
           // Insert swc loader and plugin
           rule
-            .test(test || SCRIPT_REGEX)
+            .test(test || /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/)
             .use(CHAIN_ID.USE.SWC)
             .loader(path.resolve(__dirname, './loader.cjs'))
             .options(removeUselessOptions(swcConfig) satisfies TransformConfig);

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -31,6 +31,7 @@
     "@rsbuild/shared": "workspace:*",
     "copy-webpack-plugin": "11.0.0",
     "mini-css-extract-plugin": "2.9.0",
+    "picocolors": "^1.0.1",
     "reduce-configs": "^1.0.0",
     "tsconfig-paths-webpack-plugin": "4.1.0",
     "webpack": "^5.92.1"

--- a/packages/compat/webpack/src/plugin.ts
+++ b/packages/compat/webpack/src/plugin.ts
@@ -5,7 +5,8 @@ import type {
   RsbuildTarget,
   RspackChain,
 } from '@rsbuild/core';
-import { type CopyPluginOptions, castArray } from '@rsbuild/shared';
+import type { CopyPluginOptions } from '@rsbuild/shared';
+import { castArray } from './shared';
 
 async function applyTsConfigPathsPlugin({
   chain,

--- a/packages/compat/webpack/src/progress/ProgressPlugin.ts
+++ b/packages/compat/webpack/src/progress/ProgressPlugin.ts
@@ -1,10 +1,10 @@
 import { logger } from '@rsbuild/core';
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 import webpack from 'webpack';
 import { prettyTime } from '../shared';
 import { bus, createFriendlyPercentage } from './helpers';
 import { createNonTTYLogger } from './helpers/nonTty';
-import type { Props } from './helpers/type';
+import type { Props } from './helpers/types';
 
 export interface ProgressOptions
   extends Omit<Partial<Props>, 'message' | 'total' | 'current' | 'done'> {

--- a/packages/compat/webpack/src/progress/helpers/bar.ts
+++ b/packages/compat/webpack/src/progress/helpers/bar.ts
@@ -1,6 +1,6 @@
-import { color as colors } from '@rsbuild/shared';
 import cliTruncate from 'cli-truncate';
-import type { Props } from './type';
+import colors from 'picocolors';
+import type { Props } from './types';
 import { clamp } from './utils';
 
 const defaultOption: Props = {

--- a/packages/compat/webpack/src/progress/helpers/bus.ts
+++ b/packages/compat/webpack/src/progress/helpers/bus.ts
@@ -1,11 +1,10 @@
 import { Console } from 'node:console';
-import type { Colors } from '@rsbuild/shared';
 import cliTruncate from 'cli-truncate';
 import patchConsole from 'patch-console';
 import { FULL_WIDTH, renderBar } from './bar';
 import { create } from './log';
 import type { LogUpdate } from './log';
-import type { Props } from './type';
+import type { Colors, Props } from './types';
 
 const colorList: Colors[] = ['green', 'cyan', 'yellow', 'blue', 'magenta'];
 

--- a/packages/compat/webpack/src/progress/helpers/index.ts
+++ b/packages/compat/webpack/src/progress/helpers/index.ts
@@ -1,4 +1,4 @@
 export * from './bus';
 export * from './bar';
-export * from './type';
+export * from './types';
 export * from './percentage';

--- a/packages/compat/webpack/src/progress/helpers/nonTty.ts
+++ b/packages/compat/webpack/src/progress/helpers/nonTty.ts
@@ -1,5 +1,5 @@
 import { logger } from '@rsbuild/core';
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 
 export function createNonTTYLogger() {
   let prevPercentage = 0;

--- a/packages/compat/webpack/src/progress/helpers/types.ts
+++ b/packages/compat/webpack/src/progress/helpers/types.ts
@@ -1,4 +1,9 @@
-import type { Colors } from '@rsbuild/shared';
+import type color from 'picocolors';
+
+export type Colors = Omit<
+  keyof typeof color,
+  'createColor' | 'isColorSupported'
+>;
 
 export type Props = {
   total: number;

--- a/packages/compat/webpack/src/shared.ts
+++ b/packages/compat/webpack/src/shared.ts
@@ -33,3 +33,10 @@ export {
 };
 
 export type InternalContext = __internalHelper.InternalContext;
+
+export const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -4,16 +4,16 @@ import {
   __internalHelper,
   logger,
 } from '@rsbuild/core';
-import {
-  type EnvironmentContext,
-  type ModifyWebpackChainUtils,
-  type ModifyWebpackConfigUtils,
-  castArray,
+import type {
+  EnvironmentContext,
+  ModifyWebpackChainUtils,
+  ModifyWebpackConfigUtils,
 } from '@rsbuild/shared';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import type { RuleSetRule, WebpackPluginInstance } from 'webpack';
 import {
   type InternalContext,
+  castArray,
   chainToConfig,
   getChainUtils as getBaseChainUtils,
   modifyBundlerChain,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,7 @@
     "connect": "3.7.0",
     "connect-history-api-fallback": "^2.0.0",
     "css-loader": "7.1.2",
+    "deepmerge": "^4.3.1",
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "fs-extra": "^11.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,6 +77,7 @@
     "launch-editor-middleware": "^2.8.0",
     "on-finished": "2.4.1",
     "open": "^8.4.0",
+    "picocolors": "^1.0.1",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
     "postcss-value-parser": "4.2.0",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -61,7 +61,7 @@ export default {
       name: 'launch-editor-middleware',
       ignoreDts: true,
       externals: {
-        picocolors: '@rsbuild/shared/picocolors',
+        picocolors: 'picocolors',
       },
     },
     {

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
-import { type RsbuildMode, color } from '@rsbuild/shared';
+import type { RsbuildMode } from '@rsbuild/shared';
 import { type Command, program } from 'commander';
+import color from 'picocolors';
 import { isEmptyDir } from '../helpers';
 import { logger } from '../logger';
 import { init } from './init';

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { RspackChain, color } from '@rsbuild/shared';
+import { RspackChain } from '@rsbuild/shared';
 import type {
   InspectConfigOptions,
   InspectConfigResult,
@@ -20,6 +20,7 @@ import type {
   RsbuildConfig,
   RsbuildEntry,
 } from '@rsbuild/shared';
+import color from 'picocolors';
 import {
   CSS_DIST_DIR,
   DEFAULT_ASSET_PREFIX,

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -7,9 +7,8 @@ import {
   type Rspack,
   RspackChain,
   type RspackConfig,
-  castArray,
 } from '@rsbuild/shared';
-import { isPlainObject } from './helpers';
+import { castArray, isPlainObject } from './helpers';
 import { logger } from './logger';
 import type { RsbuildConfig } from './types';
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -38,6 +38,7 @@ export const DEFAULT_BROWSERSLIST: Record<string, string[]> = {
 // RegExp
 export const HTML_REGEX: RegExp = /\.html$/;
 export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
+export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 export const CSS_REGEX: RegExp = /\.css$/;
 export const NODE_MODULES_REGEX: RegExp = /[\\/]node_modules[\\/]/;
 

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -13,6 +13,7 @@ import type {
   StatsError,
 } from '@rsbuild/shared';
 import type { StatsCompilation, StatsValue } from '@rspack/core';
+import deepmerge from 'deepmerge';
 import color from 'picocolors';
 import type {
   Compiler as WebpackCompiler,
@@ -48,6 +49,13 @@ export const castArray = <T>(arr?: T | T[]): T[] => {
     return [];
   }
   return Array.isArray(arr) ? arr : [arr];
+};
+
+export const cloneDeep = <T>(value: T): T => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  return deepmerge<T>({}, value);
 };
 
 const compareSemver = (version1: string, version2: string) => {

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -12,9 +12,9 @@ import {
   type Stats,
   type StatsError,
   castArray,
-  color,
 } from '@rsbuild/shared';
 import type { StatsCompilation, StatsValue } from '@rspack/core';
+import color from 'picocolors';
 import type {
   Compiler as WebpackCompiler,
   MultiCompiler as WebpackMultiCompiler,

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,17 +1,16 @@
 import fs from 'node:fs';
 import path, { posix } from 'node:path';
-import {
-  type FilenameConfig,
-  type MultiStats,
-  type NodeEnv,
-  type NormalizedConfig,
-  type NormalizedEnvironmentConfig,
-  type RsbuildTarget,
-  type Rspack,
-  type RspackChain,
-  type Stats,
-  type StatsError,
-  castArray,
+import type {
+  FilenameConfig,
+  MultiStats,
+  NodeEnv,
+  NormalizedConfig,
+  NormalizedEnvironmentConfig,
+  RsbuildTarget,
+  Rspack,
+  RspackChain,
+  Stats,
+  StatsError,
 } from '@rsbuild/shared';
 import type { StatsCompilation, StatsValue } from '@rspack/core';
 import color from 'picocolors';
@@ -43,6 +42,13 @@ export const isObject = (obj: unknown): obj is Record<string, any> =>
 
 export const isPlainObject = (obj: unknown): obj is Record<string, any> =>
   isObject(obj) && Object.prototype.toString.call(obj) === '[object Object]';
+
+export const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};
 
 const compareSemver = (version1: string, version2: string) => {
   const parts1 = version1.split('.').map(Number);

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,4 +1,4 @@
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 import { type Logger, logger } from 'rslog';
 
 export const isDebug = (): boolean => {

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -1,5 +1,5 @@
-import { type RsbuildConfig, cloneDeep } from '@rsbuild/shared';
-import { castArray, isFunction, isPlainObject } from './helpers';
+import type { RsbuildConfig } from '@rsbuild/shared';
+import { castArray, cloneDeep, isFunction, isPlainObject } from './helpers';
 
 const OVERRIDE_PATHS = [
   'performance.removeConsole',

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -1,5 +1,5 @@
-import { type RsbuildConfig, castArray, cloneDeep } from '@rsbuild/shared';
-import { isFunction, isPlainObject } from './helpers';
+import { type RsbuildConfig, cloneDeep } from '@rsbuild/shared';
+import { castArray, isFunction, isPlainObject } from './helpers';
 
 const OVERRIDE_PATHS = [
   'performance.removeConsole',

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -1,4 +1,3 @@
-import { color } from '@rsbuild/shared';
 import type {
   BundlerPluginInstance,
   Falsy,
@@ -6,6 +5,7 @@ import type {
   RsbuildPlugin,
   RsbuildPluginAPI,
 } from '@rsbuild/shared';
+import color from 'picocolors';
 import { isFunction } from './helpers';
 import { logger } from './logger';
 

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -1,5 +1,6 @@
 import { sep } from 'node:path';
-import { type EnvironmentContext, color } from '@rsbuild/shared';
+import type { EnvironmentContext } from '@rsbuild/shared';
+import color from 'picocolors';
 import { emptyDir } from '../helpers';
 import { logger } from '../logger';
 import type { RsbuildPlugin } from '../types';

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,16 +1,16 @@
 import path from 'node:path';
-import {
-  type AutoprefixerOptions,
-  type CSSLoaderModulesMode,
-  type CSSLoaderOptions,
-  type ModifyChainUtils,
-  type PostCSSLoaderOptions,
-  type PostCSSOptions,
-  type RsbuildContext,
-  type RsbuildTarget,
-  type RspackChain,
-  deepmerge,
+import type {
+  AutoprefixerOptions,
+  CSSLoaderModulesMode,
+  CSSLoaderOptions,
+  ModifyChainUtils,
+  PostCSSLoaderOptions,
+  PostCSSOptions,
+  RsbuildContext,
+  RsbuildTarget,
+  RspackChain,
 } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import type { AcceptedPlugin } from 'postcss';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
 import { CSS_REGEX, LOADER_PATH } from '../constants';

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,5 +1,6 @@
-import { castArray, color } from '@rsbuild/shared';
+import { castArray } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
+import color from 'picocolors';
 import { createVirtualModule } from '../helpers';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,7 +1,6 @@
-import { castArray } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
 import color from 'picocolors';
-import { createVirtualModule } from '../helpers';
+import { castArray, createVirtualModule } from '../helpers';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginEntry = (): RsbuildPlugin => ({

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -4,8 +4,8 @@
  */
 import fs from 'node:fs';
 import path from 'node:path';
-import { color } from '@rsbuild/shared';
 import type { PrintFileSizeOptions, Stats, StatsAsset } from '@rsbuild/shared';
+import color from 'picocolors';
 import { CSS_REGEX, HTML_REGEX, JS_REGEX } from '../constants';
 import { logger } from '../logger';
 import type { RsbuildPlugin } from '../types';

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
-import { type MinifyJSOptions, castArray, deepmerge } from '@rsbuild/shared';
+import { type MinifyJSOptions, deepmerge } from '@rsbuild/shared';
 import type {
   HTMLPluginOptions,
   HtmlConfig,
@@ -15,6 +15,7 @@ import {
 } from 'reduce-configs';
 import { STATIC_PATH } from '../constants';
 import {
+  castArray,
   getPublicPathFromChain,
   isFileExists,
   isPlainObject,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
-import { type MinifyJSOptions, deepmerge } from '@rsbuild/shared';
+import type { MinifyJSOptions } from '@rsbuild/shared';
 import type {
   HTMLPluginOptions,
   HtmlConfig,
@@ -8,6 +8,7 @@ import type {
   NormalizedEnvironmentConfig,
 } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
+import deepmerge from 'deepmerge';
 import color from 'picocolors';
 import {
   reduceConfigsMergeContext,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,11 +1,6 @@
 import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
-import {
-  type MinifyJSOptions,
-  castArray,
-  color,
-  deepmerge,
-} from '@rsbuild/shared';
+import { type MinifyJSOptions, castArray, deepmerge } from '@rsbuild/shared';
 import type {
   HTMLPluginOptions,
   HtmlConfig,
@@ -13,6 +8,7 @@ import type {
   NormalizedEnvironmentConfig,
 } from '@rsbuild/shared';
 import type { EntryDescription } from '@rspack/core';
+import color from 'picocolors';
 import {
   reduceConfigsMergeContext,
   reduceConfigsWithContext,

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -2,10 +2,10 @@ import {
   CHAIN_ID,
   type HTMLPluginOptions,
   type NormalizedEnvironmentConfig,
-  deepmerge,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import type { SwcJsMinimizerRspackPluginOptions } from '@rspack/core';
+import deepmerge from 'deepmerge';
 import { isObject } from '../helpers';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/open.ts
+++ b/packages/core/src/plugins/open.ts
@@ -1,8 +1,8 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
-import { type Routes, castArray } from '@rsbuild/shared';
+import type { Routes } from '@rsbuild/shared';
 import { STATIC_PATH } from '../constants';
-import { canParse } from '../helpers';
+import { canParse, castArray } from '../helpers';
 import { logger } from '../logger';
 import type { NormalizedConfig, RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -1,10 +1,10 @@
-import {
-  type ChainIdentifier,
-  type NormalizedEnvironmentConfig,
-  type RspackChain,
-  castArray,
+import type {
+  ChainIdentifier,
+  NormalizedEnvironmentConfig,
+  RspackChain,
 } from '@rsbuild/shared';
 import { reduceConfigs } from 'reduce-configs';
+import { castArray } from '../helpers';
 import { ensureAbsolutePath } from '../helpers/path';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -1,4 +1,5 @@
-import { type BundlerPluginInstance, color } from '@rsbuild/shared';
+import type { BundlerPluginInstance } from '@rsbuild/shared';
+import color from 'picocolors';
 import { logger } from '../logger';
 import type { RsbuildPlugin } from '../types';
 

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -1,17 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  type Polyfill,
-  type RsbuildContext,
-  type RspackChain,
-  SCRIPT_REGEX,
-  cloneDeep,
-  deepmerge,
-} from '@rsbuild/shared';
+import type { Polyfill, RsbuildContext, RspackChain } from '@rsbuild/shared';
 import type { SwcLoaderOptions } from '@rspack/core';
+import deepmerge from 'deepmerge';
 import { reduceConfigs } from 'reduce-configs';
-import { NODE_MODULES_REGEX, PLUGIN_SWC_NAME } from '../constants';
-import { castArray, isWebTarget } from '../helpers';
+import {
+  NODE_MODULES_REGEX,
+  PLUGIN_SWC_NAME,
+  SCRIPT_REGEX,
+} from '../constants';
+import { castArray, cloneDeep, isWebTarget } from '../helpers';
 import type {
   NormalizedEnvironmentConfig,
   NormalizedSourceConfig,

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -5,14 +5,13 @@ import {
   type RsbuildContext,
   type RspackChain,
   SCRIPT_REGEX,
-  castArray,
   cloneDeep,
   deepmerge,
 } from '@rsbuild/shared';
 import type { SwcLoaderOptions } from '@rspack/core';
 import { reduceConfigs } from 'reduce-configs';
 import { NODE_MODULES_REGEX, PLUGIN_SWC_NAME } from '../constants';
-import { isWebTarget } from '../helpers';
+import { castArray, isWebTarget } from '../helpers';
 import type {
   NormalizedEnvironmentConfig,
   NormalizedSourceConfig,

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -1,12 +1,7 @@
-import {
-  type MultiStats,
-  type Rspack,
-  type RspackConfig,
-  type Stats,
-  color,
-} from '@rsbuild/shared';
+import type { MultiStats, Rspack, RspackConfig, Stats } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import type { StatsCompilation } from '@rspack/core';
+import color from 'picocolors';
 import {
   formatStats,
   getStatsOptions,

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -5,12 +5,11 @@ import {
   type ModifyRspackConfigUtils,
   type RsbuildTarget,
   type RspackConfig,
-  castArray,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
 import { reduceConfigsAsyncWithContext } from 'reduce-configs';
 import { chainToConfig, modifyBundlerChain } from '../configChain';
-import { getNodeEnv } from '../helpers';
+import { castArray, getNodeEnv } from '../helpers';
 import { logger } from '../logger';
 import { getHTMLPlugin } from '../pluginHelper';
 import type { InternalContext } from '../types';

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -3,7 +3,6 @@ import net from 'node:net';
 import type { Socket } from 'node:net';
 import os from 'node:os';
 import { join, relative } from 'node:path';
-import { color } from '@rsbuild/shared';
 import type {
   NormalizedConfig,
   OutputStructure,
@@ -11,6 +10,7 @@ import type {
   Routes,
   RsbuildEntry,
 } from '@rsbuild/shared';
+import color from 'picocolors';
 import { DEFAULT_DEV_HOST, DEFAULT_PORT } from '../constants';
 import { isFunction } from '../helpers';
 import { logger } from '../logger';

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 import { parse } from 'node:url';
-import {
-  type HtmlFallback,
-  type RequestHandler as Middleware,
-  type Rspack,
-  color,
+import type {
+  HtmlFallback,
+  RequestHandler as Middleware,
+  Rspack,
 } from '@rsbuild/shared';
 import type Connect from 'connect';
+import color from 'picocolors';
 import { logger } from '../logger';
 
 export const faviconFallbackMiddleware: Middleware = (req, res, next) => {

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 import { init } from '../cli/init';
 import { logger } from '../logger';
 

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.5",
+    "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0",
     "upath": "2.0.1"
   },

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -5,7 +5,6 @@ import type {
   NormalizedConfig,
   RspackChain,
 } from '@rsbuild/core';
-import { castArray } from '@rsbuild/shared';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import upath from 'upath';
 import type {
@@ -19,6 +18,13 @@ import type {
 } from './types';
 
 export const BABEL_JS_RULE = 'babel-js';
+
+export const castArray = <T>(arr?: T | T[]): T[] => {
+  if (arr === undefined) {
+    return [];
+  }
+  return Array.isArray(arr) ? arr : [arr];
+};
 
 const normalizeToPosixPath = (p: string | undefined) =>
   upath

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -6,8 +6,8 @@ import type {
   RsbuildContext,
   RsbuildPlugin,
 } from '@rsbuild/core';
-import { SCRIPT_REGEX, castArray, cloneDeep } from '@rsbuild/shared';
-import { BABEL_JS_RULE, applyUserBabelConfig } from './helper';
+import { SCRIPT_REGEX, cloneDeep } from '@rsbuild/shared';
+import { BABEL_JS_RULE, applyUserBabelConfig, castArray } from './helper';
 import type { BabelLoaderOptions, PluginBabelOptions } from './types';
 
 export const PLUGIN_BABEL_NAME = 'rsbuild:babel';

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -6,11 +6,12 @@ import type {
   RsbuildContext,
   RsbuildPlugin,
 } from '@rsbuild/core';
-import { SCRIPT_REGEX, cloneDeep } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import { BABEL_JS_RULE, applyUserBabelConfig, castArray } from './helper';
 import type { BabelLoaderOptions, PluginBabelOptions } from './types';
 
 export const PLUGIN_BABEL_NAME = 'rsbuild:babel';
+const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 
 /**
  * The `@babel/preset-typescript` default options.
@@ -109,7 +110,7 @@ export const pluginBabel = (
       const baseOptions = getDefaultBabelOptions(config, api.context);
 
       const mergedOptions = applyUserBabelConfig(
-        cloneDeep(baseOptions),
+        deepmerge({}, baseOptions),
         options.babelLoaderOptions,
       );
 

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -31,6 +31,7 @@
     "acorn": "^8.12.0",
     "browserslist-to-es-version": "^1.0.0",
     "htmlparser2": "9.1.0",
+    "picocolors": "^1.0.1",
     "source-map": "^0.7.4"
   },
   "devDependencies": {

--- a/packages/plugin-check-syntax/src/helpers/generateError.ts
+++ b/packages/plugin-check-syntax/src/helpers/generateError.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 import { SourceMapConsumer } from 'source-map';
 import {
   type AcornParseError,

--- a/packages/plugin-check-syntax/src/helpers/printErrors.ts
+++ b/packages/plugin-check-syntax/src/helpers/printErrors.ts
@@ -1,5 +1,5 @@
 import { logger } from '@rsbuild/core';
-import { color } from '@rsbuild/shared';
+import color from 'picocolors';
 import type { ECMASyntaxError, EcmaVersion } from '../types';
 
 type Error = {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -4,12 +4,7 @@ import type {
   RsbuildPlugin,
   Rspack,
 } from '@rsbuild/core';
-import {
-  type FileFilterUtil,
-  castArray,
-  cloneDeep,
-  deepmerge,
-} from '@rsbuild/shared';
+import { type FileFilterUtil, cloneDeep, deepmerge } from '@rsbuild/shared';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import type Less from '../compiled/less';
 
@@ -58,7 +53,7 @@ const getLessLoaderOptions = (
   const excludes: (RegExp | string)[] = [];
 
   const addExcludes: FileFilterUtil = (items) => {
-    excludes.push(...castArray(items));
+    excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 
   const defaultLessLoaderOptions: LessLoaderOptions = {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -133,16 +133,14 @@ export const pluginLess = (
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = deepmerge<Record<string, any>>(
-          {},
-          loader.get('options'),
-        );
+        const options = loader.get('options') ?? {};
+        const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
-          options.importLoaders = 2;
+          clonedOptions.importLoaders = 2;
         }
 
-        rule.use(id).loader(loader.get('loader')).options(options);
+        rule.use(id).loader(loader.get('loader')).options(clonedOptions);
       }
 
       rule

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -4,7 +4,8 @@ import type {
   RsbuildPlugin,
   Rspack,
 } from '@rsbuild/core';
-import { type FileFilterUtil, cloneDeep, deepmerge } from '@rsbuild/shared';
+import type { FileFilterUtil } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import type Less from '../compiled/less';
 
@@ -132,10 +133,15 @@ export const pluginLess = (
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = cloneDeep(loader.get('options'));
+        const options = deepmerge<Record<string, any>>(
+          {},
+          loader.get('options'),
+        );
+
         if (id === CHAIN_ID.USE.CSS) {
           options.importLoaders = 2;
         }
+
         rule.use(id).loader(loader.get('loader')).options(options);
       }
 

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -6,7 +6,6 @@ import type {
   Rspack,
   RspackChain,
 } from '@rsbuild/core';
-import { SCRIPT_REGEX, deepmerge } from '@rsbuild/shared';
 import type { PluginReactOptions } from '.';
 
 const modifySwcLoaderOptions = ({
@@ -51,20 +50,17 @@ export const applyBasicReactSupport = (
         chain,
         CHAIN_ID,
         modifier: (opts) => {
-          const extraOptions: Rspack.SwcLoaderOptions = {
-            jsc: {
-              parser: {
-                syntax: 'typescript',
-                // enable supports for React JSX/TSX compilation
-                tsx: true,
-              },
-              transform: {
-                react: reactOptions,
-              },
-            },
+          opts.jsc ||= {};
+          opts.jsc.transform ||= {};
+          opts.jsc.transform.react = reactOptions;
+          opts.jsc.parser = {
+            ...opts.jsc.parser,
+            syntax: 'typescript',
+            // enable supports for React JSX/TSX compilation
+            tsx: true,
           };
 
-          return deepmerge(opts, extraOptions);
+          return opts;
         },
       });
 
@@ -80,6 +76,7 @@ export const applyBasicReactSupport = (
       const { default: ReactRefreshRspackPlugin } = await import(
         '@rspack/plugin-react-refresh'
       );
+      const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 
       chain
         .plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "deepmerge": "^4.3.1",
     "terser": "5.31.1"
   },
   "devDependencies": {

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -1,5 +1,5 @@
 import type { PostCSSPlugin, RsbuildPlugin } from '@rsbuild/core';
-import { cloneDeep } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import type { PluginRemOptions, PxToRemOptions } from './types';
 
 const defaultOptions: PluginRemOptions = {
@@ -31,7 +31,7 @@ export const pluginRem = (options: PluginRemOptions = {}): RsbuildPlugin => ({
         rootValue: userOptions.rootFontSize,
         unitPrecision: 5,
         propList: ['*'],
-        ...(userOptions.pxtorem ? cloneDeep(userOptions.pxtorem) : {}),
+        ...(userOptions.pxtorem ? deepmerge({}, userOptions.pxtorem) : {}),
       });
     };
 

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "deepmerge": "^4.3.1",
     "loader-utils": "^2.0.4",
     "postcss": "^8.4.39",
     "reduce-configs": "^1.0.0",

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { type FileFilterUtil, cloneDeep, deepmerge } from '@rsbuild/shared';
+import type { FileFilterUtil } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import { getResolveUrlJoinFn, patchCompilerGlobalLocation } from './helpers';
 import type { PluginSassOptions, SassLoaderOptions } from './types';
@@ -98,11 +99,16 @@ export const pluginSass = (
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = cloneDeep(loader.get('options'));
+        const options = deepmerge<Record<string, any>>(
+          {},
+          loader.get('options'),
+        );
+
         if (id === CHAIN_ID.USE.CSS) {
           // postcss-loader, resolve-url-loader, sass-loader
           options.importLoaders = 3;
         }
+
         rule.use(id).loader(loader.get('loader')).options(options);
       }
 

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -99,17 +99,15 @@ export const pluginSass = (
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = deepmerge<Record<string, any>>(
-          {},
-          loader.get('options'),
-        );
+        const options = loader.get('options') ?? {};
+        const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
           // postcss-loader, resolve-url-loader, sass-loader
-          options.importLoaders = 3;
+          clonedOptions.importLoaders = 3;
         }
 
-        rule.use(id).loader(loader.get('loader')).options(options);
+        rule.use(id).loader(loader.get('loader')).options(clonedOptions);
       }
 
       rule

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,11 +1,6 @@
 import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import {
-  type FileFilterUtil,
-  castArray,
-  cloneDeep,
-  deepmerge,
-} from '@rsbuild/shared';
+import { type FileFilterUtil, cloneDeep, deepmerge } from '@rsbuild/shared';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import { getResolveUrlJoinFn, patchCompilerGlobalLocation } from './helpers';
 import type { PluginSassOptions, SassLoaderOptions } from './types';
@@ -24,7 +19,7 @@ const getSassLoaderOptions = (
   const excludes: (RegExp | string)[] = [];
 
   const addExcludes: FileFilterUtil = (items) => {
-    excludes.push(...castArray(items));
+    excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 
   const mergeFn = (

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0",
     "stylus": "0.63.0",
     "stylus-loader": "8.1.0"

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -1,5 +1,5 @@
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { cloneDeep, deepmerge } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import { reduceConfigs } from 'reduce-configs';
 
 export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';
@@ -51,10 +51,15 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = cloneDeep(loader.get('options'));
+        const options = deepmerge<Record<string, any>>(
+          {},
+          loader.get('options'),
+        );
+
         if (id === CHAIN_ID.USE.CSS) {
           options.importLoaders = 2;
         }
+
         rule.use(id).loader(loader.get('loader')).options(options);
       }
 

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -51,16 +51,14 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       // Copy the builtin CSS rules
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
-        const options = deepmerge<Record<string, any>>(
-          {},
-          loader.get('options'),
-        );
+        const options = loader.get('options') ?? {};
+        const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
-          options.importLoaders = 2;
+          clonedOptions.importLoaders = 2;
         }
 
-        rule.use(id).loader(loader.get('loader')).options(options);
+        rule.use(id).loader(loader.get('loader')).options(clonedOptions);
       }
 
       rule

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { logger } from '@rsbuild/core';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import { deepmerge } from '@rsbuild/shared';
 import type { sveltePreprocess } from 'svelte-preprocess';
 import type { CompileOptions } from 'svelte/compiler';
 
@@ -91,19 +90,19 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             },
           });
 
-          const svelteLoaderOptions = deepmerge(
-            {
-              compilerOptions: {
-                dev: isDev,
-              },
-              preprocess: sveltePreprocess(options.preprocessOptions),
-              // NOTE emitCss: true is currently not supported with HMR
-              // See https://github.com/web-infra-dev/rsbuild/issues/2744
-              emitCss: isProd && !environmentConfig.output.injectStyles,
-              hotReload: isDev && environmentConfig.dev.hmr,
+          const userLoaderOptions = options.svelteLoaderOptions ?? {};
+          const svelteLoaderOptions = {
+            preprocess: sveltePreprocess(options.preprocessOptions),
+            // NOTE emitCss: true is currently not supported with HMR
+            // See https://github.com/web-infra-dev/rsbuild/issues/2744
+            emitCss: isProd && !environmentConfig.output.injectStyles,
+            hotReload: isDev && environmentConfig.dev.hmr,
+            ...userLoaderOptions,
+            compilerOptions: {
+              dev: isDev,
+              ...userLoaderOptions.compilerOptions,
             },
-            options.svelteLoaderOptions ?? {},
-          );
+          };
 
           chain.module
             .rule(CHAIN_ID.RULE.SVELTE)

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -33,6 +33,7 @@
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0",
+    "deepmerge": "^4.3.1",
     "loader-utils": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -1,8 +1,8 @@
 import path from 'node:path';
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
-import { SCRIPT_REGEX, deepmerge } from '@rsbuild/shared';
 import type { Config } from '@svgr/core';
+import deepmerge from 'deepmerge';
 
 export type SvgDefaultExport = 'component' | 'url';
 
@@ -124,7 +124,10 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
       if (mixedImport || svgrOptions.exportType) {
         const { exportType = mixedImport ? 'named' : undefined } = svgrOptions;
 
-        const issuerInclude = [SCRIPT_REGEX, /\.mdx$/];
+        const issuerInclude = [
+          /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/,
+          /\.mdx$/,
+        ];
         const issuer = options.excludeImporter
           ? { and: [issuerInclude, { not: options.excludeImporter }] }
           : issuerInclude;

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "deepmerge": "^4.3.1",
     "fork-ts-checker-webpack-plugin": "9.0.2",
     "json5": "^2.2.3",
     "reduce-configs": "^1.0.0",

--- a/packages/plugin-type-check/src/index.ts
+++ b/packages/plugin-type-check/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { type RsbuildPlugin, logger } from '@rsbuild/core';
-import { CHAIN_ID, deepmerge } from '@rsbuild/shared';
+import { CHAIN_ID } from '@rsbuild/shared';
+import deepmerge from 'deepmerge';
 import type ForkTSCheckerPlugin from 'fork-ts-checker-webpack-plugin';
 import { type ConfigChain, reduceConfigs } from 'reduce-configs';
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,10 +24,6 @@
       "types": "./compiled/gzip-size/index.d.ts",
       "default": "./compiled/gzip-size/index.js"
     },
-    "./picocolors": {
-      "types": "./compiled/picocolors/picocolors.d.ts",
-      "default": "./compiled/picocolors/index.js"
-    },
     "./browserslist": {
       "types": "./compiled/browserslist/index.d.ts",
       "default": "./compiled/browserslist/index.js"
@@ -79,7 +75,6 @@
     "deepmerge": "^4.3.1",
     "gzip-size": "^6.0.0",
     "http-proxy-middleware": "^2.0.6",
-    "picocolors": "1.0.1",
     "prebundle": "1.1.0",
     "rspack-chain": "^0.7.3",
     "terser": "5.31.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -72,7 +72,6 @@
     "autoprefixer": "10.4.19",
     "browserslist": "4.23.1",
     "chokidar": "3.6.0",
-    "deepmerge": "^4.3.1",
     "gzip-size": "^6.0.0",
     "http-proxy-middleware": "^2.0.6",
     "prebundle": "1.1.0",

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -50,16 +50,6 @@ export default {
       },
     },
     {
-      name: 'picocolors',
-      beforeBundle({ depPath }) {
-        const typesFile = join(depPath, 'types.ts');
-        // Fix type bundle
-        if (fs.existsSync(typesFile)) {
-          fs.renameSync(typesFile, join(depPath, 'types.d.ts'));
-        }
-      },
-    },
-    {
       name: 'http-proxy-middleware',
       externals: {
         // express is a peer dependency, no need to provide express type
@@ -87,9 +77,9 @@ export default {
     {
       name: 'autoprefixer',
       externals: {
-        picocolors: '../picocolors',
         browserslist: '../browserslist',
         // Can be enabled after moving to core
+        // picocolors: 'picocolors',
         // 'postcss-value-parser': '../postcss-value-parser',
       },
     },

--- a/packages/shared/prebundle.config.mjs
+++ b/packages/shared/prebundle.config.mjs
@@ -21,7 +21,6 @@ export default {
     typescript: 'typescript',
   },
   dependencies: [
-    'deepmerge',
     {
       name: 'chokidar',
       externals: {
@@ -46,7 +45,8 @@ export default {
       name: 'rspack-chain',
       externals: {
         '@rspack/core': '@rspack/core',
-        deepmerge: '../deepmerge',
+        // TODO
+        // deepmerge: '../deepmerge',
       },
     },
     {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,13 +9,6 @@ export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 
 export { deepmerge };
 
-export const castArray = <T>(arr?: T | T[]): T[] => {
-  if (arr === undefined) {
-    return [];
-  }
-  return Array.isArray(arr) ? arr : [arr];
-};
-
 export const cloneDeep = <T>(value: T): T => {
   if (value === null || value === undefined) {
     return value;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,20 +1,7 @@
-import deepmerge from '../compiled/deepmerge/index.js';
 import RspackChain from '../compiled/rspack-chain/index.js';
 import type { CacheGroups } from './types';
 
 export * from './types';
-
-// RegExp
-export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
-
-export { deepmerge };
-
-export const cloneDeep = <T>(value: T): T => {
-  if (value === null || value === undefined) {
-    return value;
-  }
-  return deepmerge({}, value);
-};
 
 const DEP_MATCH_TEMPLATE = /[\\/]node_modules[\\/](<SOURCES>)[\\/]/.source;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,4 @@
 import deepmerge from '../compiled/deepmerge/index.js';
-import color from '../compiled/picocolors/index.js';
 import RspackChain from '../compiled/rspack-chain/index.js';
 import type { CacheGroups } from './types';
 
@@ -8,12 +7,7 @@ export * from './types';
 // RegExp
 export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 
-export { color, deepmerge };
-
-export type Colors = Omit<
-  keyof typeof color,
-  'createColor' | 'isColorSupported'
->;
+export { deepmerge };
 
 export const castArray = <T>(arr?: T | T[]): T[] => {
   if (arr === undefined) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,6 +613,9 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
+      picocolors:
+        specifier: ^1.0.1
+        version: 1.0.1
       semver:
         specifier: ^7.6.2
         version: 7.6.2
@@ -650,6 +653,9 @@ importers:
       mini-css-extract-plugin:
         specifier: 2.9.0
         version: 2.9.0(webpack@5.92.1)
+      picocolors:
+        specifier: ^1.0.1
+        version: 1.0.1
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -754,6 +760,9 @@ importers:
       open:
         specifier: ^8.4.0
         version: 8.4.2
+      picocolors:
+        specifier: ^1.0.1
+        version: 1.0.1
       postcss-load-config:
         specifier: 6.0.1
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.39)(tsx@4.14.0)(yaml@2.4.5)
@@ -912,6 +921,9 @@ importers:
       htmlparser2:
         specifier: 9.1.0
         version: 9.1.0
+      picocolors:
+        specifier: ^1.0.1
+        version: 1.0.1
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
@@ -1523,9 +1535,6 @@ importers:
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.6
-      picocolors:
-        specifier: 1.0.1
-        version: 1.0.1
       prebundle:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.5.2)
@@ -6476,9 +6485,6 @@ packages:
   picocolors@0.2.1:
     resolution: {integrity: sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==}
 
-  picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
-
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
@@ -9522,7 +9528,7 @@ snapshots:
   '@clack/prompts@0.7.0':
     dependencies:
       '@clack/core': 0.3.4
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       sisteransi: 1.0.5
 
   '@discoveryjs/json-ext@0.5.7': {}
@@ -13573,7 +13579,7 @@ snapshots:
 
   nano-staged@0.8.0:
     dependencies:
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   nanoid@3.3.7: {}
 
@@ -13855,8 +13861,6 @@ snapshots:
       is-reference: 3.0.2
 
   picocolors@0.2.1: {}
-
-  picocolors@1.0.0: {}
 
   picocolors@1.0.1: {}
 
@@ -14149,7 +14153,7 @@ snapshots:
   postcss@8.4.38:
     dependencies:
       nanoid: 3.3.7
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       source-map-js: 1.2.0
 
   postcss@8.4.39:
@@ -15091,7 +15095,7 @@ snapshots:
       css-tree: 2.3.1
       css-what: 6.1.0
       csso: 5.0.5
-      picocolors: 1.0.0
+      picocolors: 1.0.1
 
   table@6.8.2:
     dependencies:
@@ -15422,7 +15426,7 @@ snapshots:
       local-pkg: 0.5.0
       magic-string: 0.30.10
       pathe: 1.1.2
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       std-env: 3.7.0
       strip-literal: 2.1.0
       tinybench: 2.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,9 @@ importers:
       core-js:
         specifier: ~3.37.1
         version: 3.37.1
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -736,6 +739,9 @@ importers:
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))(webpack@5.92.1)
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       dotenv:
         specifier: 16.4.5
         version: 16.4.5
@@ -881,6 +887,9 @@ importers:
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1006,6 +1015,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1099,6 +1111,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1133,6 +1148,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       loader-utils:
         specifier: ^2.0.4
         version: 2.0.4
@@ -1248,6 +1266,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1313,6 +1334,9 @@ importers:
       '@svgr/plugin-svgo':
         specifier: 8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.5.2))(typescript@5.5.2)
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       loader-utils:
         specifier: ^2.0.4
         version: 2.0.4
@@ -1344,6 +1368,9 @@ importers:
       '@rsbuild/shared':
         specifier: workspace:*
         version: link:../shared
+      deepmerge:
+        specifier: ^4.3.1
+        version: 4.3.1
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
         version: 9.0.2(typescript@5.5.2)(webpack@5.92.1)
@@ -1526,9 +1553,6 @@ importers:
       chokidar:
         specifier: 3.6.0
         version: 3.6.0
-      deepmerge:
-        specifier: ^4.3.1
-        version: 4.3.1
       gzip-size:
         specifier: ^6.0.0
         version: 6.0.0


### PR DESCRIPTION
## Summary

Move more helpers from `shared` to `core` or direct dependencies, and the `@rsbuild/shared` package can be removed soon.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
