### PR TITLE
feat(core): Remove the default exportOnlyLocals value from cssloader …

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -6,7 +6,6 @@ import { CSS_REGEX, LOADER_PATH } from '../constants';
 import { getCompiledPath } from '../helpers/path';
 import { getCssExtractPlugin } from '../pluginHelper';
 import type {
-  CSSLoaderModulesMode,
   CSSLoaderOptions,
   ModifyChainUtils,
   NormalizedEnvironmentConfig,


### PR DESCRIPTION

## Summary
Remove the default value of exportOnlyLocals when cssmodule is enabled，

When module is enabled, exportOnlyLocals is set to true by default，the exported value is incorrectly mounted

![image](https://github.com/user-attachments/assets/9ee89a49-121f-4f63-96ac-0d17052aa77a)

Therefore, exportOnlyLocals does not need a default value, leaving it up to the user to select


## Related Links
[[Bug]: SCSS files not loaded #1999](https://github.com/web-infra-dev/rsbuild/issues/1999)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
