### PR TITLE
fix: css-loader type declaration is outdated

### DIFF
--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -131,7 +131,7 @@ export interface CSSLoaderModulesOptions {
   /**
    * Enables a callback to output the CSS modules mapping JSON.
    */
-  getJSON: (context: {
+  getJSON?: (context: {
     resourcePath: string;
     imports: object[];
     exports: object[];

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -128,6 +128,15 @@ export interface CSSLoaderModulesOptions {
    * Enables/disables ES modules named export for locals.
    */
   namedExport?: boolean;
+  /**
+   * Enables a callback to output the CSS modules mapping JSON.
+   */
+  getJSON: (context: {
+    resourcePath: string;
+    imports: object[];
+    exports: object[];
+    replacements: object[];
+  }) => Promise<void> | void;
 }
 
 export interface CSSLoaderOptions {
@@ -137,7 +146,11 @@ export interface CSSLoaderOptions {
    *
    * @default true
    */
-  url?: boolean | ((url: string, resourcePath: string) => boolean);
+  url?:
+    | boolean
+    | {
+        filter: (url: string, resourcePath: string) => boolean;
+      };
   /**
    * Allows to enables/disables @import at-rules handling.
    *
@@ -145,7 +158,15 @@ export interface CSSLoaderOptions {
    */
   import?:
     | boolean
-    | ((url: string, media: string, resourcePath: string) => boolean);
+    | {
+        filter: (
+          url: string,
+          media: string,
+          resourcePath: string,
+          supports?: string,
+          layer?: string,
+        ) => boolean;
+      };
   /**
    * Allows to enable/disable CSS Modules or ICSS and setup configuration:
    */


### PR DESCRIPTION
## Summary

Fix css-loader type declaration is outdated.

## Related Links

- https://github.com/webpack-contrib/css-loader/releases/tag/v6.0.0
- https://github.com/webpack-contrib/css-loader?tab=readme-ov-file

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
