### PR TITLE
docs: add app icon to website

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -165,6 +165,19 @@ export default defineConfig({
           },
         },
       ],
+      appIcon: {
+        name: 'Rsbuild',
+        icons: [
+          {
+            src: 'https://assets.rspack.dev/rsbuild/rsbuild-logo-192x192.png',
+            size: 192,
+          },
+          {
+            src: 'https://assets.rspack.dev/rsbuild/rsbuild-logo-512x512.png',
+            size: 512,
+          },
+        ],
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Add app icon to the website.

https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
