### PR TITLE
fix: clean rsbuild outputs by default

### DIFF
--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -38,7 +38,7 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
 
       const { cleanDistPath } = config.output;
 
-      if (cleanDistPath && isStrictSubdir(rootPath, cleanPath)) {
+      if (cleanDistPath !== false && isStrictSubdir(rootPath, cleanPath)) {
         return cleanPath;
       }
       return undefined;

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -38,7 +38,10 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
 
       const { cleanDistPath } = config.output;
 
-      if (cleanDistPath !== false && isStrictSubdir(rootPath, cleanPath)) {
+      if (
+        cleanDistPath ||
+        (cleanDistPath === undefined && isStrictSubdir(rootPath, cleanPath))
+      ) {
         return cleanPath;
       }
       return undefined;


### PR DESCRIPTION
## Summary

By default, if the rsbuild outputs directory (`.rsbuild/`) is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/3189

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
