### PR TITLE
test: enable lazy compilation case for Windows

### DIFF
--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -1,14 +1,10 @@
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import test, { expect } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rspack/issues/6633
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation and add new initial chunk',
   async ({ page }) => {
-    // TODO fix this case in Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
     const rsbuild = await dev({
       cwd: __dirname,
       page,

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,14 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
-    // TODO fix this case in Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
     });


### PR DESCRIPTION
## Summary

Enable lazy compilation case for Windows.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
