### PR TITLE
feat: allow to custom CSS minify options

### DIFF
--- a/e2e/cases/css/css-minify-options/index.test.ts
+++ b/e2e/cases/css/css-minify-options/index.test.ts
@@ -1,0 +1,15 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should allow to custom CSS minify options', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {},
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+  expect(content).toEqual('.bar{color:green}');
+});

--- a/e2e/cases/css/css-minify-options/rsbuild.config.ts
+++ b/e2e/cases/css/css-minify-options/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    minify: {
+      cssOptions: {
+        unusedSymbols: ['foo', 'fade-in', '--color'],
+      },
+    },
+  },
+});

--- a/e2e/cases/css/css-minify-options/src/index.css
+++ b/e2e/cases/css/css-minify-options/src/index.css
@@ -1,0 +1,20 @@
+:root {
+  --color: red;
+}
+
+.foo {
+  color: var(--color);
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.bar {
+  color: green;
+}

--- a/e2e/cases/css/css-minify-options/src/index.js
+++ b/e2e/cases/css/css-minify-options/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -1,7 +1,8 @@
 /**
- * @license
- * Copyright 2018 Google Inc.
+ * This method is modified based on source found in
  * https://github.com/vuejs/preload-webpack-plugin/blob/master/src/index.js
+ *
+ * Copyright 2018 Google Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/core/src/rspack/preload/helpers/determineAsValue.ts
+++ b/packages/core/src/rspack/preload/helpers/determineAsValue.ts
@@ -1,8 +1,8 @@
 /**
- * @license
- * Copyright 2018 Google Inc.
+ * This method is modified based on source found in
  * https://github.com/vuejs/preload-webpack-plugin/blob/master/src/lib/determine-as-value.js
  *
+ * Copyright 2018 Google Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -1,7 +1,8 @@
 /**
- * @license
- * Copyright 2018 Google Inc.
+ * This method is modified based on source found in
  * https://github.com/vuejs/preload-webpack-plugin/blob/master/src/lib/does-chunk-belong-to-html.js
+ *
+ * Copyright 2018 Google Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/core/src/rspack/preload/helpers/extractChunks.ts
+++ b/packages/core/src/rspack/preload/helpers/extractChunks.ts
@@ -1,7 +1,8 @@
 /**
- * @license
- * Copyright 2018 Google Inc.
+ * This method is modified based on source found in
  * https://github.com/vuejs/preload-webpack-plugin/blob/master/src/lib/extract-chunks.js
+ *
+ * Copyright 2018 Google Inc.
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/packages/core/src/types/config/output.ts
+++ b/packages/core/src/types/config/output.ts
@@ -1,6 +1,7 @@
 import type {
   CopyRspackPluginOptions,
   Externals,
+  LightningCssMinimizerRspackPluginOptions,
   SwcJsMinimizerRspackPluginOptions,
 } from '@rspack/core';
 import type { CSSLoaderModulesOptions } from '../../types';
@@ -168,13 +169,17 @@ export type Minify =
        */
       js?: boolean;
       /**
-       * Minimizer options of JavaScript, which will be passed to swc.
+       * Minimizer options of JavaScript, which will be passed to SWC.
        */
       jsOptions?: SwcJsMinimizerRspackPluginOptions;
       /**
        * Whether to enable CSS minimization.
        */
       css?: boolean;
+      /**
+       * Minimizer options of CSS, which will be passed to LightningCSS.
+       */
+      cssOptions?: LightningCssMinimizerRspackPluginOptions;
     };
 
 export type InlineChunkTestFunction = (params: {

--- a/website/docs/en/config/output/minify.mdx
+++ b/website/docs/en/config/output/minify.mdx
@@ -9,6 +9,7 @@ type Minify =
       js?: boolean;
       jsOptions?: SwcJsMinimizerRspackPluginOptions;
       css?: boolean;
+      cssOptions?: LightningCssMinimizerRspackPluginOptions;
     };
 ```
 
@@ -24,10 +25,11 @@ Here are explanations for each field:
 - `js`: Whether to enable minification for JavaScript code.
 - `jsOptions`: JS code minification configuration, which will be merged with the default configuration and passed to SWC.
 - `css`: Whether to enable minification for CSS code.
+- `cssOptions`: CSS code minification configuration, which will be merged with the default configuration and passed to Lightning CSS.
 
 ## Example
 
-### Disable all code minification
+### Disable all minification
 
 ```js
 export default {
@@ -41,7 +43,7 @@ export default {
 This configuration is usually used for debugging and troubleshooting. It is not recommended to disable code minification in production builds, as it will significantly degrade the page performance.
 :::
 
-### Disable JavaScript code minification
+### Disable JavaScript minification
 
 ```js
 export default {
@@ -53,7 +55,7 @@ export default {
 };
 ```
 
-### Customize JavaScript code minification
+### JavaScript minify options
 
 `output.minify.jsOptions` is used to configure SWC's minification options. For specific configuration items, please refer to [SWC Documentation](https://swc.rs/docs/configuration/minification#configuration). The following configuration will override the default settings, turning off code obfuscation and the removal of `console` statements.
 
@@ -66,6 +68,22 @@ export default {
         compress: {
           drop_console: false,
         },
+      },
+    },
+  },
+};
+```
+
+### CSS minify options
+
+`output.minify.cssOptions` is used to configure Lightning CSS's minification options. For specific configuration items, please refer to [LightningCssMinimizerRspackPlugin Documentation](https://rspack.dev/plugins/rspack/lightning-css-minimizer-rspack-plugin).
+
+```js
+export default {
+  output: {
+    minify: {
+      cssOptions: {
+        errorRecovery: false,
       },
     },
   },

--- a/website/docs/zh/config/output/minify.mdx
+++ b/website/docs/zh/config/output/minify.mdx
@@ -9,6 +9,7 @@ type Minify =
       js?: boolean;
       jsOptions?: SwcJsMinimizerRspackPluginOptions;
       css?: boolean;
+      cssOptions?: LightningCssMinimizerRspackPluginOptions;
     };
 ```
 
@@ -21,13 +22,14 @@ type Minify =
 
 下面是各个字段的说明：
 
-- `js`: 是否开启对 JavaScript 代码的压缩
-- `jsOptions`: JS 代码压缩配置，将会与默认配置合并传给 SWC
-- `css`: 是否开启对 CSS 代码的压缩
+- `js`: 是否开启对 JavaScript 代码的压缩。
+- `jsOptions`: JS 代码压缩配置，将会与默认配置合并传给 SWC。
+- `css`: 是否开启对 CSS 代码的压缩。
+- `cssOptions`: CSS 代码压缩配置，将会与默认配置合并传给 Lightning CSS。
 
 ## 示例
 
-### 禁用所有代码压缩
+### 禁用所有压缩
 
 ```js
 export default {
@@ -41,7 +43,7 @@ export default {
 该配置项通常用于代码调试和问题排查，不建议在生产环境禁用代码压缩，否则会导致页面性能显著下降。
 :::
 
-### 禁用 JavaScript 代码压缩
+### 禁用 JavaScript 压缩
 
 ```js
 export default {
@@ -53,7 +55,7 @@ export default {
 };
 ```
 
-### 对 JavaScript 代码进行自定义压缩
+### JavaScript 压缩选项
 
 `output.minify.jsOptions` 用于配置 SWC 的压缩选项，具体配置项请参考 [SWC 文档](https://swc.rs/docs/configuration/minification#configuration)。如下配置将覆盖默认配置，关闭代码混淆和移除 `console` 语句。
 
@@ -66,6 +68,22 @@ export default {
         compress: {
           drop_console: false,
         },
+      },
+    },
+  },
+};
+```
+
+### CSS 压缩选项
+
+`output.minify.cssOptions` 用于配置 Lightning CSS 的压缩选项，具体配置项请参考 [LightningCssMinimizerRspackPlugin 文档](https://rspack.dev/plugins/rspack/lightning-css-minimizer-rspack-plugin)。
+
+```js
+export default {
+  output: {
+    minify: {
+      cssOptions: {
+        errorRecovery: false,
       },
     },
   },


### PR DESCRIPTION
## Summary

Added a new `output.minify.cssOptions` config to custom CSS minify options.

## Related Links

https://www.rspack.dev/plugins/rspack/lightning-css-minimizer-rspack-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
