### PR TITLE
fix: avoid merging boolean config with object config

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -16,7 +16,6 @@ import type {
   RsbuildConfig,
   RsbuildContext,
   RsbuildEntry,
-  RsbuildTarget,
 } from './types';
 
 function getAbsolutePath(root: string, filepath: string) {
@@ -93,25 +92,11 @@ export async function getBrowserslistByEnvironment(
   return DEFAULT_BROWSERSLIST[target];
 }
 
-const hasHTML = (
-  config: NormalizedEnvironmentConfig,
-  target: RsbuildTarget,
-) => {
-  const { htmlPlugin } = config.tools as {
-    htmlPlugin: boolean | Array<unknown>;
-  };
-  const pluginDisabled =
-    htmlPlugin === false ||
-    (Array.isArray(htmlPlugin) && htmlPlugin.includes(false));
-
-  return target === 'web' && !pluginDisabled;
-};
-
 const getEnvironmentHTMLPaths = (
   entry: RsbuildEntry,
   config: NormalizedEnvironmentConfig,
 ) => {
-  if (!hasHTML(config, config.output.target)) {
+  if (config.output.target !== 'web' || config.tools.htmlPlugin === false) {
     return {};
   }
 

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -38,6 +38,11 @@ const merge = (x: unknown, y: unknown, path = '') => {
     return isPlainObject(x) ? cloneDeep(x) : x;
   }
 
+  // no need to merge boolean with object or function, such as `tools.htmlPlugin`
+  if (typeof x === 'boolean' || typeof y === 'boolean') {
+    return y;
+  }
+
   const pair = [x, y];
 
   // combine array

--- a/packages/core/tests/html.test.ts
+++ b/packages/core/tests/html.test.ts
@@ -120,19 +120,6 @@ describe('plugin-html', () => {
     expect(await rsbuild.matchBundlerPlugin('HtmlRspackPlugin')).toBeFalsy();
   });
 
-  it('should disable html plugin when htmlPlugin is an array and contains false', async () => {
-    const rsbuild = await createStubRsbuild({
-      plugins: [pluginEntry(), pluginHtml()],
-      rsbuildConfig: {
-        tools: {
-          htmlPlugin: [{}, false],
-        },
-      },
-    });
-
-    expect(await rsbuild.matchBundlerPlugin('HtmlRspackPlugin')).toBeFalsy();
-  });
-
   it('should support multi entry', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml()],

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -214,6 +214,46 @@ describe('mergeRsbuildConfig', () => {
     });
   });
 
+  test('should merge tools.htmlPlugin correctly', async () => {
+    expect(
+      mergeRsbuildConfig(
+        {
+          tools: {
+            htmlPlugin: {},
+          },
+        },
+        {
+          tools: {
+            htmlPlugin: false,
+          },
+        },
+      ),
+    ).toEqual({
+      tools: {
+        htmlPlugin: false,
+      },
+    });
+
+    expect(
+      mergeRsbuildConfig(
+        {
+          tools: {
+            htmlPlugin: false,
+          },
+        },
+        {
+          tools: {
+            htmlPlugin: {},
+          },
+        },
+      ),
+    ).toEqual({
+      tools: {
+        htmlPlugin: {},
+      },
+    });
+  });
+
   it('should merge SWC plugins as expected', () => {
     expect(
       mergeRsbuildConfig(


### PR DESCRIPTION
## Summary

Avoid merging boolean config with object config, because the `reduceConfigs()` helper can not handle it.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
