### PR TITLE
fix(type): webpack type should works with moduleResolution node16+

### DIFF
--- a/packages/compat/webpack/modern.config.ts
+++ b/packages/compat/webpack/modern.config.ts
@@ -1,3 +1,22 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { defineConfig, moduleTools } from '@modern-js/module-tools';
+import {
+  cjsBuildConfig,
+  emitTypePkgJsonPlugin,
+  esmBuildConfig,
+} from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default defineConfig({
+  plugins: [moduleTools(), emitTypePkgJsonPlugin],
+  buildConfig: [
+    cjsBuildConfig,
+    esmBuildConfig,
+    // Types
+    {
+      buildType: 'bundleless',
+      dts: {
+        distPath: '../dist-types',
+        only: true,
+      },
+    },
+  ],
+});

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -11,16 +11,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "static",
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
+    "declarationDir": "./dist-types",
     "outDir": "./dist",
     "baseUrl": "./",
     "rootDir": "src",


### PR DESCRIPTION
## Summary

`@rsbuild/webpack` type should works with moduleResolution node16+.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
