### PR TITLE
feat: `output.cleanDistPath` defaults to `auto`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -129,6 +129,7 @@ const getDefaultPerformanceConfig = (): NormalizedPerformanceConfig => ({
 
 const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   target: 'web',
+  cleanDistPath: 'auto',
   distPath: {
     root: ROOT_DIST_DIR,
     css: CSS_DIST_DIR,

--- a/packages/core/src/plugins/cleanOutput.ts
+++ b/packages/core/src/plugins/cleanOutput.ts
@@ -39,8 +39,8 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
       const { cleanDistPath } = config.output;
 
       if (
-        cleanDistPath ||
-        (cleanDistPath === undefined && isStrictSubdir(rootPath, cleanPath))
+        cleanDistPath === true ||
+        (cleanDistPath === 'auto' && isStrictSubdir(rootPath, cleanPath))
       ) {
         return cleanPath;
       }
@@ -54,7 +54,7 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
       let { cleanDistPath } = config.output;
 
       // only enable cleanDistPath when the dist path is a subdir of root path
-      if (cleanDistPath === undefined) {
+      if (cleanDistPath === 'auto') {
         cleanDistPath = isStrictSubdir(rootPath, distPath);
 
         if (!cleanDistPath) {
@@ -72,6 +72,7 @@ export const pluginCleanOutput = (): RsbuildPlugin => ({
       if (cleanDistPath) {
         return distPath;
       }
+
       return undefined;
     };
 

--- a/packages/core/src/types/config/output.ts
+++ b/packages/core/src/types/config/output.ts
@@ -250,8 +250,9 @@ export interface OutputConfig {
   legalComments?: LegalComments;
   /**
    * Whether to clean all files in the dist path before starting compilation.
+   * @default 'auto'
    */
-  cleanDistPath?: boolean;
+  cleanDistPath?: boolean | 'auto';
   /**
    * Allow to custom CSS Modules options.
    */

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -33,6 +33,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
   "output": {
     "assetPrefix": "/",
     "charset": "ascii",
+    "cleanDistPath": "auto",
     "cssModules": {
       "auto": true,
       "exportGlobals": false,
@@ -156,6 +157,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
   "output": {
     "assetPrefix": "/",
     "charset": "ascii",
+    "cleanDistPath": "auto",
     "cssModules": {
       "auto": true,
       "exportGlobals": false,
@@ -280,6 +282,7 @@ exports[`environment config > should print environment config when inspect confi
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -436,6 +439,7 @@ exports[`environment config > should print environment config when inspect confi
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -610,6 +614,7 @@ exports[`environment config > should support modify environment config by api.mo
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -767,6 +772,7 @@ exports[`environment config > should support modify environment config by api.mo
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -925,6 +931,7 @@ exports[`environment config > should support modify environment config by api.mo
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -1086,6 +1093,7 @@ exports[`environment config > should support modify single environment config by
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,
@@ -1243,6 +1251,7 @@ exports[`environment config > should support modify single environment config by
     "output": {
       "assetPrefix": "/",
       "charset": "ascii",
+      "cleanDistPath": "auto",
       "cssModules": {
         "auto": true,
         "exportGlobals": false,

--- a/website/docs/en/config/output/clean-dist-path.mdx
+++ b/website/docs/en/config/output/clean-dist-path.mdx
@@ -1,13 +1,13 @@
 # output.cleanDistPath
 
-- **Type:** `boolean`
-- **Default:** `undefined`
+- **Type:** `boolean | 'auto'`
+- **Default:** `'auto'`
 
 Whether to clean up all files under the output directory before the build starts (the output directory defaults to `dist`).
 
 ## Default Behavior
 
-By default, if the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.
+The default value of `output.cleanDistPath` is `'auto'`. If the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the build directory.
 
 When [output.distPath.root](/config/output/dist-path) is an external directory, or equals to the project root directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
 

--- a/website/docs/zh/config/output/clean-dist-path.mdx
+++ b/website/docs/zh/config/output/clean-dist-path.mdx
@@ -1,13 +1,13 @@
 # output.cleanDistPath
 
-- **类型：** `boolean`
-- **默认值：** `undefined`
+- **类型：** `boolean | 'auto'`
+- **默认值：** `'auto'`
 
 是否在构建开始前清理产物目录下的所有文件（产物目录默认为 `dist`）。
 
 ## 默认行为
 
-默认情况下，如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
+`output.cleanDistPath` 的默认值为 `'auto'`。如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
 
 当 [output.distPath.root](/config/output/dist-path) 为外部目录，或等于项目根目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
 


### PR DESCRIPTION
## Summary

`output.cleanDistPath` defaults to `auto`, this makes the default behavior of cleanDistPath more explicit.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
