### PR TITLE
fix: targets options of lightningcss-loader

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -15,6 +15,7 @@ import type {
   RsbuildContext,
   RsbuildPlugin,
   RsbuildTarget,
+  Rspack,
   RspackChain,
 } from '../types';
 
@@ -236,8 +237,8 @@ async function applyCSSRule({
         .use(CHAIN_ID.USE.LIGHTNINGCSS)
         .loader('builtin:lightningcss-loader')
         .options({
-          target: environment.browserslist,
-        });
+          targets: environment.browserslist,
+        } satisfies Rspack.LightningcssLoaderOptions);
     }
 
     const postcssLoaderOptions = await getPostcssLoaderOptions({

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -56,7 +56,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -1,51 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugin-css > should override browserslist of autoprefixer when using output.overrideBrowserslist config 1`] = `
-{
-  "module": {
-    "rules": [
-      {
-        "resolve": {
-          "preferRelative": true,
-        },
-        "sideEffects": true,
-        "test": /\\\\\\.css\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
-          },
-          {
-            "loader": "<ROOT>/packages/core/compiled/css-loader",
-            "options": {
-              "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
-              "sourceMap": false,
-            },
-          },
-          {
-            "loader": "builtin:lightningcss-loader",
-            "options": {
-              "target": [
-                "Chrome 80",
-              ],
-            },
-          },
-        ],
-      },
-    ],
-  },
-  "plugins": [
-    RsbuildCorePlugin {},
-  ],
-}
-`;
-
 exports[`plugin-css > should use custom cssModules rule when using output.cssModules config 1`] = `
 {
   "module": {
@@ -77,7 +31,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",
@@ -165,7 +119,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -56,7 +56,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",
@@ -453,7 +453,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",
@@ -1207,7 +1207,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1406,7 +1406,7 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             {
               "loader": "builtin:lightningcss-loader",
               "options": {
-                "target": [
+                "targets": [
                   "chrome >= 87",
                   "edge >= 88",
                   "firefox >= 78",

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -36,19 +36,6 @@ describe('normalizeCssLoaderOptions', () => {
 });
 
 describe('plugin-css', () => {
-  it('should override browserslist of autoprefixer when using output.overrideBrowserslist config', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginCss()],
-      rsbuildConfig: {
-        output: {
-          overrideBrowserslist: ['Chrome 80'],
-        },
-      },
-    });
-    const bundlerConfigs = await rsbuild.initConfigs();
-    expect(bundlerConfigs[0]).toMatchSnapshot();
-  });
-
   it('should enable source map when output.sourceMap.css is true', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -84,7 +84,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -142,7 +142,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -197,7 +197,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -72,7 +72,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "target": [
+              "targets": [
                 "chrome >= 87",
                 "edge >= 88",
                 "firefox >= 78",

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -94,7 +94,7 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -165,7 +165,7 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -224,7 +224,7 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -298,7 +298,7 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -86,7 +86,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -146,7 +146,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -29,7 +29,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",
@@ -77,7 +77,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "target": [
+          "targets": [
             "chrome >= 87",
             "edge >= 88",
             "firefox >= 78",


### PR DESCRIPTION
## Summary

Fix targets options of lightningcss-loader, `target` -> `targets`.

## Related Links

https://www.rspack.dev/guide/features/builtin-lightningcss-loader#options
https://github.com/web-infra-dev/rsbuild/pull/3034

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
