### PR TITLE
feat: allow to override Rspack config validate env

### DIFF
--- a/e2e/cases/rspack-config-validate/index.test.ts
+++ b/e2e/cases/rspack-config-validate/index.test.ts
@@ -1,0 +1,18 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should allow to override rspack config validate', async () => {
+  const { RSPACK_CONFIG_VALIDATE } = process.env;
+  process.env.RSPACK_CONFIG_VALIDATE = 'strict';
+
+  try {
+    await build({
+      cwd: __dirname,
+    });
+  } catch (e) {
+    expect(e).toBeTruthy();
+    expect((e as Error).message).toContain('Expected object, received number');
+  }
+
+  process.env.RSPACK_CONFIG_VALIDATE = RSPACK_CONFIG_VALIDATE;
+});

--- a/e2e/cases/rspack-config-validate/rsbuild.config.ts
+++ b/e2e/cases/rspack-config-validate/rsbuild.config.ts
@@ -1,0 +1,7 @@
+export default {
+  tools: {
+    rspack: {
+      entry: 1,
+    },
+  },
+};

--- a/e2e/cases/rspack-config-validate/src/index.js
+++ b/e2e/cases/rspack-config-validate/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -63,7 +63,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           );
         }
 
-        process.env.RSPACK_CONFIG_VALIDATE = 'loose-silent';
+        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-silent';
 
         // improve kill process performance
         // https://github.com/web-infra-dev/rspack/pull/5486


### PR DESCRIPTION
## Summary

allow to override Rspack config validate env: `process.env.RSPACK_CONFIG_VALIDATE`.

## Related Links

https://rspack.dev/guide/migration/webpack#updating-configuration

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
