### PR TITLE
fix(webpack): should generate config files correctly when output is specified

### DIFF
--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -34,6 +34,34 @@ test('should generate config files when writeToDisk is true', async () => {
   fs.rmSync(bundlerConfig, { force: true });
 });
 
+test('should generate config files correctly when output is specified', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {},
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+    outputPath: 'foo',
+  });
+
+  const bundlerConfig = path.resolve(
+    __dirname,
+    `./dist/foo/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
+  );
+
+  const rsbuildConfig = path.resolve(
+    __dirname,
+    './dist/foo/rsbuild.config.mjs',
+  );
+
+  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+
+  fs.rmSync(rsbuildConfig, { force: true });
+  fs.rmSync(bundlerConfig, { force: true });
+});
+
+
 test('should generate bundler config for node when target contains node', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,

--- a/packages/compat/webpack/src/inspectConfig.ts
+++ b/packages/compat/webpack/src/inspectConfig.ts
@@ -50,7 +50,10 @@ export async function inspectConfig({
     pluginManager,
   });
 
-  let outputPath = inspectOptions.outputPath || context.distPath;
+  let outputPath = inspectOptions.outputPath
+    ? join(context.distPath, inspectOptions.outputPath)
+    : context.distPath;
+
   if (!isAbsolute(outputPath)) {
     outputPath = join(context.rootPath, outputPath);
   }


### PR DESCRIPTION
## Summary

fix webpack config inspect error when output is specified, outputPath should join with distPath.

<img width="707" alt="image" src="https://github.com/user-attachments/assets/951b5f0b-74bd-4ba9-b04f-ca2db48f9265">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
