### PR TITLE
perf(mf): only patch split chunks for provider app

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -147,9 +147,11 @@ export function pluginModuleFederation(): RsbuildPlugin {
             .use(rspack.container.ModuleFederationPlugin, [options]);
 
           if (options.name) {
-            chain
-              .plugin('mf-patch-split-chunks')
-              .use(PatchSplitChunksPlugin, [options.name]);
+            if (options.exposes) {
+              chain
+                .plugin('mf-patch-split-chunks')
+                .use(PatchSplitChunksPlugin, [options.name]);
+            }
 
             // `uniqueName` is required for react refresh to work
             if (!chain.output.get('uniqueName')) {


### PR DESCRIPTION
## Summary

The `PatchSplitChunksPlugin` will slow down the build process because it uses function `chunks` option, and the function will slow down Rspack when there are thousands of modules.

We can only apply `PatchSplitChunksPlugin` for the provider app (which uses `exposes` option) because `PatchSplitChunksPlugin` is designed to handle remote entries.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3067

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
