### PR TITLE
feat: allow to disable HTML for specific entry

### DIFF
--- a/e2e/cases/source/entry-disable-html/index.test.ts
+++ b/e2e/cases/source/entry-disable-html/index.test.ts
@@ -1,0 +1,15 @@
+import path from 'node:path';
+import { build, globContentJSON } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to disable HTML for specific entry', async () => {
+  await build({
+    cwd: __dirname,
+  });
+
+  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputFiles = Object.keys(outputs);
+
+  expect(outputFiles.find((item) => item.includes('foo.html'))).toBeTruthy();
+  expect(outputFiles.find((item) => item.includes('bar.html'))).toBeFalsy();
+});

--- a/e2e/cases/source/entry-disable-html/rsbuild.config.ts
+++ b/e2e/cases/source/entry-disable-html/rsbuild.config.ts
@@ -1,0 +1,13 @@
+export default {
+  source: {
+    entry: {
+      foo: {
+        import: './src/foo.js',
+      },
+      bar: {
+        import: './src/bar.js',
+        html: false,
+      },
+    },
+  },
+};

--- a/e2e/cases/source/entry-disable-html/src/bar.js
+++ b/e2e/cases/source/entry-disable-html/src/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/e2e/cases/source/entry-disable-html/src/foo.js
+++ b/e2e/cases/source/entry-disable-html/src/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -77,7 +77,17 @@ const getEnvironmentHTMLPaths = (
   }
 
   return Object.keys(entry).reduce<Record<string, string>>((prev, key) => {
-    prev[key] = getHTMLPathByEntry(key, config);
+    const entryValue = entry[key];
+
+    // Should not generate HTML file for the entry if `html` is false
+    if (
+      typeof entryValue === 'string' ||
+      Array.isArray(entryValue) ||
+      entryValue.html !== false
+    ) {
+      prev[key] = getHTMLPathByEntry(key, config);
+    }
+
     return prev;
   }, {});
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,7 @@ export type {
   RsbuildConfig,
   RsbuildContext,
   RsbuildEntry,
+  RsbuildEntryDescription,
   RsbuildInstance,
   RsbuildMode,
   RsbuildPlugin,

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -15,7 +15,7 @@ export const pluginEntry = (): RsbuildPlugin => ({
       for (const entryName of Object.keys(entry)) {
         const entryPoint = chain.entry(entryName);
         const addEntry = (item: string | RsbuildEntryDescription) => {
-          if (typeof item === 'object' && item.html) {
+          if (typeof item === 'object' && 'html' in item) {
             const { html, ...rest } = item;
             entryPoint.add(rest);
           } else {

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -1,7 +1,6 @@
-import type { EntryDescription } from '@rspack/core';
 import color from 'picocolors';
 import { castArray, createVirtualModule } from '../helpers';
-import type { RsbuildPlugin } from '../types';
+import type { RsbuildEntryDescription, RsbuildPlugin } from '../types';
 
 export const pluginEntry = (): RsbuildPlugin => ({
   name: 'rsbuild:entry',
@@ -15,8 +14,13 @@ export const pluginEntry = (): RsbuildPlugin => ({
 
       for (const entryName of Object.keys(entry)) {
         const entryPoint = chain.entry(entryName);
-        const addEntry = (item: string | EntryDescription) => {
-          entryPoint.add(item);
+        const addEntry = (item: string | RsbuildEntryDescription) => {
+          if (typeof item === 'object' && item.html) {
+            const { html, ...rest } = item;
+            entryPoint.add(rest);
+          } else {
+            entryPoint.add(item);
+          }
         };
 
         preEntry.forEach(addEntry);

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -224,7 +224,9 @@ export const pluginHtml = (
 
         const assetPrefix = getPublicPathFromChain(chain, false);
         const entries = chain.entryPoints.entries() || {};
-        const entryNames = Object.keys(entries);
+        const entryNames = Object.keys(entries).filter((entryName) =>
+          Boolean(htmlPaths[entryName]),
+        );
         const htmlInfoMap: Record<string, HtmlInfo> = {};
 
         const finalOptions = await Promise.all(

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -1,4 +1,3 @@
-import type { EntryDescription } from '@rspack/core';
 import type { Compiler, MultiCompiler } from '@rspack/core';
 import type { RsbuildDevServer } from '../server/devServer';
 import type { StartServerResult } from '../server/helper';
@@ -156,6 +155,18 @@ export type RsbuildInstance = {
 
 export type RsbuildTarget = 'web' | 'node' | 'web-worker';
 
-export type RsbuildEntry = Record<string, string | string[] | EntryDescription>;
+export type RsbuildEntry = Record<
+  string,
+  | string
+  | string[]
+  | (Rspack.EntryDescription & {
+      /**
+       * Whether to generate an HTML file for the entry.
+       *
+       * @default true
+       */
+      html?: boolean;
+    })
+>;
 
 export type RsbuildMode = 'development' | 'production' | 'none';

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -155,18 +155,18 @@ export type RsbuildInstance = {
 
 export type RsbuildTarget = 'web' | 'node' | 'web-worker';
 
+export type RsbuildEntryDescription = Rspack.EntryDescription & {
+  /**
+   * Whether to generate an HTML file for the entry.
+   *
+   * @default true
+   */
+  html?: boolean;
+};
+
 export type RsbuildEntry = Record<
   string,
-  | string
-  | string[]
-  | (Rspack.EntryDescription & {
-      /**
-       * Whether to generate an HTML file for the entry.
-       *
-       * @default true
-       */
-      html?: boolean;
-    })
+  string | string[] | RsbuildEntryDescription
 >;
 
 export type RsbuildMode = 'development' | 'production' | 'none';

--- a/website/docs/en/config/source/entry.mdx
+++ b/website/docs/en/config/source/entry.mdx
@@ -3,7 +3,10 @@
 - **Type:**
 
 ```ts
-type Entry = Record<string, string | string[] | EntryDescription>;
+type Entry = Record<
+  string,
+  string | string[] | (Rspack.EntryDescription & { html?: boolean })
+>;
 ```
 
 - **Default:**
@@ -70,7 +73,25 @@ export default {
 };
 ```
 
-For the complete usage of the description object, please refer to [Rspack - Entry Description Object](https://rspack.dev/config/entry#entry-description-object).
+Rsbuild has added an `html` attribute for the description object, which is used to control whether an HTML file is generated.
+
+For example, the `bar` entry does not generate an HTML file:
+
+```ts title="rsbuild.config.ts"
+export default {
+  source: {
+    entry: {
+      foo: './src/foo.js',
+      bar: {
+        import: './src/bar.js',
+        html: false,
+      },
+    },
+  },
+};
+```
+
+> For the complete usage of the description object, please refer to [Rspack - Entry Description Object](https://rspack.dev/config/entry#entry-description-object).
 
 ## Set by environment
 

--- a/website/docs/zh/config/source/entry.mdx
+++ b/website/docs/zh/config/source/entry.mdx
@@ -3,7 +3,10 @@
 - **类型：**
 
 ```ts
-type Entry = Record<string, string | string[] | EntryDescription>;
+type Entry = Record<
+  string,
+  string | string[] | (Rspack.EntryDescription & { html?: boolean })
+>;
 ```
 
 - **默认值：**
@@ -70,7 +73,25 @@ export default {
 };
 ```
 
-关于描述对象的完整用法，请参考 [Rspack - 入口描述对象](https://rspack.dev/config/entry#%E5%85%A5%E5%8F%A3%E6%8F%8F%E8%BF%B0%E5%AF%B9%E8%B1%A1)。
+Rsbuild 为描述对象添加了 `html` 属性，用于控制是否生成 HTML 文件。
+
+例如，`bar` 入口不生成 HTML 文件：
+
+```ts title="rsbuild.config.ts"
+export default {
+  source: {
+    entry: {
+      foo: './src/foo.js',
+      bar: {
+        import: './src/bar.js',
+        html: false,
+      },
+    },
+  },
+};
+```
+
+> 关于描述对象的完整用法，请参考 [Rspack - 入口描述对象](https://rspack.dev/config/entry#%E5%85%A5%E5%8F%A3%E6%8F%8F%E8%BF%B0%E5%AF%B9%E8%B1%A1)。
 
 ## 基于 environment 设置
 


### PR DESCRIPTION
## Summary

Allow to disable HTML for specific entry:

```js
export default {
  source: {
    entry: {
      foo: {
        import: './src/foo.js',
      },
      bar: {
        import: './src/bar.js',
        html: false,
      },
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
