### PR TITLE
docs: display top level fields in the overview page

### DIFF
--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -5,8 +5,8 @@
     "label": "Overview"
   },
   "mode",
-  "environments",
   "plugins",
+  "environments",
   {
     "type": "dir",
     "name": "dev",

--- a/website/docs/zh/config/_meta.json
+++ b/website/docs/zh/config/_meta.json
@@ -5,8 +5,8 @@
     "label": "Overview"
   },
   "mode",
-  "environments",
   "plugins",
+  "environments",
   {
     "type": "dir",
     "name": "dev",

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -14,7 +14,25 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
     const globPath = path.join(root, '**/*.{mdx,md}');
 
     const files = await glob(globPath);
-    const groups: Group[] = [];
+    const groups: Group[] = [
+      {
+        name: 'root',
+        items: [
+          {
+            text: 'mode',
+            link: '/config/mode',
+          },
+          {
+            text: 'plugins',
+            link: '/config/plugins',
+          },
+          {
+            text: 'environments',
+            link: '/config/environments',
+          },
+        ],
+      },
+    ];
 
     for (const file of files) {
       const filename = file.replace(root, '').replace(/\.mdx?/, '');
@@ -40,6 +58,7 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
     }
 
     const order = [
+      'root',
       'source',
       'output',
       'html',

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -16,7 +16,7 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
     const files = await glob(globPath);
     const groups: Group[] = [
       {
-        name: 'root',
+        name: 'top level',
         items: [
           {
             text: 'mode',
@@ -58,7 +58,7 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
     }
 
     const order = [
-      'root',
+      'top level',
       'source',
       'output',
       'html',


### PR DESCRIPTION
## Summary

Display top level fields in the overview page.

![image](https://github.com/user-attachments/assets/42376491-7b7c-46a0-b070-6e2a8965cb08)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
