### PR TITLE
feat!: enable Rspack config schema validation by default

### DIFF
--- a/e2e/cases/rspack-config-validate/index.test.ts
+++ b/e2e/cases/rspack-config-validate/index.test.ts
@@ -1,18 +1,67 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
+import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should allow to override rspack config validate', async () => {
-  const { RSPACK_CONFIG_VALIDATE } = process.env;
-  process.env.RSPACK_CONFIG_VALIDATE = 'strict';
-
+rspackOnlyTest('should validate rspack config by default', async () => {
   try {
     await build({
       cwd: __dirname,
+      rsbuildConfig: {
+        tools: {
+          // @ts-expect-error mock invalid config
+          rspack: {
+            entry: 1,
+          },
+        },
+      },
     });
   } catch (e) {
     expect(e).toBeTruthy();
     expect((e as Error).message).toContain('Expected object, received number');
   }
+});
+
+rspackOnlyTest('should warn when passing unrecognized keys', async () => {
+  const { logs, restore } = proxyConsole();
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      tools: {
+        rspack: {
+          // @ts-expect-error mock invalid config
+          unrecognized: 1,
+        },
+      },
+    },
+  });
+
+  expect(
+    logs.some((log) =>
+      log.includes(`Unrecognized key(s) in object: 'unrecognized'`),
+    ),
+  );
+  restore();
+});
+
+rspackOnlyTest('should allow to override rspack config validate', async () => {
+  const { RSPACK_CONFIG_VALIDATE } = process.env;
+  process.env.RSPACK_CONFIG_VALIDATE = 'loose';
+
+  const { logs, restore } = proxyConsole();
+
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      tools: {
+        // @ts-expect-error mock invalid config
+        rspack: {
+          entry: 1,
+        },
+      },
+    },
+  });
+
+  expect(logs.some((log) => log.includes('Expected object, received number')));
 
   process.env.RSPACK_CONFIG_VALIDATE = RSPACK_CONFIG_VALIDATE;
+  restore();
 });

--- a/e2e/cases/rspack-config-validate/rsbuild.config.ts
+++ b/e2e/cases/rspack-config-validate/rsbuild.config.ts
@@ -1,7 +1,0 @@
-export default {
-  tools: {
-    rspack: {
-      entry: 1,
-    },
-  },
-};

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -63,7 +63,8 @@ export const pluginBasic = (): RsbuildPlugin => ({
           );
         }
 
-        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-silent';
+        // enable Rspack config schema validation, unrecognized keys are allowed
+        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-unrecognized-keys';
 
         // improve kill process performance
         // https://github.com/web-infra-dev/rspack/pull/5486

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -107,6 +107,7 @@ subpage
 subresource
 subresources
 svgr
+sveltejs
 swcrc
 systemjs
 tailwindcss


### PR DESCRIPTION
## Summary

Enable Rspack config schema validation by default, this can help users find invalid Rspack config in advance and avoid unexpected errors during the build process.

![image](https://github.com/user-attachments/assets/e45a3c4e-168e-469d-845a-29d914328472)

## Related Links

https://github.com/web-infra-dev/rspack/pull/7705

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
