### PR TITLE
docs: move environment context to separate page

### DIFF
--- a/website/docs/en/api/javascript-api/_meta.json
+++ b/website/docs/en/api/javascript-api/_meta.json
@@ -1,1 +1,1 @@
-["core", "instance", "types"]
+["core", "instance", "types", "environment-context"]

--- a/website/docs/en/api/javascript-api/environment-context.mdx
+++ b/website/docs/en/api/javascript-api/environment-context.mdx
@@ -1,6 +1,8 @@
-## EnvironmentContext
+# Environment Context
 
-Environment context is a read-only object that provides some context infos about the current environment.
+Environment context is a read-only object that provides some context information about the current environment.
+
+In Rsbuild's hooks, you can get the environment context object through the `environment` or `environments` parameter.
 
 ```ts
 type EnvironmentContext = {
@@ -14,19 +16,19 @@ type EnvironmentContext = {
 };
 ```
 
-### environment.name
+## name
 
 The unique name of the current environment is used to distinguish and locate the environment, corresponds to the key in the [environments](/config/environments) configuration.
 
 - **Type:** `string`
 
-### environment.browserslist
+## browserslist
 
 The range of target browsers that the project is compatible with. See details in [Browserslist](/guide/advanced/browserslist).
 
 - **Type:** `string[]`
 
-### environment.config
+## config
 
 The Rsbuild environment configuration after normalization.
 
@@ -47,13 +49,13 @@ type NormalizedEnvironmentConfig = DeepReadonly<{
 }>;
 ```
 
-### environment.distPath
+## distPath
 
-The absolute path of the output directory, corresponding to the `output.distPath.root` config in `RsbuildConfig`.
+The absolute path of the output directory, corresponding to the [output.distPath.root](/config/output/dist-path) config in `RsbuildConfig`.
 
 - **Type:** `string`
 
-### environment.entry
+## entry
 
 The entry object from the [source.entry](/config/source/entry) option.
 
@@ -63,7 +65,7 @@ The entry object from the [source.entry](/config/source/entry) option.
 type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
 ```
 
-### environment.htmlPaths
+## htmlPaths
 
 The path information for all HTML assets.
 
@@ -75,7 +77,7 @@ This API will return an object, the key is the entry name and the value is the r
 type htmlPaths = Record<string, string>;
 ```
 
-### environment.tsconfigPath
+## tsconfigPath
 
 The absolute path of the tsconfig.json file, or `undefined` if the tsconfig.json file does not exist in current project.
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -28,11 +28,11 @@ type RootPath = string;
 
 ### context.distPath
 
-The absolute path of the output directory, corresponding to the `output.distPath.root` config in `RsbuildConfig`.
+The absolute path of the output directory, corresponding to the [output.distPath.root](/config/output/dist-path) config in `RsbuildConfig`.
 
 When there are multiple environments, Rsbuild will try to get the parent distPath of all environments as `context.distPath`.
 
-If you want to get the absolute path to the output directory of a specified environment, it is recommended to use [environment.distPath](/api/javascript-api/types#environmentdistpath).
+If you want to get the absolute path to the output directory of a specified environment, it is recommended to use [environment.distPath](/api/javascript-api/environment-context#distpath).
 
 - **Type:**
 
@@ -110,7 +110,7 @@ try {
 }
 ```
 
-### Development environment build
+### Development build
 
 If you need to perform a development build, you can set the `mode` option to `'development'`.
 

--- a/website/docs/en/api/javascript-api/types.mdx
+++ b/website/docs/en/api/javascript-api/types.mdx
@@ -122,10 +122,6 @@ The type of build target.
 import type { RsbuildTarget } from '@rsbuild/core';
 ```
 
-import EnvironmentContext from '@en/shared/environmentContext.mdx';
-
-<EnvironmentContext />
-
 ## CreateRsbuildOptions
 
 The param type of [createRsbuild](/api/javascript-api/core#creatersbuild) method.

--- a/website/docs/en/config/output/clean-dist-path.mdx
+++ b/website/docs/en/config/output/clean-dist-path.mdx
@@ -9,7 +9,7 @@ Whether to clean up all files under the output directory before the build starts
 
 By default, if the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.
 
-When `output.distPath.root` is an external directory, or equals to the project root directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
+When [output.distPath.root](/config/output/dist-path) is an external directory, or equals to the project root directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
 
 ```js
 export default {

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -146,21 +146,16 @@ const myPlugin = () => ({
 
 ## Environment context
 
-[Environment context](/api/javascript-api/types#environmentcontext) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hooks.
+[Environment context](/api/javascript-api/environment-context) is a read-only object that provides some context infos about the current environment. Rsbuild supports obtaining environment context information in plugin hooks.
 
-For some plugin hooks related to the build environment (such as [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain) and [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig)), Rsbuild supports obtaining the current environment context through the `environment` parameter.
+For some plugin hooks related to the build environment (such as [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) and [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)), Rsbuild supports obtaining the current environment context through the `environment` parameter.
 
 ```ts
 const myPlugin = () => ({
   setup: (api) => {
-    api.modifyBundlerChain((chain, { environment }) => {
-      const { name, config, entry } = environment;
-
-      if (config.output.minify !== false) {
-        chain.optimization
-          .minimizer(CHAIN_ID.MINIMIZER.JS)
-          .use(SwcJsMinimizerRspackPlugin)
-          .end();
+    api.modifyRspackConfig((rspackConfig, { environment }) => {
+      if (environment.name === 'node') {
+        // do some thing
       }
     });
   },
@@ -173,7 +168,9 @@ For some global plugin hooks (such as [onDevCompileDone](/plugins/dev/hooks#onde
 const myPlugin = () => ({
   setup: (api) => {
     api.onDevCompileDone(({ environments }) => {
-      const entries = Object.values(environments).map((e) => e.entry);
+      environments.forEach((environment) => {
+        console.log('environment', environment);
+      });
     });
   },
 });

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -296,7 +296,7 @@ The `handler` function provides the following params:
 - `resource`: The absolute path of the module, including the query.
 - `resourcePath`: The absolute path of the module, without the query.
 - `resourceQuery`: The query of the module.
-- `environment`: The [environment context](/api/javascript-api/types#environmentcontext) for current build.
+- `environment`: The [environment context](/api/javascript-api/environment-context) for current build.
 - `addDependency`: Add an additional file as the dependency. The file will be watched and changes to the file will trigger rebuild.
 - `emitFile`: Emits a file to the build output.
 

--- a/website/docs/zh/api/javascript-api/_meta.json
+++ b/website/docs/zh/api/javascript-api/_meta.json
@@ -1,1 +1,1 @@
-["core", "instance", "types"]
+["core", "instance", "types", "environment-context"]

--- a/website/docs/zh/api/javascript-api/environment-context.mdx
+++ b/website/docs/zh/api/javascript-api/environment-context.mdx
@@ -1,6 +1,8 @@
-## EnvironmentContext
+# Environment Context
 
 Environment context 是一个只读对象，提供一些和当前环境有关的上下文信息。
+
+在 Rsbuild 的 hooks 中，你可以通过 `environment` 或 `environments` 入参获取 environment context 对象。
 
 ```ts
 type EnvironmentContext = {
@@ -14,19 +16,19 @@ type EnvironmentContext = {
 };
 ```
 
-### environment.name
+## name
 
 当前环境的唯一名称，用于区分和定位环境，对应于 [environments](/config/environments) 配置中的 key。
 
 - **类型：** `string`
 
-### environment.browserslist
+## browserslist
 
 项目兼容的目标浏览器范围。详情可参考 [设置浏览器范围](/guide/advanced/browserslist).
 
 - **类型：** `string[]`
 
-### environment.config
+## config
 
 归一化后当前环境的 Rsbuild 配置
 
@@ -47,13 +49,13 @@ type NormalizedEnvironmentConfig = DeepReadonly<{
 }>;
 ```
 
-### environment.distPath
+## distPath
 
-构建产物输出目录的绝对路径，对应 RsbuildConfig 中的 `output.distPath.root` 配置项。
+构建产物输出目录的绝对路径，对应 RsbuildConfig 中的 [output.distPath.root](/config/output/dist-path) 配置项。
 
 - **类型：** `string`
 
-### environment.entry
+## entry
 
 构建入口对象，对应 [source.entry](/config/source/entry) 选项。
 
@@ -63,7 +65,7 @@ type NormalizedEnvironmentConfig = DeepReadonly<{
 type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
 ```
 
-### environment.htmlPaths
+## htmlPaths
 
 HTML 产物的路径信息。该 API 会返回一个对象，对象的 key 为 entry 名称，value 为 HTML 文件在产物目录下的相对路径。
 
@@ -73,7 +75,7 @@ HTML 产物的路径信息。该 API 会返回一个对象，对象的 key 为 e
 type htmlPaths = Record<string, string>;
 ```
 
-### environment.tsconfigPath
+## tsconfigPath
 
 tsconfig.json 文件的绝对路径，若项目中不存在 tsconfig.json 文件，则为 undefined。
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -28,11 +28,11 @@ type RootPath = string;
 
 ### context.distPath
 
-构建产物输出目录的绝对路径，对应 `RsbuildConfig` 中的 `output.distPath.root` 配置项。
+构建产物输出目录的绝对路径，对应 `RsbuildConfig` 中的 [output.distPath.root](/config/output/dist-path) 配置项。
 
 当有多个环境时，Rsbuild 会尝试获取所有环境的父 distPath 作为 `context.distPath`。
 
-如果要获取指定环境的输出目录的绝对路径，建议使用 [environment.distPath](/api/javascript-api/types#environmentdistpath)。
+如果要获取指定环境的输出目录的绝对路径，建议使用 [environment.distPath](/api/javascript-api/environment-context#distpath)。
 
 - **类型：**
 

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -122,10 +122,6 @@ Rsbuild 构建产物的类型。
 import type { RsbuildTarget } from '@rsbuild/core';
 ```
 
-import EnvironmentContext from '@zh/shared/environmentContext.mdx';
-
-<EnvironmentContext />
-
 ## CreateRsbuildOptions
 
 [createRsbuild](/api/javascript-api/core#creatersbuild) 方法的入参类型。

--- a/website/docs/zh/config/output/clean-dist-path.mdx
+++ b/website/docs/zh/config/output/clean-dist-path.mdx
@@ -9,7 +9,7 @@
 
 默认情况下，如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
 
-当 `output.distPath.root` 为外部目录，或等于项目根目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
+当 [output.distPath.root](/config/output/dist-path) 为外部目录，或等于项目根目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
 
 ```js
 export default {

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -146,34 +146,31 @@ const myPlugin = () => ({
 
 ## Environment 上下文
 
-[Environment context](/api/javascript-api/types#environmentcontext) 是一个只读对象，提供一些和当前环境有关的上下文信息。Rsbuild 支持在 plugin hook 中获取 environment context 信息。
+[Environment context](/api/javascript-api/environment-context) 是一个只读对象，提供一些和当前环境有关的上下文信息。Rsbuild 支持在 plugin hook 中获取 environment context 信息。
 
-对于一些与构建环境相关的 plugin hooks (如 [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)、[modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig) 等), Rsbuild 支持通过 `environment` 参数获取当前 environment 上下文。
+对于一些与构建环境相关的 plugin hooks（如 [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig)、[modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain) 等）, Rsbuild 支持通过 `environment` 参数获取当前 environment 上下文。
 
 ```ts
 const myPlugin = () => ({
   setup: (api) => {
-    api.modifyBundlerChain((chain, { environment }) => {
-      const { name, config, entry } = environment;
-
-      if (config.output.minify !== false) {
-        chain.optimization
-          .minimizer(CHAIN_ID.MINIMIZER.JS)
-          .use(SwcJsMinimizerRspackPlugin)
-          .end();
+    api.modifyRspackConfig((rspackConfig, { environment }) => {
+      if (environment.name === 'node') {
+        // do some thing
       }
     });
   },
 });
 ```
 
-对于一些全局的 plugin hooks (如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等)， Rsbuild 支持通过 `environments` 参数获取所有环境的上下文。
+对于一些全局的 plugin hooks（如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等）， Rsbuild 支持通过 `environments` 参数获取所有环境的上下文。
 
 ```ts
 const myPlugin = () => ({
   setup: (api) => {
     api.onDevCompileDone(({ environments }) => {
-      const entries = Object.values(environments).map((e) => e.entry);
+      environments.forEach((environment) => {
+        console.log('environment', environment);
+      });
     });
   },
 });

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -294,7 +294,7 @@ handler 函数提供以下参数：
 - `resource`：模块的绝对路径，包含 query。
 - `resourcePath`：模块的绝对路径，不包含 query。
 - `resourceQuery`：模块路径上的 query。
-- `environment`: 当前构建的 [environment 上下文](/api/javascript-api/types#environmentcontext).
+- `environment`: 当前构建的 [environment 上下文](/api/javascript-api/environment-context).
 - `addDependency`：添加一个额外的文件作为依赖。该文件将被监听，并在发生变更时触发重新构建。
 - `emitFile`：将一个文件输出到构建结果中。
 


### PR DESCRIPTION
## Summary

Move environment context to separate page, and we can add more examples / properties to this page in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
