### PR TITLE
fix: specify SWC cache directory

### DIFF
--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -62,7 +62,10 @@ function applyScriptCondition({
   }
 }
 
-function getDefaultSwcConfig(browserslist: string[]): SwcLoaderOptions {
+function getDefaultSwcConfig(
+  browserslist: string[],
+  cacheRoot: string,
+): SwcLoaderOptions {
   return {
     jsc: {
       externalHelpers: true,
@@ -74,6 +77,9 @@ function getDefaultSwcConfig(browserslist: string[]): SwcLoaderOptions {
       // Avoid the webpack magic comment to be removed
       // https://github.com/swc-project/swc/issues/6403
       preserveAllComments: true,
+      experimental: {
+        cacheRoot,
+      },
     },
     isModule: 'unknown',
     env: {
@@ -93,6 +99,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
       order: 'pre',
       handler: async (chain, { CHAIN_ID, target, environment }) => {
         const { config, browserslist } = environment;
+        const cacheRoot = path.join(api.context.cachePath, '.swc');
 
         const rule = chain.module
           .rule(CHAIN_ID.RULE.JS)
@@ -119,7 +126,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           return;
         }
 
-        const swcConfig = getDefaultSwcConfig(browserslist);
+        const swcConfig = getDefaultSwcConfig(browserslist, cacheRoot);
 
         applyTransformImport(swcConfig, config.source.transformImport);
         applySwcDecoratorConfig(swcConfig, config);

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -115,6 +115,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -156,6 +159,9 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -115,6 +115,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -156,6 +159,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -525,6 +531,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -566,6 +575,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -927,6 +939,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -964,6 +979,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -1285,6 +1303,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -1326,6 +1347,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1445,6 +1445,9 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1486,6 +1489,9 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1768,6 +1774,9 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1805,6 +1814,9 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -38,6 +38,9 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -79,6 +82,9 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -141,6 +147,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -179,6 +188,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -245,6 +257,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -293,6 +308,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -409,6 +427,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": false,
             "parser": {
               "decorators": true,
@@ -450,6 +471,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": false,
             "parser": {
               "decorators": true,
@@ -510,6 +534,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": true,
             "parser": {
               "decorators": true,
@@ -563,6 +590,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": true,
             "parser": {
               "decorators": true,
@@ -619,6 +649,9 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": true,
             "parser": {
               "decorators": true,
@@ -663,6 +696,9 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "isModule": "unknown",
           "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+            },
             "externalHelpers": true,
             "parser": {
               "decorators": true,
@@ -727,6 +763,9 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -768,6 +807,9 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -829,6 +871,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -866,6 +911,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -932,6 +980,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -973,6 +1024,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1046,6 +1100,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1091,6 +1148,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1164,6 +1224,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1210,6 +1273,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1283,6 +1349,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1328,6 +1397,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1390,6 +1462,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,
@@ -1427,6 +1502,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "isModule": "unknown",
                 "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
                   "externalHelpers": true,
                   "parser": {
                     "decorators": true,

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -34,6 +34,9 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
         },
         "isModule": "unknown",
         "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+          },
           "externalHelpers": true,
           "parser": {
             "decorators": true,
@@ -113,6 +116,9 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
         },
         "isModule": "unknown",
         "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+          },
           "externalHelpers": true,
           "parser": {
             "decorators": true,
@@ -188,6 +194,9 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
         },
         "isModule": "unknown",
         "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+          },
           "externalHelpers": true,
           "parser": {
             "decorators": true,

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -131,6 +131,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,
@@ -177,6 +180,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
               },
               "isModule": "unknown",
               "jsc": {
+                "experimental": {
+                  "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
+                },
                 "externalHelpers": true,
                 "parser": {
                   "decorators": true,

--- a/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-styled-components/tests/__snapshots__/index.test.ts.snap
@@ -31,6 +31,7 @@ exports[`plugins/styled-components > should apply styledComponents option to swc
         "isModule": "unknown",
         "jsc": {
           "experimental": {
+            "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
             "plugins": [
               [
                 "<ROOT>/node_modules/<PNPM_INNER>/@swc/plugin-styled-components/swc_plugin_styled_components.wasm",
@@ -88,6 +89,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
         "isModule": "unknown",
         "jsc": {
           "experimental": {
+            "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
             "plugins": [
               [
                 "<ROOT>/node_modules/<PNPM_INNER>/@swc/plugin-styled-components/swc_plugin_styled_components.wasm",
@@ -149,6 +151,7 @@ exports[`plugins/styled-components > should enable ssr option when target contai
         "isModule": "unknown",
         "jsc": {
           "experimental": {
+            "cacheRoot": "<ROOT>/node_modules/.cache/.swc",
             "plugins": [
               [
                 "<ROOT>/node_modules/<PNPM_INNER>/@swc/plugin-styled-components/swc_plugin_styled_components.wasm",

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -32,6 +32,9 @@ exports[`svgr > 'configure SVGR options' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -122,6 +125,9 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -184,6 +190,9 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -273,6 +282,9 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -335,6 +347,9 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -424,6 +439,9 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -486,6 +504,9 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -575,6 +596,9 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,
@@ -637,6 +661,9 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
             },
             "isModule": "unknown",
             "jsc": {
+              "experimental": {
+                "cacheRoot": "<ROOT>/packages/plugin-svgr/tests/node_modules/.cache/.swc",
+              },
               "externalHelpers": true,
               "parser": {
                 "decorators": true,


### PR DESCRIPTION
## Summary

The swc plugin uses `.swc` as the cache directory by default, but `.swc` is not in the default `.gitignore`. So, in rsbuild, `.swc` should be placed in the cache root directory.

<img width="349" alt="image" src="https://github.com/user-attachments/assets/ad4a9b6a-4a47-4060-8177-8888e80d799e">


## Related Links

https://github.com/swc-project/swc/discussions/4023#discussioncomment-6095185

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
