### PR TITLE
feat: set default entry when entry is set to an empty object

### DIFF
--- a/e2e/cases/source/entry-empty-object/index.test.ts
+++ b/e2e/cases/source/entry-empty-object/index.test.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { build, globContentJSON } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should set default entry when entry is set to an empty object', async () => {
+  await build({
+    cwd: __dirname,
+  });
+
+  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
+
+  expect(
+    outputFiles.find((item) => item.includes('static/js/index.')),
+  ).toBeTruthy();
+});

--- a/e2e/cases/source/entry-empty-object/rsbuild.config.ts
+++ b/e2e/cases/source/entry-empty-object/rsbuild.config.ts
@@ -1,0 +1,5 @@
+export default {
+  source: {
+    entry: {},
+  },
+};

--- a/e2e/cases/source/entry-empty-object/src/index.js
+++ b/e2e/cases/source/entry-empty-object/src/index.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -86,7 +86,7 @@ const initEnvironmentConfigs = (
     !specifiedEnvironments || specifiedEnvironments.includes(name);
 
   const applyEnvironmentDefaultConfig = (config: MergedEnvironmentConfig) => {
-    if (!config.source.entry) {
+    if (!config.source.entry || Object.keys(config.source.entry).length === 0) {
       config.source.entry = getDefaultEntryWithMemo();
     }
 


### PR DESCRIPTION
## Summary

In some scenarios using JS API, such as Rslib, entry may be processed as an empty object, and we need to keep the default value available.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
