### PR TITLE
feat: allow absolute output path for inspectConfig

### DIFF
--- a/e2e/cases/inspect-config/index.test.ts
+++ b/e2e/cases/inspect-config/index.test.ts
@@ -21,7 +21,6 @@ const bundlerNodeConfig = path.resolve(
 test('should generate config files when writeToDisk is true', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {},
   });
   await rsbuild.inspectConfig({
     writeToDisk: true,
@@ -37,7 +36,6 @@ test('should generate config files when writeToDisk is true', async () => {
 test('should generate config files correctly when output is specified', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {},
   });
   await rsbuild.inspectConfig({
     writeToDisk: true,
@@ -60,7 +58,6 @@ test('should generate config files correctly when output is specified', async ()
   fs.rmSync(rsbuildConfig, { force: true });
   fs.rmSync(bundlerConfig, { force: true });
 });
-
 
 test('should generate bundler config for node when target contains node', async () => {
   const rsbuild = await createRsbuild({
@@ -97,7 +94,6 @@ test('should generate bundler config for node when target contains node', async 
 test('should not generate config files when writeToDisk is false', async () => {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {},
   });
   await rsbuild.inspectConfig({
     writeToDisk: false,
@@ -105,4 +101,22 @@ test('should not generate config files when writeToDisk is false', async () => {
 
   expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
   expect(fs.existsSync(bundlerConfig)).toBeFalsy();
+});
+
+test('should allow to specify absolute output path', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+  });
+  const outputPath = path.join(__dirname, 'test-temp-output');
+
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+    outputPath,
+  });
+
+  expect(
+    fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
+  ).toBeTruthy();
+
+  fs.rmSync(rsbuildConfig, { force: true });
 });

--- a/packages/compat/webpack/src/inspectConfig.ts
+++ b/packages/compat/webpack/src/inspectConfig.ts
@@ -2,11 +2,27 @@ import { isAbsolute, join } from 'node:path';
 import type { InspectConfigOptions, InspectConfigResult } from '@rsbuild/core';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 import {
+  type InternalContext,
   getRsbuildInspectConfig,
   outputInspectConfigFiles,
   stringifyConfig,
 } from './shared';
 import type { WebpackConfig } from './types';
+
+const getInspectOutputPath = (
+  context: InternalContext,
+  inspectOptions: InspectConfigOptions,
+) => {
+  if (inspectOptions.outputPath) {
+    if (isAbsolute(inspectOptions.outputPath)) {
+      return inspectOptions.outputPath;
+    }
+
+    return join(context.distPath, inspectOptions.outputPath);
+  }
+
+  return context.distPath;
+};
 
 export async function inspectConfig({
   context,
@@ -50,13 +66,7 @@ export async function inspectConfig({
     pluginManager,
   });
 
-  let outputPath = inspectOptions.outputPath
-    ? join(context.distPath, inspectOptions.outputPath)
-    : context.distPath;
-
-  if (!isAbsolute(outputPath)) {
-    outputPath = join(context.rootPath, outputPath);
-  }
+  const outputPath = getInspectOutputPath(context, inspectOptions);
 
   if (inspectOptions.writeToDisk) {
     await outputInspectConfigFiles({

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -130,7 +130,7 @@ export function runCli(): void {
   inspectCommand
     .description('inspect the Rspack and Rsbuild configs')
     .option('--env <env>', 'specify env mode', 'development')
-    .option('--output <output>', 'specify inspect content output path', '/')
+    .option('--output <output>', 'specify inspect content output path')
     .option('--verbose', 'show full function definitions in output')
     .action(async (options: InspectOptions) => {
       try {

--- a/packages/core/src/provider/inspectConfig.ts
+++ b/packages/core/src/provider/inspectConfig.ts
@@ -8,9 +8,25 @@ import { getNodeEnv, setNodeEnv } from '../helpers';
 import type {
   InspectConfigOptions,
   InspectConfigResult,
+  InternalContext,
   RspackConfig,
 } from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
+
+const getInspectOutputPath = (
+  context: InternalContext,
+  inspectOptions: InspectConfigOptions,
+) => {
+  if (inspectOptions.outputPath) {
+    if (isAbsolute(inspectOptions.outputPath)) {
+      return inspectOptions.outputPath;
+    }
+
+    return join(context.distPath, inspectOptions.outputPath);
+  }
+
+  return context.distPath;
+};
 
 export async function inspectConfig({
   context,
@@ -54,12 +70,7 @@ export async function inspectConfig({
     pluginManager,
   });
 
-  let outputPath = inspectOptions.outputPath
-    ? join(context.distPath, inspectOptions.outputPath)
-    : context.distPath;
-  if (!isAbsolute(outputPath)) {
-    outputPath = join(context.rootPath, outputPath);
-  }
+  const outputPath = getInspectOutputPath(context, inspectOptions);
 
   if (inspectOptions.writeToDisk) {
     await outputInspectConfigFiles({

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -553,7 +553,7 @@ type InspectConfigOptions = {
   // defaults to `false`
   verbose?: boolean;
   // Specify the output path
-  // defaults to the value configured by `output.distPath.root`
+  // defaults to the value of `output.distPath.root`
   outputPath?: string;
   // Whether to write the result to disk
   // defaults to `false`
@@ -572,9 +572,9 @@ async function InspectConfig(options?: InspectConfigOptions): Promise<{
 }>;
 ```
 
-- **Example:**
+### Example
 
-Get the config content in string format:
+Get the content of configs in string format:
 
 ```ts
 const { rsbuildConfig, bundlerConfigs } = await rsbuild.inspectConfig();
@@ -587,6 +587,21 @@ Write the config content to disk:
 ```ts
 await rsbuild.inspectConfig({
   writeToDisk: true,
+});
+```
+
+### Output Path
+
+You can set the output path using `outputPath`. The default value is [output.distPath.root](/config/output/dist-path).
+
+If `outputPath` is a relative path, it will be concatenated relative to the value of `output.distPath.root`. You can also set `outputPath` to an absolute path, in which case the files will be written directly to that path. For example:
+
+```ts
+import path from 'node:path';
+
+await rsbuild.inspectConfig({
+  writeToDisk: true,
+  outputPath: path.join(__dirname, 'custom-dir'),
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -567,7 +567,7 @@ type InspectConfigOptions = {
   // 默认为 `false`
   verbose?: boolean;
   // 指定输出路径
-  // 默认为 `output.distPath.root` 配置的值
+  // 默认为 `output.distPath.root` 的值
   outputPath?: string;
   // 是否将结果写入到磁盘中
   // 默认为 `false`
@@ -586,9 +586,9 @@ async function InspectConfig(options?: InspectConfigOptions): Promise<{
 }>;
 ```
 
-- **示例：**
+### 示例
 
-拿到字符串格式的 Config 内容：
+拿到字符串格式的 configs 内容：
 
 ```ts
 const { rsbuildConfig, bundlerConfigs } = await rsbuild.inspectConfig();
@@ -601,6 +601,21 @@ console.log(rsbuildConfig, bundlerConfigs);
 ```ts
 await rsbuild.inspectConfig({
   writeToDisk: true,
+});
+```
+
+### 输出路径
+
+你可以通过 `outputPath` 来设置输出目录，默认为 [output.distPath.root](/config/output/dist-path) 的值。
+
+当 `outputPath` 是一个相对路径时，会相对于 `output.distPath.root` 的值进行拼接。你也可以将 `outputPath` 设置为一个绝对路径，此时会直接将文件写入到该路径下。比如：
+
+```ts
+import path from 'node:path';
+
+await rsbuild.inspectConfig({
+  writeToDisk: true,
+  outputPath: path.join(__dirname, 'custom-dir'),
 });
 ```
 


### PR DESCRIPTION
## Summary

Allow absolute output path for inspectConfig:

```ts
import path from 'node:path';

await rsbuild.inspectConfig({
  writeToDisk: true,
  outputPath: path.join(__dirname, 'custom-dir'),
});
```

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3023

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
