### PR TITLE
test(e2e): avoid write to committed file

### DIFF
--- a/e2e/cases/svelte/hmr/index.test.ts
+++ b/e2e/cases/svelte/hmr/index.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import { pluginSvelte } from '@rsbuild/plugin-svelte';
+
+rspackOnlyTest('hmr should work properly', async ({ page }) => {
+  // HMR cases will fail in Windows
+  if (process.platform === 'win32') {
+    test.skip();
+  }
+
+  const root = __dirname;
+  const bPath = path.join(root, 'src/test-temp-B.svelte');
+  fs.writeFileSync(
+    bPath,
+    fs.readFileSync(path.join(root, 'src/B.svelte'), 'utf-8'),
+  );
+
+  const rsbuild = await dev({
+    cwd: root,
+    plugins: [pluginSvelte()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          index: path.join(root, 'src/index.js'),
+        },
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  const a = page.locator('#A');
+  const b = page.locator('#B');
+
+  await expect(a).toHaveText('A: 0');
+  await expect(b).toHaveText('B: 0');
+
+  await a.click({ clickCount: 5 });
+  await expect(a).toHaveText('A: 5');
+  await expect(b).toHaveText('B: 5');
+
+  // simulate a change to component B's source code
+  const sourceCodeB = fs.readFileSync(bPath, 'utf-8');
+  fs.writeFileSync(bPath, sourceCodeB.replace('B:', 'Beep:'), 'utf-8');
+
+  // content of B changed to `Beep: 5` means HMR has taken effect
+  await expect(b).toHaveText('Beep: 5');
+  // the state (count) of A should be kept
+  await expect(a).toHaveText('A: 5');
+
+  fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
+  rsbuild.close();
+});

--- a/e2e/cases/svelte/hmr/src/A.svelte
+++ b/e2e/cases/svelte/hmr/src/A.svelte
@@ -1,5 +1,5 @@
 <script>
-  import B from './B.svelte';
+  import B from './test-temp-B.svelte';
   export let count = 0;
 </script>
 

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -1,7 +1,6 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
 const buildFixture = (
@@ -38,52 +37,6 @@ rspackOnlyTest(
     rsbuild.close();
   },
 );
-
-rspackOnlyTest('hmr should work properly', async ({ page }) => {
-  // HMR cases will fail in Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
-  const root = path.join(__dirname, 'hmr');
-
-  const rsbuild = await dev({
-    cwd: root,
-    plugins: [pluginSvelte()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          index: path.join(root, 'src/index.js'),
-        },
-      },
-    },
-  });
-
-  await gotoPage(page, rsbuild);
-
-  const a = page.locator('#A');
-  const b = page.locator('#B');
-
-  await expect(a).toHaveText('A: 0');
-  await expect(b).toHaveText('B: 0');
-
-  await a.click({ clickCount: 5 });
-  await expect(a).toHaveText('A: 5');
-  await expect(b).toHaveText('B: 5');
-
-  // simulate a change to component B's source code
-  const bPath = path.join(root, 'src/B.svelte');
-  const sourceCodeB = fs.readFileSync(bPath, 'utf-8');
-  fs.writeFileSync(bPath, sourceCodeB.replace('B:', 'Beep:'), 'utf-8');
-
-  // content of B changed to `Beep: 5` means HMR has taken effect
-  await expect(b).toHaveText('Beep: 5');
-  // the state (count) of A should be kept
-  await expect(a).toHaveText('A: 5');
-
-  fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
-  rsbuild.close();
-});
 
 rspackOnlyTest(
   'should build svelte component with typescript',


### PR DESCRIPTION
## Summary

Avoid write to committed file when running e2e test, use temp files instead.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
