### PR TITLE
fix: missing picocolors dependency

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -54,6 +54,16 @@ export default {
       },
     },
     {
+      name: 'picocolors',
+      beforeBundle({ depPath }) {
+        const typesFile = join(depPath, 'types.ts');
+        // Fix type bundle
+        if (fs.existsSync(typesFile)) {
+          fs.renameSync(typesFile, join(depPath, 'types.d.ts'));
+        }
+      },
+    },
+    {
       name: 'rslog',
       afterBundle(task) {
         // use the cjs bundle of rslog
@@ -71,7 +81,7 @@ export default {
       name: 'launch-editor-middleware',
       ignoreDts: true,
       externals: {
-        picocolors: 'picocolors',
+        picocolors: '../picocolors',
       },
     },
     {
@@ -135,7 +145,7 @@ export default {
       externals: {
         browserslist: '../browserslist',
         'postcss-value-parser': '../postcss-value-parser',
-        picocolors: 'picocolors',
+        picocolors: '../picocolors',
       },
     },
     {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -19,6 +19,7 @@
       "connect": ["./compiled/connect"],
       "chokidar": ["./compiled/chokidar"],
       "commander": ["./compiled/commander"],
+      "picocolors": ["./compiled/picocolors"],
       "on-finished": ["./compiled/on-finished"],
       "autoprefixer": ["./compiled/autoprefixer"],
       "browserslist": ["./compiled/browserslist"],


### PR DESCRIPTION
## Summary

Fix missing picocolors dependency.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/2829

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
