### PR TITLE
test(e2e): improve helper for going to page

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -1,9 +1,10 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: 'auto',
@@ -11,7 +12,6 @@ test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();
@@ -20,6 +20,7 @@ test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
 test('should allow dev.assetPrefix to be true', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: true,
@@ -27,7 +28,6 @@ test('should allow dev.assetPrefix to be true', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();
@@ -38,6 +38,7 @@ test('should allow dev.assetPrefix to have <port> placeholder', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: 'http://localhost:<port>/',
@@ -45,7 +46,6 @@ test('should allow dev.assetPrefix to have <port> placeholder', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#test-port');
   await expect(testEl).toHaveText(`http://localhost:${rsbuild.port}`);
   await rsbuild.close();
@@ -54,7 +54,7 @@ test('should allow dev.assetPrefix to have <port> placeholder', async ({
 test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       output: {
         assetPrefix: 'auto',
@@ -62,7 +62,6 @@ test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();
@@ -73,7 +72,7 @@ test('should inject assetPrefix to env var and template correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       html: {
         template: './src/template.html',
@@ -85,7 +84,6 @@ test('should inject assetPrefix to env var and template correctly', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
   await expect(page.locator('#prefix1')).toHaveText('http://example.com');
   await expect(page.locator('#prefix2')).toHaveText('http://example.com');
   await rsbuild.close();

--- a/e2e/cases/async-plugin/index.test.ts
+++ b/e2e/cases/async-plugin/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
@@ -28,11 +28,9 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [asyncPlugin()],
     });
-
-    await gotoPage(page, rsbuild);
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/babel/basic/index.test.ts
+++ b/e2e/cases/babel/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
@@ -7,7 +7,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [
         pluginBabel({
           babelLoaderOptions: (_, { addPlugins }) => {
@@ -17,7 +17,6 @@ rspackOnlyTest(
       ],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.b')).toBe(10);
 
     await rsbuild.close();
@@ -29,7 +28,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         source: {
           exclude: [/aa/],
@@ -44,7 +43,6 @@ rspackOnlyTest(
       ],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.b')).toBe(10);
     expect(await page.evaluate('window.bb')).toBeUndefined();
 

--- a/e2e/cases/babel/decorator/index.test.ts
+++ b/e2e/cases/babel/decorator/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
@@ -7,11 +7,10 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [pluginBabel()],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.aaa')).toBe('hello');
     expect(await page.evaluate('window.bbb')).toBe('world');
     expect(await page.evaluate('window.FooService')).toBeTruthy();
@@ -24,7 +23,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [pluginBabel()],
       rsbuildConfig: {
         source: {
@@ -35,7 +34,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.aaa')).toBe('hello');
     expect(await page.evaluate('window.bbb')).toBe('world');
     expect(await page.evaluate('window.FooService')).toBeTruthy();
@@ -48,7 +46,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [
         pluginBabel({
           babelLoaderOptions(options, { addPresets }) {
@@ -76,7 +74,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.aaa')).toBe('hello');
     expect(await page.evaluate('window.bbb')).toBe('world');
     expect(await page.evaluate('window.FooService')).toBeTruthy();

--- a/e2e/cases/bundler-chain/index.test.ts
+++ b/e2e/cases/bundler-chain/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
@@ -7,7 +7,7 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       tools: {
         bundlerChain: (chain) => {
@@ -19,7 +19,6 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 
   await rsbuild.close();
@@ -30,7 +29,7 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       tools: {
         bundlerChain: async (chain) => {
@@ -47,7 +46,6 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
     },
   });
 
-  await gotoPage(page, rsbuild);
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
 
   await rsbuild.close();

--- a/e2e/cases/configure-rspack/index.test.ts
+++ b/e2e/cases/configure-rspack/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,7 +6,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         tools: {
           rspack: (config, { rspack }) => {
@@ -20,8 +20,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
-
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');
 
@@ -34,7 +32,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         tools: {
           rspack: async (config, { rspack }) => {
@@ -52,8 +50,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/configure-webpack/index.test.ts
+++ b/e2e/cases/configure-webpack/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, webpackOnlyTest } from '@e2e/helper';
+import { build, webpackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 webpackOnlyTest(
@@ -6,7 +6,7 @@ webpackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         tools: {
           webpackChain: (chain, { webpack }) => {
@@ -19,8 +19,6 @@ webpackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -8,7 +8,7 @@ const fixtures = resolve(__dirname);
 test('injectStyles', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       output: {
@@ -16,8 +16,6 @@ test('injectStyles', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   // injectStyles worked
   const files = await rsbuild.unwrapOutputJSON();

--- a/e2e/cases/css/css-modules-exports-global/index.test.ts
+++ b/e2e/cases/css/css-modules-exports-global/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,9 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const test1Locator = page.locator('#test1');
     await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
@@ -25,9 +24,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-    await gotoPage(page, rsbuild);
 
     const test1Locator = page.locator('#test1');
     await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/css/css-modules-ident-name/index.test.ts
+++ b/e2e/cases/css/css-modules-ident-name/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rspack/issues/6470
@@ -7,10 +7,8 @@ test('should generate unique classname for different CSS Modules files in dev bu
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const test1Locator = page.locator('#test1');
   await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
@@ -26,9 +24,8 @@ test('should generate unique classname for different CSS Modules files in prod b
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const test1Locator = page.locator('#test1');
   await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,7 +6,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -24,7 +24,6 @@ rspackOnlyTest(
       /\.classA-\w{6}{color:red}\.classB-\w{6}{color:#00f}\.classC-\w{6}{color:#ff0}/,
     );
 
-    await gotoPage(page, rsbuild);
     const root = page.locator('#root');
     const text = await root.innerHTML();
 

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -25,14 +25,13 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
       rsbuildConfig: {
         dev: {
           writeToDisk: true,
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const content = await readFile(
       join(rsbuild.instance.context.distPath, 'static/css/index.css'),

--- a/e2e/cases/css/style-loader/index.test.ts
+++ b/e2e/cases/css/style-loader/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
@@ -10,10 +10,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: fixtures,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     // injectStyles worked
     const files = await rsbuild.unwrapOutputJSON();
@@ -62,6 +60,7 @@ rspackOnlyTest(
 
     const rsbuild = await dev({
       cwd: fixtures,
+      page,
       rsbuildConfig: {
         source: {
           entry: {
@@ -70,8 +69,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     // scss worked
     const header = page.locator('#header');

--- a/e2e/cases/css/tailwindcss-hmr/index.test.ts
+++ b/e2e/cases/css/tailwindcss-hmr/index.test.ts
@@ -1,6 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const getContent = (
@@ -20,9 +20,9 @@ rspackOnlyTest('should support tailwindcss HMR', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   await expect(page.locator('#root')).toHaveCSS('color', 'rgb(0, 0, 0)');
 
   writeFileSync(tempFile, getContent('text-white'));

--- a/e2e/cases/decorator/2022-03/index.test.ts
+++ b/e2e/cases/decorator/2022-03/index.test.ts
@@ -1,14 +1,13 @@
-import { build, gotoPage, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should run stage 3 decorators correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.message')).toBe('hello');
   expect(await page.evaluate('window.method')).toBe('targetMethod');
   expect(await page.evaluate('window.field')).toBe('message');
@@ -21,11 +20,10 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [pluginBabel()],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.message')).toBe('hello');
     expect(await page.evaluate('window.method')).toBe('targetMethod');
     expect(await page.evaluate('window.field')).toBe('message');
@@ -42,7 +40,7 @@ test.fail(
     // SyntaxError: Decorators must be placed *after* the 'export' keyword
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         source: {
           entry: {
@@ -53,7 +51,6 @@ test.fail(
       plugins: [pluginBabel()],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.message')).toBe('hello');
     expect(await page.evaluate('window.method')).toBe('targetMethod');
     expect(await page.evaluate('window.field')).toBe('message');

--- a/e2e/cases/decorator/basic/index.test.ts
+++ b/e2e/cases/decorator/basic/index.test.ts
@@ -1,14 +1,13 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 
 test('should use legacy decorators by default', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello');
   expect(await page.evaluate('window.bbb')).toBe('world');
   expect(await page.evaluate('window.ccc')).toBe('hello world');
@@ -19,7 +18,7 @@ test('should use legacy decorators by default', async ({ page }) => {
 test('should allow to use stage 3 decorators', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         decorators: {
@@ -29,7 +28,6 @@ test('should allow to use stage 3 decorators', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.aaa')).toBe('hello');
   expect(await page.evaluate('window.bbb')).toBe('world');
   expect(await page.evaluate('window.ccc')).toBe('hello world');
@@ -42,11 +40,10 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [pluginBabel()],
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.aaa')).toBe('hello');
     expect(await page.evaluate('window.bbb')).toBe('world');
     expect(await page.evaluate('window.ccc')).toBe('hello world');
@@ -60,7 +57,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       plugins: [pluginBabel()],
       rsbuildConfig: {
         source: {
@@ -71,7 +68,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
     expect(await page.evaluate('window.aaa')).toBe('hello');
     expect(await page.evaluate('window.bbb')).toBe('world');
     expect(await page.evaluate('window.ccc')).toBe('hello world');

--- a/e2e/cases/environments/plugins/index.test.ts
+++ b/e2e/cases/environments/plugins/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 import { pluginReact } from '@rsbuild/plugin-react';
@@ -30,10 +30,8 @@ test('should add single environment plugin correctly', async ({ page }) => {
         },
       },
     },
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button = page.locator('#test');
   await expect(button).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/environments/vue-react-plugins/index.test.ts
+++ b/e2e/cases/environments/vue-react-plugins/index.test.ts
@@ -4,7 +4,7 @@ import { expect } from '@playwright/test';
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
   const reactUrl = new URL(`http://localhost:${rsbuild.port}/react`);

--- a/e2e/cases/glob-import/index.test.ts
+++ b/e2e/cases/glob-import/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,9 +6,9 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
 
-    await gotoPage(page, rsbuild);
     await expect(page.locator('#header')).toHaveText('Header');
     await expect(page.locator('#footer')).toHaveText('Footer');
 
@@ -21,10 +21,9 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
 
-    await gotoPage(page, rsbuild);
     await expect(page.locator('#header')).toHaveText('Header');
     await expect(page.locator('#footer')).toHaveText('Footer');
 

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should emit apple-touch-icon to dist path', async () => {
@@ -235,6 +235,7 @@ test('should allow to customize manifest filename', async () => {
 test('should append dev.assetPrefix to icon URL', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: 'http://localhost:3000',
@@ -251,8 +252,6 @@ test('should append dev.assetPrefix to icon URL', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const files = await rsbuild.unwrapOutputJSON();
 

--- a/e2e/cases/html/combined/html.test.ts
+++ b/e2e/cases/html/combined/html.test.ts
@@ -11,7 +11,6 @@ test.describe('should combine multiple html config correctly', () => {
   test.beforeAll(async () => {
     rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
       rsbuildConfig: {
         source: {
           entry: {
@@ -40,10 +39,6 @@ test.describe('should combine multiple html config correctly', () => {
       join(rsbuild.distPath, 'foo.html'),
       'utf-8',
     );
-  });
-
-  test.afterAll(async () => {
-    await rsbuild.close();
   });
 
   test('appicon', async () => {

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -1,12 +1,12 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('tools.htmlPlugin', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       tools: {
         htmlPlugin(config, { entryName }) {
@@ -17,8 +17,6 @@ test('tools.htmlPlugin', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const pagePath = join(rsbuild.distPath, 'index.html');
   const content = await fs.promises.readFile(pagePath, 'utf-8');

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 const fixtures = __dirname;
@@ -8,7 +8,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: fixtures,
-      runServer: true,
+      page,
       rsbuildConfig: {
         html: {
           template: './static/index.html',
@@ -21,8 +21,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const files = await rsbuild.unwrapOutputJSON();
 

--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -1,20 +1,18 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('html.outputStructure', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       html: {
         outputStructure: 'nested',
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const pagePath = join(rsbuild.distPath, 'index/index.html');
 

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should set template via function correctly', async () => {
@@ -39,7 +39,7 @@ test('should set template via function correctly', async () => {
 test('should allow to access templateParameters', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       html: {
         template: './static/index.html',
@@ -49,8 +49,6 @@ test('should allow to access templateParameters', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const testTemplate = page.locator('#test-template');
   await expect(testTemplate).toHaveText('text');

--- a/e2e/cases/import-json/index.test.ts
+++ b/e2e/cases/import-json/index.test.ts
@@ -1,13 +1,12 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should import JSON correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.age')).toBe(1);
   expect(await page.evaluate('window.b')).toBe('{"list":[1,2]}');
 

--- a/e2e/cases/inline-chunk/index.test.ts
+++ b/e2e/cases/inline-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import type { RspackChain } from '@rsbuild/core';
 
@@ -22,7 +22,7 @@ test('inline all scripts should work and emit all source maps', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -36,8 +36,6 @@ test('inline all scripts should work and emit all source maps', async ({
       tools: toolsConfig,
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   // test runtime
   expect(await page.evaluate('window.test')).toBe('aaaa');
@@ -161,12 +159,11 @@ test('styles are not inline by default in development mode', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       tools: toolsConfig,
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   // index.css in page
   await expect(
@@ -174,11 +171,14 @@ test('styles are not inline by default in development mode', async ({
       `document.querySelectorAll('link[href*="index.css"]').length`,
     ),
   ).resolves.toEqual(1);
+
+  await rsbuild.close();
 });
 
 test('using RegExp to inline styles in development mode', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       output: {
         inlineStyles: {
@@ -190,14 +190,14 @@ test('using RegExp to inline styles in development mode', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   // no index.css in page
   await expect(
     page.evaluate(
       `document.querySelectorAll('link[href*="index.css"]').length`,
     ),
   ).resolves.toEqual(0);
+
+  await rsbuild.close();
 });
 
 test('inline styles by filename and file size in development mode', async ({
@@ -205,6 +205,7 @@ test('inline styles by filename and file size in development mode', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       output: {
         inlineStyles: {
@@ -218,14 +219,14 @@ test('inline styles by filename and file size in development mode', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   // no index.css in page
   await expect(
     page.evaluate(
       `document.querySelectorAll('link[href*="index.css"]').length`,
     ),
   ).resolves.toEqual(0);
+
+  await rsbuild.close();
 });
 
 test('inline scripts does not work when enable is false', async () => {
@@ -325,6 +326,7 @@ test('inline does not work in development mode when enable is auto', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       output: {
         inlineScripts: {
@@ -340,8 +342,6 @@ test('inline does not work in development mode when enable is auto', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   // all index.js in page
   await expect(
     page.evaluate(
@@ -355,6 +355,8 @@ test('inline does not work in development mode when enable is auto', async ({
       `document.querySelectorAll('link[href*="index.css"]').length`,
     ),
   ).resolves.toEqual(1);
+
+  await rsbuild.close();
 });
 
 test('styles and scripts are not inline by default in development mode when enable not set', async ({
@@ -362,6 +364,7 @@ test('styles and scripts are not inline by default in development mode when enab
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       tools: toolsConfig,
       output: {
@@ -371,8 +374,6 @@ test('styles and scripts are not inline by default in development mode when enab
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   // all index.js in page
   await expect(
     page.evaluate(
@@ -386,4 +387,6 @@ test('styles and scripts are not inline by default in development mode when enab
       `document.querySelectorAll('link[href*="index.css"]').length`,
     ),
   ).resolves.toEqual(1);
+
+  await rsbuild.close();
 });

--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import test, { expect } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rspack/issues/6633
@@ -11,11 +11,11 @@ rspackOnlyTest(
     }
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
 
-    await gotoPage(page, rsbuild);
     await expect(page.locator('#test')).toHaveText('Hello World!');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/legal-comments/index.test.ts
+++ b/e2e/cases/legal-comments/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -7,7 +7,7 @@ const fixtures = __dirname;
 rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       performance: {
@@ -17,8 +17,6 @@ rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
@@ -51,7 +49,7 @@ rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
 test('legalComments none', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       performance: {
@@ -64,8 +62,6 @@ test('legalComments none', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
@@ -92,7 +88,7 @@ test('legalComments none', async ({ page }) => {
 test('legalComments inline', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       performance: {
@@ -105,8 +101,6 @@ test('legalComments inline', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 

--- a/e2e/cases/live-reload/index.test.ts
+++ b/e2e/cases/live-reload/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, gotoPage } from '@e2e/helper';
+import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const appFile = path.join(__dirname, 'src/App.jsx');
@@ -25,9 +25,8 @@ test('should fallback to live-reload when dev.hmr is false', async ({
 
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
@@ -35,7 +34,7 @@ test('should fallback to live-reload when dev.hmr is false', async ({
   fs.writeFileSync(appFile, appCode.replace('Rsbuild', 'Live Reload'), 'utf-8');
   await expect(testEl).toHaveText('Hello Live Reload!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });
 
 test('should not reload page when live-reload is disabled', async ({
@@ -43,6 +42,7 @@ test('should not reload page when live-reload is disabled', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         liveReload: false,
@@ -50,13 +50,11 @@ test('should not reload page when live-reload is disabled', async ({
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
   fs.writeFileSync(appFile, appCode.replace('Rsbuild', 'Live Reload'), 'utf-8');
   await expect(test).toHaveText('Hello Rsbuild!');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to set development mode when building', async () => {
@@ -55,6 +55,7 @@ test('should allow to set production mode when starting dev server', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       mode: 'production',
       dev: {
@@ -62,8 +63,6 @@ test('should allow to set production mode when starting dev server', async ({
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const files = await rsbuild.unwrapOutputJSON(false);
 

--- a/e2e/cases/multi-compiler/index.test.ts
+++ b/e2e/cases/multi-compiler/index.test.ts
@@ -1,10 +1,10 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('multi compiler build', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       environments: {
         web: {
@@ -21,8 +21,6 @@ test('multi compiler build', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
@@ -32,6 +30,7 @@ test('multi compiler build', async ({ page }) => {
 test('multi compiler dev', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -52,8 +51,6 @@ test('multi compiler dev', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/nonce/dynamic-chunk/index.test.ts
+++ b/e2e/cases/nonce/dynamic-chunk/index.test.ts
@@ -1,12 +1,12 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should apply nonce to dynamic chunks in dev build', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.dynamicChunkNonce')).toEqual(
     'CSP_NONCE_PLACEHOLDER',
   );
@@ -17,10 +17,9 @@ test('should apply nonce to dynamic chunks in dev build', async ({ page }) => {
 test('should apply nonce to dynamic chunks in prod build', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.dynamicChunkNonce')).toEqual(
     'CSP_NONCE_PLACEHOLDER',
   );

--- a/e2e/cases/output/assets.test.ts
+++ b/e2e/cases/output/assets.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -71,12 +71,10 @@ for (const item of cases) {
   test(item.name, async ({ page }) => {
     const rsbuild = await build({
       cwd: item.cwd,
-      runServer: true,
+      page,
       plugins: [pluginReact()],
       rsbuildConfig: item.config || {},
     });
-
-    await gotoPage(page, rsbuild);
 
     if (item.expected === 'url') {
       await expect(

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -1,10 +1,10 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to set output.charset to ascii', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       output: {
         charset: 'ascii',
@@ -12,7 +12,6 @@ test('should allow to set output.charset to ascii', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
   const files = await rsbuild.unwrapOutputJSON();
@@ -37,10 +36,9 @@ test('should allow to set output.charset to utf8', async ({ page }) => {
         charset: 'utf8',
       },
     },
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
   const files = await rsbuild.unwrapOutputJSON();

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -8,7 +8,7 @@ const fixtures = resolve(__dirname, '../');
 test('externals', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       output: {
@@ -22,8 +22,6 @@ test('externals', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');
 
@@ -34,7 +32,6 @@ test('externals', async ({ page }) => {
 
   expect(externalVar).toBeDefined();
 
-  rsbuild.clean();
   await rsbuild.close();
 });
 
@@ -56,6 +53,4 @@ test('should not external dependencies when target is web worker', async () => {
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];
   expect(content.includes('MyReact')).toBeFalsy();
-
-  rsbuild.clean();
 });

--- a/e2e/cases/polyfill/basic/index.test.ts
+++ b/e2e/cases/polyfill/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { getPolyfillContent } from '../helper';
 
@@ -23,10 +23,8 @@ test('should add polyfill when set polyfill entry (default)', async ({
         },
       },
     },
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 
@@ -55,14 +53,12 @@ rspackOnlyTest(
           },
         },
       },
-      runServer: true,
+      page,
     });
 
     page.on('pageerror', (err) => {
       console.log('page err', err);
     });
-
-    await gotoPage(page, rsbuild);
 
     expect(await page.evaluate('window.a')).toEqual(EXPECT_VALUE);
 

--- a/e2e/cases/polyfill/browserslist/index.test.ts
+++ b/e2e/cases/polyfill/browserslist/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, dev, globContentJSON, gotoPage } from '@e2e/helper';
+import { build, dev, globContentJSON } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { getPolyfillContent } from '../helper';
 
@@ -8,9 +8,8 @@ test('should read browserslist for development env correctly', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const outputs = await globContentJSON(join(__dirname, 'dist'));
   const content = getPolyfillContent(outputs);
@@ -21,7 +20,7 @@ test('should read browserslist for development env correctly', async ({
 });
 
 test('should read browserslist for production env correctly', async () => {
-  const rsbuild = await build({
+  await build({
     cwd: __dirname,
   });
 
@@ -29,6 +28,4 @@ test('should read browserslist for production env correctly', async () => {
   const content = getPolyfillContent(outputs);
 
   expect(content.includes('es.string.replace-all')).toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/preact/basic/index.test.ts
+++ b/e2e/cases/preact/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,16 +6,15 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -24,16 +23,14 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/preview/index.test.ts
+++ b/e2e/cases/preview/index.test.ts
@@ -1,18 +1,14 @@
 import { join } from 'node:path';
-import { build, getRandomPort, gotoPage } from '@e2e/helper';
+import { build, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should preview dist files correctly', async ({ page }) => {
   const cwd = join(__dirname, 'basic');
-
-  const { instance } = await build({
+  const server = await build({
     cwd,
+    page,
   });
-
-  const { port, server } = await instance.preview();
-
-  await gotoPage(page, { port });
 
   const rootEl = page.locator('#root');
   await expect(rootEl).toHaveText('Hello Rsbuild!');
@@ -37,16 +33,14 @@ test('should allow plugin to modify preview server config', async ({
     },
   };
 
-  const { instance } = await build({
+  const server = await build({
     cwd,
     plugins: [plugin],
+    page,
   });
 
-  const { port, server } = await instance.preview();
+  expect(server.port).toEqual(PORT);
 
-  expect(port).toEqual(PORT);
-
-  await gotoPage(page, { port });
   const rootEl = page.locator('#root');
   await expect(rootEl).toHaveText('Hello Rsbuild!');
   await server.close();

--- a/e2e/cases/prod-server/index.test.ts
+++ b/e2e/cases/prod-server/index.test.ts
@@ -9,7 +9,7 @@ test('should access / and htmlFallback success by default', async ({
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -38,7 +38,7 @@ test('should access / and htmlFallback success by default', async ({
 test('should return 404 when htmlFallback false', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       server: {
         htmlFallback: false,
@@ -65,7 +65,7 @@ test('should access /main.html success when entry is main', async ({
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -93,7 +93,7 @@ test('should access /main.html success when entry is main', async ({
 test('should access /main success when entry is main', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -125,7 +125,7 @@ test('should access /main success when entry is main and set assetPrefix', async
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -156,7 +156,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -187,7 +187,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
 test('should return 404 when page is not found', async ({ page }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -216,7 +216,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -257,7 +257,7 @@ test('should match resource correctly with specify assetPrefix', async ({
 
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       server: {
         port,
@@ -288,7 +288,7 @@ test('should match resource correctly with full url assetPrefix', async ({
 
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
     rsbuildConfig: {
       server: {
         port,

--- a/e2e/cases/react/basic/index.test.ts
+++ b/e2e/cases/react/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,16 +6,15 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -24,16 +23,14 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/react/enable-profiler/index.test.ts
+++ b/e2e/cases/react/enable-profiler/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
@@ -8,10 +8,8 @@ test('should render element with enabled profiler correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/react/legacy-jsx/index.test.ts
+++ b/e2e/cases/react/legacy-jsx/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
@@ -8,10 +8,8 @@ test('should render element with legacy JSX runtime correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: fixtures,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/react/react-compiler-babel/index.test.ts
+++ b/e2e/cases/react/react-compiler-babel/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,16 +6,15 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
     button.click();
     await expect(button).toHaveText('count: 1');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -24,10 +23,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
@@ -37,6 +34,6 @@ rspackOnlyTest(
     const index = await rsbuild.getIndexFile();
     expect(index.content).toContain('memo_cache_sentinel');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/resolve-pkg-imports/index.test.ts
+++ b/e2e/cases/resolve-pkg-imports/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should resolve package.json#imports correctly in dev build', async ({
@@ -6,9 +6,9 @@ test('should resolve package.json#imports correctly in dev build', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('foo');
   const test = page.locator('#test');
@@ -22,10 +22,8 @@ test('should resolve package.json#imports correctly in prod build', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('foo');

--- a/e2e/cases/server/assetPrefix/index.test.ts
+++ b/e2e/cases/server/assetPrefix/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, getRandomPort, gotoPage } from '@e2e/helper';
+import { dev, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should match resource correctly with specify assetPrefix', async ({
@@ -7,6 +7,7 @@ test('should match resource correctly with specify assetPrefix', async ({
   const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: '/subpath/',
@@ -16,8 +17,6 @@ test('should match resource correctly with specify assetPrefix', async ({
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(rsbuild.port).toBe(port);
 
@@ -33,6 +32,7 @@ test('should match resource correctly with full url assetPrefix', async ({
   const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: `http://localhost:${port}/subpath/`,
@@ -42,8 +42,6 @@ test('should match resource correctly with full url assetPrefix', async ({
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(rsbuild.port).toBe(port);
 

--- a/e2e/cases/server/custom-server/index.test.ts
+++ b/e2e/cases/server/custom-server/index.test.ts
@@ -1,5 +1,5 @@
 import { gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { startDevServerPure } from './scripts/pureServer.mjs';
 import { startDevServer } from './scripts/server.mjs';
 

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -20,6 +20,7 @@ rspackOnlyTest(
 
     const rsbuild = await dev({
       cwd,
+      page,
       rsbuildConfig: {
         plugins: [pluginReact()],
         environments: {
@@ -58,8 +59,6 @@ rspackOnlyTest(
 
     const locator1 = web1Page.locator('#test');
     await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
-
-    await gotoPage(page, rsbuild);
 
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -49,7 +49,7 @@ test('should provide history api fallback for preview server correctly', async (
   const rsbuild = await build({
     cwd,
     plugins: [pluginReact()],
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         entry: {

--- a/e2e/cases/server/hmr/index.test.ts
+++ b/e2e/cases/server/hmr/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, getRandomPort, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -17,6 +17,7 @@ rspackOnlyTest('HMR should work by default', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -31,8 +32,6 @@ rspackOnlyTest('HMR should work by default', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -81,6 +80,7 @@ rspackOnlyTest(
     const port = await getRandomPort();
     const rsbuild = await dev({
       cwd,
+      page,
       rsbuildConfig: {
         source: {
           entry: {
@@ -98,7 +98,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
     expect(rsbuild.port).toBe(port);
 
     const appPath = join(cwd, 'test-temp-src-1/App.tsx');
@@ -131,6 +130,7 @@ rspackOnlyTest(
     const port = await getRandomPort();
     const rsbuild = await dev({
       cwd,
+      page,
       rsbuildConfig: {
         source: {
           entry: {
@@ -148,7 +148,6 @@ rspackOnlyTest(
       },
     });
 
-    await gotoPage(page, rsbuild);
     expect(rsbuild.port).toBe(port);
 
     const appPath = join(cwd, 'test-temp-src-2/App.tsx');

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, gotoPage, proxyConsole } from '@e2e/helper';
+import { dev, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -19,6 +19,7 @@ test('should show overlay correctly', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       source: {
         entry: {
@@ -27,8 +28,6 @@ test('should show overlay correctly', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const errorOverlay = page.locator('rsbuild-error-overlay');
 

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, getRandomPort, gotoPage } from '@e2e/helper';
+import { dev, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to set port via server.port', async ({ page }) => {
@@ -8,14 +8,13 @@ test('should allow to set port via server.port', async ({ page }) => {
   const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       server: {
         port,
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(rsbuild.port).toBe(port);
 

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -218,7 +218,7 @@ test('allow only listen to localhost for prod preview', async ({ page }) => {
 
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
     rsbuildConfig: {
       server: {
         host: 'localhost',

--- a/e2e/cases/server/public-dir-with-multi-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-multi-template/index.test.ts
@@ -29,7 +29,7 @@ test('should serve publicDir with templates for preview server correctly', async
 }) => {
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
   });
 
   const res = await page.goto(`http://localhost:${rsbuild.port}/aa.txt`);

--- a/e2e/cases/server/public-dir-with-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-template/index.test.ts
@@ -25,7 +25,7 @@ test('should serve publicDir with template for preview server correctly', async 
 }) => {
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
   });
 
   const res = await page.goto(`http://localhost:${rsbuild.port}/aa.txt`);

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -1,5 +1,5 @@
 import path, { join } from 'node:path';
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import fse from 'fs-extra';
 
@@ -151,7 +151,7 @@ test('should serve publicDir for preview server correctly', async ({
 
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -177,7 +177,7 @@ test('should serve publicDir for preview server with assetPrefix correctly', asy
 
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: '/dev/',
@@ -208,7 +208,7 @@ test('should serve multiple publicDir for preview server correctly', async ({
 
   const rsbuild = await build({
     cwd,
-    runServer: true,
+    page,
     rsbuildConfig: {
       server: {
         publicDir: [{ name: 'test-temp-dir1' }, { name: 'test-temp-dir2' }],
@@ -233,6 +233,7 @@ test('should serve multiple publicDir for preview server correctly', async ({
 test('should reload page when publicDir file changes', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       server: {
         publicDir: {
@@ -241,8 +242,6 @@ test('should reload page when publicDir file changes', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const file = path.join(__dirname, '/public/test-temp-file.txt');
 
@@ -262,6 +261,7 @@ test('should reload page when custom publicDir file changes', async ({
 }) => {
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       server: {
         publicDir: {
@@ -271,8 +271,6 @@ test('should reload page when custom publicDir file changes', async ({
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const file = path.join(__dirname, '/public1/test-temp-file.txt');
 

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -1,7 +1,7 @@
-import { dev, gotoPage } from '@e2e/helper';
+import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-// hmr will timeout in CI
+// HMR will timeout in CI
 test('setupMiddlewares', async ({ page }) => {
   // HMR cases will fail in Windows
   if (process.platform === 'win32') {
@@ -14,6 +14,7 @@ test('setupMiddlewares', async ({ page }) => {
   // Only tested to see if it works, not all configurations.
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         setupMiddlewares: [
@@ -28,8 +29,6 @@ test('setupMiddlewares', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -1,11 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should work with string and path to file', async ({ page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {
@@ -14,7 +15,6 @@ rspackOnlyTest('should work with string and path to file', async ({ page }) => {
       },
     },
   });
-  await gotoPage(page, rsbuild);
 
   await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
@@ -33,6 +33,7 @@ rspackOnlyTest(
     const file = path.join(__dirname, '/assets/example.txt');
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
       rsbuildConfig: {
         dev: {
           watchFiles: {
@@ -41,7 +42,6 @@ rspackOnlyTest(
         },
       },
     });
-    await gotoPage(page, rsbuild);
 
     await fs.promises.writeFile(file, 'test');
 
@@ -60,6 +60,7 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
   const other = path.join(__dirname, '/other/other.txt');
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {
@@ -71,7 +72,6 @@ rspackOnlyTest('should work with string array directory', async ({ page }) => {
       },
     },
   });
-  await gotoPage(page, rsbuild);
 
   await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
@@ -97,6 +97,7 @@ rspackOnlyTest('should work with string and glob', async ({ page }) => {
   const watchDir = path.join(__dirname, '/assets');
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {
@@ -105,7 +106,6 @@ rspackOnlyTest('should work with string and glob', async ({ page }) => {
       },
     },
   });
-  await gotoPage(page, rsbuild);
 
   await fs.promises.writeFile(file, 'test');
   // check the page is reloaded
@@ -122,6 +122,7 @@ rspackOnlyTest('should work with options', async ({ page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {
@@ -133,7 +134,6 @@ rspackOnlyTest('should work with options', async ({ page }) => {
       },
     },
   });
-  await gotoPage(page, rsbuild);
 
   await fs.promises.writeFile(file, 'test');
   // check the page is reloaded

--- a/e2e/cases/server/write-to-disk/index.test.ts
+++ b/e2e/cases/server/write-to-disk/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, gotoPage } from '@e2e/helper';
+import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -6,6 +6,7 @@ const cwd = __dirname;
 test('writeToDisk default', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -14,8 +15,6 @@ test('writeToDisk default', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -26,6 +25,7 @@ test('writeToDisk default', async ({ page }) => {
 test('writeToDisk false', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -38,8 +38,6 @@ test('writeToDisk false', async ({ page }) => {
     },
   });
 
-  await gotoPage(page, rsbuild);
-
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
@@ -49,6 +47,7 @@ test('writeToDisk false', async ({ page }) => {
 test('writeToDisk true', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
+    page,
     rsbuildConfig: {
       output: {
         distPath: {
@@ -60,8 +59,6 @@ test('writeToDisk true', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/solid/hmr/index.test.ts
+++ b/e2e/cases/solid/hmr/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 rspackOnlyTest('hmr should work properly', async ({ page }) => {
@@ -13,9 +13,8 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd: root,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const a = page.locator('#A');
   const b = page.locator('#B');
@@ -46,5 +45,5 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   // recover the source code
   fs.writeFileSync(filePath, sourceCodeB, 'utf-8');
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/solid/ref/index.test.ts
+++ b/e2e/cases/solid/ref/index.test.ts
@@ -1,16 +1,15 @@
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rsbuild/issues/1963
 rspackOnlyTest('Solid ref should work', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const test = page.locator('#test');
   await expect(test).toHaveText('abc');
 
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/source/custom-tsconfig/index.test.ts
+++ b/e2e/cases/source/custom-tsconfig/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('tsconfig paths should work and override the alias config', async ({
@@ -6,10 +6,8 @@ test('tsconfig paths should work and override the alias config', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('tsconfig paths worked');

--- a/e2e/cases/source/jsconfig-paths/index.test.ts
+++ b/e2e/cases/source/jsconfig-paths/index.test.ts
@@ -1,12 +1,12 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'tsconfig paths should work and override the alias config',
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         source: {
           alias: {
@@ -16,8 +16,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('tsconfig paths worked');
@@ -31,7 +29,7 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
       rsbuildConfig: {
         source: {
           alias: {
@@ -42,8 +40,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    await gotoPage(page, rsbuild);
 
     const foo = page.locator('#foo');
     await expect(foo).toHaveText('source.alias worked');

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -46,7 +46,7 @@ test.describe('source configure multi', () => {
 test('define', async ({ page }) => {
   const rsbuild = await build({
     cwd: join(fixtures, 'global-vars'),
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         define: {

--- a/e2e/cases/source/tsconfig-paths/index.test.ts
+++ b/e2e/cases/source/tsconfig-paths/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('tsconfig paths should work and override the alias config', async ({
@@ -6,7 +6,7 @@ test('tsconfig paths should work and override the alias config', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         alias: {
@@ -15,8 +15,6 @@ test('tsconfig paths should work and override the alias config', async ({
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('tsconfig paths worked');
@@ -29,7 +27,7 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
     rsbuildConfig: {
       source: {
         alias: {
@@ -39,8 +37,6 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const foo = page.locator('#foo');
   await expect(foo).toHaveText('source.alias worked');

--- a/e2e/cases/sri/algotithm/index.test.ts
+++ b/e2e/cases/sri/algotithm/index.test.ts
@@ -1,10 +1,10 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('generate integrity using sha512 algorithm', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
   const files = await rsbuild.unwrapOutputJSON();
@@ -19,7 +19,6 @@ test('generate integrity using sha512 algorithm', async ({ page }) => {
     /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+\/=]+"/,
   );
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#root');
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();

--- a/e2e/cases/sri/basic/index.test.ts
+++ b/e2e/cases/sri/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('generate integrity for script and style tags in prod build', async ({
@@ -6,7 +6,7 @@ test('generate integrity for script and style tags in prod build', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
   const files = await rsbuild.unwrapOutputJSON();
@@ -21,7 +21,6 @@ test('generate integrity for script and style tags in prod build', async ({
     /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha384-[A-Za-z0-9+\/=]+"/,
   );
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#root');
   await expect(testEl).toHaveText('Hello Rsbuild!');
   await rsbuild.close();
@@ -32,9 +31,9 @@ test('do not generate integrity for script and style tags in dev build', async (
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#root');
   await expect(testEl).toHaveText('Hello Rsbuild!');
 

--- a/e2e/cases/sri/enable-dev/index.test.ts
+++ b/e2e/cases/sri/enable-dev/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, gotoPage } from '@e2e/helper';
+import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('generate integrity for script and style tags in dev build', async ({
@@ -6,9 +6,9 @@ test('generate integrity for script and style tags in dev build', async ({
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   const testEl = page.locator('#root');
   await expect(testEl).toHaveText('Hello Rsbuild!');
 

--- a/e2e/cases/svelte/hmr/index.test.ts
+++ b/e2e/cases/svelte/hmr/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
@@ -19,6 +19,7 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd: root,
+    page,
     plugins: [pluginSvelte()],
     rsbuildConfig: {
       source: {
@@ -28,8 +29,6 @@ rspackOnlyTest('hmr should work properly', async ({ page }) => {
       },
     },
   });
-
-  await gotoPage(page, rsbuild);
 
   const a = page.locator('#A');
   const b = page.locator('#B');

--- a/e2e/cases/svg/svg-assets/index.test.ts
+++ b/e2e/cases/svg/svg-assets/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('SVGR basic usage', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   // test svg asset
   await expect(

--- a/e2e/cases/svg/svgr-default-export-component/index.test.ts
+++ b/e2e/cases/svg/svgr-default-export-component/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('use SVGR and default export React component', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('test-svg').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-default-export-url/index.test.ts
+++ b/e2e/cases/svg/svgr-default-export-url/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should import default from SVG with SVGR correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   // test svgr（namedExport）
   await expect(

--- a/e2e/cases/svg/svgr-disable-emit-asset/index.test.ts
+++ b/e2e/cases/svg/svgr-disable-emit-asset/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should import svg with SVGR plugin and query URL correctly', async () => {

--- a/e2e/cases/svg/svgr-exclude-importer/index.test.ts
+++ b/e2e/cases/svg/svgr-exclude-importer/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('use SVGR and exclude some files', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('foo').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-exclude/index.test.ts
+++ b/e2e/cases/svg/svgr-exclude/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('use SVGR and exclude some files', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('foo').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-external-react/index.test.ts
+++ b/e2e/cases/svg/svgr-external-react/index.test.ts
@@ -1,14 +1,12 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 // It's an old bug when use svgr in css and external react.
 test('use SVGR and externals react', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   // test svgr（namedExport）
   await expect(

--- a/e2e/cases/svg/svgr-named-export-component/index.test.ts
+++ b/e2e/cases/svg/svgr-named-export-component/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('use SVGR and default export React component', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('test-svg').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-override-svgo-options/index.test.ts
+++ b/e2e/cases/svg/svgr-override-svgo-options/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('use SVGR and override svgo plugin options', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('test-svg').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-query-custom/index.test.ts
+++ b/e2e/cases/svg/svgr-query-custom/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should import default from SVG with custom query correctly', async ({
@@ -6,10 +6,8 @@ test('should import default from SVG with custom query correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('component').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-query-react-dynamic-import/index.test.ts
+++ b/e2e/cases/svg/svgr-query-react-dynamic-import/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rsbuild/issues/1766
@@ -7,10 +7,8 @@ test('should import default from SVG with react query and dynamic import correct
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('component').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-query-react/index.test.ts
+++ b/e2e/cases/svg/svgr-query-react/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should import default from SVG with react query correctly', async ({
@@ -6,10 +6,8 @@ test('should import default from SVG with react query correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(
     page.evaluate(`document.getElementById('component').tagName === 'svg'`),

--- a/e2e/cases/svg/svgr-query-url/index.test.ts
+++ b/e2e/cases/svg/svgr-query-url/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should import svg with SVGR plugin and query URL correctly', async ({
@@ -6,10 +6,8 @@ test('should import svg with SVGR plugin and query URL correctly', async ({
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   // test svg asset
   await expect(

--- a/e2e/cases/top-level-await/index.test.ts
+++ b/e2e/cases/top-level-await/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should run top level await correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(await page.evaluate('window.foo')).toEqual('hello');
 

--- a/e2e/cases/type-check/basic/index.test.ts
+++ b/e2e/cases/type-check/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev } from '@e2e/helper';
 import { proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
@@ -34,6 +34,7 @@ test('should throw error when exist type errors in dev mode', async ({
 
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
     plugins: [
       pluginTypeCheck({
         forkTsCheckerOptions: {
@@ -42,8 +43,6 @@ test('should throw error when exist type errors in dev mode', async ({
       }),
     ],
   });
-
-  await gotoPage(page, rsbuild);
 
   expect(
     logs.find((log) => log.includes('File:') && log.includes('/src/index.ts')),

--- a/e2e/cases/vue/jsx-basic/index.test.ts
+++ b/e2e/cases/vue/jsx-basic/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build basic Vue jsx correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   await expect(button1).toHaveText('A: 0');

--- a/e2e/cases/vue/jsx-hmr/index.test.ts
+++ b/e2e/cases/vue/jsx-hmr/index.test.ts
@@ -6,9 +6,8 @@ import { type Page, expect, test } from '@playwright/test';
 rspackOnlyTest('should render', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await expect(page.locator('.named')).toHaveText('named 0');
   await expect(page.locator('.named-specifier')).toHaveText(
@@ -25,9 +24,8 @@ rspackOnlyTest('should render', async ({ page }) => {
 rspackOnlyTest('should update', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   await page.locator('.named').click();
   await expect(page.locator('.named')).toHaveText('named 1');

--- a/e2e/cases/vue/sfc-basic/index.test.ts
+++ b/e2e/cases/vue/sfc-basic/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   const button2 = page.locator('#button2');

--- a/e2e/cases/vue/sfc-css-modules/index.test.ts
+++ b/e2e/cases/vue/sfc-css-modules/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,9 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const test1 = page.locator('#test1');
     const test2 = page.locator('#test2');
@@ -27,10 +26,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const test1 = page.locator('#test1');
     const test2 = page.locator('#test2');

--- a/e2e/cases/vue/sfc-lang-jsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-jsx/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-pcss/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-postcss/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-ts/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');

--- a/e2e/cases/vue/sfc-lang-tsx/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-tsx/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('0');

--- a/e2e/cases/vue/sfc-style/index.test.ts
+++ b/e2e/cases/vue/sfc-style/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button = page.locator('#button');
   await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue2/sfc-basic/index.test.ts
+++ b/e2e/cases/vue2/sfc-basic/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button1 = page.locator('#button1');
   const button2 = page.locator('#button2');

--- a/e2e/cases/vue2/sfc-css-modules/index.test.ts
+++ b/e2e/cases/vue2/sfc-css-modules/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,9 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const test1 = page.locator('#test1');
     const test2 = page.locator('#test2');
@@ -27,10 +26,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const test1 = page.locator('#test1');
     const test2 = page.locator('#test2');

--- a/e2e/cases/vue2/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-pcss/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue2/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-postcss/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/vue2/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue2/sfc-lang-ts/index.test.ts
@@ -1,4 +1,4 @@
-import { build, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -6,10 +6,8 @@ rspackOnlyTest(
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,
-      runServer: true,
+      page,
     });
-
-    await gotoPage(page, rsbuild);
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0 foo: bar');

--- a/e2e/cases/vue2/sfc-style/index.test.ts
+++ b/e2e/cases/vue2/sfc-style/index.test.ts
@@ -1,13 +1,11 @@
-import { build, gotoPage, rspackOnlyTest as test } from '@e2e/helper';
+import { build, rspackOnlyTest as test } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 test('should build Vue sfc style correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
-
-  await gotoPage(page, rsbuild);
 
   const button = page.locator('#button');
   await expect(button).toHaveCSS('color', 'rgb(255, 0, 0)');

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -1,12 +1,12 @@
 import { join } from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to import wasm file', async ({ page }) => {
   const root = join(__dirname, 'wasm-basic');
   const rsbuild = await build({
     cwd: root,
-    runServer: true,
+    page,
   });
   const files = await rsbuild.unwrapOutputJSON();
 
@@ -16,8 +16,6 @@ test('should allow to import wasm file', async ({ page }) => {
 
   expect(wasmFile).toBeTruthy();
   expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
-
-  await gotoPage(page, rsbuild);
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);
@@ -50,7 +48,7 @@ test('should allow to use new URL to get path of wasm file', async ({
   const root = join(__dirname, 'wasm-url');
   const rsbuild = await build({
     cwd: root,
-    runServer: true,
+    page,
   });
   const files = await rsbuild.unwrapOutputJSON();
 
@@ -60,8 +58,6 @@ test('should allow to use new URL to get path of wasm file', async ({
 
   expect(wasmFile).toBeTruthy();
   expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
-
-  await gotoPage(page, rsbuild);
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);

--- a/e2e/cases/web-worker/new-worker/index.test.ts
+++ b/e2e/cases/web-worker/new-worker/index.test.ts
@@ -1,15 +1,15 @@
-import path from 'node:path';
-import { build, gotoPage } from '@e2e/helper';
+import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to build web-worker with new Worker', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    runServer: true,
+    page,
   });
 
-  await gotoPage(page, rsbuild);
   await expect(page.locator('#root')).toHaveText(
     'The Answer to the Ultimate Question of Life, The Universe, and Everything: 42',
   );
+
+  await rsbuild.close();
 });


### PR DESCRIPTION
## Summary

Improve the test helper for going to page. No need to call `gotoPage` manually.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
