### PR TITLE
types: allow passing user config to mergeEnvironmentConfig

### DIFF
--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -104,14 +104,20 @@ export type ModifyRsbuildConfigUtils = {
   mergeRsbuildConfig: (...configs: RsbuildConfig[]) => RsbuildConfig;
 };
 
+declare function mergeEnvironmentConfig(
+  userConfig: EnvironmentConfig,
+  config: MergedEnvironmentConfig,
+): MergedEnvironmentConfig;
+declare function mergeEnvironmentConfig(
+  config: MergedEnvironmentConfig,
+  ...configs: EnvironmentConfig[]
+): MergedEnvironmentConfig;
+
 export type ModifyEnvironmentConfigUtils = {
   /** environment name. */
   name: string;
   /** Merge multiple Rsbuild environment config objects into one. */
-  mergeEnvironmentConfig: (
-    config: MergedEnvironmentConfig,
-    ...configs: EnvironmentConfig[]
-  ) => MergedEnvironmentConfig;
+  mergeEnvironmentConfig: typeof mergeEnvironmentConfig;
 };
 
 export type ModifyRsbuildConfigFn = (

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -104,20 +104,15 @@ export type ModifyRsbuildConfigUtils = {
   mergeRsbuildConfig: (...configs: RsbuildConfig[]) => RsbuildConfig;
 };
 
-declare function mergeEnvironmentConfig(
-  userConfig: EnvironmentConfig,
-  config: MergedEnvironmentConfig,
-): MergedEnvironmentConfig;
-declare function mergeEnvironmentConfig(
-  config: MergedEnvironmentConfig,
-  ...configs: EnvironmentConfig[]
-): MergedEnvironmentConfig;
+type ArrayAtLeastOne<A, B> = [A, ...Array<A | B>] | [...Array<A | B>, A];
 
 export type ModifyEnvironmentConfigUtils = {
   /** environment name. */
   name: string;
   /** Merge multiple Rsbuild environment config objects into one. */
-  mergeEnvironmentConfig: typeof mergeEnvironmentConfig;
+  mergeEnvironmentConfig: (
+    ...configs: ArrayAtLeastOne<MergedEnvironmentConfig, EnvironmentConfig>
+  ) => MergedEnvironmentConfig;
 };
 
 export type ModifyRsbuildConfigFn = (

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -252,6 +252,9 @@ const myPlugin = () => ({
         },
       };
 
+      // extraConfig will override fields in userConfig,
+      // If you do not want to override the fields in userConfig,
+      // you can adjust to `mergeEnvironmentConfig(extraConfig, userConfig)`
       return mergeEnvironmentConfig(userConfig, extraConfig);
     });
   },

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -203,11 +203,13 @@ In the callback function, the config object in the parameters has already been m
 - **Type:**
 
 ```ts
+type ArrayAtLeastOne<A, B> = [A, ...Array<A | B>] | [...Array<A | B>, A];
+
 type ModifyEnvironmentConfigUtils = {
   /** Current environment name */
   name: string;
   mergeEnvironmentConfig: (
-    ...configs: EnvironmentConfig[]
+    ...configs: ArrayAtLeastOne<MergedEnvironmentConfig, EnvironmentConfig>
   ) => EnvironmentConfig;
 };
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -251,6 +251,8 @@ const myPlugin = () => ({
         },
       };
 
+      // extraConfig 会覆盖 userConfig 里的字段
+      // 如果你不希望覆盖 userConfig，可以调整为 `mergeEnvironmentConfig(extraConfig, userConfig)`
       return mergeEnvironmentConfig(userConfig, extraConfig);
     });
   },

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -201,12 +201,14 @@ const myPlugin = () => ({
 
 - **类型：**
 
+type ArrayAtLeastOne<A, B> = [A, ...Array<A | B>] | [...Array<A | B>, A];
+
 ```ts
 type ModifyEnvironmentConfigUtils = {
   /** 当前 environment 名称 */
   name: string;
   mergeEnvironmentConfig: (
-    ...configs: EnvironmentConfig[]
+    ...configs: ArrayAtLeastOne<MergedEnvironmentConfig, EnvironmentConfig>
   ) => EnvironmentConfig;
 };
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -201,9 +201,9 @@ const myPlugin = () => ({
 
 - **类型：**
 
+```ts
 type ArrayAtLeastOne<A, B> = [A, ...Array<A | B>] | [...Array<A | B>, A];
 
-```ts
 type ModifyEnvironmentConfigUtils = {
   /** 当前 environment 名称 */
   name: string;


### PR DESCRIPTION
## Summary

update mergeEnvironmentConfig type, support use userConfig override extraConfig fields.

```ts
const myPlugin = () => ({
  setup: (api) => {
    api.modifyEnvironmentConfig((userConfig, { mergeEnvironmentConfig }) => {
      const extraConfig: EnvironmentConfig = {
        source: {
          // ...
        },
        output: {
          // ...
        },
      };

      return mergeEnvironmentConfig(extraConfig, userConfig);
    });
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
