### PR TITLE
fix: transform Module Federation runtime

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -88,13 +88,15 @@ export function pluginModuleFederation(): RsbuildPlugin {
 
     setup(api) {
       api.modifyEnvironmentConfig((config) => {
+        if (!config.moduleFederation?.options) {
+          return;
+        }
         /**
          * Currently, splitChunks will take precedence over module federation shared modules.
          * So we need to disable the default split chunks rules to make shared modules to work properly.
          * @see https://github.com/module-federation/module-federation-examples/issues/3161
          */
         if (
-          config.moduleFederation?.options &&
           config.performance?.chunkSplit?.strategy === 'split-by-experience'
         ) {
           config.performance.chunkSplit = {
@@ -102,6 +104,13 @@ export function pluginModuleFederation(): RsbuildPlugin {
             strategy: 'custom',
           };
         }
+
+        // Module Federation runtime uses ES6+ syntax,
+        // adding to include and let SWC transform it
+        config.source.include = [
+          ...(config.source.include || []),
+          /@module-federation[\\/]runtime/,
+        ];
       });
 
       api.modifyBundlerChain(


### PR DESCRIPTION
## Summary

Module Federation runtime uses ES6+ syntax, adding to include and let SWC transform it.

## Related Links

https://github.com/web-infra-dev/rspack/pull/7085

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
