### PR TITLE
feat: add new `tools.lightningcssLoader` config

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -284,14 +284,20 @@ async function applyCSSRule({
     // `builtin:lightningcss-loader` is not supported when using webpack
     if (context.bundlerType === 'rspack') {
       importLoaders++;
-      rule
-        .use(CHAIN_ID.USE.LIGHTNINGCSS)
-        .loader('builtin:lightningcss-loader')
-        .options({
+
+      const loaderOptions = reduceConfigs<Rspack.LightningcssLoaderOptions>({
+        initial: {
           targets: browserslistToTargets(
             browserslist(environment.browserslist),
           ),
-        } satisfies Rspack.LightningcssLoaderOptions);
+        },
+        config: config.tools.lightningcssLoader,
+      });
+
+      rule
+        .use(CHAIN_ID.USE.LIGHTNINGCSS)
+        .loader('builtin:lightningcss-loader')
+        .options(loaderOptions);
     }
 
     const postcssLoaderOptions = await getPostcssLoaderOptions({

--- a/packages/core/src/types/config/tools.ts
+++ b/packages/core/src/types/config/tools.ts
@@ -104,12 +104,15 @@ export interface ToolsConfig {
    */
   swc?: ToolsSwcConfig;
   /**
+   * Configure the `builtin:lightningcss-loader` of Rspack.
+   */
+  lightningcssLoader?: ConfigChain<Rspack.LightningcssLoaderOptions>;
+  /**
    * Modify the options of [CssExtractRspackPlugin](https://rspack.dev/plugins/rspack/css-extract-rspack-plugin).
    */
   cssExtract?: CSSExtractOptions;
   /**
    * Configure Rspack.
-   * @requires rspack
    */
   rspack?: ToolsRspackConfig;
   /**

--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -1,0 +1,48 @@
+# tools.lightningcssLoader
+
+- **Type:** `Rspack.LightningcssLoaderOptions | Function`
+- **Default:**
+
+```ts
+const defaultOptions = {
+  // use current browserslist config
+  targets: browserslist,
+};
+```
+
+You can set the options for [builtin:lightningcss-loader](https://rspack.dev/guide/features/builtin-lightningcss-loader) through `tools.lightningcssLoader`.
+
+## Object Type
+
+When `tools.lightningcssLoader` is an object, it will be merged with the default configuration using `Object.assign`.
+
+For example, you can disable the addition of vendor prefixes through `tools.lightningcssLoader.exclude`. In this case, you can use PostCSS's autoprefixer plugin to add vendor prefixes.
+
+```js
+export default {
+  tools: {
+    lightningcssLoader: {
+      exclude: {
+        vendorPrefixes: false,
+      },
+    },
+  },
+};
+```
+
+## Function Type
+
+When `tools.lightningcssLoader` is a function, the default options will be passed in as the first parameter. You can directly modify this object or return a new object as the final options to be used. For example:
+
+```js
+export default {
+  tools: {
+    lightningcssLoader: (config) => {
+      config.exclude = {
+        vendorPrefixes: false,
+      };
+      return config;
+    },
+  },
+};
+```

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -1,0 +1,48 @@
+# tools.lightningcssLoader
+
+- **类型：** `Rspack.LightningcssLoaderOptions | Function`
+- **默认值：**
+
+```ts
+const defaultOptions = {
+  // use current browserslist config
+  targets: browserslist,
+};
+```
+
+通过 `tools.lightningcssLoader` 可以设置 [builtin:lightningcss-loader](https://rspack.dev/guide/features/builtin-lightningcss-loader) 的选项。
+
+## Object 类型
+
+当 `tools.lightningcssLoader` 是一个 object 时，它会与默认配置通过 `Object.assign` 合并。
+
+比如，你可以通过 `tools.lightningcssLoader.exclude` 来关闭 vendor prefixes 的添加，此时你可以使用 PostCSS 的 autoprefixer 插件来添加 vendor prefixes。
+
+```js
+export default {
+  tools: {
+    lightningcssLoader: {
+      exclude: {
+        vendorPrefixes: false,
+      },
+    },
+  },
+};
+```
+
+## Function 类型
+
+当 `tools.lightningcssLoader` 是一个 function 时，默认选项会作为第一个参数传入，你可以直接修改这个对象，也可以返回一个新的对象作为最终使用的选项。比如：
+
+```js
+export default {
+  tools: {
+    lightningcssLoader: (config) => {
+      config.exclude = {
+        vendorPrefixes: false,
+      };
+      return config;
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

Add new `tools.lightningcssLoader` config to modify the options of `builtin:lightningcss-loader`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
