### PR TITLE
chore(ci): add timeout for e2e and unit tests

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -20,6 +20,7 @@ jobs:
   ut-mac:
     # run ut in MacOS, as SWC cases will fail in Ubuntu CI
     runs-on: macos-14
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18.x]
@@ -63,6 +64,7 @@ jobs:
   # ======== e2e ========
   e2e-ubuntu:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18.x]

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -19,6 +19,7 @@ jobs:
   # ======== ut ========
   ut-windows:
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18.x]
@@ -67,6 +68,7 @@ jobs:
   # # ======== e2e ========
   e2e-windows:
     runs-on: windows-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [18.x]


### PR DESCRIPTION
## Summary

I noticed that some e2e workflows were stuck for hours : 
https://github.com/web-infra-dev/rsbuild/actions/runs/10630679833?pr=3325

This PR adds a timeout for unit and e2e tests.
Feel free to adjust the timeout if it's too high or too low.

## Related Links

gha doc: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
