### PR TITLE
feat: allow to access environment context in process assets

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -209,24 +209,30 @@ export function getPluginAPI({
   const processAssets: ProcessAssetsFn = (descriptor, handler) => {
     const name = 'RsbuildProcessAssetsPlugin';
 
-    class RsbuildProcessAssetsPlugin {
-      apply(compiler: Compiler): void {
-        compiler.hooks.compilation.tap(name, (compilation) => {
-          compilation.hooks.processAssets.tapPromise(
-            {
-              name,
-              stage: mapProcessAssetsStage(compiler, descriptor.stage),
-            },
-            async (assets) => handler({ assets, compiler, compilation }),
-          );
-        });
-      }
-    }
-
-    hooks.modifyBundlerChain.tap((chain, { target }) => {
+    hooks.modifyBundlerChain.tap((chain, { target, environment }) => {
       // filter by targets
       if (descriptor.targets && !descriptor.targets.includes(target)) {
         return;
+      }
+
+      class RsbuildProcessAssetsPlugin {
+        apply(compiler: Compiler): void {
+          compiler.hooks.compilation.tap(name, (compilation) => {
+            compilation.hooks.processAssets.tapPromise(
+              {
+                name,
+                stage: mapProcessAssetsStage(compiler, descriptor.stage),
+              },
+              async (assets) =>
+                handler({
+                  assets,
+                  compiler,
+                  compilation,
+                  environment,
+                }),
+            );
+          });
+        }
       }
 
       chain

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -277,6 +277,10 @@ export type ProcessAssetsHandler = (context: {
   assets: Record<string, Rspack.sources.Source>;
   compiler: Rspack.Compiler;
   compilation: Rspack.Compilation;
+  /**
+   * The environment context for current build.
+   */
+  environment: EnvironmentContext;
 }) => Promise<void> | void;
 
 export type ProcessAssetsFn = (


### PR DESCRIPTION
## Summary

Allow to access environment context in the process assets plugin API.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
