### PR TITLE
release: 1.0.1-beta.7

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.6",
+  "version": "1.0.1-beta.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"

--- a/website/docs/en/guide/basic/css-usage.mdx
+++ b/website/docs/en/guide/basic/css-usage.mdx
@@ -17,7 +17,7 @@ Rsbuild uses Rspack's built-in [lightningcss-loader](https://www.rspack.dev/guid
 - You can use [tools.lightningcssLoader](/config/tools/lightningcss-loader) to customize the options for `lightningcss-loader`.
 - If Lightning CSS does not meet your needs, you can also use [PostCSS](#using-postcss) to transform CSS code.
 
-> Rsbuild has enabled Lightning CSS by default since version `1.0.1-beta.6`.
+> Rsbuild has enabled Lightning CSS by default since version `1.0.1-beta.7`.
 
 ## CSS Minification
 

--- a/website/docs/zh/guide/basic/css-usage.mdx
+++ b/website/docs/zh/guide/basic/css-usage.mdx
@@ -17,7 +17,7 @@ Rsbuild 使用 Rspack 内置的 [lightningcss-loader](https://www.rspack.dev/gui
 - 你可以使用 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 来自定义 `lightningcss-loader` 的选项。
 - 如果 Lightning CSS 无法满足你的需求，你也可以使用 [PostCSS](#使用-postcss) 来转换 CSS 代码。
 
-> Rsbuild 从 `1.0.1-beta.6` 版本开始默认启用 Lightning CSS。
+> Rsbuild 从 `1.0.1-beta.7` 版本开始默认启用 Lightning CSS。
 
 ## CSS 压缩
 


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Changes 🍭

Rsbuild now enables [lightningcss-loader](https://rspack.dev/guide/features/builtin-lightningcss-loader) by default to transform CSS files, it replaces `autoprefixer` to add vendor prefixes and provides better performance.

- `@rsbuild/plugin-lightningcss` has been deprecated and no longer needed.
- `tools.autoprefixer` config has been removed.

Considering that Lightning CSS has some uncovered edge cases, you can still enable autoprefixer via the postcss configuration file:

```js
// postcss.config.cjs
module.exports = {
  plugins: {
    autoprefixer: {},
  }
}
```


> https://github.com/web-infra-dev/rsbuild/pull/3047, https://github.com/web-infra-dev/rsbuild/pull/3034

### New Features 🎉
* feat: bump Rspack 1.0.0-beta.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3072
* feat: add new `tools.lightningcssLoader` config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3043
* feat: add `isWatch` param to determine whether it is watch mode when build by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3065
* feat: support only build specified environment by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3059
* feat(core): add `type` option to `dev.watchFiles` to support reload server by @kurorinto in https://github.com/web-infra-dev/rsbuild/pull/3069
### Performance 🚀
* perf!: remove built-in autoprefixer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3035
* perf: skip postcss-loader if no plugins are registered by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3036
* perf: prebundle postcss by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3062
* perf: remove cosmiconfig from postcss-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3063
* perf: bump rspack-manifest-plugin v5.0.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3064
### Bug Fixes 🐞
* fix: targets options of lightningcss-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3038
* fix: targets of lightningcss-loader not work by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3039
* fix: set browserset for lightningcss minimizer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3048
* fix: add uniqueName to WebSocket compilation name by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3051
* fix: processAssets callback should only called once by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3054
* fix: allow to enable Rspack `experiments.css` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3068
* fix: watchFiles options not work for reloading server by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3077
### Document 📖
* docs: add guide for builtin lightningcss loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3049
* docs: add remove plugin tip when use environment plugin by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3053
* docs: make moduleFederation.options more clear by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3060
* docs: simplify `tools.rspack` examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3061
* docs: tells that `addRules` is adding rules to the leading by @xc2 in https://github.com/web-infra-dev/rsbuild/pull/3071
### Other Changes
* chore(deps): bump pnpm@9.6.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3033
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/2982
* chore(deps): update dependency sass-loader to v16 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3042
* chore(deps): update eslint to ^9.8.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3041
* Revert "test(e2e): try to fix CI failures (#2997)" by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3045
* test(e2e): retry on CI by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3044
* test(e2e): avoid write to committed file by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3046
* chore(deps): update dependency @babel/preset-env to ^7.25.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3040
* chore: add example for module federation v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3052
* test(e2e): add basic e2e cases for MF v2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3055
* test(e2e): add test case for lightingcss-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3073
* chore: remove temp code for lightningcss-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3074
* test(e2e): should kill child process by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3076

## New Contributors
* @kurorinto made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3069

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.6...v1.0.1-beta.7