### PR TITLE
fix(plugin-sass): additionalData missing string type

### DIFF
--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -21,10 +21,12 @@ export type SassLoaderOptions = Omit<
   ) & {
     // @types/sass-loader is outdated
     // see https://github.com/web-infra-dev/rsbuild/issues/2582
-    additionalData?: (
-      content: string | Buffer,
-      loaderContext: Rspack.LoaderContext,
-    ) => string;
+    additionalData?:
+      | string
+      | ((
+          content: string | Buffer,
+          loaderContext: Rspack.LoaderContext,
+        ) => string);
   };
 
 export type PluginSassOptions = {


### PR DESCRIPTION
## Summary

Fix sass-loader additionalData missing string type.

```ts
type additionalData =
  | string
  | ((content: string | Buffer, loaderContext: LoaderContext) => string);
```

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2708
https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#additionaldata

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
