### PR TITLE
fix: exclude method options when checking `[hash].hot-update.json`

### DIFF
--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -136,7 +136,7 @@ const applyDefaultMiddlewares = async ({
 
     middlewares.push((req, res, next) => {
       // [prevFullHash].hot-update.json will 404 (expected) when rsbuild restart and some file changed
-      if (req.url?.endsWith('.hot-update.json')) {
+      if (req.url?.endsWith('.hot-update.json') && req.method !== 'OPTIONS') {
         res.statusCode = 404;
         res.end();
       } else {


### PR DESCRIPTION
## Summary

Addressed an issue causing HTTP 404 errors for `[hash].hot-update.json` files when using the `OPTIONS` method, leading to CORS problems.

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
