### PR TITLE
fix: define NODE_ENV conflicts when setting mode

### DIFF
--- a/e2e/cases/mode/index.test.ts
+++ b/e2e/cases/mode/index.test.ts
@@ -1,0 +1,28 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to override mode', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    runServer: true,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON(false);
+
+  // should have no filename hash in development mode
+  const indexFile = Object.keys(files).find((key) =>
+    key.endsWith('static/js/index.js'),
+  )!;
+
+  // should replace `process.env.NODE_ENV` with `'development'`
+  expect(files[indexFile]).toContain('this is development mode!');
+
+  // should not remove comments
+  expect(files[indexFile]).toContain('// this is a comment');
+
+  // should have JavaScript source map
+  const indexSourceMap = Object.keys(files).find((key) =>
+    key.endsWith('static/js/index.js.map'),
+  );
+  expect(indexSourceMap).toBeTruthy();
+});

--- a/e2e/cases/mode/rsbuild.config.ts
+++ b/e2e/cases/mode/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  mode: 'development',
+});

--- a/e2e/cases/mode/src/index.ts
+++ b/e2e/cases/mode/src/index.ts
@@ -1,0 +1,6 @@
+// this is a comment
+if (process.env.NODE_ENV === 'production') {
+  console.log('this is production mode!');
+} else {
+  console.log('this is development mode!');
+}

--- a/e2e/cases/mode/tsconfig.json
+++ b/e2e/cases/mode/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "module": "ES2022",
+    "target": "ES2017",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "*.test.ts"]
+}

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -308,7 +308,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
-        "process.env.NODE_ENV": ""development"",
       },
     },
     ProgressPlugin {
@@ -669,7 +668,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
-        "process.env.NODE_ENV": ""production"",
       },
     },
     ProgressPlugin {
@@ -974,7 +972,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
-        "process.env.NODE_ENV": ""production"",
       },
     },
     ProgressPlugin {
@@ -1262,7 +1259,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     DefinePlugin {
       "definitions": {
         "process.env.ASSET_PREFIX": """",
-        "process.env.NODE_ENV": ""production"",
       },
     },
     ProgressPlugin {

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -71,7 +71,6 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
   DefinePlugin {
     "definitions": {
       "process.env.ASSET_PREFIX": """",
-      "process.env.NODE_ENV": ""test"",
     },
   },
   ProgressPlugin {

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -5,10 +5,9 @@ export const pluginDefine = (): RsbuildPlugin => ({
   name: 'rsbuild:define',
 
   setup(api) {
-    api.modifyBundlerChain((chain, { CHAIN_ID, env, bundler, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, bundler, environment }) => {
       const { config } = environment;
       const builtinVars: Define = {
-        'process.env.NODE_ENV': JSON.stringify(env),
         'process.env.ASSET_PREFIX': JSON.stringify(
           getPublicPathFromChain(chain, false),
         ),

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -368,7 +368,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""development"",
         },
       ],
       "affectedHooks": "compilation",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -368,7 +368,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""development"",
         },
       ],
       "affectedHooks": "compilation",
@@ -819,7 +818,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""production"",
         },
       ],
       "affectedHooks": "compilation",
@@ -1155,7 +1153,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""test"",
         },
       ],
       "affectedHooks": "compilation",
@@ -1561,7 +1558,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""development"",
         },
       ],
       "affectedHooks": "compilation",

--- a/packages/core/tests/__snapshots__/define.test.ts.snap
+++ b/packages/core/tests/__snapshots__/define.test.ts.snap
@@ -9,7 +9,6 @@ exports[`plugin-define > should register define plugin correctly 1`] = `
         {
           "NAME": ""Jack"",
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""test"",
         },
       ],
       "affectedHooks": "compilation",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1685,7 +1685,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "_args": [
           {
             "process.env.ASSET_PREFIX": """",
-            "process.env.NODE_ENV": ""development"",
           },
         ],
         "affectedHooks": "compilation",
@@ -2002,7 +2001,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
         "_args": [
           {
             "process.env.ASSET_PREFIX": """",
-            "process.env.NODE_ENV": ""development"",
           },
         ],
         "affectedHooks": "compilation",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -403,7 +403,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "_args": [
         {
           "process.env.ASSET_PREFIX": """",
-          "process.env.NODE_ENV": ""test"",
         },
       ],
       "affectedHooks": "compilation",

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -79,7 +79,6 @@ DefinePlugin {
       "__VUE_PROD_DEVTOOLS__": false,
       "__VUE_PROD_HYDRATION_MISMATCH_DETAILS__": false,
       "process.env.ASSET_PREFIX": """",
-      "process.env.NODE_ENV": ""test"",
     },
   ],
   "affectedHooks": "compilation",

--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -47,6 +47,7 @@ If the value of `mode` is `development`:
 
 - Enable HMR and register the [HotModuleReplacementPlugin](https://rspack.dev/plugins/webpack/hot-module-replacement-plugin).
 - Generate JavaScript source maps, but do not generate CSS source maps. See [output.sourceMap](/config/output/source-map) for details.
+- The `process.env.NODE_ENV` in the source code will be replaced with `'development'`.
 
 ## Production Mode
 
@@ -57,6 +58,7 @@ If the value of `mode` is `production`:
 - Generated JavaScript and CSS filenames will have hash suffixes, see [output.filenameHash](/config/output/filename-hash).
 - Generated CSS Modules classnames will be shorter, see [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname).
 - Do not generate JavaScript and CSS source maps, see [output.sourceMap](/config/output/source-map).
+- The `process.env.NODE_ENV` in the source code will be replaced with `'production'`.
 
 ## None Mode
 

--- a/website/docs/zh/config/mode.mdx
+++ b/website/docs/zh/config/mode.mdx
@@ -47,6 +47,7 @@ export default {
 
 - 开启 HMR，注册 [HotModuleReplacementPlugin](https://rspack.dev/plugins/webpack/hot-module-replacement-plugin)。
 - 生成 JavaScript 的 source map，不生成 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。
+- 源代码中的 `process.env.NODE_ENV` 会被替换为 `'development'`。
 
 ## Production 模式
 
@@ -57,6 +58,7 @@ export default {
 - 生成的 JavaScript 和 CSS 文件名会带有 hash 后缀，详见 [output.filenameHash](/config/output/filename-hash)。
 - 生成的 CSS Modules 类名更简短，详见 [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname)。
 - 不生成 JavaScript 和 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。
+- 源代码中的 `process.env.NODE_ENV` 会被替换为 `'production'`。
 
 ## None 模式
 


### PR DESCRIPTION
## Summary

Fix define `NODE_ENV` conflicts when setting `mode`, Rspack already defines `process.env.NODE_ENV` by Rspack's mode, so Rsbuild do not need to define it again.

<img width="894" alt="截屏2024-08-08 10 55 16" src="https://github.com/user-attachments/assets/8f38b676-cab6-4ae4-aef9-5f330c257b34">

## Related Links

https://rspack.dev/config/mode

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
