### PR TITLE
feat(core): add `type` option to `dev.watchFiles` to support reload server

### DIFF
--- a/e2e/cases/cli/reload-extra-config/.gitignore
+++ b/e2e/cases/cli/reload-extra-config/.gitignore
@@ -1,0 +1,2 @@
+server.ts
+rsbuild.config.ts

--- a/e2e/cases/cli/reload-extra-config/index.test.ts
+++ b/e2e/cases/cli/reload-extra-config/index.test.ts
@@ -1,0 +1,118 @@
+import { exec } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { awaitFileExists } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should restart dev server and reload config when extra config file changed', async () => {
+  const distPath = 'dist';
+  const dist = path.join(__dirname, distPath);
+
+  const extraConfigPath = './server.ts';
+  const extraConfigFile = path.join(__dirname, extraConfigPath);
+
+  const configFile = path.join(__dirname, 'rsbuild.config.ts');
+
+  fs.rmSync(extraConfigFile, { force: true });
+  fs.rmSync(configFile, { force: true });
+  fs.rmSync(dist, { recursive: true, force: true });
+
+  // configs/server.ts
+  fs.writeFileSync(extraConfigFile, 'export default {};');
+
+  // rsbuild.config.ts
+  fs.writeFileSync(
+    configFile,
+    `
+    import { defineConfig } from '@rsbuild/core';
+    import server from '${extraConfigPath}';
+
+    export default defineConfig({
+      dev: {
+        writeToDisk: true,
+        watchFiles: {
+          type: 'reload-server',
+          paths: ['${extraConfigPath}'],
+        }
+      },
+      output: {
+        distPath: {
+          root: '${distPath}',
+        },
+      },
+      server,
+    });`,
+  );
+
+  const process = exec('npx rsbuild dev', {
+    cwd: __dirname,
+  });
+
+  await awaitFileExists(dist);
+
+  fs.rmSync(dist, { recursive: true });
+  // configs/server.ts changed
+  fs.writeFileSync(extraConfigFile, 'export default {};');
+
+  await awaitFileExists(dist);
+
+  process.kill();
+});
+
+test('should not restart dev server when extra config file changed but `dev.watchFiles.type` is not set to `reload-server`', async () => {
+  const distPath = 'dist';
+  const dist = path.join(__dirname, distPath);
+
+  const extraConfigPath = './server.ts';
+  const extraConfigFile = path.join(__dirname, extraConfigPath);
+
+  const configFile = path.join(__dirname, 'rsbuild.config.ts');
+
+  fs.rmSync(extraConfigFile, { force: true });
+  fs.rmSync(configFile, { force: true });
+  fs.rmSync(dist, { recursive: true, force: true });
+
+  // configs/server.ts
+  fs.writeFileSync(extraConfigFile, 'export default {};');
+
+  // rsbuild.config.ts
+  fs.writeFileSync(
+    configFile,
+    `
+    import { defineConfig } from '@rsbuild/core';
+    import server from '${extraConfigPath}';
+
+    export default defineConfig({
+      dev: {
+        writeToDisk: true,
+        watchFiles: {
+          // should not restart dev server
+          type: 'foo',
+          paths: ['${extraConfigPath}'],
+        }
+      },
+      output: {
+        distPath: {
+          root: '${distPath}',
+        },
+      },
+      server,
+    });`,
+  );
+
+  const process = exec('npx rsbuild dev', {
+    cwd: __dirname,
+  });
+
+  await awaitFileExists(dist);
+
+  fs.rmSync(dist, { recursive: true });
+  // configs/server.ts changed
+  fs.writeFileSync(extraConfigFile, 'export default {};');
+
+  await expect(awaitFileExists(dist)).rejects.toThrow(
+    `awaitFileExists failed: ${dist}`,
+  );
+
+  process.kill();
+});

--- a/e2e/cases/cli/reload-extra-config/src/index.js
+++ b/e2e/cases/cli/reload-extra-config/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/e2e/cases/cli/reload-extra-config/tsconfig.json
+++ b/e2e/cases/cli/reload-extra-config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist"
+  },
+  "include": ["src", "*.test.ts"]
+}

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -49,6 +49,13 @@ export async function init({
       const files = [...envs.filePaths];
       if (configFilePath) {
         files.push(configFilePath);
+        if (config.dev?.watchFiles?.type === 'reload-server') {
+          const extraConfigFiles =
+            typeof config.dev.watchFiles.paths === 'string'
+              ? [config.dev.watchFiles.paths]
+              : config.dev.watchFiles.paths;
+          files.push(...extraConfigFiles);
+        }
       }
 
       watchFiles(files);

--- a/packages/core/src/types/config/dev.ts
+++ b/packages/core/src/types/config/dev.ts
@@ -59,6 +59,7 @@ export type ChokidarWatchOptions = WatchOptions;
 export type WatchFiles = {
   paths: string | string[];
   options?: WatchOptions;
+  type?: 'reload-page' | 'reload-server';
 };
 
 export interface DevConfig {


### PR DESCRIPTION
## Summary
Add `type` option to `dev.watchFiles` to choose 'reload-page'(default) or 'reload-server'
#### Type
```typescript
type WatchFiles = {
  paths: string | string[];
  options?: WatchOptions;
  type?: 'reload-page' | 'reload-server';
};
```
#### Usage
- type: 'reload-page' is the default value, align with the current usage.
```javascript
export default {
  dev: {
    watchFiles: {
      type: 'reload-page',
      paths: ['public/foo.txt'],
    },
  },
};
```
- type: 'reload-server' is the new value, can be used to watch some config files and reload the server.
```javascript
import proxy from './configs/proxy.ts';

export default {
  dev: {
    watchFiles: {
      type: 'reload-server',
      paths: ['configs/proxy.ts'],
    },
  },
  server: {
    proxy,
  },
};
```
## Related Links
https://github.com/web-infra-dev/rsbuild/pull/3057
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
