### PR TITLE
fix: escape characters in compilationId

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -386,7 +386,10 @@ export const getAddressUrls = ({
 // A unique name for WebSocket communication
 export const getCompilationId = (
   compiler: Rspack.Compiler | Rspack.Compilation,
-) => `${compiler.name ?? ''}_${compiler.options.output.uniqueName ?? ''}`;
+) => {
+  const uniqueName = compiler.options.output.uniqueName ?? '';
+  return `${compiler.name ?? ''}_${uniqueName.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+};
 
 export function getServerTerminator(
   server: Server | Http2SecureServer,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -384,11 +384,12 @@ export const getAddressUrls = ({
 };
 
 // A unique name for WebSocket communication
+const COMPILATION_ID_REGEX = /[^a-zA-Z0-9_-]/g;
 export const getCompilationId = (
   compiler: Rspack.Compiler | Rspack.Compilation,
 ) => {
   const uniqueName = compiler.options.output.uniqueName ?? '';
-  return `${compiler.name ?? ''}_${uniqueName.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+  return `${compiler.name ?? ''}_${uniqueName.replace(COMPILATION_ID_REGEX, '_')}`;
 };
 
 export function getServerTerminator(


### PR DESCRIPTION
## Summary

Escape characters in compilationId.

- before: `ws://localhost:3000/rsbuild-hmr?compilationId=web_%40examples%2Freact`
- after: `ws://localhost:3000/rsbuild-hmr?compilationId=web__examples_react`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
