### PR TITLE
types: fix plugins type mismatch

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -6,7 +6,6 @@ import { URL } from 'node:url';
 import type {
   CreateRsbuildOptions,
   RsbuildConfig,
-  RsbuildPlugin,
   RsbuildPlugins,
 } from '@rsbuild/core';
 import { pluginSwc } from '@rsbuild/plugin-swc';
@@ -135,7 +134,7 @@ export async function dev({
   plugins,
   ...options
 }: CreateRsbuildOptions & {
-  plugins?: RsbuildPlugin[];
+  plugins?: RsbuildPlugins;
 }) {
   process.env.NODE_ENV = 'development';
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,11 @@
       "vue": "2.x"
     },
     "overrides": {
-      "esbuild": "~0.19.0"
+      "esbuild": "~0.19.0",
+      "@rsbuild/core": "link:packages/core",
+      "@rsbuild/plugin-less": "link:packages/plugin-less",
+      "@rsbuild/plugin-sass": "link:packages/plugin-sass",
+      "@rsbuild/plugin-react": "link:packages/plugin-react"
     }
   }
 }

--- a/packages/compat/webpack/tests/helper.ts
+++ b/packages/compat/webpack/tests/helper.ts
@@ -1,4 +1,4 @@
-import type { CreateRsbuildOptions, RsbuildPlugin } from '@rsbuild/core';
+import type { CreateRsbuildOptions, RsbuildPlugins } from '@rsbuild/core';
 import { createStubRsbuild as createBaseRsbuild } from '@scripts/test-helper';
 import { webpackProvider } from '../src/provider';
 
@@ -7,7 +7,7 @@ export async function createStubRsbuild({
   plugins,
   ...options
 }: CreateRsbuildOptions & {
-  plugins?: RsbuildPlugin[];
+  plugins?: RsbuildPlugins;
 }) {
   rsbuildConfig.provider = webpackProvider;
   return createBaseRsbuild({

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -129,10 +129,18 @@ export type RsbuildPlugin = {
   remove?: string[];
 };
 
+// Support for registering lower version Rsbuild plugins in the new version of
+// Rsbuild core without throwing type mismatches. In most cases, Rsbuild core
+// only adds new methods or properties to the API object, which means that lower
+// version plugins will usually work fine.
+type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
+  setup: (api: any) => MaybePromise<void>;
+};
+
 export type RsbuildPlugins = (
-  | RsbuildPlugin
+  | LooseRsbuildPlugin
   | Falsy
-  | Promise<RsbuildPlugin | Falsy>
+  | Promise<LooseRsbuildPlugin | Falsy>
 )[];
 
 export type GetRsbuildConfig = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   esbuild: ~0.19.0
+  '@rsbuild/core': link:packages/core
+  '@rsbuild/plugin-less': link:packages/plugin-less
+  '@rsbuild/plugin-sass': link:packages/plugin-sass
+  '@rsbuild/plugin-react': link:packages/plugin-react
 
 importers:
 
@@ -94,7 +98,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/compat/babel-preset
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../packages/core
         version: link:../packages/core
       '@rsbuild/plugin-assets-retry':
         specifier: workspace:*
@@ -109,7 +113,7 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-image-compress
       '@rsbuild/plugin-less':
-        specifier: workspace:*
+        specifier: link:../packages/plugin-less
         version: link:../packages/plugin-less
       '@rsbuild/plugin-lightningcss':
         specifier: workspace:*
@@ -118,13 +122,13 @@ importers:
         specifier: workspace:*
         version: link:../packages/plugin-preact
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: link:../packages/plugin-react
         version: link:../packages/plugin-react
       '@rsbuild/plugin-rem':
         specifier: workspace:*
         version: link:../packages/plugin-rem
       '@rsbuild/plugin-sass':
-        specifier: workspace:*
+        specifier: link:../packages/plugin-sass
         version: link:../packages/plugin-sass
       '@rsbuild/plugin-solid':
         specifier: workspace:*
@@ -319,7 +323,7 @@ importers:
         version: 3.4.23(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../../../packages/core
         version: link:../../../../packages/core
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -342,7 +346,7 @@ importers:
   examples/lit:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       lit:
         specifier: ^3.1.4
@@ -361,10 +365,10 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../../packages/core
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: link:../../../packages/plugin-react
         version: link:../../../packages/plugin-react
 
   examples/module-federation/remote:
@@ -377,16 +381,16 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../../packages/core
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: link:../../../packages/plugin-react
         version: link:../../../packages/plugin-react
 
   examples/node:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@types/node':
         specifier: 18.x
@@ -402,7 +406,7 @@ importers:
         version: 10.22.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-preact':
         specifier: workspace:*
@@ -421,10 +425,10 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: link:../../packages/plugin-react
         version: link:../../packages/plugin-react
       '@types/react':
         specifier: ^18.3.3
@@ -443,7 +447,7 @@ importers:
         version: 1.8.18
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -459,7 +463,7 @@ importers:
         version: 4.2.18
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-svelte':
         specifier: workspace:*
@@ -468,7 +472,7 @@ importers:
   examples/vanilla:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       typescript:
         specifier: ^5.5.2
@@ -481,7 +485,7 @@ importers:
         version: 2.7.16
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-vue2':
         specifier: workspace:*
@@ -494,7 +498,7 @@ importers:
         version: 3.4.23(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-vue':
         specifier: workspace:*
@@ -510,7 +514,7 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@rsbuild/plugin-swc':
         specifier: workspace:*
@@ -599,7 +603,7 @@ importers:
         version: 7.6.2
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../core
         version: link:../../core
       '@rsbuild/webpack':
         specifier: workspace:*
@@ -620,7 +624,7 @@ importers:
   packages/compat/webpack:
     dependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../core
         version: link:../../core
       copy-webpack-plugin:
         specifier: 11.0.0
@@ -849,7 +853,7 @@ importers:
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.24.7)
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@types/serialize-javascript':
         specifier: ^5.0.4
@@ -889,7 +893,7 @@ importers:
         version: 2.0.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -926,7 +930,7 @@ importers:
         version: 0.7.4
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -945,7 +949,7 @@ importers:
         version: 3.3.2
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@types/node':
         specifier: 18.x
@@ -964,7 +968,7 @@ importers:
         version: 1.0.0
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -998,7 +1002,7 @@ importers:
         version: 1.0.0
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1013,7 +1017,7 @@ importers:
   packages/plugin-preact:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@types/node':
         specifier: 18.x
@@ -1032,7 +1036,7 @@ importers:
         version: 0.14.2
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1054,13 +1058,13 @@ importers:
         version: 5.31.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@rsbuild/plugin-less':
-        specifier: workspace:*
+        specifier: link:../plugin-less
         version: link:../plugin-less
       '@rsbuild/plugin-sass':
-        specifier: workspace:*
+        specifier: link:../plugin-sass
         version: link:../plugin-sass
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1094,7 +1098,7 @@ importers:
         version: 1.77.5
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1128,7 +1132,7 @@ importers:
         version: 0.6.3(solid-js@1.8.18)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1150,7 +1154,7 @@ importers:
         version: 2.2.3
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -1175,7 +1179,7 @@ importers:
         version: 1.0.0
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@types/node':
         specifier: 18.x
@@ -1200,7 +1204,7 @@ importers:
         version: 8.1.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1219,7 +1223,7 @@ importers:
         version: 6.0.1(@babel/core@7.24.7)(less@4.2.0)(postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.39)(tsx@4.14.0)(yaml@2.4.5))(postcss@8.4.39)(pug@3.0.3)(sass@1.77.6)(stylus@0.63.0)(svelte@4.2.18)(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1237,7 +1241,7 @@ importers:
   packages/plugin-svgr:
     dependencies:
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: link:../plugin-react
         version: link:../plugin-react
       '@svgr/core':
         specifier: 8.1.0
@@ -1256,7 +1260,7 @@ importers:
         version: 2.0.4
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1296,7 +1300,7 @@ importers:
         version: 5.92.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1308,7 +1312,7 @@ importers:
   packages/plugin-typed-css-modules:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1333,7 +1337,7 @@ importers:
         version: 5.92.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1361,7 +1365,7 @@ importers:
         specifier: ^7.24.7
         version: 7.24.7
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1380,7 +1384,7 @@ importers:
         version: 5.92.1
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1402,7 +1406,7 @@ importers:
         specifier: ^7.24.7
         version: 7.24.7
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../core
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1423,7 +1427,7 @@ importers:
   scripts/test-helper:
     dependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../../packages/core
         version: link:../../packages/core
       '@types/lodash':
         specifier: ^4.17.6
@@ -1444,7 +1448,7 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: workspace:*
+        specifier: link:../packages/core
         version: link:../packages/core
       '@rspress/plugin-rss':
         specifier: 1.26.0
@@ -3124,26 +3128,6 @@ packages:
     resolution: {integrity: sha512-0QbCkfk6cnnVKWqqlC0cUrrUMDMfu5ffvYMTUHf+qMN2uAb3MKP31LPcwiMXBNsvoFGs/kYdFOsuLmvppCopXA==}
     cpu: [x64]
     os: [win32]
-
-  '@rsbuild/core@1.0.0-alpha.6':
-    resolution: {integrity: sha512-BgZGaqbd0EspNbE4P19DopzyHV/QKCr47tdUm2jsEeMZCEbkPVIE8eT5Nh5ubeTkdM7DLHu3/+DLb7Un2xFeaw==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-
-  '@rsbuild/plugin-less@1.0.0-alpha.6':
-    resolution: {integrity: sha512-dygUrnmJw539PIkZ4nY2+zj14zQhbsKJIJy7N4HFQpMn9qCI151Qya3QG4bH8jUiA9snX/qcQ0N04hj5SB6lZg==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0-alpha.6
-
-  '@rsbuild/plugin-react@1.0.0-alpha.6':
-    resolution: {integrity: sha512-sYrLavNv6y3282k1/LdAarfDUfAksa4xwJq+4grcjspcO2kH6aoOi2qJWs1/0QKBe3yyqmprioLQ6Ax+3kDsjg==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0-alpha.6
-
-  '@rsbuild/plugin-sass@1.0.0-alpha.6':
-    resolution: {integrity: sha512-GXmrMlVOsP5IqijK+wOR78CST+ikq5DryHb4fnz2hLOYY/sEbMGuuGjYeQQnLXI0BopbCJ/FgT3p2ED8QMn8Wg==}
-    peerDependencies:
-      '@rsbuild/core': ^1.0.0-alpha.6
 
   '@rspack/binding-darwin-arm64@1.0.0-alpha.2':
     resolution: {integrity: sha512-TPxUVWQKLS65erwi5BW5h5/LtaQt2ieXViLXrVCMzAohewkBrrrnwYOGI19KAoXIiX3G9nWf0M7g3Cgqfw5CxQ==}
@@ -5137,15 +5121,6 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-rspack-plugin@6.0.0-beta.3:
-    resolution: {integrity: sha512-H1jVj3GnyqbZmhycUHwdlGvSdXHmzdtVaZcFIsTJ+i0q0hH+gGe+t+d0y5SIGfsozeTjjSdOZPWfzI/hM/5OXQ==}
-    engines: {node: '>=10.13.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-
   html-rspack-plugin@6.0.0-beta.7:
     resolution: {integrity: sha512-9Zve5TfgC2SWNHX1ZjVqBecflYKhoGHPALu8jC+9+m3zUeX0YKWk72Y8h8QPIm5Bh3HVsKaSyPrqWotp+7SDiA==}
     engines: {node: '>=18.0.0'}
@@ -6738,7 +6713,7 @@ packages:
   rsbuild-plugin-google-analytics@1.0.0:
     resolution: {integrity: sha512-Z2hVetWq48QT+X/HMmtp+YTxzPw+ujt/KUrbQXn98LmUDYqJyGSCBAjit8atAoRiThUSKlkG+NU3+zkFvKoLdA==}
     peerDependencies:
-      '@rsbuild/core': 0.x
+      '@rsbuild/core': link:packages/core
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -6746,7 +6721,7 @@ packages:
   rsbuild-plugin-open-graph@1.0.0:
     resolution: {integrity: sha512-SuN9w2FH2v9Mp9/jBowH/RvR74i5A1KzM8+3JrCwCpsuny2HQ3iZqVETgDJ0VIcXqLHUxPnI0aGMgbAcqmlzcg==}
     peerDependencies:
-      '@rsbuild/core': 0.x
+      '@rsbuild/core': link:packages/core
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -9750,38 +9725,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.1':
     optional: true
 
-  '@rsbuild/core@1.0.0-alpha.6':
-    dependencies:
-      '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-      '@swc/helpers': 0.5.11
-      caniuse-lite: 1.0.30001640
-      core-js: 3.37.1
-      html-rspack-plugin: 6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))
-      postcss: 8.4.39
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  '@rsbuild/plugin-less@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
-    dependencies:
-      '@rsbuild/core': 1.0.0-alpha.6
-      deepmerge: 4.3.1
-      reduce-configs: 1.0.0
-
-  '@rsbuild/plugin-react@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
-    dependencies:
-      '@rsbuild/core': 1.0.0-alpha.6
-      '@rspack/plugin-react-refresh': 1.0.0-alpha.2(react-refresh@0.14.2)
-      react-refresh: 0.14.2
-
-  '@rsbuild/plugin-sass@1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)':
-    dependencies:
-      '@rsbuild/core': 1.0.0-alpha.6
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.4.39
-      reduce-configs: 1.0.0
-      sass-embedded: 1.77.5
-
   '@rspack/binding-darwin-arm64@1.0.0-alpha.2':
     optional: true
 
@@ -9846,10 +9789,10 @@ snapshots:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
       '@modern-js/utils': 2.54.6
-      '@rsbuild/core': 1.0.0-alpha.6
-      '@rsbuild/plugin-less': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
-      '@rsbuild/plugin-react': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
-      '@rsbuild/plugin-sass': 1.0.0-alpha.6(@rsbuild/core@1.0.0-alpha.6)
+      '@rsbuild/core': link:packages/core
+      '@rsbuild/plugin-less': link:packages/plugin-less
+      '@rsbuild/plugin-react': link:packages/plugin-react
+      '@rsbuild/plugin-sass': link:packages/plugin-sass
       '@rspress/mdx-rs': 0.5.7
       '@rspress/plugin-auto-nav-sidebar': 1.26.0
       '@rspress/plugin-container-syntax': 1.26.0
@@ -9964,7 +9907,7 @@ snapshots:
 
   '@rspress/shared@1.26.0':
     dependencies:
-      '@rsbuild/core': 1.0.0-alpha.6
+      '@rsbuild/core': link:packages/core
       chalk: 4.1.2
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -12034,12 +11977,6 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@6.0.0-beta.3(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)):
-    dependencies:
-      '@rspack/lite-tapable': 1.0.0-alpha.2
-    optionalDependencies:
-      '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-
   html-rspack-plugin@6.0.0-beta.7(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11)):
     dependencies:
       '@rspack/lite-tapable': 1.0.0-alpha.2
@@ -13987,7 +13924,7 @@ snapshots:
 
   rspress@1.26.0(webpack@5.92.1):
     dependencies:
-      '@rsbuild/core': 1.0.0-alpha.6
+      '@rsbuild/core': link:packages/core
       '@rspress/core': 1.26.0(webpack@5.92.1)
       '@rspress/shared': 1.26.0
       cac: 6.7.14

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -2,7 +2,7 @@ import type {
   BundlerPluginInstance,
   CreateRsbuildOptions,
   RsbuildInstance,
-  RsbuildPlugin,
+  RsbuildPlugins,
   Rspack,
 } from '@rsbuild/core';
 
@@ -29,7 +29,7 @@ export async function createStubRsbuild({
   plugins,
   ...options
 }: CreateRsbuildOptions & {
-  plugins?: RsbuildPlugin[];
+  plugins?: RsbuildPlugins;
 }): Promise<
   RsbuildInstance & {
     unwrapConfig: () => Promise<Record<string, any>>;
@@ -56,7 +56,7 @@ export async function createStubRsbuild({
   if (plugins) {
     // remove all builtin plugins
     rsbuild.removePlugins(rsbuild.getPlugins().map((item) => item.name));
-    rsbuild.addPlugins(plugins);
+    rsbuild.addPlugins(await Promise.all(plugins));
   }
 
   const unwrapConfig = async () => {


### PR DESCRIPTION
## Summary

Support for registering lower version Rsbuild plugins in the new version of Rsbuild core without throwing type mismatches. 

In most cases, Rsbuild core only adds new methods or properties to the API object, which means that lower version plugins will usually work fine.

Fix the following error:

![image](https://github.com/web-infra-dev/rsbuild/assets/7237365/2f5cadbd-7744-4b9e-8f2d-9b69b21e1335)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
