### PR TITLE
docs: enable sitemap for SEO

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1489,6 +1489,9 @@ importers:
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
+      rspress-plugin-sitemap:
+        specifier: ^1.0.1
+        version: 1.0.1
 
 packages:
 
@@ -6789,6 +6792,9 @@ packages:
 
   rspress-plugin-font-open-sans@1.0.0:
     resolution: {integrity: sha512-4GP0pd7h3W8EWdqE0VkA62nzUJZNy4ZnYK7be8+lOKHQKsQ5nZ+22A/VurNssi1eZFx3kjwbmIuoAkgb5W8S9Q==}
+
+  rspress-plugin-sitemap@1.0.1:
+    resolution: {integrity: sha512-1hLh2v2OMTjPD+jnHxKPnMRNWojUwao5gPyBFwd6YR8URRU4TNg5pvd9TSpszid1WNGt4OokqYwnL96tZGaDZQ==}
 
   rspress@1.25.2:
     resolution: {integrity: sha512-BvElBR8+Iwv7jau5B+dRCvXRIdsmPSr9mlwFsMMUeTFpy05OP1I/yO7HjE2TehzKfYitKDBJIKVo82eWDB4yuQ==}
@@ -14023,6 +14029,8 @@ snapshots:
       fs-extra: 11.2.0
 
   rspress-plugin-font-open-sans@1.0.0: {}
+
+  rspress-plugin-sitemap@1.0.1: {}
 
   rspress@1.25.2(@swc/helpers@0.5.3)(webpack@5.92.1):
     dependencies:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -13,6 +13,7 @@ Chunktmp
 classname
 codegen
 codesandbox
+codeva
 compat
 consolas
 contentful

--- a/website/package.json
+++ b/website/package.json
@@ -21,6 +21,7 @@
     "rsbuild-plugin-open-graph": "1.0.0",
     "rsfamily-nav-icon": "^1.0.3",
     "rspress": "1.25.2",
-    "rspress-plugin-font-open-sans": "1.0.0"
+    "rspress-plugin-font-open-sans": "1.0.0",
+    "rspress-plugin-sitemap": "^1.0.1"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -3,11 +3,15 @@ import { pluginRss } from '@rspress/plugin-rss';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
+import pluginSitemap from 'rspress-plugin-sitemap';
 import { defineConfig } from 'rspress/config';
 import { rsbuildPluginOverview } from './theme/rsbuildPluginOverview';
 
 export default defineConfig({
   plugins: [
+    pluginSitemap({
+      domain: 'https://rsbuild.dev',
+    }),
     pluginFontOpenSans(),
     pluginRss({
       siteUrl: 'https://rsbuild.dev',

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -7,14 +7,16 @@ import pluginSitemap from 'rspress-plugin-sitemap';
 import { defineConfig } from 'rspress/config';
 import { rsbuildPluginOverview } from './theme/rsbuildPluginOverview';
 
+const siteUrl = 'https://rsbuild.dev';
+
 export default defineConfig({
   plugins: [
     pluginSitemap({
-      domain: 'https://rsbuild.dev',
+      domain: siteUrl,
     }),
     pluginFontOpenSans(),
     pluginRss({
-      siteUrl: 'https://rsbuild.dev',
+      siteUrl,
       feed: [
         {
           id: 'releases-rss',
@@ -130,7 +132,7 @@ export default defineConfig({
       pluginOpenGraph({
         title: 'Rsbuild',
         type: 'website',
-        url: 'https://rsbuild.dev/',
+        url: siteUrl,
         image: 'https://assets.rspack.dev/rsbuild/rsbuild-og-image.png',
         description: 'The Rspack-based build tool',
         twitter: {

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -158,7 +158,7 @@ export default defineConfig({
           tag: 'meta',
           attrs: {
             name: 'baidu-site-verification',
-            content: 'codeva-ztxThXWOiy',
+            content: 'codeva-AgtVD3w3iV',
           },
         },
       ],


### PR DESCRIPTION
## Summary

Enable sitemap for SEO.

## Related Links

https://github.com/jl917/rspress-plugin-sitemap

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
