### PR TITLE
fix: watchFiles options not work for reloading server

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
+import type { WatchOptions } from 'chokidar';
 import color from 'picocolors';
 import RspackChain from 'rspack-chain';
 import {
@@ -296,7 +297,10 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
   return null;
 };
 
-export async function watchFiles(files: string[]): Promise<void> {
+export async function watchFiles(
+  files: string[],
+  watchOptions?: WatchOptions,
+): Promise<void> {
   if (!files.length) {
     return;
   }
@@ -307,6 +311,7 @@ export async function watchFiles(files: string[]): Promise<void> {
     ignoreInitial: true,
     // If watching fails due to read permissions, the errors will be suppressed silently.
     ignorePermissionErrors: true,
+    ...watchOptions,
   });
 
   const callback = debounce(

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -96,15 +96,17 @@ async function startWatchFiles(
   { paths, options, type }: ReturnType<typeof prepareWatchOptions>,
   compileMiddlewareAPI: CompileMiddlewareAPI,
 ) {
-  // If `type` is not 'reload-server', treat it as 'reload-page'.
-  if (type !== 'reload-server') {
-    const chokidar = await import('chokidar');
-    const watcher = chokidar.watch(paths, options);
-
-    watcher.on('change', () => {
-      compileMiddlewareAPI.sockWrite('static-changed');
-    });
-
-    return watcher;
+  // If `type` is 'reload-server', skip it.
+  if (type === 'reload-server') {
+    return;
   }
+
+  const chokidar = await import('chokidar');
+  const watcher = chokidar.watch(paths, options);
+
+  watcher.on('change', () => {
+    compileMiddlewareAPI.sockWrite('static-changed');
+  });
+
+  return watcher;
 }


### PR DESCRIPTION
## Summary

Fix `watchFiles.options` not work for reloading server.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
