### PR TITLE
perf: resolve mjs config first

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -275,9 +275,11 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
   }
 
   const CONFIG_FILES = [
+    // `.mjs` and `.ts` are the most used configuration types,
+    // so we resolve them first for performance
+    'rsbuild.config.mjs',
     'rsbuild.config.ts',
     'rsbuild.config.js',
-    'rsbuild.config.mjs',
     'rsbuild.config.cjs',
     'rsbuild.config.mts',
     'rsbuild.config.cts',


### PR DESCRIPTION
## Summary

`.mjs` and `.ts` are the most used configuration types, so we resolve them first for performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
