### PR TITLE
fix(create-rsbuild): lit should be dependency

### DIFF
--- a/packages/create-rsbuild/template-lit-js/package.json
+++ b/packages/create-rsbuild/template-lit-js/package.json
@@ -7,8 +7,10 @@
     "build": "rsbuild build",
     "preview": "rsbuild preview"
   },
-  "devDependencies": {
-    "@rsbuild/core": "workspace:*",
+  "dependencies": {
     "lit": "^3.1.4"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "workspace:*"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -7,9 +7,11 @@
     "build": "rsbuild build",
     "preview": "rsbuild preview"
   },
+  "dependencies": {
+    "lit": "^3.1.4"
+  },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "lit": "^3.1.4",
     "typescript": "^5.5.2"
   }
 }


### PR DESCRIPTION
## Summary

lit should be a dependency instead of dev dependency.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
