### PR TITLE
fix: missing default mode when using `rsbuild.startDevServer`

### DIFF
--- a/e2e/cases/mode/define/index.test.ts
+++ b/e2e/cases/mode/define/index.test.ts
@@ -10,6 +10,9 @@ test('should define vars in production mode correctly', async () => {
   expect(file.content).toContain(
     'console.log("import.meta.env.MODE","production")',
   );
+  expect(file.content).toContain(
+    'console.log("process.env.NODE_ENV","production")',
+  );
   expect(file.content).not.toContain('console.log("import.meta.env.DEV")');
   expect(file.content).toContain('console.log("import.meta.env.PROD")');
 });
@@ -26,6 +29,9 @@ test('should define vars in development mode correctly', async () => {
   expect(file.content).toContain(
     'console.log(\'import.meta.env.MODE\', "development");',
   );
+  expect(file.content).toContain(
+    'console.log(\'process.env.NODE_ENV\', "development")',
+  );
   expect(file.content).toContain("console.log('import.meta.env.DEV');");
   expect(file.content).not.toContain("console.log('import.meta.env.PROD');");
 });
@@ -41,6 +47,9 @@ test('should define vars in none mode correctly', async () => {
   const file = await rsbuild.getIndexFile();
   expect(file.content).toContain(
     'console.log(\'import.meta.env.MODE\', "none");',
+  );
+  expect(file.content).toContain(
+    "console.log('process.env.NODE_ENV', process.env.NODE_ENV)",
   );
   expect(file.content).not.toContain("console.log('import.meta.env.DEV');");
   expect(file.content).not.toContain("console.log('import.meta.env.PROD');");

--- a/e2e/cases/mode/define/src/index.js
+++ b/e2e/cases/mode/define/src/index.js
@@ -1,7 +1,10 @@
+console.log('process.env.NODE_ENV', process.env.NODE_ENV);
 console.log('import.meta.env.MODE', import.meta.env.MODE);
+
 if (import.meta.env.DEV) {
   console.log('import.meta.env.DEV');
 }
+
 if (import.meta.env.PROD) {
   console.log('import.meta.env.PROD');
 }

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -1,5 +1,4 @@
 import { rspack } from '@rspack/core';
-import { getNodeEnv, setNodeEnv } from '../helpers';
 import { registerBuildHook } from '../hooks';
 import { logger } from '../logger';
 import type { BuildOptions, MultiStats, Rspack, Stats } from '../types';
@@ -12,10 +11,6 @@ export const build = async (
 ): Promise<void | {
   close: () => Promise<void>;
 }> => {
-  if (!getNodeEnv()) {
-    setNodeEnv('production');
-  }
-
   const { context } = initOptions;
 
   let compiler: Rspack.Compiler | Rspack.MultiCompiler;

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,12 +1,7 @@
 import fs from 'node:fs';
 import type Connect from 'connect';
 import { ROOT_DIST_DIR } from '../constants';
-import {
-  getNodeEnv,
-  getPublicPathFromCompiler,
-  isMultiCompiler,
-  setNodeEnv,
-} from '../helpers';
+import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers';
 import { logger } from '../logger';
 import type { CreateDevMiddlewareReturns } from '../provider/createCompiler';
 import type {
@@ -109,10 +104,6 @@ export async function createDevServer<
     runCompile = true,
   }: CreateDevServerOptions = {},
 ): Promise<RsbuildDevServer> {
-  if (!getNodeEnv()) {
-    setNodeEnv('development');
-  }
-
   logger.debug('create dev server');
 
   const { port, host, https } = await getServerConfig({

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,7 +1,6 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type Connect from 'connect';
-import { getNodeEnv, setNodeEnv } from '../helpers';
 import { pathnameParse } from '../helpers/path';
 import { logger } from '../logger';
 import type {
@@ -149,10 +148,6 @@ export async function startProdServer(
   config: NormalizedConfig,
   { getPortSilently }: PreviewServerOptions = {},
 ): Promise<StartServerResult> {
-  if (!getNodeEnv()) {
-    setNodeEnv('production');
-  }
-
   const { port, host, https } = await getServerConfig({
     config,
     getPortSilently,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -79,25 +79,31 @@ export type CreateRsbuildOptions = {
 export type ResolvedCreateRsbuildOptions = CreateRsbuildOptions &
   Required<Omit<CreateRsbuildOptions, 'environment'>>;
 
+export type CreateDevServer = (
+  options?: CreateDevServerOptions,
+) => Promise<RsbuildDevServer>;
+
+export type StartDevServer = (
+  options?: StartDevServerOptions,
+) => Promise<StartServerResult>;
+
+export type Build = (options?: BuildOptions) => Promise<void | {
+  close: () => Promise<void>;
+}>;
+
 export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = {
   readonly bundler: Bundler;
 
   createCompiler: CreateCompiler;
 
   /**
-   * It is designed for high-level frameworks that require a custom server
+   * It is designed for upper-level frameworks that require a custom server
    */
-  createDevServer: (
-    options?: CreateDevServerOptions,
-  ) => Promise<RsbuildDevServer>;
+  createDevServer: CreateDevServer;
 
-  startDevServer: (
-    options?: StartDevServerOptions,
-  ) => Promise<StartServerResult>;
+  startDevServer: StartDevServer;
 
-  build: (options?: BuildOptions) => Promise<void | {
-    close: () => Promise<void>;
-  }>;
+  build: Build;
 
   initConfigs: () => Promise<
     B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[]

--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -50,6 +50,9 @@ If the value of `mode` is `development`:
 - Enable HMR and register the [HotModuleReplacementPlugin](https://rspack.dev/plugins/webpack/hot-module-replacement-plugin).
 - Generate JavaScript source maps, but do not generate CSS source maps. See [output.sourceMap](/config/output/source-map) for details.
 - The `process.env.NODE_ENV` in the source code will be replaced with `'development'`.
+- The `import.meta.env.MODE` in the source code will be replaced with `'development'`.
+- The `import.meta.env.DEV` in the source code will be replaced with `true`.
+- The `import.meta.env.PROD` in the source code will be replaced with `false`.
 
 ## Production Mode
 
@@ -61,9 +64,16 @@ If the value of `mode` is `production`:
 - Generated CSS Modules classnames will be shorter, see [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname).
 - Do not generate JavaScript and CSS source maps, see [output.sourceMap](/config/output/source-map).
 - The `process.env.NODE_ENV` in the source code will be replaced with `'production'`.
+- The `import.meta.env.MODE` in the source code will be replaced with `'production'`.
+- The `import.meta.env.DEV` in the source code will be replaced with `false`.
+- The `import.meta.env.PROD` in the source code will be replaced with `true`.
 
 ## None Mode
 
 If the value of `mode` is `none`:
 
 - Do not enable any optimizations.
+- The `process.env.NODE_ENV` in the source code will not be replaced.
+- The `import.meta.env.MODE` in the source code will be replaced with `'none'`.
+- The `import.meta.env.DEV` in the source code will be replaced with `false`.
+- The `import.meta.env.PROD` in the source code will be replaced with `false`.

--- a/website/docs/zh/config/mode.mdx
+++ b/website/docs/zh/config/mode.mdx
@@ -50,6 +50,9 @@ export default {
 - 开启 HMR，注册 [HotModuleReplacementPlugin](https://rspack.dev/plugins/webpack/hot-module-replacement-plugin)。
 - 生成 JavaScript 的 source map，不生成 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。
 - 源代码中的 `process.env.NODE_ENV` 会被替换为 `'development'`。
+- 源代码中的 `import.meta.env.MODE` 会被替换为 `'development'`。
+- 源代码中的 `import.meta.env.DEV` 会被替换为 `true`。
+- 源代码中的 `import.meta.env.PROD` 会被替换为 `false`。
 
 ## Production 模式
 
@@ -61,9 +64,16 @@ export default {
 - 生成的 CSS Modules 类名更简短，详见 [cssModules.localIdentName](/config/output/css-modules#cssmoduleslocalidentname)。
 - 不生成 JavaScript 和 CSS 的 source map，详见 [output.sourceMap](/config/output/source-map)。
 - 源代码中的 `process.env.NODE_ENV` 会被替换为 `'production'`。
+- 源代码中的 `import.meta.env.MODE` 会被替换为 `'production'`。
+- 源代码中的 `import.meta.env.DEV` 会被替换为 `false`。
+- 源代码中的 `import.meta.env.PROD` 会被替换为 `true`。
 
 ## None 模式
 
 当 `mode` 的值为 `none` 时：
 
 - 不开启任何优化。
+- 源代码中的 `process.env.NODE_ENV` 不会被替换。
+- 源代码中的 `import.meta.env.MODE` 会被替换为 `'none'`。
+- 源代码中的 `import.meta.env.DEV` 会被替换为 `false`。
+- 源代码中的 `import.meta.env.PROD` 会被替换为 `false`。


### PR DESCRIPTION
## Summary

Fix missing default mode when using `rsbuild.startDevServer()` and `rsbuild.createDevServer()`.

We should set the default `process.env.NODE_ENV` before calling `initRsbuildConfig()`, otherwise the default value of `mode` will be `none` instead of `development`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3206

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
