### PR TITLE
fix: not inline scripts / styles when enable not set

### DIFF
--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -356,3 +356,34 @@ test('inline does not work in development mode when enable is auto', async ({
     ),
   ).resolves.toEqual(1);
 });
+
+test('styles and scripts are not inline by default in development mode when enable not set', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      tools: toolsConfig,
+      output: {
+        inlineStyles: true,
+        inlineScripts: /\.js$/,
+      },
+    },
+  });
+
+  await gotoPage(page, rsbuild);
+
+  // all index.js in page
+  await expect(
+    page.evaluate(
+      `document.querySelectorAll('script[src*="index.js"]').length`,
+    ),
+  ).resolves.toEqual(1);
+
+  // all index.css in page
+  await expect(
+    page.evaluate(
+      `document.querySelectorAll('link[href*="index.css"]').length`,
+    ),
+  ).resolves.toEqual(1);
+});

--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -240,9 +240,9 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
         if (inlineScripts) {
           if (inlineScripts === true) {
-            scriptTests.push(JS_REGEX);
+            isProdMode && scriptTests.push(JS_REGEX);
           } else if (isRegExp(inlineScripts) || isFunction(inlineScripts)) {
-            scriptTests.push(inlineScripts);
+            isProdMode && scriptTests.push(inlineScripts);
           } else {
             const enable =
               inlineScripts.enable === 'auto'
@@ -256,9 +256,9 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
         if (inlineStyles) {
           if (inlineStyles === true) {
-            styleTests.push(CSS_REGEX);
+            isProdMode && styleTests.push(CSS_REGEX);
           } else if (isRegExp(inlineStyles) || isFunction(inlineStyles)) {
-            styleTests.push(inlineStyles);
+            isProdMode && styleTests.push(inlineStyles);
           } else {
             const enable =
               inlineStyles.enable === 'auto' ? isProdMode : inlineStyles.enable;


### PR DESCRIPTION
## Summary

Be consistent with documentation.  Setting `inlineStyles` / `inlineScripts` as  true / regexp / function is equivalent to setting `enable` to 'auto'. This indicates that inline will only be enabled in production mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
