### PR TITLE
test(e2e): should kill child process

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -10,9 +10,10 @@ rspackOnlyTest('should run onExit hook before process exit', async () => {
   fs.rmSync(distFile, { force: true });
 
   await new Promise<void>((resolve) => {
-    exec('node ./run.mjs', { cwd: __dirname }, () => {
+    const process = exec('node ./run.mjs', { cwd: __dirname }, () => {
       expect(fs.readFileSync(distFile, 'utf-8')).toEqual('1');
       resolve();
+      process.kill();
     });
   });
 });


### PR DESCRIPTION
## Summary

Should kill child process, otherwise the e2e process may not exit.

https://github.com/web-infra-dev/rsbuild/pull/2997

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
