### PR TITLE
fix(create-rsbuild): useDefineForClassFields in lit template

### DIFF
--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -9,7 +9,7 @@
     "isolatedModules": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
-    "useDefineForClassFields": true,
+    "useDefineForClassFields": false,
     "allowImportingTsExtensions": true,
     "experimentalDecorators": true
   },


### PR DESCRIPTION
## Summary

From https://lit.dev/docs/components/decorators/#earlier-decorator-proposals:

> You should also ensure that the `useDefineForClassFields` setting is false. 

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3521

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
