### PR TITLE
docs: update tailwindcss content usage

### DIFF
--- a/website/docs/en/guide/basic/tailwindcss.mdx
+++ b/website/docs/en/guide/basic/tailwindcss.mdx
@@ -47,7 +47,7 @@ module.exports = {
 The above configuration is for reference only and can be modified to suit the needs of your project. For example, non-TypeScript projects do not need to include ts and tsx files.
 :::
 
-It should be noted that the `content` configuration should include the paths to all source files that contain Tailwind class names. For details, please refer to [tailwindcss - Content Configuration](https://tailwindcss.com/docs/content-configuration).
+It should be noted that the `content` option should include the paths to all source files that contain Tailwind class names. For details, please refer to [tailwindcss - Content Configuration](https://tailwindcss.com/docs/content-configuration).
 
 ```js title="tailwind.config.js"
 /** @type {import('tailwindcss').Config} */

--- a/website/docs/zh/guide/basic/tailwindcss.mdx
+++ b/website/docs/zh/guide/basic/tailwindcss.mdx
@@ -47,7 +47,7 @@ module.exports = {
 上述配置仅供参考，你可以根据项目需要进行调整，比如非 TypeScript 项目不需要包含 ts 和 tsx 文件。
 :::
 
-需要注意的是，`content` 配置应包含所有用到 Tailwind 类名的源文件的路径。详情可参考 [tailwindcss - Content 配置](https://tailwindcss.com/docs/content-configuration)。
+需要注意的是，`content` 选项应包含所有用到 Tailwind 类名的源文件的路径。详情可参考 [tailwindcss - Content 配置](https://tailwindcss.com/docs/content-configuration)。
 
 ```js title="tailwind.config.js"
 /** @type {import('tailwindcss').Config} */


### PR DESCRIPTION
## Summary

It's easy to encounter problems in monorepo: the `content` configuration should include the paths to all source files that contain Tailwind class names.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
