### PR TITLE
docs: port value should be string instead of int

### DIFF
--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -52,7 +52,7 @@ export default {
       protocol: 'ws',
       // Usually `127.0.0.1` is used to avoid cross-origin requests being blocked by the browser
       host: '127.0.0.1',
-      port: 3000,
+      port: '3000',
     },
   },
 };


### PR DESCRIPTION
## Summary

[doc] port value should be string instead of int

## Related Links
From the same doc
```
port?: string;
```

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
