### PR TITLE
docs: update `source.exclude` usage

### DIFF
--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -21,7 +21,7 @@ export default {
 
 ### Not compiled vs Not bundled
 
-`source.exclude` is used to specify JavaScript/TypeScript files that do not need to be compiled. This means that these files will not be translated by `swc` or `babel`, but they will still be bundled into the product (if referenced).
+`source.exclude` is used to specify JavaScript/TypeScript files that do not need to be compiled. This means that these files will not be translated by `swc` or `babel`, but they will still be bundled into the outputs (if referenced).
 
 If you want certain files to be ignored and not bundled into the outputs, you can use Rspack's [IgnorePlugin](https://rspack.dev/plugins/webpack/ignore-plugin).
 

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -18,3 +18,25 @@ export default {
 ```
 
 > Refer to [source.include](/config/source/include) to learn more.
+
+### Not compiled vs Not bundled
+
+`source.exclude` is used to specify JavaScript/TypeScript files that do not need to be compiled. This means that these files will not be translated by `swc` or `babel`, but they will still be bundled into the product (if referenced).
+
+If you want certain files to be ignored and not bundled into the outputs, you can use Rspack's [IgnorePlugin](https://rspack.dev/plugins/webpack/ignore-plugin).
+
+```ts
+export default {
+  tools: {
+    rspack: (config, { rspack }) => {
+      config.plugins?.push(
+        new rspack.IgnorePlugin({
+          resourceRegExp: /^\.\/locale$/,
+          contextRegExp: /moment$/,
+        }),
+      );
+      return config;
+    },
+  },
+};
+```

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -21,7 +21,7 @@ export default {
 
 ### Not compiled vs Not bundled
 
-`source.exclude` is used to specify JavaScript/TypeScript files that do not need to be compiled. This means that these files will not be translated by `swc` or `babel`, but they will still be bundled into the outputs (if referenced).
+`source.exclude` is used to specify JavaScript/TypeScript files that do not need to be compiled. This means that these files will not be translated by SWC or Babel, but they will still be bundled into the outputs (if referenced).
 
 If you want certain files to be ignored and not bundled into the outputs, you can use Rspack's [IgnorePlugin](https://rspack.dev/plugins/webpack/ignore-plugin).
 

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -21,7 +21,7 @@ export default {
 
 ### 不编译 vs 不打包
 
-`source.exclude` 用于指定不需要编译的 JavaScript/TypeScript 文件。这意味着这些文件不会经过 `swc` / `babel` 转译，但这些文件仍然会被打包到产物中（如果被引用）。
+`source.exclude` 用于指定不需要编译的 JavaScript/TypeScript 文件。这意味着这些文件不会经过 SWC 或 Babel 转译，但这些文件仍然会被打包到产物中（如果被引用）。
 
 如果你希望某些文件在打包过程中被忽略，不被打包到产物中，可以使用 Rspack 的 [IgnorePlugin](https://rspack.dev/zh/plugins/webpack/ignore-plugin)。
 

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -18,3 +18,25 @@ export default {
 ```
 
 > 参考 [source.include](/config/source/include) 来了解更多。
+
+### 不编译 vs 不打包
+
+`source.exclude` 用于指定不需要编译的 JavaScript/TypeScript 文件。这意味着这些文件不会经过 `swc` / `babel` 转译，但这些文件仍然会被打包到产物中（如果被引用）。
+
+如果你希望某些文件在打包过程中被忽略，不被打包到产物中，可以使用 Rspack 的 [IgnorePlugin](https://rspack.dev/zh/plugins/webpack/ignore-plugin)。
+
+```ts
+export default {
+  tools: {
+    rspack: (config, { rspack }) => {
+      config.plugins?.push(
+        new rspack.IgnorePlugin({
+          resourceRegExp: /^\.\/locale$/,
+          contextRegExp: /moment$/,
+        }),
+      );
+      return config;
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

update `source.exclude` usage. `source.exclude` is only used to specify JavaScript/TypeScript files that do not need to be compiled. This does not mean that these files will not be bundled into the output.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
