### PR TITLE
fix(plugin-sass): sassOptions type should defaults to modern API

### DIFF
--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -7,20 +7,20 @@ import type SassLoader from '../compiled/sass-loader/index.js';
 
 export type SassLoaderOptions = Omit<
   SassLoader.Options,
-  'sassOptions' | 'additionalData'
+  'api' | 'sassOptions' | 'additionalData'
 > &
   (
     | {
-        api?: 'legacy';
-        sassOptions?: Partial<LegacySassOptions<'async'>>;
-      }
-    | {
-        api: 'modern' | 'modern-compiler';
+        api?: 'modern' | 'modern-compiler';
         sassOptions?: SassOptions<'async'>;
       }
+    | {
+        api: 'legacy';
+        sassOptions?: Partial<LegacySassOptions<'async'>>;
+      }
   ) & {
-    // @types/sass-loader is outdated
-    // see https://github.com/web-infra-dev/rsbuild/issues/2582
+    // Use `Rspack.LoaderContext` instead of `webpack.LoaderContext`
+    // see https://github.com/web-infra-dev/rsbuild/pull/2708
     additionalData?:
       | string
       | ((


### PR DESCRIPTION
## Summary

`sassOptions` type should defaults to modern API, because sass-loader >= 16.0.0 uses modern API by default.

## Related Links

https://github.com/webpack-contrib/sass-loader/releases/tag/v16.0.0
https://github.com/web-infra-dev/rsbuild/pull/2708

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
