### PR TITLE
fix!(cli): rename env option of inspect command to mode

### DIFF
--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -2,9 +2,16 @@ import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { globContentJSON } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { removeSync } from 'fs-extra';
+
+const clean = () => {
+  removeSync(path.join(__dirname, 'dist'));
+  delete process.env.NODE_ENV;
+};
 
 test('should run inspect command correctly', async () => {
-  delete process.env.NODE_ENV;
+  clean();
+
   execSync('npx rsbuild inspect', {
     cwd: __dirname,
   });
@@ -26,8 +33,31 @@ test('should run inspect command correctly', async () => {
   expect(files[rspackConfig!]).toContain("mode: 'development'");
 });
 
+test('should run inspect command with mode option correctly', async () => {
+  clean();
+
+  execSync('npx rsbuild inspect --mode production', {
+    cwd: __dirname,
+  });
+
+  const files = await globContentJSON(path.join(__dirname, 'dist'));
+  const fileNames = Object.keys(files);
+
+  const rsbuildConfig = fileNames.find((item) =>
+    item.includes('rsbuild.config.mjs'),
+  );
+  expect(rsbuildConfig).toBeTruthy();
+
+  const rspackConfig = fileNames.find((item) =>
+    item.includes('rspack.config.web.mjs'),
+  );
+  expect(rspackConfig).toBeTruthy();
+  expect(files[rspackConfig!]).toContain("mode: 'production'");
+});
+
 test('should run inspect command with output option correctly', async () => {
-  delete process.env.NODE_ENV;
+  clean();
+
   execSync('npx rsbuild inspect --output foo', {
     cwd: __dirname,
   });

--- a/packages/compat/webpack/src/inspectConfig.ts
+++ b/packages/compat/webpack/src/inspectConfig.ts
@@ -34,8 +34,8 @@ export async function inspectConfig({
   inspectOptions?: InspectConfigOptions;
   bundlerConfigs?: WebpackConfig[];
 }): Promise<InspectConfigResult<'webpack'>> {
-  if (inspectOptions.env) {
-    process.env.NODE_ENV = inspectOptions.env;
+  if (inspectOptions.mode) {
+    process.env.NODE_ENV = inspectOptions.mode;
   } else if (!process.env.NODE_ENV) {
     process.env.NODE_ENV = 'development';
   }

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -21,7 +21,7 @@ export type BuildOptions = CommonOptions & {
 };
 
 export type InspectOptions = CommonOptions & {
-  env: RsbuildMode;
+  mode: RsbuildMode;
   output: string;
   verbose?: boolean;
 };
@@ -135,14 +135,14 @@ export function runCli(): void {
 
   inspectCommand
     .description('inspect the Rspack and Rsbuild configs')
-    .option('--env <env>', 'specify env mode', 'development')
+    .option('--mode <mode>', 'specify the mode for Rsbuild', 'development')
     .option('--output <output>', 'specify inspect content output path')
     .option('--verbose', 'show full function definitions in output')
     .action(async (options: InspectOptions) => {
       try {
         const rsbuild = await init({ cliOptions: options });
         await rsbuild?.inspectConfig({
-          env: options.env,
+          mode: options.mode,
           verbose: options.verbose,
           outputPath: options.output,
           writeToDisk: true,

--- a/packages/core/src/provider/inspectConfig.ts
+++ b/packages/core/src/provider/inspectConfig.ts
@@ -38,8 +38,8 @@ export async function inspectConfig({
   inspectOptions?: InspectConfigOptions;
   bundlerConfigs?: RspackConfig[];
 }): Promise<InspectConfigResult<'rspack'>> {
-  if (inspectOptions.env) {
-    setNodeEnv(inspectOptions.env);
+  if (inspectOptions.mode) {
+    setNodeEnv(inspectOptions.mode);
   } else if (!getNodeEnv()) {
     setNodeEnv('development');
   }

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -38,7 +38,7 @@ export type BuildOptions = {
 };
 
 export type InspectConfigOptions = {
-  env?: RsbuildMode;
+  mode?: RsbuildMode;
   verbose?: boolean;
   outputPath?: string;
   writeToDisk?: boolean;

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -560,7 +560,7 @@ If you need to view the Rsbuild and Rspack configurations during the build proce
 type InspectConfigOptions = {
   // View the config in the specified environment
   // defaults to "development", can be set to "production"
-  env?: RsbuildMode;
+  mode?: RsbuildMode;
   // Whether to enable verbose mode, display the complete content of the function in the config
   // defaults to `false`
   verbose?: boolean;

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -574,7 +574,7 @@ inspectConfig 方法通常用于调试 Rsbuild 内部的配置，它会返回 Rs
 type InspectConfigOptions = {
   // 查看指定环境下的配置
   // 默认为 "development"，可以设置为 "production"
-  env?: RsbuildMode;
+  mode?: RsbuildMode;
   // 是否开启冗余模式，展示配置中函数的完整内容
   // 默认为 `false`
   verbose?: boolean;


### PR DESCRIPTION
## Summary

Rename the `env` option of `rsbuild inspect` command to `mode`. This is to align with other APIs, such as the `mode` option of `rsbuild.build()`.

```bash
# before
npx rsbuild inspect --env production

# after
npx rsbuild inspect --mode production
```

## Related Links

https://rsbuild.dev/api/javascript-api/instance#rsbuildbuild

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
