### PR TITLE
fix: plugin type missing when set moduleResolution node16+

### DIFF
--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build && node scripts/postCompile.mjs",

--- a/packages/plugin-babel/modern.config.ts
+++ b/packages/plugin-babel/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -11,16 +11,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "dist",
-    "compiled"
+    "compiled",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-check-syntax/modern.config.ts
+++ b/packages/plugin-check-syntax/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-less/modern.config.ts
+++ b/packages/plugin-less/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -12,16 +12,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "dist",
-    "compiled"
+    "compiled",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-preact/modern.config.ts
+++ b/packages/plugin-preact/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -11,15 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-react/modern.config.ts
+++ b/packages/plugin-react/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -11,15 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-rem/modern.config.ts
+++ b/packages/plugin-rem/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -12,16 +12,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "dist",
-    "compiled"
+    "compiled",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-solid/modern.config.ts
+++ b/packages/plugin-solid/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-source-build/modern.config.ts
+++ b/packages/plugin-source-build/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-styled-components/modern.config.ts
+++ b/packages/plugin-styled-components/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -11,15 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-stylus/modern.config.ts
+++ b/packages/plugin-stylus/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-svelte/modern.config.ts
+++ b/packages/plugin-svelte/modern.config.ts
@@ -1,14 +1,35 @@
 import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import {
+  cjsBuildConfig,
+  emitTypePkgJsonPlugin,
+  esmBuildConfig,
+} from '@rsbuild/config/modern.config.ts';
 
 export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs.map((config) => {
-    config.externals = [
-      ...(config.externals || []),
-      'svelte/compiler',
-      'svelte-preprocess/dist/types',
-    ];
-    return config;
-  }),
+  plugins: [moduleTools(), emitTypePkgJsonPlugin],
+  buildConfig: [
+    {
+      ...esmBuildConfig,
+      externals: [
+        ...(esmBuildConfig.externals || []),
+        'svelte/compiler',
+        'svelte-preprocess/dist/types',
+      ],
+    },
+    {
+      ...cjsBuildConfig,
+      externals: [
+        ...(cjsBuildConfig.externals || []),
+        'svelte/compiler',
+        'svelte-preprocess/dist/types',
+      ],
+    },
+    {
+      buildType: 'bundleless',
+      dts: {
+        distPath: '../dist-types',
+        only: true,
+      },
+    },
+  ],
 };

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -11,15 +11,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-svgr/modern.config.ts
+++ b/packages/plugin-svgr/modern.config.ts
@@ -1,13 +1,25 @@
-import { moduleTools } from '@modern-js/module-tools';
-import { dualBuildConfigs } from '@rsbuild/config/modern.config.ts';
+import { defineConfig, moduleTools } from '@modern-js/module-tools';
+import {
+  cjsBuildConfig,
+  emitTypePkgJsonPlugin,
+  esmBuildConfig,
+} from '@rsbuild/config/modern.config.ts';
 
-export default {
-  plugins: [moduleTools()],
-  buildConfig: dualBuildConfigs.map((config) => {
-    if (config.format === 'cjs') {
+export default defineConfig({
+  plugins: [moduleTools(), emitTypePkgJsonPlugin],
+  buildConfig: [
+    esmBuildConfig,
+    {
+      ...cjsBuildConfig,
       // add loader to entry
-      config.input = ['src/index.ts', 'src/loader.ts'];
-    }
-    return config;
-  }),
-};
+      input: ['src/index.ts', 'src/loader.ts'],
+    },
+    {
+      buildType: 'bundleless',
+      dts: {
+        distPath: '../dist-types',
+        only: true,
+      },
+    },
+  ],
+});

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -11,16 +11,17 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
     "dist",
-    "compiled"
+    "compiled",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-type-check/modern.config.ts
+++ b/packages/plugin-type-check/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-vue-jsx/modern.config.ts
+++ b/packages/plugin-vue-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-vue/modern.config.ts
+++ b/packages/plugin-vue/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-vue2-jsx/modern.config.ts
+++ b/packages/plugin-vue2-jsx/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",

--- a/packages/plugin-vue2/modern.config.ts
+++ b/packages/plugin-vue2/modern.config.ts
@@ -1,3 +1,3 @@
-import { configForDualPackage } from '@rsbuild/config/modern.config.ts';
+import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
 
-export default configForDualPackage;
+export default configForSeparateTypesPackage;

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -12,15 +12,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist-types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist/index.d.ts",
+  "types": "./dist-types/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist-types"
   ],
   "scripts": {
     "build": "modern build",


### PR DESCRIPTION
## Summary

fix plugin type resolve failed when moduleResolution is Node16+

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
