### PR TITLE
test(e2e): skip test of hmr in windows

### DIFF
--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -1,10 +1,14 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import test, { expect } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rspack/issues/6633
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation and add new initial chunk',
   async ({ page }) => {
+    // TODO fix this case in Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
     const rsbuild = await dev({
       cwd: __dirname,
     });


### PR DESCRIPTION
## Summary

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2743#issuecomment-2213054306