### PR TITLE
docs: add get environment context info guide

### DIFF
--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -135,7 +135,7 @@ const myPlugin = () => ({
 
 ## Get environment context
 
-Rsbuild supports obtaining [environment context](/api/javascript-api/types#environmentcontext) information in plugin hook.
+[Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hook.
 
 In some plugin hooks related to the current build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain), [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig), etc.), Rsbuild supports obtaining the current environment information through parameters.
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -156,7 +156,7 @@ const myPlugin = () => ({
 });
 ```
 
-In some global plugin hooks (such as [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver), etc.), Rsbuild supports obtaining all environment information through parameters.
+For some global plugin hooks (such as [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver), etc.), Rsbuild supports obtaining the context of all environments through the `environments` parameter.
 
 ```ts
 const myPlugin = () => ({

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -133,7 +133,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Get environment context
+## Get environment context info
 
 [Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hook.
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -133,7 +133,7 @@ const myPlugin = () => ({
 });
 ```
 
-## Get environment context info
+## Get environment context
 
 [Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hooks.
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -137,7 +137,7 @@ const myPlugin = () => ({
 
 [Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hooks.
 
-In some plugin hooks related to the current build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain), [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig), etc.), Rsbuild supports obtaining the current environment information through parameters.
+For some plugin hooks related to the build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain) and [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig)), Rsbuild supports obtaining the current environment context through the `environment` parameter.
 
 ```ts
 const myPlugin = () => ({

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -132,3 +132,38 @@ const myPlugin = () => ({
   },
 });
 ```
+
+## Get environment context
+
+Rsbuild supports obtaining [environment context](/api/javascript-api/types#environmentcontext) information in plugin hook.
+
+In some plugin hooks related to the current build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain), [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig), etc.), Rsbuild supports obtaining the current environment information through parameters.
+
+```ts
+const myPlugin = () => ({
+  setup: (api) => {
+    api.modifyBundlerChain((chain, { environment }) => {
+      const { name, config, entry } = environment;
+
+      if (config.output.minify !== false) {
+        chain.optimization
+          .minimizer(CHAIN_ID.MINIMIZER.JS)
+          .use(SwcJsMinimizerRspackPlugin)
+          .end();
+      }
+    });
+  },
+});
+```
+
+In some global plugin hooks (such as [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver), etc.), Rsbuild supports obtaining all environment information through parameters.
+
+```ts
+const myPlugin = () => ({
+  setup: (api) => {
+    api.onDevCompileDone(({ environments }) => {
+      const entries = Object.values(environments).map((e) => e.entry);
+    });
+  },
+});
+```

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -135,7 +135,7 @@ const myPlugin = () => ({
 
 ## Get environment context info
 
-[Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hook.
+[Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hooks.
 
 In some plugin hooks related to the current build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain), [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig), etc.), Rsbuild supports obtaining the current environment information through parameters.
 

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -99,7 +99,7 @@ For example, if you register both the Foo and Bar plugins mentioned above, the F
 
 `api.context` is a read-only object that provides some context information.
 
-The content of `api.context` is exactly the same as `rsbuild.context`, please refer to [rsbuild.context](/api/javascript-api/instance#rsbuild-context).
+The content of `api.context` is exactly the same as `rsbuild.context`, please refer to [rsbuild.context](/api/javascript-api/instance#rsbuildcontext).
 
 - **Example:**
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -394,7 +394,7 @@ type Context = {
    * @example 'index.html'
    */
   filename: string;
-  /** The related environment context. */
+  /** The environment context for current build. */
   environment: EnvironmentContext;
 };
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -196,7 +196,6 @@ const myPlugin = () => ({
 
 ### modifyEnvironmentConfig
 
-
 Modify the Rsbuild configuration of a specific environment.
 
 In the callback function, the config object in the parameters has already been merged with the common Rsbuild configuration. You can directly modify this config object, or you can return a new object to replace it.
@@ -267,6 +266,7 @@ To modify the final Rspack config object, you can directly modify the config obj
 
 ```ts
 type ModifyRspackConfigUtils = {
+  environment: EnvironmentContext;
   env: NodeEnv;
   isDev: boolean;
   isProd: boolean;
@@ -312,6 +312,7 @@ This hook only supports modifying the configuration of the non-differentiated pa
 
 ```ts
 type ModifyBundlerChainUtils = {
+  environment: EnvironmentContext;
   env: NodeEnv;
   isDev: boolean;
   isProd: boolean;
@@ -393,8 +394,8 @@ type Context = {
    * @example 'index.html'
    */
   filename: string;
-  /** The name of the environment to which this build belongs. */
-  environment: string;
+  /** The related environment context. */
+  environment: EnvironmentContext;
 };
 
 function ModifyHTMLTags(

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -133,7 +133,7 @@ const myPlugin = () => ({
 });
 ```
 
-## 获取 environment 信息
+## 获取 environment 上下文
 
 [Environment context](/api/javascript-api/types#environmentcontext) 是一个只读对象，提供一些和当前环境有关的上下文信息。Rsbuild 支持在 plugin hook 中获取 environment context 信息。
 

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -156,7 +156,7 @@ const myPlugin = () => ({
 });
 ```
 
-在一些全局 plugin hook 中 (如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等)， Rsbuild 支持通过参数形式获取所有 environment 信息。
+对于一些全局的 plugin hooks (如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等)， Rsbuild 支持通过 `environments` 参数获取所有环境的上下文。
 
 ```ts
 const myPlugin = () => ({

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -137,7 +137,7 @@ const myPlugin = () => ({
 
 [Environment context](/api/javascript-api/types#environmentcontext) 是一个只读对象，提供一些和当前环境有关的上下文信息。Rsbuild 支持在 plugin hook 中获取 environment context 信息。
 
-在一些和当前构建环境相关的 plugin hook 中 (如 [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)、[modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) 等), Rsbuild 支持通过参数形式获取当前 environment 信息。
+对于一些与构建环境相关的 plugin hooks (如 [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)、[modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) 等), Rsbuild 支持通过 `environment` 参数获取当前 environment 上下文。
 
 ```ts
 const myPlugin = () => ({

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -135,7 +135,7 @@ const myPlugin = () => ({
 
 ## 获取 environment 信息
 
-Rsbuild 支持在 plugin hook 中获取 [environment context](/api/javascript-api/types#environmentcontext) 信息。
+[Environment context](/api/javascript-api/types#environmentcontext) 是一个只读对象，提供一些和当前环境有关的上下文信息。Rsbuild 支持在 plugin hook 中获取 environment context 信息。
 
 在一些和当前构建环境相关的 plugin hook 中 (如 [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)、[modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) 等), Rsbuild 支持通过参数形式获取当前 environment 信息。
 

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -132,3 +132,38 @@ const myPlugin = () => ({
   },
 });
 ```
+
+## 获取 environment 信息
+
+Rsbuild 支持在 plugin hook 中获取 [environment context](/api/javascript-api/types#environmentcontext) 信息。
+
+在一些和当前构建环境相关的 plugin hook 中 (如 [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)、[modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) 等), Rsbuild 支持通过参数形式获取当前 environment 信息。
+
+```ts
+const myPlugin = () => ({
+  setup: (api) => {
+    api.modifyBundlerChain((chain, { environment }) => {
+      const { name, config, entry } = environment;
+
+      if (config.output.minify !== false) {
+        chain.optimization
+          .minimizer(CHAIN_ID.MINIMIZER.JS)
+          .use(SwcJsMinimizerRspackPlugin)
+          .end();
+      }
+    });
+  },
+});
+```
+
+在一些全局 plugin hook 中 (如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等)， Rsbuild 支持通过参数形式获取所有 environment 信息。
+
+```ts
+const myPlugin = () => ({
+  setup: (api) => {
+    api.onDevCompileDone(({ environments }) => {
+      const entries = Object.values(environments).map((e) => e.entry);
+    });
+  },
+});
+```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -97,7 +97,7 @@ const pluginBar = {
 
 `api.context` 是一个只读对象，提供一些上下文信息。
 
-`api.context` 的内容与 `rsbuild.context` 完全一致，请参考 [rsbuild.context](/api/javascript-api/instance#rsbuild-context)。
+`api.context` 的内容与 `rsbuild.context` 完全一致，请参考 [rsbuild.context](/api/javascript-api/instance#rsbuildcontext)。
 
 - **示例：**
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -265,6 +265,7 @@ const myPlugin = () => ({
 
 ```ts
 type ModifyRspackConfigUtils = {
+  environment: EnvironmentContext;
   env: NodeEnv;
   isDev: boolean;
   isProd: boolean;
@@ -308,6 +309,7 @@ import RspackChain from '@zh/shared/rspackChain.mdx';
 
 ```ts
 type ModifyBundlerChainUtils = {
+  environment: EnvironmentContext;
   env: NodeEnv;
   isDev: boolean;
   isProd: boolean;
@@ -390,9 +392,9 @@ type Context = {
    */
   filename: string;
   /**
-   * 本次构建所属的环境名称
+   * 本次构建关联的环境信息
    */
-  environment: string;
+  environment: EnvironmentContext;
 };
 
 function ModifyHTMLTags(

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -392,7 +392,7 @@ type Context = {
    */
   filename: string;
   /**
-   * 本次构建关联的环境信息
+   * 本次构建的 environment 上下文
    */
   environment: EnvironmentContext;
 };


### PR DESCRIPTION
## Summary

add guide about how to get environment context info.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2721

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
