### PR TITLE
release: 1.0.1-beta.9

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-check-syntax/package.json
+++ b/packages/plugin-check-syntax/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-check-syntax",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Check syntax plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "yaml": "^2.5.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.8"
+    "@rsbuild/core": "workspace:^1.0.1-beta.9"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.8",
+  "version": "1.0.1-beta.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: allow to disable buit-in lightningcss-loader by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3082
* feat!: `onBeforeBuild` hook supports calling multiple times in watch mode by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3066
* feat: support using `<port>` in `dev.assetPrefix` by @colinaaa in https://github.com/web-infra-dev/rsbuild/pull/3098
### Performance 🚀
* perf(server): adjust gzip level for faster compression by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3090
* perf(mf): only patch split chunks for provider app by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3102
* perf(mf): set splitChunks.chunks to `async` by default if using module federation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3104
### Bug Fixes 🐞
* fix: avoid merging boolean config with object config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3081
* fix: plugin type missing when set moduleResolution node16+ by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3089
* fix: set gzip level to 6 for preview server by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3101
### Document 📖
* docs: what is environment by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3080
* docs: add migration guide for Rsbuild 0.x by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3084
* docs: add environment dependencies by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3085
* docs: list which hooks will be triggered again when rebuild by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3091
* docs: distinguish between Global Hooks and Environment Hooks by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3092
* docs: add FAQ for Vue deprecated deep selector by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3095
### Other Changes
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3050
* chore(deps): update dependency typescript-eslint to v8 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3088
* test(e2e): improve onExit test case by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3103


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.8...v1.0.1-beta.9