### PR TITLE
fix: set gzip level to 6 for preview server

### DIFF
--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -83,7 +83,7 @@ const applyDefaultMiddlewares = async ({
   // compression should be the first middleware
   if (server.compress) {
     const { gzipMiddleware } = await import('./gzipMiddleware');
-    middlewares.push(gzipMiddleware);
+    middlewares.push(gzipMiddleware());
   }
 
   middlewares.push((req, res, next) => {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -61,7 +61,12 @@ export class RsbuildProdServer {
     // compression should be the first middleware
     if (compress) {
       const { gzipMiddleware } = await import('./gzipMiddleware');
-      this.middlewares.use(gzipMiddleware);
+      this.middlewares.use(
+        gzipMiddleware({
+          // simulates the common gzip compression rates
+          level: 6,
+        }),
+      );
     }
 
     if (headers) {


### PR DESCRIPTION
## Summary

In the previous PR (https://github.com/web-infra-dev/rsbuild/pull/3090), I changed the default gzip level to 1 for better performance. But for the preview server, it is better to use `level: 6` because it can simulate the common gzip compression rates and reflects a more realistic file size.

## Related Links

https://github.com/madler/zlib/blob/ac8f12c97d1afd9bafa9c710f827d40a407d3266/zlib.h#L239

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
