### PR TITLE
fix: skip resolution if Rsdoctor plugin is registered

### DIFF
--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -1,9 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
-// @ts-expect-error
-import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
+import { expect, test } from '@playwright/test';
 
 const packagePath = path.join(
   __dirname,
@@ -11,12 +9,14 @@ const packagePath = path.join(
 );
 const testFile = path.join(packagePath, 'test-temp.txt');
 
+test.beforeEach(() => {
+  fs.rmSync(packagePath, { recursive: true, force: true });
+  fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
+});
+
 rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
   async () => {
-    fs.rmSync(packagePath, { recursive: true, force: true });
-    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
-
     const { logs, restore } = proxyConsole();
     process.env.RSDOCTOR = 'true';
 
@@ -37,9 +37,6 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
   async () => {
-    fs.rmSync(packagePath, { recursive: true, force: true });
-    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
-
     process.env.RSDOCTOR = 'false';
 
     await build({
@@ -54,10 +51,9 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered',
   async () => {
-    fs.rmSync(packagePath, { recursive: true, force: true });
-    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
-
     const { logs, restore } = proxyConsole();
+    const { RsdoctorRspackPlugin } = require('@rsdoctor/rspack-plugin');
+
     process.env.RSDOCTOR = 'true';
 
     await build({

--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -2,12 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+// @ts-expect-error
+import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 
 const packagePath = path.join(
   __dirname,
   'node_modules/@rsdoctor/rspack-plugin',
 );
-const testFile = path.join(packagePath, 'test.txt');
+const testFile = path.join(packagePath, 'test-temp.txt');
 
 rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
@@ -46,5 +48,34 @@ rspackOnlyTest(
 
     expect(fs.existsSync(testFile)).toBe(false);
     process.env.RSDOCTOR = '';
+  },
+);
+
+rspackOnlyTest(
+  'should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered',
+  async () => {
+    fs.rmSync(packagePath, { recursive: true, force: true });
+    fs.cpSync(path.join(__dirname, 'mock'), packagePath, { recursive: true });
+
+    const { logs, restore } = proxyConsole();
+    process.env.RSDOCTOR = 'true';
+
+    await build({
+      cwd: __dirname,
+      rsbuildConfig: {
+        tools: {
+          rspack: {
+            plugins: [new RsdoctorRspackPlugin()],
+          },
+        },
+      },
+    });
+
+    expect(
+      logs.some((log) => log.includes('@rsdoctor') && log.includes('enabled')),
+    ).toBe(false);
+
+    process.env.RSDOCTOR = '';
+    restore();
   },
 );

--- a/e2e/cases/rsdoctor/mock/index.cjs
+++ b/e2e/cases/rsdoctor/mock/index.cjs
@@ -6,7 +6,7 @@ class RsdoctorRspackPlugin {
 
   apply(compiler) {
     compiler.hooks.done.tap('rsdoctor:test', () => {
-      fse.outputFileSync(path.join(__dirname, './test.txt'), 'test');
+      fse.outputFileSync(path.join(__dirname, './test-temp.txt'), 'test');
     });
   }
 }

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -73,7 +73,6 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         return;
       }
 
-      // TODO: support for multiple compiler
       for (const config of bundlerConfigs) {
         config.plugins ||= [];
         config.plugins.push(new module[pluginName]());

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -24,40 +24,16 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       // Add Rsdoctor plugin to start analysis.
       const isRspack = api.context.bundlerType === 'rspack';
-      const packageName = isRspack
-        ? '@rsdoctor/rspack-plugin'
-        : '@rsdoctor/webpack-plugin';
-
-      let module: RsdoctorExports;
-
-      try {
-        const path = require.resolve(packageName, {
-          paths: [api.context.rootPath],
-        });
-        module = await import(path);
-      } catch (err) {
-        logger.warn(
-          `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow(packageName))} package.`,
-        );
-        return;
-      }
-
       const pluginName = isRspack
         ? 'RsdoctorRspackPlugin'
         : 'RsdoctorWebpackPlugin';
-
-      if (!module || !module[pluginName]) {
-        return;
-      }
-
-      let isAutoRegister = false;
 
       const isRsdoctorPlugin = (plugin: MaybeRsdoctorPlugin) =>
         plugin?.isRsdoctorPlugin === true ||
         plugin?.constructor?.name === pluginName;
 
       for (const config of bundlerConfigs) {
-        // If user has added the Rsdoctor plugin to the config file, it will return.
+        // If user has added the Rsdoctor plugin manually, skip the auto-registration.
         const registered = config.plugins?.some((plugin) =>
           isRsdoctorPlugin(plugin as unknown as MaybeRsdoctorPlugin),
         );
@@ -65,15 +41,45 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
         if (registered) {
           return;
         }
+      }
 
+      const packageName = isRspack
+        ? '@rsdoctor/rspack-plugin'
+        : '@rsdoctor/webpack-plugin';
+      let packagePath: string;
+
+      try {
+        packagePath = require.resolve(packageName, {
+          paths: [api.context.rootPath],
+        });
+      } catch (err) {
+        logger.warn(
+          `\`process.env.RSDOCTOR\` enabled, please install ${color.bold(color.yellow(packageName))} package.`,
+        );
+        return;
+      }
+
+      let module: RsdoctorExports;
+      try {
+        module = await import(packagePath);
+      } catch (err) {
+        logger.error(
+          `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,
+        );
+        return;
+      }
+
+      if (!module || !module[pluginName]) {
+        return;
+      }
+
+      // TODO: support for multiple compiler
+      for (const config of bundlerConfigs) {
         config.plugins ||= [];
         config.plugins.push(new module[pluginName]());
-        isAutoRegister = true;
       }
 
-      if (isAutoRegister) {
-        logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
-      }
+      logger.info(`${color.bold(color.yellow(packageName))} enabled.`);
     });
   },
 });


### PR DESCRIPTION
## Summary

If Rsdoctor plugin has been registered, Rsbuild does not need to resolve the Rsdoctor plugin package.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3358

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
