### PR TITLE
fix(plugin-react): allow configuring `tools.swc` to override react runtime

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -8,9 +8,6 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
     },
   },
   RsbuildCorePlugin {},
-  HotModuleReplacementPlugin {
-    "options": {},
-  },
   MiniCssExtractPlugin {
     "_sortedModulesCache": WeakMap {},
     "options": {

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -17,7 +17,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { env, isProd, target, bundler, environment, CHAIN_ID }) => {
+      (chain, { env, isDev, target, bundler, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);
@@ -46,7 +46,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           },
         });
 
-        const usingHMR = !isProd && config.dev.hmr && target === 'web';
+        const usingHMR = isDev && config.dev.hmr && target === 'web';
 
         if (usingHMR) {
           chain

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -1,33 +1,11 @@
 import path from 'node:path';
 import type {
-  ChainIdentifier,
+  EnvironmentConfig,
   RsbuildConfig,
   RsbuildPluginAPI,
   Rspack,
-  RspackChain,
 } from '@rsbuild/core';
 import type { PluginReactOptions } from '.';
-
-const modifySwcLoaderOptions = ({
-  chain,
-  CHAIN_ID,
-  modifier,
-}: {
-  chain: RspackChain;
-  CHAIN_ID: ChainIdentifier;
-  modifier: (config: Rspack.SwcLoaderOptions) => Rspack.SwcLoaderOptions;
-}) => {
-  const ruleIds = [CHAIN_ID.RULE.JS, CHAIN_ID.RULE.JS_DATA_URI];
-
-  for (const ruleId of ruleIds) {
-    if (chain.module.rules.has(ruleId)) {
-      const rule = chain.module.rule(ruleId);
-      if (rule.uses.has(CHAIN_ID.USE.SWC)) {
-        rule.use(CHAIN_ID.USE.SWC).tap(modifier);
-      }
-    }
-  }
-};
 
 export const applyBasicReactSupport = (
   api: RsbuildPluginAPI,
@@ -35,35 +13,41 @@ export const applyBasicReactSupport = (
 ): void => {
   const REACT_REFRESH_PATH = require.resolve('react-refresh');
 
+  api.modifyEnvironmentConfig((userConfig, { mergeEnvironmentConfig }) => {
+    const isDev = userConfig.mode === 'development';
+
+    const reactOptions: Rspack.SwcLoaderTransformConfig['react'] = {
+      development: isDev,
+      refresh:
+        isDev && userConfig.dev.hmr && userConfig.output.target === 'web',
+      runtime: 'automatic',
+      ...options.swcReactOptions,
+    };
+
+    const extraConfig: EnvironmentConfig = {
+      tools: {
+        swc: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              // enable supports for JSX/TSX compilation
+              tsx: true,
+            },
+            transform: {
+              react: reactOptions,
+            },
+          },
+        },
+      },
+    };
+
+    return mergeEnvironmentConfig(extraConfig, userConfig);
+  });
+
   api.modifyBundlerChain(
-    async (chain, { CHAIN_ID, environment, isDev, isProd, target }) => {
+    async (chain, { CHAIN_ID, environment, isProd, target }) => {
       const { config } = environment;
       const usingHMR = !isProd && config.dev.hmr && target === 'web';
-      const reactOptions: Rspack.SwcLoaderTransformConfig['react'] = {
-        development: isDev,
-        refresh: usingHMR,
-        runtime: 'automatic',
-        ...options.swcReactOptions,
-      };
-
-      modifySwcLoaderOptions({
-        chain,
-        CHAIN_ID,
-        modifier: (opts) => {
-          opts.jsc ||= {};
-          opts.jsc.transform ||= {};
-          opts.jsc.transform.react = reactOptions;
-          opts.jsc.parser = {
-            ...opts.jsc.parser,
-            syntax: 'typescript',
-            // enable supports for React JSX/TSX compilation
-            tsx: true,
-          };
-
-          return opts;
-        },
-      });
-
       if (!usingHMR) {
         return;
       }

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -45,9 +45,9 @@ export const applyBasicReactSupport = (
   });
 
   api.modifyBundlerChain(
-    async (chain, { CHAIN_ID, environment, isProd, target }) => {
+    async (chain, { CHAIN_ID, environment, isDev, target }) => {
       const { config } = environment;
-      const usingHMR = !isProd && config.dev.hmr && target === 'web';
+      const usingHMR = isDev && config.dev.hmr && target === 'web';
       if (!usingHMR) {
         return;
       }

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,69 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugins/react > should configuring \`tools.swc\` to override react runtime 1`] = `
+[
+  {
+    "resolve": {
+      "fullySpecified": false,
+    },
+    "test": /\\\\\\.m\\?js/,
+  },
+  {
+    "include": [
+      {
+        "and": [
+          "<ROOT>/packages/plugin-react/tests",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": true,
+            },
+            "preserveAllComments": true,
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+              "react": {
+                "development": true,
+                "refresh": true,
+                "runtime": "classic",
+              },
+            },
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
 exports[`plugins/react > should not apply splitChunks rule when strategy is not split-by-experience 1`] = `
 {
   "cacheGroups": {
@@ -16,423 +80,65 @@ exports[`plugins/react > should not apply splitChunks rule when strategy is not 
 `;
 
 exports[`plugins/react > should work with swc-loader 1`] = `
-{
-  "context": "<ROOT>/packages/plugin-react/tests",
-  "devtool": "cheap-module-source-map",
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
-  "experiments": {
-    "asyncWebAssembly": true,
-  },
-  "infrastructureLogging": {
-    "level": "error",
-  },
-  "mode": "development",
-  "module": {
-    "parser": {
-      "javascript": {
-        "exportsPresence": "error",
-      },
+[
+  {
+    "resolve": {
+      "fullySpecified": false,
     },
-    "rules": [
+    "test": /\\\\\\.m\\?js/,
+  },
+  {
+    "include": [
       {
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "test": /\\\\\\.m\\?js/,
-      },
-      {
-        "resolve": {
-          "preferRelative": true,
-        },
-        "sideEffects": true,
-        "test": /\\\\\\.css\\$/,
-        "type": "javascript/auto",
-        "use": [
+        "and": [
+          "<ROOT>/packages/plugin-react/tests",
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
-          },
-          {
-            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
-            "options": {
-              "_skipReuseAST": true,
-              "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
-              "sourceMap": false,
-            },
-          },
-          {
-            "loader": "builtin:lightningcss-loader",
-            "options": {
-              "targets": [
-                "chrome >= 87",
-                "edge >= 88",
-                "firefox >= 78",
-                "safari >= 14",
-              ],
-            },
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
         ],
       },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
       {
-        "include": [
-          {
-            "and": [
-              "<ROOT>/packages/plugin-react/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
             ],
           },
-          /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
-        ],
-        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
-        "use": [
-          {
-            "loader": "builtin:swc-loader",
-            "options": {
-              "env": {
-                "mode": undefined,
-                "targets": [
-                  "chrome >= 87",
-                  "edge >= 88",
-                  "firefox >= 78",
-                  "safari >= 14",
-                ],
-              },
-              "isModule": "unknown",
-              "jsc": {
-                "experimental": {
-                  "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
-                },
-                "externalHelpers": true,
-                "parser": {
-                  "decorators": true,
-                  "syntax": "typescript",
-                  "tsx": true,
-                },
-                "preserveAllComments": true,
-                "transform": {
-                  "decoratorVersion": "2022-03",
-                  "legacyDecorator": false,
-                  "react": {
-                    "development": true,
-                    "refresh": true,
-                    "runtime": "automatic",
-                  },
-                },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": true,
+            },
+            "preserveAllComments": true,
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+              "react": {
+                "development": true,
+                "refresh": true,
+                "runtime": "automatic",
               },
             },
           },
-        ],
-      },
-      {
-        "mimetype": {
-          "or": [
-            "text/javascript",
-            "application/javascript",
-          ],
         },
-        "resolve": {
-          "fullySpecified": false,
-        },
-        "use": [
-          {
-            "loader": "builtin:swc-loader",
-            "options": {
-              "env": {
-                "mode": undefined,
-                "targets": [
-                  "chrome >= 87",
-                  "edge >= 88",
-                  "firefox >= 78",
-                  "safari >= 14",
-                ],
-              },
-              "isModule": "unknown",
-              "jsc": {
-                "experimental": {
-                  "cacheRoot": "<ROOT>/packages/plugin-react/tests/node_modules/.cache/.swc",
-                },
-                "externalHelpers": true,
-                "parser": {
-                  "decorators": true,
-                  "syntax": "typescript",
-                  "tsx": true,
-                },
-                "preserveAllComments": true,
-                "transform": {
-                  "decoratorVersion": "2022-03",
-                  "legacyDecorator": false,
-                  "react": {
-                    "development": true,
-                    "refresh": true,
-                    "runtime": "automatic",
-                  },
-                },
-              },
-            },
-          },
-        ],
-      },
-      {
-        "oneOf": [
-          {
-            "generator": {
-              "filename": "static/image/[name].[contenthash:8][ext]",
-            },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
-            "type": "asset/resource",
-          },
-          {
-            "resourceQuery": /inline/,
-            "type": "asset/inline",
-          },
-          {
-            "generator": {
-              "filename": "static/image/[name].[contenthash:8][ext]",
-            },
-            "parser": {
-              "dataUrlCondition": {
-                "maxSize": 4096,
-              },
-            },
-            "type": "asset",
-          },
-        ],
-        "test": /\\\\\\.\\(\\?:png\\|jpg\\|jpeg\\|pjpeg\\|pjp\\|gif\\|bmp\\|webp\\|ico\\|apng\\|avif\\|tif\\|tiff\\|jfif\\)\\$/i,
-      },
-      {
-        "oneOf": [
-          {
-            "generator": {
-              "filename": "static/svg/[name].[contenthash:8].svg",
-            },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
-            "type": "asset/resource",
-          },
-          {
-            "resourceQuery": /inline/,
-            "type": "asset/inline",
-          },
-          {
-            "generator": {
-              "filename": "static/svg/[name].[contenthash:8].svg",
-            },
-            "parser": {
-              "dataUrlCondition": {
-                "maxSize": 4096,
-              },
-            },
-            "type": "asset",
-          },
-        ],
-        "test": /\\\\\\.svg\\$/i,
-      },
-      {
-        "oneOf": [
-          {
-            "generator": {
-              "filename": "static/media/[name].[contenthash:8][ext]",
-            },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
-            "type": "asset/resource",
-          },
-          {
-            "resourceQuery": /inline/,
-            "type": "asset/inline",
-          },
-          {
-            "generator": {
-              "filename": "static/media/[name].[contenthash:8][ext]",
-            },
-            "parser": {
-              "dataUrlCondition": {
-                "maxSize": 4096,
-              },
-            },
-            "type": "asset",
-          },
-        ],
-        "test": /\\\\\\.\\(\\?:mp4\\|webm\\|ogg\\|mov\\|mp3\\|wav\\|flac\\|aac\\|m4a\\|opus\\)\\$/i,
-      },
-      {
-        "oneOf": [
-          {
-            "generator": {
-              "filename": "static/font/[name].[contenthash:8][ext]",
-            },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
-            "type": "asset/resource",
-          },
-          {
-            "resourceQuery": /inline/,
-            "type": "asset/inline",
-          },
-          {
-            "generator": {
-              "filename": "static/font/[name].[contenthash:8][ext]",
-            },
-            "parser": {
-              "dataUrlCondition": {
-                "maxSize": 4096,
-              },
-            },
-            "type": "asset",
-          },
-        ],
-        "test": /\\\\\\.\\(\\?:woff\\|woff2\\|eot\\|ttf\\|otf\\|ttc\\)\\$/i,
-      },
-      {
-        "dependency": "url",
-        "generator": {
-          "filename": "static/wasm/[hash].module.wasm",
-        },
-        "test": /\\\\\\.wasm\\$/,
-        "type": "asset/resource",
       },
     ],
   },
-  "name": "web",
-  "optimization": {
-    "minimize": false,
-    "splitChunks": {
-      "cacheGroups": {
-        "lib-axios": {
-          "name": "lib-axios",
-          "priority": 0,
-          "test": /node_modules\\[\\\\\\\\/\\]axios\\(-\\.\\+\\)\\?\\[\\\\\\\\/\\]/,
-        },
-        "react": {
-          "name": "lib-react",
-          "priority": 0,
-          "test": /node_modules\\[\\\\\\\\/\\]\\(\\?:react\\|react-dom\\|scheduler\\|react-refresh\\|@rspack\\[\\\\\\\\/\\]plugin-react-refresh\\)\\[\\\\\\\\/\\]/,
-        },
-        "router": {
-          "name": "lib-router",
-          "priority": 0,
-          "test": /node_modules\\[\\\\\\\\/\\]\\(\\?:react-router\\|react-router-dom\\|history\\|@remix-run\\[\\\\\\\\/\\]router\\)\\[\\\\\\\\/\\]/,
-        },
-      },
-      "chunks": "all",
-    },
-  },
-  "output": {
-    "chunkFilename": "static/js/async/[name].js",
-    "filename": "static/js/[name].js",
-    "hashFunction": "xxhash64",
-    "path": "<ROOT>/packages/plugin-react/tests/dist",
-    "pathinfo": false,
-    "publicPath": "/",
-    "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
-  },
-  "performance": {
-    "hints": false,
-  },
-  "plugins": [
-    RsbuildCorePlugin {},
-    HotModuleReplacementPlugin {
-      "name": "HotModuleReplacementPlugin",
-    },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "static/css/async/[name].css",
-        "filename": "static/css/[name].css",
-        "ignoreOrder": true,
-      },
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
-      "name": "RsbuildHtmlPlugin",
-      "options": {
-        "index": {
-          "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        },
-      },
-    },
-    DefinePlugin {
-      "_args": [
-        {
-          "import.meta.env.DEV": true,
-          "import.meta.env.MODE": ""development"",
-          "import.meta.env.PROD": false,
-          "process.env.ASSET_PREFIX": """",
-        },
-      ],
-      "affectedHooks": "compilation",
-      "name": "DefinePlugin",
-    },
-    ReactRefreshRspackPlugin {
-      "options": {
-        "exclude": /node_modules/i,
-        "forceEnable": false,
-        "include": [
-          /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        ],
-        "overlay": false,
-      },
-    },
-  ],
-  "resolve": {
-    "alias": {
-      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      "react-refresh": "<ROOT>/node_modules/<PNPM_INNER>/react-refresh",
-    },
-    "extensions": [
-      ".ts",
-      ".tsx",
-      ".mjs",
-      ".js",
-      ".jsx",
-      ".json",
-    ],
-  },
-  "target": [
-    "web",
-    "es2017",
-  ],
-}
+]
 `;

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createStubRsbuild, matchRules } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
 import { pluginReact } from '../src';
 
@@ -13,7 +13,31 @@ describe('plugins/react', () => {
     rsbuild.addPlugins([pluginReact()]);
     const config = await rsbuild.unwrapConfig();
 
-    expect(config).toMatchSnapshot();
+    expect(matchRules(config, 'a.js')).toMatchSnapshot();
+  });
+
+  it('should configuring `tools.swc` to override react runtime', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        mode: 'development',
+        tools: {
+          swc: {
+            jsc: {
+              transform: {
+                react: {
+                  runtime: 'classic',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReact()]);
+    const config = await rsbuild.unwrapConfig();
+
+    expect(matchRules(config, 'a.js')).toMatchSnapshot();
   });
 
   it('should not apply react refresh when dev.hmr is false', async () => {

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -47,7 +47,7 @@ exports[`svgr > 'configure SVGR options' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -140,7 +140,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -205,7 +205,7 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -297,7 +297,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -362,7 +362,7 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -454,7 +454,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -519,7 +519,7 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -611,7 +611,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },
@@ -676,7 +676,7 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
                 "legacyDecorator": false,
                 "react": {
                   "development": false,
-                  "refresh": true,
+                  "refresh": false,
                   "runtime": "automatic",
                 },
               },


### PR DESCRIPTION
## Summary

Allow configuring `tools.swc` to override react runtime.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3418

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
