### PR TITLE
feat: allow to disable gzip compression size

### DIFF
--- a/e2e/cases/performance/print-file-size/index.test.ts
+++ b/e2e/cases/performance/print-file-size/index.test.ts
@@ -181,4 +181,21 @@ test.describe('should print file size correctly', async () => {
       ),
     ).toBeTruthy();
   });
+
+  test('should allow to disable gzip-compressed size', async () => {
+    await build({
+      cwd,
+      rsbuildConfig: {
+        performance: {
+          printFileSize: {
+            compressed: false,
+          },
+        },
+      },
+    });
+
+    expect(logs.some((log) => log.includes('index.html'))).toBeTruthy();
+    expect(logs.some((log) => log.includes('Total size:'))).toBeTruthy();
+    expect(logs.some((log) => log.includes('Gzipped size:'))).toBeFalsy();
+  });
 });

--- a/packages/core/src/types/config/performance.ts
+++ b/packages/core/src/types/config/performance.ts
@@ -13,6 +13,7 @@ export type BuildCacheOptions = {
 export type PrintFileSizeOptions = {
   total?: boolean;
   detail?: boolean;
+  compressed?: boolean;
 };
 
 export interface PreconnectOption {

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -13,6 +13,10 @@ type PrintFileSizeOptions =
        * whether to print size of each file
        */
       detail?: boolean;
+      /**
+       * whether to print gzip-compressed size
+       */
+      compressed?: boolean;
     }
   | boolean;
 ```
@@ -21,7 +25,9 @@ type PrintFileSizeOptions =
 
 Whether to print the file sizes after production build.
 
-If it is a Boolean type, it will be decided according to the config whether to print the file sizes. The default output is as follows.
+## Default Outputs
+
+The default output log is as follows:
 
 ```bash
 info    Production file sizes:
@@ -36,9 +42,23 @@ info    Production file sizes:
   Gzipped size:  46.5 kB
 ```
 
-You can also configure whether to print the sum of the size of all static resource files and whether to print the size of each static resource file through the Object type.
+## Disable Outputs
 
-If you don't want to print the size of each static resource file, you can:
+If you don't want to print any information, you can disable it by setting `printFileSize` to `false`:
+
+```ts
+export default {
+  performance: {
+    printFileSize: false,
+  },
+};
+```
+
+## Custom Outputs
+
+You can customize the output format through the options.
+
+- If you don't need to output the size of each static asset, you can set `detail` to false. In this case, only the total size will be output:
 
 ```ts
 export default {
@@ -50,12 +70,14 @@ export default {
 };
 ```
 
-If you don't want to print any information, you can disable it by setting `printFileSize` to `false`:
+- If you don't need to output the gzipped size, you can set `compressed` to false. This can save some gzip computation time for large projects:
 
 ```ts
 export default {
   performance: {
-    printFileSize: false,
+    printFileSize: {
+      compressed: false,
+    },
   },
 };
 ```

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -13,6 +13,10 @@ type PrintFileSizeOptions =
        * 是否输出每个静态资源文件的体积
        */
       detail?: boolean;
+      /**
+       * 是否输出 gzip 压缩后的体积
+       */
+      compressed?: boolean;
     }
   | boolean;
 ```
@@ -21,7 +25,9 @@ type PrintFileSizeOptions =
 
 是否在生产环境构建后输出所有静态资源文件的体积。
 
-如果是 Boolean 类型，将根据配置决定是否输出所有静态资源文件的体积，默认输出如下。
+## 默认输出
+
+默认输出的日志如下：
 
 ```bash
 info    Production file sizes:
@@ -36,9 +42,23 @@ info    Production file sizes:
   Gzipped size:  46.5 kB
 ```
 
-你也可以通过 Object 类型分别对输出所有静态资源文件的体积和以及输出每个静态资源文件的体积进行配置。
+## 禁用输出
 
-如果你不想输出每个静态资源文件的体积，可以：
+如果不需要输出任何信息，可以将 `printFileSize` 置为 `false` 将其禁用：
+
+```ts
+export default {
+  performance: {
+    printFileSize: false,
+  },
+};
+```
+
+## 自定义输出
+
+你可以通过选项来自定义输出的格式。
+
+- 如果不需要输出每个静态资源文件的体积，可以把 `detail` 设置为 false，此时仅输出总体积：
 
 ```ts
 export default {
@@ -50,12 +70,14 @@ export default {
 };
 ```
 
-如果你不想输出任何信息，可以将 `printFileSize` 置为 `false` 将其禁用掉：
+- 如果不需要输出 gzip 压缩后的体积，可以把 `compressed` 设置为 false，这在大型项目中可以节省一些 gzip 计算的耗时：
 
 ```ts
 export default {
   performance: {
-    printFileSize: false,
+    printFileSize: {
+      compressed: false,
+    },
   },
 };
 ```


### PR DESCRIPTION
## Summary

Add new `performance.printFileSize.compresed` option to disable gzip compression size. This can save some gzip computation time for large projects.

```ts
export default {
  performance: {
    printFileSize: {
      compressed: false,
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
