### PR TITLE
release: 1.0.1-beta.4

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-lightningcss/package.json
+++ b/packages/plugin-lightningcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-lightningcss",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "lightningcss for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.3",
+  "version": "1.0.1-beta.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: add new plugin API to process assets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2966
* feat: allow to process assets for specific target by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2967
* feat: allow to access environment context in transform API by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2968
* feat: allow to access environment context in process assets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2970
* feat: allow to access compiler in modifyHTMLTags hook by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2975
### Bug Fixes 🐞
* fix: exclude method options when checking `[hash].hot-update.json` by @huuduy005 in https://github.com/web-infra-dev/rsbuild/pull/2977
* fix(plugin-svgr): dedupe SVGO plugins config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2984
### Document 📖
* docs: fix `tools.htmlPlugin` default options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2952
* docs: fix output.externals type by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/2955
* docs: add tool stack to homepage by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2958
* docs: use Rspress i18n API by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2963
* docs: fix Vue JSX example by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2965
* docs: move environment context to separate page by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2969
### Other Changes
* chore(deps): update dependency nx to ^19.5.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2961
* chore(deps): update dependency eslint-plugin-svelte to ^2.43.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2960
* refactor: use new processAssets api to handle SRI by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2971
* refactor: use unified Rspack plugin to attach to plugin hooks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2972
* refactor(plugin-rem): use new processAssets api by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2973
* refactor: implement appIcon via Rsbuild plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2974
* refactor: implement inline chunks via Rsbuild plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2976
* chore(deps): update dependency @modern-js/module-tools to ^2.56.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2980
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2979

## New Contributors
* @huuduy005 made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/2977

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.3...v1.0.1-beta.4