### PR TITLE
docs: update tools.htmlPlugin options tip

### DIFF
--- a/website/docs/en/config/tools/html-plugin.mdx
+++ b/website/docs/en/config/tools/html-plugin.mdx
@@ -18,11 +18,15 @@ const defaultOptions = {
 
 The configs of [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) can be modified through `tools.htmlPlugin`.
 
-:::tip
 Rsbuild internally implements HTML-related features based on [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin). It is a fork of [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin), with the same features and options.
+
+:::tip
+If you need to modify options such as `title`, `template`, `templateParameters`, `meta`, it is recommended to use the corresponding HTML configurations provided by Rsbuild first, such as [html.title](/config/html/title), [html .template](/config/html/template) etc.
+
+This is because Rsbuild provides some internal optimization processing for these HTML configurations. For example, if the HTML template used by the current project already contains the `<title>` tag, then `html.title` will not take effect.
 :::
 
-### Object Type
+## Object Type
 
 When `tools.htmlPlugin` is `Object` type, the value will be merged with the default config via `Object.assign`.
 
@@ -36,7 +40,7 @@ export default {
 };
 ```
 
-### Function Type
+## Function Type
 
 When `tools.htmlPlugin` is a Function:
 

--- a/website/docs/zh/config/tools/html-plugin.mdx
+++ b/website/docs/zh/config/tools/html-plugin.mdx
@@ -18,11 +18,15 @@ const defaultOptions = {
 
 通过 `tools.htmlPlugin` 可以修改 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) 的配置项。
 
-:::tip
 Rsbuild 内部基于 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) 实现 HTML 相关的能力。它是 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的一个 fork 版本，具备完全一致的功能和选项。
+
+:::tip
+如果你需要修改 `title`、`template`、`templateParameters`、`meta` 等选项，推荐优先使用 Rsbuild 提供的对应 HTML 配置项，如 [html.title](/config/html/title)、 [html.template](/config/html/template) 等。
+
+这是因为这些配置间存在一些关联关系，Rsbuild 对于 HTML 配置项提供了一些内部的优化处理，例如，如果当前项目使用的 HTML 模板中已经包含了 `<title>` 标签，那么 `html.title` 将不会生效。
 :::
 
-### Object 类型
+## Object 类型
 
 当 `tools.htmlPlugin` 的值为 `Object` 类型时，会与默认配置通过 `Object.assign` 合并。
 
@@ -36,7 +40,7 @@ export default {
 };
 ```
 
-### Function 类型
+## Function 类型
 
 当 `tools.htmlPlugin` 为 Function 类型时：
 

--- a/website/docs/zh/config/tools/html-plugin.mdx
+++ b/website/docs/zh/config/tools/html-plugin.mdx
@@ -21,7 +21,7 @@ const defaultOptions = {
 Rsbuild 内部基于 [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin) 实现 HTML 相关的能力。它是 [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) 的一个 fork 版本，具备完全一致的功能和选项。
 
 :::tip
-如果你需要修改 `title`、`template`、`templateParameters`、`meta` 等选项，推荐优先使用 Rsbuild 提供的对应 HTML 配置项，如 [html.title](/config/html/title)、 [html.template](/config/html/template) 等。
+如果你需要修改 `title`、`template`、`templateParameters`、`meta` 等选项，推荐优先使用 Rsbuild 提供的对应 HTML 配置项，如 [html.title](/config/html/title)、[html.template](/config/html/template) 等。
 
 这是因为这些配置间存在一些关联关系，Rsbuild 对于 HTML 配置项提供了一些内部的优化处理，例如，如果当前项目使用的 HTML 模板中已经包含了 `<title>` 标签，那么 `html.title` 将不会生效。
 :::


### PR DESCRIPTION
## Summary

update `tools.htmlPlugin` options tip.  it is recommended to use the Rsbuild HTML configurations instead of the corresponding `tools.htmlPlugin` configurations.

## Related Links

close: https://github.com/web-infra-dev/rsbuild/issues/3546

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
