### PR TITLE
fix(create-rsbuild): eslint-plugin-react-hooks version conflict

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -28,7 +28,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "1.0.1"
+    "create-rstack": "1.0.2"
   },
   "devDependencies": {
     "@rslib/core": "0.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,8 +739,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 1.0.2
+        version: 1.0.2
     devDependencies:
       '@rslib/core':
         specifier: 0.0.5
@@ -3930,8 +3930,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.0.1:
-    resolution: {integrity: sha512-zx+ynJiBJc8BSrtOpDKeFv+3DJm2MOajrMoxpsHHji3vsC+BAflQo4XTcTZ+UMZrI6FKd3sk4WCtlB0bYEzONg==}
+  create-rstack@1.0.2:
+    resolution: {integrity: sha512-0zG6G4YeUewWZ/TWGuijWI5XuUrlWSScYSNaqw/Pw8qbrSEnmwLlIDAI4K0bl6DNoskcgxSRiP6YT96wWGDdtA==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -10652,7 +10652,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.2
 
-  create-rstack@1.0.1: {}
+  create-rstack@1.0.2: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fix eslint-plugin-react-hooks version conflict.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/3427
- https://github.com/rspack-contrib/create-rstack/pull/3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
