### PR TITLE
release: 1.0.1-beta.12

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.11"
+    "@rsbuild/core": "workspace:^1.0.1-beta.12"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.11",
+  "version": "1.0.1-beta.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: add new `root` config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3170
* feat(CLI): add new `root` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3173
* feat(deps): bump Rspack 1.0.0-beta.4 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3178
* feat!: output inspect config to .rsbuild dir by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3189
* feat: add type attribute for SVG favicon by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3200
### Bug Fixes 🐞
* fix: no need to print file size if there is any build error by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3190
* fix: no need to print file size after rebuilding by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3197
* fix: onBeforeBuild hook should before onBeforeEnvironmentCompile hook by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3196
### Document 📖
* docs: add tip for using root with env files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3174
* docs: remove unnecessary version tips by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3175
* docs: add MarsCode to online examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3176
* docs: Fix minor grammar errors in the contribution docs 📙 by @BrinsilElias in https://github.com/web-infra-dev/rsbuild/pull/3181
* docs: update benchmark data by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3195
* docs: optimize module federation version selection by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3202
### Other Changes
* test(helpers): migrate path-serializer to npm package  by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/3165
* chore(deps): update dependency core-js to ~3.38.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3131
* chore: remove unused ts comments by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3177
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3179
* chore(deps): update eslint to ^9.9.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3180
* chore(deps): update dependency html-rspack-plugin to v6.0.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3184
* chore(deps): update dependency rspack-chain to v1 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3186
* chore: move styled components plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3183
* test(e2e): print line for each test being run in CI by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3187
* chore(deps): update dependency lit to ^3.2.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3185
* chore: move rem plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3192
* chore(deps): update dependency @modern-js/module-tools to ^2.58.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3188
* refactor: favicon generation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3198

## New Contributors
* @BrinsilElias made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3181

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.11...v1.0.1-beta.12