### PR TITLE
fix(core): incorrect exports fields

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,12 +20,12 @@
       "require": "./dist/index.cjs"
     },
     "./client/hmr": {
-      "types": "./dist-types/client/hmr/index.d.ts",
-      "default": "./dist/client/hmr.js"
+      "types": "./dist-types/client/hmr.d.ts",
+      "import": "./dist/client/hmr.js"
     },
     "./client/overlay": {
       "types": "./dist-types/client/overlay.d.ts",
-      "default": "./dist/client/overlay.js"
+      "import": "./dist/client/overlay.js"
     },
     "./types": {
       "types": "./types.d.ts"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,11 +21,11 @@
     },
     "./client/hmr": {
       "types": "./dist-types/client/hmr.d.ts",
-      "import": "./dist/client/hmr.js"
+      "default": "./dist/client/hmr.js"
     },
     "./client/overlay": {
       "types": "./dist-types/client/overlay.d.ts",
-      "import": "./dist/client/overlay.js"
+      "default": "./dist/client/overlay.js"
     },
     "./types": {
       "types": "./types.d.ts"


### PR DESCRIPTION
## Summary

Fix incorrect exports fields of `@rsbuild/core`:

![image](https://github.com/user-attachments/assets/2f447ffa-680f-43b9-965e-382c5de2a908)

## Related Links

https://arethetypeswrong.github.io/?p=%40rsbuild%2Fcore%401.0.1-beta.5

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
