### PR TITLE
release: 1.0.1-beta.15

### DIFF
--- a/packages/compat/plugin-swc/package.json
+++ b/packages/compat/plugin-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-swc",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "SWC plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -44,7 +44,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -43,7 +43,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -46,7 +46,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -38,7 +38,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",
@@ -47,7 +47,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-type-check/package.json
+++ b/packages/plugin-type-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-type-check",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "TS checker plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -40,7 +40,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue-jsx/package.json
+++ b/packages/plugin-vue-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue-jsx",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Vue 3 JSX plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "typescript": "^5.5.2"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -39,7 +39,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue2/package.json
+++ b/packages/plugin-vue2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue2",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "description": "Vue 2 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {
@@ -38,7 +38,7 @@
     "webpack": "^5.93.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "workspace:^1.0.1-beta.14"
+    "@rsbuild/core": "workspace:^1.0.1-beta.15"
   },
   "publishConfig": {
     "access": "public",

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/config",
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "private": true,
   "devDependencies": {
     "@types/node": "18.x",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@scripts/test-helper",
   "private": true,
-  "version": "1.0.1-beta.14",
+  "version": "1.0.1-beta.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild"


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### Breaking Changes 🍭
* feat!: change default charset to utf8 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3250
### New Features 🎉
* feat: set default entry when entry is set to an empty object by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/3225
* feat: allow to custom web app manifest filename by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3228
* feat: add mime type for web app manifest by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3234
* feat: allow to specify target for app icons by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3235
* feat: allow to set URL as app icon by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3237
* feat: allow to disable HTML for specific entry by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3246
### Performance 🚀
* perf: use compilation.inputFileSystem to read app icons by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3226
### Document 📖
* docs: update documentation for `html.appIcon` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3223
* docs: add app icon to website by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3238
* docs: add example for inlining async chunks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3241
* docs: update Rspack stack layers by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3243
* docs: add more breaking changes about rsbuild 1.0 by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3245
### Other Changes
* chore: simplify plugin-swc inspected config by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3224
* chore(deps): update dependency nx to ^19.6.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3233
* chore(deps): update dependency @module-federation/rspack to v0.5.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3232
* chore(deps): update dependency typescript-eslint to ^8.1.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3236
* chore: move vue2-jsx plugin to separate repo by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3239
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3242
* test: update ip in test files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3248


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1-beta.14...v1.0.1-beta.15