### PR TITLE
feat: add more oneOf to `CHAIN_ID`

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -129,6 +129,18 @@ export const CHAIN_ID = {
   },
   /** Predefined rule groups */
   ONE_OF: {
+    IMAGE_URL: 'image-asset-url',
+    IMAGE_ASSET: 'image-asset',
+    IMAGE_INLINE: 'image-asset-inline',
+
+    MEDIA_URL: 'media-asset-url',
+    MEDIA_ASSET: 'media-asset',
+    MEDIA_INLINE: 'media-asset-inline',
+
+    FONT_URL: 'font-asset-url',
+    FONT_ASSET: 'font-asset',
+    FONT_INLINE: 'font-asset-inline',
+
     SVG: 'svg',
     SVG_URL: 'svg-asset-url',
     SVG_ASSET: 'svg-asset',

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { GeneratorOptionsByModuleType } from '@rspack/core';
+import type { CHAIN_ID } from '../configChain';
 import {
   AUDIO_EXTENSIONS,
   FONT_EXTENSIONS,
@@ -8,6 +9,8 @@ import {
 } from '../constants';
 import { getFilename } from '../helpers';
 import type { RsbuildPlugin, RspackChain } from '../types';
+
+type ValueOf<T> = T[keyof T];
 
 const chainStaticAssetRule = ({
   emit,
@@ -20,7 +23,7 @@ const chainStaticAssetRule = ({
   rule: RspackChain.Rule;
   maxSize: number;
   filename: string;
-  assetType: string;
+  assetType: 'image' | 'media' | 'font' | 'svg';
 }) => {
   const generatorOptions:
     | GeneratorOptionsByModuleType['asset']
@@ -34,20 +37,22 @@ const chainStaticAssetRule = ({
 
   // force to url: "foo.png?url" or "foo.png?__inline=false"
   rule
-    .oneOf(`${assetType}-asset-url`)
+    .oneOf(`${assetType}-asset-url` satisfies ValueOf<typeof CHAIN_ID.ONE_OF>)
     .type('asset/resource')
     .resourceQuery(/(__inline=false|url)/)
     .set('generator', generatorOptions);
 
   // force to inline: "foo.png?inline"
   rule
-    .oneOf(`${assetType}-asset-inline`)
+    .oneOf(
+      `${assetType}-asset-inline` satisfies ValueOf<typeof CHAIN_ID.ONE_OF>,
+    )
     .type('asset/inline')
     .resourceQuery(/inline/);
 
   // default: when size < dataUrlCondition.maxSize will inline
   rule
-    .oneOf(`${assetType}-asset`)
+    .oneOf(`${assetType}-asset` satisfies ValueOf<typeof CHAIN_ID.ONE_OF>)
     .type('asset')
     .parser({
       dataUrlCondition: {

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -189,11 +189,20 @@ For example, the `RULE.STYLUS` rule exists only when the Stylus plugin is regist
 
 `ONE_OF.[ID]` can match a certain type of rule in the rule array.
 
-| ID                  | Description                                                        |
-| ------------------- | ------------------------------------------------------------------ |
-| `ONE_OF.SVG_URL`    | Rules for SVG, output as a separate file                           |
-| `ONE_OF.SVG_INLINE` | Rules for SVG, inlined into bundles as data URIs                   |
-| `ONE_OF.SVG_ASSETS` | Rules for SVG, automatic choice between data URI and separate file |
+| ID                    | Description                                                          |
+| --------------------- | -------------------------------------------------------------------- |
+| `ONE_OF.IMAGE_URL`    | Rules for IMAGE, output as a separate file                           |
+| `ONE_OF.IMAGE_INLINE` | Rules for IMAGE, inlined into bundles as data URIs                   |
+| `ONE_OF.IMAGE_ASSETS` | Rules for IMAGE, automatic choice between data URI and separate file |
+| `ONE_OF.MEDIA_URL`    | Rules for MEDIA, output as a separate file                           |
+| `ONE_OF.MEDIA_INLINE` | Rules for MEDIA, inlined into bundles as data URIs                   |
+| `ONE_OF.MEDIA_ASSETS` | Rules for MEDIA, automatic choice between data URI and separate file |
+| `ONE_OF.FONT_URL`     | Rules for FONT, output as a separate file                            |
+| `ONE_OF.FONT_INLINE`  | Rules for FONT, inlined into bundles as data URIs                    |
+| `ONE_OF.FONT_ASSETS`  | Rules for FONT, automatic choice between data URI and separate file  |
+| `ONE_OF.SVG_URL`      | Rules for SVG, output as a separate file                             |
+| `ONE_OF.SVG_INLINE`   | Rules for SVG, inlined into bundles as data URIs                     |
+| `ONE_OF.SVG_ASSETS`   | Rules for SVG, automatic choice between data URI and separate file   |
 
 ### CHAIN_ID.USE
 

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -188,11 +188,20 @@ Rsbuild 中预先定义了一些常用的 Chain ID，你可以通过这些 ID �
 
 通过 `ONE_OF.[ID]` 可以匹配到规则数组中的某一类规则。
 
-| ID                  | 描述                                                |
-| ------------------- | --------------------------------------------------- |
-| `ONE_OF.SVG_URL`    | 处理 SVG 的规则，输出为单独文件                     |
-| `ONE_OF.SVG_INLINE` | 处理 SVG 的规则，作为 data URI 内联到 bundle 中     |
-| `ONE_OF.SVG_ASSETS` | 处理 SVG 的规则，在 data URI 和单独文件之间自动选择 |
+| ID                    | 描述                                                  |
+| --------------------- | ----------------------------------------------------- |
+| `ONE_OF.IMAGE_URL`    | 处理 IMAGE 的规则，输出为单独文件                     |
+| `ONE_OF.IMAGE_INLINE` | 处理 IMAGE 的规则，作为 data URI 内联到 bundle 中     |
+| `ONE_OF.IMAGE_ASSETS` | 处理 IMAGE 的规则，在 data URI 和单独文件之间自动选择 |
+| `ONE_OF.MEDIA_URL`    | 处理 MEDIA 的规则，输出为单独文件                     |
+| `ONE_OF.MEDIA_INLINE` | 处理 MEDIA 的规则，作为 data URI 内联到 bundle 中     |
+| `ONE_OF.MEDIA_ASSETS` | 处理 MEDIA 的规则，在 data URI 和单独文件之间自动选择 |
+| `ONE_OF.FONT_URL`     | 处理 FONT 的规则，输出为单独文件                      |
+| `ONE_OF.FONT_INLINE`  | 处理 FONT 的规则，作为 data URI 内联到 bundle 中      |
+| `ONE_OF.FONT_ASSETS`  | 处理 FONT 的规则，在 data URI 和单独文件之间自动选择  |
+| `ONE_OF.SVG_URL`      | 处理 SVG 的规则，输出为单独文件                       |
+| `ONE_OF.SVG_INLINE`   | 处理 SVG 的规则，作为 data URI 内联到 bundle 中       |
+| `ONE_OF.SVG_ASSETS`   | 处理 SVG 的规则，在 data URI 和单独文件之间自动选择   |
 
 ### CHAIN_ID.USE
 


### PR DESCRIPTION
## Summary

Add the following values to `CHAIN_ID.ONE_OF`

- `IMAGE_URL`: `'image-asset-url'`
- `IMAGE_ASSET`: `'image-asset'`
- `IMAGE_INLINE`: `'image-asset-inline'`
- `MEDIA_URL`: `'media-asset-url'`
- `MEDIA_ASSET`: `'media-asset'`
- `MEDIA_INLINE`: `'media-asset-inline'`
- `FONT_URL`: `'font-asset-url'`
- `FONT_ASSET`: `'font-asset'`
- `FONT_INLINE`: `'font-asset-inline'`

This is useful for modifying the asset-related Rspack configuraion.

E.g.: Remove the hash from image assets.

```js
// rsbuild.config.ts
export default defineConfig({
  tools: {
    bundlerChain(chain, { CHAIN_ID }) {
      chain.module
        .rule(CHAIN_ID.RULE.IMAGE)
        .oneOf(CHAIN_ID.ONE_OF.IMAGE_URL)
        .generator({
          filename: 'static/img/[name].[ext]',
        })
    },
  },
})
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [x] Documentation updated (or not required).
