### PR TITLE
fix(mf): should compile `@module-federation/sdk`

### DIFF
--- a/e2e/cases/module-federation/index.test.ts
+++ b/e2e/cases/module-federation/index.test.ts
@@ -93,45 +93,47 @@ rspackOnlyTest(
   },
 );
 
-// TODO: fix this test
-test.fail('should transform module federation runtime with SWC', async () => {
-  writeButtonCode();
+rspackOnlyTest(
+  'should transform module federation runtime with SWC',
+  async () => {
+    writeButtonCode();
 
-  const remotePort = await getRandomPort();
+    const remotePort = await getRandomPort();
 
-  process.env.REMOTE_PORT = remotePort.toString();
+    process.env.REMOTE_PORT = remotePort.toString();
 
-  await expect(
-    build({
-      cwd: remote,
-      rsbuildConfig: {
-        output: {
-          overrideBrowserslist: ['Chrome >= 51'],
-        },
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
+    await expect(
+      build({
+        cwd: remote,
+        rsbuildConfig: {
+          output: {
+            overrideBrowserslist: ['Chrome >= 51'],
           },
-        },
-        plugins: [pluginCheckSyntax()],
-      },
-    }),
-  ).resolves.toBeTruthy();
-
-  await expect(
-    build({
-      cwd: host,
-      rsbuildConfig: {
-        output: {
-          overrideBrowserslist: ['Chrome >= 51'],
-        },
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
+          performance: {
+            chunkSplit: {
+              strategy: 'all-in-one',
+            },
           },
+          plugins: [pluginCheckSyntax()],
         },
-        plugins: [pluginCheckSyntax()],
-      },
-    }),
-  ).resolves.toBeTruthy();
-});
+      }),
+    ).resolves.toBeTruthy();
+
+    await expect(
+      build({
+        cwd: host,
+        rsbuildConfig: {
+          output: {
+            overrideBrowserslist: ['Chrome >= 51'],
+          },
+          performance: {
+            chunkSplit: {
+              strategy: 'all-in-one',
+            },
+          },
+          plugins: [pluginCheckSyntax()],
+        },
+      }),
+    ).resolves.toBeTruthy();
+  },
+);

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -130,6 +130,7 @@ export function pluginModuleFederation(): RsbuildPlugin {
         // adding to include and let SWC transform it
         config.source.include = [
           ...(config.source.include || []),
+          /@module-federation[\\/]sdk/,
           /@module-federation[\\/]runtime/,
         ];
       });


### PR DESCRIPTION
## Summary

`@module-federation/sdk` now contains ESNext syntax and Rsbuild should compile it by default:

![img_v3_02e1_3de0bd99-170d-44aa-be76-d82eef1e224g](https://github.com/user-attachments/assets/f3d9d3c3-7c40-4baf-a45e-ed5d818b4370)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
