### PR TITLE
feat(create-rsbuild): improve tool selection instruction in prompt

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -161,7 +161,8 @@ async function getTools({ tools, dir, template }: Argv) {
 
   return checkCancel<string[]>(
     await multiselect({
-      message: 'Select additional tools (press enter to continue)',
+      message:
+        'Select additional tools (Use <space> to select, <enter> to continue)',
       options: [
         { value: 'biome', label: 'Add Biome for code linting and formatting' },
         { value: 'eslint', label: 'Add ESLint for code linting' },

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -64,7 +64,7 @@ When creating a project, you can choose from the following templates provided by
 `create-rsbuild` can help you set up some commonly used tools, including [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), and [prettier](https://github.com/prettier/prettier). You can use the arrow keys and the space bar to make your selections. If you don't need these tools, you can simply press Enter to skip.
 
 ```text
-◆  Select additional tools (press enter to continue)
+◆  Select additional tools (Use <space> to select, <enter> to continue)
 │  ◻ Add Biome for code linting and formatting
 │  ◻ Add ESLint for code linting
 │  ◻ Add Prettier for code formatting

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -69,7 +69,7 @@ import { PackageManagerTabs } from '@theme';
 `create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint) 和 [prettier](https://github.com/prettier/prettier)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。
 
 ```text
-◆  Select additional tools (press enter to continue)
+◆  Select additional tools (Use <space> to select, <enter> to continue)
 │  ◻ Add Biome for code linting and formatting
 │  ◻ Add ESLint for code linting
 │  ◻ Add Prettier for code formatting


### PR DESCRIPTION
## Summary
Improve CLI prompt usability for additional tool selection. Users may be unsure on how to select additional tools, leading to confusion.

It happened to me, when I was trying to select additional tools for linting and formatting, I wasn't quite sure why hitting enter was not selecting the tools 😅
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
