### PR TITLE
release: 1.0.1-beta.1

### DIFF
--- a/packages/compat/babel-preset/package.json
+++ b/packages/compat/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/babel-preset",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "The babel config of Rsbuild.",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-typed-css-modules/package.json
+++ b/packages/plugin-typed-css-modules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-typed-css-modules",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Generate TypeScript declaration file for CSS Modules",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.0",
+  "version": "1.0.1-beta.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(create-rsbuild): allow to create via CLI options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2903
* feat: allow dev.client.port to be a number by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2907
### Bug Fixes 🐞
* fix(create-rsbuild): lit should be dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2910
* fix(create-rsbuild): skip tools selection when using CLI options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2911
* fix: es template string breaks template compiling by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2914
* fix: allow setting NODE_ENV from env files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2915
### Document 📖
* docs: port value should be string instead of int by @vikas5914 in https://github.com/web-infra-dev/rsbuild/pull/2905
* docs: add create-rsbuild quick creation guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2918
* docs: update the builtin CHAIN_ID list by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2920
### Other Changes
* test(e2e): add cases for create-rsbuild by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2912
* chore(deps): update dependency vitest to v2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2909
* chore(deps): update dependency @modern-js/module-tools to ^2.55.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2908

## New Contributors
* @vikas5914 made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2905

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.0...v1.0.1-beta.1