### PR TITLE
chore: rename internal HTML plugin to RsbuildHtmlPlugin

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -295,10 +295,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -656,10 +656,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -58,10 +58,10 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
     },
     "version": 6,
   },
-  HtmlBasicPlugin {
+  RsbuildHtmlPlugin {
     "getEnvironment": [Function],
     "modifyTagsFn": [Function],
-    "name": "HtmlBasicPlugin",
+    "name": "RsbuildHtmlPlugin",
     "options": {
       "index": {
         "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -203,8 +203,6 @@ export const CHAIN_ID = {
     BUNDLE_ANALYZER: 'bundle-analyze',
     /** ModuleFederationPlugin */
     MODULE_FEDERATION: 'module-federation',
-    /** HtmlBasicPlugin */
-    HTML_BASIC: 'html-basic-plugin',
     /** htmlPrefetchPlugin */
     HTML_PREFETCH: 'html-prefetch-plugin',
     /** htmlPreloadPlugin */

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -13,7 +13,7 @@ import {
   isPlainObject,
   isURL,
 } from '../helpers';
-import type { HtmlInfo, TagConfig } from '../rspack/HtmlBasicPlugin';
+import type { HtmlInfo, TagConfig } from '../rspack/RsbuildHtmlPlugin';
 import type {
   HtmlConfig,
   HtmlRspackPlugin,
@@ -322,13 +322,15 @@ export const pluginHtml = (
             .use(HtmlPlugin, [finalOptions[index]]);
         });
 
-        const { HtmlBasicPlugin } = await import('../rspack/HtmlBasicPlugin');
+        const { RsbuildHtmlPlugin } = await import(
+          '../rspack/RsbuildHtmlPlugin'
+        );
 
         chain
-          .plugin(CHAIN_ID.PLUGIN.HTML_BASIC)
-          .use(HtmlBasicPlugin, [
+          .plugin('rsbuild-html-plugin')
+          .use(RsbuildHtmlPlugin, [
             htmlInfoMap,
-            environment,
+            () => environment,
             modifyTagsFn?.(environment.name),
           ]);
 

--- a/packages/core/src/plugins/nonce.ts
+++ b/packages/core/src/plugins/nonce.ts
@@ -16,12 +16,15 @@ export const pluginNonce = (): RsbuildPlugin => ({
         return;
       }
 
+      const environmentList = Object.values(environments);
+
       applyToCompiler(compiler, (compiler, index) => {
         const nonce = nonces[index];
-        const { plugins } = compiler.options;
-        const hasHTML = plugins.some(
-          (plugin) => plugin && plugin.constructor.name === 'HtmlBasicPlugin',
+        const environment = environmentList.find(
+          (item) => item.index === index,
         );
+        const hasHTML = Object.keys(environment?.htmlPaths ?? {}).length;
+
         if (!hasHTML || !nonce) {
           return;
         }

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -62,7 +62,7 @@ export type HtmlInfo = {
   templateContent?: string;
 };
 
-export type HtmlBasicPluginOptions = Record<string, HtmlInfo>;
+export type RsbuildHtmlPluginOptions = Record<string, HtmlInfo>;
 
 export type AlterAssetTagGroupsData = {
   headTags: HtmlTagObject[];
@@ -234,24 +234,24 @@ const addFavicon = (headTags: HtmlTagObject[], favicon?: string) => {
   }
 };
 
-export class HtmlBasicPlugin {
+export class RsbuildHtmlPlugin {
   readonly name: string;
 
   readonly getEnvironment: () => EnvironmentContext;
 
-  readonly options: HtmlBasicPluginOptions;
+  readonly options: RsbuildHtmlPluginOptions;
 
   readonly modifyTagsFn?: ModifyHTMLTagsFn;
 
   constructor(
-    options: HtmlBasicPluginOptions,
-    environment: EnvironmentContext,
+    options: RsbuildHtmlPluginOptions,
+    getEnvironment: () => EnvironmentContext,
     modifyTagsFn?: ModifyHTMLTagsFn,
   ) {
-    this.name = 'HtmlBasicPlugin';
-    this.getEnvironment = () => environment;
+    this.name = 'RsbuildHtmlPlugin';
     this.options = options;
     this.modifyTagsFn = modifyTagsFn;
+    this.getEnvironment = getEnvironment;
   }
 
   apply(compiler: Compiler): void {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -354,10 +354,10 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -354,10 +354,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -776,10 +776,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -1518,10 +1518,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -76,10 +76,10 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "foo": {
           "tagConfig": {
@@ -152,10 +152,10 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -207,10 +207,10 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -262,10 +262,10 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -317,10 +317,10 @@ exports[`plugin-html > should enable minify in production 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -372,10 +372,10 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -427,10 +427,10 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -482,10 +482,10 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
@@ -538,10 +538,10 @@ exports[`plugin-html > should support environment html config 1`] = `
         },
         "version": 6,
       },
-      HtmlBasicPlugin {
+      RsbuildHtmlPlugin {
         "getEnvironment": [Function],
         "modifyTagsFn": undefined,
-        "name": "HtmlBasicPlugin",
+        "name": "RsbuildHtmlPlugin",
         "options": {
           "main": {
             "templateContent": "<!doctype html><html><head></head><body><div id=\\"app\\"></div></body></html>",
@@ -590,10 +590,10 @@ exports[`plugin-html > should support environment html config 1`] = `
         },
         "version": 6,
       },
-      HtmlBasicPlugin {
+      RsbuildHtmlPlugin {
         "getEnvironment": [Function],
         "modifyTagsFn": undefined,
-        "name": "HtmlBasicPlugin",
+        "name": "RsbuildHtmlPlugin",
         "options": {
           "index": {
             "templateContent": "<!doctype html><html><head></head><body><div id=\\"app1\\"></div></body></html>",
@@ -681,10 +681,10 @@ exports[`plugin-html > should support multi entry 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": undefined,
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "foo": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",

--- a/packages/core/tests/htmlHelper.test.ts
+++ b/packages/core/tests/htmlHelper.test.ts
@@ -1,6 +1,6 @@
 import type { NormalizedConfig } from '../src';
 import { getHTMLPathByEntry } from '../src/initPlugins';
-import { hasTitle } from '../src/rspack/HtmlBasicPlugin';
+import { hasTitle } from '../src/rspack/RsbuildHtmlPlugin';
 
 test('should detect HTML title via "hasTitle" correctly', () => {
   expect(hasTitle()).toEqual(false);

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -389,10 +389,10 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       },
       "version": 6,
     },
-    HtmlBasicPlugin {
+    RsbuildHtmlPlugin {
       "getEnvironment": [Function],
       "modifyTagsFn": [Function],
-      "name": "HtmlBasicPlugin",
+      "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",


### PR DESCRIPTION
## Summary

Rename the internal HTML plugin to `RsbuildHtmlPlugin`. `HtmlBasicPlugin` is inappropriate.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
