### PR TITLE
release: 1.0.1-beta.14

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2-jsx/package.json
+++ b/packages/plugin-vue2-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2-jsx",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Vue 2 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.13"
+    "@rsbuild/core": "workspace:^1.0.1-beta.14"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.13",
+  "version": "1.0.1-beta.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Change 💡

* feat!: support generating web app manifest when using `html.appIcon` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3219
* feat!: use `connectWebSocket` instead of `onHTTPUpdate` method by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3216
* feat(deps): bump Rspack 1.0.0-beta.5 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3221

### New Features 🎉
* feat(create-rsbuild): improve tool selection instruction in prompt by @BrinsilElias in https://github.com/web-infra-dev/rsbuild/pull/3208
* feat: `output.cleanDistPath` defaults to `auto` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3213
### Bug Fixes 🐞
* fix: clean rsbuild outputs by default by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3210
* fix: missing default mode when using `rsbuild.startDevServer` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3214
### Document 📖
* docs(type-check): add exclude examples by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3207
* docs: enable strict SSG and update X logo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3218
### Other Changes
* doc: fix typo in security by @liyincode in https://github.com/web-infra-dev/rsbuild/pull/3209
* chore(deps): update dependency @module-federation/rspack to v0.4.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3211
* chore(deps): update rspress to v1.28.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3212
* test(e2e): add cases for `html.appIcon` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3222


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.13...v1.0.1-beta.14