### PR TITLE
docs: htmlPaths typo

### DIFF
--- a/website/docs/en/guide/migration/rsbuild-0-x.mdx
+++ b/website/docs/en/guide/migration/rsbuild-0-x.mdx
@@ -403,7 +403,7 @@ Includes:
 
 - The `onBeforeBuild` hook supports triggering multiple times in watch mode.
 - Added `onBeforeEnvironmentCompile` and `onAfterEnvironmentCompile` hooks, which are triggered before/after executing the build of a single environment respectively.
-- Removed `api.getHtmlPath` and replaced it with `environment.htmlPaths`.
+- Removed `api.getHtmlPaths` and replaced it with `environment.htmlPaths`.
 - Removed `api.context.entry` and replaced it with `environment.entry`.
 - Removed `api.context.targets` and replaced it with `environment.target`.
 - Removed `rsbuildServer.onHTTPUpgrade` and replaced it with `rsbuildServer.connectWebSocket`.

--- a/website/docs/zh/guide/migration/rsbuild-0-x.mdx
+++ b/website/docs/zh/guide/migration/rsbuild-0-x.mdx
@@ -403,7 +403,7 @@ Rsbuild 1.0 对插件、dev server 等 API 进行了部分调整和优化。
 
 - `onBeforeBuild` 钩子在 watch 模式下支持触发多次。
 - 新增 `onBeforeEnvironmentCompile` 和 `onAfterEnvironmentCompile` 钩子，分别在执行单个 environment 的构建前/后触发。
-- 移除 `api.getHtmlPath`，改为 `environment.htmlPaths`。
+- 移除 `api.getHtmlPaths`，改为 `environment.htmlPaths`。
 - 移除 `api.context.entry`，改为 `environment.entry`。
 - 移除 `api.context.targets`，改为 `environment.target`。
 - 移除 `rsbuildServer.onHTTPUpgrade`，改为 `rsbuildServer.connectWebSocket`。


### PR DESCRIPTION
## Summary

Fix `htmlPaths` typo, in rsbuild 0.x it is `api.getHtmlPaths`, not `api.getHtmlPath`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
