### PR TITLE
docs: fix `tools.htmlPlugin` default options

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -228,7 +228,7 @@ export type TransformDescriptor = {
   environments?: string[];
   /**
    * If raw is `true`, the transform handler will receive the Buffer type code instead of the string type.
-   * @see https://rspack.dev/api/loader-api#raw-loader
+   * @see https://rspack.dev/api/loader-api/examples#raw-loader
    */
   raw?: boolean;
 };

--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -72,11 +72,9 @@ It will add a `script` tag to the end of the `head` of the HTML:
 </html>
 ```
 
-Fields in the tag that indicate the path to the external assets are affected by the `publicPath` and `hash` options.
-These fields include `src` for the `script` tag and `href` for the `link` tag.
+Fields in the tag that indicate the path to the external assets are affected by the `publicPath` and `hash` options. These fields include `src` for the `script` tag and `href` for the `link` tag.
 
-Enabling `publicPath` will splice the `output.assetPrefix` field before the attribute representing the path in the tag.
-And the `hash` field causes the filename to be followed by an additional hash query to control browser caching, with the same hash string as the HTML file product.
+Enabling `publicPath` will splice the [output.assetPrefix](/config/output/asset-prefix) field before the attribute representing the path in the tag. And the `hash` field causes the filename to be followed by an additional hash query to control browser caching, with the same hash string as the HTML file product.
 
 You can also pass functions to those fields to control the path joining.
 

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -16,3 +16,5 @@ export default {
   },
 };
 ```
+
+> Refer to [source.include](/config/source/include) to learn more.

--- a/website/docs/en/config/tools/html-plugin.mdx
+++ b/website/docs/en/config/tools/html-plugin.mdx
@@ -4,26 +4,15 @@
 - **Default:**
 
 ```js
-const defaultHtmlPluginOptions = {
-  inject, // corresponding to the html.inject config
-  favicon, // corresponding to html.favicon config
-  filename, // generated based on output.distPath and entryName
-  templateParameters, // corresponding to the html.templateParameters config
+const defaultOptions = {
+  meta, // Corresponds to `html.meta` config
+  title, // Corresponds to `html.title` config
+  inject, // Corresponds to `html.inject` config
+  favicon, // Corresponds to `html.favicon` config
+  template, // Corresponds to `html.template` config
+  filename, // Generated based on `output.distPath` and `entryName`
+  templateParameters, // Corresponds to `html.templateParameters` config
   chunks: [entryName],
-  minify: {
-    // generated based on output.minify
-    removeComments: false,
-    useShortDoctype: true,
-    keepClosingSlash: true,
-    collapseWhitespace: true,
-    removeRedundantAttributes: true,
-    removeScriptTypeAttributes: true,
-    removeStyleLinkTypeAttributes: true,
-    removeEmptyAttributes: true,
-    minifyJS,
-    minifyCSS: true,
-    minifyURLs: true,
-  },
 };
 ```
 
@@ -99,21 +88,6 @@ export default {
 };
 ```
 
-### Disable JS/CSS minify
+## HTML Minification
 
-By default, Rsbuild will compresses JavaScript/CSS code inside HTML during the production build to improve the page performance. This ability is often helpful when using custom templates or inserting custom scripts.
-
-However, when `output.inlineScripts` or `output.inlineStyles` is turned on, inline JavaScript/CSS code will be repeatedly compressed, which will have a certain impact on build performance. You can modify the default minify behavior by modifying the `tools.htmlPlugin.minify` configuration.
-
-```js
-export default {
-  tools: {
-    htmlPlugin: (config) => {
-      if (typeof config.minify === 'object') {
-        config.minify.minifyJS = false;
-        config.minify.minifyCSS = false;
-      }
-    },
-  },
-};
-```
+Rsbuild currently does not minify HTML files. If you need to minify HTML files, you can use the [rsbuild-plugin-html-minifier-terser plugin](https://github.com/rspack-contrib/rsbuild-plugin-html-minifier-terser).

--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -279,7 +279,7 @@ export default {
 
 The final insertion position of the tag is determined by the `head` and `append` options, and two elements with the same configuration will be inserted into the same area and hold their relative positions to each other.
 
-The `publicPath` configuration is enabled by default for tags, the value of `output.assetPrefix` will be stitched to the `src` property of the `script` tag that represents the path.
+The `publicPath` configuration is enabled by default for tags, the value of [output.assetPrefix](/config/output/asset-prefix) will be stitched to the `src` property of the `script` tag that represents the path.
 
 So the HTML output built with the above configuration will look like this.
 

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -71,11 +71,9 @@ export default {
 </html>
 ```
 
-标签中表示外部资源文件路径的字段会受到 `publicPath` 和 `hash` 选项的影响，
-这些字段包括 `script` 标签的 `src` 和 `link` 标签的 `href`。
+标签中表示外部资源文件路径的字段会受到 `publicPath` 和 `hash` 选项的影响，这些字段包括 `script` 标签的 `src` 和 `link` 标签的 `href`。
 
-启用 `publicPath` 会让标签中表示路径的属性被拼接上 `output.assetPrefix` 字段。
-而 `hash` 字段会让文件名后多出一个哈希查询用于控制浏览器缓存，哈希字符串与 HTML 文件产物的哈希值相同。
+启用 `publicPath` 会让标签中表示路径的属性被拼接上 [output.assetPrefix](/config/output/asset-prefix) 字段。而 `hash` 字段会让文件名后多出一个哈希查询用于控制浏览器缓存，哈希字符串与 HTML 文件产物的哈希值相同。
 
 用户也可以向这两个配置传入函数，以自行控制路径拼接的逻辑。
 

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -16,3 +16,5 @@ export default {
   },
 };
 ```
+
+> 参考 [source.include](/config/source/include) 来了解更多。

--- a/website/docs/zh/config/tools/html-plugin.mdx
+++ b/website/docs/zh/config/tools/html-plugin.mdx
@@ -4,26 +4,15 @@
 - **默认值：**
 
 ```js
-const defaultHtmlPluginOptions = {
-  inject, // 对应 html.inject 配置项
-  favicon, // 对应 html.favicon 配置项
-  filename, // 基于 output.distPath 和 entryName 生成
-  templateParameters, // 对应 html.templateParameters 配置项
+const defaultOptions = {
+  meta, // 对应 `html.meta` 配置
+  title, // 对应 `html.title` 配置
+  inject, // 对应 `html.inject` 配置
+  favicon, // 对应 `html.favicon` 配置
+  template, // 对应 `html.template` 配置
+  filename, // 基于 `output.distPath` 和 `entryName` 生成
+  templateParameters, // 对应 `html.templateParameters` 配置
   chunks: [entryName],
-  minify: {
-    // 基于 output.minify 生成
-    removeComments: false,
-    useShortDoctype: true,
-    keepClosingSlash: true,
-    collapseWhitespace: true,
-    removeRedundantAttributes: true,
-    removeScriptTypeAttributes: true,
-    removeStyleLinkTypeAttributes: true,
-    removeEmptyAttributes: true,
-    minifyJS,
-    minifyCSS: true,
-    minifyURLs: true,
-  },
 };
 ```
 
@@ -99,19 +88,6 @@ export default {
 };
 ```
 
-### 禁用 JS / CSS 压缩
+## HTML 压缩
 
-默认情况下，Rsbuild 会在生产环境构建时压缩 HTML 内的 JavaScript / CSS 代码，从而提升页面性能。此能力通常在使用自定义模版或插入自定义脚本时会有帮助。然而，当开启 `output.inlineScripts` 或 `output.inlineStyles` 时，会出现对 inline JavaScript / CSS 代码重复压缩的情况，对构建性能会有一定影响。你可以通过修改 `tools.htmlPlugin.minify` 配置项来修改默认的压缩行为。
-
-```js
-export default {
-  tools: {
-    htmlPlugin: (config) => {
-      if (typeof config.minify === 'object') {
-        config.minify.minifyJS = false;
-        config.minify.minifyCSS = false;
-      }
-    },
-  },
-};
-```
+Rsbuild 目前不对 HTML 文件进行压缩，如果你需要压缩 HTML 文件，可以使用 [rsbuild-plugin-html-minifier-terser 插件](https://github.com/rspack-contrib/rsbuild-plugin-html-minifier-terser)。

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -279,7 +279,7 @@ export default {
 
 标签最终的插入位置由 `head` 和 `append` 选项决定，两个配置相同的元素将被插入到相同区域，并且维持彼此之间的相对位置。
 
-标签默认会启用 `publicPath` 配置，即会将 `output.assetPrefix` 的值拼接到 `script` 标签的 `src` 等表示路径的属性上。
+标签默认会启用 `publicPath` 配置，即会将 [output.assetPrefix](/config/output/asset-prefix) 的值拼接到 `script` 标签的 `src` 等表示路径的属性上。
 
 所以以上配置构建出的 HTML 产物将会类似：
 


### PR DESCRIPTION
## Summary

Fix `tools.htmlPlugin` default options, the `minify` feature has been moved to `rsbuild-plugin-html-minifier-terser`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
