### PR TITLE
fix(create-rsbuild): skip tools selection when using CLI options

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -148,7 +148,7 @@ async function getTools({ tools, dir, template }: Argv) {
     return Array.isArray(tools) ? tools : [tools];
   }
   // skip tools selection when using CLI options
-  if (dir || template) {
+  if (dir && template) {
     return [];
   }
 

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -143,9 +143,13 @@ async function getTemplate({ template }: Argv) {
   };
 }
 
-async function getTools({ tools }: Argv) {
+async function getTools({ tools, dir, template }: Argv) {
   if (tools) {
     return Array.isArray(tools) ? tools : [tools];
+  }
+  // skip tools selection when using CLI options
+  if (dir || template) {
+    return [];
   }
 
   return checkCancel<string[]>(


### PR DESCRIPTION
## Summary

Skip tools selection when using CLI options and both `dir` and `template` are provided. tools are not required in this case.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
