### PR TITLE
feat: enable lightningcss-loader by default

### DIFF
--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -42,7 +42,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -51,6 +51,17 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -17,7 +17,7 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -26,6 +26,14 @@ exports[`plugin-css > should override browserslist of autoprefixer when using ou
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "Chrome 80",
+              ],
             },
           },
           {
@@ -80,7 +88,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": [Function],
                 "exportGlobals": false,
@@ -89,6 +97,17 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {
@@ -188,7 +207,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -197,6 +216,17 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -42,7 +42,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -51,6 +51,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {
@@ -459,7 +470,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -468,6 +479,17 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {
@@ -1233,7 +1255,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -1242,6 +1264,17 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1392,7 +1392,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             {
               "loader": "<ROOT>/packages/core/compiled/css-loader",
               "options": {
-                "importLoaders": 1,
+                "importLoaders": 2,
                 "modules": {
                   "auto": true,
                   "exportGlobals": false,
@@ -1401,6 +1401,17 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
                   "namedExport": false,
                 },
                 "sourceMap": false,
+              },
+            },
+            {
+              "loader": "builtin:lightningcss-loader",
+              "options": {
+                "target": [
+                  "chrome >= 87",
+                  "edge >= 88",
+                  "firefox >= 78",
+                  "safari >= 14",
+                ],
               },
             },
             {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -136,7 +136,8 @@ export const pluginLess = (
         const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
-          clonedOptions.importLoaders = 2;
+          // add less-loader
+          clonedOptions.importLoaders += 1;
         }
 
         rule.use(id).loader(loader.get('loader')).options(clonedOptions);

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -24,6 +24,17 @@ exports[`plugin-less > should add less-loader 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -90,7 +101,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -99,6 +110,17 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -168,7 +190,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -177,6 +199,17 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -243,7 +276,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -252,6 +285,17 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-lightningcss/tests/__snapshots__/index.test.ts.snap
@@ -23,7 +23,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -101,7 +101,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should be configurable by us
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -167,7 +167,7 @@ exports[`plugins/lightningcss > plugin-lightningcss should replace postcss-loade
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -58,7 +58,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader",
             "options": {
-              "importLoaders": 1,
+              "importLoaders": 2,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -67,6 +67,17 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                 "namedExport": false,
               },
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "target": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
           {

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -24,6 +24,17 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -83,7 +94,7 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -92,6 +103,17 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -151,7 +173,7 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 1,
+          "importLoaders": 2,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -160,6 +182,17 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -219,7 +252,7 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 3,
+          "importLoaders": 4,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -228,6 +261,17 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -302,7 +346,7 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -311,6 +355,17 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -102,8 +102,8 @@ export const pluginSass = (
         const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
-          // postcss-loader, resolve-url-loader, sass-loader
-          clonedOptions.importLoaders = 3;
+          // add resolve-url-loader and sass-loader
+          clonedOptions.importLoaders += 2;
         }
 
         rule.use(id).loader(loader.get('loader')).options(clonedOptions);

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 3,
+          "importLoaders": 4,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -24,6 +24,17 @@ exports[`plugin-sass > should add sass-loader 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -92,7 +103,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 3,
+          "importLoaders": 4,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -101,6 +112,17 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -172,7 +194,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 3,
+          "importLoaders": 4,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -181,6 +203,17 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -55,7 +55,8 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         const clonedOptions = deepmerge<Record<string, any>>({}, options);
 
         if (id === CHAIN_ID.USE.CSS) {
-          clonedOptions.importLoaders = 2;
+          // add stylus-loader
+          clonedOptions.importLoaders += 1;
         }
 
         rule.use(id).loader(loader.get('loader')).options(clonedOptions);

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -15,7 +15,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -24,6 +24,17 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -83,7 +94,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader",
         "options": {
-          "importLoaders": 2,
+          "importLoaders": 3,
           "modules": {
             "auto": true,
             "exportGlobals": false,
@@ -92,6 +103,17 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
             "namedExport": false,
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "target": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/website/docs/en/config/tools/css-loader.mdx
+++ b/website/docs/en/config/tools/css-loader.mdx
@@ -6,8 +6,6 @@
 const defaultOptions = {
   modules: rsbuildConfig.output.cssModules,
   sourceMap: rsbuildConfig.output.sourceMap.css,
-  // value is `1` when compiling css files, and is `2` when compiling sass/less files
-  importLoaders: 1 || 2,
 };
 ```
 

--- a/website/docs/zh/config/tools/css-loader.mdx
+++ b/website/docs/zh/config/tools/css-loader.mdx
@@ -7,8 +7,6 @@
 const defaultOptions = {
   modules: rsbuildConfig.output.cssModules,
   sourceMap: rsbuildConfig.output.sourceMap.css,
-  // 在编译 css 文件时为 `1`，在编译 sass/less 文件时为 `2`
-  importLoaders: 1 || 2,
 };
 ```
 


### PR DESCRIPTION
## Summary

Enable lightningcss-loader by default.

Lightning CSS is much more faster than PostCSS / autoprefixer. And it can downgrade modern CSS features like CSS nesting.

TODO:

- remove the built-in autoprefixer
- remove the @rsbuild/plugin-lightningcss
- update documentation

## Related Links

- https://lightningcss.dev/
- https://www.rspack.dev/guide/features/builtin-lightningcss-loader

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
