### PR TITLE
test(e2e): validate all production source map types

### DIFF
--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -61,6 +61,7 @@ mrmime
 mYbzBtlg6o
 napi
 nolyfill
+nosources
 ntqry
 oklab
 onclosetag


### PR DESCRIPTION
## Summary

Add test case to validate all production source map types.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
