### PR TITLE
types: export HtmlRspackPlugin type

### DIFF
--- a/packages/compat/webpack/tests/webpackConfig.test.ts
+++ b/packages/compat/webpack/tests/webpackConfig.test.ts
@@ -128,7 +128,7 @@ describe('webpackConfig', () => {
     expect(config).toMatchSnapshot();
   });
 
-  it('should export HtmlWebpackPlugin instance', async () => {
+  it('should expose HtmlWebpackPlugin instance via params', async () => {
     await createStubRsbuild({
       rsbuildConfig: {
         tools: {

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -193,9 +193,9 @@ export const CHAIN_ID = {
   PLUGIN: {
     /** HotModuleReplacementPlugin */
     HMR: 'hmr',
-    /** CopyWebpackPlugin */
+    /** CopyRspackPlugin */
     COPY: 'copy',
-    /** HtmlWebpackPlugin */
+    /** HtmlRspackPlugin */
     HTML: 'html',
     /** ESLintWebpackPlugin */
     ESLINT: 'eslint',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,7 @@ export type {
   EnvironmentContext,
   FilenameConfig,
   HtmlConfig,
+  HtmlRspackPlugin,
   HtmlTagHandler,
   HtmlTagDescriptor,
   InspectConfigOptions,

--- a/packages/core/src/pluginHelper.ts
+++ b/packages/core/src/pluginHelper.ts
@@ -2,20 +2,20 @@
  * This file is used to get/set the global instance for html-plugin and css-extract plugin.
  */
 import rspack from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
+import type { HtmlRspackPlugin } from './types';
 
-let htmlPlugin: typeof HtmlWebpackPlugin;
+let htmlPlugin: typeof HtmlRspackPlugin;
 
 /**
  * This method is used to override the Rsbuild default html-plugin (html-rspack-plugin).
  */
-export const setHTMLPlugin = (plugin: typeof HtmlWebpackPlugin): void => {
+export const setHTMLPlugin = (plugin: typeof HtmlRspackPlugin): void => {
   if (plugin) {
     htmlPlugin = plugin;
   }
 };
 
-export const getHTMLPlugin = (): typeof HtmlWebpackPlugin => {
+export const getHTMLPlugin = (): typeof HtmlRspackPlugin => {
   if (!htmlPlugin) {
     htmlPlugin = require('html-rspack-plugin');
   }

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -1,8 +1,8 @@
 import type { Compilation, Compiler } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type { HtmlTagObject } from 'html-rspack-plugin';
 import { ensureAssetPrefix, isFunction, partition } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
+import type { HtmlRspackPlugin } from '../types';
 import type {
   EnvironmentContext,
   HtmlBasicTag,
@@ -68,7 +68,7 @@ export type AlterAssetTagGroupsData = {
   bodyTags: HtmlTagObject[];
   outputName: string;
   publicPath: string;
-  plugin: HtmlWebpackPlugin;
+  plugin: HtmlRspackPlugin;
 };
 
 export const hasTitle = (html?: string): boolean =>

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -22,10 +22,9 @@ import type {
   Compiler,
   RspackPluginInstance,
 } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import { ensureAssetPrefix, upperFirst } from '../../helpers';
 import { getHTMLPlugin } from '../../pluginHelper';
-import type { PreloadOrPreFetchOption } from '../../types';
+import type { HtmlRspackPlugin, PreloadOrPreFetchOption } from '../../types';
 import {
   type As,
   type BeforeAssetTagGenerationHtmlPluginData,
@@ -49,9 +48,9 @@ interface Attributes {
 }
 
 function filterResourceHints(
-  resourceHints: HtmlWebpackPlugin.HtmlTagObject[],
-  scripts: HtmlWebpackPlugin.HtmlTagObject[],
-): HtmlWebpackPlugin.HtmlTagObject[] {
+  resourceHints: HtmlRspackPlugin.HtmlTagObject[],
+  scripts: HtmlRspackPlugin.HtmlTagObject[],
+): HtmlRspackPlugin.HtmlTagObject[] {
   return resourceHints.filter(
     (resourceHint) =>
       !scripts.find(
@@ -66,7 +65,7 @@ function generateLinks(
   compilation: Compilation,
   htmlPluginData: BeforeAssetTagGenerationHtmlPluginData,
   HTMLCount: number,
-): HtmlWebpackPlugin.HtmlTagObject[] {
+): HtmlRspackPlugin.HtmlTagObject[] {
   // get all chunks
   const extractedChunks = extractChunks({
     compilation,
@@ -77,7 +76,7 @@ function generateLinks(
     // Handle all chunks.
     options.type === 'all-assets' || HTMLCount === 1
       ? extractedChunks
-      : // Only handle chunks imported by this HtmlWebpackPlugin.
+      : // Only handle chunks imported by this HtmlRspackPlugin.
         extractedChunks.filter((chunk) =>
           doesChunkBelongToHtml({
             chunk: chunk as Chunk,
@@ -118,7 +117,7 @@ function generateLinks(
 
   // Sort to ensure the output is predictable.
   const sortedFilteredFiles = filteredFiles.sort();
-  const links: HtmlWebpackPlugin.HtmlTagObject[] = [];
+  const links: HtmlRspackPlugin.HtmlTagObject[] = [];
   const { publicPath, crossOriginLoading } = compilation.outputOptions;
 
   for (const file of sortedFilteredFiles) {
@@ -168,7 +167,7 @@ function generateLinks(
 export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   readonly options: PreloadOrPreFetchOption;
 
-  resourceHints: HtmlWebpackPlugin.HtmlTagObject[] = [];
+  resourceHints: HtmlRspackPlugin.HtmlTagObject[] = [];
 
   type: LinkType;
 

--- a/packages/core/src/rspack/preload/helpers/type.ts
+++ b/packages/core/src/rspack/preload/helpers/type.ts
@@ -1,4 +1,4 @@
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
+import type { HtmlRspackPlugin } from '../../../types';
 
 export type BeforeAssetTagGenerationHtmlPluginData = {
   assets: {
@@ -9,7 +9,7 @@ export type BeforeAssetTagGenerationHtmlPluginData = {
     manifest?: string;
   };
   outputName: string;
-  plugin: HtmlWebpackPlugin;
+  plugin: HtmlRspackPlugin;
 };
 
 export type As =

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,4 +1,3 @@
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type { ChainIdentifier } from '..';
 import type {
@@ -11,7 +10,7 @@ import type {
 import type { RsbuildEntry, RsbuildTarget } from './rsbuild';
 import type { Rspack } from './rspack';
 import type { MultiStats, Stats } from './stats';
-import type { WebpackConfig } from './thirdParty';
+import type { HtmlRspackPlugin, WebpackConfig } from './thirdParty';
 import type { MaybePromise, NodeEnv } from './utils';
 
 export type OnBeforeBuildFn<B = 'rspack'> = (params: {
@@ -145,7 +144,7 @@ export type ModifyChainUtils = {
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
   environment: EnvironmentContext;
-  HtmlPlugin: typeof HtmlWebpackPlugin;
+  HtmlPlugin: typeof HtmlRspackPlugin;
 };
 
 interface PluginInstance {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1,5 +1,4 @@
 import type { RuleSetCondition } from '@rspack/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type {
   RuleSetRule,
@@ -34,6 +33,7 @@ import type {
 } from './hooks';
 import type { RsbuildTarget } from './rsbuild';
 import type { RspackConfig, RspackSourceMap } from './rspack';
+import type { HtmlRspackPlugin } from './thirdParty';
 import type { Falsy } from './utils';
 import type { MaybePromise } from './utils';
 
@@ -64,7 +64,7 @@ export type ModifyWebpackChainUtils = ModifyChainUtils & {
   /**
    * @deprecated Use HtmlPlugin instead.
    */
-  HtmlWebpackPlugin: typeof HtmlWebpackPlugin;
+  HtmlWebpackPlugin: typeof HtmlRspackPlugin;
 };
 
 export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -3,9 +3,12 @@ import type {
   CssExtractRspackPluginOptions,
 } from '@rspack/core';
 import type Autoprefixer from 'autoprefixer';
+import type HtmlRspackPlugin from 'html-rspack-plugin';
 import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 import type { Configuration as WebpackConfig } from 'webpack';
 import type { Rspack } from './rspack';
+
+export type { HtmlRspackPlugin };
 
 type AutoprefixerOptions = Autoprefixer.Options;
 

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -35,7 +35,6 @@
     "@babel/preset-typescript": "^7.24.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
-    "html-rspack-plugin": "6.0.0-beta.5",
     "terser": "5.31.1",
     "typescript": "^5.5.2"
   },

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { type Rspack, ensureAssetPrefix } from '@rsbuild/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
+import {
+  type HtmlRspackPlugin,
+  type Rspack,
+  ensureAssetPrefix,
+} from '@rsbuild/core';
 import type { PluginAssetsRetryOptions } from './types';
 
 export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
@@ -13,7 +16,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
 
   readonly minify?: boolean;
 
-  readonly HtmlPlugin: typeof HtmlWebpackPlugin;
+  readonly HtmlPlugin: typeof HtmlRspackPlugin;
 
   scriptPath: string;
 
@@ -22,7 +25,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
   constructor(
     options: PluginAssetsRetryOptions & {
       distDir: string;
-      HtmlPlugin: typeof HtmlWebpackPlugin;
+      HtmlPlugin: typeof HtmlRspackPlugin;
     },
   ) {
     const {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -37,7 +37,6 @@
     "@rsbuild/plugin-less": "workspace:*",
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
-    "html-rspack-plugin": "6.0.0-beta.5",
     "postcss-pxtorem": "6.1.0",
     "prebundle": "1.1.0",
     "typescript": "^5.5.2"

--- a/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
+++ b/packages/plugin-rem/src/AutoSetRootFontSizePlugin.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import {
+  type HtmlRspackPlugin,
   type Rspack,
   type ScriptLoading,
   ensureAssetPrefix,
   logger,
 } from '@rsbuild/core';
-import type HtmlWebpackPlugin from 'html-rspack-plugin';
 import type { PluginRemOptions } from './types';
 
 type AutoSetRootFontSizeOptions = Omit<
@@ -68,14 +68,14 @@ export class AutoSetRootFontSizePlugin implements Rspack.RspackPluginInstance {
 
   scriptPath: string;
 
-  HtmlPlugin: typeof HtmlWebpackPlugin;
+  HtmlPlugin: typeof HtmlRspackPlugin;
 
   scriptLoading: ScriptLoading;
 
   constructor(
     options: PluginRemOptions,
     entries: Array<string>,
-    HtmlPlugin: typeof HtmlWebpackPlugin,
+    HtmlPlugin: typeof HtmlRspackPlugin,
     distDir: string,
     scriptLoading: ScriptLoading,
   ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,9 +855,6 @@ importers:
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
-      html-rspack-plugin:
-        specifier: 6.0.0-beta.5
-        version: 6.0.0-beta.5(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
       terser:
         specifier: 5.31.1
         version: 5.31.1
@@ -1069,9 +1066,6 @@ importers:
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
-      html-rspack-plugin:
-        specifier: 6.0.0-beta.5
-        version: 6.0.0-beta.5(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
       postcss-pxtorem:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)


### PR DESCRIPTION
## Summary

Export `HtmlRspackPlugin` type for plugins to use.

This helps `plugin-rem` or `plugin-assets-retry` to remove the `html-rspack-plugin` dependency. We should provide more HTML-related plugin hooks for Rsbuild plugins in the future to reduce the dependency on html-rspack-plugin hooks.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
