### PR TITLE
feat(create-rsbuild): support for project name with npm scope

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -82,7 +82,7 @@ If you need to create a project in the current directory, you can set the target
 ```text
 ◆  Create Rsbuild Project
 │
-◇  Input target folder
+◇  Project name or path
 │  .
 │
 ◇  "." is not empty, please choose:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -82,7 +82,7 @@ Biome 提供与 ESLint 和 Prettier 相似的代码检查和格式化功能。�
 ```text
 ◆  Create Rsbuild Project
 │
-◇  Input target folder
+◇  Project name or path
 │  .
 │
 ◇  "." is not empty, please choose:


### PR DESCRIPTION
## Summary

Support for project name with npm scope:

```js
/**
 * 1. Input: 'foo'
 *    Output: folder `<cwd>/foo`, `package.json#name` -> `foo`
 *
 * 2. Input: 'foo/bar'
 *    Output: folder -> `<cwd>/foo/bar` folder, `package.json#name` -> `bar`
 *
 * 3. Input: '@scope/foo'
 *    Output: folder -> `<cwd>/@scope/bar` folder, `package.json#name` -> `@scope/foo`
 *
 * 4. Input: './foo/bar'
 *    Output: folder -> `<cwd>/foo/bar` folder, `package.json#name` -> `bar`
 *
 * 5. Input: '/root/path/to/foo'
 *    Output: folder -> `'/root/path/to/foo'` folder, `package.json#name` -> `foo`
 */
```

TODO: add e2e case for `create-rsbuild`.

## Related Links

https://github.com/web-infra-dev/rspack/pull/7092

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
