### PR TITLE
refactor(core): use bundler chain to enable Rsdoctor

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -233,6 +233,8 @@ export const CHAIN_ID = {
     ASYNC_CHUNK_RETRY: 'async-chunk-retry',
     /** AutoSetRootFontSizePlugin */
     AUTO_SET_ROOT_SIZE: 'auto-set-root-size',
+    /** RsdoctorRspackPlugin */
+    RSDOCTOR: 'rsdoctor',
   },
   /** Predefined minimizers */
   MINIMIZER: {

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -11,7 +11,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
   name: 'rsbuild:rsdoctor',
 
   setup(api) {
-    api.onBeforeCreateCompiler(async ({ bundlerConfigs }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
       if (process.env.RSDOCTOR !== 'true') {
         return;
       }
@@ -43,25 +43,13 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         return;
       }
 
-      let isAutoRegister = false;
-
-      for (const config of bundlerConfigs) {
-        const registered = config.plugins?.some(
-          (plugin) => plugin?.constructor?.name === pluginName,
-        );
-
-        if (registered) {
-          return;
-        }
-
-        config.plugins ||= [];
-        config.plugins.push(new module[pluginName]());
-        isAutoRegister = true;
+      if (chain.plugins.has(CHAIN_ID.PLUGIN.RSDOCTOR)) {
+        return;
       }
 
-      if (isAutoRegister) {
-        logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
-      }
+      chain.plugin(CHAIN_ID.PLUGIN.RSDOCTOR).use(module[pluginName]);
+
+      logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
     });
   },
 });


### PR DESCRIPTION
## Summary

This makes modifying Rsdoctor options in plugin easier. E.g.:

```js
export function pluginRsdoctor(): RsbuildPlugin {
  return {
    name: 'rsdoctor-modified',
    setup(api) {
      api.modifyBundlerChain((chain, { CHAIN_ID }) => {
        chain
          .plugin(CHAIN_ID.PLUGIN.RSDOCTOR)
          .tap((options: RsdoctorOptions) => modifyRsdoctorOptions(options))
      })
    },
  }
}
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
