### PR TITLE
refacor(create-rsbuild): use Rslib to bundle package

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,6 @@
   },
   "pnpm": {
     "overrides": {
-      "@rsbuild/core": "link:packages/core",
-      "@rsbuild/plugin-less": "link:packages/plugin-less",
-      "@rsbuild/plugin-react": "link:packages/plugin-react",
-      "@rsbuild/plugin-sass": "link:packages/plugin-sass",
       "esbuild": "~0.19.0"
     }
   }

--- a/packages/create-rsbuild/modern.config.ts
+++ b/packages/create-rsbuild/modern.config.ts
@@ -1,7 +1,0 @@
-import { defineConfig, moduleTools } from '@modern-js/module-tools';
-import { esmBuildConfig } from '@rsbuild/config/modern.config.ts';
-
-export default defineConfig({
-  plugins: [moduleTools()],
-  buildConfig: [esmBuildConfig],
-});

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -22,11 +22,12 @@
     "dist"
   ],
   "scripts": {
-    "build": "modern build",
-    "dev": "modern build --watch",
+    "build": "rslib build",
+    "dev": "rslib build --watch",
     "start": "node ./dist/index.js"
   },
   "devDependencies": {
+    "@rslib/core": "0.0.3",
     "@types/node": "18.x",
     "typescript": "^5.5.2"
   },

--- a/packages/create-rsbuild/rslib.config.ts
+++ b/packages/create-rsbuild/rslib.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [{ format: 'esm' }],
+  output: {
+    target: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@rsbuild/core': link:packages/core
-  '@rsbuild/plugin-less': link:packages/plugin-less
-  '@rsbuild/plugin-react': link:packages/plugin-react
-  '@rsbuild/plugin-sass': link:packages/plugin-sass
   esbuild: ~0.19.0
 
 importers:
@@ -98,7 +94,7 @@ importers:
         specifier: 1.44.1
         version: 1.44.1
       '@rsbuild/core':
-        specifier: link:../packages/core
+        specifier: workspace:*
         version: link:../packages/core
       '@rsbuild/plugin-assets-retry':
         specifier: workspace:*
@@ -110,19 +106,19 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1(@rsbuild/core@packages+core)
       '@rsbuild/plugin-less':
-        specifier: link:../packages/plugin-less
+        specifier: workspace:*
         version: link:../packages/plugin-less
       '@rsbuild/plugin-preact':
         specifier: workspace:*
         version: link:../packages/plugin-preact
       '@rsbuild/plugin-react':
-        specifier: link:../packages/plugin-react
+        specifier: workspace:*
         version: link:../packages/plugin-react
       '@rsbuild/plugin-rem':
         specifier: ^1.0.1
         version: 1.0.1(@rsbuild/core@packages+core)
       '@rsbuild/plugin-sass':
-        specifier: link:../packages/plugin-sass
+        specifier: workspace:*
         version: link:../packages/plugin-sass
       '@rsbuild/plugin-solid':
         specifier: workspace:*
@@ -246,7 +242,7 @@ importers:
     dependencies:
       '@rsbuild/plugin-styled-components':
         specifier: ^1.0.1
-        version: 1.0.1
+        version: 1.0.1(@rsbuild/core@1.0.1-rc.0)
       styled-components:
         specifier: ^6.1.12
         version: 6.1.12(react-dom@19.0.0-rc-fb9a90fa48-20240614(react@19.0.0-rc-fb9a90fa48-20240614))(react@19.0.0-rc-fb9a90fa48-20240614)
@@ -286,7 +282,7 @@ importers:
         version: 3.4.38(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../../../packages/core
+        specifier: workspace:*
         version: link:../../../../packages/core
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -303,7 +299,7 @@ importers:
   examples/lit:
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       lit:
         specifier: ^3.2.0
@@ -325,10 +321,10 @@ importers:
         specifier: 0.6.0
         version: 0.6.0(typescript@5.5.2)
       '@rsbuild/core':
-        specifier: link:../../../packages/core
+        specifier: workspace:*
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: link:../../../packages/plugin-react
+        specifier: workspace:*
         version: link:../../../packages/plugin-react
 
   examples/module-federation-v2/remote:
@@ -344,10 +340,10 @@ importers:
         specifier: 0.6.0
         version: 0.6.0(typescript@5.5.2)
       '@rsbuild/core':
-        specifier: link:../../../packages/core
+        specifier: workspace:*
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: link:../../../packages/plugin-react
+        specifier: workspace:*
         version: link:../../../packages/plugin-react
 
   examples/module-federation/host:
@@ -360,10 +356,10 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../../packages/core
+        specifier: workspace:*
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: link:../../../packages/plugin-react
+        specifier: workspace:*
         version: link:../../../packages/plugin-react
 
   examples/module-federation/remote:
@@ -376,16 +372,16 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../../packages/core
+        specifier: workspace:*
         version: link:../../../packages/core
       '@rsbuild/plugin-react':
-        specifier: link:../../../packages/plugin-react
+        specifier: workspace:*
         version: link:../../../packages/plugin-react
 
   examples/node:
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@types/node':
         specifier: 18.x
@@ -401,7 +397,7 @@ importers:
         version: 10.23.2
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-preact':
         specifier: workspace:*
@@ -420,10 +416,10 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-react':
-        specifier: link:../../packages/plugin-react
+        specifier: workspace:*
         version: link:../../packages/plugin-react
       '@types/react':
         specifier: ^18.3.4
@@ -442,7 +438,7 @@ importers:
         version: 1.8.21
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-babel':
         specifier: workspace:*
@@ -458,7 +454,7 @@ importers:
         version: 4.2.19
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-svelte':
         specifier: workspace:*
@@ -467,7 +463,7 @@ importers:
   examples/vanilla:
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       typescript:
         specifier: ^5.5.2
@@ -480,7 +476,7 @@ importers:
         version: 3.4.38(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-vue':
         specifier: workspace:*
@@ -496,7 +492,7 @@ importers:
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@rsbuild/plugin-swc':
         specifier: workspace:*
@@ -533,7 +529,7 @@ importers:
         version: 7.6.3
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../../core
+        specifier: workspace:*
         version: link:../../core
       '@rsbuild/webpack':
         specifier: workspace:*
@@ -554,7 +550,7 @@ importers:
   packages/compat/webpack:
     dependencies:
       '@rsbuild/core':
-        specifier: link:../../core
+        specifier: workspace:*
         version: link:../../core
       copy-webpack-plugin:
         specifier: 11.0.0
@@ -749,6 +745,9 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
     devDependencies:
+      '@rslib/core':
+        specifier: 0.0.3
+        version: 0.0.3(typescript@5.5.2)
       '@types/node':
         specifier: 18.x
         version: 18.19.31
@@ -772,7 +771,7 @@ importers:
         specifier: ^7.24.7
         version: 7.24.7(@babel/core@7.25.2)
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@types/serialize-javascript':
         specifier: ^5.0.4
@@ -812,7 +811,7 @@ importers:
         version: 2.0.1
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -840,7 +839,7 @@ importers:
         version: 1.0.0
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -864,7 +863,7 @@ importers:
   packages/plugin-preact:
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@types/node':
         specifier: 18.x
@@ -883,7 +882,7 @@ importers:
         version: 0.14.2
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -914,7 +913,7 @@ importers:
         version: 1.77.8
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -948,7 +947,7 @@ importers:
         version: 0.6.3(solid-js@1.8.21)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -976,7 +975,7 @@ importers:
         version: 8.1.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(stylus@0.63.0)(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -995,7 +994,7 @@ importers:
         version: 6.0.2(@babel/core@7.25.2)(less@4.2.0)(postcss-load-config@6.0.1(jiti@1.21.6)(postcss@8.4.41)(tsx@4.14.0)(yaml@2.5.0))(postcss@8.4.41)(pug@3.0.3)(sass@1.77.8)(stylus@0.63.0)(svelte@4.2.19)(typescript@5.5.2)
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1013,7 +1012,7 @@ importers:
   packages/plugin-svgr:
     dependencies:
       '@rsbuild/plugin-react':
-        specifier: link:../plugin-react
+        specifier: workspace:*
         version: link:../plugin-react
       '@svgr/core':
         specifier: 8.1.0
@@ -1032,7 +1031,7 @@ importers:
         version: 2.0.4
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1075,7 +1074,7 @@ importers:
         version: 5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1094,7 +1093,7 @@ importers:
         version: 5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1122,7 +1121,7 @@ importers:
         specifier: ^7.25.2
         version: 7.25.2
       '@rsbuild/core':
-        specifier: link:../core
+        specifier: workspace:*
         version: link:../core
       '@scripts/test-helper':
         specifier: workspace:*
@@ -1143,7 +1142,7 @@ importers:
   scripts/test-helper:
     dependencies:
       '@rsbuild/core':
-        specifier: link:../../packages/core
+        specifier: workspace:*
         version: link:../../packages/core
       '@types/lodash':
         specifier: ^4.17.7
@@ -1167,7 +1166,7 @@ importers:
   website:
     devDependencies:
       '@rsbuild/core':
-        specifier: link:../packages/core
+        specifier: workspace:*
         version: link:../packages/core
       '@rspress/plugin-rss':
         specifier: 1.28.1
@@ -2494,17 +2493,26 @@ packages:
       vue-tsc:
         optional: true
 
+  '@module-federation/runtime-tools@0.2.3':
+    resolution: {integrity: sha512-capN8CVTCEqNAjnl102girrkevczoQfnQYyiYC4WuyKsg7+LUqfirIe1Eiyv6VSE2UgvOTZDnqvervA6rBOlmg==}
+
   '@module-federation/runtime-tools@0.5.1':
     resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
 
   '@module-federation/runtime-tools@0.6.0':
     resolution: {integrity: sha512-VB/umcooJx8dSrhv0sGy74LR2Od6xZLCs1tu+Zs5HsnUfbmPc0WNUc+nHn4evp5nHl17HOreQL3Q3c3vrQpbWg==}
 
+  '@module-federation/runtime@0.2.3':
+    resolution: {integrity: sha512-N+ZxBUb1mkmfO9XT1BwgYQgShtUTlijHbukqQ4afFka5lRAT+ayC7RKfHJLz0HbuexKPCmPBDfdmCnErR5WyTQ==}
+
   '@module-federation/runtime@0.5.1':
     resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
 
   '@module-federation/runtime@0.6.0':
     resolution: {integrity: sha512-48GqtmJd3xvbrJwvf3Gl8wE1KTxGLflH7VSs73nNiAMUcK24qTrQAwvbZWzmD3sGuTV8wM0Nd5w+mKoQ/bi6Ng==}
+
+  '@module-federation/sdk@0.2.3':
+    resolution: {integrity: sha512-W9zrPchLocyCBc/B8CW21akcfJXLl++9xBe1L1EtgxZGfj/xwHt0GcBWE/y+QGvYTL2a1iZjwscbftbUhxgxXg==}
 
   '@module-federation/sdk@0.5.1':
     resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
@@ -2514,6 +2522,9 @@ packages:
 
   '@module-federation/third-party-dts-extractor@0.6.0':
     resolution: {integrity: sha512-VVIrirO80wKdL0OIiumIijX2rAvAv5J3ji5/1t06tYAGdnpNydoYlDcpcnv5sCnAHLb8IkM8hG3uF8n0tTEKfw==}
+
+  '@module-federation/webpack-bundler-runtime@0.2.3':
+    resolution: {integrity: sha512-L/jt2uJ+8dwYiyn9GxryzDR6tr/Wk8rpgvelM2EBeLIhu7YxCHSmSjQYhw3BTux9zZIr47d1K9fGjBFsVRd/SQ==}
 
   '@module-federation/webpack-bundler-runtime@0.5.1':
     resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
@@ -2703,32 +2714,85 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rsbuild/core@1.0.1-beta.16':
+    resolution: {integrity: sha512-/0s6E3bKqyxUby2X4H11xQppuXpPWqZzPWkynUX19o9T2K7FuPw5cyuE0iL3f2XlGucmgftSn06Am5HsQV+A+w==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
+  '@rsbuild/core@1.0.1-beta.9':
+    resolution: {integrity: sha512-F9npL47TFmNVhPBqoE6jBvKGxXEKNszBA7skhbi3opskmX7Ako9vfXvtgi2W2jQjq837/WUL8gG/ua9zRqKFEQ==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
+  '@rsbuild/core@1.0.1-rc.0':
+    resolution: {integrity: sha512-tSszHL2sp/iNZkYMOOorgBonh4XAIfJODlt6JBTg5PMAywm+XXdFoEglaKeAM6WiQ/0rQYOataKrHbMkfxmh/A==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
   '@rsbuild/plugin-check-syntax@1.0.1':
     resolution: {integrity: sha512-LN6OVmLJahFwv3dp9Q6k1E4GIpF78cUf7aXxKBvtvYXD0/rRP/1PPs4OWeyOqIcqSikcIdmERj50OECzPdWmpA==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 0.x || 1.x
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
+
+  '@rsbuild/plugin-less@1.0.1-beta.9':
+    resolution: {integrity: sha512-frpPaKqV5btKJJKZZeIrk+CA3edU4N7CzKN5gd2DuvcMb74MUIW5IkpcSalcdrmu6fd6TKEOV9uptoUZ/s4e/A==}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.1-beta.9
+
+  '@rsbuild/plugin-react@1.0.1-beta.9':
+    resolution: {integrity: sha512-MX5bWSEW5Nr8jhNAVxWlNVnraJxtOYTEZna5znaypLv7m4V8w0go1Nzb210ueRSbFCEYvP+zJZzkq33m+3TWXQ==}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.1-beta.9
 
   '@rsbuild/plugin-rem@1.0.1':
     resolution: {integrity: sha512-wsaEvFLVpWsvGi5Bh1j3Yxq1C5RgD+AyveNTbEHaoHHj7ChDx1lrTSRZhre3Jmgjse02gUZjbnAhcO+v5aJPVw==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 1.x || ^1.0.1-beta.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
+
+  '@rsbuild/plugin-sass@1.0.1-beta.9':
+    resolution: {integrity: sha512-5L5Ic5irHEgueIgj/VpIKuOn7MpUjmlm+wBl6gLix4EdEzOto4njFUQs1O4rVQsksenJn6PtSaqf+RG/3jkUrA==}
+    peerDependencies:
+      '@rsbuild/core': ^1.0.1-beta.9
 
   '@rsbuild/plugin-styled-components@1.0.1':
     resolution: {integrity: sha512-1NL0yu5yr7S9wv4xTBYE++CaCved96yoAyd+r/xu4dGfi0w+BrshHNDrPwYBKPX+DC3NZrHGMIsfvpy3QmtloA==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 1.x || ^1.0.1-beta.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
 
+  '@rslib/core@0.0.3':
+    resolution: {integrity: sha512-QtLhmqBn64VvRo8/7L+Xm001XhUVgEE6PMX6KupzD4A499gBjVvk5aUgShuXOou2yLL4/tGaHNBP9x8f70zhzg==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
   '@rspack/binding-darwin-arm64@1.0.0':
     resolution: {integrity: sha512-ZHQk9YK+swlTG48kJTgzFUW9T26KjhLXRok5la7t2AMoiuHyhGHHgC5iQfPJLZ62XzcJ/rfqs2rwakl97151jQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-arm64@1.0.0-beta.1':
+    resolution: {integrity: sha512-KyC+xEMy9Y5JivO2e5rlKFGT74uwDhbwJjSCR5KOLQtZjDWeLwhf7aZhkoSQJUEsK5tAuuUoTP02RJFzK5llpA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-arm64@1.0.0-rc.0':
+    resolution: {integrity: sha512-4S/+q8HN69ErWUjGDePExqiNuKIEGYKEoT+91+Wz55jQV4NY1mNGRojKVKjZkz7MvbPEZ1howtpDcHuUE2+QhQ==}
     cpu: [arm64]
     os: [darwin]
 
@@ -2737,8 +2801,28 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rspack/binding-darwin-x64@1.0.0-beta.1':
+    resolution: {integrity: sha512-Onc35+qQ7YwE6+aB66l/ZnRFXfhA1hXH5aNnNJmIFEAmqzkvOGREkWy3CdfsklF/l/xt33iUM7ccnNgdpk7yKw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@1.0.0-rc.0':
+    resolution: {integrity: sha512-IN96SG6yRz4JwlzuNrhdApEg4J2UI9S8uD38vrJvH9TOO/Dv1puL82EpqTYBZYfbaddZsiZG9+5LNnsU9OEXJg==}
+    cpu: [x64]
+    os: [darwin]
+
   '@rspack/binding-linux-arm64-gnu@1.0.0':
     resolution: {integrity: sha512-yKnlsWgvydJRxDBGGKC+cyDeoSzIvOzuVqCloy5oAFAGOMXMY6bznxrkE6/olGZncdeLEpnJzZmXSuF1dYc8ow==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-gnu@1.0.0-beta.1':
+    resolution: {integrity: sha512-NlXtRlKcoBzB6EQEiXegW0nMToEPXD+hExaev0j1+uzsFrMJ0uIY49k6+DapwWZ8A2jUdvH7xdWT+eAXD3l/EA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
+    resolution: {integrity: sha512-gqURooSNYGlwvgLE1xu8rz68E4Mfa2MONGTNMkre5aIYX2ZOd/MKGaB/R062Oj/78BIHmIGWcoz5GnBxBwToyw==}
     cpu: [arm64]
     os: [linux]
 
@@ -2747,8 +2831,28 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rspack/binding-linux-arm64-musl@1.0.0-beta.1':
+    resolution: {integrity: sha512-fPS8ukoPgmBSUX4dt74flObcbYzO3uaP1bk4k/98Gr3Bw0ACDZ6h5nqlxoXoeVzhNcNMBcfv45un8H3i411AyA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rspack/binding-linux-arm64-musl@1.0.0-rc.0':
+    resolution: {integrity: sha512-302IJXw7F4YpHUEVJA2bkzlNfYp26jKXIddHpG4A3diw0/+5w1C4eDGrC9kuq642kFtu4nwP/8rjP0090/Orxw==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rspack/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-fRk9i8aE4FiwW7+LkNyw+5vfFzJ8BZ2seAL9V5U2iwYwYibzFJsukg3h3Uh+IsGm30/7+ZRENtGwybQiMruL4g==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu@1.0.0-beta.1':
+    resolution: {integrity: sha512-9U78G7BtevPZ9GEJ2AhGHt03n+GEhKVvEZ/tgu+flFV0tYGjq75QQX345x4m+uercTqzRBTyuWITweIzppeWuQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
+    resolution: {integrity: sha512-VsHzd7iAwZA3j48PSj9beKva9wqde1BP2K3AF0aZe7amQoatG57YZtiOthZSWyDlwEm7VCuE6/4Jgf8vOQJX2g==}
     cpu: [x64]
     os: [linux]
 
@@ -2757,8 +2861,28 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rspack/binding-linux-x64-musl@1.0.0-beta.1':
+    resolution: {integrity: sha512-qqNPseWAOKmV33YL7tihY0N9xwY+N1G9na6lT7iqZnsrzPkIZmESI9Z24fXVJqLC/UhfxAth4RKhVBeKTsPk1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rspack/binding-linux-x64-musl@1.0.0-rc.0':
+    resolution: {integrity: sha512-M6/SC33xWdlV2pmR3O3MrhfBZBpicMCl+GrJ0MXFb9ziC7auuuLfMmfqMakorphfL2yOOwSfcfZF8V2iiYoENw==}
+    cpu: [x64]
+    os: [linux]
+
   '@rspack/binding-win32-arm64-msvc@1.0.0':
     resolution: {integrity: sha512-gqtakP0Yl2aj+Q/Giwgt31hz8eOZpo2s+sJlkMJGVdIF4dejB31a8vbj/VNGeSN1tDRiLI4cyqa5eQU//t26aQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.0.0-beta.1':
+    resolution: {integrity: sha512-VeBGYItHWqImYt23rBChXrk1o7fQxwTv6BEhtMpTnMJV10O6+Db9NckPEplcKLmNKAAA5anxH40GcpPc4nff8A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
+    resolution: {integrity: sha512-ob510ObXoIBAMjPE8iBwvhWQ8Hd4v7bJSgImUBhSGExYI+z8b/gl8tNg8y1fttLtNO8j05rj9QFsGcZmv89Zsg==}
     cpu: [arm64]
     os: [win32]
 
@@ -2767,16 +2891,60 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@1.0.0-beta.1':
+    resolution: {integrity: sha512-ZxLQ1zOpyCKefsKvDYGGIHM019avNPfesJKdw7wYqeC+EIvWZfs86lnhlSL5PlZzV5AfFZQyQJFRjAv4JPpe4Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
+    resolution: {integrity: sha512-1A+3JorREQJqBcTLEY0LhGMb5B3Qlz/LmRr3K+gNBZinscZU+DKiDnZkSGdn8FuCn40E39T8V4i73mxQCqVuvQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.0.0':
     resolution: {integrity: sha512-H9PqjgtZMw5aP+eXdFo7bgSP/Ycwn3oW81uI9qFqOOQ90W+o3T9ItghHBf2/ksc5GHibd208EwOBNxbKwjZDSQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.0.0-beta.1':
+    resolution: {integrity: sha512-tMrjEA/2SGMVLbh/zOQoZrr1Xx+oI6RZnkXH6l95ON4yZiD+8wM84w8Ernj1N8KwclTuvBzxM0r3DLHTNZcDhw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
+    resolution: {integrity: sha512-t6E4t668CvP+DqNDluYJMivrDtFZ0iQhUYxXd0UUhDSwXKTbGW2tOwBXGaZ3gzj9OpqWCUVJ3pqP11KiBckorw==}
     cpu: [x64]
     os: [win32]
 
   '@rspack/binding@1.0.0':
     resolution: {integrity: sha512-eLyqSEM1h/exJYn98k+9MRktP8AYDB13x5oVn8hoxVucuhk0TubFqQSX8h9SQcZp1O3j/Z8eWWwOaNPe3JU40Q==}
 
+  '@rspack/binding@1.0.0-beta.1':
+    resolution: {integrity: sha512-p7XBvk1+fAmvrlmdeRr5J9wdXx5idVZjHFJu/3qPHWf5mHKRw2/tQVbqzExj+B1nwR6HXFgxCiiddaWauMS/YQ==}
+
+  '@rspack/binding@1.0.0-rc.0':
+    resolution: {integrity: sha512-mx0x4ho0ndHpOnSjAEOoQZohTqJLYOl4hLEvQLEnXIPTdMjZtpiLUyuyKtzv6DrXDV5La3bsZuzbcdMyqkSWpg==}
+
   '@rspack/core@1.0.0':
     resolution: {integrity: sha512-F4RA9uOLLvD1oTKa96Gcly+Sro1qaqPNENadFyiPwepa7DrwexQa/ym6CQKbvKMOYGKlVSFDPUmgFAirz35ETg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.0.0-beta.1':
+    resolution: {integrity: sha512-aUWR/FUUw7x0L/qEZ0qrXC+7YYOL0Ezwd95TqDIDIYkSODJ6ZPt3a8poPwWc7IBdONgb8sGDPTzAXXEjcsBMwQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@swc/helpers': '>=0.5.1'
+    peerDependenciesMeta:
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@1.0.0-rc.0':
+    resolution: {integrity: sha512-sxS6QfVm7FbuKIYai8CyxMv5WH3MVdQmowVEqIZ/Fa8+PX17/sO5dg8tAFYAEzpCe/4dC93eYh9APr3Vc4ditQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2788,8 +2956,20 @@ packages:
     resolution: {integrity: sha512-7MZf4lburSUZoEenwazwUDKHhqyfnLCGnQ/tKcUtztfmVzfjZfRn/EaiT0AKkYGnL2U8AGsw89oUeVyvaOLVCw==}
     engines: {node: '>=16.0.0'}
 
+  '@rspack/lite-tapable@1.0.0-beta.1':
+    resolution: {integrity: sha512-r4xtbJp6QhW6A1twkgTP0UQkPC9cOT3sFjjjlx22j/q669HJRz+CVTlVcNxPomK7Q3Kg6dVsyv16MjGRl/fl5g==}
+    engines: {node: '>=16.0.0'}
+
   '@rspack/plugin-react-refresh@1.0.0':
     resolution: {integrity: sha512-WvXkLewW5G0Mlo5H1b251yDh5FFiH4NDAbYlFpvFjcuXX2AchZRf9zdw57BDE/ADyWsJgA8kixN/zZWBTN3iYA==}
+    peerDependencies:
+      react-refresh: '>=0.10.0 <1.0.0'
+    peerDependenciesMeta:
+      react-refresh:
+        optional: true
+
+  '@rspack/plugin-react-refresh@1.0.0-beta.1':
+    resolution: {integrity: sha512-TLv3aB0NJtGPY38cMktnEkJ64RGLCed7MxQhc7f6V5FzOc3cZldTYSMThTZw1R/APc7GIHC4A26Ny5IogYlzvw==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
     peerDependenciesMeta:
@@ -3042,6 +3222,9 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
+
+  '@swc/helpers@0.5.11':
+    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@swc/helpers@0.5.12':
     resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
@@ -3846,6 +4029,9 @@ packages:
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+
+  core-js@3.37.1:
+    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
 
   core-js@3.38.1:
     resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
@@ -6208,10 +6394,23 @@ packages:
       webpack:
         optional: true
 
+  rsbuild-plugin-dts@0.0.3:
+    resolution: {integrity: sha512-61qs3CMkP/kWAchghCw1Oj/JQJhxXC2K/UgNKrNYdy4x6jb4x/SububXKJmGS77rNR+tztOVNHrDwX4FTL2weA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@microsoft/api-extractor': ^7
+      '@rsbuild/core': 1.x
+      typescript: ^5
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      typescript:
+        optional: true
+
   rsbuild-plugin-google-analytics@1.0.2:
     resolution: {integrity: sha512-V2RjSPW0xFDCpH5W6N7zYuYxyZxklsaE/H3WwNCDW+52vBouYAZ8/SDJ1w8ogbfzysX7TcNm3hId42dJU49IOg==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 0.x || 1.x || ^1.0.1-beta.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -6219,7 +6418,7 @@ packages:
   rsbuild-plugin-open-graph@1.0.2:
     resolution: {integrity: sha512-JGBMM9T7GNX47Y3jiSJkhoK2rT1bb7+TOO6yYpMHW+/3PLD9i0vv2S4qfdskTnVo8kTNEAYzTZrd+k+XuWxcNA==}
     peerDependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 0.x || 1.x || ^1.0.1-beta.0
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
@@ -8966,6 +9165,11 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@module-federation/runtime-tools@0.2.3':
+    dependencies:
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/webpack-bundler-runtime': 0.2.3
+
   '@module-federation/runtime-tools@0.5.1':
     dependencies:
       '@module-federation/runtime': 0.5.1
@@ -8976,6 +9180,10 @@ snapshots:
       '@module-federation/runtime': 0.6.0
       '@module-federation/webpack-bundler-runtime': 0.6.0
 
+  '@module-federation/runtime@0.2.3':
+    dependencies:
+      '@module-federation/sdk': 0.2.3
+
   '@module-federation/runtime@0.5.1':
     dependencies:
       '@module-federation/sdk': 0.5.1
@@ -8983,6 +9191,8 @@ snapshots:
   '@module-federation/runtime@0.6.0':
     dependencies:
       '@module-federation/sdk': 0.6.0
+
+  '@module-federation/sdk@0.2.3': {}
 
   '@module-federation/sdk@0.5.1': {}
 
@@ -8993,6 +9203,11 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
+
+  '@module-federation/webpack-bundler-runtime@0.2.3':
+    dependencies:
+      '@module-federation/runtime': 0.2.3
+      '@module-federation/sdk': 0.2.3
 
   '@module-federation/webpack-bundler-runtime@0.5.1':
     dependencies:
@@ -9127,6 +9342,37 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.1':
     optional: true
 
+  '@rsbuild/core@1.0.1-beta.16':
+    dependencies:
+      '@rspack/core': 1.0.0-rc.0(@swc/helpers@0.5.12)
+      '@rspack/lite-tapable': 1.0.0
+      '@swc/helpers': 0.5.12
+      caniuse-lite: 1.0.30001653
+      core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  '@rsbuild/core@1.0.1-beta.9':
+    dependencies:
+      '@rspack/core': 1.0.0-beta.1(@swc/helpers@0.5.11)
+      '@rspack/lite-tapable': 1.0.0-beta.1
+      '@swc/helpers': 0.5.11
+      caniuse-lite: 1.0.30001653
+      core-js: 3.37.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  '@rsbuild/core@1.0.1-rc.0':
+    dependencies:
+      '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
+      '@rspack/lite-tapable': 1.0.0
+      '@swc/helpers': 0.5.12
+      caniuse-lite: 1.0.30001653
+      core-js: 3.38.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    optional: true
+
   '@rsbuild/plugin-check-syntax@1.0.1(@rsbuild/core@packages+core)':
     dependencies:
       acorn: 8.12.1
@@ -9137,6 +9383,18 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
+  '@rsbuild/plugin-less@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+    dependencies:
+      '@rsbuild/core': 1.0.1-beta.9
+      deepmerge: 4.3.1
+      reduce-configs: 1.0.0
+
+  '@rsbuild/plugin-react@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+    dependencies:
+      '@rsbuild/core': 1.0.1-beta.9
+      '@rspack/plugin-react-refresh': 1.0.0-beta.1(react-refresh@0.14.2)
+      react-refresh: 0.14.2
+
   '@rsbuild/plugin-rem@1.0.1(@rsbuild/core@packages+core)':
     dependencies:
       deepmerge: 4.3.1
@@ -9144,36 +9402,108 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-styled-components@1.0.1':
+  '@rsbuild/plugin-sass@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+    dependencies:
+      '@rsbuild/core': 1.0.1-beta.9
+      deepmerge: 4.3.1
+      loader-utils: 2.0.4
+      postcss: 8.4.41
+      reduce-configs: 1.0.0
+      sass-embedded: 1.77.8
+
+  '@rsbuild/plugin-styled-components@1.0.1(@rsbuild/core@1.0.1-rc.0)':
     dependencies:
       '@swc/plugin-styled-components': 2.0.11
       reduce-configs: 1.0.0
+    optionalDependencies:
+      '@rsbuild/core': 1.0.1-rc.0
+
+  '@rslib/core@0.0.3(typescript@5.5.2)':
+    dependencies:
+      '@rsbuild/core': 1.0.1-beta.16
+      rsbuild-plugin-dts: 0.0.3(@rsbuild/core@1.0.1-beta.16)(typescript@5.5.2)
+    optionalDependencies:
+      typescript: 5.5.2
 
   '@rspack/binding-darwin-arm64@1.0.0':
+    optional: true
+
+  '@rspack/binding-darwin-arm64@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.0':
     optional: true
 
+  '@rspack/binding-darwin-x64@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-darwin-x64@1.0.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-arm64-gnu@1.0.0':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.0':
     optional: true
 
+  '@rspack/binding-linux-arm64-musl@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-arm64-musl@1.0.0-rc.0':
+    optional: true
+
   '@rspack/binding-linux-x64-gnu@1.0.0':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.0':
     optional: true
 
+  '@rspack/binding-linux-x64-musl@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@1.0.0-rc.0':
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.0.0':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.0':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.0.0':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.0.0-beta.1':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding@1.0.0':
@@ -9188,6 +9518,30 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.0
       '@rspack/binding-win32-x64-msvc': 1.0.0
 
+  '@rspack/binding@1.0.0-beta.1':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.0-beta.1
+      '@rspack/binding-darwin-x64': 1.0.0-beta.1
+      '@rspack/binding-linux-arm64-gnu': 1.0.0-beta.1
+      '@rspack/binding-linux-arm64-musl': 1.0.0-beta.1
+      '@rspack/binding-linux-x64-gnu': 1.0.0-beta.1
+      '@rspack/binding-linux-x64-musl': 1.0.0-beta.1
+      '@rspack/binding-win32-arm64-msvc': 1.0.0-beta.1
+      '@rspack/binding-win32-ia32-msvc': 1.0.0-beta.1
+      '@rspack/binding-win32-x64-msvc': 1.0.0-beta.1
+
+  '@rspack/binding@1.0.0-rc.0':
+    optionalDependencies:
+      '@rspack/binding-darwin-arm64': 1.0.0-rc.0
+      '@rspack/binding-darwin-x64': 1.0.0-rc.0
+      '@rspack/binding-linux-arm64-gnu': 1.0.0-rc.0
+      '@rspack/binding-linux-arm64-musl': 1.0.0-rc.0
+      '@rspack/binding-linux-x64-gnu': 1.0.0-rc.0
+      '@rspack/binding-linux-x64-musl': 1.0.0-rc.0
+      '@rspack/binding-win32-arm64-msvc': 1.0.0-rc.0
+      '@rspack/binding-win32-ia32-msvc': 1.0.0-rc.0
+      '@rspack/binding-win32-x64-msvc': 1.0.0-rc.0
+
   '@rspack/core@1.0.0(@swc/helpers@0.5.12)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
@@ -9197,9 +9551,36 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.12
 
+  '@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.2.3
+      '@rspack/binding': 1.0.0-beta.1
+      '@rspack/lite-tapable': 1.0.0-beta.1
+      caniuse-lite: 1.0.30001653
+    optionalDependencies:
+      '@swc/helpers': 0.5.11
+
+  '@rspack/core@1.0.0-rc.0(@swc/helpers@0.5.12)':
+    dependencies:
+      '@module-federation/runtime-tools': 0.5.1
+      '@rspack/binding': 1.0.0-rc.0
+      '@rspack/lite-tapable': 1.0.0
+      caniuse-lite: 1.0.30001653
+    optionalDependencies:
+      '@swc/helpers': 0.5.12
+
   '@rspack/lite-tapable@1.0.0': {}
 
+  '@rspack/lite-tapable@1.0.0-beta.1': {}
+
   '@rspack/plugin-react-refresh@1.0.0(react-refresh@0.14.2)':
+    dependencies:
+      error-stack-parser: 2.1.4
+      html-entities: 2.3.3
+    optionalDependencies:
+      react-refresh: 0.14.2
+
+  '@rspack/plugin-react-refresh@1.0.0-beta.1(react-refresh@0.14.2)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.3.3
@@ -9213,10 +9594,10 @@ snapshots:
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
       '@modern-js/utils': 2.58.1
-      '@rsbuild/core': link:packages/core
-      '@rsbuild/plugin-less': link:packages/plugin-less
-      '@rsbuild/plugin-react': link:packages/plugin-react
-      '@rsbuild/plugin-sass': link:packages/plugin-sass
+      '@rsbuild/core': 1.0.1-beta.9
+      '@rsbuild/plugin-less': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
+      '@rsbuild/plugin-react': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
+      '@rsbuild/plugin-sass': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
       '@rspress/mdx-rs': 0.5.7
       '@rspress/plugin-auto-nav-sidebar': 1.28.1
       '@rspress/plugin-container-syntax': 1.28.1
@@ -9330,7 +9711,7 @@ snapshots:
 
   '@rspress/shared@1.28.1':
     dependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 1.0.1-beta.9
       chalk: 5.3.0
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -9502,6 +9883,10 @@ snapshots:
     optional: true
 
   '@swc/counter@0.1.3': {}
+
+  '@swc/helpers@0.5.11':
+    dependencies:
+      tslib: 2.6.2
 
   '@swc/helpers@0.5.12':
     dependencies:
@@ -10447,6 +10832,8 @@ snapshots:
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.23.3
+
+  core-js@3.37.1: {}
 
   core-js@3.38.1: {}
 
@@ -13272,6 +13659,14 @@ snapshots:
     optionalDependencies:
       webpack: 5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
 
+  rsbuild-plugin-dts@0.0.3(@rsbuild/core@1.0.1-beta.16)(typescript@5.5.2):
+    dependencies:
+      '@rsbuild/core': 1.0.1-beta.16
+      fast-glob: 3.3.2
+      picocolors: 1.0.1
+    optionalDependencies:
+      typescript: 5.5.2
+
   rsbuild-plugin-google-analytics@1.0.2(@rsbuild/core@packages+core):
     optionalDependencies:
       '@rsbuild/core': link:packages/core
@@ -13303,7 +13698,7 @@ snapshots:
 
   rspress@1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
-      '@rsbuild/core': link:packages/core
+      '@rsbuild/core': 1.0.1-beta.9
       '@rspress/core': 1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       '@rspress/shared': 1.28.1
       cac: 6.7.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1169,8 +1169,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@rspress/plugin-rss':
-        specifier: 1.28.1
-        version: 1.28.1(react@18.3.1)(rspress@1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))))
+        specifier: 1.28.2
+        version: 1.28.2(react@18.3.1)(rspress@1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))))
       '@rstack-dev/doc-ui':
         specifier: ^1.2.0
         version: 1.2.0(@emotion/is-prop-valid@1.2.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1199,8 +1199,8 @@ importers:
         specifier: 1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
       rspress:
-        specifier: 1.28.1
-        version: 1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
+        specifier: 1.28.2
+        version: 1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -2458,9 +2458,6 @@ packages:
   '@modern-js/types@2.58.2':
     resolution: {integrity: sha512-D1RC9s5k9b2ym2zNtMXYTkyD7E6Bnv/z3+XGMM65q784ydWtWcuf/c14XYwmdsiK/ACAzBTyzenZ/L7n7LUYmA==}
 
-  '@modern-js/utils@2.58.1':
-    resolution: {integrity: sha512-JemTkJ4UqqFbJ72NqBXzMFG0dqw70HTGDoX7VAXdYPrEmn8LRvSqHlSCIeX5KF1U+KNa0a7OEdsb9Q56UESjdQ==}
-
   '@modern-js/utils@2.58.2':
     resolution: {integrity: sha512-nIT6jOdYSqNDDZq3arf8WoIcxhznTdK+AgwWZ5dqpL7IUzfUBt80MgOThttVZL8c10N0SGgbeEsQZpdpkCA+gA==}
 
@@ -2493,26 +2490,17 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/runtime-tools@0.2.3':
-    resolution: {integrity: sha512-capN8CVTCEqNAjnl102girrkevczoQfnQYyiYC4WuyKsg7+LUqfirIe1Eiyv6VSE2UgvOTZDnqvervA6rBOlmg==}
-
   '@module-federation/runtime-tools@0.5.1':
     resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
 
   '@module-federation/runtime-tools@0.6.0':
     resolution: {integrity: sha512-VB/umcooJx8dSrhv0sGy74LR2Od6xZLCs1tu+Zs5HsnUfbmPc0WNUc+nHn4evp5nHl17HOreQL3Q3c3vrQpbWg==}
 
-  '@module-federation/runtime@0.2.3':
-    resolution: {integrity: sha512-N+ZxBUb1mkmfO9XT1BwgYQgShtUTlijHbukqQ4afFka5lRAT+ayC7RKfHJLz0HbuexKPCmPBDfdmCnErR5WyTQ==}
-
   '@module-federation/runtime@0.5.1':
     resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
 
   '@module-federation/runtime@0.6.0':
     resolution: {integrity: sha512-48GqtmJd3xvbrJwvf3Gl8wE1KTxGLflH7VSs73nNiAMUcK24qTrQAwvbZWzmD3sGuTV8wM0Nd5w+mKoQ/bi6Ng==}
-
-  '@module-federation/sdk@0.2.3':
-    resolution: {integrity: sha512-W9zrPchLocyCBc/B8CW21akcfJXLl++9xBe1L1EtgxZGfj/xwHt0GcBWE/y+QGvYTL2a1iZjwscbftbUhxgxXg==}
 
   '@module-federation/sdk@0.5.1':
     resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
@@ -2522,9 +2510,6 @@ packages:
 
   '@module-federation/third-party-dts-extractor@0.6.0':
     resolution: {integrity: sha512-VVIrirO80wKdL0OIiumIijX2rAvAv5J3ji5/1t06tYAGdnpNydoYlDcpcnv5sCnAHLb8IkM8hG3uF8n0tTEKfw==}
-
-  '@module-federation/webpack-bundler-runtime@0.2.3':
-    resolution: {integrity: sha512-L/jt2uJ+8dwYiyn9GxryzDR6tr/Wk8rpgvelM2EBeLIhu7YxCHSmSjQYhw3BTux9zZIr47d1K9fGjBFsVRd/SQ==}
 
   '@module-federation/webpack-bundler-runtime@0.5.1':
     resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
@@ -2719,11 +2704,6 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.0.1-beta.9':
-    resolution: {integrity: sha512-F9npL47TFmNVhPBqoE6jBvKGxXEKNszBA7skhbi3opskmX7Ako9vfXvtgi2W2jQjq837/WUL8gG/ua9zRqKFEQ==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-
   '@rsbuild/core@1.0.1-rc.0':
     resolution: {integrity: sha512-tSszHL2sp/iNZkYMOOorgBonh4XAIfJODlt6JBTg5PMAywm+XXdFoEglaKeAM6WiQ/0rQYOataKrHbMkfxmh/A==}
     engines: {node: '>=16.7.0'}
@@ -2737,15 +2717,15 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-less@1.0.1-beta.9':
-    resolution: {integrity: sha512-frpPaKqV5btKJJKZZeIrk+CA3edU4N7CzKN5gd2DuvcMb74MUIW5IkpcSalcdrmu6fd6TKEOV9uptoUZ/s4e/A==}
+  '@rsbuild/plugin-less@1.0.1-beta.16':
+    resolution: {integrity: sha512-uZ0YwUTEX2c0o63hfF4Xz0SIaSlPfqRWyvKSB2c8/He8u/8nlBXcjCHbmiCA5lzp134y5SwfhO7nC6CdY7LdWA==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.1-beta.9
+      '@rsbuild/core': ^1.0.1-beta.16
 
-  '@rsbuild/plugin-react@1.0.1-beta.9':
-    resolution: {integrity: sha512-MX5bWSEW5Nr8jhNAVxWlNVnraJxtOYTEZna5znaypLv7m4V8w0go1Nzb210ueRSbFCEYvP+zJZzkq33m+3TWXQ==}
+  '@rsbuild/plugin-react@1.0.1-beta.16':
+    resolution: {integrity: sha512-c9TyoM+y8tJkmPAfnqC0u8FxuOxCXIjdGhYeAFUniVJrBEwZfJ+O/SvzqjbCtPF+3AhWJAYwDdecq0GhDN2FmQ==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.1-beta.9
+      '@rsbuild/core': ^1.0.1-beta.16
 
   '@rsbuild/plugin-rem@1.0.1':
     resolution: {integrity: sha512-wsaEvFLVpWsvGi5Bh1j3Yxq1C5RgD+AyveNTbEHaoHHj7ChDx1lrTSRZhre3Jmgjse02gUZjbnAhcO+v5aJPVw==}
@@ -2755,10 +2735,10 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-sass@1.0.1-beta.9':
-    resolution: {integrity: sha512-5L5Ic5irHEgueIgj/VpIKuOn7MpUjmlm+wBl6gLix4EdEzOto4njFUQs1O4rVQsksenJn6PtSaqf+RG/3jkUrA==}
+  '@rsbuild/plugin-sass@1.0.1-beta.16':
+    resolution: {integrity: sha512-nbQf802dgwikxqsziIHP88F1ds3jaQ04rekoDx0qGX57jpU/oCbWeSEMydwEuvddjuOdE2epM/aaM5oPN693Hw==}
     peerDependencies:
-      '@rsbuild/core': ^1.0.1-beta.9
+      '@rsbuild/core': ^1.0.1-beta.16
 
   '@rsbuild/plugin-styled-components@1.0.1':
     resolution: {integrity: sha512-1NL0yu5yr7S9wv4xTBYE++CaCved96yoAyd+r/xu4dGfi0w+BrshHNDrPwYBKPX+DC3NZrHGMIsfvpy3QmtloA==}
@@ -2786,11 +2766,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rspack/binding-darwin-arm64@1.0.0-beta.1':
-    resolution: {integrity: sha512-KyC+xEMy9Y5JivO2e5rlKFGT74uwDhbwJjSCR5KOLQtZjDWeLwhf7aZhkoSQJUEsK5tAuuUoTP02RJFzK5llpA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     resolution: {integrity: sha512-4S/+q8HN69ErWUjGDePExqiNuKIEGYKEoT+91+Wz55jQV4NY1mNGRojKVKjZkz7MvbPEZ1howtpDcHuUE2+QhQ==}
     cpu: [arm64]
@@ -2798,11 +2773,6 @@ packages:
 
   '@rspack/binding-darwin-x64@1.0.0':
     resolution: {integrity: sha512-qhTXm9wUhv2lBjsqqfCu59RchH1/2jursdPAmTqGc7zMReZdZvtJs2Ri6Ma1M48BLLu+7fS4fbL8Rw1g78TOOQ==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.0.0-beta.1':
-    resolution: {integrity: sha512-Onc35+qQ7YwE6+aB66l/ZnRFXfhA1hXH5aNnNJmIFEAmqzkvOGREkWy3CdfsklF/l/xt33iUM7ccnNgdpk7yKw==}
     cpu: [x64]
     os: [darwin]
 
@@ -2816,11 +2786,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-arm64-gnu@1.0.0-beta.1':
-    resolution: {integrity: sha512-NlXtRlKcoBzB6EQEiXegW0nMToEPXD+hExaev0j1+uzsFrMJ0uIY49k6+DapwWZ8A2jUdvH7xdWT+eAXD3l/EA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     resolution: {integrity: sha512-gqURooSNYGlwvgLE1xu8rz68E4Mfa2MONGTNMkre5aIYX2ZOd/MKGaB/R062Oj/78BIHmIGWcoz5GnBxBwToyw==}
     cpu: [arm64]
@@ -2828,11 +2793,6 @@ packages:
 
   '@rspack/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-dKFmlqlF4FELT/AX02hSwX8aRawjH5zAliQzYnvgrqcEyCKE60vKacGJQ3ZeRyru6dh5MlbUNW4H1+TDT+cDVA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.0.0-beta.1':
-    resolution: {integrity: sha512-fPS8ukoPgmBSUX4dt74flObcbYzO3uaP1bk4k/98Gr3Bw0ACDZ6h5nqlxoXoeVzhNcNMBcfv45un8H3i411AyA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2846,11 +2806,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.0.0-beta.1':
-    resolution: {integrity: sha512-9U78G7BtevPZ9GEJ2AhGHt03n+GEhKVvEZ/tgu+flFV0tYGjq75QQX345x4m+uercTqzRBTyuWITweIzppeWuQ==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
     resolution: {integrity: sha512-VsHzd7iAwZA3j48PSj9beKva9wqde1BP2K3AF0aZe7amQoatG57YZtiOthZSWyDlwEm7VCuE6/4Jgf8vOQJX2g==}
     cpu: [x64]
@@ -2858,11 +2813,6 @@ packages:
 
   '@rspack/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-qcTJC8o3KvLwsnrJJcuBjfzSrjEbACMiCB4RtbFNecXDtI+Nputx1CO1SlUrINC25/44ILketf0/hsdBQHk60g==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.0.0-beta.1':
-    resolution: {integrity: sha512-qqNPseWAOKmV33YL7tihY0N9xwY+N1G9na6lT7iqZnsrzPkIZmESI9Z24fXVJqLC/UhfxAth4RKhVBeKTsPk1w==}
     cpu: [x64]
     os: [linux]
 
@@ -2876,11 +2826,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rspack/binding-win32-arm64-msvc@1.0.0-beta.1':
-    resolution: {integrity: sha512-VeBGYItHWqImYt23rBChXrk1o7fQxwTv6BEhtMpTnMJV10O6+Db9NckPEplcKLmNKAAA5anxH40GcpPc4nff8A==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     resolution: {integrity: sha512-ob510ObXoIBAMjPE8iBwvhWQ8Hd4v7bJSgImUBhSGExYI+z8b/gl8tNg8y1fttLtNO8j05rj9QFsGcZmv89Zsg==}
     cpu: [arm64]
@@ -2888,11 +2833,6 @@ packages:
 
   '@rspack/binding-win32-ia32-msvc@1.0.0':
     resolution: {integrity: sha512-nLfGu5DjdzwawzZ7zK69vZX5aL1Gt9+Ovfz4RlngDq/D5ZzqCnNWw93cqKADgFRWS4qK9vOD9RXNNnkyWB2SEw==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.0.0-beta.1':
-    resolution: {integrity: sha512-ZxLQ1zOpyCKefsKvDYGGIHM019avNPfesJKdw7wYqeC+EIvWZfs86lnhlSL5PlZzV5AfFZQyQJFRjAv4JPpe4Q==}
     cpu: [ia32]
     os: [win32]
 
@@ -2906,11 +2846,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.0.0-beta.1':
-    resolution: {integrity: sha512-tMrjEA/2SGMVLbh/zOQoZrr1Xx+oI6RZnkXH6l95ON4yZiD+8wM84w8Ernj1N8KwclTuvBzxM0r3DLHTNZcDhw==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
     resolution: {integrity: sha512-t6E4t668CvP+DqNDluYJMivrDtFZ0iQhUYxXd0UUhDSwXKTbGW2tOwBXGaZ3gzj9OpqWCUVJ3pqP11KiBckorw==}
     cpu: [x64]
@@ -2919,23 +2854,11 @@ packages:
   '@rspack/binding@1.0.0':
     resolution: {integrity: sha512-eLyqSEM1h/exJYn98k+9MRktP8AYDB13x5oVn8hoxVucuhk0TubFqQSX8h9SQcZp1O3j/Z8eWWwOaNPe3JU40Q==}
 
-  '@rspack/binding@1.0.0-beta.1':
-    resolution: {integrity: sha512-p7XBvk1+fAmvrlmdeRr5J9wdXx5idVZjHFJu/3qPHWf5mHKRw2/tQVbqzExj+B1nwR6HXFgxCiiddaWauMS/YQ==}
-
   '@rspack/binding@1.0.0-rc.0':
     resolution: {integrity: sha512-mx0x4ho0ndHpOnSjAEOoQZohTqJLYOl4hLEvQLEnXIPTdMjZtpiLUyuyKtzv6DrXDV5La3bsZuzbcdMyqkSWpg==}
 
   '@rspack/core@1.0.0':
     resolution: {integrity: sha512-F4RA9uOLLvD1oTKa96Gcly+Sro1qaqPNENadFyiPwepa7DrwexQa/ym6CQKbvKMOYGKlVSFDPUmgFAirz35ETg==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
-
-  '@rspack/core@1.0.0-beta.1':
-    resolution: {integrity: sha512-aUWR/FUUw7x0L/qEZ0qrXC+7YYOL0Ezwd95TqDIDIYkSODJ6ZPt3a8poPwWc7IBdONgb8sGDPTzAXXEjcsBMwQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@swc/helpers': '>=0.5.1'
@@ -2956,10 +2879,6 @@ packages:
     resolution: {integrity: sha512-7MZf4lburSUZoEenwazwUDKHhqyfnLCGnQ/tKcUtztfmVzfjZfRn/EaiT0AKkYGnL2U8AGsw89oUeVyvaOLVCw==}
     engines: {node: '>=16.0.0'}
 
-  '@rspack/lite-tapable@1.0.0-beta.1':
-    resolution: {integrity: sha512-r4xtbJp6QhW6A1twkgTP0UQkPC9cOT3sFjjjlx22j/q669HJRz+CVTlVcNxPomK7Q3Kg6dVsyv16MjGRl/fl5g==}
-    engines: {node: '>=16.0.0'}
-
   '@rspack/plugin-react-refresh@1.0.0':
     resolution: {integrity: sha512-WvXkLewW5G0Mlo5H1b251yDh5FFiH4NDAbYlFpvFjcuXX2AchZRf9zdw57BDE/ADyWsJgA8kixN/zZWBTN3iYA==}
     peerDependencies:
@@ -2968,16 +2887,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspack/plugin-react-refresh@1.0.0-beta.1':
-    resolution: {integrity: sha512-TLv3aB0NJtGPY38cMktnEkJ64RGLCed7MxQhc7f6V5FzOc3cZldTYSMThTZw1R/APc7GIHC4A26Ny5IogYlzvw==}
-    peerDependencies:
-      react-refresh: '>=0.10.0 <1.0.0'
-    peerDependenciesMeta:
-      react-refresh:
-        optional: true
-
-  '@rspress/core@1.28.1':
-    resolution: {integrity: sha512-JNlOiTGz9123zDzg/+cUod+4He1Pn2oHNq2vVb2W52HXOrFUwWRCc/WplkWsqK7wywBzvCKZkh0auRowg0pzzA==}
+  '@rspress/core@1.28.2':
+    resolution: {integrity: sha512-8ul7vc/unTxLIlDA4zNkX3qvap4rLLwU3ltdyVll6i911WyfjxKsCNnn0pS7Jxf8VSFN8qqREnQFUe4CkTYI9w==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.5.7':
@@ -3032,40 +2943,40 @@ packages:
     resolution: {integrity: sha512-Ie9TqTeMF7yCBqKAOxyLD1W2cDhRZkMsIFD4UJ9nAJTuV4zMj1aXoaKL94phsnl6ImDykF/dohTeuBUrwch08g==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.28.1':
-    resolution: {integrity: sha512-ESEHfzxVQUq71Uz0/VvpSIcNPFvhyCQRDDHo9WwBHKl0lyHSY5bFUVyhApi2JoASk/9jw1Xh1feklrdnkf1sDQ==}
+  '@rspress/plugin-auto-nav-sidebar@1.28.2':
+    resolution: {integrity: sha512-/1Vu5QecxDrPiwFR3ZwdUQyp1obdHIL4d1018aTCMc/VxgsYbr4GTdFBoNmcFCitezNDuBXUVlM/bU/b2d+dMA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-container-syntax@1.28.1':
-    resolution: {integrity: sha512-hi2QuAdEqz9dxB5EBs0p10GbK4fDPd9Uan0LQdsUzdOnY6sJTZyEVMUtdxfUbX9YSdr+wm649PSjRnkp0dYGeA==}
+  '@rspress/plugin-container-syntax@1.28.2':
+    resolution: {integrity: sha512-ejFQXseX0bixlRmuhRkc4BIiqTFwAUpefJB/ptnpPTXSyCQ1U2eVbm3/rh+sNPstNy6iTcJO21fZSf1da7qtyw==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@1.28.1':
-    resolution: {integrity: sha512-ZZPkHtnMpl6aGsXY8RHrYzVyjjYD5FPG8OwNGtk7pRxEVml1z2cxbs9Hc6K2SqzjmNibI/ILSw+GgzGsjsVs5A==}
+  '@rspress/plugin-last-updated@1.28.2':
+    resolution: {integrity: sha512-bQML2v3PFllt9KbZ1TD8+F7V1qcTjywE8ig6ky3pl4xCKEWJnFSgQiL8mOgf8purOF8JZhc5X4N3yWvv0zVA9g==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@1.28.1':
-    resolution: {integrity: sha512-RcWiGXClE8ZdCs35cAPwT1J7MDuWbvVUyDSxnfFTq4a1bOsAhNIkqeda5erTd9HfAXdENWXVM+e3sLd9kQY26g==}
+  '@rspress/plugin-medium-zoom@1.28.2':
+    resolution: {integrity: sha512-qx0e3FOPpsoDomSqHpySElVsTxvWRJCDcTaCRvqiql1Sdz1cAY0Lh3JCG24Tn/ZI3Js6oPVTzQu/7iz75E/Xbw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.28.1
+      '@rspress/runtime': ^1.28.2
 
-  '@rspress/plugin-rss@1.28.1':
-    resolution: {integrity: sha512-01NZL1BwlVjGvhXWP6imIzxNyVgVNWYRJD2gyDijG6Wh2Bq2JeY80+b3XDBUUmbI0qYHZ1e2OFn9cgp4+QpsQA==}
+  '@rspress/plugin-rss@1.28.2':
+    resolution: {integrity: sha512-JzsWKRyKwxDPeTNFWcOq4bP1qlo3TrbuixNM9RopKCAInNfqMVfW0hNEdn+N/ymw/MOSdReVkTF/9EA4BLvI7g==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: ^1.28.1
+      rspress: ^1.28.2
 
-  '@rspress/runtime@1.28.1':
-    resolution: {integrity: sha512-uhFYJg9lSYTlqjfiet4GqMsBY4rekX0IqC5NX/yF9UNYKaFmckze05VKSJV0O+Di4fGWOdd7f/rGQDTPouauVA==}
+  '@rspress/runtime@1.28.2':
+    resolution: {integrity: sha512-LT2/wCnSAbrVqYRsrGOftpz5h5KQHOvWghMfqxBAhJYzKwEShVY71niWBHlC7usoYea2P0gWt+6HeA5HcP/0lg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.28.1':
-    resolution: {integrity: sha512-v6u0/eeA5eQAQ/QRt9bT6k8ByjVZ2oAfJoF4TdmzXbtOMLkBobVoZW2A3KIX7pfl5UXMnqI0mNa9ZBWOIJIINw==}
+  '@rspress/shared@1.28.2':
+    resolution: {integrity: sha512-HiGUMqnUIAXIt+vZ91A5NXlgjjHToyj0RTWgAn17IbKvgmcPK7ZkB8U90ZlXFDoSxKVg3hWALkhk0lc15HQMow==}
 
-  '@rspress/theme-default@1.28.1':
-    resolution: {integrity: sha512-V7oTe2Nb5ch4bpTp/Uv7f4KsuLOReOV2t4bmGZ3cDztvPXs40FE61J36itRZ8bmChh7tAk7DM8ktqs3/0kzMmA==}
+  '@rspress/theme-default@1.28.2':
+    resolution: {integrity: sha512-bwZldJkS0tZfPrS04JAgrhuvGU81fOZ1BTd/wgPCRXJshuU5nBo01JHoq3D8WaTa4wtRQKo0i1yMs6pS+Xu0EA==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.2.0':
@@ -3222,9 +3133,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.11':
-    resolution: {integrity: sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==}
 
   '@swc/helpers@0.5.12':
     resolution: {integrity: sha512-KMZNXiGibsW9kvZAO1Pam2JPTDBm+KSHMMHWdsyI/1DbIZjT2A6Gy3hblVXUMEDvUAKq+e0vL0X0o54owWji7g==}
@@ -4029,9 +3937,6 @@ packages:
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
-
-  core-js@3.37.1:
-    resolution: {integrity: sha512-Xn6qmxrQZyB0FFY8E3bgRXei3lWDJHhvI+u0q9TKIYM49G8pAr0FgnnrFRAmsbptZL1yxRADVXn+x5AGsbBfyw==}
 
   core-js@3.38.1:
     resolution: {integrity: sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==}
@@ -6448,8 +6353,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@1.28.1:
-    resolution: {integrity: sha512-1pU2XW8dvO8JPHvw70z584t/U5xjH84b+jgZsQgU+Ik/IeVuu5Nuv36MmMzLzbIMYad9UMX/pbhIIwKDkayFmQ==}
+  rspress@1.28.2:
+    resolution: {integrity: sha512-4AyGOBfG+u0bFZCRM9VTPZuOjA461t5sGKwGchbcEOnnlvcEUYwWbAXQJcf8eMM9yaU69ter5fGwWLoOXU2nyg==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -9084,13 +8989,6 @@ snapshots:
 
   '@modern-js/types@2.58.2': {}
 
-  '@modern-js/utils@2.58.1':
-    dependencies:
-      '@swc/helpers': 0.5.3
-      caniuse-lite: 1.0.30001653
-      lodash: 4.17.21
-      rslog: 1.2.2
-
   '@modern-js/utils@2.58.2':
     dependencies:
       '@swc/helpers': 0.5.3
@@ -9165,11 +9063,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/runtime-tools@0.2.3':
-    dependencies:
-      '@module-federation/runtime': 0.2.3
-      '@module-federation/webpack-bundler-runtime': 0.2.3
-
   '@module-federation/runtime-tools@0.5.1':
     dependencies:
       '@module-federation/runtime': 0.5.1
@@ -9180,10 +9073,6 @@ snapshots:
       '@module-federation/runtime': 0.6.0
       '@module-federation/webpack-bundler-runtime': 0.6.0
 
-  '@module-federation/runtime@0.2.3':
-    dependencies:
-      '@module-federation/sdk': 0.2.3
-
   '@module-federation/runtime@0.5.1':
     dependencies:
       '@module-federation/sdk': 0.5.1
@@ -9191,8 +9080,6 @@ snapshots:
   '@module-federation/runtime@0.6.0':
     dependencies:
       '@module-federation/sdk': 0.6.0
-
-  '@module-federation/sdk@0.2.3': {}
 
   '@module-federation/sdk@0.5.1': {}
 
@@ -9203,11 +9090,6 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
-
-  '@module-federation/webpack-bundler-runtime@0.2.3':
-    dependencies:
-      '@module-federation/runtime': 0.2.3
-      '@module-federation/sdk': 0.2.3
 
   '@module-federation/webpack-bundler-runtime@0.5.1':
     dependencies:
@@ -9352,16 +9234,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  '@rsbuild/core@1.0.1-beta.9':
-    dependencies:
-      '@rspack/core': 1.0.0-beta.1(@swc/helpers@0.5.11)
-      '@rspack/lite-tapable': 1.0.0-beta.1
-      '@swc/helpers': 0.5.11
-      caniuse-lite: 1.0.30001653
-      core-js: 3.37.1
-    optionalDependencies:
-      fsevents: 2.3.3
-
   '@rsbuild/core@1.0.1-rc.0':
     dependencies:
       '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
@@ -9383,16 +9255,16 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-less@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+  '@rsbuild/plugin-less@1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)':
     dependencies:
-      '@rsbuild/core': 1.0.1-beta.9
+      '@rsbuild/core': 1.0.1-beta.16
       deepmerge: 4.3.1
       reduce-configs: 1.0.0
 
-  '@rsbuild/plugin-react@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+  '@rsbuild/plugin-react@1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)':
     dependencies:
-      '@rsbuild/core': 1.0.1-beta.9
-      '@rspack/plugin-react-refresh': 1.0.0-beta.1(react-refresh@0.14.2)
+      '@rsbuild/core': 1.0.1-beta.16
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
   '@rsbuild/plugin-rem@1.0.1(@rsbuild/core@packages+core)':
@@ -9402,9 +9274,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-sass@1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)':
+  '@rsbuild/plugin-sass@1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)':
     dependencies:
-      '@rsbuild/core': 1.0.1-beta.9
+      '@rsbuild/core': 1.0.1-beta.16
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.41
@@ -9428,16 +9300,10 @@ snapshots:
   '@rspack/binding-darwin-arm64@1.0.0':
     optional: true
 
-  '@rspack/binding-darwin-arm64@1.0.0-beta.1':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.0':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.0.0-beta.1':
     optional: true
 
   '@rspack/binding-darwin-x64@1.0.0-rc.0':
@@ -9446,16 +9312,10 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@1.0.0':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.0.0-beta.1':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.0':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.0.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.0.0-rc.0':
@@ -9464,16 +9324,10 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@1.0.0':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.0.0-beta.1':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.0':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.0.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.0.0-rc.0':
@@ -9482,25 +9336,16 @@ snapshots:
   '@rspack/binding-win32-arm64-msvc@1.0.0':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.0.0-beta.1':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.0.0':
     optional: true
 
-  '@rspack/binding-win32-ia32-msvc@1.0.0-beta.1':
-    optional: true
-
   '@rspack/binding-win32-ia32-msvc@1.0.0-rc.0':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.0':
-    optional: true
-
-  '@rspack/binding-win32-x64-msvc@1.0.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.0.0-rc.0':
@@ -9517,18 +9362,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.0.0
       '@rspack/binding-win32-ia32-msvc': 1.0.0
       '@rspack/binding-win32-x64-msvc': 1.0.0
-
-  '@rspack/binding@1.0.0-beta.1':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.0.0-beta.1
-      '@rspack/binding-darwin-x64': 1.0.0-beta.1
-      '@rspack/binding-linux-arm64-gnu': 1.0.0-beta.1
-      '@rspack/binding-linux-arm64-musl': 1.0.0-beta.1
-      '@rspack/binding-linux-x64-gnu': 1.0.0-beta.1
-      '@rspack/binding-linux-x64-musl': 1.0.0-beta.1
-      '@rspack/binding-win32-arm64-msvc': 1.0.0-beta.1
-      '@rspack/binding-win32-ia32-msvc': 1.0.0-beta.1
-      '@rspack/binding-win32-x64-msvc': 1.0.0-beta.1
 
   '@rspack/binding@1.0.0-rc.0':
     optionalDependencies:
@@ -9551,15 +9384,6 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.12
 
-  '@rspack/core@1.0.0-beta.1(@swc/helpers@0.5.11)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.2.3
-      '@rspack/binding': 1.0.0-beta.1
-      '@rspack/lite-tapable': 1.0.0-beta.1
-      caniuse-lite: 1.0.30001653
-    optionalDependencies:
-      '@swc/helpers': 0.5.11
-
   '@rspack/core@1.0.0-rc.0(@swc/helpers@0.5.12)':
     dependencies:
       '@module-federation/runtime-tools': 0.5.1
@@ -9571,8 +9395,6 @@ snapshots:
 
   '@rspack/lite-tapable@1.0.0': {}
 
-  '@rspack/lite-tapable@1.0.0-beta.1': {}
-
   '@rspack/plugin-react-refresh@1.0.0(react-refresh@0.14.2)':
     dependencies:
       error-stack-parser: 2.1.4
@@ -9580,32 +9402,25 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspack/plugin-react-refresh@1.0.0-beta.1(react-refresh@0.14.2)':
-    dependencies:
-      error-stack-parser: 2.1.4
-      html-entities: 2.3.3
-    optionalDependencies:
-      react-refresh: 0.14.2
-
-  '@rspress/core@1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))':
+  '@rspress/core@1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))':
     dependencies:
       '@loadable/component': 5.16.4(react@18.3.1)
       '@mdx-js/loader': 2.3.0(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@modern-js/utils': 2.58.1
-      '@rsbuild/core': 1.0.1-beta.9
-      '@rsbuild/plugin-less': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
-      '@rsbuild/plugin-react': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
-      '@rsbuild/plugin-sass': 1.0.1-beta.9(@rsbuild/core@1.0.1-beta.9)
+      '@modern-js/utils': 2.58.2
+      '@rsbuild/core': 1.0.1-beta.16
+      '@rsbuild/plugin-less': 1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)
+      '@rsbuild/plugin-react': 1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)
+      '@rsbuild/plugin-sass': 1.0.1-beta.16(@rsbuild/core@1.0.1-beta.16)
       '@rspress/mdx-rs': 0.5.7
-      '@rspress/plugin-auto-nav-sidebar': 1.28.1
-      '@rspress/plugin-container-syntax': 1.28.1
-      '@rspress/plugin-last-updated': 1.28.1
-      '@rspress/plugin-medium-zoom': 1.28.1(@rspress/runtime@1.28.1)
-      '@rspress/runtime': 1.28.1
-      '@rspress/shared': 1.28.1
-      '@rspress/theme-default': 1.28.1
+      '@rspress/plugin-auto-nav-sidebar': 1.28.2
+      '@rspress/plugin-container-syntax': 1.28.2
+      '@rspress/plugin-last-updated': 1.28.2
+      '@rspress/plugin-medium-zoom': 1.28.2(@rspress/runtime@1.28.2)
+      '@rspress/runtime': 1.28.2
+      '@rspress/shared': 1.28.2
+      '@rspress/theme-default': 1.28.2
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       enhanced-resolve: 5.17.0
@@ -9677,52 +9492,52 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.5.7
       '@rspress/mdx-rs-win32-x64-msvc': 0.5.7
 
-  '@rspress/plugin-auto-nav-sidebar@1.28.1':
+  '@rspress/plugin-auto-nav-sidebar@1.28.2':
     dependencies:
-      '@rspress/shared': 1.28.1
+      '@rspress/shared': 1.28.2
 
-  '@rspress/plugin-container-syntax@1.28.1':
+  '@rspress/plugin-container-syntax@1.28.2':
     dependencies:
-      '@rspress/shared': 1.28.1
+      '@rspress/shared': 1.28.2
 
-  '@rspress/plugin-last-updated@1.28.1':
+  '@rspress/plugin-last-updated@1.28.2':
     dependencies:
-      '@rspress/shared': 1.28.1
+      '@rspress/shared': 1.28.2
 
-  '@rspress/plugin-medium-zoom@1.28.1(@rspress/runtime@1.28.1)':
+  '@rspress/plugin-medium-zoom@1.28.2(@rspress/runtime@1.28.2)':
     dependencies:
-      '@rspress/runtime': 1.28.1
+      '@rspress/runtime': 1.28.2
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.28.1(react@18.3.1)(rspress@1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))))':
+  '@rspress/plugin-rss@1.28.2(react@18.3.1)(rspress@1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))))':
     dependencies:
-      '@rspress/shared': 1.28.1
+      '@rspress/shared': 1.28.2
       feed: 4.2.2
       react: 18.3.1
-      rspress: 1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
+      rspress: 1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
 
-  '@rspress/runtime@1.28.1':
+  '@rspress/runtime@1.28.2':
     dependencies:
-      '@rspress/shared': 1.28.1
+      '@rspress/shared': 1.28.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@rspress/shared@1.28.1':
+  '@rspress/shared@1.28.2':
     dependencies:
-      '@rsbuild/core': 1.0.1-beta.9
+      '@rsbuild/core': 1.0.1-beta.16
       chalk: 5.3.0
       execa: 5.1.1
       fs-extra: 11.2.0
       gray-matter: 4.0.3
       unified: 10.1.2
 
-  '@rspress/theme-default@1.28.1':
+  '@rspress/theme-default@1.28.2':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.28.1
-      '@rspress/shared': 1.28.1
+      '@rspress/runtime': 1.28.2
+      '@rspress/shared': 1.28.2
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -9883,10 +9698,6 @@ snapshots:
     optional: true
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.11':
-    dependencies:
-      tslib: 2.6.2
 
   '@swc/helpers@0.5.12':
     dependencies:
@@ -10832,8 +10643,6 @@ snapshots:
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.23.3
-
-  core-js@3.37.1: {}
 
   core-js@3.38.1: {}
 
@@ -13696,11 +13505,11 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
+  rspress@1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
     dependencies:
-      '@rsbuild/core': 1.0.1-beta.9
-      '@rspress/core': 1.28.1(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
-      '@rspress/shared': 1.28.1
+      '@rsbuild/core': 1.0.1-beta.16
+      '@rspress/core': 1.28.2(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
+      '@rspress/shared': 1.28.2
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rspress/plugin-rss": "1.28.1",
+    "@rspress/plugin-rss": "1.28.2",
     "@types/node": "18.x",
     "@types/react": "^18.3.4",
     "@types/react-dom": "^18.3.0",
@@ -20,7 +20,7 @@
     "rsbuild-plugin-google-analytics": "1.0.2",
     "rsbuild-plugin-open-graph": "1.0.2",
     "@rstack-dev/doc-ui": "^1.2.0",
-    "rspress": "1.28.1",
+    "rspress": "1.28.2",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.1"
   }


### PR DESCRIPTION
## Summary

Use Rslib to bundle package, replace the legacy Modern.js Module.

## Related Links

https://github.com/web-infra-dev/rslib

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
