### PR TITLE
fix: set resolve.tsConfig by rspack-chain

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,7 +90,7 @@
     "reduce-configs": "^1.0.0",
     "rsbuild-dev-middleware": "0.1.1",
     "rslog": "^1.2.3",
-    "rspack-chain": "^1.0.0",
+    "rspack-chain": "^1.0.1",
     "rspack-manifest-plugin": "5.0.1",
     "sirv": "^2.0.4",
     "style-loader": "3.3.4",

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -5,7 +5,6 @@ import { ensureAbsolutePath } from '../helpers/path';
 import type {
   NormalizedEnvironmentConfig,
   RsbuildPlugin,
-  Rspack,
   RspackChain,
 } from '../types';
 
@@ -108,16 +107,8 @@ export const pluginResolve = (): RsbuildPlugin => ({
           api.context.bundlerType === 'rspack' &&
           config.source.aliasStrategy === 'prefer-tsconfig'
         ) {
-          const tsConfig: Rspack.ResolveOptions['tsConfig'] =
-            chain.resolve.get('tsConfig');
-
-          if (typeof tsConfig === 'string') {
-            return;
-          }
-
           chain.resolve.tsConfig({
             configFile: tsconfigPath,
-            ...tsConfig,
           });
         }
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       rspack-chain:
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       rspack-manifest-plugin:
         specifier: 5.0.1
         version: 5.0.1(@rspack/core@1.0.4(@swc/helpers@0.5.13))
@@ -6296,8 +6296,8 @@ packages:
     resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
     engines: {node: '>=14.17.6'}
 
-  rspack-chain@1.0.0:
-    resolution: {integrity: sha512-bsIz9BUhJXNojd7EzDsRNJAJu9eEV06tJZx0zKQWZt2LHW6yTC7Ref0/dCgXTBsRsc7FNn+3WoQzWEtNCgR5gg==}
+  rspack-chain@1.0.1:
+    resolution: {integrity: sha512-WuKu6d7Vj+rGz6gHnBMha41qNTEleXjKyJhwUjnfiJ3Hxksn3hKl9zPdXUopYTBIJAbpKfDgIRewp/aGca1YeQ==}
 
   rspack-manifest-plugin@5.0.1:
     resolution: {integrity: sha512-K2g7kcOdj+cHTi+xvzwdLZ4rdL1nnphJhs9P8VH5sVcoQd1U/FxpNXnEm5ARxhE7qZO0yfqaL74aXwcQH0T0Ig==}
@@ -13485,7 +13485,7 @@ snapshots:
 
   rslog@1.2.3: {}
 
-  rspack-chain@1.0.0:
+  rspack-chain@1.0.1:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Set r`esolve.tsConfig` by rspack-chain instead of `api.modifyRspackConfig`.

## Related Links

https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.0.1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
