### PR TITLE
feat: disable preserveAllComments by default

### DIFF
--- a/packages/compat/plugin-webpack-swc/src/plugin.ts
+++ b/packages/compat/plugin-webpack-swc/src/plugin.ts
@@ -166,9 +166,6 @@ export function getDefaultSwcConfig(): TransformConfig {
           runtime: 'automatic',
         },
       },
-      // Avoid the webpack magic comment to be removed
-      // https://github.com/swc-project/swc/issues/6403
-      preserveAllComments: true,
     },
   };
 }

--- a/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -41,7 +41,6 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -99,7 +98,6 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -155,7 +153,6 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorMetadata": true,
                     "legacyDecorator": true,
@@ -211,7 +208,6 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorMetadata": true,
                     "legacyDecorator": true,
@@ -275,7 +271,6 @@ exports[`plugin-webpack-swc > should apply source.include and source.exclude cor
                   "syntax": "typescript",
                   "tsx": true,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -333,7 +328,6 @@ exports[`plugin-webpack-swc > should apply source.include and source.exclude cor
                   "syntax": "typescript",
                   "tsx": true,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -394,7 +388,6 @@ exports[`plugin-webpack-swc > should disable react refresh when dev.hmr is false
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -452,7 +445,6 @@ exports[`plugin-webpack-swc > should disable react refresh when dev.hmr is false
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -506,7 +498,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -561,7 +552,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -618,7 +608,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -676,7 +665,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -733,7 +721,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -791,7 +778,6 @@ exports[`plugin-webpack-swc > should disable react refresh when target is not we
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -901,7 +887,6 @@ exports[`plugin-webpack-swc > should set multiple swc-loader 1`] = `
               "syntax": "typescript",
               "tsx": true,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -952,7 +937,6 @@ exports[`plugin-webpack-swc > should set multiple swc-loader 1`] = `
               "syntax": "typescript",
               "tsx": true,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -1011,7 +995,6 @@ exports[`plugin-webpack-swc > should set multiple swc-loader 1`] = `
               "syntax": "typescript",
               "tsx": true,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -1095,7 +1078,6 @@ exports[`plugin-webpack-swc > should set swc-loader 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -1153,7 +1135,6 @@ exports[`plugin-webpack-swc > should set swc-loader 1`] = `
                   "syntax": "typescript",
                   "tsx": true,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -1216,7 +1197,6 @@ exports[`plugin-webpack-swc > should use output config 1`] = `
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1274,7 +1254,6 @@ exports[`plugin-webpack-swc > should use output config 1`] = `
                     "syntax": "typescript",
                     "tsx": true,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -75,9 +75,6 @@ function getDefaultSwcConfig(
         syntax: 'typescript',
         decorators: true,
       },
-      // Avoid the webpack magic comment to be removed
-      // https://github.com/swc-project/swc/issues/6403
-      preserveAllComments: true,
       experimental: {
         cacheRoot,
       },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -106,7 +106,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -150,7 +149,6 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -106,7 +106,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -150,7 +149,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -501,7 +499,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -545,7 +542,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -944,7 +940,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -984,7 +979,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -1293,7 +1287,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
@@ -1337,7 +1330,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "syntax": "typescript",
                   "tsx": false,
                 },
-                "preserveAllComments": true,
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1478,7 +1478,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1522,7 +1521,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1806,7 +1804,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1846,7 +1843,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -45,7 +45,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -86,7 +85,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -158,7 +156,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -209,7 +206,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -331,7 +327,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -375,7 +370,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -438,7 +432,6 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -494,7 +487,6 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -553,7 +545,6 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -600,7 +591,6 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
               "syntax": "typescript",
               "tsx": false,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -668,7 +658,6 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -722,7 +711,6 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -804,7 +792,6 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -848,7 +835,6 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -916,7 +902,6 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -956,7 +941,6 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1028,7 +1012,6 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1072,7 +1055,6 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1151,7 +1133,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1199,7 +1180,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1278,7 +1258,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1327,7 +1306,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1406,7 +1384,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1454,7 +1431,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1522,7 +1498,6 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
@@ -1562,7 +1537,6 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                     "syntax": "typescript",
                     "tsx": false,
                   },
-                  "preserveAllComments": true,
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -43,7 +43,6 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
             "syntax": "typescript",
             "tsx": false,
           },
-          "preserveAllComments": true,
           "transform": {
             "decoratorVersion": "2022-03",
             "legacyDecorator": false,
@@ -125,7 +124,6 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
             "syntax": "typescript",
             "tsx": false,
           },
-          "preserveAllComments": true,
           "transform": {
             "decoratorVersion": "2022-03",
             "legacyDecorator": false,
@@ -203,7 +201,6 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
             "syntax": "typescript",
             "tsx": false,
           },
-          "preserveAllComments": true,
           "transform": {
             "decoratorMetadata": true,
             "legacyDecorator": true,

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -46,7 +46,6 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
               "syntax": "typescript",
               "tsx": true,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
@@ -125,7 +124,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
               "syntax": "typescript",
               "tsx": true,
             },
-            "preserveAllComments": true,
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -41,7 +41,6 @@ exports[`svgr > 'configure SVGR options' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -134,7 +133,6 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -199,7 +197,6 @@ exports[`svgr > 'exportType default / mixedImport false' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -291,7 +288,6 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -356,7 +352,6 @@ exports[`svgr > 'exportType default / mixedImport true' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -448,7 +443,6 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -513,7 +507,6 @@ exports[`svgr > 'exportType named / mixedImport false' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -605,7 +598,6 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
@@ -670,7 +662,6 @@ exports[`svgr > 'exportType named / mixedImport true' 1`] = `
                 "syntax": "typescript",
                 "tsx": true,
               },
-              "preserveAllComments": true,
               "transform": {
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,

--- a/website/docs/en/config/tools/swc.mdx
+++ b/website/docs/en/config/tools/swc.mdx
@@ -12,7 +12,6 @@ const defaultOptions = {
       syntax: 'typescript',
       decorators: true,
     },
-    preserveAllComments: true,
   },
   isModule: 'unknown',
   // ...some other conditional options

--- a/website/docs/zh/config/tools/swc.mdx
+++ b/website/docs/zh/config/tools/swc.mdx
@@ -12,7 +12,6 @@ const defaultOptions = {
       syntax: 'typescript',
       decorators: true,
     },
-    preserveAllComments: true,
   },
   isModule: 'unknown',
   // ...some other conditional options


### PR DESCRIPTION
## Summary

Since https://github.com/swc-project/swc/issues/6403 is fixed, we do not need to enable `preserveAllComments` by default. This will cause comments in type cannot be deleted.

## Related Links

#3502 

https://github.com/web-infra-dev/rslib/issues/210

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
