### PR TITLE
fix(plugin-solid): remove `@babel/preset-typescript` for resolve the babel warning

### DIFF
--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -25,11 +25,13 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
             chain,
             CHAIN_ID,
             modifier: (babelOptions) => {
-              babelOptions.presets ??= [];
-              babelOptions.presets.push([
-                require.resolve('babel-preset-solid'),
-                options.solidPresetOptions || {},
-              ]);
+              babelOptions.presets = [
+                [
+                  require.resolve('babel-preset-solid'),
+                  options.solidPresetOptions || {},
+                ],
+              ];
+              babelOptions.parserOpts = { plugins: ['jsx', 'typescript'] };
 
               const usingHMR =
                 !isProd && environmentConfig.dev.hmr && target === 'web';

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -13,6 +13,12 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
+              "parserOpts": {
+                "plugins": [
+                  "jsx",
+                  "typescript",
+                ],
+              },
               "plugins": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
@@ -25,16 +31,6 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
                 ],
               ],
               "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/babel-preset-solid/index.js",
                   {
@@ -70,6 +66,12 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
               "babelrc": false,
               "compact": false,
               "configFile": false,
+              "parserOpts": {
+                "plugins": [
+                  "jsx",
+                  "typescript",
+                ],
+              },
               "plugins": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
@@ -82,16 +84,6 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
                 ],
               ],
               "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/babel-preset-solid/index.js",
                   {},
@@ -124,6 +116,12 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
               "babelrc": false,
               "compact": false,
               "configFile": false,
+              "parserOpts": {
+                "plugins": [
+                  "jsx",
+                  "typescript",
+                ],
+              },
               "plugins": [
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
@@ -136,16 +134,6 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
                 ],
               ],
               "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
                 [
                   "<ROOT>/node_modules/<PNPM_INNER>/babel-preset-solid/index.js",
                   {},


### PR DESCRIPTION
## Summary

## Related Links
https://github.com/solidjs/vite-plugin-solid/issues/137
https://github.com/solidjs/vite-plugin-solid/pull/103
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
