### PR TITLE
fix: should print stats.file as file name when have build errors

### DIFF
--- a/e2e/cases/type-check/basic/index.test.ts
+++ b/e2e/cases/type-check/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@e2e/helper';
+import { build, dev, gotoPage } from '@e2e/helper';
 import { proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
@@ -11,6 +11,43 @@ test('should throw error when exist type errors', async () => {
       plugins: [pluginTypeCheck()],
     }),
   ).rejects.toThrowError('build failed!');
+
+  expect(
+    logs.find((log) => log.includes('File:') && log.includes('/src/index.ts')),
+  ).toBeTruthy();
+
+  expect(
+    logs.find((log) =>
+      log.includes(
+        `Argument of type 'string' is not assignable to parameter of type 'number'.`,
+      ),
+    ),
+  ).toBeTruthy();
+
+  restore();
+});
+
+test('should throw error when exist type errors in dev mode', async ({
+  page,
+}) => {
+  const { logs, restore } = proxyConsole();
+
+  const rsbuild = await dev({
+    cwd: __dirname,
+    plugins: [
+      pluginTypeCheck({
+        forkTsCheckerOptions: {
+          async: false,
+        },
+      }),
+    ],
+  });
+
+  await gotoPage(page, rsbuild);
+
+  expect(
+    logs.find((log) => log.includes('File:') && log.includes('/src/index.ts')),
+  ).toBeTruthy();
 
   expect(
     logs.find((log) =>

--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -15,8 +15,9 @@ function resolveFileName(stats: StatsError) {
     }
   }
 
-  // fallback to moduleName if moduleIdentifier parse failed
-  return stats.moduleName ? `File: ${stats.moduleName}\n` : '';
+  // fallback to file or moduleName if moduleIdentifier parse failed
+  const file = stats.file || stats.moduleName;
+  return file ? `File: ${file}\n` : '';
 }
 
 function hintUnknownFiles(message: string): string {


### PR DESCRIPTION
## Summary

Should print `stats.file` as the file name when have build errors:

![image](https://github.com/user-attachments/assets/357eded7-073a-4935-9241-8e66acb8151f)

## Related Links

https://github.com/web-infra-dev/rspack/issues/6654

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
