### PR TITLE
feat: minify CSS for injected styles

### DIFF
--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -35,7 +35,7 @@ rspackOnlyTest(
     const files = await rsbuild.unwrapOutputJSON();
     const content =
       files[Object.keys(files).find((file) => file.endsWith('index.js'))!];
-    expect(content).toContain('color: red;');
+    expect(content).toContain('color:red');
 
     // should have no warnings
     expect(logs.some((log) => log.includes('Compile Warning'))).toBeFalsy();

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -5,43 +5,46 @@ import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
 
-test('should inline style when injectStyles is true', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: fixtures,
-    runServer: true,
-  });
+rspackOnlyTest(
+  'should inline style when injectStyles is true',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: fixtures,
+      runServer: true,
+    });
 
-  await gotoPage(page, rsbuild);
+    await gotoPage(page, rsbuild);
 
-  // injectStyles worked
-  const files = await rsbuild.unwrapOutputJSON();
-  const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
-  expect(cssFiles.length).toBe(0);
+    // injectStyles worked
+    const files = await rsbuild.unwrapOutputJSON();
+    const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
+    expect(cssFiles.length).toBe(0);
 
-  // should inline minified css
-  const indexJsFile = Object.keys(files).find(
-    (file) => file.includes('index.') && file.endsWith('.js'),
-  )!;
+    // should inline minified css
+    const indexJsFile = Object.keys(files).find(
+      (file) => file.includes('index.') && file.endsWith('.js'),
+    )!;
 
-  expect(
-    files[indexJsFile].includes('html,body{margin:0;padding:0}'),
-  ).toBeTruthy();
-  expect(
-    files[indexJsFile].includes(
-      '.description{text-align:center;font-size:16px;line-height:1.5}',
-    ),
-  ).toBeTruthy();
+    expect(
+      files[indexJsFile].includes('html,body{margin:0;padding:0}'),
+    ).toBeTruthy();
+    expect(
+      files[indexJsFile].includes(
+        '.description{text-align:center;font-size:16px;line-height:1.5}',
+      ),
+    ).toBeTruthy();
 
-  // scss worked
-  const header = page.locator('#header');
-  await expect(header).toHaveCSS('font-size', '20px');
+    // scss worked
+    const header = page.locator('#header');
+    await expect(header).toHaveCSS('font-size', '20px');
 
-  // less worked
-  const title = page.locator('#title');
-  await expect(title).toHaveCSS('font-size', '20px');
+    // less worked
+    const title = page.locator('#title');
+    await expect(title).toHaveCSS('font-size', '20px');
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);
 
 rspackOnlyTest(
   'hmr should work well when injectStyles is true',

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -23,9 +23,14 @@ test('should inline style when injectStyles is true', async ({ page }) => {
     (file) => file.includes('index.') && file.endsWith('.js'),
   )!;
 
-  expect(files[indexJsFile].includes('padding: 0;')).toBeTruthy();
-  expect(files[indexJsFile].includes('margin: 0;')).toBeTruthy();
-  expect(files[indexJsFile].includes('text-align: center;')).toBeTruthy();
+  expect(
+    files[indexJsFile].includes('html,body{margin:0;padding:0}'),
+  ).toBeTruthy();
+  expect(
+    files[indexJsFile].includes(
+      '.description{text-align:center;font-size:16px;line-height:1.5}',
+    ),
+  ).toBeTruthy();
 
   // scss worked
   const header = page.locator('#header');

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -252,6 +252,7 @@ async function applyCSSRule({
       const loaderOptions = reduceConfigs<Rspack.LightningcssLoaderOptions>({
         initial: {
           targets: environment.browserslist,
+          minify: config.mode === 'production' && config.output.injectStyles,
         },
         config: userOptions,
       });

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -249,11 +249,16 @@ async function applyCSSRule({
           ? {}
           : config.tools.lightningcssLoader;
 
+      const initialOptions: Rspack.LightningcssLoaderOptions = {
+        targets: environment.browserslist,
+      };
+
+      if (config.mode === 'production' && config.output.injectStyles) {
+        initialOptions.minify = true;
+      }
+
       const loaderOptions = reduceConfigs<Rspack.LightningcssLoaderOptions>({
-        initial: {
-          targets: environment.browserslist,
-          minify: config.mode === 'production' && config.output.injectStyles,
-        },
+        initial: initialOptions,
         config: userOptions,
       });
 

--- a/website/docs/en/config/output/inject-styles.mdx
+++ b/website/docs/en/config/output/inject-styles.mdx
@@ -36,26 +36,3 @@ export default {
   },
 };
 ```
-
-If you need to enable this option in production mode, please note that the inlined CSS code will not go through Rsbuild's default CSS minimizer. You can manually register the [cssnano](https://github.com/cssnano/cssnano) plugin for PostCSS to compress the inlined code.
-
-1. Install cssnano:
-
-```bash
-npm add cssnano -D
-```
-
-2. Register cssnano using `tools.postcss`:
-
-```ts
-export default {
-  tools: {
-    postcss: (opts) => {
-      // apply cssnano in production build
-      if (process.env.NODE_ENV === 'production') {
-        opts.postcssOptions?.plugins?.push(require('cssnano'));
-      }
-    },
-  },
-};
-```

--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -7,6 +7,8 @@
 const defaultOptions = {
   // use current browserslist config
   targets: browserslist,
+  // minify is enabled when output.injectStyles is true and in production mode
+  minify: config.mode === 'production' && config.output.injectStyles,
 };
 ```
 

--- a/website/docs/zh/config/output/inject-styles.mdx
+++ b/website/docs/zh/config/output/inject-styles.mdx
@@ -36,26 +36,3 @@ export default {
   },
 };
 ```
-
-如果你需要在生产模式下开启该选项，请留意内联的 CSS 代码不会经过 Rsbuild 默认的 CSS 压缩器，你可以手动注册 PostCSS 的 [cssnano](https://github.com/cssnano/cssnano) 插件来对内联代码进行压缩。
-
-1. 安装 cssnano：
-
-```bash
-npm add cssnano -D
-```
-
-2. 使用 `tools.postcss` 注册 cssnano：
-
-```ts
-export default {
-  tools: {
-    postcss: (opts) => {
-      // apply cssnano in production build
-      if (process.env.NODE_ENV === 'production') {
-        opts.postcssOptions?.plugins?.push(require('cssnano'));
-      }
-    },
-  },
-};
-```

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -5,8 +5,10 @@
 
 ```ts
 const defaultOptions = {
-  // use current browserslist config
+  // 使用当前项目的 browserslist 配置
   targets: browserslist,
+  // 在生产模式，且 output.injectStyles 为 true 时，minify 会被启用
+  minify: config.mode === 'production' && config.output.injectStyles,
 };
 ```
 


### PR DESCRIPTION
## Summary

Use the `lightningcss-loader` to minify CSS for injected styles. No longer need to install `cssnano`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/3247
- https://github.com/web-infra-dev/rsbuild/pull/3254

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
