### PR TITLE
fix: only print children compiler time when multi compiler

### DIFF
--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -85,6 +85,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     const hasErrors = stats.hasErrors();
 
     if (!hasErrors) {
+      // only print children compiler time when multi compiler
       if (rspackConfigs.length > 1 && statsJson.children?.length) {
         statsJson.children.forEach((c, index) => {
           printTime(c, index);

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -85,7 +85,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     const hasErrors = stats.hasErrors();
 
     if (!hasErrors) {
-      if (statsJson.children && statsJson.children.length > 0) {
+      if (rspackConfigs.length > 1 && statsJson.children?.length) {
         statsJson.children.forEach((c, index) => {
           printTime(c, index);
         });


### PR DESCRIPTION
## Summary

`statsJson.children` get different children stats when call `stats.toJson({ children: true })` . In single compiler, statsJson.children will return childCompiler stats, and in multiCompiler, it will return compiler 1 / 2 / ... stats.
Rsbuild only need print children compiler time when multi compiler.

![20240930-154507](https://github.com/user-attachments/assets/64d9a677-7c68-4d86-9046-11fc2956f542)


## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/3610

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
