### PR TITLE
fix: compat invalid route

### DIFF
--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -36,6 +36,11 @@ test('should access / success and htmlFallback success by default', async ({
 
   await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
 
+  // compat invalid route and fallback success
+  await page.goto(`http://localhost:${rsbuild.port}//aaaaa`);
+
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+
   await rsbuild.close();
 });
 

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from 'node:http';
 import path from 'node:path';
-import { parse } from 'node:url';
 import type Connect from 'connect';
 import color from 'picocolors';
 import { logger } from '../logger';
@@ -103,6 +102,12 @@ const maybeHTMLRequest = (req: IncomingMessage) => {
   );
 };
 
+const postfixRE = /[?#].*$/;
+
+const getUrlPathname = (url: string): string => {
+  return url.replace(postfixRE, '');
+};
+
 /**
  * Support access HTML without suffix
  */
@@ -117,17 +122,8 @@ export const getHtmlCompletionMiddleware: (params: {
     }
 
     const url = req.url!;
-    let pathname: string;
 
-    // Handle invalid URLs
-    try {
-      pathname = parse(url, false, true).pathname!;
-    } catch (err) {
-      logger.error(
-        new Error(`Invalid URL: ${color.yellow(url)}`, { cause: err }),
-      );
-      return next();
-    }
+    const pathname = getUrlPathname(url);
 
     const rewrite = (newUrl: string) => {
       req.url = newUrl;


### PR DESCRIPTION
## Summary

compat invalid route, such as `http://localhost:3000//someroute`
## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/3588
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
