### PR TITLE
fix: avoid passing unsupported Rspack config

### DIFF
--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -246,11 +246,15 @@ export const pluginSplitChunks = (): RsbuildPlugin => ({
               'async'
             : // split both `initial` and `async` chunks for normal app
               'all',
-          // When chunk size >= 50000 bytes, split it into separate chunk
-          // @ts-expect-error Rspack type missing
-          enforceSizeThreshold: 50000,
           cacheGroups: {},
         };
+
+        if (api.context.bundlerType === 'webpack') {
+          // When chunk size >= 50000 bytes, split it into separate chunk
+          // @ts-expect-error Rspack does not support enforceSizeThreshold yet
+          // https://github.com/web-infra-dev/rspack/issues/3565
+          defaultConfig.enforceSizeThreshold = 50000;
+        }
 
         const { chunkSplit } = config.performance;
         let forceSplittingGroups = {};

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -294,7 +294,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -294,7 +294,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {
@@ -751,7 +750,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {
@@ -1490,7 +1488,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1671,7 +1671,6 @@ exports[`environment config > tools.rspack / bundlerChain can be used in environ
           },
         },
         "chunks": "all",
-        "enforceSizeThreshold": 50000,
       },
     },
     "output": {

--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -7,7 +7,6 @@ exports[`plugin-module-federation > should set environment module federation con
       "splitChunks": {
         "cacheGroups": {},
         "chunks": "async",
-        "enforceSizeThreshold": 50000,
       },
     },
     "output": {
@@ -55,7 +54,6 @@ exports[`plugin-module-federation > should set environment module federation con
           },
         },
         "chunks": "all",
-        "enforceSizeThreshold": 50000,
       },
     },
     "plugins": [
@@ -72,7 +70,6 @@ exports[`plugin-module-federation > should set module federation and environment
       "splitChunks": {
         "cacheGroups": {},
         "chunks": "async",
-        "enforceSizeThreshold": 50000,
       },
     },
     "output": {
@@ -146,7 +143,6 @@ exports[`plugin-module-federation > should set module federation config 1`] = `
     "splitChunks": {
       "cacheGroups": {},
       "chunks": "async",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {

--- a/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
@@ -14,7 +14,6 @@ exports[`plugin-split-chunks > should allow forceSplitting to be an object 1`] =
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "plugins": [
@@ -59,7 +58,6 @@ exports[`plugin-split-chunks > should set custom config 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "plugins": [
@@ -74,7 +72,6 @@ exports[`plugin-split-chunks > should set single-size config 1`] = `
     "splitChunks": {
       "cacheGroups": {},
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
       "maxSize": 5000,
       "minSize": 1000,
     },
@@ -99,7 +96,6 @@ exports[`plugin-split-chunks > should set single-vendor config 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "plugins": [
@@ -130,7 +126,6 @@ exports[`plugin-split-chunks > should set split-by-experience config 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "plugins": [
@@ -156,7 +151,6 @@ exports[`plugin-split-chunks > should set split-by-experience config correctly w
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "plugins": [
@@ -177,7 +171,6 @@ exports[`plugin-split-chunks > should set split-by-module config 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
       "maxInitialRequests": Infinity,
       "minSize": 0,
     },

--- a/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/features.test.ts.snap
@@ -25,7 +25,6 @@ exports[`splitChunks > should apply antd/semi/... splitChunks rule when pkg is i
     },
   },
   "chunks": "all",
-  "enforceSizeThreshold": 50000,
 }
 `;
 
@@ -44,7 +43,6 @@ exports[`splitChunks > should apply splitChunks.react/router plugin option when 
     },
   },
   "chunks": "all",
-  "enforceSizeThreshold": 50000,
 }
 `;
 
@@ -60,6 +58,5 @@ exports[`splitChunks > should not apply splitChunks rule when strategy is not sp
     },
   },
   "chunks": "all",
-  "enforceSizeThreshold": 50000,
 }
 `;

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -12,7 +12,6 @@ exports[`plugins/react > should not apply splitChunks rule when strategy is not 
     },
   },
   "chunks": "all",
-  "enforceSizeThreshold": 50000,
 }
 `;
 
@@ -330,7 +329,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
         },
       },
       "chunks": "all",
-      "enforceSizeThreshold": 50000,
     },
   },
   "output": {


### PR DESCRIPTION
## Summary

Avoid passing unsupported Rspack config, fix:

<img width="1124" alt="截屏2024-08-27 22 43 07" src="https://github.com/user-attachments/assets/af178dc5-c746-429b-a545-22a83df9a361">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
