### PR TITLE
docs: simplify `tools.rspack` examples

### DIFF
--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -29,9 +29,10 @@ For instance, if you want to prevent a rebuild when files in the `node_modules` 
 ```js
 export default {
   tools: {
-    rspack: (config) => {
-      config.watchOptions ??= {};
-      config.watchOptions.ignored = /node_modules/;
+    rspack: {
+      watchOptions: {
+        ignored: /node_modules/,
+      },
     },
   },
 };

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -51,13 +51,13 @@ import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 
 export default defineConfig({
   tools: {
-    rspack: (config, { appendPlugins }) => {
-      appendPlugins([
+    rspack: {
+      plugins: [
         new ModuleFederationPlugin({
           name: 'provider',
           // other options
         }),
-      ]);
+      ],
     },
   },
 });

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -29,9 +29,10 @@ Rsbuild (Rspack) 默认会监听所有构建依赖，当这些文件发生变化
 ```js
 export default {
   tools: {
-    rspack: (config) => {
-      config.watchOptions ??= {};
-      config.watchOptions.ignored = /node_modules/;
+    rspack: {
+      watchOptions: {
+        ignored: /node_modules/,
+      },
     },
   },
 };

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -51,13 +51,13 @@ import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 
 export default defineConfig({
   tools: {
-    rspack: (config, { appendPlugins }) => {
-      appendPlugins([
+    rspack: {
+      plugins: [
         new ModuleFederationPlugin({
           name: 'provider',
           // other options
         }),
-      ]);
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary

Simplify `tools.rspack` examples, the object type is easier to use and Intuitive.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
