### PR TITLE
fix: `rsbuild.build` always return close method

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -113,6 +113,6 @@ rspackOnlyTest(
       'AfterBuild',
     ]);
 
-    await result.close?.();
+    await result.close();
   },
 );

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -68,5 +68,5 @@ export const build = async (
     });
   });
 
-  return { stats };
+  return { stats, close: async () => {} };
 };

--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -68,5 +68,10 @@ export const build = async (
     });
   });
 
-  return { stats, close: async () => {} };
+  return {
+    stats,
+    // This close method is a noop in non-watch mode
+    // In watch mode, it's defined above to stop watching
+    close: async () => {},
+  };
 };

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -69,5 +69,5 @@ export const build = async (
     });
   });
 
-  return { stats };
+  return { stats, close: async () => {} };
 };

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -69,5 +69,10 @@ export const build = async (
     });
   });
 
-  return { stats, close: async () => {} };
+  return {
+    stats,
+    // This close method is a noop in non-watch mode
+    // In watch mode, it's defined above to stop watching
+    close: async () => {},
+  };
 };

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -31,12 +31,25 @@ export type PreviewServerOptions = {
 };
 
 export type BuildOptions = {
+  /**
+   * Whether to watch for file changes and rebuild.
+   * @default false
+   */
   watch?: boolean;
+  /**
+   * Using a custom Rspack Compiler object.
+   */
   compiler?: Compiler | MultiCompiler;
 };
 
 export type Build = (options?: BuildOptions) => Promise<{
-  close?: () => Promise<void>;
+  /**
+   * Stop watching when in watch mode.
+   */
+  close: () => Promise<void>;
+  /**
+   * Rspack's [stats](https://rspack.dev/api/javascript-api/stats) object.
+   */
   stats?: Rspack.Stats | Rspack.MultiStats;
 }>;
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -83,14 +83,20 @@ Perform a production mode build.
 
 ```ts
 type BuildOptions = {
+  /**
+   * Whether to watch for file changes and rebuild.
+   * @default false
+   */
   watch?: boolean;
-  // custom Compiler object
+  /**
+   * Using a custom Rspack Compiler object.
+   */
   compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<{
   stats?: Rspack.Stats | Rspack.MultiStats;
-  close?: () => Promise<void>;
+  close: () => Promise<void>;
 }>;
 ```
 
@@ -129,7 +135,7 @@ const result = await rsbuild.build({
   watch: true,
 });
 
-await result.close?.();
+await result.close();
 ```
 
 ### Stats Object

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -105,14 +105,21 @@ type TsconfigPath = string | undefined;
 
 ```ts
 type BuildOptions = {
+  /**
+   * 是否监听文件变化并重新构建
+   *
+   * @default false
+   */
   watch?: boolean;
-  // 自定义 Compiler 对象
+  /**
+   * 使用自定义的 Rspack Compiler 对象
+   */
   compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<{
   stats?: Rspack.Stats | Rspack.MultiStats;
-  close?: () => Promise<void>;
+  close: () => Promise<void>;
 }>;
 ```
 
@@ -151,7 +158,7 @@ const result = await rsbuild.build({
   watch: true,
 });
 
-await result.close?.();
+await result.close();
 ```
 
 ### Stats 对象


### PR DESCRIPTION
## Summary

To make it easier to use, have `rsbuild.build` always return the `close` method.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
