### PR TITLE
perf: use compilation.inputFileSystem to read app icons

### DIFF
--- a/packages/core/src/helpers/fs.ts
+++ b/packages/core/src/helpers/fs.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../logger';
+import type { Rspack } from '../types';
 
 export const isFileSync = (filePath: string): boolean | undefined => {
   try {
@@ -41,6 +42,22 @@ export async function isFileExists(file: string): Promise<boolean> {
     .access(file, fs.constants.F_OK)
     .then(() => true)
     .catch(() => false);
+}
+
+export async function fileExistsByCompilation(
+  compilation: Rspack.Compilation,
+  filePath: string,
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    // TODO remove any in next Rspack release
+    compilation.inputFileSystem.stat(filePath, (err: any, stats: any) => {
+      if (err) {
+        resolve(false);
+      } else {
+        resolve(stats.isFile());
+      }
+    });
+  });
 }
 
 export async function emptyDir(dir: string): Promise<void> {

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -1,9 +1,9 @@
-import fs from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import {
   ensureAssetPrefix,
+  fileExistsByCompilation,
   getPublicPathFromCompiler,
-  isFileExists,
 } from '../helpers';
 import type { AppIconItem, HtmlBasicTag, RsbuildPlugin } from '../types';
 
@@ -76,13 +76,17 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         const tags: HtmlBasicTag[] = [];
 
         for (const icon of icons) {
-          if (!(await isFileExists(icon.absolutePath))) {
+          if (
+            !(await fileExistsByCompilation(compilation, icon.absolutePath))
+          ) {
             throw new Error(
               `[rsbuild:app-icon] Can not find the app icon, please check if the '${icon.relativePath}' file exists'.`,
             );
           }
 
-          const source = await fs.promises.readFile(icon.absolutePath);
+          const source = await promisify(compilation.inputFileSystem.readFile)(
+            icon.absolutePath,
+          );
 
           compilation.emitAsset(
             icon.relativePath,


### PR DESCRIPTION
## Summary

Use `compilation.inputFileSystem` to read app icons, reuse the cache of Rspack.

## Related Links

https://github.com/web-infra-dev/rspack/pull/7597

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
