### PR TITLE
fix(plugin-webpack-swc): swcMinimizerPlugin sourceMap config

### DIFF
--- a/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -1,5 +1,156 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`plugin-webpack-swc > output.sourceMap config for swcMinimizerPlugin 1`] = `
+[
+  {
+    "module": {
+      "rules": [
+        {
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "use": [
+            {
+              "loader": "<ROOT>/packages/compat/plugin-webpack-swc/src/loader.cjs",
+              "options": {
+                "cwd": "<ROOT>/packages/compat/plugin-webpack-swc/tests",
+                "env": {
+                  "coreJs": "3.38",
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "extensions": {
+                  "lockCorejsVersion": {
+                    "corejs": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+                    "swcHelpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+                  },
+                  "lodash": {
+                    "cwd": "<ROOT>/packages/compat/plugin-webpack-swc/tests",
+                    "ids": [
+                      "lodash",
+                      "lodash-es",
+                    ],
+                  },
+                },
+                "jsc": {
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": true,
+                  },
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                    "react": {
+                      "refresh": false,
+                      "runtime": "classic",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        {
+          "mimetype": {
+            "or": [
+              "text/javascript",
+              "application/javascript",
+            ],
+          },
+          "resolve": {
+            "fullySpecified": false,
+          },
+          "use": [
+            {
+              "loader": "<ROOT>/packages/compat/plugin-webpack-swc/src/loader.cjs",
+              "options": {
+                "cwd": "<ROOT>/packages/compat/plugin-webpack-swc/tests",
+                "env": {
+                  "coreJs": "3.38",
+                  "targets": [
+                    "chrome >= 87",
+                    "edge >= 88",
+                    "firefox >= 78",
+                    "safari >= 14",
+                  ],
+                },
+                "extensions": {
+                  "lockCorejsVersion": {
+                    "corejs": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
+                    "swcHelpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+                  },
+                  "lodash": {
+                    "cwd": "<ROOT>/packages/compat/plugin-webpack-swc/tests",
+                    "ids": [
+                      "lodash",
+                      "lodash-es",
+                    ],
+                  },
+                },
+                "jsc": {
+                  "externalHelpers": true,
+                  "parser": {
+                    "decorators": true,
+                    "syntax": "typescript",
+                    "tsx": true,
+                  },
+                  "transform": {
+                    "decoratorVersion": "2022-03",
+                    "legacyDecorator": false,
+                    "react": {
+                      "refresh": false,
+                      "runtime": "classic",
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    "optimization": {
+      "minimizer": [
+        SwcMinimizerPlugin {
+          "minifyOptions": {
+            "cssMinify": undefined,
+            "jsMinify": {
+              "format": {
+                "asciiOnly": false,
+              },
+              "mangle": true,
+            },
+          },
+          "name": "swc-minimizer-plugin",
+          "rsbuildSourceMapConfig": {
+            "css": false,
+            "js": "cheap-source-map",
+          },
+        },
+        SwcMinimizerPlugin {
+          "minifyOptions": {
+            "cssMinify": {},
+            "jsMinify": undefined,
+          },
+          "name": "swc-minimizer-plugin",
+          "rsbuildSourceMapConfig": {
+            "css": false,
+            "js": "cheap-source-map",
+          },
+        },
+      ],
+    },
+    "plugins": [
+      RsbuildCorePlugin {},
+    ],
+  },
+]
+`;
+
 exports[`plugin-webpack-swc > should apply multiple environment configs correctly 1`] = `
 [
   {
@@ -810,6 +961,10 @@ exports[`plugin-webpack-swc > should set correct swc minimizer options in produc
         },
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
     SwcMinimizerPlugin {
       "minifyOptions": {
@@ -817,6 +972,10 @@ exports[`plugin-webpack-swc > should set correct swc minimizer options in produc
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
   ],
 }
@@ -837,6 +996,10 @@ exports[`plugin-webpack-swc > should set correct swc minimizer options using raw
         },
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
     SwcMinimizerPlugin {
       "minifyOptions": {
@@ -844,6 +1007,10 @@ exports[`plugin-webpack-swc > should set correct swc minimizer options using raw
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
   ],
 }
@@ -1026,6 +1193,10 @@ exports[`plugin-webpack-swc > should set swc minimizer in production 1`] = `
         },
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
     SwcMinimizerPlugin {
       "minifyOptions": {
@@ -1033,6 +1204,10 @@ exports[`plugin-webpack-swc > should set swc minimizer in production 1`] = `
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
+      "rsbuildSourceMapConfig": {
+        "css": false,
+        "js": undefined,
+      },
     },
   ],
 }
@@ -1285,6 +1460,10 @@ exports[`plugin-webpack-swc > should use output config 1`] = `
             },
           },
           "name": "swc-minimizer-plugin",
+          "rsbuildSourceMapConfig": {
+            "css": false,
+            "js": undefined,
+          },
         },
       ],
     },

--- a/packages/compat/plugin-webpack-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-webpack-swc/tests/plugin.test.ts
@@ -467,5 +467,31 @@ describe('plugin-webpack-swc', () => {
     const configs = await rsbuild.initConfigs();
 
     expect(configs).toMatchSnapshot();
+    process.env.NODE_ENV = 'test'
+  });
+
+  it('output.sourceMap config for swcMinimizerPlugin', async () => {
+    process.env.NODE_ENV = 'production';
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginSwc()],
+      rsbuildConfig: {
+        provider: webpackProvider,
+        environments: {
+          web: {
+            output: {
+              sourceMap: {
+                js: 'cheap-source-map',
+                css: false,
+              }
+            },
+          },
+        },
+      },
+    });
+    const configs = await rsbuild.initConfigs();
+
+    expect(configs).toMatchSnapshot();
+    
+    process.env.NODE_ENV = 'test'
   });
 });


### PR DESCRIPTION

## Summary
fix(plugin-webpack-swc): the rsbuildConfig's sourcemap should transmit to the swcMinimizerPlugin
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
