### PR TITLE
refactor: favicon generation

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -11,7 +11,6 @@ import {
   getPublicPathFromChain,
   isFileExists,
   isPlainObject,
-  isURL,
 } from '../helpers';
 import type { HtmlInfo, TagConfig } from '../rspack/RsbuildHtmlPlugin';
 import type {
@@ -288,12 +287,7 @@ export const pluginHtml = (
 
             const favicon = getFavicon(entryName, config);
             if (favicon) {
-              if (isURL(favicon)) {
-                htmlInfo.favicon = favicon;
-              } else {
-                // HTMLWebpackPlugin only support favicon file path
-                pluginOptions.favicon = favicon;
-              }
+              htmlInfo.favicon = favicon;
             }
 
             const finalOptions = reduceConfigsWithContext({

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -186,7 +186,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
         "compile": true,
         "entryName": "index",
         "excludeChunks": [],
-        "favicon": "./src/favicon.ico",
+        "favicon": false,
         "filename": "index.html",
         "hash": false,
         "inject": "head",
@@ -213,6 +213,7 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
+          "favicon": "./src/favicon.ico",
           "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
         },
       },


### PR DESCRIPTION
## Summary

Use `RsbuildHtmlPlugin` to generate favicon, instead of using the `favicon` option of `html-rspack-plugin`.

This allows Rsbuild to have full control over favicon generation and add some advanced features in the future.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
