### PR TITLE
docs: add tools.lightningcssLoader false tip

### DIFF
--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -64,5 +64,5 @@ export default {
 ```
 
 :::tip
-`tools.lightningcssLoader` false only disables the `lightningcss-loader`. If you need to disable the full functionality of Lightning CSS, please refer to [Disabling Lightning CSS](/guide/basic/css-usage#disabling-lightning-css).
+Set `tools.lightningcssLoader` to `false` only disables the `lightningcss-loader`. If you need to disable the full functionality of Lightning CSS, please refer to [Disabling Lightning CSS](/guide/basic/css-usage#disabling-lightning-css).
 :::

--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -62,3 +62,7 @@ export default {
   },
 };
 ```
+
+:::tip
+`tools.lightningcssLoader` false only disables the `lightningcss-loader`. If you need to disable the full functionality of Lightning CSS, please refer to [Disabling Lightning CSS](/guide/basic/css-usage#disabling-lightning-css).
+:::

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -62,3 +62,7 @@ export default {
   },
 };
 ```
+
+:::tip
+`tools.lightningcssLoader` false 仅用于禁用 `lightningcss-loader`。如果你需要禁用 lightningcss 完整功能可参考 [禁用 Lightning CSS](/guide/basic/css-usage#禁用-lightning-css)。
+:::

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -64,5 +64,5 @@ export default {
 ```
 
 :::tip
-`tools.lightningcssLoader` false 仅用于禁用 `lightningcss-loader`。如果你需要禁用 lightningcss 完整功能可参考 [禁用 Lightning CSS](/guide/basic/css-usage#禁用-lightning-css)。
+将 `tools.lightningcssLoader` 设置为 `false` 仅用于禁用 `lightningcss-loader`。如果你需要禁用 Lightning CSS 完整功能可参考 [禁用 Lightning CSS](/guide/basic/css-usage#禁用-lightning-css)。
 :::

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -64,5 +64,5 @@ export default {
 ```
 
 :::tip
-将 `tools.lightningcssLoader` 设置为 `false` 仅用于禁用 `lightningcss-loader`。如果你需要禁用 Lightning CSS 完整功能可参考 [禁用 Lightning CSS](/guide/basic/css-usage#禁用-lightning-css)。
+将 `tools.lightningcssLoader` 设置为 `false` 仅用于禁用 `lightningcss-loader`。如果你需要禁用 Lightning CSS 完整功能，请参考 [禁用 Lightning CSS](/guide/basic/css-usage#禁用-lightning-css)。
 :::


### PR DESCRIPTION
## Summary

Lightningcss is used in Rsbuild not only to transform CSS code, but also to minify CSS.  `tools.lightningcssLoader` false only disables the `lightningcss-loader`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
