### PR TITLE
test(e2e): print line for each test being run in CI

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,4 +3,6 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   // Retry on CI
   retries: process.env.CI ? 3 : 0,
+  // Print line for each test being run in CI
+  reporter: 'list',
 });


### PR DESCRIPTION
## Summary

Print line for each test being run in CI, playwright uses `process.env.CI ? 'dot' : 'list'` by default.

## Related Links

https://playwright.dev/docs/test-reporters

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
