### PR TITLE
refactor: use unified Rspack plugin to attach to plugin hooks

### DIFF
--- a/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -115,6 +115,9 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
   {
     "module": {
@@ -225,6 +228,9 @@ exports[`plugin-swc > should apply multiple environment configs correctly 1`] = 
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;
@@ -343,6 +349,9 @@ exports[`plugin-swc > should apply source.include and source.exclude correctly 1
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -1160,6 +1169,9 @@ exports[`plugin-swc > should set swc-loader 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -1297,6 +1309,9 @@ exports[`plugin-swc > should use output config 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -274,6 +274,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "options": {},
     },
@@ -340,7 +341,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "process.env.NODE_ENV": ""development"",
       },
     },
-    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -668,6 +668,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
@@ -731,7 +732,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "process.env.NODE_ENV": ""production"",
       },
     },
-    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -1029,14 +1029,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
-    RsbuildTransformPlugin {},
+    RsbuildCorePlugin {},
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
         "process.env.NODE_ENV": ""production"",
       },
     },
-    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,
@@ -1317,13 +1316,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
         "process.env.NODE_ENV": ""production"",
       },
     },
-    RsbuildProcessAssetsPlugin {},
     ProgressPlugin {
       "compileTime": null,
       "dependenciesCount": 10000,

--- a/packages/compat/webpack/tests/__snapshots__/environment.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/environment.test.ts.snap
@@ -7,12 +7,18 @@ exports[`environment config > tools.webpack / bundlerChain can be used in enviro
     "output": {
       "filename": "[name].web.js",
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
   {
     "devtool": "eval",
     "output": {
       "filename": "bundle.js",
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -7,6 +7,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "foo": "2",
     },
   },
+  RsbuildCorePlugin {},
   HotModuleReplacementPlugin {
     "options": {},
   },
@@ -73,7 +74,6 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "process.env.NODE_ENV": ""test"",
     },
   },
-  RsbuildProcessAssetsPlugin {},
   ProgressPlugin {
     "compileTime": null,
     "dependenciesCount": 10000,
@@ -100,41 +100,62 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
 exports[`webpackConfig > should allow to use tools.webpackChain to modify config 1`] = `
 {
   "devtool": "eval",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
 {
   "devtool": "source-map",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
 {
   "devtool": "eval",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should allow tools.webpack to modify config object 1`] = `
 {
   "devtool": "eval-cheap-source-map",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
 {
   "devtool": "eval",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
 {
   "devtool": "source-map",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
 exports[`webpackConfig > should provide mergeConfig util in tools.webpack function 1`] = `
 {
   "devtool": "eval",
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/compat/webpack/tests/default.test.ts
+++ b/packages/compat/webpack/tests/default.test.ts
@@ -94,6 +94,9 @@ describe('bundlerApi', () => {
     expect(config).toMatchInlineSnapshot(`
       {
         "devtool": "hidden-source-map",
+        "plugins": [
+          RsbuildCorePlugin {},
+        ],
         "target": "node",
       }
     `);

--- a/packages/compat/webpack/tests/webpackConfig.test.ts
+++ b/packages/compat/webpack/tests/webpackConfig.test.ts
@@ -175,8 +175,7 @@ describe('webpackConfig', () => {
       plugins: [],
     });
 
-    const config = await rsbuild.unwrapConfig();
-    expect(config.plugins).toEqual([]);
+    expect(await rsbuild.matchBundlerPlugin('DefinePlugin')).toBeFalsy();
   });
 
   it('should allow to add rules', async () => {

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -114,6 +114,9 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -231,6 +234,9 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -348,6 +354,9 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -465,5 +474,8 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -23,6 +23,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -49,5 +50,8 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "performance": {
     "hints": false,
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -330,6 +330,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -392,7 +393,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
-    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {

--- a/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
+++ b/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
@@ -37,6 +38,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle analyze is enabled in environments 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
@@ -71,6 +73,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle an
 exports[`plugin-bundle-analyze > should enable bundle analyze plugin when performance.profile is enable 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -57,6 +57,9 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -123,6 +126,9 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -159,6 +165,9 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -225,5 +234,8 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -330,6 +330,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -392,7 +393,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
-    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -767,6 +767,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].[contenthash:8].css",
@@ -835,7 +836,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "affectedHooks": undefined,
       "name": "ProgressPlugin",
     },
-    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -1151,7 +1151,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
-    RsbuildTransformPlugin {},
+    RsbuildCorePlugin {},
     DefinePlugin {
       "_args": [
         {
@@ -1162,7 +1162,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
-    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {
@@ -1525,6 +1524,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     TestPlugin {
       "name": "TestPlugin",
     },
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -1587,7 +1587,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
-    RsbuildProcessAssetsPlugin {},
   ],
   "resolve": {
     "alias": {

--- a/packages/core/tests/__snapshots__/define.test.ts.snap
+++ b/packages/core/tests/__snapshots__/define.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-define > should register define plugin correctly 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     DefinePlugin {
       "_args": [
         {

--- a/packages/core/tests/__snapshots__/entry.test.ts.snap
+++ b/packages/core/tests/__snapshots__/entry.test.ts.snap
@@ -8,6 +8,9 @@ exports[`plugin-entry > should apply different environments entry config correct
         "src/index.client",
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
   {
     "entry": {
@@ -15,6 +18,9 @@ exports[`plugin-entry > should apply different environments entry config correct
         "src/index.ssr",
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;
@@ -27,6 +33,9 @@ exports[`plugin-entry > should apply environments entry config correctly 1`] = `
         "src/index.client",
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
   {
     "entry": {
@@ -34,6 +43,9 @@ exports[`plugin-entry > should apply environments entry config correctly 1`] = `
         "src/index.ssr",
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1660,6 +1660,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
       "hints": false,
     },
     "plugins": [
+      RsbuildCorePlugin {},
       HotModuleReplacementPlugin {
         "name": "HotModuleReplacementPlugin",
       },
@@ -1680,7 +1681,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "affectedHooks": "compilation",
         "name": "DefinePlugin",
       },
-      RsbuildProcessAssetsPlugin {},
     ],
     "resolve": {
       "alias": {
@@ -1986,7 +1986,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
       "hints": false,
     },
     "plugins": [
-      RsbuildTransformPlugin {},
+      RsbuildCorePlugin {},
       DefinePlugin {
         "_args": [
           {
@@ -1997,7 +1997,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "affectedHooks": "compilation",
         "name": "DefinePlugin",
       },
-      RsbuildProcessAssetsPlugin {},
     ],
     "resolve": {
       "alias": {

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -11,6 +11,7 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -126,6 +127,7 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -172,6 +174,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -226,6 +229,7 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -280,6 +284,7 @@ exports[`plugin-html > should enable minify in production 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -334,6 +339,7 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -388,6 +394,7 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -442,6 +449,7 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -497,6 +505,7 @@ exports[`plugin-html > should support environment html config 1`] = `
       ],
     },
     "plugins": [
+      RsbuildCorePlugin {},
       HtmlRspackPlugin {
         "options": {
           "base": false,
@@ -548,6 +557,7 @@ exports[`plugin-html > should support environment html config 1`] = `
       ],
     },
     "plugins": [
+      RsbuildCorePlugin {},
       HtmlRspackPlugin {
         "options": {
           "base": false,
@@ -606,6 +616,7 @@ exports[`plugin-html > should support multi entry 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,

--- a/packages/core/tests/__snapshots__/inlineChunk.test.ts.snap
+++ b/packages/core/tests/__snapshots__/inlineChunk.test.ts.snap
@@ -8,6 +8,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineScrip
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -74,6 +75,7 @@ exports[`plugin-inline-chunk > should use proper plugin options when inlineStyle
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HtmlRspackPlugin {
       "options": {
         "base": false,

--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -14,6 +14,7 @@ exports[`plugin-module-federation > should set environment module federation con
       "uniqueName": "remote",
     },
     "plugins": [
+      RsbuildCorePlugin {},
       ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -57,6 +58,9 @@ exports[`plugin-module-federation > should set environment module federation con
         "enforceSizeThreshold": 50000,
       },
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
   },
 ]
 `;
@@ -75,6 +79,7 @@ exports[`plugin-module-federation > should set module federation and environment
       "uniqueName": "remote",
     },
     "plugins": [
+      RsbuildCorePlugin {},
       ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -107,6 +112,7 @@ exports[`plugin-module-federation > should set module federation and environment
       "uniqueName": "remote",
     },
     "plugins": [
+      RsbuildCorePlugin {},
       ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -147,6 +153,7 @@ exports[`plugin-module-federation > should set module federation config 1`] = `
     "uniqueName": "remote",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     ModuleFederationPlugin {
       "_options": {
         "exposes": {

--- a/packages/core/tests/__snapshots__/nodeAddons.test.ts.snap
+++ b/packages/core/tests/__snapshots__/nodeAddons.test.ts.snap
@@ -19,7 +19,7 @@ exports[`plugin-node-addons > should add node addons rule properly 1`] = `
     ],
   },
   "plugins": [
-    RsbuildTransformPlugin {},
+    RsbuildCorePlugin {},
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -13,6 +13,9 @@ exports[`plugin-output > output config should works when target is node 1`] = `
     "pathinfo": false,
     "publicPath": "/",
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -29,6 +32,9 @@ exports[`plugin-output > should allow to custom server directory with distPath.r
     "pathinfo": false,
     "publicPath": "/",
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -43,6 +49,7 @@ exports[`plugin-output > should allow to set distPath.js and distPath.css to emp
     "publicPath": "/",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "async/[name].css",
@@ -65,6 +72,7 @@ exports[`plugin-output > should allow to use copy plugin 1`] = `
     "publicPath": "/",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CopyRspackPlugin {
       "_args": [
         {
@@ -100,6 +108,7 @@ exports[`plugin-output > should allow to use copy plugin with multiple config 1`
     "publicPath": "/",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CopyRspackPlugin {
       "_args": [
         {
@@ -137,6 +146,7 @@ exports[`plugin-output > should allow to use filename.js to modify filename 1`] 
     "publicPath": "/",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",
@@ -159,6 +169,7 @@ exports[`plugin-output > should set output correctly 1`] = `
     "publicPath": "/",
   },
   "plugins": [
+    RsbuildCorePlugin {},
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",

--- a/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
@@ -17,6 +17,9 @@ exports[`plugin-split-chunks > should allow forceSplitting to be an object 1`] =
       "enforceSizeThreshold": 50000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -25,6 +28,9 @@ exports[`plugin-split-chunks > should not split chunks when target is node 1`] =
   "optimization": {
     "splitChunks": false,
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -33,6 +39,9 @@ exports[`plugin-split-chunks > should set all-in-one config 1`] = `
   "optimization": {
     "splitChunks": false,
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -53,6 +62,9 @@ exports[`plugin-split-chunks > should set custom config 1`] = `
       "enforceSizeThreshold": 50000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -67,6 +79,9 @@ exports[`plugin-split-chunks > should set single-size config 1`] = `
       "minSize": 1000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -87,6 +102,9 @@ exports[`plugin-split-chunks > should set single-vendor config 1`] = `
       "enforceSizeThreshold": 50000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -115,6 +133,9 @@ exports[`plugin-split-chunks > should set split-by-experience config 1`] = `
       "enforceSizeThreshold": 50000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -138,6 +159,9 @@ exports[`plugin-split-chunks > should set split-by-experience config correctly w
       "enforceSizeThreshold": 50000,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -158,5 +182,8 @@ exports[`plugin-split-chunks > should set split-by-module config 1`] = `
       "minSize": 0,
     },
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -103,6 +103,9 @@ exports[`plugin-swc > should add antd pluginImport 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -209,6 +212,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -336,6 +342,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -828,6 +837,9 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -932,6 +944,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -1045,6 +1060,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -1169,6 +1187,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -1294,6 +1315,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -1418,6 +1442,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
@@ -1523,6 +1550,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
         },
       ],
     },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
     "resolve": {
       "alias": {
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",

--- a/packages/core/tests/__snapshots__/wasm.test.ts.snap
+++ b/packages/core/tests/__snapshots__/wasm.test.ts.snap
@@ -20,5 +20,8 @@ exports[`plugin-wasm > should add wasm rule properly 1`] = `
   "output": {
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -103,6 +103,9 @@ describe('bundlerApi', () => {
     expect(bundlerConfigs[0]).toMatchInlineSnapshot(`
       {
         "devtool": "hidden-source-map",
+        "plugins": [
+          RsbuildCorePlugin {},
+        ],
         "target": "node",
       }
     `);
@@ -143,6 +146,9 @@ describe('bundlerApi', () => {
             },
           ],
         },
+        "plugins": [
+          RsbuildCorePlugin {},
+        ],
       }
     `);
   });
@@ -182,6 +188,9 @@ describe('bundlerApi', () => {
             },
           ],
         },
+        "plugins": [
+          RsbuildCorePlugin {},
+        ],
       }
     `);
   });

--- a/packages/core/tests/entry.test.ts
+++ b/packages/core/tests/entry.test.ts
@@ -10,9 +10,7 @@ describe('plugin-entry', () => {
       },
       preEntry: [],
       expected: {
-        entry: {
-          main: ['./src/main.ts'],
-        },
+        main: ['./src/main.ts'],
       },
     },
     {
@@ -23,10 +21,8 @@ describe('plugin-entry', () => {
       },
       preEntry: [],
       expected: {
-        entry: {
-          bar: ['./src/polyfill.ts', './src/bar.ts'],
-          foo: ['./src/polyfill.ts', './src/foo.ts'],
-        },
+        bar: ['./src/polyfill.ts', './src/bar.ts'],
+        foo: ['./src/polyfill.ts', './src/foo.ts'],
       },
     },
     {
@@ -37,10 +33,8 @@ describe('plugin-entry', () => {
       },
       preEntry: ['./src/pre-entry.ts'],
       expected: {
-        entry: {
-          bar: ['./src/pre-entry.ts', './src/bar.ts'],
-          foo: ['./src/pre-entry.ts', './src/polyfill.ts', './src/foo.ts'],
-        },
+        bar: ['./src/pre-entry.ts', './src/bar.ts'],
+        foo: ['./src/pre-entry.ts', './src/polyfill.ts', './src/foo.ts'],
       },
     },
   ];
@@ -58,7 +52,7 @@ describe('plugin-entry', () => {
 
     const config = await rsbuild.unwrapConfig();
 
-    expect(config).toEqual(item.expected);
+    expect(config.entry).toEqual(item.expected);
   });
 
   it('should apply environments entry config correctly', async () => {

--- a/packages/core/tests/target.test.ts
+++ b/packages/core/tests/target.test.ts
@@ -6,20 +6,20 @@ describe('plugin-target', () => {
     {
       target: 'node' as const,
       browserslist: ['Chrome 100'],
-      expected: { target: 'node' },
+      expected: 'node',
     },
     {
       browserslist: ['Chrome 100'],
-      expected: { target: ['web', 'es2018'] },
+      expected: ['web', 'es2018'],
     },
     {
       browserslist: null,
-      expected: { target: ['web', 'es2017'] },
+      expected: ['web', 'es2017'],
     },
     {
       target: 'web-worker' as const,
       browserslist: null,
-      expected: { target: ['webworker', 'es2017'] },
+      expected: ['webworker', 'es2017'],
     },
   ];
 
@@ -36,6 +36,6 @@ describe('plugin-target', () => {
 
     const config = await rsbuild.unwrapConfig();
 
-    expect(config).toEqual(item.expected);
+    expect(config.target).toEqual(item.expected);
   });
 });

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-assets-retry > should accept user custom options 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     AssetsRetryPlugin {
       "HtmlPlugin": [Function],
       "distDir": "static/js",
@@ -57,6 +58,7 @@ exports[`plugin-assets-retry > should accept user custom options 1`] = `
 exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     AssetsRetryPlugin {
       "HtmlPlugin": [Function],
       "distDir": "static/js",
@@ -78,4 +80,10 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
 }
 `;
 
-exports[`plugin-assets-retry > should't add assets retry plugin when target is set to 'node' 1`] = `{}`;
+exports[`plugin-assets-retry > should't add assets retry plugin when target is set to 'node' 1`] = `
+{
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
+}
+`;

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -284,6 +284,9 @@ exports[`plugins/babel > should set babel-loader 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -337,5 +340,8 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/plugin-check-syntax/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-check-syntax/tests/__snapshots__/index.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-check-syntax > should add check-syntax plugin properly 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     CheckSyntaxPlugin {
       "ecmaVersion": 2017,
       "errors": [],
@@ -19,11 +20,18 @@ exports[`plugin-check-syntax > should add check-syntax plugin properly 1`] = `
 }
 `;
 
-exports[`plugin-check-syntax > should not add check-syntax plugin when target node 1`] = `{}`;
+exports[`plugin-check-syntax > should not add check-syntax plugin when target node 1`] = `
+{
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
+}
+`;
 
 exports[`plugin-check-syntax > should use default browserslist as targets when only set checkSyntax.exclude 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     CheckSyntaxPlugin {
       "ecmaVersion": 5,
       "errors": [],

--- a/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
@@ -1,6 +1,12 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugins/lightningcss > plugin-lightningcss should be cancelable by users with false options 1`] = `{}`;
+exports[`plugins/lightningcss > plugin-lightningcss should be cancelable by users with false options 1`] = `
+{
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
+}
+`;
 
 exports[`plugins/lightningcss > plugin-lightningcss should be configurable by users 1`] = `
 [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -365,6 +365,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "hints": false,
   },
   "plugins": [
+    RsbuildCorePlugin {},
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -427,7 +428,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "affectedHooks": "compilation",
       "name": "DefinePlugin",
     },
-    RsbuildProcessAssetsPlugin {},
     ReactRefreshRspackPlugin {
       "options": {
         "exclude": /node_modules/i,

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -45,6 +45,9 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",
@@ -95,6 +98,9 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",
@@ -145,6 +151,9 @@ exports[`plugin-solid > should apply solid preset correctly in rspack mode 1`] =
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "solid-refresh": "<ROOT>/node_modules/<PNPM_INNER>/solid-refresh/dist/solid-refresh.mjs",

--- a/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-source-build/tests/__snapshots__/index.test.ts.snap
@@ -49,6 +49,9 @@ exports[`plugin-source-build > should allow to set resolve priority 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "tsConfig": {
       "configFile": "<ROOT>/packages/plugin-source-build/tests/tsconfig.json",

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -26,6 +26,9 @@ exports[`plugin-svelte > should add svelte loader properly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",
@@ -72,6 +75,9 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",
@@ -122,6 +128,9 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",
@@ -172,6 +181,9 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",
@@ -222,6 +234,9 @@ exports[`plugin-svelte > should turn off hmr by hand correctly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
   "resolve": {
     "alias": {
       "svelte": "<ROOT>/node_modules/<PNPM_INNER>/svelte/src/runtime",

--- a/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-type-check/tests/__snapshots__/index.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-plugin options 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     ForkTsCheckerWebpackPlugin {
       "options": {
         "issue": {
@@ -33,6 +34,7 @@ exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-p
 exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-plugin options via function 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     ForkTsCheckerWebpackPlugin {
       "options": {
         "async": false,
@@ -61,6 +63,7 @@ exports[`plugin-type-check > should allow to configure fork-ts-checker-webpack-p
 exports[`plugin-type-check > should apply fork-ts-checker-webpack-plugin correctly 1`] = `
 {
   "plugins": [
+    RsbuildCorePlugin {},
     ForkTsCheckerWebpackPlugin {
       "options": {
         "issue": {

--- a/packages/plugin-type-check/tests/index.test.ts
+++ b/packages/plugin-type-check/tests/index.test.ts
@@ -75,11 +75,11 @@ describe('plugin-type-check', () => {
     });
 
     expect(
-      await rsbuild.matchBundlerPlugin('ForkTsCheckerWebpackPlugin'),
+      await rsbuild.matchBundlerPlugin('ForkTsCheckerWebpackPlugin', 0),
     ).toBeTruthy();
-
-    const configs = await rsbuild.initConfigs();
-    expect(configs[1].plugins).toBeFalsy();
+    expect(
+      await rsbuild.matchBundlerPlugin('ForkTsCheckerWebpackPlugin', 1),
+    ).toBeFalsy();
   });
 
   it('should disable type checker when enable is false', async () => {

--- a/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue-jsx/tests/__snapshots__/index.test.ts.snap
@@ -48,6 +48,9 @@ exports[`plugin-vue-jsx > should allow to configure jsx babel plugin options 1`]
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -97,6 +100,9 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -146,5 +152,8 @@ exports[`plugin-vue-jsx > should apply jsx babel plugin correctly in rspack mode
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -24,6 +24,7 @@ exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 1`] = 
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     Plugin {},
   ],
   "resolve": {
@@ -59,6 +60,7 @@ exports[`plugin-vue > should allow to configure vueLoader options 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     Plugin {},
   ],
   "resolve": {

--- a/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2-jsx/tests/__snapshots__/index.test.ts.snap
@@ -45,6 +45,9 @@ exports[`plugin-vue2-jsx > should allow to configure jsx babel plugin options 1`
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;
 
@@ -93,5 +96,8 @@ exports[`plugin-vue2-jsx > should apply jsx babel plugin correctly 1`] = `
       },
     ],
   },
+  "plugins": [
+    RsbuildCorePlugin {},
+  ],
 }
 `;

--- a/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue2/tests/__snapshots__/index.test.ts.snap
@@ -24,6 +24,7 @@ exports[`plugin-vue2 > should add vue-loader and VueLoaderPlugin correctly 1`] =
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     VueLoaderPlugin {},
     VueLoader15PitchFixPlugin {
       "name": "VueLoader15PitchFixPlugin",
@@ -65,6 +66,7 @@ exports[`plugin-vue2 > should allow to configure vueLoader options 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     VueLoaderPlugin {},
     VueLoader15PitchFixPlugin {
       "name": "VueLoader15PitchFixPlugin",
@@ -121,6 +123,7 @@ exports[`plugin-vue2 > should include polyfill resolve config 1`] = `
     ],
   },
   "plugins": [
+    RsbuildCorePlugin {},
     VueLoaderPlugin {},
     VueLoader15PitchFixPlugin {
       "name": "VueLoader15PitchFixPlugin",

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -59,14 +59,14 @@ export async function createStubRsbuild({
     rsbuild.addPlugins(await Promise.all(plugins));
   }
 
-  const unwrapConfig = async () => {
+  const unwrapConfig = async (index = 0) => {
     const configs = await rsbuild.initConfigs();
-    return configs[0];
+    return configs[index];
   };
 
   /** Match rspack/webpack plugin by constructor name. */
-  const matchBundlerPlugin = async (pluginName: string) => {
-    const config = await unwrapConfig();
+  const matchBundlerPlugin = async (pluginName: string, index?: number) => {
+    const config = await unwrapConfig(index);
 
     return matchPlugin(config, pluginName) as BundlerPluginInstance;
   };


### PR DESCRIPTION
## Summary

Use one unified Rspack plugin to attach to plugin hooks, such as `api.transform()` and `api.processAssets()`.

With this, we do not need to register multiple Rspack plugins if `api.processAssets()` is called multiple times.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
