### PR TITLE
feat!: `onBeforeBuild` hook supports calling multiple times in watch mode

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-watch/.gitignore
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/.gitignore
@@ -1,0 +1,1 @@
+src/index.js

--- a/e2e/cases/plugin-api/plugin-hooks-watch/.gitignore
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/.gitignore
@@ -1,1 +1,0 @@
-src/index.js

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
+import fse from 'fs-extra';
 
 const createPlugin = () => {
   const names: string[] = [];
@@ -66,11 +67,11 @@ rspackOnlyTest(
   'should run plugin hooks correctly when running build with watch',
   async () => {
     const cwd = __dirname;
+    fse.ensureDirSync(join(cwd, 'src'));
 
-    await fs.promises.writeFile(
-      join(cwd, 'src', 'index.js'),
-      "console.log('1');",
-    );
+    const filePath = join(cwd, 'src', 'index.js');
+
+    await fs.promises.writeFile(filePath, "console.log('1');");
 
     const { plugin, names } = createPlugin();
     const rsbuild = await createRsbuild({
@@ -88,10 +89,7 @@ rspackOnlyTest(
 
     const watching = await rsbuild.build({ watch: true });
 
-    await fs.promises.writeFile(
-      join(cwd, 'src', 'index.js'),
-      "console.log('2');",
-    );
+    await fs.promises.writeFile(filePath, "console.log('2');");
 
     await new Promise((resolve) => setTimeout(resolve, 1000));
 

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -113,6 +113,6 @@ rspackOnlyTest(
       'AfterBuild',
     ]);
 
-    watching!.close();
+    await watching?.close();
   },
 );

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -67,9 +67,9 @@ rspackOnlyTest(
   'should run plugin hooks correctly when running build with watch',
   async () => {
     const cwd = __dirname;
-    fse.ensureDirSync(join(cwd, 'src'));
+    fse.ensureDirSync(join(cwd, 'test-temp-src'));
 
-    const filePath = join(cwd, 'src', 'index.js');
+    const filePath = join(cwd, 'test-temp-src', 'index.js');
 
     await fs.promises.writeFile(filePath, "console.log('1');");
 
@@ -80,6 +80,11 @@ rspackOnlyTest(
         plugins: [plugin],
         server: {
           printUrls: false,
+        },
+        source: {
+          entry: {
+            index: './test-temp-src/index.js',
+          },
         },
         performance: {
           printFileSize: false,

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
+
+const createPlugin = () => {
+  const names: string[] = [];
+
+  const plugin: RsbuildPlugin = {
+    name: 'test-plugin',
+    setup(api) {
+      api.modifyRspackConfig(() => {
+        names.push('ModifyBundlerConfig');
+      });
+      api.modifyWebpackChain(() => {
+        names.push('ModifyBundlerConfig');
+      });
+      api.modifyRsbuildConfig(() => {
+        names.push('ModifyRsbuildConfig');
+      });
+      api.modifyBundlerChain(() => {
+        names.push('ModifyBundlerChain');
+      });
+      api.modifyHTMLTags((tags) => {
+        names.push('ModifyHTMLTags');
+        return tags;
+      });
+      api.onBeforeStartDevServer(() => {
+        names.push('BeforeStartDevServer');
+      });
+      api.onAfterStartDevServer(() => {
+        names.push('AfterStartDevServer');
+      });
+      api.onBeforeCreateCompiler(() => {
+        names.push('BeforeCreateCompiler');
+      });
+      api.onAfterCreateCompiler(() => {
+        names.push('AfterCreateCompiler');
+      });
+      api.onBeforeBuild(() => {
+        names.push('BeforeBuild');
+      });
+      api.onAfterBuild(() => {
+        names.push('AfterBuild');
+      });
+      api.onBeforeStartProdServer(() => {
+        names.push('BeforeStartProdServer');
+      });
+      api.onCloseDevServer(() => {
+        names.push('OnCloseDevServer');
+      });
+      api.onAfterStartProdServer(() => {
+        names.push('AfterStartProdServer');
+      });
+      api.onDevCompileDone(() => {
+        names.push('OnDevCompileDone');
+      });
+    },
+  };
+
+  return { plugin, names };
+};
+
+rspackOnlyTest(
+  'should run plugin hooks correctly when running build with watch',
+  async () => {
+    const cwd = __dirname;
+
+    await fs.promises.writeFile(
+      join(cwd, 'src', 'index.js'),
+      "console.log('1');",
+    );
+
+    const { plugin, names } = createPlugin();
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [plugin],
+        server: {
+          printUrls: false,
+        },
+        performance: {
+          printFileSize: false,
+        },
+      },
+    });
+
+    const watching = await rsbuild.build({ watch: true });
+
+    await fs.promises.writeFile(
+      join(cwd, 'src', 'index.js'),
+      "console.log('2');",
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    expect(names).toEqual([
+      'ModifyRsbuildConfig',
+      'ModifyBundlerChain',
+      'ModifyBundlerConfig',
+      'BeforeCreateCompiler',
+      'AfterCreateCompiler',
+      'BeforeBuild',
+      'ModifyHTMLTags',
+      'AfterBuild',
+      // below hooks should called when rebuild
+      'BeforeBuild',
+      'ModifyHTMLTags',
+      'AfterBuild',
+    ]);
+
+    watching!.close();
+  },
+);

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -10,7 +10,7 @@ export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
 ): Promise<void | {
-  close: (callback?: () => void) => void;
+  close: () => Promise<void>;
 }> => {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = mode;
@@ -64,7 +64,12 @@ export const build = async (
         logger.error(err);
       }
     });
-    return watching;
+    return {
+      close: () =>
+        new Promise((resolve) => {
+          watching.close(resolve);
+        }),
+    };
   }
 
   await new Promise<{ stats: Rspack.Stats | Rspack.MultiStats }>(

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -4,7 +4,7 @@ import type { Configuration as WebpackConfig } from 'webpack';
 import WebpackMultiStats from 'webpack/lib/MultiStats.js';
 import { createCompiler } from './createCompiler';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
-import { onBeforeCompile, onCompileDone } from './shared';
+import { onBeforeBuild, onCompileDone } from './shared';
 
 export const build = async (
   initOptions: InitConfigsOptions,
@@ -35,7 +35,7 @@ export const build = async (
   }
 
   let isFirstCompile = true;
-  const onBeforeBuild = async () =>
+  const beforeBuild = async () =>
     await context.hooks.onBeforeBuild.call({
       bundlerConfigs: bundlerConfigs as Rspack.Configuration[],
       environments: context.environments,
@@ -54,7 +54,7 @@ export const build = async (
     await p;
   };
 
-  onBeforeCompile(compiler, onBeforeBuild);
+  onBeforeBuild(compiler, beforeBuild, watch);
 
   onCompileDone(compiler, onDone, WebpackMultiStats);
 

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -4,12 +4,14 @@ import type { Configuration as WebpackConfig } from 'webpack';
 import WebpackMultiStats from 'webpack/lib/MultiStats.js';
 import { createCompiler } from './createCompiler';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
-import { onCompileDone } from './shared';
+import { onBeforeCompile, onCompileDone } from './shared';
 
 export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
-) => {
+): Promise<void | {
+  close: (callback?: () => void) => void;
+}> => {
   if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = mode;
   }
@@ -33,11 +35,13 @@ export const build = async (
   }
 
   let isFirstCompile = true;
-  await context.hooks.onBeforeBuild.call({
-    bundlerConfigs: bundlerConfigs as Rspack.Configuration[],
-    environments: context.environments,
-    isWatch: Boolean(watch),
-  });
+  const onBeforeBuild = async () =>
+    await context.hooks.onBeforeBuild.call({
+      bundlerConfigs: bundlerConfigs as Rspack.Configuration[],
+      environments: context.environments,
+      isWatch: Boolean(watch),
+      isFirstCompile,
+    });
 
   const onDone = async (stats: Rspack.Stats | Rspack.MultiStats) => {
     const p = context.hooks.onAfterBuild.call({
@@ -50,15 +54,17 @@ export const build = async (
     await p;
   };
 
+  onBeforeCompile(compiler, onBeforeBuild);
+
   onCompileDone(compiler, onDone, WebpackMultiStats);
 
   if (watch) {
-    compiler.watch({}, (err) => {
+    const watching = compiler.watch({}, (err) => {
       if (err) {
         logger.error(err);
       }
     });
-    return;
+    return watching;
   }
 
   await new Promise<{ stats: Rspack.Stats | Rspack.MultiStats }>(

--- a/packages/compat/webpack/src/initConfigs.ts
+++ b/packages/compat/webpack/src/initConfigs.ts
@@ -39,7 +39,14 @@ export async function initConfigs({
 
   // write Rsbuild config and webpack config to disk in debug mode
   if (logger.level === 'verbose') {
-    const inspect = () => {
+    const inspect = (params: {
+      isFirstCompile?: boolean;
+      [key: string]: unknown;
+    }) => {
+      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
+        return;
+      }
+
       const inspectOptions: InspectConfigOptions = {
         verbose: true,
         writeToDisk: true,

--- a/packages/compat/webpack/src/initConfigs.ts
+++ b/packages/compat/webpack/src/initConfigs.ts
@@ -39,14 +39,7 @@ export async function initConfigs({
 
   // write Rsbuild config and webpack config to disk in debug mode
   if (logger.level === 'verbose') {
-    const inspect = (params: {
-      isFirstCompile?: boolean;
-      [key: string]: unknown;
-    }) => {
-      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
-        return;
-      }
-
+    const inspect = () => {
       const inspectOptions: InspectConfigOptions = {
         verbose: true,
         writeToDisk: true,
@@ -61,7 +54,11 @@ export async function initConfigs({
     };
 
     // run inspect later to avoid cleaned by cleanOutput plugin
-    context.hooks.onBeforeBuild.tap(inspect);
+    context.hooks.onBeforeBuild.tap(({ isFirstCompile }) => {
+      if (isFirstCompile) {
+        inspect();
+      }
+    });
     context.hooks.onAfterStartDevServer.tap(inspect);
   }
 

--- a/packages/compat/webpack/src/shared.ts
+++ b/packages/compat/webpack/src/shared.ts
@@ -12,7 +12,7 @@ const {
   getRsbuildInspectConfig,
   chainToConfig,
   modifyBundlerChain,
-  onBeforeCompile,
+  onBeforeBuild,
   onCompileDone,
   prettyTime,
 } = __internalHelper;
@@ -29,7 +29,7 @@ export {
   chainToConfig,
   modifyBundlerChain,
   onCompileDone,
-  onBeforeCompile,
+  onBeforeBuild,
   prettyTime,
   getRsbuildInspectConfig,
 };

--- a/packages/compat/webpack/src/shared.ts
+++ b/packages/compat/webpack/src/shared.ts
@@ -12,6 +12,7 @@ const {
   getRsbuildInspectConfig,
   chainToConfig,
   modifyBundlerChain,
+  onBeforeCompile,
   onCompileDone,
   prettyTime,
 } = __internalHelper;
@@ -28,6 +29,7 @@ export {
   chainToConfig,
   modifyBundlerChain,
   onCompileDone,
+  onBeforeCompile,
   prettyTime,
   getRsbuildInspectConfig,
 };

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -565,6 +565,44 @@ export const isMultiCompiler = <
   return compiler.constructor.name === 'MultiCompiler';
 };
 
+export const onBeforeCompile = (
+  compiler: Rspack.Compiler | Rspack.MultiCompiler,
+  onBefore: () => Promise<any>,
+): void => {
+  const name = 'rsbuild:beforeCompile';
+
+  if (isMultiCompiler(compiler)) {
+    const { compilers } = compiler;
+
+    let doneCompilers = 0;
+
+    for (let index = 0; index < compilers.length; index++) {
+      const compiler = compilers[index];
+      let compilerDone = false;
+
+      compiler.hooks.beforeCompile.tapPromise(name, async () => {
+        if (!compilerDone) {
+          compilerDone = true;
+          doneCompilers++;
+        }
+
+        if (doneCompilers === compilers.length) {
+          await onBefore();
+        }
+      });
+
+      compiler.hooks.invalid.tap(name, () => {
+        if (compilerDone) {
+          compilerDone = false;
+          doneCompilers--;
+        }
+      });
+    }
+  } else {
+    compiler.hooks.beforeCompile.tapPromise(name, onBefore);
+  }
+};
+
 export const onCompileDone = (
   compiler: Rspack.Compiler | Rspack.MultiCompiler,
   onDone: (stats: Rspack.Stats | Rspack.MultiStats) => Promise<void>,

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -20,7 +20,7 @@ export {
   formatStats,
   getStatsOptions,
   onCompileDone,
-  onBeforeCompile,
+  onBeforeBuild,
   prettyTime,
 } from './helpers';
 export { getChainUtils, getConfigUtils } from './provider/rspackConfig';

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -20,6 +20,7 @@ export {
   formatStats,
   getStatsOptions,
   onCompileDone,
+  onBeforeCompile,
   prettyTime,
 } from './helpers';
 export { getChainUtils, getConfigUtils } from './provider/rspackConfig';

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -45,11 +45,7 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
 
     const cleanAll = async (params: {
       environments: Record<string, EnvironmentContext>;
-      isFirstCompile?: boolean;
     }) => {
-      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
-        return;
-      }
       const environments = Object.values(params.environments).reduce<
         Array<EnvironmentContext>
       >((total, curr) => {
@@ -62,7 +58,11 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
       await Promise.all(environments.map((e) => clean(e)));
     };
 
-    api.onBeforeBuild(cleanAll);
+    api.onBeforeBuild(async ({ isFirstCompile, environments }) => {
+      if (isFirstCompile) {
+        await cleanAll({ environments });
+      }
+    });
     api.onBeforeStartDevServer(cleanAll);
   },
 });

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -45,7 +45,11 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
 
     const cleanAll = async (params: {
       environments: Record<string, EnvironmentContext>;
+      isFirstCompile?: boolean;
     }) => {
+      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
+        return;
+      }
       const environments = Object.values(params.environments).reduce<
         Array<EnvironmentContext>
       >((total, curr) => {

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -53,13 +53,7 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     const enableLogging =
       RSPACK_PROFILE === 'ALL' || RSPACK_PROFILE.includes('LOGGING');
 
-    const onStart = (params: {
-      isFirstCompile?: boolean;
-      [key: string]: unknown;
-    }) => {
-      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
-        return;
-      }
+    const onStart = () => {
       // can't get precise api.context.distPath before config init
       const profileDir = path.join(api.context.distPath, profileDirName);
 
@@ -85,7 +79,11 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
       }
     };
 
-    api.onBeforeBuild(onStart);
+    api.onBeforeBuild(({ isFirstCompile }) => {
+      if (isFirstCompile) {
+        onStart();
+      }
+    });
     api.onBeforeStartDevServer(onStart);
 
     api.onAfterBuild(async ({ stats }) => {

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -53,7 +53,13 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
     const enableLogging =
       RSPACK_PROFILE === 'ALL' || RSPACK_PROFILE.includes('LOGGING');
 
-    const onStart = () => {
+    const onStart = (params: {
+      isFirstCompile?: boolean;
+      [key: string]: unknown;
+    }) => {
+      if (params.isFirstCompile !== undefined && !params.isFirstCompile) {
+        return;
+      }
       // can't get precise api.context.distPath before config init
       const profileDir = path.join(api.context.distPath, profileDirName);
 

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -8,7 +8,10 @@ export const pluginServer = (): RsbuildPlugin => ({
   name: 'rsbuild:server',
 
   setup(api) {
-    api.onBeforeBuild(async () => {
+    api.onBeforeBuild(async (params: { isFirstCompile?: boolean }) => {
+      if (!params.isFirstCompile) {
+        return;
+      }
       const config = api.getNormalizedConfig();
       const publicDirs = normalizePublicDirs(config.server.publicDir);
 

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -8,8 +8,8 @@ export const pluginServer = (): RsbuildPlugin => ({
   name: 'rsbuild:server',
 
   setup(api) {
-    api.onBeforeBuild(async (params: { isFirstCompile?: boolean }) => {
-      if (!params.isFirstCompile) {
+    api.onBeforeBuild(async ({ isFirstCompile }) => {
+      if (!isFirstCompile) {
         return;
       }
       const config = api.getNormalizedConfig();

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -1,5 +1,10 @@
 import { rspack } from '@rspack/core';
-import { getNodeEnv, onCompileDone, setNodeEnv } from '../helpers';
+import {
+  getNodeEnv,
+  onBeforeCompile,
+  onCompileDone,
+  setNodeEnv,
+} from '../helpers';
 import { logger } from '../logger';
 import type {
   BuildOptions,
@@ -14,7 +19,9 @@ import { type InitConfigsOptions, initConfigs } from './initConfigs';
 export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
-): Promise<void> => {
+): Promise<void | {
+  close: (callback?: () => void) => void;
+}> => {
   if (!getNodeEnv()) {
     setNodeEnv(mode);
   }
@@ -36,11 +43,14 @@ export const build = async (
   }
 
   let isFirstCompile = true;
-  await context.hooks.onBeforeBuild.call({
-    bundlerConfigs,
-    environments: context.environments,
-    isWatch: Boolean(watch),
-  });
+
+  const onBeforeBuild = async () =>
+    await context.hooks.onBeforeBuild.call({
+      bundlerConfigs,
+      environments: context.environments,
+      isWatch: Boolean(watch),
+      isFirstCompile,
+    });
 
   const onDone = async (stats: Stats | MultiStats) => {
     const p = context.hooks.onAfterBuild.call({
@@ -53,15 +63,17 @@ export const build = async (
     await p;
   };
 
+  onBeforeCompile(compiler, onBeforeBuild);
+
   onCompileDone(compiler, onDone, rspack.MultiStats);
 
   if (watch) {
-    compiler.watch({}, (err) => {
+    const watching = compiler.watch({}, (err) => {
       if (err) {
         logger.error(err);
       }
     });
-    return;
+    return watching;
   }
 
   await new Promise<{ stats?: Stats | MultiStats }>((resolve, reject) => {

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -20,7 +20,7 @@ export const build = async (
   initOptions: InitConfigsOptions,
   { mode = 'production', watch, compiler: customCompiler }: BuildOptions = {},
 ): Promise<void | {
-  close: (callback?: () => void) => void;
+  close: () => Promise<void>;
 }> => {
   if (!getNodeEnv()) {
     setNodeEnv(mode);
@@ -73,7 +73,12 @@ export const build = async (
         logger.error(err);
       }
     });
-    return watching;
+    return {
+      close: () =>
+        new Promise((resolve) => {
+          watching.close(resolve);
+        }),
+    };
   }
 
   await new Promise<{ stats?: Stats | MultiStats }>((resolve, reject) => {

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -1,7 +1,7 @@
 import { rspack } from '@rspack/core';
 import {
   getNodeEnv,
-  onBeforeCompile,
+  onBeforeBuild,
   onCompileDone,
   setNodeEnv,
 } from '../helpers';
@@ -44,7 +44,7 @@ export const build = async (
 
   let isFirstCompile = true;
 
-  const onBeforeBuild = async () =>
+  const beforeBuild = async () =>
     await context.hooks.onBeforeBuild.call({
       bundlerConfigs,
       environments: context.environments,
@@ -63,7 +63,7 @@ export const build = async (
     await p;
   };
 
-  onBeforeCompile(compiler, onBeforeBuild);
+  onBeforeBuild(compiler, beforeBuild, watch);
 
   onCompileDone(compiler, onDone, rspack.MultiStats);
 

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -222,7 +222,11 @@ export async function initConfigs({
     };
 
     // run inspect later to avoid cleaned by cleanOutput plugin
-    context.hooks.onBeforeBuild.tap(inspect);
+    context.hooks.onBeforeBuild.tap(({ isFirstCompile }) => {
+      if (isFirstCompile) {
+        inspect();
+      }
+    });
     context.hooks.onAfterStartDevServer.tap(inspect);
   }
 

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -14,6 +14,7 @@ import type { HtmlRspackPlugin, WebpackConfig } from './thirdParty';
 import type { MaybePromise, NodeEnv } from './utils';
 
 export type OnBeforeBuildFn<B = 'rspack'> = (params: {
+  isFirstCompile: boolean;
   isWatch: boolean;
   bundlerConfigs?: B extends 'rspack'
     ? Rspack.Configuration[]

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -90,7 +90,7 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   ) => Promise<StartServerResult>;
 
   build: (options?: BuildOptions) => Promise<void | {
-    close: (callback?: () => void) => void;
+    close: () => Promise<void>;
   }>;
 
   initConfigs: () => Promise<

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -89,7 +89,9 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
     options?: StartDevServerOptions,
   ) => Promise<StartServerResult>;
 
-  build: (options?: BuildOptions) => Promise<void>;
+  build: (options?: BuildOptions) => Promise<void | {
+    close: (callback?: () => void) => void;
+  }>;
 
   initConfigs: () => Promise<
     B extends 'rspack' ? RspackConfig[] : WebpackConfig[]

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -132,7 +132,7 @@ await rsbuild.build({
 });
 ```
 
-The build method returns a Watching instance in watch mode that exposes `.close(callback)` method. Calling this method will end watching:
+The build method returns a `Watching` instance in watch mode that exposes `.close(callback)` method. Calling this method will end watching:
 
 ```ts
 const watching = await rsbuild.build({

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -90,7 +90,7 @@ type BuildOptions = {
 };
 
 function Build(options?: BuildOptions): Promise<void | {
-  close: (callback?: () => void) => void;
+  close: () => Promise<void>;
 }>;
 ```
 
@@ -139,7 +139,7 @@ const watching = await rsbuild.build({
   watch: true,
 });
 
-watching?.close();
+await watching?.close();
 ```
 
 ### Custom Compiler

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -89,7 +89,9 @@ type BuildOptions = {
   compiler?: Compiler | MultiCompiler;
 };
 
-function Build(options?: BuildOptions): Promise<void>;
+function Build(options?: BuildOptions): Promise<void | {
+  close: (callback?: () => void) => void;
+}>;
 ```
 
 - **Example:**
@@ -128,6 +130,16 @@ If you need to watch file changes and re-build, you can set the `watch` option t
 await rsbuild.build({
   watch: true,
 });
+```
+
+The build method returns a Watching instance in watch mode that exposes `.close(callback)` method. Calling this method will end watching:
+
+```ts
+const watching = await rsbuild.build({
+  watch: true,
+});
+
+watching?.close();
 ```
 
 ### Custom Compiler

--- a/website/docs/en/shared/onBeforeBuild.mdx
+++ b/website/docs/en/shared/onBeforeBuild.mdx
@@ -2,7 +2,7 @@
 
 You can access the Rspack configuration array through the `bundlerConfigs` parameter. The array may contain one or more [Rspack configurations](https://rspack.dev/config/). It depends on whether multiple [environments](/config/environments) are configured.
 
-Moreover, you can use `isWatch` to determine whether it is watch mode.
+Moreover, you can use `isWatch` to determine whether it is watch mode, and use `isFirstCompile` to determine whether it is the first build on watch mode.
 
 - **Type:**
 
@@ -10,6 +10,7 @@ Moreover, you can use `isWatch` to determine whether it is watch mode.
 function OnBeforeBuild(
   callback: (params: {
     isWatch: boolean;
+    isFirstCompile: boolean;
     bundlerConfigs?: WebpackConfig[] | RspackConfig[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -154,7 +154,7 @@ await rsbuild.build({
 });
 ```
 
-watch 模式下 build 方法会返回一个 Watching 实例，该实例会暴露一个 `.close(callback)` 方法。调用该方法将会结束监听：
+watch 模式下 build 方法会返回一个 `Watching` 实例，该实例会暴露一个 `.close(callback)` 方法。调用该方法将会结束监听：
 
 ```ts
 const watching = await rsbuild.build({

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -111,7 +111,9 @@ type BuildOptions = {
   compiler?: Compiler | MultiCompiler;
 };
 
-function Build(options?: BuildOptions): Promise<void>;
+function Build(options?: BuildOptions): Promise<void | {
+  close: (callback?: () => void) => void;
+}>;
 ```
 
 - **示例：**
@@ -150,6 +152,16 @@ await rsbuild.build({
 await rsbuild.build({
   watch: true,
 });
+```
+
+watch 模式下 build 方法会返回一个 Watching 实例，该实例会暴露一个 `.close(callback)` 方法。调用该方法将会结束监听：
+
+```ts
+const watching = await rsbuild.build({
+  watch: true,
+});
+
+watching?.close();
 ```
 
 ### 自定义 Compiler

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -112,7 +112,7 @@ type BuildOptions = {
 };
 
 function Build(options?: BuildOptions): Promise<void | {
-  close: (callback?: () => void) => void;
+  close: () => Promise<void>;
 }>;
 ```
 
@@ -161,7 +161,7 @@ const watching = await rsbuild.build({
   watch: true,
 });
 
-watching?.close();
+await watching?.close();
 ```
 
 ### 自定义 Compiler

--- a/website/docs/zh/shared/onBeforeBuild.mdx
+++ b/website/docs/zh/shared/onBeforeBuild.mdx
@@ -2,7 +2,7 @@
 
 你可以通过 `bundlerConfigs` 参数获取到 Rspack 配置数组，数组中可能包含一份或多份 [Rspack 配置](https://rspack.dev/config/)，这取决于是否配置了多个 [environments](/config/environments)。
 
-另外，你可以通过 `isWatch` 判断是否是 watch 模式。
+另外，你可以通过 `isWatch` 判断是否是 watch 模式，并在 watch 模式下通过 `isFirstCompile` 来判断是否为首次构建。
 
 - **类型：**
 
@@ -10,6 +10,7 @@
 function OnBeforeBuild(
   callback: (params: {
     isWatch: boolean;
+    isFirstCompile: boolean;
     bundlerConfigs?: WebpackConfig[] | RspackConfig[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,


### PR DESCRIPTION
## Summary

`onBeforeBuild` hook should calling multiple times **in watch mode**. 

This modification may cause breaking for plugins that originally use `onBeforeBuild` hook.

If you want `onBeforeBuild` to be executed **only once** even in watch mode, you can use `isFirstCompile` to determine whether it is the first build on watch mode.

```diff
const myPlugin = () => ({
  setup: (api) => {
    api.onBeforeBuild(({ bundlerConfigs, isFirstCompile }) => {
+    if (!isFirstCompile) {
+        return;
+     }
      console.log('the bundler config is ', bundlerConfigs);
    });
  },
});
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
