### PR TITLE
chore: remove temp code for lightningcss-loader

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import browserslist from 'browserslist';
 import deepmerge from 'deepmerge';
 import type { AcceptedPlugin } from 'postcss';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
@@ -183,56 +182,6 @@ const getCSSLoaderOptions = ({
   return cssLoaderOptions;
 };
 
-const BROWSER_MAPPING: Record<string, string | null> = {
-  and_chr: 'chrome',
-  and_ff: 'firefox',
-  ie_mob: 'ie',
-  op_mob: 'opera',
-  and_qq: null,
-  and_uc: null,
-  baidu: null,
-  bb: null,
-  kaios: null,
-  op_mini: null,
-};
-
-function parseVersion(version: string) {
-  const [major, minor = 0, patch = 0] = version
-    .split('-')[0]
-    .split('.')
-    .map((v) => Number.parseInt(v, 10));
-
-  if (Number.isNaN(major) || Number.isNaN(minor) || Number.isNaN(patch)) {
-    return null;
-  }
-
-  return (major << 16) | (minor << 8) | patch;
-}
-
-// code modified based on https://github.com/parcel-bundler/lightningcss/blob/34b67a431c043fda5d4979bcdccb3008d082e243/node/browserslistToTargets.js
-// MIT License
-// TODO: no need to call browserslist in next Rspack version
-function browserslistToTargets(browserslist: string[]): Record<string, number> {
-  const targets: Record<string, number> = {};
-  for (const browser of browserslist) {
-    const [name, v] = browser.split(' ');
-    if (BROWSER_MAPPING[name] === null) {
-      continue;
-    }
-
-    const version = parseVersion(v);
-    if (version == null) {
-      continue;
-    }
-
-    if (targets[name] == null || version < targets[name]) {
-      targets[name] = version;
-    }
-  }
-
-  return targets;
-}
-
 async function applyCSSRule({
   rule,
   config,
@@ -287,9 +236,7 @@ async function applyCSSRule({
 
       const loaderOptions = reduceConfigs<Rspack.LightningcssLoaderOptions>({
         initial: {
-          targets: browserslistToTargets(
-            browserslist(environment.browserslist),
-          ),
+          targets: environment.browserslist,
         },
         config: config.tools.lightningcssLoader,
       });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -57,12 +57,12 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -32,12 +32,12 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],
@@ -122,12 +122,12 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -57,12 +57,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],
@@ -455,12 +455,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],
@@ -1218,12 +1218,12 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1407,12 +1407,12 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
             {
               "loader": "builtin:lightningcss-loader",
               "options": {
-                "targets": {
-                  "chrome": 5701632,
-                  "edge": 5767168,
-                  "firefox": 5111808,
-                  "safari": 917504,
-                },
+                "targets": [
+                  "chrome >= 87",
+                  "edge >= 88",
+                  "firefox >= 78",
+                  "safari >= 14",
+                ],
               },
             },
           ],

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -84,12 +84,12 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -142,12 +142,12 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -197,12 +197,12 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -73,12 +73,12 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
-              "targets": {
-                "chrome": 5701632,
-                "edge": 5767168,
-                "firefox": 5111808,
-                "safari": 917504,
-              },
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
             },
           },
         ],

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -30,12 +30,12 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -96,12 +96,12 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -168,12 +168,12 @@ exports[`plugin-rem > should run rem plugin with default config 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -227,12 +227,12 @@ exports[`plugin-rem > should run rem plugin with default config 2`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -301,12 +301,12 @@ exports[`plugin-rem > should run rem plugin with default config 3`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -86,12 +86,12 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -146,12 +146,12 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -29,12 +29,12 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {
@@ -77,12 +77,12 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
-          "targets": {
-            "chrome": 5701632,
-            "edge": 5767168,
-            "firefox": 5111808,
-            "safari": 917504,
-          },
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary

Remove temp code for lightningcss-loader since the bug of Rspack has been fixed.

## Related Links

https://github.com/web-infra-dev/rspack/pull/7331

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
