### PR TITLE
fix: only listen to process exit when onExit hook is used

### DIFF
--- a/e2e/cases/cli/vue/rsbuild.config.mjs
+++ b/e2e/cases/cli/vue/rsbuild.config.mjs
@@ -1,6 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
-module.exports = defineConfig({
+export default defineConfig({
   plugins: [pluginVue()],
 });

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -252,9 +252,17 @@ export function initPluginAPI({
       processAssetsFns.push({ environment, descriptor, handler });
     };
 
-  process.on('exit', () => {
-    hooks.onExit.call();
-  });
+  let onExitListened = false;
+
+  const onExit: typeof hooks.onExit.tap = (cb) => {
+    if (!onExitListened) {
+      process.on('exit', () => {
+        hooks.onExit.call();
+      });
+      onExitListened = true;
+    }
+    hooks.onExit.tap(cb);
+  };
 
   // Each plugin returns different APIs depending on the registered environment info.
   return (environment?: string) => ({
@@ -268,7 +276,7 @@ export function initPluginAPI({
     isPluginExists: pluginManager.isPluginExists,
 
     // Hooks
-    onExit: hooks.onExit.tap,
+    onExit,
     onAfterBuild: hooks.onAfterBuild.tap,
     onBeforeBuild: hooks.onBeforeBuild.tap,
     onCloseDevServer: hooks.onCloseDevServer.tap,


### PR DESCRIPTION
## Summary

Only listen to process exit event when the `onExit` hook is used, fix the following warning when creating many Rsbuild instances:

<img width="1302" alt="截屏2024-07-21 09 58 04" src="https://github.com/user-attachments/assets/9a319268-5495-4571-9f5d-df9d45b540f8">

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
