### PR TITLE
refactor: use new processAssets api to handle SRI

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,7 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  html: {
-    template: './index.html',
-  },
 });

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -340,6 +340,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "process.env.NODE_ENV": ""development"",
       },
     },
+    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -730,6 +731,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "process.env.NODE_ENV": ""production"",
       },
     },
+    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -1034,6 +1036,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "process.env.NODE_ENV": ""production"",
       },
     },
+    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -1320,6 +1323,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "process.env.NODE_ENV": ""production"",
       },
     },
+    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -73,6 +73,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "process.env.NODE_ENV": ""test"",
     },
   },
+  RsbuildProcessAssetsPlugin {},
   ProgressPlugin {
     "compileTime": null,
     "dependenciesCount": 10000,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -392,6 +392,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
+    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -392,6 +392,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
+    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -834,6 +835,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "affectedHooks": undefined,
       "name": "ProgressPlugin",
     },
+    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -1160,6 +1162,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
+    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -1584,6 +1587,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
+    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1680,6 +1680,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "affectedHooks": "compilation",
         "name": "DefinePlugin",
       },
+      RsbuildProcessAssetsPlugin {},
     ],
     "resolve": {
       "alias": {
@@ -1996,6 +1997,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "affectedHooks": "compilation",
         "name": "DefinePlugin",
       },
+      RsbuildProcessAssetsPlugin {},
     ],
     "resolve": {
       "alias": {

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -427,6 +427,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
+    RsbuildProcessAssetsPlugin {},
     ReactRefreshRspackPlugin {
       "options": {
         "exclude": /node_modules/i,


### PR DESCRIPTION
## Summary

Use new processAssets api to handle SRI.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2966

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
