### PR TITLE
expose watcher api on devServer

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -36,6 +36,7 @@ import { createHttpServer } from './httpServer';
 import { notFoundMiddleware } from './middlewares';
 import { onBeforeRestartServer } from './restart';
 import { setupWatchFiles } from './watchFiles';
+import type { FSWatcher } from 'chokidar'
 
 export type RsbuildDevServer = {
   /**
@@ -54,6 +55,13 @@ export type RsbuildDevServer = {
   /** The Rsbuild server environment API */
   environments: EnvironmentAPI;
 
+  /**
+   *  to watch source files 
+   *
+   *  Return a chokidar `FSWatcher` object, please refer to the API: https://github.com/paulmillr/chokidar
+   */
+  watcher: FSWatcher
+  
   /**
    * The resolved port.
    *
@@ -344,6 +352,7 @@ export async function createDevServer<
         port,
         routes,
         environments: options.context.environments,
+        watcher: fileWatcher
       });
     },
     onHTTPUpgrade: devMiddlewares.onUpgrade,


### PR DESCRIPTION
## Summary

我在项目中使用到了`@generouted/react-router`，这是一个vite插件实现的功能是自动生成基于文件的路由。

其插件的核心代码如下：
```ts
export default function Generouted(options?: Partial<Options>): Plugin {
  const resolvedOptions = { ...defaultOptions, ...options }

  return {
    name: 'generouted/react-router',
    enforce: 'pre',
    configureServer(server) {
      const listener = (file = '') => (file.includes(path.normalize('/src/pages/')) ? generate(resolvedOptions) : null)
      server.watcher.on('add', listener)
      server.watcher.on('change', listener)
      server.watcher.on('unlink', listener)
    },
    buildStart(): Promise<void> {
      return generate(resolvedOptions)
    },
  }
}
```
在`buildStart`时生成路由的逻辑，然后使用`vite`开放的watch API进行动态侦听进行重新生成路由。

我发现`rsbuild`没有暴露此`api`，我觉得此API对插件开发者可能是有用的，所以提了此`PR`

## Release Notes

```ts
export default function Generouted(options?: Partial<Options>): Plugin {
  const resolvedOptions = { ...defaultOptions, ...options }

  return {
    name: 'generouted/react-router',
    enforce: 'pre',
    configureServer(server) {
      const listener = (file = '') => (file.includes(path.normalize('/src/pages/')) ? generate(resolvedOptions) : null)
      server.watcher.on('add', listener)
      server.watcher.on('change', listener)
      server.watcher.on('unlink', listener)
    },
    buildStart(): Promise<void> {
      return generate(resolvedOptions)
    },
  }
}
```

本次`PR`在`onAfterStartDevServer`暴露了`watcher`，所以我迁移`@generouted/react-router`就变得比较简单了。

因为`vite`的`watch`也是用的是`chokidar`。

```ts
export default (options?:  Options ): RsbuildPlugin => ({
  name: 'rsbuild-plugin-generouted',
  setup(api) {
    const resolvedOptions = { ...defaultOptions, ...options }

    api.modifyRsbuildConfig(({config}) => {
        config.dev?.watchFiles.push('src/pages/**/*')   
    });
    api.onAfterStartDevServer(({watcher}) => {
        const listener = (file = '') => (file.includes(path.normalize('/src/pages/')) ? generate(resolvedOptions) : null) 
        watcher.on('add', listener)
        watcher.on('change', listener)
        watcher.on('unlink', listener)
    }); 
  },
});
```

## Related Links


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
