### PR TITLE
fix(plugin-sass): mute the legacy API deprecation warnings

### DIFF
--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -54,6 +54,15 @@ const getSassLoaderOptions = (
     mergeFn,
   });
 
+  if (
+    mergedOptions.api === 'legacy' &&
+    !mergedOptions.sassOptions?.silenceDeprecations
+  ) {
+    // mute the noisy Sass legacy API warnings
+    mergedOptions.sassOptions ||= {};
+    mergedOptions.sassOptions.silenceDeprecations = ['legacy-js-api'];
+  }
+
   return {
     options: mergedOptions,
     excludes,

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -58,7 +58,7 @@ const getSassLoaderOptions = (
     mergedOptions.api === 'legacy' &&
     !mergedOptions.sassOptions?.silenceDeprecations
   ) {
-    // mute the noisy Sass legacy API warnings
+    // mute the noisy legacy API deprecation warnings
     mergedOptions.sassOptions ||= {};
     mergedOptions.sassOptions.silenceDeprecations = ['legacy-js-api'];
   }

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -173,3 +173,65 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
   },
 ]
 `;
+
+exports[`plugin-sass > should allow to use legacy API and mute deprecation warnings 1`] = `
+[
+  {
+    "resolve": {
+      "preferRelative": true,
+    },
+    "sideEffects": true,
+    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/@rspack/core/dist/builtin-plugin/css-extract/loader.js",
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+        "options": {
+          "importLoaders": 3,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/plugin-sass/compiled/resolve-url-loader/index.js",
+        "options": {
+          "join": [Function],
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/plugin-sass/compiled/sass-loader/index.js",
+        "options": {
+          "api": "legacy",
+          "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+          "sassOptions": {
+            "silenceDeprecations": [
+              "legacy-js-api",
+            ],
+          },
+          "sourceMap": true,
+        },
+      },
+    ],
+  },
+]
+`;

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -44,4 +44,21 @@ describe('plugin-sass', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
   });
+
+  it('should allow to use legacy API and mute deprecation warnings', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginSass({
+            sassLoaderOptions: {
+              api: 'legacy',
+            },
+          }),
+        ],
+      },
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.scss')).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

Mute the noisy Sass legacy API deprecation warnings when using the `legacy` API.

<img width="837" alt="Screenshot 2024-10-02 at 21 10 48" src="https://github.com/user-attachments/assets/7992d544-4142-476e-b0c8-84d21f941237">

## Related Links

https://sass-lang.com/documentation/breaking-changes/legacy-js-api/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
