### PR TITLE
docs: update Rstack repo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ To get started with Rsbuild, see the [Quick Start](https://rsbuild.dev/guide/sta
 - [rspack-examples](https://github.com/rspack-contrib/rspack-examples): Examples for Rspack, Rsbuild, Rspress and Rsdoctor.
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：Use this template to create your own Rsbuild plugin.
-- [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources)：Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.
+- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.
 
 ## 🤝 Contribution
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -82,7 +82,7 @@ Rsbuild 具备以下特性：
 - [rspack-examples](https://github.com/rspack-contrib/rspack-examples)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的示例项目。
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
-- [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。
+- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。
 
 ## 🤝 参与贡献
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1367,6 +1367,9 @@ importers:
       '@rspress/plugin-rss':
         specifier: 1.26.2
         version: 1.26.2(react@18.3.1)(rspress@1.26.2(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))))
+      '@rstack-dev/doc-ui':
+        specifier: ^1.1.2
+        version: 1.1.2(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: 18.x
         version: 18.19.31
@@ -1391,9 +1394,6 @@ importers:
       rsbuild-plugin-open-graph:
         specifier: 1.0.1
         version: 1.0.1(@rsbuild/core@packages+core)
-      rsfamily-doc-ui:
-        specifier: ^1.1.2
-        version: 1.1.2(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rspress:
         specifier: 1.26.2
         version: 1.26.2(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
@@ -3067,6 +3067,9 @@ packages:
   '@rspress/theme-default@1.26.2':
     resolution: {integrity: sha512-NpVo2zPwYuIML5ka1S7jbktTWXOQmagvtujtzPFIPxaEmYdVRu+6mNSxmBzXnby9zjlpwntz4JYzOjF69mE06Q==}
     engines: {node: '>=14.17.6'}
+
+  '@rstack-dev/doc-ui@1.1.2':
+    resolution: {integrity: sha512-R2iQBsfdtvLfiFMWpkrsigDKvlu1PizZ9YmLVyF4J9H2nZOTJSSYroTg33Ae6rfbpbTRAKpL1qZ36Kml1SwXZA==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -6485,9 +6488,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsfamily-doc-ui@1.1.2:
-    resolution: {integrity: sha512-6GHgf1zg50HwjVDFUNMfT2TM4fa8BtoTDGJCCReJu6MPfrvJKqb221XaPS4XAVwv9wc1V5UpCg56e48kPruCCg==}
-
   rslog@1.2.2:
     resolution: {integrity: sha512-tZP8KjrI1nz6qOYCrFxAV7cfmfS2GV94jotU2zOmF/6ByO1zNvGR6/+0inylpjqyBjAdnnutTUW0m4th06bSTw==}
     engines: {node: '>=14.17.6'}
@@ -9565,6 +9565,14 @@ snapshots:
       react-syntax-highlighter: 15.5.0(react@18.3.1)
       react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rspack-plugin-virtual-module: 0.1.12
+
+  '@rstack-dev/doc-ui@1.1.2(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      framer-motion: 11.3.4(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@emotion/is-prop-valid'
+      - react
+      - react-dom
 
   '@selderee/plugin-htmlparser2@0.11.0':
     dependencies:
@@ -13428,14 +13436,6 @@ snapshots:
   rsbuild-plugin-open-graph@1.0.1(@rsbuild/core@packages+core):
     optionalDependencies:
       '@rsbuild/core': link:packages/core
-
-  rsfamily-doc-ui@1.1.2(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      framer-motion: 11.3.4(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-    transitivePeerDependencies:
-      - '@emotion/is-prop-valid'
-      - react
-      - react-dom
 
   rslog@1.2.2: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -87,6 +87,7 @@ rsfamily
 rslog
 rspack
 rspress
+rstack
 selfsign
 selfsigned
 sirv

--- a/website/README.md
+++ b/website/README.md
@@ -8,6 +8,6 @@ Currently Rsbuild provides documentation in English and Chinese. If you can use 
 
 ### Image Assets
 
-For images you use in the document, it's better to upload them to the [rspack-contrib/rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources) repository, so the size of the current repository doesn't get too big.
+For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
 After you upload the images there, they will be automatically deployed under the <https://assets.rspack.dev/>.

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -66,7 +66,7 @@ The following diagram illustrates the relationship between Rsbuild and other too
 - [rspack-examples](https://github.com/rspack-contrib/rspack-examples): Examples for Rspack, Rsbuild, Rspress and Rsdoctor.
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
-- [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources): Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.
+- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.
 
 ## 🧑‍💻 Community
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -66,7 +66,7 @@ Rsbuild 具备以下特性：
 - [rspack-examples](https://github.com/rspack-contrib/rspack-examples)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的示例项目。
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
-- [rsfamily-design-resources](https://github.com/rspack-contrib/rsfamily-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。
+- [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。
 
 ## 🧑‍💻 社区
 

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,7 @@
     "react-dom": "^18.3.1",
     "rsbuild-plugin-google-analytics": "1.0.1",
     "rsbuild-plugin-open-graph": "1.0.1",
-    "rsfamily-doc-ui": "^1.1.2",
+    "@rstack-dev/doc-ui": "^1.1.2",
     "rspress": "1.26.2",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.0"

--- a/website/theme/components/Benchmark.tsx
+++ b/website/theme/components/Benchmark.tsx
@@ -1,7 +1,7 @@
 import {
   Benchmark as BaseBenchmark,
   type BenchmarkData,
-} from 'rsfamily-doc-ui/benchmark';
+} from '@rstack-dev/doc-ui/benchmark';
 import { useI18n } from 'rspress/runtime';
 import styles from './Benchmark.module.scss';
 

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,4 +1,4 @@
-import { ToolStack as BaseToolStack } from 'rsfamily-doc-ui/tool-stack';
+import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
 import { useLang } from 'rspress/runtime';
 import { useI18n } from 'rspress/runtime';
 import styles from './ToolStack.module.scss';

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,4 +1,4 @@
-import { NavIcon } from 'rsfamily-doc-ui/nav-icon';
+import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
 import Theme from 'rspress/theme';
 import { HomeLayout } from './pages';
 import './index.scss';


### PR DESCRIPTION
## Summary

Update Rstack repo links, `Rsfamily` -> `Rstack`.

## Related Links

https://github.com/rspack-contrib/rstack-design-resources

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
