### PR TITLE
docs: enable strict SSG and update X logo

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -68,6 +68,9 @@ export default defineConfig({
     light: 'https://assets.rspack.dev/rsbuild/navbar-logo-light.png',
     dark: 'https://assets.rspack.dev/rsbuild/navbar-logo-dark.png',
   },
+  ssg: {
+    strict: true,
+  },
   markdown: {
     checkDeadLinks: true,
   },
@@ -87,7 +90,7 @@ export default defineConfig({
         content: 'https://github.com/web-infra-dev/rsbuild',
       },
       {
-        icon: 'twitter',
+        icon: 'x',
         mode: 'link',
         content: 'https://twitter.com/rspack_dev',
       },


### PR DESCRIPTION
## Summary

- use x logo to replace twitter logo.
- enable `ssg.strict` to ensure SSG can pass.

## Related Links

the same as https://github.com/web-infra-dev/rspack/pull/7581

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
