### PR TITLE
fix(plugin-stylus): updated StylusOptions type

### DIFF
--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -6,7 +6,7 @@ export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';
 
 type StylusOptions = {
   use?: string[];
-  include?: string;
+  include?: string[];
   import?: string;
   resolveURL?: boolean;
   lineNumbers?: boolean;


### PR DESCRIPTION
## Summary
According to the [stylus-loader documentation](https://github.com/webpack-contrib/stylus-loader?tab=readme-ov-file#stylusOptions), the include value must be an array of strings. I tried using a string value as specified, but it didn't work (an array of strings works as expected).

Note: still there are minor difference b/w [stylus-loader](https://github.com/webpack-contrib/stylus-loader?tab=readme-ov-file#stylusOptions) options and type used here, we may need to check that as well.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
