### PR TITLE
fix(server): register OPTIONS fallback middleware at last

### DIFF
--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -206,6 +206,7 @@ const applyDefaultMiddlewares = async ({
   // see: https://github.com/webpack/webpack-dev-server/pull/4559
   middlewares.push((req, res, next) => {
     if (req.method === 'OPTIONS') {
+      // Use 204 as no content to send in the response body
       res.statusCode = 204;
       res.setHeader('Content-Length', '0');
       res.end();

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -203,7 +203,7 @@ const applyDefaultMiddlewares = async ({
 
   // OPTIONS request fallback middleware
   // Should register this middleware as the last
-  // see: https://github.com/webpack/webpack-dev-server/pull/4559
+  // see: https://github.com/web-infra-dev/rsbuild/pull/2867
   middlewares.push((req, res, next) => {
     if (req.method === 'OPTIONS') {
       // Use 204 as no content to send in the response body

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -109,16 +109,6 @@ const applyDefaultMiddlewares = async ({
     next();
   });
 
-  middlewares.push((req, res, next) => {
-    if (req.method === 'OPTIONS') {
-      res.statusCode = 200;
-      res.setHeader('Content-Length', '0');
-      res.end();
-      return;
-    }
-    next();
-  });
-
   // dev proxy handler, each proxy has own handler
   if (server.proxy) {
     const { createProxyMiddleware } = await import('./proxy');
@@ -210,6 +200,19 @@ const applyDefaultMiddlewares = async ({
   }
 
   middlewares.push(faviconFallbackMiddleware);
+
+  // OPTIONS request fallback middleware
+  // Should register this middleware as the last
+  // see: https://github.com/webpack/webpack-dev-server/pull/4559
+  middlewares.push((req, res, next) => {
+    if (req.method === 'OPTIONS') {
+      res.statusCode = 204;
+      res.setHeader('Content-Length', '0');
+      res.end();
+      return;
+    }
+    next();
+  });
 
   return {
     onUpgrade: (...args) => {


### PR DESCRIPTION
## Summary

- Change the status code from `200` to `204`, because server does not response any data.
- Move the middleware to the last as a fallback.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2867
https://github.com/webpack/webpack-dev-server/pull/4559

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
