### PR TITLE
docs: add guide for migrating env vars

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -167,6 +167,39 @@ export default defineConfig({
 });
 ```
 
+Rsbuild injects the following [environment variables](/guide/advanced/env-vars) by default:
+
+- `import.meta.env.MODE`
+- `import.meta.env.BASE_URL`
+- `import.meta.env.PROD`
+- `import.meta.env.DEV`
+
+For `import.meta.env.SSR`, you can set it through the [environments](/config/environments) configuration option:
+
+```ts title="rsbuild.config.ts"
+export default defineConfig({
+  environments: {
+    web: {
+      source: {
+        define: {
+          'import.meta.env.SSR': JSON.stringify(false),
+        },
+      },
+    },
+    node: {
+      source: {
+        define: {
+          'import.meta.env.SSR': JSON.stringify(true),
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
+  },
+});
+```
+
 ## Preset Types
 
 Vite provides some preset type definitions through the `vite-env.d.ts` file. When migrating to Rsbuild, you can use the [preset types](/guide/basic/typescript#preset-types) provided by `@rsbuild/core`:

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -174,7 +174,7 @@ Rsbuild injects the following [environment variables](/guide/advanced/env-vars) 
 - `import.meta.env.PROD`
 - `import.meta.env.DEV`
 
-For `import.meta.env.SSR`, you can set it through the [environments](/config/environments) configuration option:
+For `import.meta.env.SSR`, you can set it through the [environments](/config/environments) and [source.define](/config/source/define) configuration options:
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -167,6 +167,39 @@ export default defineConfig({
 });
 ```
 
+Rsbuild 默认注入了以下 [环境变量](/guide/advanced/env-vars)：
+
+- `import.meta.env.MODE`
+- `import.meta.env.BASE_URL`
+- `import.meta.env.PROD`
+- `import.meta.env.DEV`
+
+对于 `import.meta.env.SSR`，你可以通过 [environments](/config/environments) 配置项来设置：
+
+```ts title="rsbuild.config.ts"
+export default defineConfig({
+  environments: {
+    web: {
+      source: {
+        define: {
+          'import.meta.env.SSR': JSON.stringify(false),
+        },
+      },
+    },
+    node: {
+      source: {
+        define: {
+          'import.meta.env.SSR': JSON.stringify(true),
+        },
+      },
+      output: {
+        target: 'node',
+      },
+    },
+  },
+});
+```
+
 ## 预设类型
 
 Vite 通过 `vite-env.d.ts` 文件提供了一些预设的类型定义，迁移到 Rsbuild 时，你可以使用 `@rsbuild/core` 提供的 [预设类型](/guide/basic/typescript#预设类型)：

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -174,7 +174,7 @@ Rsbuild 默认注入了以下 [环境变量](/guide/advanced/env-vars)：
 - `import.meta.env.PROD`
 - `import.meta.env.DEV`
 
-对于 `import.meta.env.SSR`，你可以通过 [environments](/config/environments) 配置项来设置：
+对于 `import.meta.env.SSR`，你可以通过 [environments](/config/environments) 和 [source.define](/config/source/define) 配置项来设置：
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({


### PR DESCRIPTION
## Summary

Add guide for migrating env vars from Vite.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/3623

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
