### PR TITLE
test(e2e): enable test case for browserslist extends

### DIFF
--- a/e2e/cases/browserslist/extends-browserslist/index.test.ts
+++ b/e2e/cases/browserslist/extends-browserslist/index.test.ts
@@ -1,8 +1,10 @@
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-// TODO Rspack does not supports extends browserslist yet
-test.fail('extends browserslist and downgrade the syntax', async () => {
+test('extends browserslist and downgrade the syntax', async () => {
+  const originalCwd = process.cwd();
+  process.chdir(__dirname);
+
   const rsbuild = await build({
     cwd: __dirname,
   });
@@ -13,4 +15,6 @@ test.fail('extends browserslist and downgrade the syntax', async () => {
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];
 
   expect(indexFile.includes('async ')).toBeFalsy();
+
+  process.chdir(originalCwd);
 });


### PR DESCRIPTION
## Summary

Enable the e2e test case for browserslist extends.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2443

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
