### PR TITLE
feat: transformImport support function type

### DIFF
--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -26,9 +26,6 @@ const castArray = <T>(arr?: T | T[]): T[] => {
   return Array.isArray(arr) ? arr : [arr];
 };
 
-const isFunction = (func: unknown): func is (...args: any[]) => any =>
-  typeof func === 'function';
-
 async function findUp({
   filename,
   cwd = process.cwd(),
@@ -205,7 +202,7 @@ const reduceTransformImportConfig = (
 
   let imports: TransformImport[] = [];
   for (const item of castArray(options)) {
-    if (isFunction(item)) {
+    if (typeof item === 'function') {
       imports = item(imports) ?? imports;
     } else {
       imports.push(item);

--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -193,7 +193,23 @@ const isPrimitiveTransformImport = (
     (item) => Object.prototype.toString.call(item) === '[object Object]',
   );
 
-const applyTransformImportChain = (
+const reduceTransformImportConfig = (
+  options: NormalizedSourceConfig['transformImport'],
+): TransformImport[] | false => {
+  if (options === false || !options) {
+    return false;
+  }
+
+  let imports: TransformImport[] = [];
+  for (const item of castArray(options)) {
+    if (isFunction(item)) {
+      imports = item(imports) ?? imports;
+    } else {
+      imports.push(item);
+    }
+  }
+  return imports;
+};
   defaults: TransformImport[] | false,
   options: NormalizedSourceConfig['transformImport'],
 ): TransformImport[] | false => {

--- a/packages/core/src/types/config/source.ts
+++ b/packages/core/src/types/config/source.ts
@@ -61,7 +61,7 @@ export interface SourceConfig {
   /**
    * Used to import the code and style of the component library on demand.
    */
-  transformImport?: false | TransformImport[];
+  transformImport?: ConfigChain<TransformImport[]> | false;
   /**
    * Configure a custom tsconfig.json file path to use, can be a relative or absolute path.
    * @default 'tsconfig.json'

--- a/packages/core/src/types/config/source.ts
+++ b/packages/core/src/types/config/source.ts
@@ -61,7 +61,10 @@ export interface SourceConfig {
   /**
    * Used to import the code and style of the component library on demand.
    */
-  transformImport?: ConfigChain<TransformImport[]> | false;
+  transformImport?:
+    | TransformImportFn
+    | Array<TransformImport | TransformImportFn>
+    | false;
   /**
    * Configure a custom tsconfig.json file path to use, can be a relative or absolute path.
    * @default 'tsconfig.json'
@@ -81,6 +84,10 @@ export type TransformImport = {
   // Use a loose type to compat webpack
   customStyleName?: any;
 };
+
+type TransformImportFn = (
+  imports: TransformImport[],
+) => TransformImport[] | void;
 
 export interface NormalizedSourceConfig extends SourceConfig {
   define: Define;

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -734,6 +734,142 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
 ]
 `;
 
+exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] = `
+[
+  {
+    "entry": {
+      "main": [
+        "./src/index.js",
+      ],
+    },
+    "module": {
+      "rules": [
+        {
+          "include": [
+            {
+              "and": [
+                "<ROOT>/packages/core/tests",
+                {
+                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+                },
+              ],
+            },
+            /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+          ],
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "builtin:swc-loader",
+              "options": {
+                "env": {
+                  "mode": undefined,
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "isModule": "unknown",
+                "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": false,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "import": [
+                    {
+                      "libraryName": "foo",
+                    },
+                    {
+                      "libraryName": "bar",
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+        {
+          "mimetype": {
+            "or": [
+              "text/javascript",
+              "application/javascript",
+            ],
+          },
+          "resolve": {
+            "fullySpecified": false,
+          },
+          "use": [
+            {
+              "loader": "builtin:swc-loader",
+              "options": {
+                "env": {
+                  "mode": undefined,
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "isModule": "unknown",
+                "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": false,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "import": [
+                    {
+                      "libraryName": "foo",
+                    },
+                    {
+                      "libraryName": "bar",
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
+    "resolve": {
+      "alias": {
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
+    },
+  },
+]
+`;
+
 exports[`plugin-swc > should disable all pluginImport 1`] = `
 {
   "entry": {
@@ -846,6 +982,122 @@ exports[`plugin-swc > should disable all pluginImport 1`] = `
     },
   },
 }
+`;
+
+exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
+[
+  {
+    "entry": {
+      "main": [
+        "./src/index.js",
+      ],
+    },
+    "module": {
+      "rules": [
+        {
+          "include": [
+            {
+              "and": [
+                "<ROOT>/packages/core/tests",
+                {
+                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+                },
+              ],
+            },
+            /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+          ],
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "builtin:swc-loader",
+              "options": {
+                "env": {
+                  "mode": undefined,
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "isModule": "unknown",
+                "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": false,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          "mimetype": {
+            "or": [
+              "text/javascript",
+              "application/javascript",
+            ],
+          },
+          "resolve": {
+            "fullySpecified": false,
+          },
+          "use": [
+            {
+              "loader": "builtin:swc-loader",
+              "options": {
+                "env": {
+                  "mode": undefined,
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "isModule": "unknown",
+                "jsc": {
+                  "experimental": {
+                    "cacheRoot": "<ROOT>/packages/core/tests/node_modules/.cache/.swc",
+                  },
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": false,
+                  },
+                  "preserveAllComments": true,
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
+    "resolve": {
+      "alias": {
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
+    },
+  },
+]
 `;
 
 exports[`plugin-swc > should disable preset_env in target other than web 1`] = `

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -72,6 +72,45 @@ describe('plugin-swc', () => {
     });
   });
 
+  it('should disable pluginImport when return undefined', async () => {
+    await matchConfigSnapshot({
+      source: {
+        transformImport: () => {},
+      },
+    });
+  });
+
+  it('should apply pluginImport correctly when ConfigChain', async () => {
+    await matchConfigSnapshot({
+      source: {
+        transformImport: [
+          [
+            {
+              libraryName: 'foo1',
+            },
+          ],
+          // ignore foo1
+          () => [],
+          [
+            {
+              libraryName: 'foo',
+            },
+            {
+              libraryName: 'baz',
+            },
+          ],
+          [
+            {
+              libraryName: 'bar',
+            },
+          ],
+          // ignore baz
+          (value) => value.filter((v) => v.libraryName !== 'baz'),
+        ],
+      },
+    });
+  });
+
   it('should disable all pluginImport', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc(), pluginEntry()],

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -84,26 +84,20 @@ describe('plugin-swc', () => {
     await matchConfigSnapshot({
       source: {
         transformImport: [
-          [
-            {
-              libraryName: 'foo1',
-            },
-          ],
+          {
+            libraryName: 'foo1',
+          },
           // ignore foo1
           () => [],
-          [
-            {
-              libraryName: 'foo',
-            },
-            {
-              libraryName: 'baz',
-            },
-          ],
-          [
-            {
-              libraryName: 'bar',
-            },
-          ],
+          {
+            libraryName: 'foo',
+          },
+          {
+            libraryName: 'baz',
+          },
+          {
+            libraryName: 'bar',
+          },
           // ignore baz
           (value) => value.filter((v) => v.libraryName !== 'baz'),
         ],

--- a/website/docs/en/config/source/transform-import.mdx
+++ b/website/docs/en/config/source/transform-import.mdx
@@ -14,7 +14,8 @@ type TransformImport =
       transformToDefaultImport?: boolean;
       customName?: string;
       customStyleName?: string;
-    }>;
+    }>
+  | Function;
 ```
 
 - **Default:** `undefined`
@@ -253,3 +254,35 @@ The following formats are supported:
 - **Default:** `undefined`
 
 Customize the transformed style path, the usage is consistent with `customName`.
+
+## Function Type
+
+The `transformImport` can be a function, it will accept the previous value, and you can modify it.
+
+```ts
+export default {
+  source: {
+    transformImport: (imports) => {
+      return imports.filter(import => import.libraryName !== 'antd');
+    },
+  },
+};
+```
+
+You can also return a new value as the final result in the function, which will replace the previous value.
+
+```ts
+export default {
+  source: {
+    transformImport: () => {
+      return [
+        {
+          libraryName: 'antd',
+          libraryDirectory: 'es',
+          style: 'css',
+        },
+      ];
+    },
+  },
+};
+```

--- a/website/docs/zh/config/source/transform-import.mdx
+++ b/website/docs/zh/config/source/transform-import.mdx
@@ -14,7 +14,8 @@ type TransformImport =
       transformToDefaultImport?: boolean;
       customName?: string;
       customStyleName?: string;
-    }>;
+    }>
+  | Function;
 ```
 
 - **默认值：** `undefined`
@@ -253,3 +254,35 @@ export default {
 - **默认值：** `undefined`
 
 自定义转换后的样式导入路径，用法与 `customName` 一致。
+
+## Function 类型
+
+`transformImport` 的值定义为函数时，可以接受原本的 transformImport 配置，并对其进行修改。
+
+```ts
+export default {
+  source: {
+    transformImport: (imports) => {
+      return imports.filter(import => import.libraryName !== 'antd');
+    },
+  },
+};
+```
+
+也可以在函数中返回一个新数组作为最终结果，新数组会覆盖原本的 transformImport 配置。
+
+```ts
+export default {
+  source: {
+    transformImport: () => {
+      return [
+        {
+          libraryName: 'antd',
+          libraryDirectory: 'es',
+          style: 'css',
+        },
+      ];
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

support modify previous `transformImport` value via  `transformImport`  function.


eg:
```ts
export default {
  source: {
    transformImport: (imports) => {
      return imports.filter(import => import.libraryName !== 'antd');
    },
  },
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
