### PR TITLE
feat!: use `connectWebSocket` instead of `onHTTPUpdate` method

### DIFF
--- a/e2e/cases/server/custom-server/scripts/pureServer.mjs
+++ b/e2e/cases/server/custom-server/scripts/pureServer.mjs
@@ -48,9 +48,6 @@ export async function startDevServerPure(fixtures) {
     await rsbuildServer.afterListen();
   });
 
-  // subscribe the server's http upgrade event to handle WebSocket upgrade
-  server.on('upgrade', rsbuildServer.onHTTPUpgrade);
-
   return {
     config: { port: rsbuildServer.port },
     close: async () => {

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -35,7 +35,7 @@ export async function startDevServer(fixtures) {
     await rsbuildServer.afterListen();
   });
 
-  rsbuildServer.connectSocket({ server });
+  rsbuildServer.connectWebSocket({ server });
 
   return {
     config: { port },

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -19,8 +19,7 @@ export async function startDevServer(fixtures) {
 
   const rsbuildServer = await rsbuild.createDevServer();
 
-  const { middlewares, close, onHTTPUpgrade, afterListen, port } =
-    rsbuildServer;
+  const { middlewares, close, port } = rsbuildServer;
 
   app.get('/aaa', (_req, res) => {
     res.end('Hello World!');
@@ -36,8 +35,7 @@ export async function startDevServer(fixtures) {
     await rsbuildServer.afterListen();
   });
 
-  // subscribe the server's http upgrade event to handle WebSocket upgrade
-  server.on('upgrade', onHTTPUpgrade);
+  rsbuildServer.connectSocket({ server });
 
   return {
     config: { port },

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -80,7 +80,7 @@ export type RsbuildDevServer = {
    *
    * It will used when you use custom server
    */
-  connectSocket: (options: { server: HTTPServer }) => void;
+  connectWebSocket: (options: { server: HTTPServer }) => void;
   /**
    * Close the Rsbuild server.
    */
@@ -345,7 +345,7 @@ export async function createDevServer<
         environments: options.context.environments,
       });
     },
-    connectSocket: ({ server }: { server: HTTPServer }) => {
+    connectWebSocket: ({ server }: { server: HTTPServer }) => {
       server.on('upgrade', devMiddlewares.onUpgrade);
     },
     close: async () => {

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -360,6 +360,27 @@ const server = await rsbuild.createDevServer();
 await server.listen();
 ```
 
+### connectSocket
+
+Rsbuild has a builtin Socket server to support HMR:
+
+1. When a user accesses a page through browser, a Web Socket connection request is automatically initiated to the server.
+2. After the Rsbuild dev server detects the connection request, it instructs the builtin Socket server to process it.
+3. After the browser successfully establishes a connection with the Rsbuild Socket server, real-time communication is possible.
+4. The Rsbuild Socket server notifies the browser after each recompilation is complete. The browser then sends a `hot-update.(js|json)` request to the dev server to load the new compiled module.
+
+When you use custom server, you may encounter HMR connection error problems. This is because the custom server does not forward Web Socket connection requests to Rsbuild's Socket server.
+
+At this time, you need to use the `connectSocket` method to enable Rsbuild to sense and process the Socket connection request from the browser.
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+
+const httpServer = app.listen(rsbuildServer.port);
+
+rsbuildServer.connectSocket({ server: httpServer });
+```
+
 ## rsbuild.preview
 
 Start a server to preview the production build locally. This method should be executed after `rsbuild.build`.

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -299,8 +299,7 @@ type RsbuildDevServer = {
   /** Notify Rsbuild that the custom server has started */
   afterListen: () => Promise<void>;
 
-  /** Subscribe to the http upgrade event */
-  onHTTPUpgrade: UpgradeEvent;
+  connectSocket: (options: { server: HTTPServer }) => void;
 
   /** close the Rsbuild DevServer */
   close: () => Promise<void>;
@@ -347,8 +346,7 @@ export async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  // Subscribe to the server's http upgrade event to handle WebSocket upgrades
-  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+  rsbuildServer.connectSocket({ server: httpServer });
 }
 ```
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -299,7 +299,7 @@ type RsbuildDevServer = {
   /** Notify Rsbuild that the custom server has started */
   afterListen: () => Promise<void>;
 
-  connectSocket: (options: { server: HTTPServer }) => void;
+  connectWebSocket: (options: { server: HTTPServer }) => void;
 
   /** close the Rsbuild DevServer */
   close: () => Promise<void>;
@@ -346,7 +346,7 @@ export async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  rsbuildServer.connectSocket({ server: httpServer });
+  rsbuildServer.connectWebSocket({ server: httpServer });
 }
 ```
 
@@ -360,25 +360,25 @@ const server = await rsbuild.createDevServer();
 await server.listen();
 ```
 
-### connectSocket
+### connectWebSocket
 
-Rsbuild has a builtin Socket server to support HMR:
+Rsbuild has a builtin WebSocket handler to support HMR:
 
-1. When a user accesses a page through browser, a Web Socket connection request is automatically initiated to the server.
-2. After the Rsbuild dev server detects the connection request, it instructs the builtin Socket server to process it.
-3. After the browser successfully establishes a connection with the Rsbuild Socket server, real-time communication is possible.
-4. The Rsbuild Socket server notifies the browser after each recompilation is complete. The browser then sends a `hot-update.(js|json)` request to the dev server to load the new compiled module.
+1. When a user accesses a page through browser, a WebSocket connection request is automatically initiated to the server.
+2. After the Rsbuild dev server detects the connection request, it instructs the builtin WebSocket handler to process it.
+3. After the browser successfully establishes a connection with the Rsbuild WebSocket handler, real-time communication is possible.
+4. The Rsbuild WebSocket handler notifies the browser after each recompilation is complete. The browser then sends a `hot-update.(js|json)` request to the dev server to load the new compiled module.
 
-When you use custom server, you may encounter HMR connection error problems. This is because the custom server does not forward Web Socket connection requests to Rsbuild's Socket server.
+When you use custom server, you may encounter HMR connection error problems. This is because the custom server does not forward WebSocket connection requests to Rsbuild's WebSocket handler.
 
-At this time, you need to use the `connectSocket` method to enable Rsbuild to sense and process the Socket connection request from the browser.
+At this time, you need to use the `connectWebSocket` method to enable Rsbuild to sense and process the WebSocket connection request from the browser.
 
 ```ts
 const rsbuildServer = await rsbuild.createDevServer();
 
 const httpServer = app.listen(rsbuildServer.port);
 
-rsbuildServer.connectSocket({ server: httpServer });
+rsbuildServer.connectWebSocket({ server: httpServer });
 ```
 
 ## rsbuild.preview

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -126,7 +126,7 @@ async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  rsbuildServer.connectSocket({ server: httpServer });
+  rsbuildServer.connectWebSocket({ server: httpServer });
 }
 
 startDevServer(process.cwd());

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -126,7 +126,7 @@ async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+  rsbuildServer.connectSocket({ server: httpServer });
 }
 
 startDevServer(process.cwd());

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -360,7 +360,6 @@ export async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  // 订阅服务器的 http 升级事件来处理 WebSocket 升级
   rsbuildServer.connectSocket({ server: httpServer });
 }
 ```
@@ -373,6 +372,25 @@ export async function startDevServer() {
 const server = await rsbuild.createDevServer();
 
 await server.listen();
+```
+
+### connectSocket
+
+Rsbuild 内置了 Socket 服务器以支持 HMR 功能：
+
+1. 当用户通过浏览器访问页面时，会自动向服务器发起 Web Socket 连接请求。
+2. Rsbuild 开发服务器检测到连接请求后，会指示内置的 Socket 服务器进行处理。
+3. 浏览器与 Rsbuild Socket 服务器成功建立连接后，便可进行实时通信。
+4. 每次重新编译完成后，Rsbuild Socket 服务器会通知浏览器。随后，浏览器向开发服务器发送 `hot-update.(js|json)` 请求，以加载编译后的新模块。
+
+当你使用自定义的 server 时，可能会遇到 HMR 连接报错的问题，这是因为自定义的 server 没有将 Web Socket 连接请求转发给 Rsbuild 的 Socket 服务器。此时需要通过 `connectSocket` 方法已使 Rsbuild 能够感知并处理来自浏览器的 Socket 连接请求。
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+
+const httpServer = app.listen(rsbuildServer.port);
+
+rsbuildServer.connectSocket({ server: httpServer });
 ```
 
 ## rsbuild.preview

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -313,8 +313,7 @@ type RsbuildDevServer = {
   /** 通知 Rsbuild 自定义 Server 已启动 */
   afterListen: () => Promise<void>;
 
-  /** 订阅 http upgrade 事件 */
-  onHTTPUpgrade: UpgradeEvent;
+  connectSocket: (options: { server: HTTPServer }) => void;
 
   /** 关闭 Rsbuild DevServer */
   close: () => Promise<void>;
@@ -362,7 +361,7 @@ export async function startDevServer() {
   });
 
   // 订阅服务器的 http 升级事件来处理 WebSocket 升级
-  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+  rsbuildServer.connectSocket({ server: httpServer });
 }
 ```
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -313,7 +313,7 @@ type RsbuildDevServer = {
   /** 通知 Rsbuild 自定义 Server 已启动 */
   afterListen: () => Promise<void>;
 
-  connectSocket: (options: { server: HTTPServer }) => void;
+  connectWebSocket: (options: { server: HTTPServer }) => void;
 
   /** 关闭 Rsbuild DevServer */
   close: () => Promise<void>;
@@ -360,7 +360,7 @@ export async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  rsbuildServer.connectSocket({ server: httpServer });
+  rsbuildServer.connectWebSocket({ server: httpServer });
 }
 ```
 
@@ -374,23 +374,23 @@ const server = await rsbuild.createDevServer();
 await server.listen();
 ```
 
-### connectSocket
+### connectWebSocket
 
-Rsbuild 内置了 Socket 服务器以支持 HMR 功能：
+Rsbuild 内置了 WebSocket 处理器以支持 HMR 功能：
 
-1. 当用户通过浏览器访问页面时，会自动向服务器发起 Web Socket 连接请求。
-2. Rsbuild 开发服务器检测到连接请求后，会指示内置的 Socket 服务器进行处理。
-3. 浏览器与 Rsbuild Socket 服务器成功建立连接后，便可进行实时通信。
-4. 每次重新编译完成后，Rsbuild Socket 服务器会通知浏览器。随后，浏览器向开发服务器发送 `hot-update.(js|json)` 请求，以加载编译后的新模块。
+1. 当用户通过浏览器访问页面时，会自动向服务器发起 WebSocket 连接请求。
+2. Rsbuild 开发服务器检测到连接请求后，会指示内置的 WebSocket 处理器进行处理。
+3. 浏览器与 Rsbuild WebSocket 处理器成功建立连接后，便可进行实时通信。
+4. 每次重新编译完成后，Rsbuild WebSocket 处理器会通知浏览器。随后，浏览器向开发服务器发送 `hot-update.(js|json)` 请求，以加载编译后的新模块。
 
-当你使用自定义的 server 时，可能会遇到 HMR 连接报错的问题，这是因为自定义的 server 没有将 Web Socket 连接请求转发给 Rsbuild 的 Socket 服务器。此时需要通过 `connectSocket` 方法已使 Rsbuild 能够感知并处理来自浏览器的 Socket 连接请求。
+当你使用自定义的 server 时，可能会遇到 HMR 连接报错的问题，这是因为自定义的 server 没有将 WebSocket 连接请求转发给 Rsbuild 的 WebSocket 处理器。此时需要通过 `connectWebSocket` 方法已使 Rsbuild 能够感知并处理来自浏览器的 WebSocket 连接请求。
 
 ```ts
 const rsbuildServer = await rsbuild.createDevServer();
 
 const httpServer = app.listen(rsbuildServer.port);
 
-rsbuildServer.connectSocket({ server: httpServer });
+rsbuildServer.connectWebSocket({ server: httpServer });
 ```
 
 ## rsbuild.preview

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -126,7 +126,7 @@ async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  rsbuildServer.connectSocket({ server: httpServer });
+  rsbuildServer.connectWebSocket({ server: httpServer });
 }
 
 startDevServer(process.cwd());

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -126,7 +126,7 @@ async function startDevServer() {
     await rsbuildServer.afterListen();
   });
 
-  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+  rsbuildServer.connectSocket({ server: httpServer });
 }
 
 startDevServer(process.cwd());


### PR DESCRIPTION
## Summary

This PR will cause **breaking change** for users who use Rsbuild's `createDevServer` JavaScript API directly.

The `﻿onHTTPUpgrade` method does not fully convey its actual purpose, which is to activate the webSocket connection for Rsbuild.

Users who use rsbuild createDevServer directly need to make the following modifications:
```diff
  const rsbuildServer = await rsbuild.createDevServer();

  const httpServer = app.listen(rsbuildServer.port);

-  httpServer.on('upgrade', rsbuildServer.onHTTPUpgrade);
+  rsbuildServer.connectWebSocket({ server: httpServer });

```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
