### PR TITLE
docs: fix Benchmark graph width

### DIFF
--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -30,7 +30,7 @@ Rsbuild's build performance is on par with native Rspack. This is the time it ta
 
 import { BenchmarkGraph } from '@components/Benchmark';
 
-<BenchmarkGraph />
+<BenchmarkGraph short />
 
 > The above data comes from the [performance-compare](https://github.com/rspack-contrib/performance-compare) benchmark.
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -30,7 +30,7 @@ Rsbuild 的构建性能与原生 Rspack 处于同一水平，以下是构建 100
 
 import { BenchmarkGraph } from '@components/Benchmark';
 
-<BenchmarkGraph />
+<BenchmarkGraph short />
 
 > 以上数据来自 [performance-compare](https://github.com/rspack-contrib/performance-compare) benchmark。
 

--- a/website/theme/components/Benchmark.module.scss
+++ b/website/theme/components/Benchmark.module.scss
@@ -21,6 +21,13 @@
   margin-top: 4rem;
 }
 
+.short {
+  // Temp code to fix the width of the graph
+  :global(.container_72b36) {
+    width: 40vw;
+  }
+}
+
 @media (min-width: 640px) {
   .title {
     font-size: 3rem;

--- a/website/theme/components/Benchmark.tsx
+++ b/website/theme/components/Benchmark.tsx
@@ -79,8 +79,14 @@ const BENCHMARK_DATA: BenchmarkData = {
   },
 };
 
-export function BenchmarkGraph() {
-  return <BaseBenchmark data={BENCHMARK_DATA} />;
+export function BenchmarkGraph(props: { short?: boolean }) {
+  return props.short ? (
+    <div className={styles.short}>
+      <BaseBenchmark data={BENCHMARK_DATA} />
+    </div>
+  ) : (
+    <BaseBenchmark data={BENCHMARK_DATA} />
+  );
 }
 
 export function Benchmark() {


### PR DESCRIPTION
## Summary

Temp fix for Benchmark graph width.

<img width="1233" alt="截屏2024-08-29 22 58 18" src="https://github.com/user-attachments/assets/f4a915c2-8f69-4c8e-a96e-2d201c7ffc98">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
