### PR TITLE
fix: no need to override Rspack configuration type

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -6,7 +6,6 @@ import type {
   ModifyBundlerChainUtils,
   RsbuildEntry,
   Rspack,
-  RspackConfig,
 } from './types';
 
 export function getBundlerChain(): RspackChain {
@@ -40,12 +39,12 @@ export async function modifyBundlerChain(
   return modifiedBundlerChain;
 }
 
-export function chainToConfig(chain: RspackChain): RspackConfig {
+export function chainToConfig(chain: RspackChain): Rspack.Configuration {
   const config = chain.toConfig();
   const { entry } = config;
 
   if (!isPlainObject(entry)) {
-    return config as RspackConfig;
+    return config as Rspack.Configuration;
   }
 
   const formattedEntry: RsbuildEntry = {};
@@ -86,7 +85,7 @@ export function chainToConfig(chain: RspackChain): RspackConfig {
 
   config.entry = formattedEntry;
 
-  return config as RspackConfig;
+  return config as Rspack.Configuration;
 }
 
 export const CHAIN_ID = {

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -28,7 +28,6 @@ import type {
   OnDevCompileDoneFn,
   OnExitFn,
   Rspack,
-  RspackConfig,
   Stats,
 } from './types';
 
@@ -323,7 +322,7 @@ export const registerBuildHook = ({
   bundlerConfigs,
   MultiStatsCtor,
 }: {
-  bundlerConfigs?: RspackConfig[];
+  bundlerConfigs?: Rspack.Configuration[];
   context: InternalContext;
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
   isWatch: boolean;
@@ -405,7 +404,7 @@ export const registerDevHook = ({
   bundlerConfigs,
   MultiStatsCtor,
 }: {
-  bundlerConfigs?: RspackConfig[];
+  bundlerConfigs?: Rspack.Configuration[];
   context: InternalContext;
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
   MultiStatsCtor: new (stats: Rspack.Stats[]) => Rspack.MultiStats;

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -2,13 +2,7 @@ import { rspack } from '@rspack/core';
 import { getNodeEnv, setNodeEnv } from '../helpers';
 import { registerBuildHook } from '../hooks';
 import { logger } from '../logger';
-import type {
-  BuildOptions,
-  MultiStats,
-  Rspack,
-  RspackConfig,
-  Stats,
-} from '../types';
+import type { BuildOptions, MultiStats, Rspack, Stats } from '../types';
 import { createCompiler } from './createCompiler';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 
@@ -25,7 +19,7 @@ export const build = async (
   const { context } = initOptions;
 
   let compiler: Rspack.Compiler | Rspack.MultiCompiler;
-  let bundlerConfigs: RspackConfig[] | undefined;
+  let bundlerConfigs: Rspack.Configuration[] | undefined;
 
   if (customCompiler) {
     compiler = customCompiler as any;

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -18,7 +18,6 @@ import type {
   InternalContext,
   MultiStats,
   Rspack,
-  RspackConfig,
   Stats,
 } from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
@@ -28,7 +27,7 @@ export async function createCompiler({
   rspackConfigs,
 }: {
   context: InternalContext;
-  rspackConfigs: RspackConfig[];
+  rspackConfigs: Rspack.Configuration[];
 }): Promise<Rspack.Compiler | Rspack.MultiCompiler> {
   logger.debug('create compiler');
   await context.hooks.onBeforeCreateCompiler.call({

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -19,7 +19,7 @@ import type {
   PluginManager,
   ResolvedCreateRsbuildOptions,
   RsbuildEntry,
-  RspackConfig,
+  Rspack,
 } from '../types';
 import { inspectConfig } from './inspectConfig';
 import { generateRspackConfig } from './rspackConfig';
@@ -213,7 +213,7 @@ export async function initConfigs({
   pluginManager,
   rsbuildOptions,
 }: InitConfigsOptions): Promise<{
-  rspackConfigs: RspackConfig[];
+  rspackConfigs: Rspack.Configuration[];
 }> {
   const normalizedConfig = await initRsbuildConfig({ context, pluginManager });
 

--- a/packages/core/src/provider/inspectConfig.ts
+++ b/packages/core/src/provider/inspectConfig.ts
@@ -9,7 +9,7 @@ import type {
   InspectConfigOptions,
   InspectConfigResult,
   InternalContext,
-  RspackConfig,
+  Rspack,
 } from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 
@@ -36,7 +36,7 @@ export async function inspectConfig({
   inspectOptions = {},
 }: InitConfigsOptions & {
   inspectOptions?: InspectConfigOptions;
-  bundlerConfigs?: RspackConfig[];
+  bundlerConfigs?: Rspack.Configuration[];
 }): Promise<InspectConfigResult<'rspack'>> {
   if (inspectOptions.mode) {
     setNodeEnv(inspectOptions.mode);

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -11,12 +11,11 @@ import type {
   ModifyRspackConfigUtils,
   RsbuildTarget,
   Rspack,
-  RspackConfig,
 } from '../types';
 
 async function modifyRspackConfig(
   context: InternalContext,
-  rspackConfig: RspackConfig,
+  rspackConfig: Rspack.Configuration,
   utils: ModifyRspackConfigUtils,
 ) {
   logger.debug('modify Rspack config');
@@ -121,7 +120,7 @@ export async function generateRspackConfig({
   environment: string;
   target: RsbuildTarget;
   context: InternalContext;
-}): Promise<RspackConfig> {
+}): Promise<Rspack.Configuration> {
   const chainUtils = getChainUtils(target, context.environments[environment]);
   const {
     BannerPlugin,

--- a/packages/core/src/types/config/output.ts
+++ b/packages/core/src/types/config/output.ts
@@ -6,7 +6,7 @@ import type {
 } from '@rspack/core';
 import type { CSSLoaderModulesOptions } from '../../types';
 import type { RsbuildTarget } from '../rsbuild';
-import type { Rspack, RspackConfig } from '../rspack';
+import type { Rspack } from '../rspack';
 
 export type DistPathConfig = {
   /**
@@ -128,7 +128,7 @@ export type NormalizedDataUriLimit = Required<DataUriLimit>;
 export type Polyfill = 'usage' | 'entry' | 'off';
 
 export type SourceMap = {
-  js?: RspackConfig['devtool'];
+  js?: Rspack.Configuration['devtool'];
   css?: boolean;
 };
 
@@ -312,7 +312,7 @@ export interface NormalizedOutputConfig extends OutputConfig {
   };
   polyfill: Polyfill;
   sourceMap: {
-    js?: RspackConfig['devtool'];
+    js?: Rspack.Configuration['devtool'];
     css: boolean;
   };
   filenameHash: boolean | string;

--- a/packages/core/src/types/config/tools.ts
+++ b/packages/core/src/types/config/tools.ts
@@ -6,12 +6,7 @@ import type {
   ModifyWebpackChainUtils,
   ModifyWebpackConfigUtils,
 } from '../plugin';
-import type {
-  BundlerPluginInstance,
-  Rspack,
-  RspackConfig,
-  RspackRule,
-} from '../rspack';
+import type { BundlerPluginInstance, Rspack, RspackRule } from '../rspack';
 import type { HtmlRspackPlugin } from '../thirdParty';
 import type {
   CSSExtractOptions,
@@ -65,7 +60,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
 };
 
 export type ToolsRspackConfig = ConfigChainAsyncWithContext<
-  RspackConfig,
+  Rspack.Configuration,
   ModifyRspackConfigUtils
 >;
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -34,8 +34,7 @@ import type {
   OnExitFn,
 } from './hooks';
 import type { RsbuildTarget } from './rsbuild';
-import type { Rspack } from './rspack';
-import type { RspackConfig, RspackSourceMap } from './rspack';
+import type { Rspack, RspackSourceMap } from './rspack';
 import type { HtmlRspackPlugin } from './thirdParty';
 import type { Falsy } from './utils';
 import type { MaybePromise } from './utils';
@@ -72,9 +71,9 @@ export type AsyncHook<Callback extends (...args: any[]) => any> = {
 };
 
 export type ModifyRspackConfigFn = (
-  config: RspackConfig,
+  config: Rspack.Configuration,
   utils: ModifyRspackConfigUtils,
-) => Promise<RspackConfig | void> | RspackConfig | void;
+) => MaybePromise<Rspack.Configuration | void>;
 
 export type ModifyWebpackChainUtils = ModifyChainUtils & {
   webpack: typeof import('webpack');

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -6,7 +6,7 @@ import type { RsbuildConfig } from './config';
 import type { NormalizedConfig, NormalizedEnvironmentConfig } from './config';
 import type { InternalContext, RsbuildContext } from './context';
 import type { PluginManager, RsbuildPluginAPI } from './plugin';
-import type { RspackConfig } from './rspack';
+import type { Rspack } from './rspack';
 import type { WebpackConfig } from './thirdParty';
 
 export type Bundler = 'rspack' | 'webpack';
@@ -58,7 +58,9 @@ export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {
         pluginNames: string[];
       }
     >;
-    bundlerConfigs: B extends 'rspack' ? RspackConfig[] : WebpackConfig[];
+    bundlerConfigs: B extends 'rspack'
+      ? Rspack.Configuration[]
+      : WebpackConfig[];
   };
 };
 
@@ -99,7 +101,7 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   }>;
 
   initConfigs: () => Promise<
-    B extends 'rspack' ? RspackConfig[] : WebpackConfig[]
+    B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[]
   >;
 
   inspectConfig: (

--- a/packages/core/src/types/rspack.ts
+++ b/packages/core/src/types/rspack.ts
@@ -15,16 +15,11 @@ export interface BundlerPluginInstance {
   apply: (compiler: any) => void;
 }
 
-export type RspackConfig = Omit<Rspack.Configuration, 'plugins'> & {
-  // Use a loose type here, so that user can pass webpack plugins
-  plugins?: BundlerPluginInstance[];
-};
-
 /** T[] => T */
 type GetElementType<T extends any[]> = T extends (infer U)[] ? U : never;
 
 export type RspackRule = GetElementType<
-  NonNullable<NonNullable<RspackConfig['module']>['rules']>
+  NonNullable<NonNullable<Rspack.Configuration['module']>['rules']>
 >;
 
 export type RspackSourceMap = {

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -536,7 +536,7 @@ Usually, you do not need to call the initConfigs method, because it will be auto
 
 ```ts
 function InitConfigs(): Promise<{
-  rspackConfigs: RspackConfig[];
+  rspackConfigs: Rspack.Configuration[];
 }>;
 ```
 

--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -4,7 +4,7 @@
 
 ```ts
 type SourceMap = {
-  js?: RspackConfig['devtool'];
+  js?: Rspack.Configuration['devtool'];
   css?: boolean;
 };
 ```

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -312,7 +312,7 @@ export default {
 
 ### mergeConfig
 
-- **Type:** `(...configs: RspackConfig[]) => RspackConfig`
+- **Type:** `(...configs:Rspack.Configuration[]) =>Rspack.Configuration`
 
 Used to merge multiple Rspack configs, same as [webpack-merge](https://github.com/survivejs/webpack-merge).
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -348,9 +348,9 @@ type ModifyRspackConfigUtils = {
 
 function ModifyRspackConfig(
   callback: (
-    config: RspackConfig,
+    config: Rspack.Configuration,
     utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | RspackConfig | void,
+  ) => Promise<RspackConfig | void> | Rspack.Configuration | void,
 ): void;
 ```
 

--- a/website/docs/en/shared/onBeforeBuild.mdx
+++ b/website/docs/en/shared/onBeforeBuild.mdx
@@ -11,7 +11,7 @@ function OnBeforeBuild(
   callback: (params: {
     isWatch: boolean;
     isFirstCompile: boolean;
-    bundlerConfigs?: WebpackConfig[] | RspackConfig[];
+    bundlerConfigs?: Rspack.Configuration[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/en/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/en/shared/onBeforeCreateCompiler.mdx
@@ -7,7 +7,7 @@ You can access the Rspack configuration array through the `bundlerConfigs` param
 ```ts
 function OnBeforeCreateCompiler(
   callback: (params: {
-    bundlerConfigs: WebpackConfig[] | RspackConfig[];
+    bundlerConfigs: Rspack.Configuration[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/en/shared/onBeforeEnvironmentCompile.mdx
+++ b/website/docs/en/shared/onBeforeEnvironmentCompile.mdx
@@ -11,7 +11,7 @@ function OnBeforeEnvironmentCompile(
   callback: (params: {
     isWatch: boolean;
     isFirstCompile: boolean;
-    bundlerConfig?: RspackConfig;
+    bundlerConfig?: Rspack.Configuration;
     environment: EnvironmentContext;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -550,7 +550,7 @@ initConfigs 方法用于初始化 Rsbuild 内部的配置，并返回 Rsbuild �
 
 ```ts
 function InitConfigs(): Promise<{
-  rspackConfigs: RspackConfig[];
+  rspackConfigs: Rspack.Configuration[];
 }>;
 ```
 

--- a/website/docs/zh/config/output/source-map.mdx
+++ b/website/docs/zh/config/output/source-map.mdx
@@ -4,7 +4,7 @@
 
 ```ts
 type SourceMap = {
-  js?: RspackConfig['devtool'];
+  js?: Rspack.Configuration['devtool'];
   css?: boolean;
 };
 ```

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -312,7 +312,7 @@ export default {
 
 ### mergeConfig
 
-- **类型：** `(...configs: RspackConfig[]) => RspackConfig`
+- **类型：** `(...configs:Rspack.Configuration[]) =>Rspack.Configuration`
 
 用于合并多份 Rspack 配置，等价于 [webpack-merge](https://github.com/survivejs/webpack-merge)。
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -346,9 +346,9 @@ type ModifyRspackConfigUtils = {
 
 function ModifyRspackConfig(
   callback: (
-    config: RspackConfig,
+    config: Rspack.Configuration,
     utils: ModifyRspackConfigUtils,
-  ) => Promise<RspackConfig | void> | RspackConfig | void,
+  ) => Promise<RspackConfig | void> | Rspack.Configuration | void,
 ): void;
 ```
 

--- a/website/docs/zh/shared/onBeforeBuild.mdx
+++ b/website/docs/zh/shared/onBeforeBuild.mdx
@@ -11,7 +11,7 @@ function OnBeforeBuild(
   callback: (params: {
     isWatch: boolean;
     isFirstCompile: boolean;
-    bundlerConfigs?: WebpackConfig[] | RspackConfig[];
+    bundlerConfigs?: Rspack.Configuration[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/zh/shared/onBeforeCreateCompiler.mdx
+++ b/website/docs/zh/shared/onBeforeCreateCompiler.mdx
@@ -7,7 +7,7 @@
 ```ts
 function OnBeforeCreateCompiler(
   callback: (params: {
-    bundlerConfigs: WebpackConfig[] | RspackConfig[];
+    bundlerConfigs: Rspack.Configuration[];
     environments: Record<string, EnvironmentContext>;
   }) => Promise<void> | void,
 ): void;

--- a/website/docs/zh/shared/onBeforeEnvironmentCompile.mdx
+++ b/website/docs/zh/shared/onBeforeEnvironmentCompile.mdx
@@ -11,7 +11,7 @@ function OnBeforeEnvironmentCompile(
   callback: (params: {
     isWatch: boolean;
     isFirstCompile: boolean;
-    bundlerConfig?: RspackConfig;
+    bundlerConfig?: Rspack.Configuration;
     environment: EnvironmentContext;
   }) => Promise<void> | void,
 ): void;


### PR DESCRIPTION
## Summary

No need to override Rspack configuration type, Rspack now supports webpack plugin type by default, see https://github.com/web-infra-dev/rspack/pull/7455.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
