### PR TITLE
perf: prebundle postcss

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -86,7 +86,6 @@
     "picocolors": "^1.0.1",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "postcss-value-parser": "4.2.0",
     "prebundle": "1.2.2",
     "reduce-configs": "^1.0.0",
     "rslog": "^1.2.2",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -36,7 +36,6 @@ export default {
     '/^caniuse-lite(/.*)/': 'caniuse-lite$1',
     '@rspack/core': '@rspack/core',
     webpack: 'webpack',
-    postcss: 'postcss',
     typescript: 'typescript',
   },
   dependencies: [
@@ -87,10 +86,6 @@ export default {
       externals: {
         picocolors: '../picocolors',
       },
-    },
-    {
-      name: 'postcss-value-parser',
-      ignoreDts: true,
     },
     {
       name: 'sirv',
@@ -169,8 +164,8 @@ export default {
       name: 'css-loader',
       ignoreDts: true,
       externals: {
-        'postcss-value-parser': '../postcss-value-parser',
         semver: './semver',
+        picocolors: '../picocolors',
       },
       afterBundle: writeEmptySemver,
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,9 +750,6 @@ importers:
       postcss-loader:
         specifier: 8.1.1
         version: 8.1.1(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11))(postcss@8.4.40)(typescript@5.5.2)(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
-      postcss-value-parser:
-        specifier: 4.2.0
-        version: 4.2.0
       prebundle:
         specifier: 1.2.2
         version: 1.2.2(typescript@5.5.2)


### PR DESCRIPTION
## Summary

`postcss` is only used by `css-loader` and it can be prebundled to reduce dependencies and module count.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
