### PR TITLE
chore(workflow): no longer fix package version

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,6 @@
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",
-  "fixed": [["@rsbuild/*", "create-rsbuild"]],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true,
     "updateInternalDependents": "always"


### PR DESCRIPTION
## Summary

Starting from Rsbuild 1.0, we no longer require all Rsbuild packages to use the same version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
