### PR TITLE
docs: add link for Rsbuild 0.x website

### DIFF
--- a/website/docs/en/_meta.json
+++ b/website/docs/en/_meta.json
@@ -23,5 +23,18 @@
     "text": "Community",
     "link": "/community/",
     "activeMatch": "/community/"
+  },
+  {
+    "text": "Version",
+    "items": [
+      {
+        "text": "Changelog",
+        "link": "https://github.com/web-infra-dev/rsbuild/releases"
+      },
+      {
+        "text": "Rsbuild 0.x Doc",
+        "link": "http://v0.rsbuild.dev/"
+      }
+    ]
   }
 ]

--- a/website/docs/zh/_meta.json
+++ b/website/docs/zh/_meta.json
@@ -23,5 +23,18 @@
     "text": "社区",
     "link": "/community/",
     "activeMatch": "/community/"
+  },
+  {
+    "text": "版本",
+    "items": [
+      {
+        "text": "更新日志",
+        "link": "https://github.com/web-infra-dev/rsbuild/releases"
+      },
+      {
+        "text": "Rsbuild 0.x 文档",
+        "link": "http://v0.rsbuild.dev/zh/"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

Add link for Rsbuild 0.x website.

- https://v0.rsbuild.dev/ is hosted on Netlify.
- The website is deployed from the Rsbuild repo [v0.x branch](https://github.com/web-infra-dev/rsbuild/tree/v0.x).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
