### PR TITLE
perf: bump html plugin to redue appcache overhead

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "@swc/helpers": "0.5.11",
     "caniuse-lite": "^1.0.30001640",
     "core-js": "~3.37.1",
-    "html-rspack-plugin": "5.7.3",
+    "html-rspack-plugin": "5.8.0",
     "postcss": "^8.4.39"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-rspack-plugin": "5.7.3",
+    "html-rspack-plugin": "5.8.0",
     "terser": "5.31.1",
     "typescript": "^5.5.2"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/plugin-less": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-rspack-plugin": "5.7.3",
+    "html-rspack-plugin": "5.8.0",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,8 +679,8 @@ importers:
         specifier: ~3.37.1
         version: 3.37.1
       html-rspack-plugin:
-        specifier: 5.7.3
-        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.8.0
+        version: 5.8.0(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
@@ -862,8 +862,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       html-rspack-plugin:
-        specifier: 5.7.3
-        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.8.0
+        version: 5.8.0(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1076,8 +1076,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-rspack-plugin:
-        specifier: 5.7.3
-        version: 5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
+        specifier: 5.8.0
+        version: 5.8.0(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)
@@ -5165,8 +5165,8 @@ packages:
       '@rspack/core':
         optional: true
 
-  html-rspack-plugin@5.7.3:
-    resolution: {integrity: sha512-hzLOXfoYy2trAtgqV/RcFIe2pGGRGosULYLdHKsWr4p4S/HYZbtFHBNUUKsJQjA3VCzXZgJBK9bh7QZH4n1Kqg==}
+  html-rspack-plugin@5.8.0:
+    resolution: {integrity: sha512-ilfK60cxmBzglkHw91SlHDwbTd8uS7+poG12ueuwn012XPdFq8jU0pFuGEqoryJ+1l/uQuVffJ2jlpJDlhJBsg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 1.0.0-alpha.1
@@ -12087,7 +12087,7 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.1(@swc/helpers@0.5.3)
 
-  html-rspack-plugin@5.7.3(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11)):
+  html-rspack-plugin@5.8.0(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11)):
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.1(@swc/helpers@0.5.11)
 


### PR DESCRIPTION
`html-rspack-plugin@5.8.0` has removed support for HTML5 Application caches, it is a deprecated feature.

Tested in https://github.com/liangyuetian/rsbuild-hmr-slow-demo

- before (74ms):

<img width="472" alt="截屏2024-07-06 20 42 01" src="https://github.com/rspack-contrib/html-rspack-plugin/assets/7237365/b4b9a962-ba03-46ad-a23b-1981244cbd38">

- after (10ms):

<img width="462" alt="截屏2024-07-06 20 41 26" src="https://github.com/rspack-contrib/html-rspack-plugin/assets/7237365/74a4ee02-41bc-4af3-a235-f80b1b2724d1">

## Related Links

https://github.com/rspack-contrib/html-rspack-plugin/pull/9

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
