### PR TITLE
fix: processAssets callback should only called once

### DIFF
--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
@@ -1,0 +1,19 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should allow plugin to process assets', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const indexJs = Object.keys(files).find(
+    (file) => file.includes('index') && file.endsWith('.js'),
+  );
+  const indexCss = Object.keys(files).find(
+    (file) => file.includes('index') && file.endsWith('.css'),
+  );
+
+  expect(indexJs).toBeTruthy();
+  expect(indexCss).toBeFalsy();
+});

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/myPlugin.ts
@@ -1,0 +1,21 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    let count = 0;
+    api.processAssets({ stage: 'summarize' }, ({ assets, compilation }) => {
+      count++;
+
+      if (count > 1) {
+        throw new Error('processAssets callback should only called once');
+      }
+
+      for (const key of Object.keys(assets)) {
+        if (key.endsWith('.css')) {
+          compilation.deleteAsset(key);
+        }
+      }
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { myPlugin } from './myPlugin';
+
+export default {
+  plugins: [myPlugin],
+  html: {
+    template: './static/index.html',
+  },
+};

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/src/index.css
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/src/index.js
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+console.log('hello');

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/static/index.html
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/static/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>custom template</title>
+</head>
+
+<body>
+  <div id="test-template">test</div>
+  <div id="root" />
+</body>
+
+</html>

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -155,9 +155,7 @@ export function initPluginAPI({
           compilation.hooks.childCompiler.tap(pluginName, (childCompiler) => {
             childCompiler.__rsbuildTransformer = transformer;
           });
-        });
 
-        compiler.hooks.compilation.tap(pluginName, (compilation) => {
           const { sources } = compiler.webpack;
 
           for (const {


### PR DESCRIPTION
## Summary

use `thisCompilation` hook instead of `compilation` hook to ensure `processAssets` callback only called once, because compilation hook will also called when has `childCompiler`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
