### PR TITLE
fix: no need to print file size after rebuilding

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -221,9 +221,9 @@ export const pluginFileSize = (): RsbuildPlugin => ({
   name: 'rsbuild:file-size',
 
   setup(api) {
-    api.onAfterBuild(async ({ stats, environments }) => {
+    api.onAfterBuild(async ({ stats, environments, isFirstCompile }) => {
       // No need to print file sizes if there is any compilation error
-      if (!stats || stats.hasErrors()) {
+      if (!stats || stats.hasErrors() || !isFirstCompile) {
         return;
       }
 


### PR DESCRIPTION
## Summary

No need to print file size after rebuilding, take Rslib as an example:

<img width="914" alt="Screenshot 2024-08-13 at 14 27 27" src="https://github.com/user-attachments/assets/45b9a1e8-3802-4680-bde1-0d2d112e0bd2">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
