### PR TITLE
docs: add remove plugin tip when use environment plugin

### DIFF
--- a/packages/core/tests/pluginStore.test.ts
+++ b/packages/core/tests/pluginStore.test.ts
@@ -69,6 +69,54 @@ describe('initPlugins', () => {
 
     expect(result).toEqual([0, 2]);
   });
+
+  it('should remove environment plugin correctly', async () => {
+    const pluginManager = createPluginManager();
+    const result: number[] = [];
+
+    pluginManager.addPlugins(
+      [
+        {
+          name: 'plugin0',
+          // environment plugin can't remove global plugin
+          remove: ['plugin2', 'plugin3'],
+          setup() {
+            result.push(0);
+          },
+        },
+        {
+          name: 'plugin1',
+          setup() {
+            result.push(1);
+          },
+        },
+        {
+          name: 'plugin3',
+          setup() {
+            result.push(3);
+          },
+        },
+      ],
+      {
+        environment: 'A',
+      },
+    );
+
+    pluginManager.addPlugins([
+      {
+        name: 'plugin2',
+        // global plugin can remove environment plugin
+        remove: ['plugin1'],
+        setup() {
+          result.push(2);
+        },
+      },
+    ]);
+
+    await initPlugins({ pluginManager, getPluginAPI: () => ({}) as any });
+
+    expect(result).toEqual([0, 2]);
+  });
 });
 
 describe('pluginManager', () => {

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -95,6 +95,8 @@ const pluginBar = {
 
 For example, if you register both the Foo and Bar plugins mentioned above, the Foo plugin will not take effect because the Bar plugin declares the removal of the Foo plugin.
 
+It should be noted that if the current plugin is registered as a [specific environment plugin](https://rsbuild.dev/guide/advanced/environments#add-plugins-for-specified-environment), only the removal of plugins in the same environment is supported, and global plugins cannot be removed.
+
 ## api.context
 
 `api.context` is a read-only object that provides some context information.

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -93,6 +93,8 @@ const pluginBar = {
 
 比如同时注册上述的 Foo 和 Bar 插件，由于 Bar 插件声明 remove 了 Foo 插件，因此 Foo 插件不会生效。
 
+需要注意的是：如果当前插件注册为[特定环境插件](/guide/advanced/environments#为指定环境添加插件)，则仅支持移除同环境插件，不能移除全局插件。
+
 ## api.context
 
 `api.context` 是一个只读对象，提供一些上下文信息。


### PR DESCRIPTION
## Summary

global plugin can remove environment plugin, but environment plugin can't remove global plugin
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
