### PR TITLE
feat: add type attribute for SVG favicon

### DIFF
--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -23,6 +23,29 @@ test('should emit local favicon to dist path', async () => {
   expect(html).toContain('<link rel="icon" href="/icon.png">');
 });
 
+test('should add type attribute for SVG favicon', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        favicon: '../../../assets/mobile.svg',
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  expect(
+    Object.keys(files).some((file) => file.endsWith('/mobile.svg')),
+  ).toBeTruthy();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).toContain(
+    '<link rel="icon" href="/mobile.svg" type="image/svg+xml">',
+  );
+});
+
 test('should apply asset prefix to favicon URL', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -277,7 +277,7 @@ export class RsbuildHtmlPlugin {
         href = ensureAssetPrefix(name, publicPath);
       }
 
-      headTags.unshift({
+      const tag: HtmlRspackPlugin.HtmlTagObject = {
         tagName: 'link',
         voidTag: true,
         attributes: {
@@ -285,7 +285,13 @@ export class RsbuildHtmlPlugin {
           href,
         },
         meta: {},
-      });
+      };
+
+      if (href.endsWith('.svg')) {
+        tag.attributes.type = 'image/svg+xml';
+      }
+
+      headTags.unshift(tag);
     };
 
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {


### PR DESCRIPTION
## Summary

Should add`type="image/svg+xml"` attribute for SVG favicon.

## Related Links

https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
