### PR TITLE
Revert "test(e2e): try to fix CI failures (#2997)"

### DIFF
--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -1,5 +1,5 @@
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest('support SSR', async ({ page }) => {
   const rsbuild = await dev({
@@ -16,9 +16,7 @@ rspackOnlyTest('support SSR', async ({ page }) => {
   await rsbuild.close();
 });
 
-// TODO: depend on Node.js NODE_OPTIONS=--experimental-vm-modules
-// but this flag sometimes breaks the CI
-test.skip('support SSR with esm target', async ({ page }) => {
+rspackOnlyTest('support SSR with esm target', async ({ page }) => {
   process.env.TEST_ESM_LIBRARY = '1';
 
   const rsbuild = await dev({

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pnpm test:rspack && pnpm test:webpack",
-    "test:rspack": "cross-env playwright test",
+    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules playwright test",
     "test:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
This reverts commit 0f22361f8c945c428b063f79125cd1d295c63f30.

## Summary

Revert https://github.com/web-infra-dev/rsbuild/pull/2997. The CI failture is un-related to `experimental-vm-modules`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/3044

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
