### PR TITLE
docs: remove import keyword in example

### DIFF
--- a/website/docs/en/config/source/transform-import.mdx
+++ b/website/docs/en/config/source/transform-import.mdx
@@ -263,7 +263,7 @@ The `transformImport` can be a function, it will accept the previous value, and 
 export default {
   source: {
     transformImport: (imports) => {
-      return imports.filter(import => import.libraryName !== 'antd');
+      return imports.filter((data) => data.libraryName !== 'antd');
     },
   },
 };

--- a/website/docs/zh/config/source/transform-import.mdx
+++ b/website/docs/zh/config/source/transform-import.mdx
@@ -263,7 +263,7 @@ export default {
 export default {
   source: {
     transformImport: (imports) => {
-      return imports.filter(import => import.libraryName !== 'antd');
+      return imports.filter((data) => data.libraryName !== 'antd');
     },
   },
 };


### PR DESCRIPTION
## Summary

Cannot use `import` as variable because `import` is a reserved word of js.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
