### PR TITLE
feat: add mime type for web app manifest

### DIFF
--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -70,8 +70,8 @@ test('should emit manifest.webmanifest to dist path', async () => {
   expect(JSON.parse(files[manifestPath!])).toEqual({
     name: 'My Website',
     icons: [
-      { src: '/static/image/icon.png', sizes: '180x180' },
-      { src: '/static/image/image.png', sizes: '512x512' },
+      { src: '/static/image/icon.png', sizes: '180x180', type: 'image/png' },
+      { src: '/static/image/image.png', sizes: '512x512', type: 'image/png' },
     ],
   });
 });
@@ -107,8 +107,8 @@ test('should allow to customize manifest filename', async () => {
   expect(JSON.parse(files[manifestPath!])).toEqual({
     name: 'My Website',
     icons: [
-      { src: '/static/image/icon.png', sizes: '180x180' },
-      { src: '/static/image/image.png', sizes: '512x512' },
+      { src: '/static/image/icon.png', sizes: '180x180', type: 'image/png' },
+      { src: '/static/image/image.png', sizes: '512x512', type: 'image/png' },
     ],
   });
 });
@@ -162,8 +162,16 @@ test('should append dev.assetPrefix to icon URL', async ({ page }) => {
   expect(JSON.parse(files[manifestPath!])).toEqual({
     name: 'My Website',
     icons: [
-      { src: 'http://localhost:3000/static/image/icon.png', sizes: '180x180' },
-      { src: 'http://localhost:3000/static/image/image.png', sizes: '512x512' },
+      {
+        src: 'http://localhost:3000/static/image/icon.png',
+        sizes: '180x180',
+        type: 'image/png',
+      },
+      {
+        src: 'http://localhost:3000/static/image/image.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
     ],
   });
 
@@ -215,8 +223,16 @@ test('should append output.assetPrefix to icon URL', async () => {
   expect(JSON.parse(files[manifestPath!])).toEqual({
     name: 'My Website',
     icons: [
-      { src: 'https://example.com/static/image/icon.png', sizes: '180x180' },
-      { src: 'https://example.com/static/image/image.png', sizes: '512x512' },
+      {
+        src: 'https://example.com/static/image/icon.png',
+        sizes: '180x180',
+        type: 'image/png',
+      },
+      {
+        src: 'https://example.com/static/image/image.png',
+        sizes: '512x512',
+        type: 'image/png',
+      },
     ],
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,6 +79,7 @@
     "http-proxy-middleware": "^2.0.6",
     "jiti": "^1.21.6",
     "launch-editor-middleware": "^2.8.1",
+    "mrmime": "^2.0.0",
     "on-finished": "2.4.1",
     "open": "^8.4.0",
     "picocolors": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -704,6 +704,9 @@ importers:
       launch-editor-middleware:
         specifier: ^2.8.1
         version: 2.8.1
+      mrmime:
+        specifier: ^2.0.0
+        version: 2.0.0
       on-finished:
         specifier: 2.4.1
         version: 2.4.1

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -57,6 +57,7 @@ Mergeable
 microfrontend
 microfrontends
 modularly
+mrmime
 mYbzBtlg6o
 napi
 nolyfill

--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -65,8 +65,16 @@ Here, `manifest.webmanifest` is a JSON file that contains information about the 
 {
   "name": "My Website",
   "icons": [
-    { "src": "/static/image/logo-192.png", "sizes": "192x192" },
-    { "src": "/static/image/logo-512.png", "sizes": "512x512" }
+    {
+      "src": "/static/image/logo-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/image/logo-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ]
 }
 ```

--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -72,12 +72,18 @@ export default {
 };
 ```
 
-You can also set the apple-touch-icon for iOS system through the [html.appIcon](/config/html/app-icon) config.
+You can also set the web application icons to display when added to the home screen of a mobile device through the [html.appIcon](/config/html/app-icon) config.
 
 ```ts
 export default {
   html: {
-    appIcon: './src/assets/icon.png',
+    appIcon: {
+      name: 'My Website',
+      icons: [
+        { src: './src/assets/logo-192.png', size: 192 },
+        { src: './src/assets/logo-512.png', size: 512 },
+      ],
+    },
   },
 };
 ```

--- a/website/docs/zh/config/html/app-icon.mdx
+++ b/website/docs/zh/config/html/app-icon.mdx
@@ -65,8 +65,16 @@ export default {
 {
   "name": "My Website",
   "icons": [
-    { "src": "/static/image/logo-192.png", "sizes": "192x192" },
-    { "src": "/static/image/logo-512.png", "sizes": "512x512" }
+    {
+      "src": "/static/image/logo-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/image/logo-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ]
 }
 ```

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -72,12 +72,18 @@ export default {
 };
 ```
 
-也可以通过 [html.appIcon](/config/html/app-icon) 配置项来设置 iOS 系统下的 apple-touch-icon 图标。
+你也可以通过 [html.appIcon](/config/html/app-icon) 配置项来设置 Web 应用的图标，用于在添加到移动设备的主屏幕时显示。
 
 ```ts
 export default {
   html: {
-    appIcon: './src/assets/icon.png',
+    appIcon: {
+      name: 'My Website',
+      icons: [
+        { src: './src/assets/logo-192.png', size: 192 },
+        { src: './src/assets/logo-512.png', size: 512 },
+      ],
+    },
   },
 };
 ```


### PR DESCRIPTION
## Summary

Add mime type for web app manifest, using `mrmime` (A tiny (2.8kB) and fast utility for getting a MIME type)

> `type`: The [MIME type](https://developer.mozilla.org/en-US/docs/Glossary/MIME_type) of the image file which the operating system can use to quickly ignore images it does not support.

## Related Links

- https://github.com/lukeed/mrmime
- https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Define_app_icons

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
