### PR TITLE
feat: allow dev.client.port to be a number

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,9 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  dev: {
-    client: {
-      port: 3080,
-    },
-  },
 });

--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,4 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  dev: {
+    client: {
+      port: 3080,
+    },
+  },
 });

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -13,14 +13,14 @@ function formatURL({
   hostname,
   pathname,
 }: {
-  port: string;
+  port: string | number;
   protocol: string;
   hostname: string;
   pathname: string;
 }) {
   if (typeof URL !== 'undefined') {
     const url = new URL('http://localhost');
-    url.port = port;
+    url.port = String(port);
     url.hostname = hostname;
     url.protocol = protocol;
     url.pathname = pathname;

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -102,7 +102,7 @@ export function pluginModuleFederation(): RsbuildPlugin {
         ) {
           config.dev ||= {};
           config.dev.client ||= {};
-          config.dev.client.port = String(config.server.port);
+          config.dev.client.port = config.server.port;
         }
       });
 

--- a/packages/core/src/types/config/dev.ts
+++ b/packages/core/src/types/config/dev.ts
@@ -47,7 +47,7 @@ export type ServerAPIs = {
 
 export type ClientConfig = {
   path?: string;
-  port?: string;
+  port?: string | number;
   host?: string;
   protocol?: 'ws' | 'wss';
   /** Shows an overlay in the browser when there are compiler errors. */
@@ -79,7 +79,9 @@ export interface DevConfig {
    * Whether to display progress bar during compilation.
    */
   progressBar?: boolean | ProgressBarConfig;
-  /** config of Rsbuild client code. */
+  /**
+   * Config for Rsbuild client code.
+   */
   client?: ClientConfig;
   /** Provides the ability to execute a custom function and apply custom middlewares */
   setupMiddlewares?: Array<

--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -11,7 +11,7 @@ type Client = {
   /** Specify the path for the WebSocket request */
   path?: string;
   /** Specify the port number for the WebSocket request */
-  port?: string;
+  port?: string | number;
   /** Specify the host for the WebSocket request */
   host?: string;
   /**
@@ -52,7 +52,7 @@ export default {
       protocol: 'ws',
       // Usually `127.0.0.1` is used to avoid cross-origin requests being blocked by the browser
       host: '127.0.0.1',
-      port: '3000',
+      port: 3000,
     },
   },
 };

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -11,7 +11,7 @@ type Client = {
   /** 指定 WebSocket 请求的路径 */
   path?: string;
   /** 指定 WebSocket 请求的端口号 */
-  port?: string;
+  port?: string | number;
   /** 指定 WebSocket 请求的 host */
   host?: string;
   /**


### PR DESCRIPTION
## Summary

Allow `dev.client.port` to be a number, be consistent with `server.port`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2905

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
