### PR TITLE
chore: use Node.js built-in isRegExp util

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -546,9 +546,6 @@ export const isURL = (str: string): boolean =>
 export const createVirtualModule = (content: string) =>
   `data:text/javascript,${content}`;
 
-export const isRegExp = (obj: any): obj is RegExp =>
-  Object.prototype.toString.call(obj) === '[object RegExp]';
-
 export function isWebTarget(target: RsbuildTarget | RsbuildTarget[]): boolean {
   const targets = castArray(target);
   return targets.includes('web') || target.includes('web-worker');

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { isRegExp } from 'node:util/types';
 import { CSS_REGEX, JS_REGEX } from '../constants';
 import {
   addTrailingSlash,
@@ -240,10 +241,7 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
         if (inlineScripts) {
           if (inlineScripts === true) {
             scriptTests.push(JS_REGEX);
-          } else if (
-            inlineScripts instanceof RegExp ||
-            inlineScripts instanceof Function
-          ) {
+          } else if (isRegExp(inlineScripts) || isFunction(inlineScripts)) {
             scriptTests.push(inlineScripts);
           } else {
             const enable =
@@ -257,10 +255,7 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
         if (inlineStyles) {
           if (inlineStyles === true) {
             styleTests.push(CSS_REGEX);
-          } else if (
-            inlineStyles instanceof RegExp ||
-            inlineStyles instanceof Function
-          ) {
+          } else if (isRegExp(inlineStyles) || isFunction(inlineStyles)) {
             styleTests.push(inlineStyles);
           } else {
             const enable =


### PR DESCRIPTION
## Summary

Use Node.js built-in isRegExp util.

## Related Links

https://nodejs.org/api/util.html#utiltypesisregexpvalue

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
