### PR TITLE
docs: add rspack config modification order

### DIFF
--- a/website/docs/en/guide/basic/configure-rspack.mdx
+++ b/website/docs/en/guide/basic/configure-rspack.mdx
@@ -280,3 +280,14 @@ export default {
 ```
 
 The above are some common configuration examples. For the complete rspack-chain API, please refer to the [rspack-chain documentation](https://github.com/rspack-contrib/rspack-chain).
+
+## Configuration modification order
+
+Rsbuild supports modifying the Rspack configuration object through `tools.rspack`, `tools.bundlerChain`, `modifyBundlerChain`, etc.
+
+The order of execution between them is:
+
+- [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)
+- [tools.bundleChain](/config/tools/bundler-chain)
+- [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig)
+- [tools.rspack](/config/tools/rspack)

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -332,7 +332,11 @@ const myPlugin = () => ({
 
 ### modifyRspackConfig
 
-To modify the final Rspack config, you can directly modify the config object, or return a new object to replace the previous object.
+To modify the Rspack config, you can directly modify the config object, or return a new object to replace the previous object.
+
+:::tip
+`modifyRspackConfig` is executed earlier than [tools.rspack](/config/tools/rspack). Therefore, the modifications made by `tools.rspack` cannot be obtained in `modifyRspackConfig`.
+:::
 
 - **Type:**
 

--- a/website/docs/zh/guide/basic/configure-rspack.mdx
+++ b/website/docs/zh/guide/basic/configure-rspack.mdx
@@ -283,3 +283,14 @@ export default {
 ```
 
 以上是一些常见的配置示例，完整的 API 请见 [rspack-chain 文档](https://github.com/rspack-contrib/rspack-chain)。
+
+## 配置修改顺序
+
+Rsbuild 支持通过 `tools.rspack`、`tools.bundlerChain`、`modifyBundlerChain` 等方式修改 Rspack 配置对象。
+
+它们之间的执行顺序依次为：
+
+- [modifyBundlerChain](/plugins/dev/hooks#modifybundlerchain)
+- [tools.bundleChain](/config/tools/bundler-chain)
+- [modifyRspackConfig](/plugins/dev/hooks#modifyrspackconfig)
+- [tools.rspack](/config/tools/rspack)

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -328,7 +328,11 @@ const myPlugin = () => ({
 
 ### modifyRspackConfig
 
-修改最终的 Rspack 配置，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
+修改 Rspack 配置，你可以直接修改传入的 config 对象，也可以返回一个新的对象来替换传入的对象。
+
+:::tip
+`modifyRspackConfig` 的执行时机早于 [tools.rspack](/config/tools/rspack)。因此，无法在 `modifyRspackConfig` 中获取到 `tools.rspack` 所做的修改。
+:::
 
 - **类型：**
 


### PR DESCRIPTION
## Summary

Rsbuild supports modifying the Rspack configuration object through `tools.rspack`, `tools.bundlerChain`, `modifyBundlerChain`, etc. We should list the order of execution between them.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
