### PR TITLE
docs: add tip for deprecated tilde

### DIFF
--- a/website/docs/en/guide/basic/css-usage.mdx
+++ b/website/docs/en/guide/basic/css-usage.mdx
@@ -92,7 +92,7 @@ This will increase the size of your JS Bundle, so it is usually not recommended 
 
 ## Import CSS in node_modules
 
-You can directly import CSS files in node_modules.
+Rsbuild supports importing CSS files in `node_modules`.
 
 - Import in a JS file:
 

--- a/website/docs/en/guide/basic/css-usage.mdx
+++ b/website/docs/en/guide/basic/css-usage.mdx
@@ -94,21 +94,26 @@ This will increase the size of your JS Bundle, so it is usually not recommended 
 
 You can directly import CSS files in node_modules.
 
-- Import in a component:
+- Import in a JS file:
 
-```ts title="src/App.tsx"
-// Import the Arco Design style:
-import '@arco-design/web-react/dist/css/arco.css';
-```
-
-- Import in a style file:
-
-```css title="src/App.css"
+```ts title="src/index.js"
 /* reference normalize.css */
 /* https://github.com/necolas/normalize.css */
+import 'normalize.css';
+```
+
+- Import in a CSS file:
+
+```css title="src/index.css"
 @import 'normalize.css';
 
 body {
   /* */
 }
+```
+
+In Sass and Less files, it is also allowed to add the `~` prefix to resolve style files in `node_modules`. However, this is a **deprecated feature** and it is recommended to remove the `~` prefix from the code.
+
+```scss title="src/index.scss"
+@import 'normalize.css';
 ```

--- a/website/docs/zh/guide/basic/css-usage.mdx
+++ b/website/docs/zh/guide/basic/css-usage.mdx
@@ -92,7 +92,7 @@ export default {
 
 ## 引用 node_modules 里的样式
 
-Rsbuild 支持直接引用 node_modules 里的样式文件。
+Rsbuild 支持引用 node_modules 里的 CSS 文件。
 
 - 在 JS 文件中引用：
 

--- a/website/docs/zh/guide/basic/css-usage.mdx
+++ b/website/docs/zh/guide/basic/css-usage.mdx
@@ -92,23 +92,28 @@ export default {
 
 ## 引用 node_modules 里的样式
 
-你可以直接引用 node_modules 里的样式文件。
+Rsbuild 支持直接引用 node_modules 里的样式文件。
 
-- 在组件中引用：
+- 在 JS 文件中引用：
 
-```ts title="src/App.tsx"
-// 引用 Arco Design 样式：
-import '@arco-design/web-react/dist/css/arco.css';
-```
-
-- 在样式文件中引用：
-
-```css title="src/App.css"
+```ts title="src/index.js"
 /* 引用 normalize.css */
 /* https://github.com/necolas/normalize.css */
+import 'normalize.css';
+```
+
+- 在 CSS 文件中引用：
+
+```css title="src/index.css"
 @import 'normalize.css';
 
 body {
   /* */
 }
+```
+
+- 在 Sass 和 Less 文件中，也允许添加 `~` 前缀来解析 node_modules 里的样式文件，但这是一个**废弃的特性**，建议从代码中移除 `~` 前缀。
+
+```scss title="src/index.scss"
+@import '~normalize.css';
 ```


### PR DESCRIPTION
## Summary

Add tip for deprecated tilde `~`:

![image](https://github.com/user-attachments/assets/715761a6-76e7-4360-84a8-5a3c766a8bb6)

## Related Links

https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#resolving-import-at-rules

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
