### PR TITLE
fix(create-rsbuild): broken shebang line in bin file

### DIFF
--- a/packages/create-rsbuild/bin.js
+++ b/packages/create-rsbuild/bin.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import './dist/index.js';

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -15,11 +15,12 @@
   },
   "main": "./dist/index.js",
   "bin": {
-    "create-rsbuild": "./dist/index.js"
+    "create-rsbuild": "./bin.js"
   },
   "files": [
     "template-*",
-    "dist"
+    "dist",
+    "bin.js"
   ],
   "scripts": {
     "build": "rslib build",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 import path from 'node:path';
 import {
   type Argv,


### PR DESCRIPTION
## Summary

Fix Rslib breaks bin shebang line.

![image](https://github.com/user-attachments/assets/49380a0f-73f3-4d26-8b29-6a374ae37dc3)

## Related Links

https://github.com/web-infra-dev/rslib/issues/166

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
