### PR TITLE
feat: improve logs order when port is in use

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -109,9 +109,8 @@ export async function createDevServer<
 ): Promise<RsbuildDevServer> {
   logger.debug('create dev server');
 
-  const { port, host, https } = await getServerConfig({
+  const { port, host, https, portTip } = await getServerConfig({
     config,
-    getPortSilently,
   });
   const devConfig = formatDevConfig(config.dev, port);
 
@@ -195,6 +194,10 @@ export async function createDevServer<
       protocol,
       printUrls: config.server.printUrls,
     });
+
+    if (!getPortSilently && portTip) {
+      logger.info(portTip);
+    }
   };
 
   if (runCompile) {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -266,15 +266,16 @@ export const getServerConfig = async ({
     strictPort: config.server.strictPort || false,
   });
   const https = Boolean(config.server.https) || false;
+  const portTip =
+    port !== originalPort
+      ? `Port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
+      : undefined;
 
   return {
     port,
     host,
     https,
-    portTip:
-      port !== originalPort
-        ? `Port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
-        : undefined,
+    portTip,
   };
 };
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -109,7 +109,7 @@ function getURLMessages(
     return urls
       .map(
         ({ label, url }) =>
-          `  ${`> ${label.padEnd(10)}`}${color.cyan(
+          `  ${`➜ ${label.padEnd(10)}`}${color.cyan(
             normalizeUrl(`${url}${routes[0].pathname}`),
           )}\n`,
       )
@@ -122,7 +122,7 @@ function getURLMessages(
     if (index > 0) {
       message += '\n';
     }
-    message += `  ${`> ${label}`}\n`;
+    message += `  ${`➜ ${label}`}\n`;
 
     for (const r of routes) {
       message += `  ${color.dim('-')} ${color.dim(
@@ -199,13 +199,11 @@ export const getPort = async ({
   port,
   strictPort,
   tryLimits = 20,
-  silent = false,
 }: {
   host: string;
   port: string | number;
   strictPort: boolean;
   tryLimits?: number;
-  silent?: boolean;
 }): Promise<number> => {
   if (typeof port === 'string') {
     port = Number.parseInt(port, 10);
@@ -245,11 +243,6 @@ export const getPort = async ({
         `Port "${original}" is occupied, please choose another one.`,
       );
     }
-    if (!silent) {
-      logger.info(
-        `Port ${original} is in use, ${color.yellow(`using port ${port}.`)}\n`,
-      );
-    }
   }
 
   return port;
@@ -257,24 +250,32 @@ export const getPort = async ({
 
 export const getServerConfig = async ({
   config,
-  getPortSilently,
 }: {
   config: NormalizedConfig;
-  getPortSilently?: boolean;
 }): Promise<{
   port: number;
   host: string;
   https: boolean;
+  portTip: string | undefined;
 }> => {
   const host = config.server.host || DEFAULT_DEV_HOST;
+  const originalPort = config.server.port || DEFAULT_PORT;
   const port = await getPort({
     host,
-    port: config.server.port || DEFAULT_PORT,
+    port: originalPort,
     strictPort: config.server.strictPort || false,
-    silent: getPortSilently,
   });
   const https = Boolean(config.server.https) || false;
-  return { port, host, https };
+
+  return {
+    port,
+    host,
+    https,
+    portTip:
+      port !== originalPort
+        ? `Port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
+        : undefined,
+  };
 };
 
 const getIpv4Interfaces = () => {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -149,9 +149,8 @@ export async function startProdServer(
   config: NormalizedConfig,
   { getPortSilently }: PreviewServerOptions = {},
 ): Promise<StartServerResult> {
-  const { port, host, https } = await getServerConfig({
+  const { port, host, https, portTip } = await getServerConfig({
     config,
-    getPortSilently,
   });
 
   const { default: connect } = await import('connect');
@@ -206,6 +205,10 @@ export async function startProdServer(
           protocol,
           printUrls: serverConfig.printUrls,
         });
+
+        if (portTip && !getPortSilently) {
+          logger.info(portTip);
+        }
 
         const onClose = async () => {
           await Promise.all([server.close(), serverTerminator()]);

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -177,8 +177,8 @@ test('printServerURLs', () => {
   });
 
   expect(message!).toMatchInlineSnapshot(`
-    "  > local     http://localhost:3000/
-      > network   http://192.168.0.1:3000/
+    "  ➜ local     http://localhost:3000/
+      ➜ network   http://192.168.0.1:3000/
     "
   `);
 
@@ -212,12 +212,12 @@ test('printServerURLs', () => {
   });
 
   expect(message!).toMatchInlineSnapshot(`
-    "  > local
+    "  ➜ local
       - index    http://localhost:3000/
       - foo      http://localhost:3000/html/foo
       - bar      http://localhost:3000/bar
 
-      > network
+      ➜ network
       - index    http://192.168.0.1:3000/
       - foo      http://192.168.0.1:3000/html/foo
       - bar      http://192.168.0.1:3000/bar

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -211,8 +211,8 @@ try {
 After successfully starting dev server, you can see the following logs:
 
 ```
-  > Local:    http://localhost:3000
-  > Network:  http://192.168.0.1:3000
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 `startDevServer` returns the following parameters:

--- a/website/docs/en/api/start/index.mdx
+++ b/website/docs/en/api/start/index.mdx
@@ -39,8 +39,8 @@ await rsbuild.startDevServer();
 After successfully starting dev server, you can see the following logs:
 
 ```
-  > Local:    http://localhost:3000
-  > Network:  http://192.168.0.1:3000
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 To deploy the App to production environment, it is recommended to use the [rsbuild.build](/api/javascript-api/instance#rsbuild-build) method, which will build the production outputs.

--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -16,15 +16,15 @@ After configuring this option, you can enable HTTPS Server, and disabling the HT
 HTTP:
 
 ```
-  > Local: http://localhost:3000/
-  > Network: http://192.168.0.1:3000/
+  ➜ Local: http://localhost:3000/
+  ➜ Network: http://192.168.0.1:3000/
 ```
 
 HTTPS:
 
 ```
-  > Local: https://localhost:3000/
-  > Network: https://192.168.0.1:3000/
+  ➜ Local: https://localhost:3000/
+  ➜ Network: https://192.168.0.1:3000/
 ```
 
 :::tip

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -24,9 +24,9 @@ Whether to print the server's urls.
 
 By default, when you start the dev server or preview server, Rsbuild will print the following logs:
 
-```text
-> Local:    http://localhost:3000
-> Network:  http://192.168.0.1:3000
+```
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 ## Custom Logging
@@ -49,9 +49,9 @@ export default {
 
 Output:
 
-```text
-> Local:    http://localhost:3000/base/
-> Network:  http://192.168.0.1:3000/base/
+```
+  ➜ Local:    http://localhost:3000/base/
+  ➜ Network:  http://192.168.0.1:3000/base/
 ```
 
 ### Fully Customizable

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -234,8 +234,8 @@ try {
 成功启动 dev server 后，可以看到以下日志信息：
 
 ```
-  > Local:    http://localhost:3000
-  > Network:  http://192.168.0.1:3000
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 `startDevServer` 会返回以下参数：

--- a/website/docs/zh/api/start/index.mdx
+++ b/website/docs/zh/api/start/index.mdx
@@ -39,8 +39,8 @@ await rsbuild.startDevServer();
 成功启动 dev server 后，可以看到以下日志信息：
 
 ```
-  > Local:    http://localhost:3000
-  > Network:  http://192.168.0.1:3000
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 在生产环境部署场景，建议使用 [rsbuild.build](/api/javascript-api/instance#rsbuild-build) 方法，调用后会构建出生产模式产物。

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -16,15 +16,15 @@ type Https = ServerOptions | SecureServerSessionOptions;
 开启前：
 
 ```
-  > Local:    http://localhost:3000/
-  > Network:  http://192.168.0.1:3000/
+  ➜ Local:    http://localhost:3000/
+  ➜ Network:  http://192.168.0.1:3000/
 ```
 
 开启后：
 
 ```
-  > Local:    https://localhost:3000/
-  > Network:  https://192.168.0.1:3000/
+  ➜ Local:    https://localhost:3000/
+  ➜ Network:  https://192.168.0.1:3000/
 ```
 
 :::tip

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -24,9 +24,9 @@ type PrintUrls =
 
 默认情况下，当你启动 dev server 或 preview server 后，Rsbuild 会输出以下日志信息：
 
-```text
-> Local:    http://localhost:3000
-> Network:  http://192.168.0.1:3000
+```
+  ➜ Local:    http://localhost:3000
+  ➜ Network:  http://192.168.0.1:3000
 ```
 
 ## 自定义日志
@@ -49,9 +49,9 @@ export default {
 
 输出为：
 
-```text
-> Local:    http://localhost:3000/base/
-> Network:  http://192.168.0.1:3000/base/
+```
+  ➜ Local:    http://localhost:3000/base/
+  ➜ Network:  http://192.168.0.1:3000/base/
 ```
 
 ### 完全自定义


### PR DESCRIPTION
## Summary

Improve logs order when port is in use:

- before:

<img width="553" alt="Screenshot 2024-09-30 at 11 30 04" src="https://github.com/user-attachments/assets/cb896d06-28d2-4178-b7c1-2449748e185a">

- after:

<img width="590" alt="Screenshot 2024-09-30 at 11 38 41" src="https://github.com/user-attachments/assets/bbed43c9-41b9-47d4-a3ce-789513f828ef">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
