### PR TITLE
perf: compute gzip size in parallel

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -65,7 +65,6 @@
 		// some loaders still depend on loader-utils v2
 		"loader-utils",
 		// pure esm packages can not be used now
-		"gzip-size",
 		"globby",
 		"open",
 		"strip-ansi",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -77,7 +77,6 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "fs-extra": "^11.2.0",
-    "gzip-size": "^6.0.0",
     "http-compression": "1.0.20",
     "http-proxy-middleware": "^2.0.6",
     "jiti": "^1.21.6",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -40,7 +40,6 @@ export default {
     'connect',
     'rspack-manifest-plugin',
     'webpack-merge',
-    'gzip-size',
     {
       name: 'chokidar',
       externals: {
@@ -127,9 +126,6 @@ export default {
       // The webpack-bundle-analyzer version was locked to v4.9.0 to be compatible with Rspack
       // If we need to upgrade the version, please check if the chunk detail can be displayed correctly
       name: 'webpack-bundle-analyzer',
-      externals: {
-        'gzip-size': '../gzip-size',
-      },
     },
     {
       name: 'autoprefixer',

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -18,7 +18,6 @@
       "semver": ["./compiled/semver"],
       "connect": ["./compiled/connect"],
       "chokidar": ["./compiled/chokidar"],
-      "gzip-size": ["./compiled/gzip-size"],
       "commander": ["./compiled/commander"],
       "on-finished": ["./compiled/on-finished"],
       "autoprefixer": ["./compiled/autoprefixer"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,9 +746,6 @@ importers:
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
-      gzip-size:
-        specifier: ^6.0.0
-        version: 6.0.0
       http-compression:
         specifier: 1.0.20
         version: 1.0.20


### PR DESCRIPTION
## Summary

Compute gzip size in parallel. From `133ms` to `1.2ms` in a [medium sized project](https://github.com/rspack-contrib/rsbuild-arco-pro).

- before:

<img width="908" alt="Screenshot 2024-07-05 at 16 22 09" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/e28a0702-2cd4-4308-8a67-c3d27f5b17fa">

- after:

<img width="915" alt="Screenshot 2024-07-05 at 16 33 49" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/cbef1205-b9a2-4e64-afa1-7b2cb64728e0">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
