### PR TITLE
fix(plugin-swc): should verify the version correctly

### DIFF
--- a/.changeset/silly-moons-drive.md
+++ b/.changeset/silly-moons-drive.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/plugin-swc': patch
+---
+
+fix(plugin-swc): should verify the version correctly
+fix(plugin-swc): 修复验证 react 版本的问题

--- a/packages/compat/plugin-swc/src/utils.ts
+++ b/packages/compat/plugin-swc/src/utils.ts
@@ -50,6 +50,10 @@ async function findUp({
   }
 }
 
+export const isVersionBeyond17 = (version: string): boolean => {
+  return semver.gte(semver.minVersion(version)!, '17.0.0');
+};
+
 const isBeyondReact17 = async (cwd: string) => {
   const pkgPath = await findUp({ cwd, filename: 'package.json' });
 
@@ -67,7 +71,7 @@ const isBeyondReact17 = async (cwd: string) => {
     return false;
   }
 
-  return semver.satisfies(semver.minVersion(deps.react)!, '>=17.0.0');
+  return isVersionBeyond17(deps.react);
 };
 
 /**

--- a/packages/compat/plugin-swc/tests/utils.test.ts
+++ b/packages/compat/plugin-swc/tests/utils.test.ts
@@ -1,0 +1,19 @@
+import { isVersionBeyond17 } from '../src/utils';
+
+describe('isVersionBeyondReact17', () => {
+  test('Should return true for version 17 and above', () => {
+    expect(isVersionBeyond17('17.0.0')).toBe(true);
+    expect(isVersionBeyond17('17.0.1')).toBe(true);
+    expect(isVersionBeyond17('17.0.1-canary')).toBe(true);
+    expect(isVersionBeyond17('^17.0.0')).toBe(true);
+    expect(isVersionBeyond17('~18.2.0')).toBe(true);
+    expect(isVersionBeyond17('18.3.0-canary')).toBe(true);
+  });
+
+  test('Should return false for below version 17', () => {
+    expect(isVersionBeyond17('16.14.0')).toBe(false);
+    expect(isVersionBeyond17('16.8.0-alpha-1')).toBe(false);
+    expect(isVersionBeyond17('^16.0.0')).toBe(false);
+    expect(isVersionBeyond17('~15.0.0')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

At present, when verifying the react beta version is inaccurate. For example, verify`18.3.0-canary-8039e6d0b-20231026` return false.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
