### PR TITLE
chore(plugin-less): use Rslib to bundle

### DIFF
--- a/packages/plugin-less/modern.config.ts
+++ b/packages/plugin-less/modern.config.ts
@@ -1,3 +1,0 @@
-import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
-
-export default configForSeparateTypesPackage;

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -12,21 +12,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist-types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist-types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "compiled",
-    "dist-types"
+    "compiled"
   ],
   "scripts": {
-    "build": "modern build",
-    "dev": "modern build --watch",
+    "build": "rslib build",
+    "dev": "rslib build --watch",
     "prebundle": "prebundle"
   },
   "dependencies": {
@@ -35,6 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
+    "@rslib/core": "0.0.6",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.6",
     "less": "^4.2.0",

--- a/packages/plugin-less/rslib.config.ts
+++ b/packages/plugin-less/rslib.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    {
+      format: 'esm',
+      dts: { bundle: false },
+    },
+    { format: 'cjs' },
+  ],
+  output: {
+    target: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,6 +838,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
+      '@rslib/core':
+        specifier: 0.0.6
+        version: 0.0.6(typescript@5.5.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper


### PR DESCRIPTION
## Summary

Use Rslib to bundle `@rsbuild/plugin-less`.

TODO:

- `getLessLoaderOptions` should not be marked as deprecated after bundling.
- The target should not become `es5` when using `syntax`: https://github.com/web-infra-dev/rslib/blob/ed9fe5b0760822e703d9703d5ec31dc86ead2e5f/packages/core/src/config.ts#L569

![image](https://github.com/user-attachments/assets/22eba2ad-063c-4432-9d38-9a1316dbb1e6)

## Related Links

https://github.com/web-infra-dev/rslib

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
