### PR TITLE
feat: support using `<port>` in `dev.assetPrefix`

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -33,6 +33,24 @@ test('should allow dev.assetPrefix to be true', async ({ page }) => {
   await rsbuild.close();
 });
 
+test('should allow dev.assetPrefix to have <port> placeholder', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        assetPrefix: 'http://localhost:<port>/',
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+  const testEl = page.locator('#test-port');
+  await expect(testEl).toHaveText(`http://localhost:${rsbuild.port}`);
+  await rsbuild.close();
+});
+
 test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/e2e/cases/asset-prefix/src/index.js
+++ b/e2e/cases/asset-prefix/src/index.js
@@ -3,3 +3,8 @@ testEl.id = 'test';
 testEl.innerHTML = 'Hello Rsbuild!';
 
 document.body.appendChild(testEl);
+
+const testPortEl = document.createElement('div');
+testPortEl.id = 'test-port';
+testPortEl.innerHTML = process.env.ASSET_PREFIX;
+document.body.appendChild(testPortEl);

--- a/packages/core/src/plugins/open.ts
+++ b/packages/core/src/plugins/open.ts
@@ -80,7 +80,7 @@ export async function openBrowser(url: string): Promise<boolean> {
   }
 }
 
-export const replacePlaceholder = (url: string, port: number): string =>
+export const replacePortPlaceholder = (url: string, port: number): string =>
   url.replace(/<port>/g, String(port));
 
 export function resolveUrl(str: string, base: string): string {
@@ -159,7 +159,7 @@ export function pluginOpen(): RsbuildPlugin {
         } else {
           urls.push(
             ...targets.map((target) =>
-              resolveUrl(replacePlaceholder(target, port), baseUrl),
+              resolveUrl(replacePortPlaceholder(target, port), baseUrl),
             ),
           );
         }

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -13,6 +13,7 @@ import type {
   RsbuildPlugin,
 } from '../types';
 import { isUseCssExtract } from './css';
+import { replacePortPlaceholder } from './open';
 
 function getPublicPath({
   isProd,
@@ -26,6 +27,7 @@ function getPublicPath({
   const { dev, output } = config;
 
   let publicPath = DEFAULT_ASSET_PREFIX;
+  const port = context.devServer?.port || DEFAULT_PORT;
 
   if (isProd) {
     if (typeof output.assetPrefix === 'string') {
@@ -36,20 +38,19 @@ function getPublicPath({
   } else if (dev.assetPrefix === true) {
     const protocol = context.devServer?.https ? 'https' : 'http';
     const hostname = context.devServer?.hostname || DEFAULT_DEV_HOST;
-    const port = context.devServer?.port || DEFAULT_PORT;
     if (hostname === DEFAULT_DEV_HOST) {
       const localHostname = 'localhost';
       // If user not specify the hostname, it would use 0.0.0.0
       // The http://0.0.0.0:port can't visit in windows, so we shouldn't set publicPath as `//0.0.0.0:${port}/`;
       // Relative to docs:
       // - https://github.com/quarkusio/quarkus/issues/12246
-      publicPath = `${protocol}://${localHostname}:${port}/`;
+      publicPath = `${protocol}://${localHostname}:<port>/`;
     } else {
-      publicPath = `${protocol}://${hostname}:${port}/`;
+      publicPath = `${protocol}://${hostname}:<port>/`;
     }
   }
 
-  return formatPublicPath(publicPath);
+  return formatPublicPath(replacePortPlaceholder(publicPath, port));
 }
 
 const getJsAsyncPath = (

--- a/packages/core/tests/open.test.ts
+++ b/packages/core/tests/open.test.ts
@@ -1,16 +1,16 @@
-import { replacePlaceholder, resolveUrl } from '../src/plugins/open';
+import { replacePortPlaceholder, resolveUrl } from '../src/plugins/open';
 
 describe('plugin-open', () => {
-  it('#replacePlaceholder - should replace port number correctly', () => {
-    expect(replacePlaceholder('http://localhost:8080', 3000)).toEqual(
+  it('#replacePortPlaceholder - should replace port number correctly', () => {
+    expect(replacePortPlaceholder('http://localhost:8080', 3000)).toEqual(
       'http://localhost:8080',
     );
-    expect(replacePlaceholder('http://localhost:<port>', 3000)).toEqual(
+    expect(replacePortPlaceholder('http://localhost:<port>', 3000)).toEqual(
       'http://localhost:3000',
     );
-    expect(replacePlaceholder('http://localhost:<port>/path/', 3000)).toEqual(
-      'http://localhost:3000/path/',
-    );
+    expect(
+      replacePortPlaceholder('http://localhost:<port>/path/', 3000),
+    ).toEqual('http://localhost:3000/path/');
   });
 
   it('#resolveUrl - should resolve url correctly', () => {

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -162,4 +162,34 @@ describe('plugin-output', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(bundlerConfigs[0]?.output?.publicPath).toEqual('auto');
   });
+
+  it('should replace `<port>` placeholder with default port', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginOutput()],
+      rsbuildConfig: {
+        dev: {
+          assetPrefix: 'http://example-<port>.com:<port>/',
+        },
+      },
+    });
+
+    const [config] = await rsbuild.initConfigs();
+    expect(config?.output?.publicPath).toEqual('http://example-3000.com:3000/');
+  });
+
+  it('should replace `<port>` placeholder of `output.assetPrefix` with default port', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginOutput()],
+      rsbuildConfig: {
+        output: {
+          assetPrefix: 'http://example.com:<port>/',
+        },
+      },
+    });
+
+    const [config] = await rsbuild.initConfigs();
+    expect(config?.output?.publicPath).toEqual('http://example.com:3000/');
+  });
 });

--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -65,6 +65,23 @@ The resource URL loaded in the browser is as follows:
 <script defer src="https://example.com/assets/static/js/index.js"></script>
 ```
 
+### Port placeholder
+
+The port number that Rsbuild server listens on may change. For example, if the port is in use, Rsbuild will automatically increment the port number until it finds an available port.
+
+To avoid `dev.assetPrefix` becoming invalid due to port changes, you can use one of the following methods:
+
+- Enable [server.strictPort](/config/server/strict-port).
+- Use the `<port>` placeholder to refer to the current port number. Rsbuild will replace the placeholder with the actual port number it is listening on.
+
+```js title="rsbuild.config.ts"
+export default {
+  dev: {
+    assetPrefix: 'http://localhost:<port>/',
+  },
+};
+```
+
 ## Path Types
 
 assetPrefix can be set to the following types of paths:

--- a/website/docs/zh/config/dev/asset-prefix.mdx
+++ b/website/docs/zh/config/dev/asset-prefix.mdx
@@ -65,6 +65,23 @@ export default {
 <script defer src="https://example.com/assets/static/js/index.js"></script>
 ```
 
+### 端口号占位符
+
+Rsbuild server 监听的端口号可能会发生变更。比如，当端口被占用时，Rsbuild 会自动递增端口号，直至找到一个可用端口。
+
+为了避免端口变化导致 `dev.assetPrefix` 失效，你可以使用以下方法之一：
+
+- 开启 [server.strictPort](/config/server/strict-port)。
+- 使用 `<port>` 占位符来指代当前端口号，Rsbuild 会将占位符替换为实际监听的端口号。
+
+```js
+export default {
+  dev: {
+    assetPrefix: 'http://localhost:<port>/',
+  },
+};
+```
+
 ## 路径类型
 
 assetPrefix 可以设置为以下类型的路径：


### PR DESCRIPTION
## Summary

fix: #3094 

Note that `<port>` is also available in `output.assetPrefix`. But I can't think of any situation in which it should be used.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
