### PR TITLE
fix(type): eco-ci fail of watching close callback type

### DIFF
--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -39,7 +39,9 @@ export const build = async (
     return {
       close: () =>
         new Promise((resolve) => {
-          watching.close(resolve);
+          watching.close(() => {
+            resolve();
+          });
         }),
     };
   }


### PR DESCRIPTION
## Summary

![img_v3_02em_10aeae3f-b9e7-43ce-a710-b1c2bdcf0e3g](https://github.com/user-attachments/assets/bcbcb7ea-c305-4b25-899b-9e908e4deba1)

close callback is "any" before,  and type is narrow now

https://github.com/web-infra-dev/rspack/pull/7824

## Related Links

<!--- Provide links of related issues or pages -->


