### PR TITLE
fix(plugin-react): exclude node_modules from react-refresh plugin

### DIFF
--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -61,12 +61,14 @@ export const applyBasicReactSupport = (
         '@rspack/plugin-react-refresh'
       );
       const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
+      const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
 
       chain
         .plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)
         .use(ReactRefreshRspackPlugin, [
           {
             include: [SCRIPT_REGEX],
+            exclude: [NODE_MODULES_REGEX],
             ...options.reactRefreshOptions,
           },
         ]);

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -204,6 +204,7 @@ type ReactRefreshOptions = {
 ```js
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+  exclude: [/[\\/]node_modules[\\/]/],
 };
 ```
 
@@ -214,7 +215,7 @@ Set the options for [@rspack/plugin-react-refresh](https://www.rspack.dev/guide/
 ```js
 pluginReact({
   reactRefreshOptions: {
-    exclude: [/some-module-to-exclude/],
+    exclude: [/some-module-to-exclude/, /[\\/]node_modules[\\/]/],
   },
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -206,6 +206,7 @@ type ReactRefreshOptions = {
 ```js
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+  exclude: [/[\\/]node_modules[\\/]/],
 };
 ```
 
@@ -216,7 +217,7 @@ const defaultOptions = {
 ```js
 pluginReact({
   reactRefreshOptions: {
-    exclude: [/some-module-to-exclude/],
+    exclude: [/some-module-to-exclude/, /[\\/]node_modules[\\/]/],
   },
 });
 ```


### PR DESCRIPTION
## Summary

Exclude node_modules from react-refresh plugin. Usually, modules in node_modules do not need to use react-refresh, which also avoids some potential conflicts.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3562

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
