### PR TITLE
perf: remove browserslist-to-es-version dependency

### DIFF
--- a/e2e/cases/browserslist/browserslist-config-mock/index.json
+++ b/e2e/cases/browserslist/browserslist-config-mock/index.json
@@ -1,1 +1,1 @@
-["Chrome >= 49", "Edge >= 79", "Firefox >= 49", "Safari >= 10"]
+["Chrome >= 40", "Edge >= 79", "Firefox >= 49", "Safari >= 10"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,7 +65,6 @@
     "@types/webpack-bundle-analyzer": "4.7.0",
     "@types/ws": "^8.5.12",
     "browserslist": "4.24.0",
-    "browserslist-to-es-version": "^1.0.0",
     "chokidar": "3.6.0",
     "commander": "^12.1.0",
     "connect": "3.7.0",

--- a/packages/core/tests/target.test.ts
+++ b/packages/core/tests/target.test.ts
@@ -10,7 +10,7 @@ describe('plugin-target', () => {
     },
     {
       browserslist: ['Chrome 100'],
-      expected: ['web', 'es2018'],
+      expected: ['web', 'browserslist:Chrome 100'],
     },
     {
       browserslist: null,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -30,7 +30,6 @@
       "rspack-manifest-plugin": ["./compiled/rspack-manifest-plugin"],
       "rsbuild-dev-middleware": ["./compiled/rsbuild-dev-middleware"],
       "launch-editor-middleware": ["./compiled/launch-editor-middleware"],
-      "browserslist-to-es-version": ["./compiled/browserslist-to-es-version"],
       "connect-history-api-fallback": [
         "./compiled/connect-history-api-fallback"
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -633,9 +633,6 @@ importers:
       browserslist:
         specifier: 4.24.0
         version: 4.24.0
-      browserslist-to-es-version:
-        specifier: ^1.0.0
-        version: 1.0.0
       chokidar:
         specifier: 3.6.0
         version: 3.6.0


### PR DESCRIPTION
## Summary

The PR removes `browserslist-to-es-version` dependency and uses Rspack's `browserslist:*` target value instead. This will improve performance in two ways:

- `@rsbuild/core` depends on fewer packages.
- Rspack can use the Rust version of browserslist to parse browserslist query in the future, which is faster than the JS version.

TODO: Rspack should support `browserslist:` for `webworker` target.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
