### PR TITLE
refactor: remove shared from all non-core packages

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -1,10 +1,9 @@
 import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { logger } from '@rsbuild/core';
+import { type RequestHandler, logger } from '@rsbuild/core';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
-import type { RequestHandler } from '@rsbuild/shared';
 import stripAnsi from 'strip-ansi';
 
 // TODO: write a common testMiddleware instead of collect DEBUG logger

--- a/e2e/cases/configure-rspack/index.test.ts
+++ b/e2e/cases/configure-rspack/index.test.ts
@@ -1,6 +1,5 @@
 import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import type { RspackConfig } from '@rsbuild/shared';
 
 rspackOnlyTest(
   'should allow to use tools.rspack to configure Rspack',

--- a/e2e/cases/esm-exports/test.mjs
+++ b/e2e/cases/esm-exports/test.mjs
@@ -25,11 +25,9 @@ import { pluginVue } from '@rsbuild/plugin-vue';
 import { pluginVueJsx } from '@rsbuild/plugin-vue-jsx';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 import { pluginVue2Jsx } from '@rsbuild/plugin-vue2-jsx';
-import * as shared from '@rsbuild/shared';
 import { webpackProvider } from '@rsbuild/webpack';
 
 export default {
-  shared,
   pluginAssetsRetry,
   pluginBabel,
   pluginCheckSyntax,

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { build, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import type { RspackChain } from '@rsbuild/shared';
+import type { RspackChain } from '@rsbuild/core';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map
 const toolsConfig = {

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -2,8 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import type { RsbuildConfig } from '@rsbuild/core';
-import type { TransformImport } from '@rsbuild/shared';
+import type { RsbuildConfig, TransformImport } from '@rsbuild/core';
 import fse from 'fs-extra';
 
 export const cases: Parameters<typeof shareTest>[] = [

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -49,7 +49,6 @@
     "@rsbuild/plugin-vue-jsx": "workspace:*",
     "@rsbuild/plugin-vue2": "workspace:*",
     "@rsbuild/plugin-vue2-jsx": "workspace:*",
-    "@rsbuild/shared": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/fs-extra": "^11.0.4",

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
-import type { ConsoleType } from '@rsbuild/shared';
+import type { ConsoleType } from '@rsbuild/core';
 import glob, {
   convertPathToPattern,
   type Options as GlobOptions,

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -15,5 +15,10 @@
     "playwright.config.ts",
     "cases/**/*.test.ts"
   ],
+  "references": [
+    {
+      "path": "../packages/core"
+    }
+  ],
   "exclude": ["**/node_modules", "**/.*/"]
 }

--- a/packages/compat/babel-preset/tsconfig.json
+++ b/packages/compat/babel-preset/tsconfig.json
@@ -12,9 +12,6 @@
       "path": "../../core"
     },
     {
-      "path": "../../shared"
-    },
-    {
       "path": "../../plugin-babel"
     }
   ],

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@modern-js/swc-plugins": "0.6.7",
-    "@rsbuild/shared": "workspace:*",
     "@swc/helpers": "0.5.11",
     "core-js": "~3.37.1",
     "deepmerge": "^4.3.1",

--- a/packages/compat/plugin-swc/tsconfig.json
+++ b/packages/compat/plugin-swc/tsconfig.json
@@ -9,9 +9,6 @@
   },
   "references": [
     {
-      "path": "../../shared"
-    },
-    {
       "path": "../../core"
     }
   ],

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/shared": "workspace:*",
     "copy-webpack-plugin": "11.0.0",
     "mini-css-extract-plugin": "2.9.0",
     "picocolors": "^1.0.1",

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -1,5 +1,4 @@
 import { type Rspack, logger } from '@rsbuild/core';
-import type { RspackConfig, Stats } from '@rsbuild/shared';
 import WebpackMultiStats from 'webpack/lib/MultiStats.js';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 import {
@@ -20,7 +19,7 @@ export async function createCompiler({
 }) {
   logger.debug('create compiler');
   await context.hooks.onBeforeCreateCompiler.call({
-    bundlerConfigs: webpackConfigs as RspackConfig[],
+    bundlerConfigs: webpackConfigs as Rspack.Configuration[],
     environments: context.environments,
   });
 
@@ -34,7 +33,7 @@ export async function createCompiler({
 
   const done = async (stats: unknown) => {
     const { message, level } = formatStats(
-      stats as Stats,
+      stats as Rspack.Stats,
       getStatsOptions(compiler),
     );
 
@@ -48,7 +47,7 @@ export async function createCompiler({
     if (process.env.NODE_ENV === 'development') {
       await context.hooks.onDevCompileDone.call({
         isFirstCompile,
-        stats: stats as Stats,
+        stats: stats as Rspack.Stats,
         environments: context.environments,
       });
     }

--- a/packages/compat/webpack/src/initConfigs.ts
+++ b/packages/compat/webpack/src/initConfigs.ts
@@ -1,9 +1,9 @@
 import {
   type CreateRsbuildOptions,
   type InspectConfigOptions,
+  type PluginManager,
   logger,
 } from '@rsbuild/core';
-import type { PluginManager } from '@rsbuild/shared';
 import { inspectConfig } from './inspectConfig';
 import { type InternalContext, initRsbuildConfig } from './shared';
 import type { WebpackConfig } from './types';

--- a/packages/compat/webpack/src/plugin.ts
+++ b/packages/compat/webpack/src/plugin.ts
@@ -3,9 +3,9 @@ import type {
   ChainIdentifier,
   RsbuildPlugin,
   RsbuildTarget,
+  Rspack,
   RspackChain,
 } from '@rsbuild/core';
-import type { CopyPluginOptions } from '@rsbuild/shared';
 import { castArray } from './shared';
 
 async function applyTsConfigPathsPlugin({
@@ -90,7 +90,7 @@ export const pluginAdaptor = (): RsbuildPlugin => ({
       if (copy) {
         const { default: CopyPlugin } = await import('copy-webpack-plugin');
 
-        const options: CopyPluginOptions = Array.isArray(copy)
+        const options: Rspack.CopyRspackPluginOptions = Array.isArray(copy)
           ? { patterns: copy }
           : copy;
 
@@ -104,7 +104,7 @@ export const pluginAdaptor = (): RsbuildPlugin => ({
     api.modifyWebpackConfig(async (config) => {
       const copyPlugin = config.plugins?.find(
         (item) => item?.constructor.name === 'CopyPlugin',
-      ) as unknown as CopyPluginOptions;
+      ) as unknown as Rspack.CopyRspackPluginOptions;
 
       if (copyPlugin) {
         // If the pattern.context directory not exists, we should remove CopyPlugin.

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -1,5 +1,4 @@
-import type { RsbuildProvider } from '@rsbuild/core';
-import type { CreateCompiler } from '@rsbuild/shared';
+import type { CreateCompiler, RsbuildProvider } from '@rsbuild/core';
 import { initConfigs } from './initConfigs';
 import { createDevServer, initRsbuildConfig } from './shared';
 

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -1,14 +1,15 @@
 import {
   type EnvironmentContext,
+  type ModifyRspackConfigUtils,
   type ModifyWebpackChainUtils,
   type ModifyWebpackConfigUtils,
   type RsbuildTarget,
+  type Rspack,
   type RspackChain,
   __internalHelper,
   logger,
 } from '@rsbuild/core';
 import { reduceConfigsWithContext } from 'reduce-configs';
-import type { RuleSetRule, WebpackPluginInstance } from 'webpack';
 import {
   type InternalContext,
   castArray,
@@ -84,54 +85,6 @@ async function getChainUtils(
   };
 }
 
-async function getConfigUtils(
-  config: WebpackConfig,
-  chainUtils: ModifyWebpackChainUtils,
-): Promise<ModifyWebpackConfigUtils> {
-  const { merge } = await import('@rsbuild/shared/webpack-merge');
-
-  return {
-    ...chainUtils,
-
-    mergeConfig: merge,
-
-    addRules(rules: RuleSetRule | RuleSetRule[]) {
-      const ruleArr = castArray(rules);
-      if (!config.module) {
-        config.module = {};
-      }
-      if (!config.module.rules) {
-        config.module.rules = [];
-      }
-      config.module.rules.unshift(...ruleArr);
-    },
-
-    prependPlugins(plugins: WebpackPluginInstance | WebpackPluginInstance[]) {
-      const pluginArr = castArray(plugins);
-      if (!config.plugins) {
-        config.plugins = [];
-      }
-      config.plugins.unshift(...pluginArr);
-    },
-
-    appendPlugins(plugins: WebpackPluginInstance | WebpackPluginInstance[]) {
-      const pluginArr = castArray(plugins);
-      if (!config.plugins) {
-        config.plugins = [];
-      }
-      config.plugins.push(...pluginArr);
-    },
-
-    removePlugin(pluginName: string) {
-      if (config.plugins) {
-        config.plugins = config.plugins.filter(
-          (item) => item?.constructor.name !== pluginName,
-        );
-      }
-    },
-  };
-}
-
 export async function generateWebpackConfig({
   target,
   context,
@@ -169,10 +122,15 @@ export async function generateWebpackConfig({
 
   let webpackConfig = chainToConfig(chain) as WebpackConfig;
 
+  const configUtils = (await __internalHelper.getConfigUtils(
+    webpackConfig as Rspack.Configuration,
+    chainUtils as unknown as ModifyRspackConfigUtils,
+  )) as unknown as ModifyWebpackConfigUtils;
+
   webpackConfig = await modifyWebpackConfig(
     context,
     webpackConfig,
-    await getConfigUtils(webpackConfig, chainUtils),
+    configUtils,
   );
 
   return webpackConfig;

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -1,14 +1,12 @@
 import {
+  type EnvironmentContext,
+  type ModifyWebpackChainUtils,
+  type ModifyWebpackConfigUtils,
   type RsbuildTarget,
   type RspackChain,
   __internalHelper,
   logger,
 } from '@rsbuild/core';
-import type {
-  EnvironmentContext,
-  ModifyWebpackChainUtils,
-  ModifyWebpackConfigUtils,
-} from '@rsbuild/shared';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import type { RuleSetRule, WebpackPluginInstance } from 'webpack';
 import {

--- a/packages/compat/webpack/tests/default.test.ts
+++ b/packages/compat/webpack/tests/default.test.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPlugin } from '@rsbuild/shared';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { createStubRsbuild } from './helper';
 
 describe('applyDefaultPlugins', () => {

--- a/packages/compat/webpack/tests/initConfigs.test.ts
+++ b/packages/compat/webpack/tests/initConfigs.test.ts
@@ -1,4 +1,4 @@
-import type { RsbuildConfig, RsbuildPluginAPI } from '@rsbuild/shared';
+import type { RsbuildConfig, RsbuildPluginAPI } from '@rsbuild/core';
 import { createStubRsbuild } from './helper';
 
 describe('modifyRsbuildConfig', () => {

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -9,9 +9,6 @@
   "references": [
     {
       "path": "../../core"
-    },
-    {
-      "path": "../../shared"
     }
   ],
   "include": ["src"]

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -547,14 +547,14 @@ export const isMultiCompiler = <
 
 export const onCompileDone = (
   compiler: Rspack.Compiler | Rspack.MultiCompiler,
-  onDone: (stats: Stats | MultiStats) => Promise<void>,
-  MultiStatsCtor: new (stats: Stats[]) => MultiStats,
+  onDone: (stats: Rspack.Stats | Rspack.MultiStats) => Promise<void>,
+  MultiStatsCtor: new (stats: Rspack.Stats[]) => Rspack.MultiStats,
 ): void => {
   // The MultiCompiler of Rspack does not supports `done.tapPromise`,
   // so we need to use the `done` hook of `MultiCompiler.compilers` to implement it.
   if (isMultiCompiler(compiler)) {
     const { compilers } = compiler;
-    const compilerStats: Stats[] = [];
+    const compilerStats: Rspack.Stats[] = [];
     let doneCompilers = 0;
 
     for (let index = 0; index < compilers.length; index++) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,9 @@ export type {
   RsbuildEntry,
   RsbuildTarget,
   RsbuildContext,
+  BuildOptions,
+  CreateCompiler,
+  CreateCompilerOptions,
   EnvironmentContext,
   InspectConfigResult,
   InspectConfigOptions,
@@ -93,6 +96,7 @@ export type {
   DistPathConfig,
   OutputStructure,
   ChainIdentifier,
+  TransformImport,
   PublicDirOptions,
   PreconnectOption,
   CSSLoaderOptions,
@@ -116,11 +120,20 @@ export type {
   OnDevCompileDoneFn,
   ModifyBundlerChainFn,
   ModifyRspackConfigFn,
+  ModifyWebpackChainFn,
   ModifyRsbuildConfigFn,
+  ModifyWebpackChainUtils,
+  ModifyWebpackConfigUtils,
+  ModifyBundlerChainUtils,
   TransformFn,
   TransformHandler,
   ServerAPIs,
   RequestHandler,
+  PluginManager,
+  // Rspack related
+  CacheGroup,
+  CacheGroups,
+  BundlerPluginInstance,
 } from '@rsbuild/shared';
 
 export {

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -22,7 +22,7 @@ export {
   onCompileDone,
   prettyTime,
 } from './helpers';
-export { getChainUtils } from './provider/rspackConfig';
+export { getChainUtils, getConfigUtils } from './provider/rspackConfig';
 export { chainToConfig, modifyBundlerChain } from './configChain';
 export { applySwcDecoratorConfig } from './plugins/swc';
 export { getSwcMinimizerOptions } from './plugins/minimize';

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -51,12 +51,7 @@ export const build = async (
     await p;
   };
 
-  onCompileDone(
-    compiler,
-    onDone,
-    // @ts-expect-error type mismatch
-    rspack.MultiStats,
-  );
+  onCompileDone(compiler, onDone, rspack.MultiStats);
 
   if (watch) {
     compiler.watch({}, (err) => {

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -112,12 +112,7 @@ export async function createCompiler({
     isFirstCompile = false;
   };
 
-  onCompileDone(
-    compiler,
-    done,
-    // @ts-expect-error type mismatch
-    rspack.MultiStats,
-  );
+  onCompileDone(compiler, done, rspack.MultiStats);
 
   await context.hooks.onAfterCreateCompiler.call({
     compiler,

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -4,6 +4,7 @@ import {
   type ModifyChainUtils,
   type ModifyRspackConfigUtils,
   type RsbuildTarget,
+  type Rspack,
   type RspackConfig,
 } from '@rsbuild/shared';
 import { rspack } from '@rspack/core';
@@ -38,8 +39,8 @@ async function modifyRspackConfig(
   return modifiedConfig;
 }
 
-async function getConfigUtils(
-  config: RspackConfig,
+export async function getConfigUtils(
+  config: Rspack.Configuration,
   chainUtils: ModifyChainUtils,
 ): Promise<ModifyRspackConfigUtils> {
   const { merge } = await import('@rsbuild/shared/webpack-merge');
@@ -79,11 +80,16 @@ async function getConfigUtils(
     },
 
     removePlugin(pluginName) {
-      if (config.plugins) {
-        config.plugins = config.plugins.filter(
-          (p) => p && p.name !== pluginName,
-        );
+      if (!config.plugins) {
+        return;
       }
+      config.plugins = config.plugins.filter((plugin) => {
+        if (!plugin) {
+          return true;
+        }
+        const name = plugin.name || plugin.constructor.name;
+        return name !== pluginName;
+      });
     },
   };
 }

--- a/packages/core/src/server/devMiddleware.ts
+++ b/packages/core/src/server/devMiddleware.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { CompilerTapFn, DevConfig, NextFunction } from '@rsbuild/shared';
+import type { DevConfig, NextFunction } from '@rsbuild/shared';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import { applyToCompiler } from '../helpers';
 import type { DevMiddlewareOptions } from '../provider/createCompiler';
@@ -35,6 +35,10 @@ const isNodeCompiler = (compiler: {
   }
 
   return false;
+};
+
+type CompilerTapFn<CallBack extends (...args: any[]) => void = () => void> = {
+  tap: (name: string, cb: CallBack) => void;
 };
 
 export const setupServerHooks = (

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "serialize-javascript": "^6.0.2"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/tsconfig.json
+++ b/packages/plugin-assets-retry/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -32,7 +32,6 @@
     "@babel/plugin-proposal-decorators": "^7.24.7",
     "@babel/plugin-transform-class-properties": "^7.24.7",
     "@babel/preset-typescript": "^7.24.7",
-    "@rsbuild/shared": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0",

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "acorn": "^8.12.0",
     "browserslist-to-es-version": "^1.0.0",
     "htmlparser2": "9.1.0",

--- a/packages/plugin-check-syntax/tsconfig.json
+++ b/packages/plugin-check-syntax/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -29,7 +29,6 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0"
   },

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -4,7 +4,6 @@ import type {
   RsbuildPlugin,
   Rspack,
 } from '@rsbuild/core';
-import type { FileFilterUtil } from '@rsbuild/shared';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import type Less from '../compiled/less';
@@ -36,7 +35,7 @@ export type PluginLessOptions = {
        * @deprecated
        * use `exclude` option instead.
        */
-      addExcludes: FileFilterUtil;
+      addExcludes: (items: string | RegExp | Array<string | RegExp>) => void;
     }
   >;
 
@@ -53,7 +52,7 @@ const getLessLoaderOptions = (
 ) => {
   const excludes: (RegExp | string)[] = [];
 
-  const addExcludes: FileFilterUtil = (items) => {
+  const addExcludes = (items: string | RegExp | Array<string | RegExp>) => {
     excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 

--- a/packages/plugin-less/tsconfig.json
+++ b/packages/plugin-less/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -26,7 +26,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "browserslist": "4.23.1",
     "lightningcss": "^1.25.1",
     "reduce-configs": "^1.0.0"

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@rsbuild/shared": "workspace:*",
+    "browserslist": "4.23.1",
     "lightningcss": "^1.25.1",
     "reduce-configs": "^1.0.0"
   },

--- a/packages/plugin-lightningcss/src/plugin.ts
+++ b/packages/plugin-lightningcss/src/plugin.ts
@@ -5,7 +5,7 @@ import type {
   RsbuildPlugin,
   RspackChain,
 } from '@rsbuild/core';
-import browserslist from '@rsbuild/shared/browserslist';
+import browserslist from 'browserslist';
 import * as lightningcss from 'lightningcss';
 import type { Targets } from 'lightningcss';
 import { reduceConfigs } from 'reduce-configs';

--- a/packages/plugin-lightningcss/tsconfig.json
+++ b/packages/plugin-lightningcss/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -26,7 +26,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "@rspack/plugin-react-refresh": "1.0.0-alpha.0",
     "react-refresh": "^0.14.2"
   },

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
-import type { CacheGroups } from '@rsbuild/shared';
+import type { CacheGroups, RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
 import type { SplitReactChunkOptions } from '.';
 
 const isPlainObject = (obj: unknown): obj is Record<string, any> =>

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -29,7 +29,6 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "deepmerge": "^4.3.1",
     "terser": "5.31.1"
   },

--- a/packages/plugin-rem/tsconfig.json
+++ b/packages/plugin-rem/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -29,7 +29,6 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "deepmerge": "^4.3.1",
     "loader-utils": "^2.0.4",
     "postcss": "^8.4.39",

--- a/packages/plugin-sass/src/helpers.ts
+++ b/packages/plugin-sass/src/helpers.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import type { CompilerTapFn } from '@rsbuild/shared';
 
 const GLOBAL_PATCHED_SYMBOL: unique symbol = Symbol('GLOBAL_PATCHED_SYMBOL');
 
@@ -25,6 +24,10 @@ function unpatchGlobalLocation() {
     delete global.location;
   }
 }
+
+type CompilerTapFn<CallBack extends (...args: any[]) => void = () => void> = {
+  tap: (name: string, cb: CallBack) => void;
+};
 
 export function patchCompilerGlobalLocation(compiler: {
   hooks: {

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,6 +1,5 @@
 import { join } from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import type { FileFilterUtil } from '@rsbuild/shared';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import { getResolveUrlJoinFn, patchCompilerGlobalLocation } from './helpers';
@@ -19,7 +18,7 @@ const getSassLoaderOptions = (
 } => {
   const excludes: (RegExp | string)[] = [];
 
-  const addExcludes: FileFilterUtil = (items) => {
+  const addExcludes = (items: string | RegExp | Array<string | RegExp>) => {
     excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 

--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -1,5 +1,4 @@
 import type { ConfigChainWithContext, Rspack } from '@rsbuild/core';
-import type { FileFilterUtil } from '@rsbuild/shared';
 import type {
   LegacyOptions as LegacySassOptions,
   Options as SassOptions,
@@ -40,7 +39,7 @@ export type PluginSassOptions = {
        * @deprecated
        * use `exclude` option instead.
        */
-      addExcludes: FileFilterUtil;
+      addExcludes: (items: string | RegExp | Array<string | RegExp>) => void;
     }
   >;
 

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "fast-glob": "^3.3.2",
     "json5": "^2.2.3"
   },

--- a/packages/plugin-source-build/tsconfig.json
+++ b/packages/plugin-source-build/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -26,7 +26,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "@swc/plugin-styled-components": "2.0.8",
     "reduce-configs": "^1.0.0"
   },

--- a/packages/plugin-styled-components/tsconfig.json
+++ b/packages/plugin-styled-components/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "deepmerge": "^4.3.1",
     "reduce-configs": "^1.0.0",
     "stylus": "0.63.0",

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -26,7 +26,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "svelte-loader": "3.2.3",
     "svelte-preprocess": "^6.0.1"
   },

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@rsbuild/plugin-react": "workspace:*",
-    "@rsbuild/shared": "workspace:*",
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0",

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -11,7 +11,6 @@
     {
       "path": "../core"
     },
-    ,
     {
       "path": "../plugin-react"
     }

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -11,9 +11,7 @@
     {
       "path": "../core"
     },
-    {
-      "path": "../shared"
-    },
+    ,
     {
       "path": "../plugin-react"
     }

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "deepmerge": "^4.3.1",
     "fork-ts-checker-webpack-plugin": "9.0.2",
     "json5": "^2.2.3",

--- a/packages/plugin-type-check/tsconfig.json
+++ b/packages/plugin-type-check/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -28,9 +28,6 @@
     "dev": "modern build --watch",
     "prebundle": "prebundle"
   },
-  "dependencies": {
-    "@rsbuild/shared": "workspace:*"
-  },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",

--- a/packages/plugin-typed-css-modules/tsconfig.json
+++ b/packages/plugin-typed-css-modules/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-umd/tsconfig.json
+++ b/packages/plugin-umd/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "vue-loader": "^17.4.0",
     "webpack": "^5.92.1"
   },

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
-import type { CacheGroups } from '@rsbuild/shared';
+import type { CacheGroups, RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
 import type { SplitVueChunkOptions } from '.';
 
 const isPlainObject = (obj: unknown): obj is Record<string, any> =>

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -27,7 +27,6 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/shared": "workspace:*",
     "vue-loader": "^15.11.1",
     "webpack": "^5.92.1"
   },

--- a/packages/plugin-vue2/src/splitChunks.ts
+++ b/packages/plugin-vue2/src/splitChunks.ts
@@ -1,5 +1,4 @@
-import type { RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
-import type { CacheGroups } from '@rsbuild/shared';
+import type { CacheGroups, RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
 import type { SplitVueChunkOptions } from '.';
 
 const isPlainObject = (obj: unknown): obj is Record<string, any> =>

--- a/packages/plugin-vue2/tsconfig.json
+++ b/packages/plugin-vue2/tsconfig.json
@@ -10,9 +10,6 @@
   "references": [
     {
       "path": "../core"
-    },
-    {
-      "path": "../shared"
     }
   ],
   "include": ["src"]

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -185,8 +185,6 @@ export type Minify =
       htmlOptions?: HTMLPluginOptions['minify'];
     };
 
-export type CopyPluginOptions = CopyRspackPluginOptions;
-
 export type InlineChunkTestFunction = (params: {
   size: number;
   name: string;
@@ -289,7 +287,9 @@ export interface OutputConfig {
   /**
    * Copies the specified file or directory to the dist directory.
    */
-  copy?: CopyPluginOptions | CopyPluginOptions['patterns'];
+  copy?:
+    | Rspack.CopyRspackPluginOptions
+    | Rspack.CopyRspackPluginOptions['patterns'];
   /**
    * Whether to emit static assets such as image, font, etc.
    * Return `false` to avoid outputting unnecessary assets for some scenarios such as SSR.

--- a/packages/shared/src/types/config/output.ts
+++ b/packages/shared/src/types/config/output.ts
@@ -287,9 +287,7 @@ export interface OutputConfig {
   /**
    * Copies the specified file or directory to the dist directory.
    */
-  copy?:
-    | Rspack.CopyRspackPluginOptions
-    | Rspack.CopyRspackPluginOptions['patterns'];
+  copy?: CopyRspackPluginOptions | CopyRspackPluginOptions['patterns'];
   /**
    * Whether to emit static assets such as image, font, etc.
    * Return `false` to avoid outputting unnecessary assets for some scenarios such as SSR.

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -14,7 +14,9 @@ import type { WebpackConfig } from './thirdParty';
 import type { MaybePromise, NodeEnv } from './utils';
 
 export type OnBeforeBuildFn<B = 'rspack'> = (params: {
-  bundlerConfigs?: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
+  bundlerConfigs?: B extends 'rspack'
+    ? Rspack.Configuration[]
+    : WebpackConfig[];
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
@@ -55,7 +57,7 @@ export type OnAfterStartProdServerFn = (params: {
 }) => MaybePromise<void>;
 
 export type OnBeforeCreateCompilerFn<B = 'rspack'> = (params: {
-  bundlerConfigs: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
+  bundlerConfigs: B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[];
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 

--- a/packages/shared/src/types/hooks.ts
+++ b/packages/shared/src/types/hooks.ts
@@ -8,7 +8,7 @@ import type {
   RsbuildConfig,
 } from './config';
 import type { RsbuildEntry, RsbuildTarget } from './rsbuild';
-import type { Rspack, RspackConfig } from './rspack';
+import type { Rspack } from './rspack';
 import type { MultiStats, Stats } from './stats';
 import type { WebpackConfig } from './thirdParty';
 import type { MaybePromise, NodeEnv } from './utils';

--- a/packages/shared/src/types/utils.ts
+++ b/packages/shared/src/types/utils.ts
@@ -12,12 +12,6 @@ export type DeepReadonly<T> = keyof T extends never
 
 export type FileFilterUtil = (items: OneOrMany<string | RegExp>) => void;
 
-export type CompilerTapFn<
-  CallBack extends (...args: any[]) => void = () => void,
-> = {
-  tap: (name: string, cb: CallBack) => void;
-};
-
 export type ConfigChain<T> = OneOrMany<T | ((config: T) => T | void)>;
 
 export type ConfigChainWithContext<T, Ctx> = OneOrMany<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       '@rsbuild/plugin-vue2-jsx':
         specifier: workspace:*
         version: link:../packages/plugin-vue2-jsx
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../packages/shared
       '@rsbuild/webpack':
         specifier: workspace:*
         version: link:../packages/compat/webpack
@@ -601,9 +598,6 @@ importers:
       '@modern-js/swc-plugins':
         specifier: 0.6.7
         version: 0.6.7(@swc/helpers@0.5.11)
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../../shared
       '@swc/helpers':
         specifier: 0.5.11
         version: 0.5.11
@@ -647,9 +641,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../core
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../../shared
       copy-webpack-plugin:
         specifier: 11.0.0
         version: 11.0.0(webpack@5.92.1)
@@ -835,9 +826,6 @@ importers:
 
   packages/plugin-assets-retry:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       serialize-javascript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -881,9 +869,6 @@ importers:
       '@babel/preset-typescript':
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -918,9 +903,6 @@ importers:
 
   packages/plugin-check-syntax:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       acorn:
         specifier: ^8.12.0
         version: 8.12.0
@@ -1012,9 +994,6 @@ importers:
 
   packages/plugin-less:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1046,9 +1025,9 @@ importers:
 
   packages/plugin-lightningcss:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
+      browserslist:
+        specifier: 4.23.1
+        version: 4.23.1
       lightningcss:
         specifier: ^1.25.1
         version: 1.25.1
@@ -1083,9 +1062,6 @@ importers:
 
   packages/plugin-react:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@rspack/plugin-react-refresh':
         specifier: 1.0.0-alpha.0
         version: 1.0.0-alpha.0(react-refresh@0.14.2)
@@ -1108,9 +1084,6 @@ importers:
 
   packages/plugin-rem:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1145,9 +1118,6 @@ importers:
 
   packages/plugin-sass:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1213,9 +1183,6 @@ importers:
 
   packages/plugin-source-build:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
@@ -1241,9 +1208,6 @@ importers:
 
   packages/plugin-styled-components:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@swc/plugin-styled-components':
         specifier: 2.0.8
         version: 2.0.8
@@ -1263,9 +1227,6 @@ importers:
 
   packages/plugin-stylus:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1291,9 +1252,6 @@ importers:
 
   packages/plugin-svelte:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       svelte-loader:
         specifier: 3.2.3
         version: 3.2.3(svelte@4.2.18)
@@ -1322,9 +1280,6 @@ importers:
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../plugin-react
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@svgr/core':
         specifier: 8.1.0
         version: 8.1.0(typescript@5.5.2)
@@ -1365,9 +1320,6 @@ importers:
 
   packages/plugin-type-check:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1395,10 +1347,6 @@ importers:
         version: 5.5.2
 
   packages/plugin-typed-css-modules:
-    dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1427,9 +1375,6 @@ importers:
 
   packages/plugin-vue:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       vue-loader:
         specifier: ^17.4.0
         version: 17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.1)
@@ -1477,9 +1422,6 @@ importers:
 
   packages/plugin-vue2:
     dependencies:
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../shared
       vue-loader:
         specifier: ^15.11.1
         version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@1.0.0-alpha.0(@swc/helpers@0.5.11))(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.1)
@@ -1595,9 +1537,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@rsbuild/shared':
-        specifier: workspace:*
-        version: link:../../packages/shared
       '@types/lodash':
         specifier: ^4.17.6
         version: 4.17.6

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rsbuild/shared": "workspace:*",
     "@types/lodash": "^4.17.6",
     "@types/node": "18.x",
     "lodash": "^4.17.21",

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -1,12 +1,16 @@
 import type {
+  BundlerPluginInstance,
   CreateRsbuildOptions,
   RsbuildInstance,
   RsbuildPlugin,
+  Rspack,
 } from '@rsbuild/core';
-import type { BundlerPluginInstance, RspackConfig } from '@rsbuild/shared';
 
 /** Match plugin by constructor name. */
-export const matchPlugin = (config: RspackConfig, pluginName: string) => {
+export const matchPlugin = (
+  config: Rspack.Configuration,
+  pluginName: string,
+) => {
   const result = config.plugins?.filter(
     (item) => item?.constructor.name === pluginName,
   );

--- a/website/docs/en/config/output/copy.mdx
+++ b/website/docs/en/config/output/copy.mdx
@@ -1,6 +1,6 @@
 # output.copy
 
-- **Type:** `CopyPluginOptions | CopyPluginOptions['patterns']`
+- **Type:** `Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns']`
 - **Default:** `undefined`
 
 Copies the specified file or directory to the dist directory, implemented based on [rspack.CopyRspackPlugin](https://rspack.dev/plugins/rspack/copy-rspack-plugin).

--- a/website/docs/en/guide/start/npm-packages.mdx
+++ b/website/docs/en/guide/start/npm-packages.mdx
@@ -182,21 +182,6 @@ Used to automatically resend requests when static assets fail to load.
 - [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-assets-retry)
 - [Documentation](/plugins/list/plugin-assets-retry)
 
-## @rsbuild/shared
-
-![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)
-
-Shared modules and helpers used internally by Rsbuild.
-
-- [npm](https://npmjs.com/package/@rsbuild/shared)
-- [Source Code](https://github.com/web-infra-dev/rsbuild/tree/main/packages/shared)
-
-:::warning
-The `@rsbuild/shared` is used internally by Rsbuild. Please avoid relying on the methods exported by `@rsbuild/shared` in web projects or community plugins.
-
-If you need to use the methods in `@rsbuild/shared`, you can directly copy the relevant code into your project, or you can provide feedback through issues. We will evaluate whether there is a need to provide an external API.
-:::
-
 ## @rsbuild/document
 
 ![](https://img.shields.io/npm/v/@rsbuild/document?style=flat-square&colorA=564341&colorB=EDED91)

--- a/website/docs/zh/config/output/copy.mdx
+++ b/website/docs/zh/config/output/copy.mdx
@@ -1,6 +1,6 @@
 # output.copy
 
-- **类型：** `CopyPluginOptions | CopyPluginOptions['patterns']`
+- **类型：** `Rspack.CopyRspackPluginOptions | Rspack.CopyRspackPluginOptions['patterns']`
 - **默认值：** `undefined`
 
 将指定的文件或目录拷贝到构建输出目录中，基于 [rspack.CopyRspackPlugin](https://rspack.dev/zh/plugins/rspack/copy-rspack-plugin) 实现。

--- a/website/docs/zh/guide/start/npm-packages.mdx
+++ b/website/docs/zh/guide/start/npm-packages.mdx
@@ -182,21 +182,6 @@ Check Syntax 插件，用于分析产物的语法兼容性，判断是否存在�
 - [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-assets-retry)
 - [文档](/plugins/list/plugin-assets-retry)
 
-## @rsbuild/shared
-
-![](https://img.shields.io/npm/v/@rsbuild/shared?style=flat-square&colorA=564341&colorB=EDED91)
-
-Rsbuild 内部使用的公共模块和 helpers。
-
-- [npm](https://npmjs.com/package/@rsbuild/shared)
-- [源代码](https://github.com/web-infra-dev/rsbuild/tree/main/packages/shared)
-
-:::warning
-`@rsbuild/shared` 是 Rsbuild 内部使用的，请避免在 Web 项目或社区插件中依赖 `@rsbuild/shared` 导出的方法。
-
-如果你需要使用 `@rsbuild/shared` 里的方法，可以直接拷贝相关代码到项目中，也可以通过 issues 反馈，我们会评估是否需要提供对外的 API。
-:::
-
 ## create-rsbuild
 
 ![](https://img.shields.io/npm/v/create-rsbuild?style=flat-square&colorA=564341&colorB=EDED91)


### PR DESCRIPTION
## Summary

Remove `@rsbuild/shared` from all non-core packages.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
