### PR TITLE
fix: rspack plugin apply error after merging config

### DIFF
--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -256,6 +256,39 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
+  it('should merge rspack plugins as expected', () => {
+    class A {
+      a = 1;
+
+      apply() {
+        return this.a;
+      }
+    }
+
+    const pluginA = new A();
+
+    const mergedConfig = mergeRsbuildConfig(
+      {
+        tools: {
+          rspack: {
+            plugins: [pluginA],
+          },
+        },
+      },
+      {},
+    );
+
+    expect(mergedConfig).toEqual({
+      tools: {
+        rspack: {
+          plugins: [pluginA],
+        },
+      },
+    });
+
+    expect(mergedConfig.tools!.rspack.plugins[0] instanceof A).toBeTruthy();
+  });
+
   test('should merge overrideBrowserslist in environments as expected', async () => {
     expect(
       mergeRsbuildConfig(

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -118,3 +118,4 @@ vnode
 watchpack
 webm
 webp
+Mergeable


### PR DESCRIPTION
## Summary

fix rspack plugin apply error, only deep merge plain object when mergeConfig.

<img width="756" alt="image" src="https://github.com/web-infra-dev/rsbuild/assets/22373761/64daef04-7156-4c21-a9e4-5437c923805f">

## Related Links

https://www.npmjs.com/package/deepmerge#ismergeableobject

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
