### PR TITLE
feat: add new `root` config

### DIFF
--- a/e2e/cases/root/index.test.ts
+++ b/e2e/cases/root/index.test.ts
@@ -1,0 +1,52 @@
+import { join } from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import fse from 'fs-extra';
+
+test('should allow to set relative root path', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      root: './test',
+    },
+  });
+
+  const index = await rsbuild.getIndexFile();
+  expect(index.content).toBeTruthy();
+  expect(rsbuild.distPath).toContain('test');
+});
+
+test('should allow to set absolute root path', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      root: join(__dirname, './test'),
+    },
+  });
+
+  const index = await rsbuild.getIndexFile();
+  expect(index.content).toBeTruthy();
+  expect(rsbuild.distPath).toContain('test');
+});
+
+test('should serve publicDir correctly when setting root', async ({ page }) => {
+  await fse.outputFile(
+    join(__dirname, 'test/public', 'test-temp-file.txt'),
+    'a',
+  );
+
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      root: './test',
+    },
+  });
+
+  const res = await page.goto(
+    `http://localhost:${rsbuild.port}/test-temp-file.txt`,
+  );
+
+  expect((await res?.body())?.toString().trim()).toBe('a');
+
+  await rsbuild.close();
+});

--- a/e2e/cases/root/test/src/index.js
+++ b/e2e/cases/root/test/src/index.js
@@ -1,0 +1,8 @@
+// this is a comment
+if (process.env.NODE_ENV === 'production') {
+  console.log('this is production mode!');
+} else if (process.env.NODE_ENV === 'development') {
+  console.log('this is development mode!');
+} else {
+  console.log('this is none mode!');
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -210,6 +210,7 @@ export const withDefaultConfig = async (
 ): Promise<RsbuildConfig> => {
   const merged = mergeRsbuildConfig(createDefaultConfig(), config);
 
+  merged.root ||= rootPath;
   merged.source ||= {};
 
   if (!merged.source.tsconfigPath) {

--- a/packages/core/src/types/config/index.ts
+++ b/packages/core/src/types/config/index.ts
@@ -81,6 +81,11 @@ export interface RsbuildConfig extends EnvironmentConfig {
    */
   mode?: RsbuildMode;
   /**
+   * Specify the project root directory. Can be an absolute path, or a path relative to `process.cwd()`.
+   * @default `process.cwd()`
+   */
+  root?: string;
+  /**
    * Options for local development.
    */
   dev?: DevConfig;
@@ -107,6 +112,7 @@ export interface RsbuildConfig extends EnvironmentConfig {
 
 export type MergedEnvironmentConfig = {
   mode: RsbuildMode;
+  root: string;
   dev: Pick<
     NormalizedDevConfig,
     'assetPrefix' | 'lazyCompilation' | 'progressBar'
@@ -126,21 +132,16 @@ export type MergedEnvironmentConfig = {
   moduleFederation?: ModuleFederationConfig;
 };
 
-/** The normalized Rsbuild environment config. */
-export type NormalizedEnvironmentConfig = DeepReadonly<{
-  mode: RsbuildMode;
-  dev: NormalizedDevConfig;
-  html: NormalizedHtmlConfig;
-  tools: NormalizedToolsConfig;
-  source: NormalizedSourceConfig;
-  server: NormalizedServerConfig;
-  output: MergedEnvironmentConfig['output'];
-  plugins?: RsbuildPlugins;
-  security: NormalizedSecurityConfig;
-  performance: NormalizedPerformanceConfig;
-  moduleFederation?: ModuleFederationConfig;
-  _privateMeta?: RsbuildConfigMeta;
-}>;
+/**
+ * The normalized Rsbuild environment config.
+ */
+export type NormalizedEnvironmentConfig = DeepReadonly<
+  Omit<MergedEnvironmentConfig, 'dev'> & {
+    dev: NormalizedDevConfig;
+    server: NormalizedServerConfig;
+    _privateMeta?: RsbuildConfigMeta;
+  }
+>;
 
 export type NormalizedConfig = NormalizedEnvironmentConfig & {
   provider?: unknown;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -82,6 +82,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
+  "root": "<ROOT>",
   "security": {
     "nonce": "",
     "sri": {
@@ -204,6 +205,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
+  "root": "<ROOT>",
   "security": {
     "nonce": "",
     "sri": {
@@ -363,6 +365,7 @@ exports[`environment config > should print environment config when inspect confi
       "rsbuild:sri",
       "rsbuild:nonce",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -518,6 +521,7 @@ exports[`environment config > should print environment config when inspect confi
       "rsbuild:sri",
       "rsbuild:nonce",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -692,6 +696,7 @@ exports[`environment config > should support modify environment config by api.mo
       "rsbuild:nonce",
       "test-environment",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -848,6 +853,7 @@ exports[`environment config > should support modify environment config by api.mo
       "rsbuild:nonce",
       "test-environment",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -1005,6 +1011,7 @@ exports[`environment config > should support modify environment config by api.mo
       "rsbuild:nonce",
       "test-environment",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -1165,6 +1172,7 @@ exports[`environment config > should support modify single environment config by
       "rsbuild:nonce",
       "test-environment",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {
@@ -1321,6 +1329,7 @@ exports[`environment config > should support modify single environment config by
       "rsbuild:nonce",
       "test-environment",
     ],
+    "root": "<ROOT>",
     "security": {
       "nonce": "",
       "sri": {

--- a/website/docs/en/config/_meta.json
+++ b/website/docs/en/config/_meta.json
@@ -4,6 +4,7 @@
     "name": "index",
     "label": "Overview"
   },
+  "root",
   "mode",
   "plugins",
   "environments",

--- a/website/docs/en/config/root.mdx
+++ b/website/docs/en/config/root.mdx
@@ -1,0 +1,29 @@
+# root
+
+- **Type:** `string`
+- **Default:** `process.cwd()`
+- **Version:** `>= 1.0.0`
+
+Specify the project root directory. Can be an absolute path, or a path relative to `process.cwd()`.
+
+The value of Rsbuild `root` is also be passed to the [context](https://rspack.dev/config/context) configuration of Rspack.
+
+## Example
+
+- Relative path:
+
+```ts title="rsbuild.config.ts"
+export default {
+  root: './foo',
+};
+```
+
+- Absolute path:
+
+```ts title="rsbuild.config.ts"
+import { join } from 'node:path';
+
+export default {
+  root: join(__dirname, 'foo'),
+};
+```

--- a/website/docs/zh/config/_meta.json
+++ b/website/docs/zh/config/_meta.json
@@ -4,6 +4,7 @@
     "name": "index",
     "label": "Overview"
   },
+  "root",
   "mode",
   "plugins",
   "environments",

--- a/website/docs/zh/config/root.mdx
+++ b/website/docs/zh/config/root.mdx
@@ -1,0 +1,29 @@
+# root
+
+- **类型：** `string`
+- **默认值：** `process.cwd()`
+- **版本：** `>= 1.0.0`
+
+指定项目根目录。可以是绝对路径，也可以是相对于 `process.cwd()` 的路径。
+
+Rsbuild `root` 的值也会传递给 Rspack 的 [context](https://rspack.dev/config/context) 配置。
+
+## 示例
+
+- 相对路径：
+
+```ts title="rsbuild.config.ts"
+export default {
+  root: './foo',
+};
+```
+
+- 绝对路径：
+
+```ts title="rsbuild.config.ts"
+import { join } from 'node:path';
+
+export default {
+  root: join(__dirname, 'foo'),
+};
+```

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -19,6 +19,10 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
         name: 'top level',
         items: [
           {
+            text: 'root',
+            link: '/config/root',
+          },
+          {
             text: 'mode',
             link: '/config/mode',
           },


### PR DESCRIPTION
## Summary

Add new `root` config to specify the project root directory.

```ts
export default {
  root: './foo',
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
