### PR TITLE
feat: support nested plugins

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -1,3 +1,4 @@
+import { isPromise } from 'node:util/types';
 import { createContext } from './createContext';
 import { getNodeEnv, pick, setNodeEnv } from './helpers';
 import { initPluginAPI } from './initPlugins';
@@ -207,7 +208,7 @@ export async function createRsbuild(
     do {
       // @ts-expect-error Depth is determined by user configuration
       plugins = (await Promise.all(plugins)).flat(Number.POSITIVE_INFINITY);
-    } while (plugins.some((v: any) => v?.then));
+    } while (plugins.some((v: any) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | Falsy>;
   };

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -206,8 +206,9 @@ export async function createRsbuild(
   const getFlattenedPlugins = async (pluginOptions: RsbuildPlugins) => {
     let plugins = pluginOptions;
     do {
-      // @ts-expect-error Depth is determined by user configuration
-      plugins = (await Promise.all(plugins)).flat(Number.POSITIVE_INFINITY);
+      plugins = (await Promise.all(plugins)).flat(
+        Number.POSITIVE_INFINITY as 1,
+      );
     } while (plugins.some((v: any) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | Falsy>;

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -209,7 +209,7 @@ export async function createRsbuild(
       plugins = (await Promise.all(plugins)).flat(
         Number.POSITIVE_INFINITY as 1,
       );
-    } while (plugins.some((v: any) => isPromise(v)));
+    } while (plugins.some((v) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | Falsy>;
   };

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -201,7 +201,8 @@ type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
 export type RsbuildPlugins = (
   | LooseRsbuildPlugin
   | Falsy
-  | Promise<LooseRsbuildPlugin | Falsy>
+  | Promise<LooseRsbuildPlugin | Falsy | RsbuildPlugins>
+  | RsbuildPlugins
 )[];
 
 export type GetRsbuildConfig = {

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -23,3 +23,44 @@ describe('should use rspack as default bundler', () => {
     process.env.NODE_ENV = NODE_ENV;
   });
 });
+
+describe('plugins', () => {
+  it('should apply nested plugins correctly', async () => {
+    function myPlugin() {
+      return [
+        {
+          name: 'plugin-foo',
+          setup() {},
+        },
+        {
+          name: 'plugin-bar',
+          setup() {},
+        },
+      ];
+    }
+
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: './src/index.js',
+          },
+        },
+        plugins: [
+          myPlugin(),
+          Promise.resolve([
+            {
+              name: 'plugin-zoo',
+              setup() {},
+            },
+          ]),
+        ],
+      },
+    });
+
+    expect(rsbuild.isPluginExists('plugin-foo')).toBeTruthy();
+    expect(rsbuild.isPluginExists('plugin-bar')).toBeTruthy();
+    expect(rsbuild.isPluginExists('plugin-zoo')).toBeTruthy();
+    expect(rsbuild.isPluginExists('plugin-404')).toBeFalsy();
+  });
+});

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -61,7 +61,7 @@ export async function createStubRsbuild({
       plugins = (await Promise.all(plugins)).flat(
         Number.POSITIVE_INFINITY as 1,
       );
-    } while (plugins.some((v: any) => isPromise(v)));
+    } while (plugins.some((v) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | false | null | undefined>;
   };

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -1,3 +1,4 @@
+import { isPromise } from 'node:util/types';
 import type {
   BundlerPluginInstance,
   CreateRsbuildOptions,
@@ -59,7 +60,7 @@ export async function createStubRsbuild({
     do {
       // @ts-expect-error Depth is determined by user configuration
       plugins = (await Promise.all(plugins)).flat(Number.POSITIVE_INFINITY);
-    } while (plugins.some((v: any) => v?.then));
+    } while (plugins.some((v: any) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | false | null | undefined>;
   };

--- a/scripts/test-helper/src/rsbuild.ts
+++ b/scripts/test-helper/src/rsbuild.ts
@@ -58,8 +58,9 @@ export async function createStubRsbuild({
   const getFlattenedPlugins = async (pluginOptions: RsbuildPlugins) => {
     let plugins = pluginOptions;
     do {
-      // @ts-expect-error Depth is determined by user configuration
-      plugins = (await Promise.all(plugins)).flat(Number.POSITIVE_INFINITY);
+      plugins = (await Promise.all(plugins)).flat(
+        Number.POSITIVE_INFINITY as 1,
+      );
     } while (plugins.some((v: any) => isPromise(v)));
 
     return plugins as Array<RsbuildPlugin | false | null | undefined>;

--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -12,7 +12,8 @@ type Falsy = false | null | undefined;
 type RsbuildPlugins = (
   | RsbuildPlugin
   | Falsy
-  | Promise<RsbuildPlugin | Falsy>
+  | Promise<RsbuildPlugin | Falsy | RsbuildPlugins>
+  | RsbuildPlugins
 )[];
 ```
 
@@ -46,6 +47,23 @@ export default defineConfig({
 By default, plugins are executed in the order they appear in the `plugins` array. Built-in Rsbuild plugins are executed before user-registered plugins.
 
 When a plugin internally uses fields that control the order, such as `pre` and `post`, the execution order is adjusted based on them. See [Pre Plugins](/plugins/dev/core#pre-pluginss) for more details.
+
+## Nested Plugins
+
+Rsbuild also supports adding nested plugins. You can pass in a collection containing multiple plugins as a plugin preset, which is helpful for implementing complex functions that require multiple plugins (such as framework integration).
+
+```ts title="rsbuild.config.ts"
+function myPlugin() {
+  return [
+    fooPlugin()
+    barPlugin()
+  ];
+}
+
+export default {
+  plugins: [myPlugin()]
+}
+```
 
 ## Local Plugins
 

--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -55,7 +55,7 @@ Rsbuild also supports adding nested plugins. You can pass in an array containing
 ```ts title="rsbuild.config.ts"
 function myPlugin() {
   return [
-    fooPlugin()
+    fooPlugin(),
     barPlugin()
   ];
 }

--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -50,7 +50,7 @@ When a plugin internally uses fields that control the order, such as `pre` and `
 
 ## Nested Plugins
 
-Rsbuild also supports adding nested plugins. You can pass in a collection containing multiple plugins as a plugin preset, which is helpful for implementing complex functions that require multiple plugins (such as framework integration).
+Rsbuild also supports adding nested plugins. You can pass in an array containing multiple plugins, similar to a plugin preset collection. This is particularly useful for implementing complex functionalities that require a combination of multiple plugins (such as framework integration).
 
 ```ts title="rsbuild.config.ts"
 function myPlugin() {

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -12,7 +12,8 @@ type Falsy = false | null | undefined;
 type RsbuildPlugins = (
   | RsbuildPlugin
   | Falsy
-  | Promise<RsbuildPlugin | Falsy>
+  | Promise<RsbuildPlugin | Falsy | RsbuildPlugins>
+  | RsbuildPlugins
 )[];
 ```
 
@@ -46,6 +47,23 @@ export default defineConfig({
 默认情况下，插件会按照 `plugins` 数组的顺序依次执行，Rsbuild 内置插件的执行时机早于用户注册的插件。
 
 当插件内部使用了控制顺序的相关字段，比如 `pre`、`post` 时，执行顺序会基于它们进行调整，详见 [前置插件](/plugins/dev/core#前置插件)。
+
+## 嵌套插件
+
+Rsbuild 还支持添加嵌套插件，你可以传入一个包含多个插件的集合作为插件预设，这对于实现需要多个插件的复杂功能（例如框架集成）很有帮助。
+
+```ts title="rsbuild.config.ts"
+function myPlugin() {
+  return [
+    fooPlugin()
+    barPlugin()
+  ];
+}
+
+export default {
+  plugins: [myPlugin()]
+}
+```
 
 ## 本地插件
 

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -50,7 +50,7 @@ export default defineConfig({
 
 ## 嵌套插件
 
-Rsbuild 还支持添加嵌套插件，你可以传入一个包含多个插件的集合作为插件预设，这对于实现需要多个插件的复杂功能（例如框架集成）很有帮助。
+Rsbuild 还支持添加嵌套插件，你可以传入一个包含多个插件的数组，类似于一个插件预设集合，这对于实现需要多个插件组合的复杂功能（例如框架集成）很有帮助。
 
 ```ts title="rsbuild.config.ts"
 function myPlugin() {

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -55,7 +55,7 @@ Rsbuild 还支持添加嵌套插件，你可以传入一个包含多个插件的
 ```ts title="rsbuild.config.ts"
 function myPlugin() {
   return [
-    fooPlugin()
+    fooPlugin(),
     barPlugin()
   ];
 }


### PR DESCRIPTION
## Summary

Support adding nested plugins in Rsbuild. 

```ts title="rsbuild.config.ts"
function myPlugin() {
  return [
    fooPlugin(),
    barPlugin()
  ];
}

export default {
  plugins: [myPlugin()]
}
```

## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/3253
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
