### PR TITLE
feat: add `environments` to `onAfterStartProdServer`

### DIFF
--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -193,6 +193,7 @@ export async function startProdServer(
         await context.hooks.onAfterStartProdServer.call({
           port,
           routes,
+          environments: context.environments,
         });
 
         const protocol = https ? 'https' : 'http';

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -76,6 +76,7 @@ export type OnAfterStartDevServerFn = (params: {
 export type OnAfterStartProdServerFn = (params: {
   port: number;
   routes: Routes;
+  environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnBeforeCreateCompilerFn<B = 'rspack'> = (params: {

--- a/website/docs/en/shared/onAfterStartProdServer.mdx
+++ b/website/docs/en/shared/onAfterStartProdServer.mdx
@@ -9,6 +9,10 @@ type Routes = Array<{
 }>;
 
 function OnAfterStartProdServer(
-  callback: (params: { port: number; routes: Routes }) => Promise<void> | void,
+  callback: (params: {
+    port: number;
+    routes: Routes;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
 ): void;
 ```

--- a/website/docs/zh/shared/onAfterStartProdServer.mdx
+++ b/website/docs/zh/shared/onAfterStartProdServer.mdx
@@ -9,6 +9,10 @@ type Routes = Array<{
 }>;
 
 function OnAfterStartProdServer(
-  callback: (params: { port: number; routes: Routes }) => Promise<void> | void,
+  callback: (params: {
+    port: number;
+    routes: Routes;
+    environments: Record<string, EnvironmentContext>;
+  }) => Promise<void> | void,
 ): void;
 ```


### PR DESCRIPTION
## Summary

I have a Rsbuild plugin to print QRCode for all entries. It works well with `rsbuild dev`:

```js
      api.onAfterStartDevServer(async ({ environments }) => {
        const fooEnvironment = environments['foo']
        const entries = Object.keys(fooEnvironment.entry)
        await printQRCode(entries)
      })
```

I would also like to print the similar QRCode for `rsbuild preview`. But I cannot get the entries from `onAfterStartProdServer`.

This patch simply add `environments` to `onAfterStartProdServer`, which will work the same as `onAfterStartDevServer`.

## Related Links

N/A

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
