### PR TITLE
perf(CLI): enable Node.js compile cache

### DIFF
--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -1,3 +1,4 @@
+import nodeModule from 'node:module';
 import { logger } from '../logger';
 
 function initNodeEnv() {
@@ -11,6 +12,16 @@ function initNodeEnv() {
 
 export function prepareCli(): void {
   initNodeEnv();
+
+  // @ts-expect-error enableCompileCache is not typed yet
+  const { enableCompileCache } = nodeModule;
+  if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+    try {
+      enableCompileCache();
+    } catch {
+      // ignore errors
+    }
+  }
 
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.


### PR DESCRIPTION
## Summary

Enable Node.js 22 new compile cache in Rsbuild CLI.

- before:

<img width="988" alt="Screenshot 2024-10-02 at 17 53 58" src="https://github.com/user-attachments/assets/1eea4efe-9f7a-4c22-bde1-c48e5d147423">

- after:

<img width="968" alt="Screenshot 2024-10-02 at 17 53 23" src="https://github.com/user-attachments/assets/e1a4c852-9776-49e4-ba7d-fe456b82b5b9">

## Related Links

- https://nodejs.org/id/blog/release/v22.8.0
- https://github.com/nodejs/node/pull/54501

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
