### PR TITLE
perf!: disable polyfill injection by default

### DIFF
--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -14,7 +14,6 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
                   "coreJs": "3.37",
-                  "mode": "usage",
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -73,7 +72,6 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
                   "coreJs": "3.37",
-                  "mode": "usage",
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -130,7 +128,6 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
                   "coreJs": "3.37",
-                  "mode": "usage",
                   "targets": [
                     "node >= 16",
                   ],
@@ -187,7 +184,6 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
                 "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
                 "env": {
                   "coreJs": "3.37",
-                  "mode": "usage",
                   "targets": [
                     "node >= 16",
                   ],
@@ -246,7 +242,6 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
                 "coreJs": "3.37",
-                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -305,7 +300,6 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
                 "coreJs": "3.37",
-                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -364,7 +358,6 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -423,7 +416,6 @@ exports[`plugin-swc > should disable react refresh when dev.hmr is false 1`] = `
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -481,7 +473,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "node >= 16",
               ],
@@ -537,7 +528,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 1`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "node >= 16",
               ],
@@ -592,7 +582,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -651,7 +640,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 2`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -709,7 +697,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -768,7 +755,6 @@ exports[`plugin-swc > should disable react refresh when target is not web 3`] = 
             "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
             "env": {
               "coreJs": "3.37",
-              "mode": "usage",
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -879,7 +865,6 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
             "coreJs": "3.37",
-            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -931,7 +916,6 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
             "coreJs": "3.37",
-            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -991,7 +975,6 @@ exports[`plugin-swc > should set multiple swc-loader 1`] = `
           "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
           "env": {
             "coreJs": "3.37",
-            "mode": "usage",
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -1076,7 +1059,6 @@ exports[`plugin-swc > should set swc-loader 1`] = `
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
                 "coreJs": "3.37",
-                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1135,7 +1117,6 @@ exports[`plugin-swc > should set swc-loader 1`] = `
               "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
               "env": {
                 "coreJs": "3.37",
-                "mode": "usage",
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -255,11 +255,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
         },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
-        },
       },
       "chunks": "all",
       "enforceSizeThreshold": 50000,
@@ -671,11 +666,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -140,7 +140,7 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   assetPrefix: DEFAULT_ASSET_PREFIX,
   filename: {},
   charset: 'ascii',
-  polyfill: 'usage',
+  polyfill: 'off',
   dataUriLimit: {
     svg: DEFAULT_DATA_URL_SIZE,
     font: DEFAULT_DATA_URL_SIZE,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -98,11 +98,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -110,9 +105,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -146,9 +139,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -156,9 +146,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -316,11 +304,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -98,11 +98,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -110,9 +105,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -146,9 +139,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -156,9 +146,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -316,11 +304,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",
@@ -541,11 +524,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -553,9 +531,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -589,9 +565,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -599,9 +572,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -794,11 +765,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",
@@ -1386,11 +1352,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -1398,9 +1359,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1434,9 +1393,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -1444,9 +1400,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1604,11 +1558,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
       },
       "chunks": "all",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -64,7 +64,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "legalComments": "linked",
     "manifest": false,
     "minify": true,
-    "polyfill": "usage",
+    "polyfill": "off",
     "sourceMap": {
       "css": false,
       "js": undefined,
@@ -185,7 +185,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "legalComments": "linked",
     "manifest": false,
     "minify": true,
-    "polyfill": "usage",
+    "polyfill": "off",
     "sourceMap": {
       "css": false,
       "js": undefined,
@@ -307,7 +307,7 @@ exports[`environment config > should print environment config when inspect confi
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -460,7 +460,7 @@ exports[`environment config > should print environment config when inspect confi
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -618,7 +618,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -772,7 +772,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -927,7 +927,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -1085,7 +1085,7 @@ exports[`environment config > should support modify single environment config by
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -1239,7 +1239,7 @@ exports[`environment config > should support modify single environment config by
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
-      "polyfill": "usage",
+      "polyfill": "off",
       "sourceMap": {
         "css": false,
         "js": undefined,
@@ -1428,11 +1428,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
-          "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
-          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1440,9 +1435,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -1476,9 +1469,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             ],
           },
           "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
             "fullySpecified": false,
           },
           "use": [
@@ -1486,9 +1476,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -1646,11 +1634,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             "name": "lib-lodash",
             "priority": 0,
             "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-          },
-          "lib-polyfill": {
-            "name": "lib-polyfill",
-            "priority": 0,
-            "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
           },
         },
         "chunks": "all",

--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -49,11 +49,6 @@ exports[`plugin-module-federation > should set environment module federation con
             "priority": 0,
             "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
           },
-          "lib-polyfill": {
-            "name": "lib-polyfill",
-            "priority": 0,
-            "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
-          },
         },
         "chunks": "all",
         "enforceSizeThreshold": 50000,

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -21,11 +21,6 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -33,9 +28,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -69,9 +62,6 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -79,9 +69,7 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -139,11 +127,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
-          "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
-          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -151,9 +134,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome 98",
                   ],
@@ -184,9 +165,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
             ],
           },
           "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
             "fullySpecified": false,
           },
           "use": [
@@ -194,9 +172,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome 98",
                   ],
@@ -252,11 +228,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
-          "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
-          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -264,9 +235,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -307,9 +276,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             ],
           },
           "resolve": {
-            "alias": {
-              "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-            },
             "fullySpecified": false,
           },
           "use": [
@@ -317,9 +283,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               "loader": "builtin:swc-loader",
               "options": {
                 "env": {
-                  "coreJs": "3.37",
-                  "mode": "usage",
-                  "shippedProposals": true,
+                  "mode": undefined,
                   "targets": [
                     "chrome >= 87",
                     "edge >= 88",
@@ -377,11 +341,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
-    "resolve": {
-      "alias": {
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-      },
-    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -403,9 +362,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       ],
     },
     "resolve": {
-      "alias": {
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-      },
       "fullySpecified": false,
     },
     "use": [
@@ -436,11 +392,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
-    "resolve": {
-      "alias": {
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-      },
-    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -448,9 +399,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.37",
-            "mode": "usage",
-            "shippedProposals": true,
+            "mode": undefined,
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -484,9 +433,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       ],
     },
     "resolve": {
-      "alias": {
-        "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-      },
       "fullySpecified": false,
     },
     "use": [
@@ -494,9 +440,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
-            "coreJs": "3.37",
-            "mode": "usage",
-            "shippedProposals": true,
+            "mode": undefined,
             "targets": [
               "chrome >= 87",
               "edge >= 88",
@@ -766,11 +710,6 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -778,9 +717,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -814,9 +751,6 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -824,9 +758,7 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -17,11 +17,6 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
   ],
-  "resolve": {
-    "alias": {
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-    },
-  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -29,9 +24,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.37",
-          "mode": "usage",
-          "shippedProposals": true,
+          "mode": undefined,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -103,11 +96,6 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
-  "resolve": {
-    "alias": {
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-    },
-  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -115,9 +103,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.37",
-          "mode": "usage",
-          "shippedProposals": true,
+          "mode": undefined,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -13,11 +13,6 @@ exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is i
       "priority": 0,
       "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
     },
-    "lib-polyfill": {
-      "name": "lib-polyfill",
-      "priority": 0,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
-    },
     "react": {
       "name": "lib-react",
       "priority": 0,
@@ -46,11 +41,6 @@ exports[`splitChunks > should apply splitChunks.react/router plugin option when 
       "name": "lib-lodash",
       "priority": 0,
       "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-    },
-    "lib-polyfill": {
-      "name": "lib-polyfill",
-      "priority": 0,
-      "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
     },
   },
   "chunks": "all",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -114,11 +114,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
-        "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
-        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -126,9 +121,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -167,9 +160,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           ],
         },
         "resolve": {
-          "alias": {
-            "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-          },
           "fullySpecified": false,
         },
         "use": [
@@ -177,9 +167,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
             "loader": "builtin:swc-loader",
             "options": {
               "env": {
-                "coreJs": "3.37",
-                "mode": "usage",
-                "shippedProposals": true,
+                "mode": undefined,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -342,11 +330,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           "name": "lib-lodash",
           "priority": 0,
           "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]lodash\\(-es\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "lib-polyfill": {
-          "name": "lib-polyfill",
-          "priority": 0,
-          "test": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]\\(\\?:tslib\\|core-js\\|@swc\\[\\\\\\\\/\\]helpers\\)\\[\\\\\\\\/\\]/,
         },
         "react": {
           "name": "lib-react",

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -13,11 +13,6 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
-  "resolve": {
-    "alias": {
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-    },
-  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -25,9 +20,7 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.37",
-          "mode": "usage",
-          "shippedProposals": true,
+          "mode": undefined,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -138,11 +131,6 @@ exports[`plugins/styled-components > should enable ssr option when target contai
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
-  "resolve": {
-    "alias": {
-      "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
-    },
-  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -150,9 +138,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
       "loader": "builtin:swc-loader",
       "options": {
         "env": {
-          "coreJs": "3.37",
-          "mode": "usage",
-          "shippedProposals": true,
+          "mode": undefined,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -22,9 +22,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -114,9 +112,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -178,9 +174,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -269,9 +263,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -333,9 +325,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -424,9 +414,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -488,9 +476,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -579,9 +565,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -643,9 +627,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
           "loader": "builtin:swc-loader",
           "options": {
             "env": {
-              "coreJs": "3.37",
-              "mode": "usage",
-              "shippedProposals": true,
+              "mode": undefined,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",

--- a/website/docs/en/config/output/polyfill.mdx
+++ b/website/docs/en/config/output/polyfill.mdx
@@ -1,9 +1,11 @@
 # output.polyfill
 
 - **Type:** `'entry' | 'usage' | 'off'`
-- **Default:** `'usage'`
+- **Default:** `'off'`
 
 Through the `output.polyfill` option, you can control the injection mode of the polyfills.
+
+> In Rsbuild v0.x, the default value of `output.polyfill` was `'usage'`. Starting from Rsbuild v1.x, the default value is `'off'`.
 
 ## Optional Value
 

--- a/website/docs/en/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/en/guide/advanced/browser-compatibility.mdx
@@ -179,13 +179,23 @@ export default {
 
 ## Polyfill mode
 
-Rsbuild compiles JavaScript code through SWC by default, and injects polyfills like [core-js](https://github.com/zloirock/core-js) and [@swc/helpers](https://npmjs.com/package/@swc/helpers).
+Rsbuild compiles JavaScript code using SWC and supports injecting polyfills such as [core-js](https://github.com/zloirock/core-js) and [@swc/helpers](https://npmjs.com/package/@swc/helpers).
 
 In different usage scenarios, you may need different polyfill solutions. Rsbuild provides [output.polyfill](/config/output/polyfill) config to switch between different polyfill modes.
 
-### Usage mode
+### Default Behavior
 
-The usage is the default mode and does not need to be set manually, it allows more precise control over which core-js polyfills need to be injected.
+Rsbuild does not inject any polyfills by default:
+
+```ts
+export default {
+  output: {
+    polyfill: 'off',
+  },
+};
+```
+
+### Usage mode
 
 When you enable the usage mode, Rsbuild will analyze the source code in the project and determine which polyfills need to be injected.
 
@@ -227,17 +237,3 @@ export default {
   },
 };
 ```
-
-### Disable Polyfill
-
-You can disable polyfill injection behavior by setting `output.polyfill` to `'off'`.
-
-```ts
-export default {
-  output: {
-    polyfill: 'off',
-  },
-};
-```
-
-When using this config, you need to ensure compatibility by yourself, such as manually import the required polyfill code through [source.preEntry](/config/source/pre-entry).

--- a/website/docs/en/guide/optimization/optimize-bundle.mdx
+++ b/website/docs/en/guide/optimization/optimize-bundle.mdx
@@ -70,7 +70,7 @@ Please read the [Browserslist](/guide/advanced/browserslist) chapter to know mor
 
 ## Usage polyfill
 
-When it is clear that third-party dependencies do not require additional polyfill, you can set [output.polyfill](/config/output/polyfill) to `usage`.
+If the current project's [output.polyfill](/config/output/polyfill) is set to `'entry'`, and you are certain that third-party dependencies do not require additional polyfills, you can change it to `usage`.
 
 In `usage` mode, Rsbuild analyzes the syntax used in the source code and injects the required polyfill code on demand to reduce the size of polyfill.
 

--- a/website/docs/zh/config/output/polyfill.mdx
+++ b/website/docs/zh/config/output/polyfill.mdx
@@ -1,9 +1,11 @@
 # output.polyfill
 
 - **类型：** `'entry' | 'usage' | 'off'`
-- **默认值：** `'usage'`
+- **默认值：** `'off'`
 
 通过 `output.polyfill` 选项，你可以控制 polyfills 的注入方式。
+
+> 在 Rsbuild 0.x 版本中，`output.polyfill` 默认值为 `'usage'`，从 Rsbuild 1.x 版本开始，默认值变为 `'off'`。
 
 ## 可选值
 

--- a/website/docs/zh/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/browser-compatibility.mdx
@@ -179,13 +179,23 @@ export default {
 
 ## Polyfill 方案
 
-Rsbuild 默认通过 SWC 编译 JavaScript 代码，并注入 [core-js](https://github.com/zloirock/core-js)、[@swc/helpers](https://npmjs.com/package/@swc/helpers) 等 polyfills。
+Rsbuild 通过 SWC 编译 JavaScript 代码，并支持注入 [core-js](https://github.com/zloirock/core-js)、[@swc/helpers](https://npmjs.com/package/@swc/helpers) 等 polyfills。
 
 在不同的使用场景下，你可能会需要不同的 polyfill 方案。Rsbuild 提供了 [output.polyfill](/config/output/polyfill) 配置项来切换不同的 polyfill 方案。
 
-### usage 方案
+### 默认行为
 
-usage 为默认方案，无须手动设置，它可以精确地控制需要注入哪些 core-js polyfill。
+Rsbuild 默认不注入任何 polyfill：
+
+```ts
+export default {
+  output: {
+    polyfill: 'off',
+  },
+};
+```
+
+### usage 方案
 
 当你开启 usage 方案时，Rsbuild 会分析项目中的源代码，并判断需要注入哪些 polyfill。
 
@@ -227,17 +237,3 @@ export default {
   },
 };
 ```
-
-### 不注入 Polyfill
-
-你可以将 `output.polyfill` 设置为 `'off'` 来禁用 polyfill 注入的行为。
-
-```ts
-export default {
-  output: {
-    polyfill: 'off',
-  },
-};
-```
-
-使用此选项时，你需要自行保证代码的兼容性，比如通过 [source.preEntry](/config/source/pre-entry) 来手动引用所需的 polyfill 代码。

--- a/website/docs/zh/guide/optimization/optimize-bundle.mdx
+++ b/website/docs/zh/guide/optimization/optimize-bundle.mdx
@@ -70,7 +70,7 @@ Rsbuild 默认的 Browserslist 配置为：
 
 ## 按需引入 polyfill
 
-在明确第三方依赖不需要额外 polyfill 的情况下，你可以将 [output.polyfill](/config/output/polyfill) 设置为 `usage`。
+如果当前项目的 [output.polyfill](/config/output/polyfill) 为 `'entry'`，在明确第三方依赖不需要额外 polyfill 的情况下，你可以将它设置为 `usage` 。
 
 在 `usage` 模式下，Rsbuild 会分析源代码中使用的语法，按需注入所需的 polyfill 代码，从而减少 polyfill 的代码量。
 


### PR DESCRIPTION
## Summary

Set `output.polyfill` to `'off'` by default, this can reduce the polyfill code and generate smaller bundles by default.

If your application need polyfill, please set `output.polyfill` to `'usage'` or `'entry'`:

```ts
// rsbuild.config.ts
export default {
  output: {
    polyfill: 'usage'
  }
};
```

See the vote on Twitter: https://x.com/rspack_dev/status/1808439138439274780

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/f316e9e6-94e2-4c3d-8216-3d62626fcd02)

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2776

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
