### PR TITLE
test(e2e): make type checker faster by not including types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,13 @@
     "useIgnoreFile": true
   },
   "files": {
-    "ignore": ["*.vue", "*.svelte", "template-lit-*/src/my-element.*"],
+    "ignore": [
+      "*.vue",
+      "*.svelte",
+      "template-lit-*/src/my-element.*",
+      "tsconfig.json",
+      "tsconfig.*.json"
+    ],
     "ignoreUnknown": true
   },
   "formatter": {

--- a/e2e/cases/source-build/app/tsconfig.json
+++ b/e2e/cases/source-build/app/tsconfig.json
@@ -4,6 +4,8 @@
     "declaration": false,
     "jsx": "react-jsx",
     "baseUrl": "./",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/source-build/components/tsconfig.json
+++ b/e2e/cases/source-build/components/tsconfig.json
@@ -6,6 +6,8 @@
     "declarationDir": "./dist/types",
     "jsx": "react-jsx",
     "baseUrl": "./",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"],
       "@card/*": ["./src/card/*"]

--- a/e2e/cases/source-build/utils/tsconfig.json
+++ b/e2e/cases/source-build/utils/tsconfig.json
@@ -7,6 +7,8 @@
     "declarationMap": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"],
       "@common/*": ["./src/common/*"]

--- a/e2e/cases/source-build/utils2/tsconfig.json
+++ b/e2e/cases/source-build/utils2/tsconfig.json
@@ -7,6 +7,8 @@
     "declarationMap": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"],
       "@common/*": ["./src/common/*"]

--- a/e2e/cases/type-check/basic/tsconfig.json
+++ b/e2e/cases/type-check/basic/tsconfig.json
@@ -4,6 +4,8 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "outDir": "./dist",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/type-check/exclude-node-modules/tsconfig.json
+++ b/e2e/cases/type-check/exclude-node-modules/tsconfig.json
@@ -4,6 +4,8 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "outDir": "./dist",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/type-check/multiple-tsconfig/tsconfig.json
+++ b/e2e/cases/type-check/multiple-tsconfig/tsconfig.json
@@ -4,6 +4,8 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "outDir": "./dist",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/type-check/multiple-tsconfig/tsconfig.server.json
+++ b/e2e/cases/type-check/multiple-tsconfig/tsconfig.server.json
@@ -4,6 +4,8 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "outDir": "./dist",
+    // make type checker faster by not including types
+    "types": [],
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary

Make type checker faster by not including types.

- before:

<img width="1205" alt="Screenshot 2024-08-02 at 13 19 31" src="https://github.com/user-attachments/assets/9f0bc9e9-70c2-4202-8a00-af0215ae4e75">

- after:

<img width="1196" alt="Screenshot 2024-08-02 at 13 19 26" src="https://github.com/user-attachments/assets/7924a07a-f4ae-4b30-9224-010fd4ab93e7">

## Related Links

https://github.com/microsoft/TypeScript/wiki/Performance#controlling-types-inclusion

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
