### PR TITLE
perf: replace dev middleware with a lightweight version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
     "typescript": "^5.5.2",
     "webpack": "^5.93.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "webpack-dev-middleware": "7.2.1",
+    "rsbuild-dev-middleware": "1.0.0-beta.0",
     "webpack-merge": "6.0.1",
     "ws": "^8.18.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,7 @@
     "typescript": "^5.5.2",
     "webpack": "^5.93.0",
     "webpack-bundle-analyzer": "^4.10.2",
-    "rsbuild-dev-middleware": "1.0.0-beta.0",
+    "rsbuild-dev-middleware": "0.1.0",
     "webpack-merge": "6.0.1",
     "ws": "^8.18.0"
   },

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -50,6 +50,7 @@ export default {
     'rspack-manifest-plugin',
     'webpack-merge',
     'html-rspack-plugin',
+    'mrmime',
     {
       name: 'chokidar',
       externals: {
@@ -139,6 +140,9 @@ export default {
     },
     {
       name: 'rsbuild-dev-middleware',
+      externals: {
+        mrmime: '../mrmime',
+      },
       ignoreDts: true,
     },
     {

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -138,14 +138,8 @@ export default {
       name: 'webpack-bundle-analyzer',
     },
     {
-      name: 'webpack-dev-middleware',
-      externals: {
-        'schema-utils': './schema-utils',
-        'schema-utils/declarations/validate':
-          'schema-utils/declarations/validate',
-      },
+      name: 'rsbuild-dev-middleware',
       ignoreDts: true,
-      afterBundle: writeEmptySchemaUtils,
     },
     {
       name: 'style-loader',

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -38,7 +38,7 @@ function getClientPaths(devConfig: DevConfig) {
 
 /**
  * Setup compiler-related logic:
- * 1. setup webpack-dev-middleware
+ * 1. setup rsbuild-dev-middleware
  * 2. establish webSocket connect
  */
 export class CompilerDevMiddleware {
@@ -152,7 +152,7 @@ export class CompilerDevMiddleware {
 
     warp.close = middleware.close;
 
-    // warp webpack-dev-middleware to handle html file（without publicPath）
+    // warp rsbuild-dev-middleware to handle html file（without publicPath）
     // maybe we should serve html file by sirv
     return warp;
   }

--- a/packages/core/src/server/devMiddleware.ts
+++ b/packages/core/src/server/devMiddleware.ts
@@ -98,7 +98,7 @@ export type DevMiddlewareAPI = Middleware & {
 
 /**
  * The rsbuild/server do nothing about compiler, the devMiddleware need do such things to ensure dev works well:
- * - Call compiler.watch （normally did by webpack-dev-middleware）.
+ * - Call compiler.watch （normally did by rsbuild-dev-middleware）.
  * - Inject the hmr client path into page （the hmr client rsbuild/server already provide）.
  * - Notify server when compiler hooks are triggered.
  */
@@ -107,8 +107,8 @@ export type DevMiddleware = (options: DevMiddlewareOptions) => DevMiddlewareAPI;
 export const getDevMiddleware = async (
   multiCompiler: Compiler | MultiCompiler,
 ): Promise<NonNullable<DevMiddleware>> => {
-  const { default: webpackDevMiddleware } = await import(
-    'webpack-dev-middleware'
+  const { default: rsbuildDevMiddleware } = await import(
+    'rsbuild-dev-middleware'
   );
   return (options) => {
     const { clientPaths, clientConfig, callbacks, liveReload, ...restOptions } =
@@ -129,6 +129,6 @@ export const getDevMiddleware = async (
 
     applyToCompiler(multiCompiler, setupCompiler);
 
-    return webpackDevMiddleware(multiCompiler, restOptions);
+    return rsbuildDevMiddleware(multiCompiler, restOptions);
   };
 };

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -189,7 +189,7 @@ const applyDefaultMiddlewares = async ({
 
     middlewares.push(historyApiFallbackMiddleware);
 
-    // ensure fallback request can be handled by webpack-dev-middleware
+    // ensure fallback request can be handled by rsbuild-dev-middleware
     compileMiddlewareAPI?.middleware &&
       middlewares.push(compileMiddlewareAPI.middleware);
   }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -30,7 +30,7 @@
       "webpack-bundle-analyzer": ["./compiled/webpack-bundle-analyzer"],
       "postcss-load-config": ["./compiled/postcss-load-config"],
       "rspack-manifest-plugin": ["./compiled/rspack-manifest-plugin"],
-      "webpack-dev-middleware": ["./compiled/webpack-dev-middleware"],
+      "rsbuild-dev-middleware": ["./compiled/rsbuild-dev-middleware"],
       "launch-editor-middleware": ["./compiled/launch-editor-middleware"],
       "browserslist-to-es-version": ["./compiled/browserslist-to-es-version"],
       "connect-history-api-fallback": [

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -15,6 +15,7 @@
       "jiti": ["./compiled/jiti"],
       "rslog": ["./compiled/rslog"],
       "dotenv": ["./compiled/dotenv"],
+      "mrmime": ["./compiled/mrmime"],
       "semver": ["./compiled/semver"],
       "connect": ["./compiled/connect"],
       "chokidar": ["./compiled/chokidar"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,6 +728,9 @@ importers:
       reduce-configs:
         specifier: ^1.0.0
         version: 1.0.0
+      rsbuild-dev-middleware:
+        specifier: 1.0.0-beta.0
+        version: 1.0.0-beta.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       rslog:
         specifier: ^1.2.2
         version: 1.2.2
@@ -755,9 +758,6 @@ importers:
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
-      webpack-dev-middleware:
-        specifier: 7.2.1
-        version: 7.2.1(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       webpack-merge:
         specifier: 6.0.1
         version: 6.0.1
@@ -6411,6 +6411,15 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rsbuild-dev-middleware@1.0.0-beta.0:
+    resolution: {integrity: sha512-6tSuFZa5UY4kOYGhZs001jbjRvMne35V4TrWR0v8K45G12keTuUTsB5gWcdHTgTV0fFGy87eDYPWZMg0/vskBA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      webpack:
+        optional: true
+
   rsbuild-plugin-google-analytics@1.0.2:
     resolution: {integrity: sha512-V2RjSPW0xFDCpH5W6N7zYuYxyZxklsaE/H3WwNCDW+52vBouYAZ8/SDJ1w8ogbfzysX7TcNm3hId42dJU49IOg==}
     peerDependencies:
@@ -7418,15 +7427,6 @@ packages:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
     engines: {node: '>= 10.13.0'}
     hasBin: true
-
-  webpack-dev-middleware@7.2.1:
-    resolution: {integrity: sha512-hRLz+jPQXo999Nx9fXVdKlg/aehsw1ajA9skAneGmT03xwmyuhvF93p6HUKKbWhXdcERtGTzUCtIQr+2IQegrA==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      webpack:
-        optional: true
 
   webpack-merge@6.0.1:
     resolution: {integrity: sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==}
@@ -13548,6 +13548,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.17.1
       fsevents: 2.3.3
 
+  rsbuild-dev-middleware@1.0.0-beta.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
+    dependencies:
+      colorette: 2.0.20
+      memfs: 4.8.2
+      mime-types: 2.1.35
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+    optionalDependencies:
+      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
+
   rsbuild-plugin-google-analytics@1.0.2(@rsbuild/core@packages+core):
     optionalDependencies:
       '@rsbuild/core': link:packages/core
@@ -14585,17 +14595,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  webpack-dev-middleware@7.2.1(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
-    dependencies:
-      colorette: 2.0.20
-      memfs: 4.8.2
-      mime-types: 2.1.35
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-    optionalDependencies:
-      webpack: 5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
   webpack-merge@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,8 +729,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       rsbuild-dev-middleware:
-        specifier: 1.0.0-beta.0
-        version: 1.0.0-beta.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
+        specifier: 0.1.0
+        version: 0.1.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       rslog:
         specifier: ^1.2.2
         version: 1.2.2
@@ -3786,9 +3786,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  colorette@2.0.20:
-    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
-
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -6411,8 +6408,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rsbuild-dev-middleware@1.0.0-beta.0:
-    resolution: {integrity: sha512-6tSuFZa5UY4kOYGhZs001jbjRvMne35V4TrWR0v8K45G12keTuUTsB5gWcdHTgTV0fFGy87eDYPWZMg0/vskBA==}
+  rsbuild-dev-middleware@0.1.0:
+    resolution: {integrity: sha512-3vJLLIJgMgTE3pPctoyIw+gAjlF4cgGkp/ujtZjgoNnFqv5AomDFv6sg0AE1ehV2zSN8Vx9aeVxARslFofHXUg==}
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       webpack: ^5.0.0
@@ -10622,8 +10619,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colorette@2.0.20: {}
-
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -13548,11 +13543,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.17.1
       fsevents: 2.3.3
 
-  rsbuild-dev-middleware@1.0.0-beta.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
+  rsbuild-dev-middleware@0.1.0(webpack@5.93.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
-      colorette: 2.0.20
       memfs: 4.8.2
-      mime-types: 2.1.35
+      mrmime: 2.0.0
       on-finished: 2.4.1
       range-parser: 1.2.1
     optionalDependencies:

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -84,7 +84,7 @@ export default {
 
 ## Rspack Dev Server
 
-The built-in dev server of Rspack CLI is [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server). Rsbuild does not use `@rspack/dev-server`, but implements a lighter version based on [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware).
+The built-in dev server of Rspack CLI is [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server). Rsbuild does not use `@rspack/dev-server`, but instead implemented its own more lightweight version.
 
 ### Comparison
 

--- a/website/docs/zh/guide/basic/server.mdx
+++ b/website/docs/zh/guide/basic/server.mdx
@@ -84,7 +84,7 @@ export default {
 
 ## Rspack Dev Server
 
-Rspack CLI 内置的开发服务器是 [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server)，Rsbuild 没有使用 `@rspack/dev-server`，而是基于 [webpack-dev-middleware](https://github.com/webpack/webpack-dev-middleware) 实现了一个更轻量的版本。
+Rspack CLI 内置的开发服务器是 [@rspack/dev-server](https://www.npmjs.com/package/@rspack/dev-server)，Rsbuild 没有使用 `@rspack/dev-server`，而是自行实现了一个更轻量的版本。
 
 ### 对比
 


### PR DESCRIPTION
## Summary

Replace `webpack-dev-middleware` with `rsbuild-dev-middleware`.

`rsbuild-dev-middleware` is forked from `webpack-dev-middleware`, and it is designed for Rsbuild. We will remove all unused options / features from this package to make it smaller and more performant. Eventually rsbuild-dev-middleware will be merged into `@rsbuild/core`

This PR introduces `rsbuild-dev-middleware` v0.1.0, the bundle size has been reduced from `348 KB` to `181 KB`.

## Related Links

https://github.com/chenjiahan/rsbuild-dev-middleware

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
