### PR TITLE
test: add e2e case for onExit hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -1,0 +1,18 @@
+import { exec } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+const distFile = path.join(__dirname, 'node_modules/hooksTempFile');
+
+rspackOnlyTest('should run onExit hook before process exit', async () => {
+  fs.rmSync(distFile, { force: true });
+
+  await new Promise<void>((resolve) => {
+    exec('node ./run.mjs', { cwd: __dirname }, () => {
+      expect(fs.readFileSync(distFile, 'utf-8')).toEqual('1');
+      resolve();
+    });
+  });
+});

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
@@ -1,0 +1,40 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRsbuild } from '@rsbuild/core';
+import fse from 'fs-extra';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distFile = path.join(__dirname, 'node_modules/hooksTempFile');
+
+const write = (str) => {
+  let content;
+  if (fs.existsSync(distFile)) {
+    content = `${fs.readFileSync(distFile, 'utf-8')},${str}`;
+  } else {
+    content = str;
+  }
+  fse.outputFileSync(distFile, content);
+};
+
+const plugin = {
+  name: 'test-plugin',
+  setup(api) {
+    api.onExit(() => {
+      write('1');
+    });
+  },
+};
+
+async function main() {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [plugin],
+    },
+  });
+
+  await rsbuild.build();
+}
+
+await main();

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/src/index.js
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');


### PR DESCRIPTION
## Summary

Add e2e case for the `onExit` hook.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/2998

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
