### PR TITLE
docs: correct addPlugins type

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -489,9 +489,9 @@ This method needs to be called before compiling. If it is called after compiling
 type AddPluginsOptions = { before?: string } | { after?: string };
 
 function AddPlugins(
-  plugins: RsbuildPlugins[],
+  plugins: Array<RsbuildPlugin | Falsy>,
   options?: AddPluginsOptions,
-): Promise<void>;
+): void;
 ```
 
 - **Example:**

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -510,9 +510,9 @@ const compiler = await rsbuild.createCompiler();
 type AddPluginsOptions = { before?: string } | { after?: string };
 
 function AddPlugins(
-  plugins: RsbuildPlugins[],
+  plugins: Array<RsbuildPlugin | Falsy>,
   options?: AddPluginsOptions,
-): Promise<void>;
+): void;
 ```
 
 - **示例：**


### PR DESCRIPTION
## Summary

`addPlugins` is a sync method and does not support add async plugins.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
