### PR TITLE
fix: failed to use html-loader

### DIFF
--- a/e2e/cases/html-loader/index.test.ts
+++ b/e2e/cases/html-loader/index.test.ts
@@ -1,0 +1,44 @@
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to use html-loader in development',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
+
+    const files = await rsbuild.unwrapOutputJSON();
+    const filenames = Object.keys(files);
+
+    expect(
+      filenames.some((filename) =>
+        filename.includes('dist/static/image/image.png'),
+      ),
+    ).toBeTruthy();
+
+    const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
+    expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest('should allow to use html-loader in production', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/image/image.png'),
+    ),
+  ).toBeTruthy();
+
+  const htmlFile = filenames.find((filename) => filename.endsWith('.html'));
+  expect(files[htmlFile!]).toContain('<img src="/static/image/image.png"');
+});

--- a/e2e/cases/html-loader/package.json
+++ b/e2e/cases/html-loader/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "name": "@e2e/html-loader",
+  "version": "1.0.0",
+  "dependencies": {
+    "html-loader": "^5.1.0"
+  }
+}

--- a/e2e/cases/html-loader/rsbuild.config.ts
+++ b/e2e/cases/html-loader/rsbuild.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      module: {
+        rules: [
+          {
+            test: /\.html$/,
+            use: ['html-loader'],
+          },
+        ],
+      },
+    },
+  },
+  output: {
+    filename: {
+      image: '[name][ext]',
+    },
+  },
+  dev: {
+    writeToDisk: true,
+  },
+  html: {
+    template: 'src/template.html',
+  },
+});

--- a/e2e/cases/html-loader/src/index.js
+++ b/e2e/cases/html-loader/src/index.js
@@ -1,0 +1,3 @@
+document.querySelector('#root').innerHTML = `
+<div class="content">Hello World</div>
+`;

--- a/e2e/cases/html-loader/src/template.html
+++ b/e2e/cases/html-loader/src/template.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>html-loader</title>
+  </head>
+  <body>
+    <nav>
+      <img src="../../../assets/image.png" alt="test" />
+    </nav>
+    <div id="root"></div>
+  </body>
+</html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "fs-extra": "^11.2.0",
-    "html-rspack-plugin": "6.0.0",
+    "html-rspack-plugin": "6.0.1",
     "http-proxy-middleware": "^2.0.6",
     "jiti": "^1.21.6",
     "launch-editor-middleware": "^2.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,12 @@ importers:
         specifier: workspace:*
         version: link:../browserslist-config-mock
 
+  e2e/cases/html-loader:
+    dependencies:
+      html-loader:
+        specifier: ^5.1.0
+        version: 5.1.0(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3)))
+
   e2e/cases/react/react-compiler-babel:
     dependencies:
       react:
@@ -664,8 +670,8 @@ importers:
         specifier: ^11.2.0
         version: 11.2.0
       html-rspack-plugin:
-        specifier: 6.0.0
-        version: 6.0.0(@rspack/core@1.0.3(@swc/helpers@0.5.12))
+        specifier: 6.0.1
+        version: 6.0.1(@rspack/core@1.0.3(@swc/helpers@0.5.12))
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.6
@@ -3770,6 +3776,9 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camel-case@4.1.2:
+    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
+
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
     engines: {node: '>= 6'}
@@ -3854,6 +3863,10 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  clean-css@5.3.3:
+    resolution: {integrity: sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==}
+    engines: {node: '>= 10.0'}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -4781,8 +4794,19 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
-  html-rspack-plugin@6.0.0:
-    resolution: {integrity: sha512-p/hXOkywyuhyt5R2onk1UH0RCfu7rmiyMHdp88jB06lnoggEswiBKKKoTEFKza8bBf99a2Vi+rKIuDOIRFQAbw==}
+  html-loader@5.1.0:
+    resolution: {integrity: sha512-Jb3xwDbsm0W3qlXrCZwcYqYGnYz55hb6aoKQTlzyZPXsPpi6tHXzAfqalecglMQgNvtEfxrCQPaKT90Irt5XDA==}
+    engines: {node: '>= 18.12.0'}
+    peerDependencies:
+      webpack: ^5.0.0
+
+  html-minifier-terser@7.2.0:
+    resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  html-rspack-plugin@6.0.1:
+    resolution: {integrity: sha512-7RAFL+4T9C9XUm0x7H9ZRvatRygc5MCAc4XqU+T+NYHRncwPS8G/r64/lcaUBWkE0Gjws27lxJZBpudTB6z6vA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -5797,6 +5821,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  param-case@3.0.4:
+    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -5831,6 +5858,9 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  pascal-case@3.1.2:
+    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
 
   patch-console@1.0.0:
     resolution: {integrity: sha512-nxl9nrnLQmh64iTzMfyylSlRozL7kAXIaxw1fVcLYdyhNkJCRUzirRZTikXGJsg+hc4fqpneTK6iU2H1Q8THSA==}
@@ -6279,6 +6309,10 @@ packages:
 
   rehype-stringify@9.0.4:
     resolution: {integrity: sha512-Uk5xu1YKdqobe5XpSskwPvo1XeHUUucWEQSl8hTrXt5selvca1e8K1EZ37E6YoZ4BT8BCqCdVfQW7OfHfthtVQ==}
+
+  relateurl@0.2.7:
+    resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
+    engines: {node: '>= 0.10'}
 
   remark-gfm@3.0.1:
     resolution: {integrity: sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==}
@@ -10534,6 +10568,11 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camel-case@4.1.2:
+    dependencies:
+      pascal-case: 3.1.2
+      tslib: 2.6.2
+
   camelcase-css@2.0.1: {}
 
   camelcase@6.3.0: {}
@@ -10620,6 +10659,10 @@ snapshots:
   chrome-trace-event@1.0.3: {}
 
   ci-info@3.9.0: {}
+
+  clean-css@5.3.3:
+    dependencies:
+      source-map: 0.6.1
 
   cli-cursor@3.1.0:
     dependencies:
@@ -11666,7 +11709,23 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
-  html-rspack-plugin@6.0.0(@rspack/core@1.0.3(@swc/helpers@0.5.12)):
+  html-loader@5.1.0(webpack@5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))):
+    dependencies:
+      html-minifier-terser: 7.2.0
+      parse5: 7.1.2
+      webpack: 5.94.0(@swc/core@1.6.13(@swc/helpers@0.5.3))
+
+  html-minifier-terser@7.2.0:
+    dependencies:
+      camel-case: 4.1.2
+      clean-css: 5.3.3
+      commander: 10.0.1
+      entities: 4.5.0
+      param-case: 3.0.4
+      relateurl: 0.2.7
+      terser: 5.31.6
+
+  html-rspack-plugin@6.0.1(@rspack/core@1.0.3(@swc/helpers@0.5.12)):
     dependencies:
       '@rspack/lite-tapable': 1.0.0
     optionalDependencies:
@@ -12927,6 +12986,11 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  param-case@3.0.4:
+    dependencies:
+      dot-case: 3.0.4
+      tslib: 2.6.2
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -12974,6 +13038,11 @@ snapshots:
       peberminta: 0.9.0
 
   parseurl@1.3.3: {}
+
+  pascal-case@3.1.2:
+    dependencies:
+      no-case: 3.0.4
+      tslib: 2.6.2
 
   patch-console@1.0.0: {}
 
@@ -13473,6 +13542,8 @@ snapshots:
       '@types/hast': 2.3.10
       hast-util-to-html: 8.0.4
       unified: 10.1.2
+
+  relateurl@0.2.7: {}
 
   remark-gfm@3.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Bump `html-rspack-plugin` 6.0.1 to support the use of `html-loader`.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/3353
- https://github.com/rspack-contrib/html-rspack-plugin/pull/20
- https://www.npmjs.com/package/html-loader

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
