### PR TITLE
chore: import from html-rspack-plugin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "@swc/helpers": "0.5.11",
     "caniuse-lite": "^1.0.30001640",
     "core-js": "~3.37.1",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
+    "html-rspack-plugin": "5.7.2",
     "postcss": "^8.4.39"
   },
   "devDependencies": {

--- a/packages/core/src/pluginHelper.ts
+++ b/packages/core/src/pluginHelper.ts
@@ -2,7 +2,7 @@
  * This file is used to get/set the global instance for html-plugin and css-extract plugin.
  */
 import rspack from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 
 let htmlPlugin: typeof HtmlWebpackPlugin;
 
@@ -17,7 +17,7 @@ export const setHTMLPlugin = (plugin: typeof HtmlWebpackPlugin): void => {
 
 export const getHTMLPlugin = (): typeof HtmlWebpackPlugin => {
   if (!htmlPlugin) {
-    htmlPlugin = require('html-webpack-plugin');
+    htmlPlugin = require('html-rspack-plugin');
   }
   return htmlPlugin;
 };

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -1,6 +1,6 @@
 import type { Compilation, Compiler } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
-import type { HtmlTagObject } from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
+import type { HtmlTagObject } from 'html-rspack-plugin';
 import { ensureAssetPrefix, isFunction, partition } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
 import type {

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -7,7 +7,7 @@
  */
 import { join } from 'node:path';
 import type { Compilation, Compiler } from '@rspack/core';
-import type { HtmlTagObject } from 'html-webpack-plugin';
+import type { HtmlTagObject } from 'html-rspack-plugin';
 import {
   addTrailingSlash,
   getPublicPathFromCompiler,
@@ -235,7 +235,7 @@ export class InlineChunkHtmlPlugin {
           name: 'InlineChunkHtmlPlugin',
           /**
            * Remove marked inline assets in summarize stage,
-           * which should be later than the emitting of html-webpack-plugin
+           * which should be later than the emitting of html-rspack-plugin
            */
           stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
         },

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -21,7 +21,7 @@ import type {
   Compiler,
   RspackPluginInstance,
 } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import { ensureAssetPrefix, upperFirst } from '../../helpers';
 import { getHTMLPlugin } from '../../pluginHelper';
 import type { PreloadOrPreFetchOption } from '../../types';

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -49,7 +49,7 @@ export function recursiveChunkEntryNames(chunk: Chunk): string[] {
   return [...new Set(names)];
 }
 
-// modify from html-webpack-plugin/index.js `filterChunks`
+// modify from html-rspack-plugin/index.js `filterChunks`
 function isChunksFiltered(
   chunkName: string,
   includeChunks?: string[] | 'all',

--- a/packages/core/src/rspack/preload/helpers/type.ts
+++ b/packages/core/src/rspack/preload/helpers/type.ts
@@ -1,4 +1,4 @@
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 
 export type BeforeAssetTagGenerationHtmlPluginData = {
   assets: {

--- a/packages/core/src/types/config/html.ts
+++ b/packages/core/src/types/config/html.ts
@@ -92,12 +92,12 @@ export interface HtmlConfig {
   outputStructure?: OutputStructure;
   /**
    * Define the path to the HTML template,
-   * corresponding to the `template` config of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
+   * corresponding to the `template` config of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin).
    */
   template?: ChainedHtmlOption<string>;
   /**
    * Define the parameters in the HTML template,
-   * corresponding to the `templateParameters` config of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
+   * corresponding to the `templateParameters` config of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin).
    */
   templateParameters?: ConfigChainWithContext<
     Record<string, unknown>,

--- a/packages/core/src/types/config/tools.ts
+++ b/packages/core/src/types/config/tools.ts
@@ -1,6 +1,6 @@
 import type { rspack } from '@rspack/core';
 import type { SwcLoaderOptions } from '@rspack/core';
-import type { Options as HTMLPluginOptions } from 'html-webpack-plugin';
+import type { Options as HTMLPluginOptions } from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
 import type {
@@ -105,7 +105,7 @@ export interface ToolsConfig {
    */
   styleLoader?: ToolsStyleLoaderConfig;
   /**
-   * Configure the html-webpack-plugin.
+   * Configure the html-rspack-plugin.
    */
   htmlPlugin?: boolean | ToolsHtmlPluginConfig;
   /**

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,4 +1,4 @@
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type { ChainIdentifier } from '..';
 import type {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1,5 +1,5 @@
 import type { RuleSetCondition } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type {
   RuleSetRule,

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
+    "html-rspack-plugin": "5.7.2",
     "terser": "5.31.1",
     "typescript": "^5.5.2"
   },

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { type Rspack, ensureAssetPrefix } from '@rsbuild/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type { PluginAssetsRetryOptions } from './types';
 
 export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/plugin-less": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-webpack-plugin": "npm:html-rspack-plugin@5.7.2",
+    "html-rspack-plugin": "5.7.2",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.5.2"

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -5,7 +5,7 @@ import {
   ensureAssetPrefix,
   logger,
 } from '@rsbuild/core';
-import type HtmlWebpackPlugin from 'html-webpack-plugin';
+import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type { PluginRemOptions } from './types';
 
 type AutoSetRootFontSizeOptions = Omit<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,9 +681,9 @@ importers:
       core-js:
         specifier: ~3.37.1
         version: 3.37.1
-      html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+      html-rspack-plugin:
+        specifier: 5.7.2
+        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
@@ -867,9 +867,9 @@ importers:
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
-      html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+      html-rspack-plugin:
+        specifier: 5.7.2
+        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1081,9 +1081,9 @@ importers:
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
-      html-webpack-plugin:
-        specifier: npm:html-rspack-plugin@5.7.2
-        version: html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+      html-rspack-plugin:
+        specifier: 5.7.2
+        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)

--- a/website/docs/en/config/html/template-parameters.mdx
+++ b/website/docs/en/config/html/template-parameters.mdx
@@ -10,7 +10,7 @@ type DefaultParameters = {
   assetPrefix: string; // the value of dev.assetPrefix or output.assetPrefix configs
   compilation: Compilation; // Compilation object of Rspack
   // htmlWebpackPlugin built-in parameters
-  // See https://github.com/jantimon/html-webpack-plugin for details
+  // See https://github.com/rspack-contrib/html-rspack-plugin for details
   htmlWebpackPlugin: {
     tags: object;
     files: object;
@@ -19,7 +19,7 @@ type DefaultParameters = {
 };
 ```
 
-Define the parameters in the HTML template, corresponding to the `templateParameters` config of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin).
+Define the parameters in the HTML template, corresponding to the `templateParameters` config of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin).
 
 ### Object Usage
 

--- a/website/docs/en/config/source/entry.mdx
+++ b/website/docs/en/config/source/entry.mdx
@@ -17,7 +17,7 @@ const defaultEntry = {
 
 Used to set the entry modules for building.
 
-The usage of `source.entry` is similar to the `entry` option in [Rspack](https://rspack.dev/config/entry). The main difference is that Rsbuild will register [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) for each entry in `source.entry` to generate the corresponding HTML files.
+The usage of `source.entry` is similar to the `entry` option in [Rspack](https://rspack.dev/config/entry). The main difference is that Rsbuild will register [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) for each entry in `source.entry` to generate the corresponding HTML files.
 
 - **Example:**
 

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -143,9 +143,9 @@ export default {
 
 ### HtmlPlugin
 
-- **Type:** `typeof import('html-webpack-plugin')`
+- **Type:** `typeof import('html-rspack-plugin')`
 
-The instance of `html-webpack-plugin`:
+The instance of `html-rspack-plugin`:
 
 ```js
 export default {

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -200,9 +200,9 @@ export default {
 
 ### HtmlPlugin
 
-- **Type:** `typeof import('html-webpack-plugin')`
+- **Type:** `typeof import('html-rspack-plugin')`
 
-The instance of `html-webpack-plugin`:
+The instance of `html-rspack-plugin`:
 
 ```js
 export default {

--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -103,7 +103,7 @@ type DefaultParameters = {
   assetPrefix: string; // the value of dev.assetPrefix or output.assetPrefix configs
   compilation: Compilation; // Compilation object of Rspack
   // htmlWebpackPlugin built-in parameters
-  // See https://github.com/jantimon/html-webpack-plugin for details
+  // See https://github.com/rspack-contrib/html-rspack-plugin for details
   htmlWebpackPlugin: {
     tags: object;
     files: object;

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -320,7 +320,7 @@ type ModifyBundlerChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  HtmlPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-rspack-plugin');
   bundler: {
     BannerPlugin: rspack.BannerPlugin;
     DefinePlugin: rspack.DefinePlugin;

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -312,7 +312,7 @@ If you need to retry assets in micro-frontend scenarios, please contact the deve
 
 Assets Retry plugin listens to the page error event to know whether the current resource fails to load and needs to be retried. Therefore, if the resource in the custom template is executed earlier than Assets Retry plugin, then Assets Retry plugin cannot listen to the event that the resource fails to load, so it will not be retried.
 
-If you want Assets Retry plugin to work on resources in custom templates, you can refer to [Custom Insertion Example](https://github.com/jantimon/html-webpack-plugin/tree/main/examples/custom-insertion-position) to modify [html.inject](/config/html/inject) configuration and custom template.
+If you want Assets Retry plugin to work on resources in custom templates, you can refer to [Custom Insertion Example](https://github.com/rspack-contrib/html-rspack-plugin/tree/main/examples/custom-insertion-position) to modify [html.inject](/config/html/inject) configuration and custom template.
 
 ```diff
 <!DOCTYPE html>

--- a/website/docs/zh/config/html/template-parameters.mdx
+++ b/website/docs/zh/config/html/template-parameters.mdx
@@ -10,7 +10,7 @@ type DefaultParameters = {
   assetPrefix: string; // 对应 dev.assetPrefix 和 output.assetPrefix 配置
   compilation: Compilation; // Rspack 的 compilation 对象
   // htmlWebpackPlugin 内置的参数
-  // 详见 https://github.com/jantimon/html-webpack-plugin
+  // 详见 https://github.com/rspack-contrib/html-rspack-plugin
   htmlWebpackPlugin: {
     tags: object;
     files: object;
@@ -19,7 +19,7 @@ type DefaultParameters = {
 };
 ```
 
-定义 HTML 模板中的参数，对应 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的 `templateParameters` 配置项。
+定义 HTML 模板中的参数，对应 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) 的 `templateParameters` 配置项。
 
 ### 对象用法
 

--- a/website/docs/zh/config/source/entry.mdx
+++ b/website/docs/zh/config/source/entry.mdx
@@ -17,7 +17,7 @@ const defaultEntry = {
 
 用于设置构建的入口模块。
 
-`source.entry` 的用法与 Rspack 的 [entry](https://rspack.dev/config/entry) 选项类似，它们的主要区别在于，Rsbuild 会为 `source.entry` 中的每一个入口注册 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin)，从而生成对应的 HTML 文件。
+`source.entry` 的用法与 Rspack 的 [entry](https://rspack.dev/config/entry) 选项类似，它们的主要区别在于，Rsbuild 会为 `source.entry` 中的每一个入口注册 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin)，从而生成对应的 HTML 文件。
 
 - **示例：**
 

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -143,9 +143,9 @@ export default {
 
 ### HtmlPlugin
 
-- **类型：** `typeof import('html-webpack-plugin')`
+- **类型：** `typeof import('html-rspack-plugin')`
 
-通过这个参数你可以拿到 `html-webpack-plugin` 插件的实例。
+通过这个参数你可以拿到 `html-rspack-plugin` 插件的实例。
 
 ```js
 export default {

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -200,9 +200,9 @@ export default {
 
 ### HtmlPlugin
 
-- **类型：** `typeof import('html-webpack-plugin')`
+- **类型：** `typeof import('html-rspack-plugin')`
 
-通过这个参数你可以拿到 `html-webpack-plugin` 插件的实例。
+通过这个参数你可以拿到 `html-rspack-plugin` 插件的实例。
 
 ```js
 export default {

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -103,7 +103,7 @@ type DefaultParameters = {
   assetPrefix: string; // 对应 dev.assetPrefix 和 output.assetPrefix 配置
   compilation: Compilation; // 对应 Rspack 的 compilation 对象
   // htmlWebpackPlugin 内置的参数
-  // 详见 https://github.com/jantimon/html-webpack-plugin
+  // 详见 https://github.com/rspack-contrib/html-rspack-plugin
   htmlWebpackPlugin: {
     tags: object;
     files: object;

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -317,7 +317,7 @@ type ModifyBundlerChainUtils = {
   isServer: boolean;
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
-  HtmlPlugin: typeof import('html-webpack-plugin');
+  HtmlPlugin: typeof import('html-rspack-plugin');
   bundler: {
     BannerPlugin: rspack.BannerPlugin;
     DefinePlugin: rspack.DefinePlugin;

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -312,7 +312,7 @@ pluginAssetsRetry({
 
 Assets Retry 插件通过监听页面 error 事件来获悉当前资源是否加载失败需要重试。因此，如果自定义模版中的资源执行早于 Assets Retry 插件，那 Assets Retry 插件无法监听到该资源加载失败的事件，retry 无法对其生效。
 
-如果想要 Assets Retry 插件对自定义模版中的资源生效，可参考 [自定义插入示例](https://github.com/jantimon/html-webpack-plugin/tree/main/examples/custom-insertion-position) 来修改 [html.inject](/config/html/inject) 配置和自定义模版。
+如果想要 Assets Retry 插件对自定义模版中的资源生效，可参考 [自定义插入示例](https://github.com/rspack-contrib/html-rspack-plugin/tree/main/examples/custom-insertion-position) 来修改 [html.inject](/config/html/inject) 配置和自定义模版。
 
 ```diff
 <!DOCTYPE html>


### PR DESCRIPTION
## Summary

Rename `html-webpack-plugin` to `html-rspack-plugin` can be confusing, so we will remove the renaming and import from `html-rspack-plugin`.

## Related Links

https://github.com/rspack-contrib/html-rspack-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
