### PR TITLE
fix: targets of lightningcss-loader not work

### DIFF
--- a/e2e/cases/css/lightningcss-prefixes/.browserslistrc
+++ b/e2e/cases/css/lightningcss-prefixes/.browserslistrc
@@ -1,0 +1,3 @@
+Edge >= 12
+iOS >= 8
+Android >= 4.0

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -1,0 +1,19 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should add vendor prefixes by current browserslist',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+    const files = await rsbuild.unwrapOutputJSON();
+
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+    expect(content).toEqual(
+      '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;user-select:none;background:linear-gradient(#fff,#000);transition:all .5s}}',
+    );
+  },
+);

--- a/e2e/cases/css/lightningcss-prefixes/src/index.css
+++ b/e2e/cases/css/lightningcss-prefixes/src/index.css
@@ -1,0 +1,7 @@
+@media (min-resolution: 2dppx) {
+  .item {
+    transition: all 0.5s;
+    user-select: none;
+    background: linear-gradient(to bottom, white, black);
+  }
+}

--- a/e2e/cases/css/lightningcss-prefixes/src/index.js
+++ b/e2e/cases/css/lightningcss-prefixes/src/index.js
@@ -1,0 +1,1 @@
+import './index.css';

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import browserslist from 'browserslist';
 import deepmerge from 'deepmerge';
 import type { AcceptedPlugin } from 'postcss';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
@@ -182,6 +183,56 @@ const getCSSLoaderOptions = ({
   return cssLoaderOptions;
 };
 
+const BROWSER_MAPPING: Record<string, string | null> = {
+  and_chr: 'chrome',
+  and_ff: 'firefox',
+  ie_mob: 'ie',
+  op_mob: 'opera',
+  and_qq: null,
+  and_uc: null,
+  baidu: null,
+  bb: null,
+  kaios: null,
+  op_mini: null,
+};
+
+function parseVersion(version: string) {
+  const [major, minor = 0, patch = 0] = version
+    .split('-')[0]
+    .split('.')
+    .map((v) => Number.parseInt(v, 10));
+
+  if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
+    return null;
+  }
+
+  return (major << 16) | (minor << 8) | patch;
+}
+
+// code modified based on https://github.com/parcel-bundler/lightningcss/blob/34b67a431c043fda5d4979bcdccb3008d082e243/node/browserslistToTargets.js
+// MIT License
+// TODO: no need to call browserslist in next Rspack version
+function browserslistToTargets(browserslist: string[]): Record<string, number> {
+  const targets: Record<string, number> = {};
+  for (const browser of browserslist) {
+    const [name, v] = browser.split(' ');
+    if (BROWSER_MAPPING[name] === null) {
+      continue;
+    }
+
+    const version = parseVersion(v);
+    if (version == null) {
+      continue;
+    }
+
+    if (targets[name] == null || version < targets[name]) {
+      targets[name] = version;
+    }
+  }
+
+  return targets;
+}
+
 async function applyCSSRule({
   rule,
   config,
@@ -237,7 +288,11 @@ async function applyCSSRule({
         .use(CHAIN_ID.USE.LIGHTNINGCSS)
         .loader('builtin:lightningcss-loader')
         .options({
-          targets: environment.browserslist,
+          targets: browserslistToTargets(
+            browserslist(environment.browserslist, {
+              ignoreUnknownVersions: true,
+            }),
+          ),
         } satisfies Rspack.LightningcssLoaderOptions);
     }
 

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -289,9 +289,7 @@ async function applyCSSRule({
         .loader('builtin:lightningcss-loader')
         .options({
           targets: browserslistToTargets(
-            browserslist(environment.browserslist, {
-              ignoreUnknownVersions: true,
-            }),
+            browserslist(environment.browserslist),
           ),
         } satisfies Rspack.LightningcssLoaderOptions);
     }

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -56,12 +56,12 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -31,12 +31,12 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],
@@ -119,12 +119,12 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -56,12 +56,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],
@@ -453,12 +453,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],
@@ -1207,12 +1207,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1406,12 +1406,12 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             {
               "loader": "builtin:lightningcss-loader",
               "options": {
-                "targets": [
-                  "chrome >= 87",
-                  "edge >= 88",
-                  "firefox >= 78",
-                  "safari >= 14",
-                ],
+                "targets": {
+                  "chrome": 5701632,
+                  "edge": 5767168,
+                  "firefox": 5111808,
+                  "safari": 917504,
+                },
               },
             },
           ],

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -84,12 +84,12 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -142,12 +142,12 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -197,12 +197,12 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -72,12 +72,12 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
+              "targets": {
+                "chrome": 5701632,
+                "edge": 5767168,
+                "firefox": 5111808,
+                "safari": 917504,
+              },
             },
           },
         ],

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -94,12 +94,12 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -165,12 +165,12 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -224,12 +224,12 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -298,12 +298,12 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -86,12 +86,12 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -146,12 +146,12 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {
@@ -77,12 +77,12 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
+          "targets": {
+            "chrome": 5701632,
+            "edge": 5767168,
+            "firefox": 5111808,
+            "safari": 917504,
+          },
         },
       },
       {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -25,6 +25,7 @@ crossorigin
 datauri
 deepmerge
 docgen
+dppx
 envinfo
 estree
 facti
@@ -44,6 +45,7 @@ jfif
 jiti
 jscpuprofile
 jsesc
+kaios
 koppers
 lightningcss
 liyincode


### PR DESCRIPTION
## Summary

Fix the targets of lightningcss-loader not work.

Rspack should convert browserslist query to browser array, but it does not. I will send a PR to Rspack later.

## Related Links

https://lightningcss.dev/transpilation.html

![image](https://github.com/user-attachments/assets/b43235d4-10b1-49ad-b6a3-90f22de24b8b)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
