### PR TITLE
fix: should format printed url when htmlPath startsWith `./`

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -20,7 +20,9 @@ test('should print server urls correctly when printUrls is true', async ({
   await page.goto(`http://localhost:${rsbuild.port}`);
 
   const localLog = logs.find(
-    (log) => log.includes('Local:') && log.includes('http://localhost'),
+    (log) =>
+      log.includes('Local:') &&
+      log.includes(`http://localhost:${rsbuild.port}`),
   );
   const networkLog = logs.find(
     (log) => log.includes('Network:') && log.includes('http://'),
@@ -28,6 +30,8 @@ test('should print server urls correctly when printUrls is true', async ({
 
   expect(localLog).toBeTruthy();
   expect(networkLog).toBeTruthy();
+
+  expect(logs.find((log) => log.includes('/./'))).toBeFalsy();
 
   await rsbuild.close();
   restore();

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -42,7 +42,13 @@ export const normalizeUrl = (url: string): string =>
 /**
  * Make sure there is slash before and after prefix
  */
-const formatPrefix = (prefix: string | undefined) => {
+const formatPrefix = (input: string | undefined) => {
+  let prefix = input;
+
+  if (prefix?.startsWith('./')) {
+    prefix = prefix.replace('./', '');
+  }
+
   if (!prefix) {
     return '/';
   }


### PR DESCRIPTION
## Summary

should format printed url when htmlPath startsWith `./`
![img_v3_02em_08ce6434-05b1-412a-9cee-5181aa132b6g](https://github.com/user-attachments/assets/5ac93dbd-f2a6-452e-a3e6-828b4c93cf90)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
