### PR TITLE
release: 1.0.1-beta.0

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -42,7 +42,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -45,7 +45,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "yaml": "^2.4.5"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -35,7 +35,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -45,7 +45,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -37,7 +37,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.0-alpha.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.0"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.1-beta.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
## Note

We are releasing `1.0.1-beta.0` instead of `1.0.0-beta.0`.

This is because Rsbuild `1.0.0` is a deprecated version. Package managers will resolve `^1.0.0-beta.0` to `1.0.0`, which is unexpected.

resolve: https://github.com/web-infra-dev/rsbuild/issues/2897, https://github.com/web-infra-dev/rsbuild/issues/2864, https://github.com/web-infra-dev/rsbuild/issues/2767, https://github.com/rspack-contrib/rsbuild-plugin-umd/issues/1


## What's Changed
### New Features 🎉
* feat(CLI): add new --env-dir option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2891
* feat: allow to disable gzip compression size by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2892
### Performance 🚀
* perf: skip template evaluation when using default template by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2896
* perf: bump html-rspack-plugin 6.0.0-beta.8 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2898
### Bug Fixes 🐞
* fix(type): webpack type should works with moduleResolution node16+ by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/2900
* fix(plugin-sass): additionalData missing string type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2901
### Document 📖
* docs: update benchmark graph by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2893
* docs: Replace 'tailwindcss' with 'UnoCSS' in unocss.mdx by @sagardwivedi in https://github.com/web-infra-dev/rsbuild/pull/2895
### Other Changes
* chore(deps): update eslint by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2890
* chore(deps): update dependency webpack to ^5.93.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2889
* chore(deps): update dependency webpack-merge to v6 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2827
* chore: move image compress plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2899

## New Contributors
* @sagardwivedi made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2895

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.0-alpha.9...v1.0.1-beta.0