### PR TITLE
fix(core): Disable buildin lightingcss when inject style

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -237,10 +237,11 @@ async function applyCSSRule({
   rule.use(CHAIN_ID.USE.CSS).loader(getCompiledPath('css-loader'));
 
   if (target === 'web') {
-    // `builtin:lightningcss-loader` is not supported when using webpack
+    // `builtin:lightningcss-loader` is not supported when using webpack and inject styles
     if (
       context.bundlerType === 'rspack' &&
-      config.tools.lightningcssLoader !== false
+      config.tools.lightningcssLoader !== false &&
+      config.output.injectStyles !== true
     ) {
       importLoaders++;
 

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -236,12 +236,27 @@ async function applyCSSRule({
 
   rule.use(CHAIN_ID.USE.CSS).loader(getCompiledPath('css-loader'));
 
+  const postcssLoaderOptions = await getPostcssLoaderOptions({
+    config,
+    root: context.rootPath,
+  });
+
+  // enable postcss-loader if using PostCSS plugins
+  if (postcssLoaderOptions.postcssOptions?.plugins?.length) {
+    importLoaders++;
+    rule
+      .use(CHAIN_ID.USE.POSTCSS)
+      .loader(getCompiledPath('postcss-loader'))
+      .options(postcssLoaderOptions);
+  }
+
+  // Put `builtin:lightningcss-loader` in front of `PostCSS`
+  // `buildin:lightningcss-loader` affects `normalizewhitespace` in the PostCss by cssnano
   if (target === 'web') {
-    // `builtin:lightningcss-loader` is not supported when using webpack and inject styles
+    // `builtin:lightningcss-loader` is not supported when using webpack
     if (
       context.bundlerType === 'rspack' &&
-      config.tools.lightningcssLoader !== false &&
-      config.output.injectStyles !== true
+      config.tools.lightningcssLoader !== false
     ) {
       importLoaders++;
 
@@ -261,20 +276,6 @@ async function applyCSSRule({
         .use(CHAIN_ID.USE.LIGHTNINGCSS)
         .loader('builtin:lightningcss-loader')
         .options(loaderOptions);
-    }
-
-    const postcssLoaderOptions = await getPostcssLoaderOptions({
-      config,
-      root: context.rootPath,
-    });
-
-    // enable postcss-loader if using PostCSS plugins
-    if (postcssLoaderOptions.postcssOptions?.plugins?.length) {
-      importLoaders++;
-      rule
-        .use(CHAIN_ID.USE.POSTCSS)
-        .loader(getCompiledPath('postcss-loader'))
-        .options(postcssLoaderOptions);
     }
   }
 

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -251,7 +251,7 @@ async function applyCSSRule({
   }
 
   // Put `builtin:lightningcss-loader` in front of `PostCSS`
-  // `buildin:lightningcss-loader` affects `normalizewhitespace` in the PostCss by cssnano
+  // `buildIn:lightningcss-loader` affects `normalizeWhitespace` in the PostCss by cssnano
   if (target === 'web') {
     // `builtin:lightningcss-loader` is not supported when using webpack
     if (

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -226,17 +226,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         },
       },
       {
-        "loader": "builtin:lightningcss-loader",
-        "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
-        },
-      },
-      {
         "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
         "options": {
           "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
@@ -249,6 +238,17 @@ exports[`should ensure isolation of PostCSS config objects between different bui
             ],
           },
           "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
         },
       },
     ],

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -140,7 +140,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
 }
 `;
 
-exports[`should ensure isolation of PostCSS config objects between different builds 1`] = `
+exports[`should ensure isolation of PostCSS config is behind builtin:lightningcss-loader 1`] = `
 [
   {
     "resolve": {
@@ -168,17 +168,6 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         },
       },
       {
-        "loader": "builtin:lightningcss-loader",
-        "options": {
-          "targets": [
-            "chrome >= 87",
-            "edge >= 88",
-            "firefox >= 78",
-            "safari >= 14",
-          ],
-        },
-      },
-      {
         "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
         "options": {
           "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
@@ -193,12 +182,23 @@ exports[`should ensure isolation of PostCSS config objects between different bui
           "sourceMap": false,
         },
       },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
     ],
   },
 ]
 `;
 
-exports[`should ensure isolation of PostCSS config objects between different builds 2`] = `
+exports[`should ensure isolation of PostCSS config is behind builtin:lightningcss-loader 2`] = `
 [
   {
     "resolve": {

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -153,7 +153,7 @@ describe('plugin-css injectStyles', () => {
   });
 });
 
-it('should ensure isolation of PostCSS config objects between different builds', async () => {
+it('should ensure isolation of PostCSS config is behind builtin:lightningcss-loader', async () => {
   const rsbuild = await createStubRsbuild({
     plugins: [pluginCss()],
     rsbuildConfig: {

--- a/website/docs/en/config/output/inject-styles.mdx
+++ b/website/docs/en/config/output/inject-styles.mdx
@@ -37,7 +37,7 @@ export default {
 };
 ```
 
-If you need to enable this option in production mode, please note that the inlined CSS code will not go through Rsbuild's default CSS minimizer. You can manually register the [cssnano](https://github.com/cssnano/cssnano) plugin for PostCSS to compress the inlined code.
+If you need to enable this option in production mode, and want to add PostCSS capabilities, such as cssnano, You can manually register the [cssnano](https://github.com/cssnano/cssnano) plugin for PostCSS to compress the inlined code.
 
 1. Install cssnano:
 

--- a/website/docs/zh/config/output/inject-styles.mdx
+++ b/website/docs/zh/config/output/inject-styles.mdx
@@ -37,7 +37,7 @@ export default {
 };
 ```
 
-如果你需要在生产模式下开启该选项，请留意内联的 CSS 代码不会经过 Rsbuild 默认的 CSS 压缩器，你可以手动注册 PostCSS 的 [cssnano](https://github.com/cssnano/cssnano) 插件来对内联代码进行压缩。
+如果你需要在生产模式下开启该选项，并且想结合 PostCSS 的能力，例如 cssnano ，你可以手动注册 PostCSS 的 [cssnano](https://github.com/cssnano/cssnano) 插件来对内联代码进行压缩。
 
 1. 安装 cssnano：
 


### PR DESCRIPTION
## Summary

For production builds, it is recommended to use the default behavior of Rsbuild, which extracts CSS into separate bundles to allow browsers to load CSS and JS assets in parallel.

## Related Links

[[Bug]: rsbuild injectStyles](https://github.com/web-infra-dev/rsbuild/issues/3247)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
