### PR TITLE
perf: remove cosmiconfig from postcss-loader

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -176,6 +176,13 @@ export default {
         semver: './semver',
       },
       ignoreDts: true,
+      beforeBundle(task) {
+        replaceFileContent(join(task.depPath, 'dist/utils.js'), (content) =>
+          // Rsbuild uses `postcss-load-config` and no need to use `cosmiconfig`.
+          // the ralevent code will never be executed, so we can replace it with an empty object.
+          content.replaceAll('require("cosmiconfig")', '{}'),
+        );
+      },
       afterBundle: writeEmptySemver,
     },
     {


### PR DESCRIPTION
## Summary

Remove `cosmiconfig` from `postcss-loader`. Rsbuild uses `postcss-load-config` and no need to use `cosmiconfig`. The ralevent code will never be executed, so we can replace it with an empty object.

Removed 7680 lines of code.

<img width="744" alt="截屏2024-07-29 22 50 24" src="https://github.com/user-attachments/assets/dea44f5e-a933-42f0-bbf1-c61057cb1efb">

<img width="715" alt="截屏2024-07-29 23 00 57" src="https://github.com/user-attachments/assets/211c5939-98e1-4cf5-82fc-29c93c4a9ea0">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
