### PR TITLE
fix(plugin-assets-retry): url calculation when using asset prefix

### DIFF
--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -94,9 +94,13 @@ async function createRsbuildWithMiddleware(
           },
         ],
       },
-      server: {
-        port,
-      },
+      ...(port
+        ? {
+            server: {
+              port,
+            },
+          }
+        : {}),
       ...(entry
         ? {
             source: { entry: { index: entry } },

--- a/e2e/cases/assets-retry/index.test.ts
+++ b/e2e/cases/assets-retry/index.test.ts
@@ -1,5 +1,5 @@
-import { dev, gotoPage, proxyConsole } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { dev, getRandomPort, gotoPage, proxyConsole } from '@e2e/helper';
+import { type Page, expect, test } from '@playwright/test';
 import { type RequestHandler, logger } from '@rsbuild/core';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
@@ -76,6 +76,7 @@ async function createRsbuildWithMiddleware(
   middleware: RequestHandler | RequestHandler[],
   options: PluginAssetsRetryOptions,
   entry?: string,
+  port?: number,
 ) {
   const rsbuild = await dev({
     cwd: __dirname,
@@ -92,6 +93,9 @@ async function createRsbuildWithMiddleware(
             middlewares.unshift(...addMiddleWares);
           },
         ],
+      },
+      server: {
+        port,
       },
       ...(entry
         ? {
@@ -264,6 +268,117 @@ function delay(ms = 300) {
   });
 }
 
+async function proxyPageConsole(page: Page, port: number) {
+  const onRetryContextList: AssetsRetryHookContext[] = [];
+  const onSuccessContextList: AssetsRetryHookContext[] = [];
+  const onFailContextList: AssetsRetryHookContext[] = [];
+
+  const origin = `http://localhost:${port}`;
+
+  page.on('console', async (msg) => {
+    if (msg.type() !== 'info') {
+      return;
+    }
+    const typeValue = (await msg.args()[0].jsonValue()) as string;
+    const contextValue = (await msg
+      .args()[1]
+      .jsonValue()) as AssetsRetryHookContext;
+
+    if (
+      typeValue === 'onRetry' ||
+      typeValue === 'onSuccess' ||
+      typeValue === 'onFail'
+    ) {
+      // For snapshot
+      contextValue.url = contextValue.url?.replace(origin, '<ORIGIN>');
+      contextValue.domain = contextValue.domain?.replace(origin, '<ORIGIN>');
+    }
+
+    if (typeValue === 'onRetry') {
+      onRetryContextList.push(contextValue);
+    } else if (typeValue === 'onSuccess') {
+      onSuccessContextList.push(contextValue);
+    } else if (typeValue === 'onFail') {
+      onFailContextList.push(contextValue);
+    }
+  });
+  return {
+    onRetryContextList,
+    onSuccessContextList,
+    onFailContextList,
+  };
+}
+
+test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying initial chunk', async ({
+  page,
+}) => {
+  const blockedMiddleware = createBlockMiddleware({
+    blockNum: 3,
+    urlPrefix: '/static/js/index.js',
+  });
+
+  const rsbuild = await createRsbuildWithMiddleware(blockedMiddleware, {
+    minify: true,
+    onRetry(context) {
+      console.info('onRetry', context);
+    },
+    onSuccess(context) {
+      console.info('onSuccess', context);
+    },
+    onFail(context) {
+      console.info('onFail', context);
+    },
+  });
+
+  const { onRetryContextList, onFailContextList, onSuccessContextList } =
+    await proxyPageConsole(page, rsbuild.port);
+  await gotoPage(page, rsbuild);
+  const compTestElement = page.locator('#comp-test');
+  await expect(compTestElement).toHaveText('Hello CompTest');
+  await delay();
+
+  expect({
+    onRetryContextList,
+    onFailContextList,
+    onSuccessContextList,
+  }).toMatchObject({
+    onRetryContextList: [
+      {
+        times: 0,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+      {
+        times: 1,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+      {
+        times: 2,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+    ],
+    onFailContextList: [],
+    onSuccessContextList: [
+      {
+        times: 3,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+    ],
+  });
+  await rsbuild.close();
+});
+
 test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying async chunk', async ({
   page,
 }) => {
@@ -285,25 +400,8 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
     },
   });
 
-  const onRetryContextList: AssetsRetryHookContext[] = [];
-  const onSuccessContextList: AssetsRetryHookContext[] = [];
-  const onFailContextList: AssetsRetryHookContext[] = [];
-
-  page.on('console', async (msg) => {
-    if (msg.type() !== 'info') {
-      return;
-    }
-    const typeValue = await msg.args()[0].jsonValue();
-    const contextValue = await msg.args()[1].jsonValue();
-
-    if (typeValue === 'onRetry') {
-      onRetryContextList.push(contextValue);
-    } else if (typeValue === 'onSuccess') {
-      onSuccessContextList.push(contextValue);
-    } else if (typeValue === 'onFail') {
-      onFailContextList.push(contextValue);
-    }
-  });
+  const { onRetryContextList, onFailContextList, onSuccessContextList } =
+    await proxyPageConsole(page, rsbuild.port);
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
@@ -318,32 +416,112 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
     onRetryContextList: [
       {
         times: 0,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
       {
         times: 1,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
       {
         times: 2,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
     ],
     onFailContextList: [],
     onSuccessContextList: [
       {
         times: 3,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
     ],
+  });
+  await rsbuild.close();
+});
+
+test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying initial chunk', async ({
+  page,
+}) => {
+  const blockedMiddleware = createBlockMiddleware({
+    blockNum: 100,
+    urlPrefix: '/static/js/index.js',
+  });
+
+  const port = await getRandomPort();
+  const rsbuild = await createRsbuildWithMiddleware(
+    blockedMiddleware,
+    {
+      minify: true,
+      domain: [`http://localhost:${port}`, 'http://a.com', 'http://b.com'],
+      onRetry(context) {
+        console.info('onRetry', context);
+      },
+      onSuccess(context) {
+        console.info('onSuccess', context);
+      },
+      onFail(context) {
+        console.info('onFail', context);
+      },
+    },
+    undefined,
+    port,
+  );
+
+  const { onRetryContextList, onFailContextList, onSuccessContextList } =
+    await proxyPageConsole(page, rsbuild.port);
+
+  await gotoPage(page, rsbuild);
+  await delay();
+
+  expect({
+    onRetryContextList,
+    onFailContextList,
+    onSuccessContextList,
+  }).toMatchObject({
+    onRetryContextList: [
+      {
+        times: 0,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+      {
+        times: 1,
+        domain: 'http://a.com',
+        url: 'http://a.com/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+      {
+        times: 2,
+        domain: 'http://b.com',
+        url: 'http://b.com/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+    ],
+    onFailContextList: [
+      {
+        times: 3,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/index.js',
+        tagName: 'script',
+        isAsyncChunk: false,
+      },
+    ],
+    onSuccessContextList: [],
   });
   await rsbuild.close();
 });
@@ -356,37 +534,28 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
     urlPrefix: '/static/js/async/src_AsyncCompTest_tsx.js',
   });
 
-  const rsbuild = await createRsbuildWithMiddleware(blockedMiddleware, {
-    minify: true,
-    onRetry(context) {
-      console.info('onRetry', context);
+  const port = await getRandomPort();
+  const rsbuild = await createRsbuildWithMiddleware(
+    blockedMiddleware,
+    {
+      minify: true,
+      domain: [`http://localhost:${port}`, 'http://a.com', 'http://b.com'],
+      onRetry(context) {
+        console.info('onRetry', context);
+      },
+      onSuccess(context) {
+        console.info('onSuccess', context);
+      },
+      onFail(context) {
+        console.info('onFail', context);
+      },
     },
-    onSuccess(context) {
-      console.info('onSuccess', context);
-    },
-    onFail(context) {
-      console.info('onFail', context);
-    },
-  });
+    undefined,
+    port,
+  );
 
-  const onRetryContextList: AssetsRetryHookContext[] = [];
-  const onSuccessContextList: AssetsRetryHookContext[] = [];
-  const onFailContextList: AssetsRetryHookContext[] = [];
-  page.on('console', async (msg) => {
-    if (msg.type() !== 'info') {
-      return;
-    }
-    const typeValue = await msg.args()?.[0].jsonValue();
-    const contextValue = await msg.args()?.[1].jsonValue();
-
-    if (typeValue === 'onRetry') {
-      onRetryContextList.push(contextValue);
-    } else if (typeValue === 'onSuccess') {
-      onSuccessContextList.push(contextValue);
-    } else if (typeValue === 'onFail') {
-      onFailContextList.push(contextValue);
-    }
-  });
+  const { onRetryContextList, onFailContextList, onSuccessContextList } =
+    await proxyPageConsole(page, rsbuild.port);
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
@@ -403,29 +572,33 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
     onRetryContextList: [
       {
         times: 0,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
       {
         times: 1,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: 'http://a.com',
+        url: 'http://a.com/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
       {
         times: 2,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: 'http://b.com',
+        url: 'http://b.com/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
     ],
     onFailContextList: [
       {
         times: 3,
-        domain: '/',
-        url: '/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
+        isAsyncChunk: true,
       },
     ],
     onSuccessContextList: [],

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -95,7 +95,6 @@ function getUrlRetryQuery(
   return '';
 }
 
-// "http://cdn.com/app/main/static/js/index.js" -> "/app/main/static/js/index.js"
 function removeDomainFromUrl(url: string): string {
   const protocolStartIndex = url.indexOf('//');
 
@@ -112,14 +111,20 @@ function removeDomainFromUrl(url: string): string {
   return url.slice(pathStartIndex);
 }
 
+// "http://cdn.com/app/main/static/js/index.js?query=1#hash" -> "/app/main/static/js/index.js"
+function getAbsolutePathFromUrl(url: string): string {
+  return cleanUrl(removeDomainFromUrl(url));
+}
+
 function getNextRetryUrl(
   existRetryTimes: number,
   nextDomain: string,
   originalSrcUrl: string,
 ) {
-  const relativeUrl = removeDomainFromUrl(originalSrcUrl);
+  const absolutePath = getAbsolutePathFromUrl(originalSrcUrl);
   return (
-    cleanUrl(nextDomain + relativeUrl) +
+    nextDomain +
+    absolutePath +
     getUrlRetryQuery(existRetryTimes, getQueryFromUrl(originalSrcUrl))
   );
 }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -117,9 +117,9 @@ function getNextRetryUrl(
   nextDomain: string,
   originalSrcUrl: string,
 ) {
-  const originalSrcUrlWithoutDomain = removeDomainFromUrl(originalSrcUrl);
+  const relativeUrl = removeDomainFromUrl(originalSrcUrl);
   return (
-    cleanUrl(nextDomain + originalSrcUrlWithoutDomain) +
+    cleanUrl(nextDomain + relativeUrl) +
     getUrlRetryQuery(existRetryTimes, getQueryFromUrl(originalSrcUrl))
   );
 }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -96,7 +96,7 @@ function getUrlRetryQuery(
 }
 
 // "http://cdn.com/app/main/static/js/index.js" -> "/app/main/static/js/index.js"
-function getPathFromUrl(url: string): string {
+function removeDomainFromUrl(url: string): string {
   const protocolStartIndex = url.indexOf('//');
 
   // case /app/main/static/js/index.js
@@ -109,8 +109,7 @@ function getPathFromUrl(url: string): string {
   const protocolEndIndex = protocolStartIndex + 2;
   const pathStartIndex = url.indexOf('/', protocolEndIndex);
 
-  const path = url.slice(pathStartIndex);
-  return path;
+  return url.slice(pathStartIndex);
 }
 
 function getNextRetryUrl(
@@ -118,7 +117,7 @@ function getNextRetryUrl(
   nextDomain: string,
   originalSrcUrl: string,
 ) {
-  const originalSrcUrlWithoutDomain = getPathFromUrl(originalSrcUrl);
+  const originalSrcUrlWithoutDomain = removeDomainFromUrl(originalSrcUrl);
   return (
     cleanUrl(nextDomain + originalSrcUrlWithoutDomain) +
     getUrlRetryQuery(existRetryTimes, getQueryFromUrl(originalSrcUrl))

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -61,7 +61,7 @@ function findCurrentDomain(url: string) {
       break;
     }
   }
-  return domain || url;
+  return domain || window.origin;
 }
 
 function findNextDomain(url: string) {
@@ -95,18 +95,37 @@ function getUrlRetryQuery(
   return '';
 }
 
+/**
+ *
+ * @param url "http://cdn.com/app/main/static/js/index.js"
+ * @returns "/app/main/static/js/index.js"
+ */
+function getPathFromUrl(url: string): string {
+  const protocolStartIndex = url.indexOf('//');
+
+  // case /app/main/static/js/index.js
+  if (protocolStartIndex === -1 && url.startsWith('/')) {
+    return url;
+  }
+
+  // case "//cdn.com/app/main/static/js/index.js"
+  // case "http://cdn.com/app/main/static/js/index.js"
+  const protocolEndIndex = protocolStartIndex + 2;
+  const pathStartIndex = url.indexOf('/', protocolEndIndex);
+
+  const path = url.slice(pathStartIndex);
+  return path;
+}
+
 function getNextRetryUrl(
   existRetryTimes: number,
   nextDomain: string,
   originalSrcUrl: string,
-  originalScriptFilename: string,
 ) {
+  const originalSrcUrlWithoutDomain = getPathFromUrl(originalSrcUrl);
   return (
-    cleanUrl(
-      nextDomain +
-        (nextDomain[nextDomain.length - 1] === '/' ? '' : '/') +
-        originalScriptFilename,
-    ) + getUrlRetryQuery(existRetryTimes, getQueryFromUrl(originalSrcUrl))
+    cleanUrl(nextDomain + originalSrcUrlWithoutDomain) +
+    getUrlRetryQuery(existRetryTimes, getQueryFromUrl(originalSrcUrl))
   );
 }
 
@@ -121,17 +140,12 @@ function initRetry(chunkId: string): Retry {
     __RUNTIME_GLOBALS_PUBLIC_PATH__ + originalScriptFilename;
 
   const existRetryTimes = 1;
-  const nextDomain = config.domain?.[0] ?? __RUNTIME_GLOBALS_PUBLIC_PATH__;
+  const nextDomain = config.domain?.[0] ?? window.origin;
 
   return {
     existRetryTimes,
     nextDomain,
-    nextRetryUrl: getNextRetryUrl(
-      existRetryTimes,
-      nextDomain,
-      originalSrcUrl,
-      originalScriptFilename,
-    ),
+    nextRetryUrl: getNextRetryUrl(existRetryTimes, nextDomain, originalSrcUrl),
 
     originalScriptFilename,
     originalSrcUrl,
@@ -156,7 +170,6 @@ function nextRetry(chunkId: string): Retry {
         existRetryTimes,
         nextDomain,
         originalSrcUrl,
-        originalScriptFilename,
       ),
 
       originalScriptFilename,

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -95,11 +95,7 @@ function getUrlRetryQuery(
   return '';
 }
 
-/**
- *
- * @param url "http://cdn.com/app/main/static/js/index.js"
- * @returns "/app/main/static/js/index.js"
- */
+// "http://cdn.com/app/main/static/js/index.js" -> "/app/main/static/js/index.js"
 function getPathFromUrl(url: string): string {
   const protocolStartIndex = url.indexOf('//');
 

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -30,7 +30,7 @@ function findCurrentDomain(url: string, domainList: string[]) {
       break;
     }
   }
-  return domain || url;
+  return domain || window.origin;
 }
 
 function findNextDomain(url: string, domainList: string[]) {


### PR DESCRIPTION
## Summary

1. url calculation when using asset_prefix

<img width="400" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/79413249/2e31f642-af02-4ac9-8874-f5e7e2353a29">

😄 should add asset_prefix/public_path

```
domain: ['https://cdn.com', 'https://cdn2.com', 'https://cdn3.com']

1: https://cdn.com/base/app1/static/js/index.js"
2: https://cdn2.com/static/js/index.js
3: https://cdn3.com/static/js/index.js
```

2. domain difference between initial chunk and async chunk

```js
// rsbuild.config.ts
pluginAssetsRetry({
	 domain: ['http://localhost:3030', 'http://a.com', 'http://b.com'],
      onRetry(context) {
        console.info('onRetry', context);
      },
      onSuccess(context) {
        console.info('onSuccess', context);
      },
      onFail(context) {
        console.info('onFail', context);
      },
})
```

before

```js
 onRetryContextList: [
      {
        times: 0,
        domain: '<ORIGIN>/static/js/index.js',
        // domain: '/'  // async
        url: '<ORIGIN>/static/js/index.js',
        tagName: 'script',
      },
      {
        times: 1,
        domain: 'http://a.com',
        url: 'http://a.com/static/js/index.js',
        tagName: 'script',
      },
      {
        times: 2,
        domain: 'http://b.com',
        url: 'http://b.com/static/js/index.js',
        tagName: 'script',
      },
    ],
    onFailContextList: [
      {
        times: 3,
        domain: '<ORIGIN>',
        url: '<ORIGIN>/static/js/index.js',
        tagName: 'script',
      },
    ],
    onSuccessContextList: [],
```


after

```js
 onRetryContextList: [
      {
        times: 0,
        domain: '<ORIGIN>',
        url: '<ORIGIN>/static/js/index.js',
        tagName: 'script',
      },
      {
        times: 1,
        domain: 'http://a.com',
        url: 'http://a.com/static/js/index.js',
        tagName: 'script',
      },
      {
        times: 2,
        domain: 'http://b.com',
        url: 'http://b.com/static/js/index.js',
        tagName: 'script',
      },
    ],
    onFailContextList: [
      {
        times: 3,
        domain: '<ORIGIN>',
        url: '<ORIGIN>/static/js/index.js',
        tagName: 'script',
      },
    ],
    onSuccessContextList: [],
```





## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
