### PR TITLE
perf: using browserslist-load-config to load browserslist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,6 @@
     "@rspack/core": "~1.0.7",
     "@rspack/lite-tapable": "~1.0.0",
     "@swc/helpers": "^0.5.13",
-    "caniuse-lite": "^1.0.30001663",
     "core-js": "~3.38.1"
   },
   "devDependencies": {
@@ -64,7 +63,7 @@
     "@types/on-finished": "2.3.4",
     "@types/webpack-bundle-analyzer": "4.7.0",
     "@types/ws": "^8.5.12",
-    "browserslist": "4.24.0",
+    "browserslist-load-config": "0.0.2",
     "chokidar": "3.6.0",
     "commander": "^12.1.0",
     "connect": "3.7.0",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -25,9 +25,6 @@ const skipSemver = (task) => {
 export default {
   prettier: true,
   externals: {
-    // External caniuse-lite data, so users can update it manually.
-    'caniuse-lite': 'caniuse-lite',
-    '/^caniuse-lite(/.*)/': 'caniuse-lite$1',
     '@rspack/core': '@rspack/core',
     '@rspack/lite-tapable': '@rspack/lite-tapable',
     webpack: 'webpack',
@@ -88,18 +85,6 @@ export default {
     {
       name: 'connect-history-api-fallback',
       ignoreDts: true,
-    },
-    {
-      name: 'browserslist',
-      // preserve the `require(require.resolve())`
-      beforeBundle(task) {
-        replaceFileContent(join(task.depPath, 'node.js'), (content) =>
-          content.replaceAll(
-            'require(require.resolve',
-            'eval("require")(require.resolve',
-          ),
-        );
-      },
     },
     {
       name: 'rspack-chain',

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import browserslist from 'browserslist';
+import { loadConfig } from 'browserslist-load-config';
 import { withDefaultConfig } from './config';
 import { DEFAULT_BROWSERSLIST, ROOT_DIST_DIR } from './constants';
 import { getAbsolutePath, getCommonParentPath } from './helpers/path';
@@ -37,11 +37,11 @@ export async function getBrowserslist(path: string): Promise<string[] | null> {
     return browsersListCache.get(cacheKey)!;
   }
 
-  const result = browserslist.loadConfig({ path, env });
+  const result = loadConfig({ path, env });
 
   if (result) {
-    browsersListCache.set(cacheKey, result);
-    return result;
+    browsersListCache.set(cacheKey, result as string[]);
+    return result as string[];
   }
 
   return null;

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -40,8 +40,8 @@ export async function getBrowserslist(path: string): Promise<string[] | null> {
   const result = loadConfig({ path, env });
 
   if (result) {
-    browsersListCache.set(cacheKey, result as string[]);
-    return result as string[];
+    browsersListCache.set(cacheKey, result);
+    return result;
   }
 
   return null;

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -20,7 +20,6 @@
       "chokidar": ["./compiled/chokidar"],
       "picocolors": ["./compiled/picocolors"],
       "on-finished": ["./compiled/on-finished"],
-      "browserslist": ["./compiled/browserslist"],
       "rspack-chain": ["./compiled/rspack-chain"],
       "webpack-merge": ["./compiled/webpack-merge"],
       "html-rspack-plugin": ["./compiled/html-rspack-plugin"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,9 +601,6 @@ importers:
       '@swc/helpers':
         specifier: ^0.5.13
         version: 0.5.13
-      caniuse-lite:
-        specifier: ^1.0.30001663
-        version: 1.0.30001663
       core-js:
         specifier: ~3.38.1
         version: 3.38.1
@@ -630,9 +627,9 @@ importers:
       '@types/ws':
         specifier: ^8.5.12
         version: 8.5.12
-      browserslist:
-        specifier: 4.24.0
-        version: 4.24.0
+      browserslist-load-config:
+        specifier: 0.0.2
+        version: 0.0.2
       chokidar:
         specifier: 3.6.0
         version: 3.6.0
@@ -3517,6 +3514,9 @@ packages:
   braces@3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
     engines: {node: '>=8'}
+
+  browserslist-load-config@0.0.2:
+    resolution: {integrity: sha512-RgkU70UnPPvnNQlYfOgkflcIz13nIlk5y1ALN9RminnqyZiYW3VxJDcm8n6gqdVoth7528URtzJFW8YwZ2zYbg==}
 
   browserslist-to-es-version@1.0.0:
     resolution: {integrity: sha512-i6dR03ClGy9ti97FSa4s0dpv01zW/t5VbvGjFfTLsrRQFsPgSeyGkCrlU7BTJuI5XDHVY5S2JgDnDsvQXifJ8w==}
@@ -10214,6 +10214,8 @@ snapshots:
   braces@3.0.2:
     dependencies:
       fill-range: 7.0.1
+
+  browserslist-load-config@0.0.2: {}
 
   browserslist-to-es-version@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Using [browserslist-load-config](https://github.com/rspack-contrib/browserslist-load-config) to load browserslist config:

- Removed 1600 LOC.
- Removed `caniuse-lite` dependency.
- Faster startup time.

<img width="639" alt="截屏2024-09-28 13 52 24" src="https://github.com/user-attachments/assets/26265ab1-5f12-493b-b1fb-7188ff81f908">

## Related Links

https://github.com/rspack-contrib/browserslist-load-config

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
