### PR TITLE
chore: reuse source map type from Rspack

### DIFF
--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -1,9 +1,5 @@
 import type { LoaderContext } from '@rspack/core';
-import type {
-  EnvironmentContext,
-  RspackSourceMap,
-  TransformContext,
-} from '../types';
+import type { EnvironmentContext, Rspack, TransformContext } from '../types';
 
 export type TransformLoaderOptions = {
   id: string;
@@ -13,7 +9,7 @@ export type TransformLoaderOptions = {
 export default async function transform(
   this: LoaderContext<TransformLoaderOptions>,
   source: string,
-  map?: string | RspackSourceMap,
+  map?: string | Rspack.sources.RawSourceMap,
 ): Promise<void> {
   const callback = this.async();
   const bypass = () => callback(null, source, map);

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -34,7 +34,7 @@ import type {
   OnExitFn,
 } from './hooks';
 import type { RsbuildTarget } from './rsbuild';
-import type { Rspack, RspackSourceMap } from './rspack';
+import type { Rspack } from './rspack';
 import type { HtmlRspackPlugin } from './thirdParty';
 import type { Falsy } from './utils';
 import type { MaybePromise } from './utils';
@@ -218,7 +218,7 @@ type TransformResult =
   | string
   | {
       code: string;
-      map?: string | RspackSourceMap | null;
+      map?: string | Rspack.sources.RawSourceMap | null;
     };
 
 export type TransformContext = {

--- a/packages/core/src/types/rspack.ts
+++ b/packages/core/src/types/rspack.ts
@@ -21,13 +21,3 @@ type GetElementType<T extends any[]> = T extends (infer U)[] ? U : never;
 export type RspackRule = GetElementType<
   NonNullable<NonNullable<Rspack.Configuration['module']>['rules']>
 >;
-
-export type RspackSourceMap = {
-  version: number;
-  sources: string[];
-  mappings: string;
-  file?: string;
-  sourceRoot?: string;
-  sourcesContent?: string[];
-  names?: string[];
-};

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -283,7 +283,7 @@ type TransformResult =
   | string
   | {
       code: string;
-      map?: string | RspackSourceMap | null;
+      map?: string | Rspack.sources.RawSourceMap | null;
     };
 
 type TransformHandler = (

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -281,7 +281,7 @@ type TransformResult =
   | string
   | {
       code: string;
-      map?: string | RspackSourceMap | null;
+      map?: string | Rspack.sources.RawSourceMap | null;
     };
 
 type TransformHandler = (


### PR DESCRIPTION
## Summary

Reuse source map type from Rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
