### PR TITLE
fix: add uniqueName to WebSocket compilation name

### DIFF
--- a/packages/core/src/server/devMiddleware.ts
+++ b/packages/core/src/server/devMiddleware.ts
@@ -3,6 +3,7 @@ import type { Compiler, MultiCompiler } from '@rspack/core';
 import { applyToCompiler } from '../helpers';
 import type { DevMiddlewareOptions } from '../provider/createCompiler';
 import type { DevConfig, NextFunction } from '../types';
+import { getCompilationName } from './helper';
 
 type ServerCallbacks = {
   onInvalid: (compilationName?: string) => void;
@@ -49,10 +50,10 @@ export const setupServerHooks = (
   const { compile, invalid, done } = compiler.hooks;
 
   compile.tap('rsbuild-dev-server', () =>
-    hookCallbacks.onInvalid(compiler.name),
+    hookCallbacks.onInvalid(getCompilationName(compiler)),
   );
   invalid.tap('rsbuild-dev-server', () =>
-    hookCallbacks.onInvalid(compiler.name),
+    hookCallbacks.onInvalid(getCompilationName(compiler)),
   );
   done.tap('rsbuild-dev-server', hookCallbacks.onDone);
 };
@@ -73,7 +74,7 @@ function applyHMREntry({
   }
 
   new compiler.webpack.DefinePlugin({
-    RSBUILD_COMPILATION_NAME: JSON.stringify(compiler.name!),
+    RSBUILD_COMPILATION_NAME: JSON.stringify(getCompilationName(compiler)),
     RSBUILD_CLIENT_CONFIG: JSON.stringify(clientConfig),
     RSBUILD_DEV_LIVE_RELOAD: liveReload,
   }).apply(compiler);

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -14,6 +14,7 @@ import type {
   PrintUrls,
   Routes,
   RsbuildEntry,
+  Rspack,
 } from '../types';
 
 /**
@@ -380,3 +381,8 @@ export const getAddressUrls = ({
 
   return addressUrls;
 };
+
+// A unique name for WebSocket communication
+export const getCompilationName = (
+  compiler: Rspack.Compiler | Rspack.Compilation,
+) => `${compiler.name ?? ''}_${compiler.options.output.uniqueName ?? ''}`;

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -5,6 +5,7 @@ import type Ws from 'ws';
 import { getAllStatsErrors, getAllStatsWarnings } from '../helpers';
 import { logger } from '../logger';
 import type { DevConfig, Stats } from '../types';
+import { getCompilationName } from './helper';
 
 interface ExtWebSocket extends Ws {
   isAlive: boolean;
@@ -92,7 +93,7 @@ export class SocketServer {
   }
 
   public updateStats(stats: Stats): void {
-    const compilationName = stats.compilation.name!;
+    const compilationName = getCompilationName(stats.compilation);
 
     this.stats[compilationName] = stats;
 


### PR DESCRIPTION
## Summary

Add uniqueName to the WebSocket compilation name, this can avoid the infinite loop when loading multiple entry chunks in a page (such as module federation).
## Related Links

see https://github.com/web-infra-dev/rsbuild/issues/3031

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
