### PR TITLE
release: @rsbuild/core v1.0.2

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-webpack-swc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "SWC plugin for Rsbuild webpack provider",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1085,9 +1085,6 @@ importers:
 
   scripts/test-helper:
     dependencies:
-      '@rsbuild/core':
-        specifier: workspace:*
-        version: link:../../packages/core
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.7
@@ -1106,6 +1103,10 @@ importers:
       upath:
         specifier: 2.0.1
         version: 2.0.1
+    devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../../packages/core
 
   website:
     devDependencies:

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -25,13 +25,15 @@
     "dev": "modern build --watch"
   },
   "dependencies": {
-    "@rsbuild/core": "workspace:*",
     "@types/lodash": "^4.17.7",
     "@types/node": "18.x",
     "lodash": "^4.17.21",
     "path-serializer": "0.0.6",
     "typescript": "^5.5.2",
     "upath": "2.0.1"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "workspace:*"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(deps): bump Rspack v1.0.4 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3443
* feat(plugin-stylus): support `define` option by @shulaoda in https://github.com/web-infra-dev/rsbuild/pull/3434
### Bug Fixes 🐞
* fix(plugin-webpack-swc): @swc/helpers version requires at least 0.5.13 by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3436
* fix(create-rsbuild): eslint-plugin-react-hooks version conflict by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3441
### Document 📖
* docs: fix typo in 1.0 announcement by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3432
* docs: add example for merging Rspack config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3437
* docs(plugin-stylus): update `StylusOptions` by @shulaoda in https://github.com/web-infra-dev/rsbuild/pull/3439
* docs: add recommended PostCSS plugins when not using Lightning CSS by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3442

## New Contributors
* @shulaoda made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3434

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.1...v1.0.2