### PR TITLE
docs(plugin-svgr): correct named export guide

### DIFF
--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -32,6 +32,8 @@ export default {
 
 ## Example
 
+### Default Usage
+
 After registering the plugin, when import an SVG in a JS file, if the imported path contains the `?react` suffix, Rsbuild will call SVGR to transform the SVG into a React component.
 
 ```jsx title="App.jsx"
@@ -48,13 +50,28 @@ import logoURL from './static/logo.svg';
 console.log(logoURL); // => "/static/logo.6c12aba3.png"
 ```
 
-Rsbuild also supports named imports of the `ReactComponent` to use SVGR:
+### Named Import
+
+`@rsbuild/plugin-svgr` supports named imports for `ReactComponent` when using SVGR. You need to set [svgrOptions.exportType](#svgroptionsexporttype) to `'named'`:
+
+```js
+pluginSvgr({
+  svgrOptions: {
+    exportType: 'named',
+  },
+});
+```
 
 ```jsx title="App.jsx"
 import { ReactComponent as Logo } from './logo.svg';
 
 export const App = () => <Logo />;
 ```
+
+`@rsbuild/plugin-svgr` also supports default imports and mixed imports:
+
+- Enable default imports by setting [svgrOptions.exportType](#svgroptionsexporttype) to `'default'`.
+- Enable mixed imports by setting the [mixedImport](#mixedimport) option to use both default and named imports at the same time.
 
 ## Options
 
@@ -163,8 +180,8 @@ Set the export type of SVG React components.
 
 `exportType` can be set as:
 
-- `default`: use default export
-- `named`: use named export (`ReactComponent`)
+- `default`: use default export.
+- `named`: use `ReactComponent` named export.
 
 For example, set the default export of SVG file as a React component:
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -32,6 +32,8 @@ export default {
 
 ## 示例
 
+### 默认用法
+
 注册插件后，当你在 **JS 文件**中引用 SVG 资源时，如果导入的路径包含 `?react` 后缀，Rsbuild 会调用 SVGR，将 SVG 图片转换为一个 React 组件。
 
 ```jsx title="App.jsx"
@@ -48,13 +50,28 @@ import logoURL from './static/logo.svg';
 console.log(logoURL); // => "/static/logo.6c12aba3.png"
 ```
 
-Rsbuild 也支持具名导入 ReactComponent 来使用 SVGR：
+### 具名导入
+
+`@rsbuild/plugin-svgr` 支持具名导入 `ReactComponent` 来使用 SVGR，你需要设置 [svgrOptions.exportType](#svgroptionsexporttype) 为 `'named'`：
+
+```js
+pluginSvgr({
+  svgrOptions: {
+    exportType: 'named',
+  },
+});
+```
 
 ```jsx title="App.jsx"
 import { ReactComponent as Logo } from './logo.svg';
 
 export const App = () => <Logo />;
 ```
+
+`@rsbuild/plugin-svgr` 也支持默认导入和混合导入等用法：
+
+- 通过 [svgrOptions.exportType](#svgroptionsexporttype) 设置为 `'default'` 来启用默认导入。
+- 通过 [mixedImport](#mixedimport) 选项来启用混合导入，从而同时使用默认导入和具名导入。
 
 ## 选项
 
@@ -163,8 +180,8 @@ const mergedSvgoConfig = {
 
 `exportType` 可以设置为：
 
-- `default`：使用默认导出
-- `named`：使用具名导出（`ReactComponent`）
+- `default`：使用默认导出。
+- `named`：使用 `ReactComponent` 具名导出。
 
 比如把 SVG 文件默认导出的内容设置为 React 组件：
 


### PR DESCRIPTION
## Summary

Correct named export guide for plugin-svgr.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3468

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
