### PR TITLE
perf: skip PostCSS AST version compasion

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -92,7 +92,6 @@
     "rslog": "^1.2.2",
     "rspack-chain": "^0.7.4",
     "rspack-manifest-plugin": "5.0.0",
-    "semver": "^7.6.2",
     "sirv": "^2.0.4",
     "style-loader": "3.3.4",
     "terser": "5.31.1",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -12,6 +12,13 @@ const writeEmptySchemaUtils = (task) => {
   fs.writeFileSync(schemaUtilsPath, 'module.exports.validate = () => {};');
 };
 
+// postcss-loader and css-loader use `semver` to compare PostCSS ast version,
+// Rsbuild uses the same PostCSS version and do not need the comparison.
+const writeEmptySemver = (task) => {
+  const schemaUtilsPath = join(task.distPath, 'semver.js');
+  fs.writeFileSync(schemaUtilsPath, 'module.exports.satisfies = () => true;');
+};
+
 function replaceFileContent(filePath, replaceFn) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const newContent = replaceFn(content);
@@ -45,10 +52,6 @@ export default {
       externals: {
         fsevents: 'fsevents',
       },
-    },
-    {
-      name: 'semver',
-      ignoreDts: true,
     },
     {
       name: 'rslog',
@@ -161,16 +164,18 @@ export default {
       ignoreDts: true,
       externals: {
         'postcss-value-parser': '../postcss-value-parser',
-        semver: '../semver',
+        semver: './semver',
       },
+      afterBundle: writeEmptySemver,
     },
     {
       name: 'postcss-loader',
       externals: {
         jiti: '../jiti',
-        semver: '../semver',
+        semver: './semver',
       },
       ignoreDts: true,
+      afterBundle: writeEmptySemver,
     },
     {
       name: 'postcss-load-config',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -788,9 +788,6 @@ importers:
       rspack-manifest-plugin:
         specifier: 5.0.0
         version: 5.0.0(@rspack/core@1.0.0-alpha.1(@swc/helpers@0.5.11))
-      semver:
-        specifier: ^7.6.2
-        version: 7.6.2
       sirv:
         specifier: ^2.0.4
         version: 2.0.4


### PR DESCRIPTION
## Summary

postcss-loader and css-loader use `semver` to compare PostCSS ast version.

Rsbuild always uses the same PostCSS version and do not need the comparison, so we can skip this step for performance.

<img width="326" alt="截屏2024-07-07 10 50 28" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/64f5ae4e-d5b0-4dab-82be-86f5638e781b">

## Related Links

https://github.com/webpack-contrib/postcss-loader/blob/a442c5cc0df02a20cdf940a7e774d875cf35745d/src/index.js#L109

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
