### PR TITLE
Release: v1.0.0-alpha.8

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-image-compress/package.json
+++ b/packages/plugin-image-compress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-image-compress",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Image compress plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -45,7 +45,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "webpack": "^5.92.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.7"
+    "@rsbuild/core": "workspace:^1.0.0-alpha.8"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.0-alpha.7",
+  "version": "1.0.0-alpha.8",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* types: export HtmlRspackPlugin type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2861
* types: allow passing user config to mergeEnvironmentConfig by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2863
* feat(create-rsbuild): support for project name with npm scope by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2874
* types: fix plugins type mismatch by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2875
### Performance 🚀
* perf: prebundle html-rspack-plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2870
### Bug Fixes 🐞
* fix: js/css are minified when both minify.js and minify.css are false by @xc2 in https://github.com/web-infra-dev/rsbuild/pull/2865
* fix: rspack plugin apply error after merging config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2877
### Document 📖
* docs: update custom loader examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2868
* docs: improve environment config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2871
### Other Changes
* release: 1.0.0-alpha.7 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2860
* chore(deps): update rspress to v1.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2869
* chore(deps): update dependency rspress-plugin-sitemap to ^1.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2873


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.0-alpha.7...v1.0.0-alpha.8