### PR TITLE
perf: bump rspack-manifest-plugin v5.0.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,8 +55,7 @@
     "@rspack/lite-tapable": "1.0.0-beta.0",
     "@swc/helpers": "0.5.11",
     "caniuse-lite": "^1.0.30001643",
-    "core-js": "~3.37.1",
-    "postcss": "^8.4.40"
+    "core-js": "~3.37.1"
   },
   "devDependencies": {
     "@types/connect": "3.4.38",
@@ -84,13 +83,14 @@
     "on-finished": "2.4.1",
     "open": "^8.4.0",
     "picocolors": "^1.0.1",
+    "postcss": "^8.4.40",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
     "prebundle": "1.2.2",
     "reduce-configs": "^1.0.0",
     "rslog": "^1.2.2",
     "rspack-chain": "^0.7.4",
-    "rspack-manifest-plugin": "5.0.0",
+    "rspack-manifest-plugin": "5.0.1",
     "sirv": "^2.0.4",
     "style-loader": "3.3.4",
     "tsc-alias": "^1.8.10",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -35,6 +35,7 @@ export default {
     'caniuse-lite': 'caniuse-lite',
     '/^caniuse-lite(/.*)/': 'caniuse-lite$1',
     '@rspack/core': '@rspack/core',
+    '@rspack/lite-tapable': '@rspack/lite-tapable',
     webpack: 'webpack',
     typescript: 'typescript',
   },
@@ -48,6 +49,7 @@ export default {
     'connect',
     'rspack-manifest-plugin',
     'webpack-merge',
+    'html-rspack-plugin',
     {
       name: 'chokidar',
       externals: {
@@ -207,12 +209,6 @@ export default {
           (content) =>
             `${content.replaceAll('await __import', 'await import')}`,
         );
-      },
-    },
-    {
-      name: 'html-rspack-plugin',
-      externals: {
-        '@rspack/lite-tapable': '@rspack/lite-tapable',
       },
     },
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -661,9 +661,6 @@ importers:
       core-js:
         specifier: ~3.37.1
         version: 3.37.1
-      postcss:
-        specifier: ^8.4.40
-        version: 8.4.40
     optionalDependencies:
       fsevents:
         specifier: ~2.3.3
@@ -744,6 +741,9 @@ importers:
       picocolors:
         specifier: ^1.0.1
         version: 1.0.1
+      postcss:
+        specifier: ^8.4.40
+        version: 8.4.40
       postcss-load-config:
         specifier: 6.0.1
         version: 6.0.1(jiti@1.21.6)(postcss@8.4.40)(tsx@4.14.0)(yaml@2.5.0)
@@ -763,8 +763,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4
       rspack-manifest-plugin:
-        specifier: 5.0.0
-        version: 5.0.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11))
+        specifier: 5.0.1-beta.0
+        version: 5.0.1-beta.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11))
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -6589,8 +6589,8 @@ packages:
     resolution: {integrity: sha512-p6C8hzEXLSWNMq2kNFMhvLPsYPSjgQ3z2JZJANBT4QEZGbXhjGf+uAb/BcvuG91Qk6B720SguW1KXmx1D2AB7g==}
     engines: {node: '>=16'}
 
-  rspack-manifest-plugin@5.0.0:
-    resolution: {integrity: sha512-Rtpn6GI4mpTASPmLOGiHzv3KqVWuWhGJG9CKO7aioPrAhukML4jtgYUvbQdBze/mZcDrvqf6sxEGRGx5fKQ+ag==}
+  rspack-manifest-plugin@5.0.1-beta.0:
+    resolution: {integrity: sha512-Q5whNQki4oh95WzJZcnqYl5na1CUaDK0/dMjwYglKqloHkM42s/7cjmIkoY27E32Z4d7FpUiFSR42ueKC2fwnA==}
     engines: {node: '>=14'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -6915,9 +6915,6 @@ packages:
 
   sorted-array-functions@1.3.0:
     resolution: {integrity: sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==}
-
-  source-list-map@2.0.1:
-    resolution: {integrity: sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==}
 
   source-map-js@1.2.0:
     resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
@@ -7567,10 +7564,6 @@ packages:
   webpack-merge@6.0.1:
     resolution: {integrity: sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==}
     engines: {node: '>=18.0.0'}
-
-  webpack-sources@2.3.1:
-    resolution: {integrity: sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==}
-    engines: {node: '>=10.13.0'}
 
   webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
@@ -13684,10 +13677,9 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.0.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11)):
+  rspack-manifest-plugin@5.0.1-beta.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11)):
     dependencies:
-      tapable: 2.2.1
-      webpack-sources: 2.3.1
+      '@rspack/lite-tapable': 1.0.0-beta.0
     optionalDependencies:
       '@rspack/core': 1.0.0-beta.0(@swc/helpers@0.5.11)
 
@@ -13960,8 +13952,6 @@ snapshots:
       - supports-color
 
   sorted-array-functions@1.3.0: {}
-
-  source-list-map@2.0.1: {}
 
   source-map-js@1.2.0: {}
 
@@ -14684,11 +14674,6 @@ snapshots:
       clone-deep: 4.0.1
       flat: 5.0.2
       wildcard: 2.0.1
-
-  webpack-sources@2.3.1:
-    dependencies:
-      source-list-map: 2.0.1
-      source-map: 0.6.1
 
   webpack-sources@3.2.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,8 +763,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4
       rspack-manifest-plugin:
-        specifier: 5.0.1-beta.0
-        version: 5.0.1-beta.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11))
+        specifier: 5.0.1
+        version: 5.0.1(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11))
       sirv:
         specifier: ^2.0.4
         version: 2.0.4
@@ -6589,8 +6589,8 @@ packages:
     resolution: {integrity: sha512-p6C8hzEXLSWNMq2kNFMhvLPsYPSjgQ3z2JZJANBT4QEZGbXhjGf+uAb/BcvuG91Qk6B720SguW1KXmx1D2AB7g==}
     engines: {node: '>=16'}
 
-  rspack-manifest-plugin@5.0.1-beta.0:
-    resolution: {integrity: sha512-Q5whNQki4oh95WzJZcnqYl5na1CUaDK0/dMjwYglKqloHkM42s/7cjmIkoY27E32Z4d7FpUiFSR42ueKC2fwnA==}
+  rspack-manifest-plugin@5.0.1:
+    resolution: {integrity: sha512-K2g7kcOdj+cHTi+xvzwdLZ4rdL1nnphJhs9P8VH5sVcoQd1U/FxpNXnEm5ARxhE7qZO0yfqaL74aXwcQH0T0Ig==}
     engines: {node: '>=14'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -13677,7 +13677,7 @@ snapshots:
       deepmerge: 1.5.2
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.0.1-beta.0(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11)):
+  rspack-manifest-plugin@5.0.1(@rspack/core@1.0.0-beta.0(@swc/helpers@0.5.11)):
     dependencies:
       '@rspack/lite-tapable': 1.0.0-beta.0
     optionalDependencies:


### PR DESCRIPTION
## Summary

Bump rspack-manifest-plugin v5.0.1, remove `webpack-sources` and `tapable` from its dependencies.

## Related Links

https://github.com/rspack-contrib/rspack-manifest-plugin/releases/tag/5.0.1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
