### PR TITLE
docs(plugin-sass): add legacy API deprecation tip

### DIFF
--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -95,17 +95,15 @@ pluginSass({
 });
 ```
 
-## Modifying Sass Version
+## Custom Sass
 
-In some scenarios, if you need to use a specific version of Sass instead of the built-in Sass embedded in Rsbuild, you can install the desired Sass version in your project and set it up using the `implementation` option of the `sass-loader`.
+### Sass Implementation
 
-```js
-pluginSass({
-  sassLoaderOptions: {
-    implementation: require('sass'),
-  },
-});
-```
+Sass provides several implementations, including [sass](https://www.npmjs.com/package/sass), [sass-embedded](https://www.npmjs.com/package/sass-embedded), and [node-sass](https://www.npmjs.com/package/node-sass).
+
+Rsbuild uses the latest `sass-embedded` implementation by default. `sass-embedded` is a JavaScript wrapper around the native Dart Sass executable, providing a consistent API and optimal performance.
+
+If you need to use a different Sass implementation instead of the built-in `sass-embedded` included in Rsbuild, you can install the preferred Sass implementation in your project and specify it using the `sass-loader`'s [implementation](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#implementation) option.
 
 ```ts
 pluginSass({
@@ -115,13 +113,22 @@ pluginSass({
 });
 ```
 
-Rsbuild defaults to using the latest `modern-compiler` API. If you are using an older version of Sass, please set the [api](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#api) option of sass-loader to `legacy` to avoid exceptions caused by version mismatches.
+:::tip
+Switching from `sass-embedded` to another Sass implementation can significantly decrease build performance.
+:::
+
+### Sass API
+
+Rsbuild uses the latest `modern-compiler` API by default. If you rely on the `legacy` API of Sass, you can set the `api` option of the sass-loader to `legacy` to maintain compatibility with some deprecated Sass syntax.
 
 ```ts
 pluginSass({
   sassLoaderOptions: {
     api: 'legacy',
-    implementation: require.resolve('sass'),
   },
 });
 ```
+
+:::tip
+Sass's `legacy` API has been deprecated and will be removed in Sass 2.0. It is recommended to migrate to the `modern-compiler` API. For more details, see [Sass - Legacy JS API](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/).
+:::

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -95,9 +95,15 @@ pluginSass({
 });
 ```
 
-## 修改 Sass 版本
+## 自定义 Sass
 
-在某些场景下，如果你需要使用特定的 Sass 版本，而不是使用 Rsbuild 内置的 Sass embedded，可以在项目中安装需要使用的 Sass 版本，并通过 `sass-loader` 的 `implementation` 选项设置。
+### Sass implementation
+
+Sass 提供了多种实现，包括 [sass](https://www.npmjs.com/package/sass)、[sass-embedded](https://www.npmjs.com/package/sass-embedded) 和 [node-sass](https://www.npmjs.com/package/node-sass)。
+
+Rsbuild 默认使用最新的 `sass-embedded` 实现。`sass-embedded` 是一个围绕原生 Dart Sass 可执行文件的 JavaScript wrapper，具备一致的 API 和最佳的性能。
+
+如果你需要使用其他 Sass 实现，而不是使用 Rsbuild 内置的 `sass-embedded`，可以在项目中安装需要使用的 Sass 实现，并通过 `sass-loader` 的 [implementation](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#implementation) 选项来设置。
 
 ```ts
 pluginSass({
@@ -107,13 +113,22 @@ pluginSass({
 });
 ```
 
-Rsbuild 默认使用最新的 `modern-compiler` API，如果你使用的 Sass 版本较低，请将 sass-loader 的 [api](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#api) 选项设置为 `legacy`，以避免版本不匹配导致的异常。
+:::tip
+将 `sass-embedded` 修改为其他 Sass 实现，可能会构建性能显著下降。
+:::
+
+### Sass API
+
+Rsbuild 默认使用最新的 `modern-compiler` API，如果你依赖了 Sass 的 `legacy` API，可以将 sass-loader 的 [api](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#api) 选项设置为 `legacy`，以兼容一些废弃的 Sass 写法。
 
 ```ts
 pluginSass({
   sassLoaderOptions: {
     api: 'legacy',
-    implementation: require.resolve('sass'),
   },
 });
 ```
+
+:::tip
+Sass 的 `legacy` API 已经被废弃，并且将在 Sass 2.0 中被移除，建议迁移到 `modern-compiler` API，详见 [Sass - Legacy JS API](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/)。
+:::


### PR DESCRIPTION
## Summary

Add Sass legacy API deprecation tip.

## Related Links

https://sass-lang.com/documentation/breaking-changes/legacy-js-api/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
