### PR TITLE
fix: ensure isolation of config objects between different builds

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -74,17 +74,18 @@ const userPostcssrcCache = new Map<
   PostCSSOptions | Promise<PostCSSOptions>
 >();
 
+// Create a new config object,
+// ensure isolation of config objects between different builds
+const clonePostCSSConfig = (config: PostCSSOptions) => ({
+  ...config,
+  plugins: config.plugins ? [...config.plugins] : undefined,
+});
+
 async function loadUserPostcssrc(root: string): Promise<PostCSSOptions> {
   const cached = userPostcssrcCache.get(root);
 
   if (cached) {
-    const config = await cached;
-    // Create a new config object,
-    // ensure isolation of config objects between different builds
-    return {
-      ...config,
-      plugins: config.plugins ? [...config.plugins] : undefined,
-    };
+    return clonePostCSSConfig(await cached);
   }
 
   const { default: postcssrc } = await import('postcss-load-config');
@@ -99,11 +100,10 @@ async function loadUserPostcssrc(root: string): Promise<PostCSSOptions> {
 
   userPostcssrcCache.set(root, promise);
 
-  promise.then((config: PostCSSOptions) => {
+  return promise.then((config: PostCSSOptions) => {
     userPostcssrcCache.set(root, config);
+    return clonePostCSSConfig(config);
   });
-
-  return promise;
 }
 
 const getPostcssLoaderOptions = async ({

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -78,7 +78,13 @@ async function loadUserPostcssrc(root: string): Promise<PostCSSOptions> {
   const cached = userPostcssrcCache.get(root);
 
   if (cached) {
-    return cached;
+    const config = await cached;
+    // Create a new config object,
+    // ensure isolation of config objects between different builds
+    return {
+      ...config,
+      plugins: config.plugins ? [...config.plugins] : undefined,
+    };
   }
 
   const { default: postcssrc } = await import('postcss-load-config');

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -139,3 +139,117 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
   ],
 }
 `;
+
+exports[`should ensure isolation of PostCSS config objects between different builds 1`] = `
+[
+  {
+    "resolve": {
+      "preferRelative": true,
+    },
+    "sideEffects": true,
+    "test": /\\\\\\.css\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/css-loader",
+        "options": {
+          "importLoaders": 2,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/postcss-loader",
+        "options": {
+          "postcssOptions": {
+            "config": false,
+            "plugins": [
+              {
+                "postcssPlugin": "foo",
+              },
+            ],
+          },
+          "sourceMap": false,
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`should ensure isolation of PostCSS config objects between different builds 2`] = `
+[
+  {
+    "resolve": {
+      "preferRelative": true,
+    },
+    "sideEffects": true,
+    "test": /\\\\\\.css\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/css-loader",
+        "options": {
+          "importLoaders": 2,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/postcss-loader",
+        "options": {
+          "postcssOptions": {
+            "config": false,
+            "plugins": [
+              {
+                "postcssPlugin": "bar",
+              },
+            ],
+          },
+          "sourceMap": false,
+        },
+      },
+    ],
+  },
+]
+`;

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -1,4 +1,4 @@
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createStubRsbuild, matchRules } from '@scripts/test-helper';
 import { normalizeCssLoaderOptions, pluginCss } from '../src/plugins/css';
 
 describe('normalizeCssLoaderOptions', () => {
@@ -151,4 +151,34 @@ describe('plugin-css injectStyles', () => {
 
     expect(bundlerConfigs[0]).toMatchSnapshot();
   });
+});
+
+it('should ensure isolation of PostCSS config objects between different builds', async () => {
+  const rsbuild = await createStubRsbuild({
+    plugins: [pluginCss()],
+    rsbuildConfig: {
+      environments: {
+        web: {
+          tools: {
+            postcss(config) {
+              config.postcssOptions ||= {};
+              config.postcssOptions.plugins = [{ postcssPlugin: 'foo' }];
+            },
+          },
+        },
+        web2: {
+          tools: {
+            postcss(config) {
+              config.postcssOptions ||= {};
+              config.postcssOptions.plugins = [{ postcssPlugin: 'bar' }];
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const bundlerConfigs = await rsbuild.initConfigs();
+  expect(matchRules(bundlerConfigs[0], 'a.css')).toMatchSnapshot();
+  expect(matchRules(bundlerConfigs[1], 'a.css')).toMatchSnapshot();
 });

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -122,12 +122,6 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
                 "Once": [Function],
                 "postcssPlugin": "postcss-pxtorem",
               },
-              {
-                "AtRule": [Function],
-                "Declaration": [Function],
-                "Once": [Function],
-                "postcssPlugin": "postcss-pxtorem",
-              },
             ],
           },
           "sourceMap": false,

--- a/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-rem/tests/__snapshots__/index.test.ts.snap
@@ -50,12 +50,6 @@ exports[`plugin-rem > should not run htmlPlugin with enableRuntime is false 1`] 
                 "Once": [Function],
                 "postcssPlugin": "postcss-pxtorem",
               },
-              {
-                "AtRule": [Function],
-                "Declaration": [Function],
-                "Once": [Function],
-                "postcssPlugin": "postcss-pxtorem",
-              },
             ],
           },
           "sourceMap": false,
@@ -110,12 +104,6 @@ exports[`plugin-rem > should run rem plugin with custom config 1`] = `
           "postcssOptions": {
             "config": false,
             "plugins": [
-              {
-                "AtRule": [Function],
-                "Declaration": [Function],
-                "Once": [Function],
-                "postcssPlugin": "postcss-pxtorem",
-              },
               {
                 "AtRule": [Function],
                 "Declaration": [Function],


### PR DESCRIPTION
## Summary

Create a new config object when getting PostCSS config object from the cache, this can ensure isolation of config objects between different builds.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/3035/files#diff-d13036c459b24b45d227646a9c9721a79332a21dabe50f80850b3d094dfb2a07L175-L178

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
