### PR TITLE
chore(create-rsbuild): prepare for 1.0 release

### DIFF
--- a/packages/create-rsbuild/template-lit-js/package.json
+++ b/packages/create-rsbuild/template-lit-js/package.json
@@ -11,6 +11,6 @@
     "lit": "^3.2.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*"
+    "@rsbuild/core": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -11,7 +11,7 @@
     "lit": "^3.2.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-preact-js/package.json
+++ b/packages/create-rsbuild/template-preact-js/package.json
@@ -11,7 +11,7 @@
     "preact": "^10.23.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-preact": "workspace:*"
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-preact": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -11,8 +11,8 @@
     "preact": "^10.23.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-preact": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-preact": "^1.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-react-js/package.json
+++ b/packages/create-rsbuild/template-react-js/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-react": "workspace:*"
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-react": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -12,8 +12,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-react": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-react": "^1.0.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
     "typescript": "^5.5.2"

--- a/packages/create-rsbuild/template-solid-js/package.json
+++ b/packages/create-rsbuild/template-solid-js/package.json
@@ -11,8 +11,8 @@
     "solid-js": "^1.8.22"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-babel": "workspace:*",
-    "@rsbuild/plugin-solid": "workspace:*"
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-babel": "^1.0.1",
+    "@rsbuild/plugin-solid": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -11,9 +11,9 @@
     "solid-js": "^1.8.22"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-babel": "workspace:*",
-    "@rsbuild/plugin-solid": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-babel": "^1.0.1",
+    "@rsbuild/plugin-solid": "^1.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-svelte-js/package.json
+++ b/packages/create-rsbuild/template-svelte-js/package.json
@@ -11,7 +11,7 @@
     "svelte": "^4.2.19"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-svelte": "workspace:*"
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-svelte": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -12,8 +12,8 @@
     "svelte": "^4.2.19"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-svelte": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-svelte": "^1.0.1",
     "svelte-check": "^4.0.1",
     "typescript": "^5.5.2"
   }

--- a/packages/create-rsbuild/template-vanilla-js/package.json
+++ b/packages/create-rsbuild/template-vanilla-js/package.json
@@ -8,6 +8,6 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*"
+    "@rsbuild/core": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -8,7 +8,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
     "typescript": "^5.5.2"
   }
 }

--- a/packages/create-rsbuild/template-vue2-js/package.json
+++ b/packages/create-rsbuild/template-vue2-js/package.json
@@ -11,7 +11,7 @@
     "vue": "^2.7.16"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
     "@rsbuild/plugin-vue2": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -11,7 +11,7 @@
     "vue": "^2.7.16"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
     "@rsbuild/plugin-vue2": "^1.0.1",
     "typescript": "^5.5.2"
   }

--- a/packages/create-rsbuild/template-vue3-js/package.json
+++ b/packages/create-rsbuild/template-vue3-js/package.json
@@ -11,7 +11,7 @@
     "vue": "^3.5.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-vue": "workspace:*"
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-vue": "^1.0.1"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -11,8 +11,8 @@
     "vue": "^3.5.3"
   },
   "devDependencies": {
-    "@rsbuild/core": "workspace:*",
-    "@rsbuild/plugin-vue": "workspace:*",
+    "@rsbuild/core": "^1.0.1",
+    "@rsbuild/plugin-vue": "^1.0.1",
     "typescript": "^5.5.2"
   }
 }


### PR DESCRIPTION
## Summary

Starting with Rsbuild 1.0, we no longer require all Rsbuild packages to use the same version, and `create-rsbuild` should unpin the `@rsbuild/*` dependencies version.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/3420

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
