### PR TITLE
fix: minify.jsOptions is not pass to SwcMinimizerPlugin

### DIFF
--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -120,7 +120,11 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
             .minimizer(CHAIN_ID.MINIMIZER.JS)
             .use(SwcMinimizerPlugin, [
               {
-                jsMinify: mainConfig.jsMinify ?? mainConfig.jsc?.minify ?? true,
+                jsMinify:
+                  (typeof minify === 'object' && minify.jsOptions) ??
+                  mainConfig.jsMinify ??
+                  mainConfig.jsc?.minify ??
+                  true,
                 environmentConfig,
               },
             ]);
@@ -131,7 +135,7 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
             .minimizer(CHAIN_ID.MINIMIZER.CSS)
             .use(SwcMinimizerPlugin, [
               {
-                cssMinify: minifyCss ? mainConfig.cssMinify ?? true : false,
+                cssMinify: mainConfig.cssMinify ?? true,
                 environmentConfig,
               },
             ]);

--- a/packages/compat/plugin-swc/src/plugin.ts
+++ b/packages/compat/plugin-swc/src/plugin.ts
@@ -121,7 +121,9 @@ export const pluginSwc = (options: PluginSwcOptions = {}): RsbuildPlugin => ({
             .use(SwcMinimizerPlugin, [
               {
                 jsMinify:
-                  (typeof minify === 'object' && minify.jsOptions) ??
+                  (typeof minify === 'object' && minify.jsOptions
+                    ? minify.jsOptions
+                    : undefined) ??
                   mainConfig.jsMinify ??
                   mainConfig.jsc?.minify ??
                   true,

--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -1162,3 +1162,141 @@ exports[`plugin-swc > should set swc-loader 1`] = `
   },
 }
 `;
+
+exports[`plugin-swc > should use output config 1`] = `
+[
+  {
+    "module": {
+      "rules": [
+        {
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "use": [
+            {
+              "loader": "<ROOT>/packages/compat/plugin-swc/src/loader.cjs",
+              "options": {
+                "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
+                "env": {
+                  "coreJs": "3.37",
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "extensions": {
+                  "lockCorejsVersion": {
+                    "corejs": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+                    "swcHelpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+                  },
+                  "lodash": {
+                    "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
+                    "ids": [
+                      "lodash",
+                      "lodash-es",
+                    ],
+                  },
+                },
+                "jsc": {
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": true,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                    "react": {
+                      "refresh": false,
+                      "runtime": "classic",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          "mimetype": {
+            "or": [
+              "text/javascript",
+              "application/javascript",
+            ],
+          },
+          "resolve": {
+            "fullySpecified": false,
+          },
+          "use": [
+            {
+              "loader": "<ROOT>/packages/compat/plugin-swc/src/loader.cjs",
+              "options": {
+                "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
+                "env": {
+                  "coreJs": "3.37",
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "extensions": {
+                  "lockCorejsVersion": {
+                    "corejs": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+                    "swcHelpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+                  },
+                  "lodash": {
+                    "cwd": "<ROOT>/packages/compat/plugin-swc/tests",
+                    "ids": [
+                      "lodash",
+                      "lodash-es",
+                    ],
+                  },
+                },
+                "jsc": {
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": true,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                    "react": {
+                      "refresh": false,
+                      "runtime": "classic",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    "optimization": {
+      "minimizer": [
+        SwcMinimizerPlugin {
+          "minifyOptions": {
+            "cssMinify": undefined,
+            "jsMinify": {
+              "compress": {
+                "ecma": 2019,
+              },
+              "format": {
+                "asciiOnly": true,
+              },
+              "mangle": true,
+            },
+          },
+          "name": "swc-minimizer-plugin",
+        },
+      ],
+    },
+  },
+]
+`;

--- a/packages/compat/plugin-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-swc/tests/plugin.test.ts
@@ -439,4 +439,31 @@ describe('plugin-swc', () => {
 
     expect(config.extensions?.lodash).toBeFalsy();
   });
+
+  it('should use output config', async () => {
+    process.env.NODE_ENV = 'production';
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginSwc()],
+      rsbuildConfig: {
+        provider: webpackProvider,
+        environments: {
+          web: {
+            output: {
+              minify: {
+                js: true,
+                jsOptions: {
+                  compress: {
+                    ecma: 2019,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    const configs = await rsbuild.initConfigs();
+
+    expect(configs).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

The [output.minify.jsOptions](https://rsbuild.dev/config/output/minify#javascript-minify-options) should be passed to the `SwcMinimizerPlugin`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
