### PR TITLE
perf(mf): set splitChunks.chunks to `async` by default if using module federation

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -1,3 +1,4 @@
+import { isRegExp } from 'node:util/types';
 import { rspack } from '@rspack/core';
 import type { RspackPluginInstance } from '@rspack/core';
 import { DEFAULT_ASSET_PREFIX } from '../constants';
@@ -23,14 +24,14 @@ class PatchSplitChunksPlugin implements RspackPluginInstance {
     }
 
     const applyPatch = (cacheGroup: CacheGroup) => {
-      if (typeof cacheGroup !== 'object' || cacheGroup instanceof RegExp) {
+      if (typeof cacheGroup !== 'object' || isRegExp(cacheGroup)) {
         return;
       }
 
       // cacheGroup.chunks will inherit splitChunks.chunks
       // so we only need to modify the chunks that are set separately.
       const { chunks } = cacheGroup;
-      if (!chunks) {
+      if (!chunks || chunks === 'async') {
         return;
       }
 
@@ -110,6 +111,7 @@ export function pluginModuleFederation(): RsbuildPlugin {
         if (!config.moduleFederation?.options) {
           return;
         }
+
         /**
          * Currently, splitChunks will take precedence over module federation shared modules.
          * So we need to disable the default split chunks rules to make shared modules to work properly.

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -238,9 +238,14 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
         }
 
         const { config } = environment;
+
         const defaultConfig: Exclude<SplitChunks, false> = {
-          // Optimize both `initial` and `async` chunks
-          chunks: 'all',
+          chunks: config.moduleFederation?.options?.exposes
+            ? // split only `async` chunks for module federation provider app
+              // this ensures that remote entries are not affected by chunk splitting
+              'async'
+            : // split both `initial` and `async` chunks for normal app
+              'all',
           // When chunk size >= 50000 bytes, split it into separate chunk
           // @ts-expect-error Rspack type missing
           enforceSizeThreshold: 50000,
@@ -259,7 +264,7 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
         // Patch the override config difference between the `custom` strategy and other strategy.
         const override =
           chunkSplit.strategy === 'custom'
-            ? chunkSplit.splitChunks ?? chunkSplit.override
+            ? (chunkSplit.splitChunks ?? chunkSplit.override)
             : chunkSplit.override;
 
         // Apply different strategy

--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -6,7 +6,7 @@ exports[`plugin-module-federation > should set environment module federation con
     "optimization": {
       "splitChunks": {
         "cacheGroups": {},
-        "chunks": "all",
+        "chunks": "async",
         "enforceSizeThreshold": 50000,
       },
     },
@@ -71,7 +71,7 @@ exports[`plugin-module-federation > should set module federation and environment
     "optimization": {
       "splitChunks": {
         "cacheGroups": {},
-        "chunks": "all",
+        "chunks": "async",
         "enforceSizeThreshold": 50000,
       },
     },
@@ -145,7 +145,7 @@ exports[`plugin-module-federation > should set module federation config 1`] = `
   "optimization": {
     "splitChunks": {
       "cacheGroups": {},
-      "chunks": "all",
+      "chunks": "async",
       "enforceSizeThreshold": 50000,
     },
   },


### PR DESCRIPTION
## Summary

Set `splitChunks.chunks` to `async` by default if using `moduleFederation.options`.

If using `chunks: 'all'`, the `PatchSplitChunksPlugin` will turn `chunks` to a function and it is quite slow when there are thousands of modules.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3067
https://github.com/web-infra-dev/rsbuild/pull/3102

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
