### PR TITLE
fix: moduleFederation option only supports Rspack

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -88,6 +88,11 @@ export function pluginModuleFederation(): RsbuildPlugin {
     name: 'rsbuild:module-federation',
 
     setup(api) {
+      // Rspack only
+      if (api.context.bundlerType === 'webpack') {
+        return;
+      }
+
       api.modifyRsbuildConfig((config) => {
         const { moduleFederation } = config;
         if (!moduleFederation?.options) {


### PR DESCRIPTION
## Summary

The `moduleFederation` option only supports Rspack, we can skip the plugin when using webpack.

Fix:

<img width="1424" alt="Screenshot 2024-09-29 at 17 17 12" src="https://github.com/user-attachments/assets/a67a2f5f-4921-4c67-aea8-879e338d2fd9">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
