### PR TITLE
docs: add tip for using root with env files

### DIFF
--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -8,7 +8,9 @@ Specify the build mode for Rsbuild, as each mode has different default behavior 
 The value of Rsbuild `mode` is also be passed to the [mode](https://rspack.dev/config/mode) configuration of Rspack.
 
 :::tip
-The value of `mode` does not affect the loading of `.env` files. Rsbuild supports the use of the `--env-mode` option to specify the env mode. See [env mode](/guide/advanced/env-vars#env-mode) for more details.
+The value of `mode` does not affect the loading results of the `.env` file, as the `.env` file is resolved before the Rsbuild configuration file.
+
+Rsbuild CLI supports using the `--env-mode` option to specify the env mode. See ["Env mode"](/guide/advanced/env-vars#env-mode) for more details.
 :::
 
 ## Default Values

--- a/website/docs/en/config/root.mdx
+++ b/website/docs/en/config/root.mdx
@@ -8,6 +8,12 @@ Specify the project root directory. Can be an absolute path, or a path relative 
 
 The value of Rsbuild `root` is also be passed to the [context](https://rspack.dev/config/context) configuration of Rspack.
 
+:::tip
+The value of `root` does not affect the path of the `.env` file, as the `.env` file is resolved before the Rsbuild configuration file.
+
+Rsbuild CLI supports using the `--root` option to specify the root directory, which can affect the path of the `.env` file. See ["CLI"](/guide/basic/cli) for more details.
+:::
+
 ## Example
 
 - Relative path:

--- a/website/docs/zh/config/mode.mdx
+++ b/website/docs/zh/config/mode.mdx
@@ -8,7 +8,9 @@
 Rsbuild `mode` 的值也会传递给 Rspack 的 [mode](https://rspack.dev/config/mode) 配置。
 
 :::tip
-`mode` 的值不会影响 `.env` 文件的加载，Rsbuild 支持使用 `--env-mode` 选项来指定 env 模式，详见 [env 模式](/guide/advanced/env-vars#env-模式)。
+`mode` 的值不会影响 `.env` 文件的加载结果， 因为 `.env` 文件早于 Rsbuild 的配置文件被解析。
+
+Rsbuild CLI 支持使用 `--env-mode` 选项来指定 env 模式，详见 ["Env 模式"](/guide/advanced/env-vars#env-模式)。
 :::
 
 ## 默认值

--- a/website/docs/zh/config/root.mdx
+++ b/website/docs/zh/config/root.mdx
@@ -8,6 +8,12 @@
 
 Rsbuild `root` 的值也会传递给 Rspack 的 [context](https://rspack.dev/config/context) 配置。
 
+:::tip
+`root` 的值不会影响 `.env` 文件的加载路径，因为 `.env` 文件早于 Rsbuild 的配置文件被解析。
+
+Rsbuild CLI 支持使用 `--root` 选项来指定根目录，它可以影响 `.env` 文件的加载路径，详见 ["CLI"](/guide/basic/cli)。
+:::
+
 ## 示例
 
 - 相对路径：


### PR DESCRIPTION
## Summary

The value of `root` does not affect the path of the `.env` file, as the `.env` file is resolved before the Rsbuild configuration file.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
