### PR TITLE
fix: set browserset for lightningcss minimizer

### DIFF
--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -13,7 +13,7 @@ rspackOnlyTest(
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 
     expect(content).toEqual(
-      '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;user-select:none;background:linear-gradient(#fff,#000);transition:all .5s}}',
+      '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;-ms-user-select:none;user-select:none;background:-webkit-linear-gradient(#fff,#000);background:linear-gradient(#fff,#000);-webkit-transition:all .5s;transition:all .5s}}',
     );
   },
 );

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -113,9 +113,14 @@ export const pluginMinimize = (): RsbuildPlugin => ({
       }
 
       if (minifyCss && isRspack) {
+        const options: LightningCssMinimizerRspackPluginOptions = {
+          browserslist: environment.browserslist,
+          ...cssOptions,
+        };
+
         chain.optimization
           .minimizer(CHAIN_ID.MINIMIZER.CSS)
-          .use(rspack.LightningCssMinimizerRspackPlugin, [cssOptions])
+          .use(rspack.LightningCssMinimizerRspackPlugin, [options])
           .end();
       }
     });

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -691,7 +691,14 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       },
       LightningCssMinimizerRspackPlugin {
         "_args": [
-          undefined,
+          {
+            "browserslist": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
         ],
         "affectedHooks": undefined,
         "name": "LightningCssMinimizerRspackPlugin",

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -42,7 +42,14 @@ describe('plugin-minimize', () => {
         },
         LightningCssMinimizerRspackPlugin {
           "_args": [
-            undefined,
+            {
+              "browserslist": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
           ],
           "affectedHooks": undefined,
           "name": "LightningCssMinimizerRspackPlugin",
@@ -189,7 +196,14 @@ describe('plugin-minimize', () => {
         },
         LightningCssMinimizerRspackPlugin {
           "_args": [
-            undefined,
+            {
+              "browserslist": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
           ],
           "affectedHooks": undefined,
           "name": "LightningCssMinimizerRspackPlugin",
@@ -238,7 +252,14 @@ describe('plugin-minimize', () => {
         },
         LightningCssMinimizerRspackPlugin {
           "_args": [
-            undefined,
+            {
+              "browserslist": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
           ],
           "affectedHooks": undefined,
           "name": "LightningCssMinimizerRspackPlugin",
@@ -281,7 +302,14 @@ describe('plugin-minimize', () => {
         },
         LightningCssMinimizerRspackPlugin {
           "_args": [
-            undefined,
+            {
+              "browserslist": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
           ],
           "affectedHooks": undefined,
           "name": "LightningCssMinimizerRspackPlugin",


### PR DESCRIPTION
## Summary

Set the browserset option for lightningcss minimizer. This can ensure the `builtin:lightningcss-loader` and `LightningCssMinimizerRspackPlugin` use the same browserslist value and avoid potential conflicts.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
