### PR TITLE
release: 1.0.1-beta.10

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-rem/package.json
+++ b/packages/plugin-rem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-rem",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Rem plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-source-build/package.json
+++ b/packages/plugin-source-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-source-build",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Source build plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "yaml": "^2.5.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-styled-components/package.json
+++ b/packages/plugin-styled-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-styled-components",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "styled-components plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -36,7 +36,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.9"
+    "@rsbuild/core": "workspace:^1.0.1-beta.10"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.9",
+  "version": "1.0.1-beta.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(deps): bump Rspack 1.0.0-beta.2 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3113
* feat: add environment hooks about compiler by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3108
* feat: allow to configure `output.filename.html` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3137
### Bug Fixes 🐞
* fix: ensure isolation of config objects between different builds by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3111
### Document 📖
* docs: add UA polyfill guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3115
* docs: add configure SWC guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3119
* docs: add guide for custom JS minimizer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3120
* docs: add tips for SWC plugin version by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3121
* docs: add guide for watching files and reload dev server by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3128
* docs: add Rslib links by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3132
* docs: bump `@rstack-dev/doc-ui` to add Rslib and awesome Rspack by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/3134
* docs: link to Rspack document instead of webpack by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3135
* docs: add guide for filename template string by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3138
### Other Changes
* test(e2e): fix a slow case case by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3109
* test(e2e): make type checker faster by not including types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3110
* chore(deps): update dependency globals to ^15.9.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3117
* chore(deps): update rspress to v1.27.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3118
* chore: move check syntax plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3123
* chore(deps): update dependency @modern-js/module-tools to ^2.57.1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3126
* chore(deps): update dependency react-router-dom to ^6.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3127
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3129
* chore(deps): update dependency @babel/core to ^7.25.2 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3130
* chore: rename internal HTML plugin to RsbuildHtmlPlugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3136


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.9...v1.0.1-beta.10