### PR TITLE
chore: let cspell ignore Portuguese README

### DIFF
--- a/cspell.config.cjs
+++ b/cspell.config.cjs
@@ -17,6 +17,7 @@ module.exports = {
     'doc_build',
     'node_modules',
     'pnpm-lock.yaml',
+    'README.pt-BR.md',
   ],
   flagWords: banWords,
   dictionaries: ['dictionary'],


### PR DESCRIPTION
## Summary

Let cspell ignore Portuguese README, fix the CI.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).