### PR TITLE
feat: add sources param to api.processAssets

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -156,6 +156,8 @@ export function getPluginAPI({
         });
 
         compiler.hooks.compilation.tap(pluginName, (compilation) => {
+          const { sources } = compiler.webpack;
+
           for (const { descriptor, handler } of processAssetsFns) {
             // filter by targets
             if (descriptor.targets && !descriptor.targets.includes(target)) {
@@ -173,6 +175,7 @@ export function getPluginAPI({
                   compiler,
                   compilation,
                   environment,
+                  sources,
                 }),
             );
           }

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -44,7 +44,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
 
     api.processAssets(
       { stage: 'additional' },
-      async ({ compiler, compilation, environment }) => {
+      async ({ compilation, environment, sources }) => {
         const iconPath = getIconPath(environment);
         if (!iconPath) {
           return;
@@ -60,7 +60,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
 
         compilation.emitAsset(
           iconPath.relativePath,
-          new compiler.webpack.sources.RawSource(source, false),
+          new sources.RawSource(source),
         );
       },
     );

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -150,7 +150,7 @@ export const pluginSri = (): RsbuildPlugin => ({
         // use to final stage to get the final asset content
         stage: 'report',
       },
-      ({ assets, compiler, environment }) => {
+      ({ assets, sources, environment }) => {
         const { htmlPaths } = environment;
 
         if (Object.keys(htmlPaths).length === 0) {
@@ -174,7 +174,7 @@ export const pluginSri = (): RsbuildPlugin => ({
             continue;
           }
 
-          assets[asset] = new compiler.webpack.sources.RawSource(
+          assets[asset] = new sources.RawSource(
             replaceIntegrity(htmlContent, assets, algorithm, integrityCache),
           );
         }

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -273,6 +273,20 @@ export type ProcessAssetsDescriptor = {
   targets?: RsbuildTarget[];
 };
 
+export type RspackSources = Pick<
+  typeof Rspack.sources,
+  | 'Source'
+  | 'RawSource'
+  | 'OriginalSource'
+  | 'SourceMapSource'
+  | 'CachedSource'
+  | 'ConcatSource'
+  | 'ReplaceSource'
+  | 'PrefixSource'
+  | 'SizeOnlySource'
+  | 'CompatSource'
+>;
+
 export type ProcessAssetsHandler = (context: {
   assets: Record<string, Rspack.sources.Source>;
   compiler: Rspack.Compiler;
@@ -281,6 +295,10 @@ export type ProcessAssetsHandler = (context: {
    * The environment context for current build.
    */
   environment: EnvironmentContext;
+  /**
+   * Contains multiple classes which represent an Rspack `Source`.
+   */
+  sources: RspackSources;
 }) => Promise<void> | void;
 
 export type ProcessAssetsFn = (

--- a/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AssetsRetryPlugin.ts
@@ -84,7 +84,7 @@ export class AssetsRetryPlugin implements Rspack.RspackPluginInstance {
               const code = await this.getRetryCode();
               compilation.emitAsset(
                 scriptPath,
-                new compiler.webpack.sources.RawSource(code, false),
+                new compiler.webpack.sources.RawSource(code),
               );
             },
           );

--- a/packages/plugin-rem/src/index.ts
+++ b/packages/plugin-rem/src/index.ts
@@ -74,7 +74,7 @@ export const pluginRem = (
 
     api.processAssets(
       { stage: 'additional' },
-      async ({ compiler, compilation, environment }) => {
+      async ({ compilation, environment, sources }) => {
         const { config } = environment;
 
         if (
@@ -87,10 +87,7 @@ export const pluginRem = (
 
         const code = await getRuntimeCode();
         const scriptPath = getScriptPath(config.output.distPath.js);
-        compilation.emitAsset(
-          scriptPath,
-          new compiler.webpack.sources.RawSource(code, false),
-        );
+        compilation.emitAsset(scriptPath, new sources.RawSource(code));
       },
     );
 


### PR DESCRIPTION
## Summary

Ad sources param to `api.processAssets`, this is a shorthand for `compiler.webpack.sources.RawSource`.

## Related Links

https://github.com/webpack/webpack-sources

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
