### PR TITLE
Revert "chore(deps): update playwright monorepo to v1.46.1 (#2725)"

### DIFF
--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -21,7 +21,7 @@ test('should compile Node addons correctly', async () => {
 
   // the `test.darwin.node` is only compatible with darwin
   if (process.platform === 'darwin') {
-    const { default: content } = await import('./dist/index.js' as string);
+    const content = await import('./dist/index.js' as string);
     expect(typeof content.default.readLength).toEqual('function');
   }
 });
@@ -66,7 +66,7 @@ test('should compile Node addons in the node_modules correctly', async () => {
   expect(fs.existsSync(join(__dirname, 'dist', 'other.node'))).toBeTruthy();
 
   if (process.platform === 'darwin') {
-    const { default: content } = await import('./dist/index.js' as string);
+    const content = await import('./dist/index.js' as string);
     expect(typeof content.default.readLength).toEqual('function');
   }
 });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@e2e/helper": "workspace:*",
-    "@playwright/test": "1.46.1",
+    "@playwright/test": "1.44.1",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-assets-retry": "workspace:*",
     "@rsbuild/plugin-babel": "workspace:*",
@@ -49,7 +49,7 @@
     "create-rsbuild": "workspace:*",
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
-    "playwright": "1.46.1",
+    "playwright": "1.44.1",
     "strip-ansi": "6.0.1",
     "tailwindcss": "^3.4.10",
     "typescript": "^5.5.2"

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -8,9 +8,7 @@ type RsdoctorExports = {
   RsdoctorWebpackPlugin: { new (): BundlerPluginInstance };
 };
 
-type MaybeRsdoctorPlugin = Configuration['plugins'] & {
-  isRsdoctorPlugin?: boolean;
-};
+type MaybeRsdoctorPlugin = Configuration['plugins'] & { isRsdoctorPlugin?: boolean };
 
 export const pluginRsdoctor = (): RsbuildPlugin => ({
   name: 'rsbuild:rsdoctor',
@@ -52,14 +50,12 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let isAutoRegister = false;
 
-      const isRsdoctorPlugin = (plugin: MaybeRsdoctorPlugin) =>
-        plugin?.isRsdoctorPlugin === true ||
-        plugin?.constructor?.name === pluginName;
+      const isRsdoctorPlugin = (plugin: MaybeRsdoctorPlugin) =>  plugin?.isRsdoctorPlugin === true || plugin?.constructor?.name === pluginName;
 
       for (const config of bundlerConfigs) {
         // If user has added the Rsdoctor plugin to the config file, it will return.
-        const registered = config.plugins?.some((plugin) =>
-          isRsdoctorPlugin(plugin as unknown as MaybeRsdoctorPlugin),
+        const registered = config.plugins?.some(          
+          (plugin) => isRsdoctorPlugin(plugin as unknown as MaybeRsdoctorPlugin),
         );
 
         if (registered) {

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -84,7 +84,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
       )
       .replaceAll(
         '__RUNTIME_GLOBALS_GET_MINI_CSS_EXTRACT_FILENAME__',
-        '__webpack_require__.miniCssF',
+        '__webpack_require__.miniCssF'
       )
       .replaceAll('__RUNTIME_GLOBALS_PUBLIC_PATH__', RuntimeGlobals.publicPath)
       .replaceAll('__RUNTIME_GLOBALS_LOAD_SCRIPT__', RuntimeGlobals.loadScript)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: 0.6.0
         version: 0.6.0(typescript@5.5.2)
       '@playwright/test':
-        specifier: 1.46.1
-        version: 1.46.1
+        specifier: 1.44.1
+        version: 1.44.1
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -175,8 +175,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0
       playwright:
-        specifier: 1.46.1
-        version: 1.46.1
+        specifier: 1.44.1
+        version: 1.44.1
       strip-ansi:
         specifier: 6.0.1
         version: 6.0.1
@@ -2594,9 +2594,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.46.1':
-    resolution: {integrity: sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.44.1':
+    resolution: {integrity: sha512-1hZ4TNvD5z9VuhNJ/walIjvMVvYkZKf71axoF/uiAqpntQJXpG64dlXhoDXE3OczPuTuvjf/M5KWFg5VAVUS3Q==}
+    engines: {node: '>=16'}
     hasBin: true
 
   '@polka/url@0.5.0':
@@ -5847,14 +5847,14 @@ packages:
     resolution: {integrity: sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==}
     engines: {node: '>=14.16'}
 
-  playwright-core@1.46.1:
-    resolution: {integrity: sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==}
-    engines: {node: '>=18'}
+  playwright-core@1.44.1:
+    resolution: {integrity: sha512-wh0JWtYTrhv1+OSsLPgFzGzt67Y7BE/ZS3jEqgGBlp2ppp1ZDj8c+9IARNW4dwf1poq5MgHreEM2KV/GuR4cFA==}
+    engines: {node: '>=16'}
     hasBin: true
 
-  playwright@1.46.1:
-    resolution: {integrity: sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==}
-    engines: {node: '>=18'}
+  playwright@1.44.1:
+    resolution: {integrity: sha512-qr/0UJ5CFAtloI3avF95Y0L1xQo6r3LQArLIg/z/PoGJ6xa+EwzrwO5lpNr/09STxdHuUoP2mvuELJS+hLdtgg==}
+    engines: {node: '>=16'}
     hasBin: true
 
   plimit-lit@1.6.1:
@@ -9147,9 +9147,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.46.1':
+  '@playwright/test@1.44.1':
     dependencies:
-      playwright: 1.46.1
+      playwright: 1.44.1
 
   '@polka/url@0.5.0': {}
 
@@ -12898,11 +12898,11 @@ snapshots:
     dependencies:
       find-up: 6.3.0
 
-  playwright-core@1.46.1: {}
+  playwright-core@1.44.1: {}
 
-  playwright@1.46.1:
+  playwright@1.44.1:
     dependencies:
-      playwright-core: 1.46.1
+      playwright-core: 1.44.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/website/docs/en/guide/basic/unocss.mdx
+++ b/website/docs/en/guide/basic/unocss.mdx
@@ -20,7 +20,9 @@ You can register the `unocss` PostCSS plugin through [postcss.config.mjs](https:
 import UnoCSS from '@unocss/postcss';
 
 export default {
-  plugins: [UnoCSS()],
+  plugins: [
+    UnoCSS(),
+  ],
 };
 ```
 


### PR DESCRIPTION
This reverts commit 5ae0c5939004942e43c293baf61c0224c8ac5e47.

## Summary

Our e2e cases become unstable after bumping playwright.

<img width="1224" alt="截屏2024-09-01 16 30 28" src="https://github.com/user-attachments/assets/a7878c24-9757-4c12-bfd6-883a6c5619cb">

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
