### PR TITLE
fix: only print verbose error logs in debug mode

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -262,8 +262,8 @@ export function formatStats(
       errors: getAllStatsErrors(statsData),
       warnings: getAllStatsWarnings(statsData),
     },
-    // display verbose messages in prod build or debug mode
-    isProd() || logger.level === 'verbose',
+    // display verbose messages in debug mode
+    logger.level === 'verbose',
   );
 
   if (stats.hasErrors()) {


### PR DESCRIPTION
## Summary

The verbose error logs are often repeated and useless, we should only print verbose error logs in debug mode.

This change makes the error log clearer and more accurate.

- before:

<img width="1304" alt="截屏2024-07-16 22 50 17" src="https://github.com/user-attachments/assets/11ccf4f4-5408-42ed-ad48-dd4315f260de">

- after:

![image](https://github.com/user-attachments/assets/ae6d5e68-3f07-41f7-890c-0ffa665999d8)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
