### PR TITLE
feat: allow to specify target for app icons

### DIFF
--- a/packages/core/src/types/config/html.ts
+++ b/packages/core/src/types/config/html.ts
@@ -61,6 +61,12 @@ export type AppIconItem = {
    * The size of the icon.
    */
   size: number;
+  /**
+   * Specifies the intended target for which the icon should be generated.
+   * - `apple-touch-icon` for iOS system.
+   * - `web-app-manifest` for web application manifest.
+   */
+  target?: 'apple-touch-icon' | 'web-app-manifest';
 };
 
 export type AppIcon = {

--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -3,7 +3,11 @@
 - **Type:**
 
 ```ts
-type AppIconItem = { src: string; size: number };
+type AppIconItem = {
+  src: string;
+  size: number;
+  target?: 'apple-touch-icon' | 'web-app-manifest';
+};
 
 type AppIcon = {
   name?: string;
@@ -100,7 +104,8 @@ The name of the application that will be displayed when it is added to the home 
 The list of icons:
 
 - `src` is the path to the icon, which can be a relative or absolute path.
-- `size` is the size of the icon in pixels. By default, the manifest file will include all icons, while the `apple-touch-icon` tag will only include icons smaller than `200x200`.
+- `size` is the size of the icon in pixels.
+- `target` refers to the intended target for the icon, which can be either `apple-touch-icon` or `web-app-manifest`. If `target` is not set, by default, the manifest file will include all icons, while the `apple-touch-icon` tags will only include icons smaller than `200x200`.
 
 `src` can be set to an absolute path:
 

--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -107,6 +107,8 @@ The list of icons:
 - `size` is the size of the icon in pixels.
 - `target` refers to the intended target for the icon, which can be either `apple-touch-icon` or `web-app-manifest`. If `target` is not set, by default, the manifest file will include all icons, while the `apple-touch-icon` tags will only include icons smaller than `200x200`.
 
+### Example
+
 `src` can be set to an absolute path:
 
 ```js
@@ -119,6 +121,35 @@ export default {
       icons: [
         { src: path.resolve(__dirname, './assets/icon-192.png'), size: 192 },
         { src: path.resolve(__dirname, './assets/icon-512.png'), size: 512 },
+      ],
+    },
+  },
+};
+```
+
+Use `target` to specify the target for the icon:
+
+```js
+export default {
+  html: {
+    appIcon: {
+      name: 'My Website',
+      icons: [
+        {
+          src: './src/assets/logo-180.png',
+          size: 180,
+          target: 'apple-touch-icon',
+        },
+        {
+          src: './src/assets/logo-192.png',
+          size: 192,
+          target: 'web-app-manifest',
+        },
+        {
+          src: './src/assets/logo-512.png',
+          size: 512,
+          target: 'web-app-manifest',
+        },
       ],
     },
   },

--- a/website/docs/zh/config/html/app-icon.mdx
+++ b/website/docs/zh/config/html/app-icon.mdx
@@ -3,7 +3,11 @@
 - **类型：**
 
 ```ts
-type AppIconItem = { src: string; size: number };
+type AppIconItem = {
+  src: string;
+  size: number;
+  target?: 'apple-touch-icon' | 'web-app-manifest';
+};
 
 type AppIcon = {
   name?: string;
@@ -100,7 +104,8 @@ export default {
 图标列表，其中：
 
 - `src` 是图标的路径，可以是相对路径或绝对路径。
-- `size` 是图标的大小，以像素为单位。默认情况下，manifest 文件会包含所有的图标，而 `apple-touch-icon` 标签只会包含小于 `200x200` 的图标。
+- `size` 是图标的大小，以像素为单位。
+- `target` 是图标的目标，可以是 `apple-touch-icon` 或 `web-app-manifest`。如果未设置 `target`，默认情况下，manifest 文件会包含所有的图标，而 `apple-touch-icon` 标签只会包含小于 `200x200` 的图标。
 
 `src` 可以设置为绝对路径：
 

--- a/website/docs/zh/config/html/app-icon.mdx
+++ b/website/docs/zh/config/html/app-icon.mdx
@@ -107,6 +107,8 @@ export default {
 - `size` 是图标的大小，以像素为单位。
 - `target` 是图标的目标，可以是 `apple-touch-icon` 或 `web-app-manifest`。如果未设置 `target`，默认情况下，manifest 文件会包含所有的图标，而 `apple-touch-icon` 标签只会包含小于 `200x200` 的图标。
 
+### 示例
+
 `src` 可以设置为绝对路径：
 
 ```js
@@ -119,6 +121,35 @@ export default {
       icons: [
         { src: path.resolve(__dirname, './assets/icon-192.png'), size: 192 },
         { src: path.resolve(__dirname, './assets/icon-512.png'), size: 512 },
+      ],
+    },
+  },
+};
+```
+
+使用 `target` 选项来指定图标的目标：
+
+```js
+export default {
+  html: {
+    appIcon: {
+      name: 'My Website',
+      icons: [
+        {
+          src: './src/assets/logo-180.png',
+          size: 180,
+          target: 'apple-touch-icon',
+        },
+        {
+          src: './src/assets/logo-192.png',
+          size: 192,
+          target: 'web-app-manifest',
+        },
+        {
+          src: './src/assets/logo-512.png',
+          size: 512,
+          target: 'web-app-manifest',
+        },
       ],
     },
   },


### PR DESCRIPTION
## Summary

Allow to specify target for app icons:


```js
export default {
  html: {
    appIcon: {
      name: 'My Website',
      icons: [
        {
          src: './src/assets/logo-180.png',
          size: 180,
          target: 'apple-touch-icon',
        },
        {
          src: './src/assets/logo-192.png',
          size: 192,
          target: 'web-app-manifest',
        },
        {
          src: './src/assets/logo-512.png',
          size: 512,
          target: 'web-app-manifest',
        },
      ],
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
