### PR TITLE
docs: correct the default HTML template

### DIFF
--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -119,7 +119,7 @@ The generated meta tag in HTML is:
 
 ## Default Template Engine
 
-Rsbuild comes with a built-in default template engine to handle HTML template files, and its syntax is a subset of EJS. When the suffix of an HTML template file is `.html`, Rsbuild will use the built-in template engine to parse the HTML template.
+Rsbuild comes with a built-in default template engine to handle HTML template files, and its syntax is similar to a subset of EJS, but it has some differences. When the suffix of an HTML template file is `.html`, Rsbuild will use the built-in template engine to parse the HTML template.
 
 For example, if a `text` param is defined in the template with the value `'world'`, Rsbuild will automatically replace `<%= text %>` with the specified value during the build process.
 

--- a/website/docs/en/guide/basic/html-template.mdx
+++ b/website/docs/en/guide/basic/html-template.mdx
@@ -117,7 +117,21 @@ The generated meta tag in HTML is:
 <meta name="description" content="a description of the page" />
 ```
 
-## Template Parameters
+## Default Template Engine
+
+Rsbuild comes with a built-in default template engine to handle HTML template files, and its syntax is a subset of EJS. When the suffix of an HTML template file is `.html`, Rsbuild will use the built-in template engine to parse the HTML template.
+
+For example, if a `text` param is defined in the template with the value `'world'`, Rsbuild will automatically replace `<%= text %>` with the specified value during the build process.
+
+```html
+<!-- Input  -->
+<div>hello <%= text %>!</div>
+
+<!-- Output -->
+<div>hello world!</div>
+```
+
+### Template Parameters
 
 In HTML templates, you can use a variety of template parameters. The template parameters injected by Rsbuild by default include:
 
@@ -144,13 +158,9 @@ type DefaultParameters = {
 };
 ```
 
-You can also use the [html.templateParameters](/config/html/template-parameters) config to pass in custom template parameters.
+You can use the [html.templateParameters](/config/html/template-parameters) config to pass in custom template parameters. For example:
 
-### Example
-
-For example:
-
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   html: {
     templateParameters: {
@@ -162,53 +172,39 @@ export default {
 
 Then you can read parameters in the HTML template with `<%= text %>`:
 
-```html
+```html title="index.html"
 <div>hello <%= text %>!</div>
 ```
 
 The compiled HTML code will be:
 
-```html
+```html title="dist/index.html"
 <div>hello world!</div>
 ```
 
 ### Parameter Escaping
 
-You can use `<%- text %>` to escape parameters.
+When using `<%= text %>`, the parameters will not be escaped. You can use `<%- text %>` to escape parameters.
 
-For example, if `text` is `'<script>'`, it will be escaped to `&lt;script&gt;`:
+For example, if the value of the parameter `text` is `'<script>'`, it will be escaped to `&lt;script&gt;`:
 
 ```html
+<!-- Input  -->
 <div>hello <%- text %>!</div>
-```
 
-The compiled HTML code will be:
-
-```html
+<!-- Output -->
 <div>hello &lt;script&gt;!</div>
 ```
 
-## Template Engine
+:::tip
+Note that Rsbuild's default escape syntax is different from EJS. In EJS, the default escape syntax is `<%= text %>`, whereas Rsbuild's default escape syntax is `<%- text %>`.
+:::
 
-Rsbuild supports using [Lodash Template](https://lodashjs.com/docs/lodash.template), [EJS](https://ejs.co/), [Pug](https://pugjs.org/) as template engines, the most basic Lodash Template is used as the default template engine.
+## Other Template Engines
 
-### [Lodash Template](https://lodashjs.com/docs/lodash.template)
+Rsbuild also supports using other template engines through plugins, such as [EJS](https://ejs.co/) and [Pug](https://pugjs.org/).
 
-When the suffix of the template is `.html`, Rsbuild will use Lodash Template to compile it.
-
-For example, if you define a `text` parameter in a template with a value of `'world'`, Rsbuild will automatically replace `<%= text %>` with the value.
-
-```html
-<!-- input -->
-<div>hello <%= text %>!</div>
-
-<!-- output -->
-<div>hello world!</div>
-```
-
-Please read the [Lodash Template](https://lodashjs.com/docs/lodash.template) documentation for details.
-
-### [EJS](https://ejs.co/)
+### EJS
 
 When the suffix of the template is `.ejs`, Rsbuild will use the EJS template engine to compile it. EJS is a simple templating language that lets you generate HTML markup with plain JavaScript.
 
@@ -236,9 +232,9 @@ Then define a `user` parameter in the template with a value of `{ name: 'Jack' }
 
 Please read the [EJS](https://ejs.co/) documentation for details.
 
-### [Pug](https://pugjs.org/)
+### Pug
 
-Rsbuild supports the Pug template engine through the Pug plugin. Please refer to the [@rsbuild/plugin-pug](https://github.com/rspack-contrib/rsbuild-plugin-pug) for usage guide.
+Rsbuild supports the [Pug](https://pugjs.org/) template engine through the Pug plugin. Please refer to the [@rsbuild/plugin-pug](https://github.com/rspack-contrib/rsbuild-plugin-pug) for usage guide.
 
 ## Injecting Tags
 

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -119,7 +119,7 @@ export default {
 
 ## 默认模板引擎
 
-Rsbuild 内置了一个默认的模板引擎来处理 HTML 模板文件，它的语法是 EJS 的子集。当 HTML 模板文件的后缀为 `.html` 时，Rsbuild 会使用内置的模板引擎来解析 HTML 模板。
+Rsbuild 内置了一个默认的模板引擎来处理 HTML 模板文件，它的语法接近 EJS 的子集，但也有一些不同。当 HTML 模板文件的后缀为 `.html` 时，Rsbuild 会使用内置的模板引擎来解析 HTML 模板。
 
 例如，在模板中定义一个 `text` 参数，值为 `'world'`。Rsbuild 在构建时会自动将 `<%= text %>` 替换为指定的值。
 

--- a/website/docs/zh/guide/basic/html-template.mdx
+++ b/website/docs/zh/guide/basic/html-template.mdx
@@ -117,7 +117,21 @@ export default {
 <meta name="description" content="a description of the page" />
 ```
 
-## 模板参数
+## 默认模板引擎
+
+Rsbuild 内置了一个默认的模板引擎来处理 HTML 模板文件，它的语法是 EJS 的子集。当 HTML 模板文件的后缀为 `.html` 时，Rsbuild 会使用内置的模板引擎来解析 HTML 模板。
+
+例如，在模板中定义一个 `text` 参数，值为 `'world'`。Rsbuild 在构建时会自动将 `<%= text %>` 替换为指定的值。
+
+```html
+<!-- 输入  -->
+<div>hello <%= text %>!</div>
+
+<!-- 输出 -->
+<div>hello world!</div>
+```
+
+### 模板参数
 
 在 HTML 模板中，你可以使用丰富的模板参数，Rsbuild 默认注入的模板参数包括：
 
@@ -144,13 +158,9 @@ type DefaultParameters = {
 };
 ```
 
-你也可以通过 [html.templateParameters](/config/html/template-parameters) 配置项来传入自定义的模板参数。
+你可以通过 [html.templateParameters](/config/html/template-parameters) 配置项来传入自定义的模板参数，比如：
 
-### 示例
-
-比如：
-
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   html: {
     templateParameters: {
@@ -162,53 +172,39 @@ export default {
 
 接下来，你可以在 HTML 模板中，通过 `<%= text %>` 来读取参数：
 
-```html
+```html title="index.html"
 <div>hello <%= text %>!</div>
 ```
 
 编译后的 HTML 代码如下：
 
-```html
+```html title="dist/index.html"
 <div>hello world!</div>
 ```
 
 ### 参数转义
 
-你可以使用 `<%- text %>` 来 escape 参数。
+使用 `<%= text %>` 时，参数不会被转义。你可以使用 `<%- text %>` 来 escape 参数。
 
-比如 text 是 `'<script>'`，则会被转义为 `&lt;script&gt;`：
-
-```html
-<div>hello <%- text %>!</div>
-```
-
-编译后的 HTML 代码如下：
-
-```html
-<div>hello &lt;script&gt;!</div>
-```
-
-## 模板引擎
-
-Rsbuild 支持 [Lodash Template](https://lodashjs.com/docs/lodash.template)、[EJS](https://ejs.co/)、[Pug](https://pugjs.org/) 等多个模板引擎，默认使用最基础的 Lodash Template 作为模板引擎。
-
-### [Lodash Template](https://lodashjs.com/docs/lodash.template)
-
-当模板文件的后缀为 `.html` 时，Rsbuild 会使用 Lodash Template 对模板进行编译。
-
-例如，在模板中定义一个 `text` 参数，值为 `'world'`，在构建时会自动将 `<%= text %>` 替换为对应的值。
+比如参数 `text` 的值是 `'<script>'`，则会被转义为 `&lt;script&gt;`：
 
 ```html
 <!-- 输入  -->
-<div>hello <%= text %>!</div>
+<div>hello <%- text %>!</div>
 
 <!-- 输出 -->
-<div>hello world!</div>
+<div>hello &lt;script&gt;!</div>
 ```
 
-请阅读 [Lodash Template](https://lodashjs.com/docs/lodash.template) 文档来了解完整用法。
+:::tip
+注意，Rsbuild 默认的转义语法是与 EJS 不同的。在 EJS 中，默认的转义语法是 `<%= text %>`，而 Rsbuild 的默认转义语法是 `<%- text %>`。
+:::
 
-### [EJS](https://ejs.co/)
+## 其他模板引擎
+
+Rsbuild 也支持通过插件来使用其他模板引擎，如 [EJS](https://ejs.co/)、[Pug](https://pugjs.org/) 等。
+
+### EJS
 
 当模板文件的后缀为 `.ejs` 时，Rsbuild 会使用 EJS 模板引擎对模板进行编译。EJS 是一套简单的模板语言，支持直接在标签内书写简单、直白的 JavaScript 代码，并通过 JavaScript 输出最终所需的 HTML。
 
@@ -236,9 +232,9 @@ export default {
 
 请阅读 [EJS](https://ejs.co/) 文档来了解完整用法。
 
-### [Pug](https://pugjs.org/)
+### Pug
 
-Rsbuild 通过 Pug 插件来支持 Pug 模板引擎，请阅读 [@rsbuild/plugin-pug](https://github.com/rspack-contrib/rsbuild-plugin-pug) 来了解用法。
+Rsbuild 通过 Pug 插件来支持 [Pug](https://pugjs.org/) 模板引擎，请阅读 [@rsbuild/plugin-pug](https://github.com/rspack-contrib/rsbuild-plugin-pug) 来了解用法。
 
 ## 注入标签
 


### PR DESCRIPTION
## Summary

The escape syntax of `lodash.template` is different from EJS, and we should add some notes for it.

## Related Links

https://github.com/jantimon/html-webpack-plugin/issues/751
https://github.com/jantimon/html-webpack-plugin/issues/1794

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
