### PR TITLE
feat: add environments as a filter of `api.processAssets`

### DIFF
--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
@@ -1,0 +1,16 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow plugin to process assets by environments',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+
+    expect(existsSync(join(rsbuild.distPath, 'static/index.js'))).toBeFalsy();
+    expect(existsSync(join(rsbuild.distPath, 'server/index.js'))).toBeTruthy();
+  },
+);

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/myPlugin.ts
@@ -1,0 +1,17 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.processAssets(
+      { stage: 'summarize', environments: ['web'] },
+      ({ assets, compilation }) => {
+        for (const key of Object.keys(assets)) {
+          if (key.endsWith('.js')) {
+            compilation.deleteAsset(key);
+          }
+        }
+      },
+    );
+  },
+};

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/rsbuild.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@rsbuild/core';
+import { myPlugin } from './myPlugin';
+
+export default defineConfig({
+  plugins: [myPlugin],
+  environments: {
+    web: {
+      output: {
+        target: 'web',
+        filenameHash: false,
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/src/index.css
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/src/index.js
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+console.log('hello');

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -163,17 +163,20 @@ export function initPluginAPI({
           for (const {
             descriptor,
             handler,
-            environment: metaEnvironment,
+            environment: pluginEnvironment,
           } of processAssetsFns) {
             // filter by targets
             if (descriptor.targets && !descriptor.targets.includes(target)) {
               return;
             }
 
-            // filter by environment
+            // filter by environments
             if (
-              metaEnvironment &&
-              !isPluginMatchEnvironment(metaEnvironment, environment.name)
+              (descriptor.environments &&
+                !descriptor.environments.includes(environment.name)) ||
+              // the plugin is registered in a specific environment config
+              (pluginEnvironment &&
+                !isPluginMatchEnvironment(pluginEnvironment, environment.name))
             ) {
               return;
             }

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -56,11 +56,11 @@ function validatePlugin(plugin: unknown) {
 export const RSBUILD_ALL_ENVIRONMENT_SYMBOL = 'RSBUILD_ALL_ENVIRONMENT_SYMBOL';
 
 export const isPluginMatchEnvironment = (
-  metaEnvironment: string,
+  pluginEnvironment: string,
   currentEnvironment: string,
 ): boolean =>
-  metaEnvironment === currentEnvironment ||
-  metaEnvironment === RSBUILD_ALL_ENVIRONMENT_SYMBOL;
+  pluginEnvironment === currentEnvironment ||
+  pluginEnvironment === RSBUILD_ALL_ENVIRONMENT_SYMBOL;
 
 export function createPluginManager(): PluginManager {
   let plugins: PluginMeta[] = [];

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -330,6 +330,11 @@ export type ProcessAssetsDescriptor = {
    * @see https://rsbuild.dev/config/output/targets
    */
   targets?: RsbuildTarget[];
+  /**
+   * Match based on the Rsbuild environment names and only process the assets of certain environments.
+   * @see https://rsbuild.dev/config/environments
+   */
+  environments?: string[];
 };
 
 export type RspackSources = Pick<

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -396,6 +396,7 @@ The descriptor parameter is an object to describes the stage and matching condit
 type ProcessAssetsDescriptor = {
   stage: ProcessAssetsStage;
   targets?: RsbuildTarget[];
+  environments?: string[];
 };
 ```
 
@@ -415,6 +416,17 @@ api.processAssets({ stage: 'additional' }, ({ assets }) => {
 api.processAssets({ stage: 'additional', targets: ['web'] }, ({ assets }) => {
   // ...
 });
+```
+
+- `environments`: matches the Rsbuild [environment](/guide/advanced/environments) name, and applies the current processAssets function only to the matched environments.
+
+```js
+api.processAssets(
+  { stage: 'additional', environments: ['web'] },
+  ({ assets }) => {
+    // ...
+  },
+);
 ```
 
 ### Handler Param

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -394,6 +394,7 @@ descriptor 参数是一个对象，用于描述 processAssets 触发的 stage �
 type ProcessAssetsDescriptor = {
   stage: ProcessAssetsStage;
   targets?: RsbuildTarget[];
+  environments?: string[];
 };
 ```
 
@@ -413,6 +414,17 @@ api.processAssets({ stage: 'additional' }, ({ assets }) => {
 api.processAssets({ stage: 'additional', targets: ['web'] }, ({ assets }) => {
   // ...
 });
+```
+
+- `environments`：匹配 Rsbuild [environment](/guide/advanced/environments) name，仅对匹配的 environments 应用当前 processAssets 函数。
+
+```js
+api.processAssets(
+  { stage: 'additional', environments: ['web'] },
+  ({ assets }) => {
+    // ...
+  },
+);
 ```
 
 ### handler 参数


### PR DESCRIPTION
## Summary

Add environments as a filter of `api.processAssets`, example:

```js
export const myPlugin: RsbuildPlugin = {
  name: 'my-plugin',
  setup(api) {
    api.processAssets(
      { stage: 'summarize', environments: ['web'] },
      ({ assets, compilation }) => {
        for (const key of Object.keys(assets)) {
          if (key.endsWith('.js')) {
            compilation.deleteAsset(key);
          }
        }
      },
    );
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
