### PR TITLE
docs: correct onAfterCreateCompiler example

### DIFF
--- a/website/docs/en/plugins/dev/index.mdx
+++ b/website/docs/en/plugins/dev/index.mdx
@@ -224,7 +224,7 @@ The Rsbuild plugin can modify the configuration of Rspack in various ways.
 
 - `api.modifyRspackConfig(config => {})` modifies the final Rspack configuration.
 - `api.modifyBundlerChain(chain => {})` modifies the `rspack-chain`, usage is similar to [rspack-chain](https://github.com/rspack-contrib/rspack-chain).
-- `api.onAfterCreateCompiler(compiler => {})` directly operates on the Rspack compiler instance.
+- `api.onAfterCreateCompiler({ compiler } => {})` directly operates on the Rspack compiler instance.
 
 ## Example References
 

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -223,7 +223,7 @@ Rsbuild 插件可以通过多种方式修改 Rspack 的配置项。
 
 - `api.modifyRspackConfig(config => {})` 修改最终的 Rspack 配置。
 - `api.modifyBundlerChain(chain => {})` 修改 `rspack-chain`，用法与 [rspack-chain](https://github.com/rspack-contrib/rspack-chain) 相同。
-- `api.onAfterCreateCompiler(compiler => {})` 直接操作 Rspack 的 compiler 实例。
+- `api.onAfterCreateCompiler({ compiler } => {})` 直接操作 Rspack 的 compiler 实例。
 
 ## 参考范例
 


### PR DESCRIPTION
## Summary

correct `onAfterCreateCompiler` example in 'Modifying Rspack Configuration' chapter.

<img width="668" alt="image" src="https://github.com/user-attachments/assets/a7bd0687-ee38-4ceb-97d3-f62e85905a3d">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
