### PR TITLE
fix: server.close should close http server

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -286,10 +286,7 @@ export async function createDevServer<
       const serverTerminator = getServerTerminator(httpServer);
       logger.debug('listen dev server');
 
-      options.context.hooks.onCloseDevServer.tap(() => {
-        console.log('serverTerminator');
-        serverTerminator();
-      });
+      options.context.hooks.onCloseDevServer.tap(serverTerminator);
 
       return new Promise<StartServerResult>((resolve) => {
         httpServer.listen(

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -120,7 +120,6 @@ export async function createDevServer<
   };
 
   let outputFileSystem: Rspack.OutputFileSystem = fs;
-
   let lastStats: Stats[];
 
   // should register onDevCompileDone hook before startCompile
@@ -283,8 +282,14 @@ export async function createDevServer<
         serverConfig: config.server,
         middlewares,
       });
+
       const serverTerminator = getServerTerminator(httpServer);
       logger.debug('listen dev server');
+
+      options.context.hooks.onCloseDevServer.tap(() => {
+        console.log('serverTerminator');
+        serverTerminator();
+      });
 
       return new Promise<StartServerResult>((resolve) => {
         httpServer.listen(
@@ -298,24 +303,19 @@ export async function createDevServer<
             }
 
             middlewares.use(notFoundMiddleware);
-
             httpServer.on('upgrade', devMiddlewares.onUpgrade);
 
             logger.debug('listen dev server done');
 
             await devServerAPI.afterListen();
 
-            const closeServer = async () => {
-              await Promise.all([devServerAPI.close(), serverTerminator()]);
-            };
-
-            onBeforeRestartServer(closeServer);
+            onBeforeRestartServer(devServerAPI.close);
 
             resolve({
               port,
               urls: urls.map((item) => item.url),
               server: {
-                close: closeServer,
+                close: devServerAPI.close,
               },
             });
           },

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -214,7 +214,7 @@ export async function startProdServer(
           port,
           urls: urls.map((item) => item.url),
           server: {
-            close: async () => onClose(),
+            close: onClose,
           },
         });
       },


### PR DESCRIPTION
## Summary

`server.close` should close http server.

```js
// unify these two APIs:
await (await (server.listen()).close());
await server.close();
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
