### PR TITLE
perf: read file async when printing file size

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -86,7 +86,7 @@ async function printFileSizes(
     distFolder: string,
   ) => {
     const fileName = asset.name.split('?')[0];
-    const contents = fs.readFileSync(path.join(distPath, fileName));
+    const contents = await fs.promises.readFile(path.join(distPath, fileName));
     const size = contents.length;
     const gzippedSize = await gzipSize(contents);
 


### PR DESCRIPTION
## Summary

Should read file async when printing file size.

Tested in https://github.com/liangyuetian/rsbuild-hmr-slow-demo:

- before (54ms):

<img width="930" alt="截屏2024-07-06 18 25 38" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/4e3d45f3-b2fb-4d13-95bd-4066b38dcc61">

- after (15ms):

<img width="1013" alt="截屏2024-07-06 18 26 54" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/5e409a3d-74bb-4502-861f-1148c9d1b8dd">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
