### PR TITLE
perf: bump html plugin to redue entrypoints overhead

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "@swc/helpers": "0.5.11",
     "caniuse-lite": "^1.0.30001640",
     "core-js": "~3.37.1",
-    "html-rspack-plugin": "5.7.2",
+    "html-rspack-plugin": "5.7.3",
     "postcss": "^8.4.39"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-rspack-plugin": "5.7.2",
+    "html-rspack-plugin": "5.7.3",
     "terser": "5.31.1",
     "typescript": "^5.5.2"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/plugin-less": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-rspack-plugin": "5.7.2",
+    "html-rspack-plugin": "5.7.3",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,8 +679,8 @@ importers:
         specifier: ~3.37.1
         version: 3.37.1
       html-rspack-plugin:
-        specifier: 5.7.2
-        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.7.3
+        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
@@ -862,8 +862,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       html-rspack-plugin:
-        specifier: 5.7.2
-        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.7.3
+        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1076,8 +1076,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-rspack-plugin:
-        specifier: 5.7.2
-        version: 5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.7.3
+        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)
@@ -5158,6 +5158,15 @@ packages:
 
   html-rspack-plugin@5.7.2:
     resolution: {integrity: sha512-uVXGYq19bcsX7Q/53VqXQjCKXw0eUMHlFGDLTaqzgj/ckverfhZQvXyA6ecFBaF9XUH16jfCTCyALYi0lJcagg==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      '@rspack/core': 1.0.0-alpha.1
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+
+  html-rspack-plugin@5.7.3:
+    resolution: {integrity: sha512-hzLOXfoYy2trAtgqV/RcFIe2pGGRGosULYLdHKsWr4p4S/HYZbtFHBNUUKsJQjA3VCzXZgJBK9bh7QZH4n1Kqg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 1.0.0-alpha.1
@@ -12074,13 +12083,13 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11)):
-    optionalDependencies:
-      '@rspack/core': 1.0.0-alpha.1(@swc/helpers@0.5.11)
-
   html-rspack-plugin@5.7.2(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.3)):
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.1(@swc/helpers@0.5.3)
+
+  html-rspack-plugin@5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11)):
+    optionalDependencies:
+      '@rspack/core': 1.0.0-alpha.1(@swc/helpers@0.5.11)
 
   html-tags@2.0.0: {}
 


### PR DESCRIPTION
## Summary

Detailed change: https://github.com/rspack-contrib/html-rspack-plugin/commit/b8e977e14efd2c86b2a3191822ffd8359f9861fd

Tested in https://github.com/liangyuetian/rsbuild-hmr-slow-demo

- before (501ms total):

<img width="461" alt="截屏2024-07-06 19 31 24" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/181732d4-7e77-4586-b52e-35596cf1a1a6">

- after (249ms total):

<img width="476" alt="截屏2024-07-06 19 34 39" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/e49aa3b8-041e-40d5-aa43-1a09bd9bcb83">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
