### PR TITLE
fix: html-rspack-plugin typo

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -16,8 +16,8 @@ import {
 } from '../helpers';
 import type { HtmlInfo, TagConfig } from '../rspack/HtmlBasicPlugin';
 import type {
-  HTMLPluginOptions,
   HtmlConfig,
+  HtmlRspackPlugin,
   ModifyHTMLTagsFn,
   NormalizedEnvironmentConfig,
   RsbuildPlugin,
@@ -124,7 +124,7 @@ function getTemplateParameters(
   entryName: string,
   config: NormalizedEnvironmentConfig,
   assetPrefix: string,
-): HTMLPluginOptions['templateParameters'] {
+): HtmlRspackPlugin.Options['templateParameters'] {
   return (compilation, assets, assetTags, pluginOptions) => {
     const { mountId, templateParameters } = config.html;
     const defaultOptions = {
@@ -233,7 +233,7 @@ export const pluginHtml = (modifyTagsFn?: ModifyHTMLTagsFn): RsbuildPlugin => ({
 
             const metaTags = getMetaTags(entryName, config, templateContent);
 
-            const pluginOptions: HTMLPluginOptions = {
+            const pluginOptions: HtmlRspackPlugin.Options = {
               meta: metaTags,
               chunks,
               inject,

--- a/packages/core/src/rspack/HtmlBasicPlugin.ts
+++ b/packages/core/src/rspack/HtmlBasicPlugin.ts
@@ -1,5 +1,4 @@
 import type { Compilation, Compiler } from '@rspack/core';
-import type { HtmlTagObject } from 'html-rspack-plugin';
 import { ensureAssetPrefix, isFunction, partition } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
 import type { HtmlRspackPlugin } from '../types';
@@ -11,6 +10,8 @@ import type {
   HtmlTagUtils,
   ModifyHTMLTagsFn,
 } from '../types';
+
+type HtmlTagObject = HtmlRspackPlugin.HtmlTagObject;
 
 export type TagConfig = {
   tags?: HtmlTagDescriptor[];

--- a/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
+++ b/packages/core/src/rspack/InlineChunkHtmlPlugin.ts
@@ -7,14 +7,15 @@
  */
 import { join } from 'node:path';
 import type { Compilation, Compiler } from '@rspack/core';
-import type { HtmlTagObject } from 'html-rspack-plugin';
 import {
   addTrailingSlash,
   getPublicPathFromCompiler,
   isFunction,
 } from '../helpers';
 import { getHTMLPlugin } from '../pluginHelper';
-import type { InlineChunkTest } from '../types';
+import type { HtmlRspackPlugin, InlineChunkTest } from '../types';
+
+type HtmlTagObject = HtmlRspackPlugin.HtmlTagObject;
 
 export type InlineChunkHtmlPluginOptions = {
   styleTests: InlineChunkTest[];

--- a/packages/core/src/types/config/tools.ts
+++ b/packages/core/src/types/config/tools.ts
@@ -1,6 +1,5 @@
 import type { rspack } from '@rspack/core';
 import type { SwcLoaderOptions } from '@rspack/core';
-import type { Options as HTMLPluginOptions } from 'html-rspack-plugin';
 import type RspackChain from 'rspack-chain';
 import type { ModifyBundlerChainUtils, ModifyChainUtils } from '../hooks';
 import type {
@@ -13,6 +12,7 @@ import type {
   RspackConfig,
   RspackRule,
 } from '../rspack';
+import type { HtmlRspackPlugin } from '../thirdParty';
 import type {
   AutoprefixerOptions,
   CSSExtractOptions,
@@ -28,8 +28,6 @@ import type {
   ConfigChainWithContext,
 } from '../utils';
 import type { MaybePromise, OneOrMany } from '../utils';
-
-export type { HTMLPluginOptions };
 
 export type ToolsSwcConfig = ConfigChain<SwcLoaderOptions>;
 
@@ -49,7 +47,7 @@ export type ToolsCSSLoaderConfig = ConfigChain<CSSLoaderOptions>;
 export type ToolsStyleLoaderConfig = ConfigChain<StyleLoaderOptions>;
 
 export type ToolsHtmlPluginConfig = ConfigChainWithContext<
-  HTMLPluginOptions,
+  HtmlRspackPlugin.Options,
   {
     entryName: string;
     entryValue: (string | string[] | Rspack.EntryDescription)[];

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -26,7 +26,7 @@
       "rspack-chain": ["./compiled/rspack-chain"],
       "dotenv-expand": ["./compiled/dotenv-expand"],
       "webpack-merge": ["./compiled/webpack-merge"],
-      "http-rspack-plugin": ["./compiled/http-rspack-plugin"],
+      "html-rspack-plugin": ["./compiled/html-rspack-plugin"],
       "http-proxy-middleware": ["./compiled/http-proxy-middleware"],
       "webpack-bundle-analyzer": ["./compiled/webpack-bundle-analyzer"],
       "http-compression": ["./compiled/http-compression"],


### PR DESCRIPTION
## Summary

`http-rspack-plugin` -> `html-rspack-plugin`, this typo will break the `tools.htmlPlugin` type.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
