### PR TITLE
fix: allow setting NODE_ENV from env files

### DIFF
--- a/e2e/cases/cli/load-node-env/.env
+++ b/e2e/cases/cli/load-node-env/.env
@@ -1,0 +1,1 @@
+NODE_ENV=development

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, test } from '@playwright/test';
 
+// see: https://github.com/web-infra-dev/rsbuild/issues/2904
 test('should load .env config and set NODE_ENV as expected', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -1,0 +1,11 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+
+test('should load .env config and set NODE_ENV as expected', async () => {
+  execSync('npx rsbuild build', {
+    cwd: __dirname,
+  });
+  expect(fs.existsSync(path.join(__dirname, 'dist/development'))).toBeTruthy();
+});

--- a/e2e/cases/cli/load-node-env/rsbuild.config.ts
+++ b/e2e/cases/cli/load-node-env/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    distPath: {
+      root: `dist/${process.env.NODE_ENV}`,
+    },
+  },
+});

--- a/e2e/cases/cli/load-node-env/src/index.js
+++ b/e2e/cases/cli/load-node-env/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -59,6 +59,13 @@ export function loadEnv({
     Object.assign(parsed, parse(fs.readFileSync(envPath)));
   }
 
+  // dotenv-expand does not override existing env vars by default,
+  // but we should allow overriding NODE_ENV, which is very common.
+  // https://github.com/web-infra-dev/rsbuild/issues/2904
+  if (parsed.NODE_ENV) {
+    process.env.NODE_ENV = parsed.NODE_ENV;
+  }
+
   expand({ parsed });
 
   const publicVars: Record<string, string> = {};


### PR DESCRIPTION
## Summary

dotenv-expand does not override existing env vars by default, but we should allow overriding NODE_ENV, which is very common.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/2904
https://github.com/motdotla/dotenv/issues/199

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
