### PR TITLE
perf: reduce stats.toJson calls

### DIFF
--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -130,37 +130,37 @@ export function getStatsOptions(
 }
 
 export function formatStats(
-  stats: Rspack.Stats | Rspack.MultiStats,
-  options: StatsValue = {},
+  statsData: Rspack.StatsCompilation,
+  hasErrors: boolean,
 ): {
   message?: string;
   level?: string;
 } {
-  const statsData = stats.toJson(
-    typeof options === 'object'
-      ? {
-          preset: 'errors-warnings',
-          children: true,
-          ...options,
-        }
-      : options,
-  );
+  // display verbose messages in debug mode
+  const verbose = logger.level === 'verbose';
 
-  const { errors, warnings } = formatStatsMessages(
-    {
-      errors: getAllStatsErrors(statsData),
-      warnings: getAllStatsWarnings(statsData),
-    },
-    // display verbose messages in debug mode
-    logger.level === 'verbose',
-  );
+  if (hasErrors) {
+    const { errors } = formatStatsMessages(
+      {
+        errors: getAllStatsErrors(statsData),
+        warnings: [],
+      },
+      verbose,
+    );
 
-  if (stats.hasErrors()) {
     return {
       message: formatErrorMessage(errors),
       level: 'error',
     };
   }
+
+  const { warnings } = formatStatsMessages(
+    {
+      errors: [],
+      warnings: getAllStatsWarnings(statsData),
+    },
+    verbose,
+  );
 
   if (warnings.length) {
     const title = color.bold(color.yellow('Compile Warning: \n'));


### PR DESCRIPTION
## Summary

Reduce stats.toJson calls to improve the build performance.

- before:

<img width="946" alt="截屏2024-09-25 22 41 31" src="https://github.com/user-attachments/assets/351f7a39-73f7-45b3-a06a-3df20c8bbcfa">

- after:

<img width="705" alt="截屏2024-09-25 22 50 14" src="https://github.com/user-attachments/assets/07cd7d88-793f-4ef0-b09d-fbf2b592e3f8">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
