### PR TITLE
feat(create-rsbuild): adds decorator configs to lit-html templates an…

### DIFF
--- a/examples/lit/rsbuild.config.ts
+++ b/examples/lit/rsbuild.config.ts
@@ -4,4 +4,9 @@ export default defineConfig({
   html: {
     template: './src/index.html',
   },
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
 });

--- a/packages/create-rsbuild/template-lit-js/rsbuild.config.mjs
+++ b/packages/create-rsbuild/template-lit-js/rsbuild.config.mjs
@@ -4,4 +4,9 @@ export default defineConfig({
   html: {
     template: './src/index.html',
   },
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
 });

--- a/packages/create-rsbuild/template-lit-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-lit-ts/rsbuild.config.ts
@@ -4,4 +4,9 @@ export default defineConfig({
   html: {
     template: './src/index.html',
   },
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
 });

--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -10,7 +10,8 @@
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "experimentalDecorators": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

Adds experimental decorator support to Lit-html templates and example.

## Related Links

[Feature Request](https://github.com/web-infra-dev/rsbuild/issues/3521)

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
