### PR TITLE
docs: add modify config tips

### DIFF
--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -6,9 +6,10 @@ This chapter introduces the plugin hooks available for Rsbuild plugins.
 
 ### Common Hooks
 
-- [modifyRsbuildConfig](#modifyrsbuildconfig): Modify the configuration object passed to Rsbuild.
-- [modifyRspackConfig](#modifyrspackconfig): Modify the configuration object passed to Rspack.
-- [modifyBundlerChain](#modifybundlerchain): Modify the configuration object of Rspack through the chain API.
+- [modifyRsbuildConfig](#modifyrsbuildconfig): Modify the configuration passed to Rsbuild.
+- [modifyEnvironmentConfig](#modifyenvironmentconfig): Modify the Rsbuild configuration of a specific environment.
+- [modifyRspackConfig](#modifyrspackconfig): Modify the configuration passed to Rspack.
+- [modifyBundlerChain](#modifybundlerchain): Modify the configuration of Rspack through the chain API.
 - [modifyHTMLTags](#modifyhtmltags): Modify the tags that are injected into the HTML.
 - [onBeforeCreateCompiler](#onbeforecreatecompiler): Called before creating a compiler instance.
 - [onAfterCreateCompiler](#onaftercreatecompiler): Called after creating a compiler instance and before building.
@@ -194,6 +195,10 @@ const myPlugin = () => ({
 });
 ```
 
+:::tip
+`modifyRsbuildConfig` cannot be used to register additional Rsbuild plugins. This is because at the time `modifyRsbuildConfig` is executed, Rsbuild has already initialized all plugins and started executing the callbacks of the hooks.
+:::
+
 ### modifyEnvironmentConfig
 
 Modify the Rsbuild configuration of a specific environment.
@@ -265,7 +270,7 @@ const myPlugin = () => ({
 
 ### modifyRspackConfig
 
-To modify the final Rspack config object, you can directly modify the config object, or return a new object to replace the previous object.
+To modify the final Rspack config, you can directly modify the config object, or return a new object to replace the previous object.
 
 - **Type:**
 

--- a/website/docs/en/shared/getNormalizedConfig.mdx
+++ b/website/docs/en/shared/getNormalizedConfig.mdx
@@ -1,4 +1,4 @@
-Get the all normalized Rsbuild config or the Rsbuild config of a specified environment, this method must be called after the `modifyRsbuildConfig` hook is executed.
+Get the all normalized Rsbuild config or the Rsbuild config of a specified environment, this method must be called after the [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) hook is executed.
 
 Compared with the `api.getRsbuildConfig` method, the config returned by this method has been normalized, and the type definition of the config will be narrowed. For example, the `undefined` type of `config.html` will be removed.
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -6,9 +6,10 @@
 
 ### Common Hooks
 
-- [modifyRsbuildConfig](#modifyrsbuildconfig)：修改传递给 Rsbuild 的配置对象。
-- [modifyRspackConfig](#modifyrspackconfig)：修改传递给 Rspack 的配置对象。
-- [modifyBundlerChain](#modifybundlerchain)：通过 chain API 修改 Rspack 的配置对象。
+- [modifyRsbuildConfig](#modifyrsbuildconfig)：修改传递给 Rsbuild 的配置。
+- [modifyEnvironmentConfig](#modifyenvironmentconfig): 修改特定 environment 的 Rsbuild 配置。
+- [modifyRspackConfig](#modifyrspackconfig)：修改传递给 Rspack 的配置。
+- [modifyBundlerChain](#modifybundlerchain)：通过 chain API 修改 Rspack 的配置。
 - [modifyHTMLTags](#modifyhtmltags)：修改注入到 HTML 中的标签。
 - [onBeforeCreateCompiler](#onbeforecreatecompiler)：在创建 compiler 实例前调用。
 - [onAfterCreateCompiler](#onaftercreatecompiler)：在创建 compiler 实例后、执行构建前调用。
@@ -193,6 +194,10 @@ const myPlugin = () => ({
 });
 ```
 
+:::tip
+`modifyRsbuildConfig` 不能用于注册额外的 Rsbuild 插件。这是因为在执行 `modifyRsbuildConfig` 时，Rsbuild 已经初始化了所有插件，并开始执行 hooks 的回调函数。
+:::
+
 ### modifyEnvironmentConfig
 
 修改特定 environment 的 Rsbuild 配置。
@@ -263,7 +268,7 @@ const myPlugin = () => ({
 
 ### modifyRspackConfig
 
-修改最终的 Rspack 配置对象，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
+修改最终的 Rspack 配置，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
 
 - **类型：**
 

--- a/website/docs/zh/shared/getNormalizedConfig.mdx
+++ b/website/docs/zh/shared/getNormalizedConfig.mdx
@@ -1,4 +1,4 @@
-获取归一化后的全部 Rsbuild 配置或指定环境的 Rsbuild 配置，该方法必须在 `modifyRsbuildConfig` 钩子执行完成后才能被调用。
+获取归一化后的全部 Rsbuild 配置，或指定环境的 Rsbuild 配置。该方法必须在 [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig) 钩子执行完成后才能被调用。
 
 相较于 `getRsbuildConfig` 方法，该方法返回的配置经过了归一化处理，配置的类型定义会得到收敛，比如 `config.html` 的 `undefined` 类型将被移除。
 


### PR DESCRIPTION
## Summary

Add modify config tips, we can not use `modifyRsbuildConfig` to register additional Rsbuild plugins.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
