### PR TITLE
docs: fix `webpackContext` link

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -171,7 +171,7 @@ export default defineConfig({
 
 Vite provides `import.meta.glob()` for importing multiple modules.
 
-When migrating to Rsbuild, you can use the [import.meta.webpackContext()](https://rspack.dev/api/modules/module-variables#importmetawebpackcontext) function of Rspack instead:
+When migrating to Rsbuild, you can use the [import.meta.webpackContext()](https://rspack.dev/api/runtime-api/module-variables#importmetawebpackcontext) function of Rspack instead:
 
 - Vite:
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -171,7 +171,7 @@ export default defineConfig({
 
 Vite 提供了 `import.meta.glob()` 来批量导入模块。
 
-迁移到 Rsbuild 时，你可以使用 Rspack 的 [import.meta.webpackContext](https://rspack.dev/zh/api/modules/module-variables#importmetawebpackcontext) 函数代替：
+迁移到 Rsbuild 时，你可以使用 Rspack 的 [import.meta.webpackContext](https://rspack.dev/zh/api/runtime-api/module-variables#importmetawebpackcontext) 函数代替：
 
 - Vite:
 


### PR DESCRIPTION
## Summary

fix `webpackContext` link

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/3520
- https://rspack.dev/api/runtime-api/module-variables#importmetawebpackcontext

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
