### PR TITLE
perf: bump html plugin to unify tapable

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "@swc/helpers": "0.5.11",
     "caniuse-lite": "^1.0.30001640",
     "core-js": "~3.37.1",
-    "html-rspack-plugin": "6.0.0-beta.2",
+    "html-rspack-plugin": "6.0.0-beta.3",
     "postcss": "^8.4.39"
   },
   "devDependencies": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -35,7 +35,7 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-rspack-plugin": "6.0.0-beta.2",
+    "html-rspack-plugin": "6.0.0-beta.3",
     "terser": "5.31.1",
     "typescript": "^5.5.2"
   },

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,7 +37,7 @@
     "@rsbuild/plugin-less": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-rspack-plugin": "6.0.0-beta.2",
+    "html-rspack-plugin": "6.0.0-beta.3",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.5.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,8 +679,8 @@ importers:
         specifier: ~3.37.1
         version: 3.37.1
       html-rspack-plugin:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
+        specifier: 6.0.0-beta.3
+        version: 6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
       postcss:
         specifier: ^8.4.39
         version: 8.4.39
@@ -856,8 +856,8 @@ importers:
         specifier: ^5.0.4
         version: 5.0.4
       html-rspack-plugin:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
+        specifier: 6.0.0-beta.3
+        version: 6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1070,8 +1070,8 @@ importers:
         specifier: workspace:*
         version: link:../../scripts/test-helper
       html-rspack-plugin:
-        specifier: 6.0.0-beta.2
-        version: 6.0.0-beta.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
+        specifier: 6.0.0-beta.3
+        version: 6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)
@@ -5159,8 +5159,8 @@ packages:
       '@rspack/core':
         optional: true
 
-  html-rspack-plugin@6.0.0-beta.2:
-    resolution: {integrity: sha512-PzDHK0dEKOC8CjGsPQQydYUBsUrjkKqEQ1UE7lrRGdfvL6paflSTvFQy1+yGhBze19064spuh0cfCNd7VE3mDQ==}
+  html-rspack-plugin@6.0.0-beta.3:
+    resolution: {integrity: sha512-H1jVj3GnyqbZmhycUHwdlGvSdXHmzdtVaZcFIsTJ+i0q0hH+gGe+t+d0y5SIGfsozeTjjSdOZPWfzI/hM/5OXQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       '@rspack/core': 1.0.0-alpha.2
@@ -12081,7 +12081,9 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.3)
 
-  html-rspack-plugin@6.0.0-beta.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)):
+  html-rspack-plugin@6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)):
+    dependencies:
+      '@rspack/lite-tapable': 1.0.0-alpha.2
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
 


### PR DESCRIPTION
## Summary

Use `@rspack/lite-tapable` for all packages.

## Related Links

https://github.com/rspack-contrib/html-rspack-plugin/pull/7

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
