### PR TITLE
perf: prettier the compiled packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
     "postcss-value-parser": "4.2.0",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "reduce-configs": "^1.0.0",
     "rslog": "^1.2.2",
     "rspack-chain": "^0.7.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
     "postcss-value-parser": "4.2.0",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "reduce-configs": "^1.0.0",
     "rslog": "^1.2.2",
     "rspack-chain": "^0.7.4",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -29,6 +29,7 @@ function replaceFileContent(filePath, replaceFn) {
 
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   externals: {
     // External caniuse-lite data, so users can update it manually.
     'caniuse-lite': 'caniuse-lite',
@@ -76,6 +77,8 @@ export default {
     },
     {
       name: 'jiti',
+      // jiti has been minified, we do not need to prettier it
+      prettier: false,
       ignoreDts: true,
     },
     {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "babel-loader": "9.1.3",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "babel-loader": "9.1.3",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/prebundle.config.mjs
+++ b/packages/plugin-babel/prebundle.config.mjs
@@ -11,6 +11,7 @@ const writeEmptySchemaUtils = (task) => {
 
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     {
       name: 'babel-loader',

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -38,7 +38,7 @@
     "@types/less": "^3.0.6",
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -38,7 +38,7 @@
     "@types/less": "^3.0.6",
     "less": "^4.2.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/prebundle.config.mjs
+++ b/packages/plugin-less/prebundle.config.mjs
@@ -12,6 +12,7 @@ function replaceFileContent(filePath, replaceFn) {
 
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     // prebundle less to make correct the types
     {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "postcss-pxtorem": "6.1.0",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/plugin-sass": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "postcss-pxtorem": "6.1.0",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-rem/prebundle.config.mjs
+++ b/packages/plugin-rem/prebundle.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     {
       name: 'postcss-pxtorem',

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -39,7 +39,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/sass-loader": "^8.0.8",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^14.2.1",
     "typescript": "^5.5.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -39,7 +39,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "@types/sass-loader": "^8.0.8",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^14.2.1",
     "typescript": "^5.5.2"

--- a/packages/plugin-sass/prebundle.config.mjs
+++ b/packages/plugin-sass/prebundle.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     // prebundle sass-loader to make it works in Node 16
     {

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -40,7 +40,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "file-loader": "6.2.0",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "typescript": "^5.5.2",
     "url-loader": "4.1.1"
   },

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -40,7 +40,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "18.x",
     "file-loader": "6.2.0",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "typescript": "^5.5.2",
     "url-loader": "4.1.1"
   },

--- a/packages/plugin-svgr/prebundle.config.mjs
+++ b/packages/plugin-svgr/prebundle.config.mjs
@@ -11,6 +11,7 @@ const writeEmptySchemaUtils = (task) => {
 
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     {
       name: 'file-loader',

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "line-diff": "2.1.1",
-    "prebundle": "1.1.0",
+    "prebundle": "1.2.1",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -32,7 +32,7 @@
     "@rsbuild/core": "workspace:*",
     "@scripts/test-helper": "workspace:*",
     "line-diff": "2.1.1",
-    "prebundle": "1.2.1",
+    "prebundle": "1.2.2",
     "typescript": "^5.5.2"
   },
   "peerDependencies": {

--- a/packages/plugin-typed-css-modules/prebundle.config.mjs
+++ b/packages/plugin-typed-css-modules/prebundle.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 /** @type {import('prebundle').Config} */
 export default {
+  prettier: true,
   dependencies: [
     {
       name: 'line-diff',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -777,8 +777,8 @@ importers:
         specifier: 4.2.0
         version: 4.2.0
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -905,8 +905,8 @@ importers:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -983,8 +983,8 @@ importers:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1073,8 +1073,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1107,8 +1107,8 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1272,8 +1272,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1321,8 +1321,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       prebundle:
-        specifier: 1.2.1
-        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
+        specifier: 1.2.2
+        version: 1.2.2(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -6480,8 +6480,8 @@ packages:
   preact@10.22.1:
     resolution: {integrity: sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==}
 
-  prebundle@1.2.1:
-    resolution: {integrity: sha512-5PMH5iXGefybbXeZSauxzuYFD2qL1snMxWinnfLiWDu5iN9P53mvU9jhARpApeAnDFas0DBi9XDFMxSO/gmNmQ==}
+  prebundle@1.2.2:
+    resolution: {integrity: sha512-lbVWLgdF0ae5Bs/Yc2byQ5y0VhExqiVEEPx4WEIdCTjVgQSuRLsMhs1ojBpZw58L9l1hpoF/6Lh9UTYh2NHYoA==}
     hasBin: true
 
   preferred-pm@3.1.3:
@@ -7409,6 +7409,11 @@ packages:
 
   terser@5.31.1:
     resolution: {integrity: sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  terser@5.31.2:
+    resolution: {integrity: sha512-LGyRZVFm/QElZHy/CPr/O4eNZOZIzsrQ92y4v9UJe/pFJjypje2yI3C2FmPtvUEnhadlSbmG2nXtdcjHOjCfxw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -10125,23 +10130,6 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.6.13':
     optional: true
 
-  '@swc/core@1.6.13(@swc/helpers@0.5.11)':
-    dependencies:
-      '@swc/counter': 0.1.3
-      '@swc/types': 0.1.9
-    optionalDependencies:
-      '@swc/core-darwin-arm64': 1.6.13
-      '@swc/core-darwin-x64': 1.6.13
-      '@swc/core-linux-arm-gnueabihf': 1.6.13
-      '@swc/core-linux-arm64-gnu': 1.6.13
-      '@swc/core-linux-arm64-musl': 1.6.13
-      '@swc/core-linux-x64-gnu': 1.6.13
-      '@swc/core-linux-x64-musl': 1.6.13
-      '@swc/core-win32-arm64-msvc': 1.6.13
-      '@swc/core-win32-ia32-msvc': 1.6.13
-      '@swc/core-win32-x64-msvc': 1.6.13
-      '@swc/helpers': 0.5.11
-
   '@swc/core@1.6.13(@swc/helpers@0.5.3)':
     dependencies:
       '@swc/counter': 0.1.3
@@ -10181,6 +10169,7 @@ snapshots:
   '@swc/types@0.1.9':
     dependencies:
       '@swc/counter': 0.1.3
+    optional: true
 
   '@trysound/sax@0.2.0': {}
 
@@ -13615,15 +13604,14 @@ snapshots:
 
   preact@10.22.1: {}
 
-  prebundle@1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2):
+  prebundle@1.2.2(typescript@5.5.2):
     dependencies:
-      '@swc/core': 1.6.13(@swc/helpers@0.5.11)
       '@vercel/ncc': 0.38.1
       prettier: 3.3.2
       rollup: 4.17.1
       rollup-plugin-dts: 6.1.0(rollup@4.17.1)(typescript@5.5.2)
+      terser: 5.31.2
     transitivePeerDependencies:
-      - '@swc/helpers'
       - typescript
 
   preferred-pm@3.1.3:
@@ -14616,6 +14604,13 @@ snapshots:
       source-map-support: 0.5.21
 
   terser@5.31.1:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.12.1
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
+  terser@5.31.2:
     dependencies:
       '@jridgewell/source-map': 0.3.6
       acorn: 8.12.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,7 +44,7 @@ importers:
         version: 0.8.0
       nx:
         specifier: ^19.4.1
-        version: 19.4.1
+        version: 19.4.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
       prettier:
         specifier: ^3.3.2
         version: 3.3.2
@@ -619,7 +619,7 @@ importers:
         version: 5.5.2
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   packages/compat/webpack:
     dependencies:
@@ -628,10 +628,10 @@ importers:
         version: link:../../core
       copy-webpack-plugin:
         specifier: 11.0.0
-        version: 11.0.0(webpack@5.92.1)
+        version: 11.0.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       mini-css-extract-plugin:
         specifier: 2.9.0
-        version: 2.9.0(webpack@5.92.1)
+        version: 2.9.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       picocolors:
         specifier: ^1.0.1
         version: 1.0.1
@@ -643,7 +643,7 @@ importers:
         version: 4.1.0
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@scripts/test-helper':
         specifier: workspace:*
@@ -703,7 +703,7 @@ importers:
         version: 2.3.4
       '@types/webpack-bundle-analyzer':
         specifier: 4.7.0
-        version: 4.7.0
+        version: 4.7.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
       '@types/ws':
         specifier: ^8.5.10
         version: 8.5.10
@@ -730,7 +730,7 @@ importers:
         version: 2.0.0
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1)
+        version: 7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -772,13 +772,13 @@ importers:
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.39)(tsx@4.14.0)(yaml@2.4.5)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(postcss@8.4.39)(typescript@5.5.2)(webpack@5.92.1)
+        version: 8.1.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(postcss@8.4.39)(typescript@5.5.2)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       postcss-value-parser:
         specifier: 4.2.0
         version: 4.2.0
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
@@ -796,7 +796,7 @@ importers:
         version: 2.0.4
       style-loader:
         specifier: 3.3.4
-        version: 3.3.4(webpack@5.92.1)
+        version: 3.3.4(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       tsc-alias:
         specifier: ^1.8.10
         version: 1.8.10
@@ -805,13 +805,13 @@ importers:
         version: 5.5.2
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
       webpack-dev-middleware:
         specifier: 7.2.1
-        version: 7.2.1(webpack@5.92.1)
+        version: 7.2.1(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       webpack-merge:
         specifier: 5.10.0
         version: 5.10.0
@@ -903,10 +903,10 @@ importers:
         version: 18.19.31
       babel-loader:
         specifier: 9.1.3
-        version: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1)
+        version: 9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -981,10 +981,10 @@ importers:
         version: 4.2.0
       less-loader:
         specifier: ^12.2.0
-        version: 12.2.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.1)
+        version: 12.2.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1073,8 +1073,8 @@ importers:
         specifier: 6.1.0
         version: 6.1.0(postcss@8.4.39)
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1107,14 +1107,14 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
       sass-loader:
         specifier: ^14.2.1
-        version: 14.2.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1)
+        version: 14.2.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1201,7 +1201,7 @@ importers:
         version: 0.63.0
       stylus-loader:
         specifier: 8.1.0
-        version: 8.1.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.1)
+        version: 8.1.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -1270,16 +1270,16 @@ importers:
         version: 18.19.31
       file-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.92.1)
+        version: 6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
       url-loader:
         specifier: 4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1))(webpack@5.92.1)
+        version: 4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
 
   packages/plugin-type-check:
     dependencies:
@@ -1288,7 +1288,7 @@ importers:
         version: 4.3.1
       fork-ts-checker-webpack-plugin:
         specifier: 9.0.2
-        version: 9.0.2(typescript@5.5.2)(webpack@5.92.1)
+        version: 9.0.2(typescript@5.5.2)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -1297,7 +1297,7 @@ importers:
         version: 1.0.0
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -1321,8 +1321,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       prebundle:
-        specifier: 1.1.0
-        version: 1.1.0(typescript@5.5.2)
+        specifier: 1.2.1
+        version: 1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2)
       typescript:
         specifier: ^5.5.2
         version: 5.5.2
@@ -1331,10 +1331,10 @@ importers:
     dependencies:
       vue-loader:
         specifier: ^17.4.0
-        version: 17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.1)
+        version: 17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -1378,10 +1378,10 @@ importers:
     dependencies:
       vue-loader:
         specifier: ^15.11.1
-        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.1)
+        version: 15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       webpack:
         specifier: ^5.92.1
-        version: 5.92.1
+        version: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@rsbuild/core':
         specifier: link:../core
@@ -1452,7 +1452,7 @@ importers:
         version: link:../packages/core
       '@rspress/plugin-rss':
         specifier: 1.26.0
-        version: 1.26.0(react@18.3.1)(rspress@1.26.0(webpack@5.92.1))
+        version: 1.26.0(react@18.3.1)(rspress@1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))
       '@types/node':
         specifier: 18.x
         version: 18.19.31
@@ -1482,7 +1482,7 @@ importers:
         version: 1.0.3
       rspress:
         specifier: 1.26.0
-        version: 1.26.0(webpack@5.92.1)
+        version: 1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -3370,6 +3370,75 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
+  '@swc/core-darwin-arm64@1.6.13':
+    resolution: {integrity: sha512-SOF4buAis72K22BGJ3N8y88mLNfxLNprTuJUpzikyMGrvkuBFNcxYtMhmomO0XHsgLDzOJ+hWzcgjRNzjMsUcQ==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@swc/core-darwin-x64@1.6.13':
+    resolution: {integrity: sha512-AW8akFSC+tmPE6YQQvK9S2A1B8pjnXEINg+gGgw0KRUUXunvu1/OEOeC5L2Co1wAwhD7bhnaefi06Qi9AiwOag==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@swc/core-linux-arm-gnueabihf@1.6.13':
+    resolution: {integrity: sha512-f4gxxvDXVUm2HLYXRd311mSrmbpQF2MZ4Ja6XCQz1hWAxXdhRl1gpnZ+LH/xIfGSwQChrtLLVrkxdYUCVuIjFg==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@swc/core-linux-arm64-gnu@1.6.13':
+    resolution: {integrity: sha512-Nf/eoW2CbG8s+9JoLtjl9FByBXyQ5cjdBsA4efO7Zw4p+YSuXDgc8HRPC+E2+ns0praDpKNZtLvDtmF2lL+2Gg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-arm64-musl@1.6.13':
+    resolution: {integrity: sha512-2OysYSYtdw79prJYuKIiux/Gj0iaGEbpS2QZWCIY4X9sGoETJ5iMg+lY+YCrIxdkkNYd7OhIbXdYFyGs/w5LDg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@swc/core-linux-x64-gnu@1.6.13':
+    resolution: {integrity: sha512-PkR4CZYJNk5hcd2+tMWBpnisnmYsUzazI1O5X7VkIGFcGePTqJ/bWlfUIVVExWxvAI33PQFzLbzmN5scyIUyGQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-linux-x64-musl@1.6.13':
+    resolution: {integrity: sha512-OdsY7wryTxCKwGQcwW9jwWg3cxaHBkTTHi91+5nm7hFPpmZMz1HivJrWAMwVE7iXFw+M4l6ugB/wCvpYrUAAjA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@swc/core-win32-arm64-msvc@1.6.13':
+    resolution: {integrity: sha512-ap6uNmYjwk9M/+bFEuWRNl3hq4VqgQ/Lk+ID/F5WGqczNr0L7vEf+pOsRAn0F6EV+o/nyb3ePt8rLhE/wjHpPg==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@swc/core-win32-ia32-msvc@1.6.13':
+    resolution: {integrity: sha512-IJ8KH4yIUHTnS/U1jwQmtbfQals7zWPG0a9hbEfIr4zI0yKzjd83lmtS09lm2Q24QBWOCFGEEbuZxR4tIlvfzA==}
+    engines: {node: '>=10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@swc/core-win32-x64-msvc@1.6.13':
+    resolution: {integrity: sha512-f6/sx6LMuEnbuxtiSL/EkR0Y6qUHFw1XVrh6rwzKXptTipUdOY+nXpKoh+1UsBm/r7H0/5DtOdrn3q5ZHbFZjQ==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@swc/core@1.6.13':
+    resolution: {integrity: sha512-eailUYex6fkfaQTev4Oa3mwn0/e3mQU4H8y1WPuImYQESOQDtVrowwUGDSc19evpBbHpKtwM+hw8nLlhIsF+Tw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@swc/helpers': '*'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -3384,6 +3453,9 @@ packages:
 
   '@swc/plugin-styled-components@2.0.9':
     resolution: {integrity: sha512-0aPv7lNed27qs8JBklLkVSlLhpPRU3YKRnKplObaAyhNWbpbOkCbVSTay5ArFT2Gz1rz844Np7l4DMozEtZRBg==}
+
+  '@swc/types@0.1.9':
+    resolution: {integrity: sha512-qKnCno++jzcJ4lM4NTfYifm1EFSCeIfKiAHAfkENZAV5Kl9PjJIyd2yeeVv6c/2CckuLyv2NmRC5pv6pm2WQBg==}
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -6408,8 +6480,8 @@ packages:
   preact@10.22.1:
     resolution: {integrity: sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==}
 
-  prebundle@1.1.0:
-    resolution: {integrity: sha512-yTfRjx0+xiveeb7kO77OcODVB8RSHMKIiVl/qferU7ZHw4Y8pycXkCAtPDViF8YDo0a8ViDpm4C1O9PFKCw1ig==}
+  prebundle@1.2.1:
+    resolution: {integrity: sha512-5PMH5iXGefybbXeZSauxzuYFD2qL1snMxWinnfLiWDu5iN9P53mvU9jhARpApeAnDFas0DBi9XDFMxSO/gmNmQ==}
     hasBin: true
 
   preferred-pm@3.1.3:
@@ -9329,11 +9401,11 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mdx-js/loader@2.3.0(webpack@5.92.1)':
+  '@mdx-js/loader@2.3.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))':
     dependencies:
       '@mdx-js/mdx': 2.3.0
       source-map: 0.7.4
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -9620,9 +9692,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
-  '@nrwl/tao@19.4.1':
+  '@nrwl/tao@19.4.1(@swc/core@1.6.13(@swc/helpers@0.5.3))':
     dependencies:
-      nx: 19.4.1
+      nx: 19.4.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -9782,10 +9854,10 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspress/core@1.26.0(webpack@5.92.1)':
+  '@rspress/core@1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))':
     dependencies:
       '@loadable/component': 5.16.4(react@18.3.1)
-      '@mdx-js/loader': 2.3.0(webpack@5.92.1)
+      '@mdx-js/loader': 2.3.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
       '@modern-js/utils': 2.54.6
@@ -9890,12 +9962,12 @@ snapshots:
       '@rspress/runtime': 1.26.0
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.26.0(react@18.3.1)(rspress@1.26.0(webpack@5.92.1))':
+  '@rspress/plugin-rss@1.26.0(react@18.3.1)(rspress@1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))':
     dependencies:
       '@rspress/shared': 1.26.0
       feed: 4.2.2
       react: 18.3.1
-      rspress: 1.26.0(webpack@5.92.1)
+      rspress: 1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
 
   '@rspress/runtime@1.26.0':
     dependencies:
@@ -10023,6 +10095,71 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
+  '@swc/core-darwin-arm64@1.6.13':
+    optional: true
+
+  '@swc/core-darwin-x64@1.6.13':
+    optional: true
+
+  '@swc/core-linux-arm-gnueabihf@1.6.13':
+    optional: true
+
+  '@swc/core-linux-arm64-gnu@1.6.13':
+    optional: true
+
+  '@swc/core-linux-arm64-musl@1.6.13':
+    optional: true
+
+  '@swc/core-linux-x64-gnu@1.6.13':
+    optional: true
+
+  '@swc/core-linux-x64-musl@1.6.13':
+    optional: true
+
+  '@swc/core-win32-arm64-msvc@1.6.13':
+    optional: true
+
+  '@swc/core-win32-ia32-msvc@1.6.13':
+    optional: true
+
+  '@swc/core-win32-x64-msvc@1.6.13':
+    optional: true
+
+  '@swc/core@1.6.13(@swc/helpers@0.5.11)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.9
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.6.13
+      '@swc/core-darwin-x64': 1.6.13
+      '@swc/core-linux-arm-gnueabihf': 1.6.13
+      '@swc/core-linux-arm64-gnu': 1.6.13
+      '@swc/core-linux-arm64-musl': 1.6.13
+      '@swc/core-linux-x64-gnu': 1.6.13
+      '@swc/core-linux-x64-musl': 1.6.13
+      '@swc/core-win32-arm64-msvc': 1.6.13
+      '@swc/core-win32-ia32-msvc': 1.6.13
+      '@swc/core-win32-x64-msvc': 1.6.13
+      '@swc/helpers': 0.5.11
+
+  '@swc/core@1.6.13(@swc/helpers@0.5.3)':
+    dependencies:
+      '@swc/counter': 0.1.3
+      '@swc/types': 0.1.9
+    optionalDependencies:
+      '@swc/core-darwin-arm64': 1.6.13
+      '@swc/core-darwin-x64': 1.6.13
+      '@swc/core-linux-arm-gnueabihf': 1.6.13
+      '@swc/core-linux-arm64-gnu': 1.6.13
+      '@swc/core-linux-arm64-musl': 1.6.13
+      '@swc/core-linux-x64-gnu': 1.6.13
+      '@swc/core-linux-x64-musl': 1.6.13
+      '@swc/core-win32-arm64-msvc': 1.6.13
+      '@swc/core-win32-ia32-msvc': 1.6.13
+      '@swc/core-win32-x64-msvc': 1.6.13
+      '@swc/helpers': 0.5.3
+    optional: true
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.11':
@@ -10038,6 +10175,10 @@ snapshots:
       '@swc/counter': 0.1.3
 
   '@swc/plugin-styled-components@2.0.9':
+    dependencies:
+      '@swc/counter': 0.1.3
+
+  '@swc/types@0.1.9':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -10199,11 +10340,11 @@ snapshots:
 
   '@types/unist@3.0.2': {}
 
-  '@types/webpack-bundle-analyzer@4.7.0':
+  '@types/webpack-bundle-analyzer@4.7.0(@swc/core@1.6.13(@swc/helpers@0.5.3))':
     dependencies:
       '@types/node': 18.19.31
       tapable: 2.2.1
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10711,12 +10852,12 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
-  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1):
+  babel-loader@9.1.3(@babel/core@7.24.7)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       '@babel/core': 7.24.7
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -11056,7 +11197,7 @@ snapshots:
     dependencies:
       toggle-selection: 1.0.6
 
-  copy-webpack-plugin@11.0.0(webpack@5.92.1):
+  copy-webpack-plugin@11.0.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
@@ -11064,7 +11205,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   core-js-compat@3.37.0:
     dependencies:
@@ -11110,7 +11251,7 @@ snapshots:
 
   css-color-keywords@1.0.0: {}
 
-  css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1):
+  css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.39)
       postcss: 8.4.39
@@ -11122,7 +11263,7 @@ snapshots:
       semver: 7.6.2
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   css-select@5.1.0:
     dependencies:
@@ -11584,11 +11725,11 @@ snapshots:
       flat-cache: 4.0.1
     optional: true
 
-  file-loader@6.2.0(webpack@5.92.1):
+  file-loader@6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   fill-range@7.0.1:
     dependencies:
@@ -11653,7 +11794,7 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.5.2)(webpack@5.92.1):
+  fork-ts-checker-webpack-plugin@9.0.2(typescript@5.5.2)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       '@babel/code-frame': 7.24.2
       chalk: 4.1.2
@@ -11668,7 +11809,7 @@ snapshots:
       semver: 7.6.2
       tapable: 2.2.1
       typescript: 5.5.2
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   form-data@4.0.0:
     dependencies:
@@ -12312,12 +12453,12 @@ snapshots:
 
   leac@0.6.0: {}
 
-  less-loader@12.2.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.1):
+  less-loader@12.2.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(less@4.2.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       less: 4.2.0
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   less@4.2.0:
     dependencies:
@@ -12984,11 +13125,11 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.9.0(webpack@5.92.1):
+  mini-css-extract-plugin@2.9.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   minimatch@3.1.2:
     dependencies:
@@ -13085,9 +13226,9 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nx@19.4.1:
+  nx@19.4.1(@swc/core@1.6.13(@swc/helpers@0.5.3)):
     dependencies:
-      '@nrwl/tao': 19.4.1
+      '@nrwl/tao': 19.4.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.7
@@ -13132,6 +13273,7 @@ snapshots:
       '@nx/nx-linux-x64-musl': 19.4.1
       '@nx/nx-win32-arm64-msvc': 19.4.1
       '@nx/nx-win32-x64-msvc': 19.4.1
+      '@swc/core': 1.6.13(@swc/helpers@0.5.3)
     transitivePeerDependencies:
       - debug
 
@@ -13387,7 +13529,7 @@ snapshots:
       tsx: 4.14.0
       yaml: 2.4.5
 
-  postcss-loader@8.1.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(postcss@8.4.39)(typescript@5.5.2)(webpack@5.92.1):
+  postcss-loader@8.1.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(postcss@8.4.39)(typescript@5.5.2)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.5.2)
       jiti: 1.21.6
@@ -13395,7 +13537,7 @@ snapshots:
       semver: 7.6.2
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     transitivePeerDependencies:
       - typescript
 
@@ -13473,12 +13615,15 @@ snapshots:
 
   preact@10.22.1: {}
 
-  prebundle@1.1.0(typescript@5.5.2):
+  prebundle@1.2.1(@swc/helpers@0.5.11)(typescript@5.5.2):
     dependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.11)
       '@vercel/ncc': 0.38.1
+      prettier: 3.3.2
       rollup: 4.17.1
       rollup-plugin-dts: 6.1.0(rollup@4.17.1)(typescript@5.5.2)
     transitivePeerDependencies:
+      - '@swc/helpers'
       - typescript
 
   preferred-pm@3.1.3:
@@ -13866,7 +14011,7 @@ snapshots:
       rollup: 4.17.1
       typescript: 5.5.2
     optionalDependencies:
-      '@babel/code-frame': 7.24.6
+      '@babel/code-frame': 7.24.7
 
   rollup@4.17.1:
     dependencies:
@@ -13922,10 +14067,10 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.0: {}
 
-  rspress@1.26.0(webpack@5.92.1):
+  rspress@1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       '@rsbuild/core': link:packages/core
-      '@rspress/core': 1.26.0(webpack@5.92.1)
+      '@rspress/core': 1.26.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       '@rspress/shared': 1.26.0
       cac: 6.7.14
       chalk: 5.3.0
@@ -14032,14 +14177,14 @@ snapshots:
       sass-embedded-win32-ia32: 1.77.5
       sass-embedded-win32-x64: 1.77.5
 
-  sass-loader@14.2.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1):
+  sass-loader@14.2.1(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(sass-embedded@1.77.5)(sass@1.77.6)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
       sass: 1.77.6
       sass-embedded: 1.77.5
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   sass@1.77.6:
     dependencies:
@@ -14270,9 +14415,9 @@ snapshots:
 
   style-inject@0.3.0: {}
 
-  style-loader@3.3.4(webpack@5.92.1):
+  style-loader@3.3.4(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   style-to-object@0.4.4:
     dependencies:
@@ -14294,14 +14439,14 @@ snapshots:
 
   stylis@4.3.2: {}
 
-  stylus-loader@8.1.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.1):
+  stylus-loader@8.1.0(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(stylus@0.63.0)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.63.0
     optionalDependencies:
       '@rspack/core': 1.0.0-alpha.2(@swc/helpers@0.5.11)
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   stylus@0.63.0:
     dependencies:
@@ -14452,14 +14597,16 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(webpack@5.92.1):
+  terser-webpack-plugin@5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.3))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.1
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
+    optionalDependencies:
+      '@swc/core': 1.6.13(@swc/helpers@0.5.3)
 
   terser@5.19.2:
     dependencies:
@@ -14650,14 +14797,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.92.1))(webpack@5.92.1):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.92.1)
+      file-loader: 6.2.0(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
 
   util-deprecate@1.0.2: {}
 
@@ -14760,15 +14907,15 @@ snapshots:
 
   vue-hot-reload-api@2.3.4: {}
 
-  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.1):
+  vue-loader@15.11.1(@vue/compiler-sfc@3.4.23)(css-loader@7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))))(lodash@4.17.21)(prettier@3.3.2)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       '@vue/component-compiler-utils': 3.3.0(lodash@4.17.21)(pug@3.0.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      css-loader: 7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1)
+      css-loader: 7.1.2(@rspack/core@1.0.0-alpha.2(@swc/helpers@0.5.11))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       hash-sum: 1.0.2
       loader-utils: 1.4.2
       vue-hot-reload-api: 2.3.4
       vue-style-loader: 4.1.3
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     optionalDependencies:
       '@vue/compiler-sfc': 3.4.23
       prettier: 3.3.2
@@ -14827,12 +14974,12 @@ snapshots:
       - walrus
       - whiskers
 
-  vue-loader@17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.1):
+  vue-loader@17.4.2(vue@3.4.23(typescript@5.5.2))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.1
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
     optionalDependencies:
       vue: 3.4.23(typescript@5.5.2)
 
@@ -14896,7 +15043,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.2.1(webpack@5.92.1):
+  webpack-dev-middleware@7.2.1(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
       colorette: 2.0.20
       memfs: 4.8.2
@@ -14905,7 +15052,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.92.1
+      webpack: 5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   webpack-merge@5.10.0:
     dependencies:
@@ -14920,7 +15067,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack@5.92.1:
+  webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -14943,7 +15090,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.92.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.6.13(@swc/helpers@0.5.3))(webpack@5.92.1(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Prettier the compiled packages and strip comments, this change makes the compiled code more readable and also 77KB smaller.

<img width="447" alt="Screenshot 2024-07-11 at 17 05 49" src="https://github.com/web-infra-dev/rsbuild/assets/7237365/ca0ae41d-3346-42f9-b3da-424e67e93273">

## Related Links

https://github.com/rspack-contrib/prebundle/releases/tag/v1.2.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
