### PR TITLE
fix(webpack): no longer need to set NODE_ENV

### DIFF
--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -12,10 +12,6 @@ export const build = async (
 ): Promise<void | {
   close: () => Promise<void>;
 }> => {
-  if (!process.env.NODE_ENV) {
-    process.env.NODE_ENV = 'production';
-  }
-
   const { context } = initOptions;
 
   let compiler: Rspack.Compiler | Rspack.MultiCompiler;


### PR DESCRIPTION
## Summary

No longer need to set NODE_ENV in the `build` method, see https://github.com/web-infra-dev/rsbuild/pull/3214

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
