### PR TITLE
fix: failed to load Rsdoctor package in Windows

### DIFF
--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -62,7 +62,8 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let module: RsdoctorExports;
       try {
-        module = await import(pathToFileURL(packagePath).href);
+        const modulePath = pathToFileURL(packagePath).href;
+        module = await import(modulePath);
       } catch (err) {
         logger.error(
           `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -62,7 +62,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let module: RsdoctorExports;
       try {
-        module = await import(pathToFileURL(packagePath).toString());
+        module = await import(pathToFileURL(packagePath).href);
       } catch (err) {
         logger.error(
           `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -62,7 +62,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let module: RsdoctorExports;
       try {
-        const modulePath = pathToFileURL(packagePath).href;
+        const modulePath = pathToFileURL(packagePath).pathname;
         module = await import(modulePath);
       } catch (err) {
         logger.error(

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -1,3 +1,4 @@
+import { pathToFileURL } from 'node:url';
 import type { Configuration } from '@rspack/core';
 import color from 'picocolors';
 import { logger } from '../logger';
@@ -61,7 +62,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let module: RsdoctorExports;
       try {
-        module = await import(packagePath);
+        module = await import(pathToFileURL(packagePath).toString());
       } catch (err) {
         logger.error(
           `\`process.env.RSDOCTOR\` enabled, but failed to load ${color.bold(color.yellow(packageName))} module.`,

--- a/packages/core/src/plugins/rsdoctor.ts
+++ b/packages/core/src/plugins/rsdoctor.ts
@@ -3,6 +3,7 @@ import type { Configuration } from '@rspack/core';
 import color from 'picocolors';
 import { logger } from '../logger';
 import type { BundlerPluginInstance, RsbuildPlugin } from '../types';
+import path from 'node:path';
 
 type RsdoctorExports = {
   RsdoctorRspackPlugin: { new (): BundlerPluginInstance };
@@ -62,7 +63,7 @@ export const pluginRsdoctor = (): RsbuildPlugin => ({
 
       let module: RsdoctorExports;
       try {
-        const modulePath = pathToFileURL(packagePath).pathname;
+        const modulePath = pathToFileURL(path.resolve(packagePath)).href;
         module = await import(modulePath);
       } catch (err) {
         logger.error(


### PR DESCRIPTION
## Summary

Fix failed to load Rsdoctor package in Windows.

![image](https://github.com/user-attachments/assets/6bbf1f2b-beec-4864-b54c-6a4228250401)


## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3358
https://nodejs.org/api/esm.html#file-urls
https://nodejs.org/api/url.html#urlpathtofileurlpath-options

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
