### PR TITLE
feat: define `import.meta.env.ASSET_PREFIX`

### DIFF
--- a/e2e/cases/asset-prefix/index.test.ts
+++ b/e2e/cases/asset-prefix/index.test.ts
@@ -13,7 +13,11 @@ test('should allow dev.assetPrefix to be `auto`', async ({ page }) => {
   });
 
   const testEl = page.locator('#test');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await expect(testEl).toHaveText('auto');
+
+  const testEl2 = page.locator('#test2');
+  await expect(testEl2).toHaveText('auto');
+
   await rsbuild.close();
 });
 
@@ -29,7 +33,7 @@ test('should allow dev.assetPrefix to be true', async ({ page }) => {
   });
 
   const testEl = page.locator('#test');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await expect(testEl).toHaveText(`http://localhost:${rsbuild.port}`);
   await rsbuild.close();
 });
 
@@ -46,8 +50,12 @@ test('should allow dev.assetPrefix to have <port> placeholder', async ({
     },
   });
 
-  const testEl = page.locator('#test-port');
+  const testEl = page.locator('#test');
   await expect(testEl).toHaveText(`http://localhost:${rsbuild.port}`);
+
+  const testEl2 = page.locator('#test2');
+  await expect(testEl2).toHaveText(`http://localhost:${rsbuild.port}`);
+
   await rsbuild.close();
 });
 
@@ -63,7 +71,7 @@ test('should allow output.assetPrefix to be `auto`', async ({ page }) => {
   });
 
   const testEl = page.locator('#test');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
+  await expect(testEl).toHaveText('auto');
   await rsbuild.close();
 });
 

--- a/e2e/cases/asset-prefix/src/index.js
+++ b/e2e/cases/asset-prefix/src/index.js
@@ -1,10 +1,9 @@
 const testEl = document.createElement('div');
 testEl.id = 'test';
-testEl.innerHTML = 'Hello Rsbuild!';
-
+testEl.innerHTML = process.env.ASSET_PREFIX;
 document.body.appendChild(testEl);
 
-const testPortEl = document.createElement('div');
-testPortEl.id = 'test-port';
-testPortEl.innerHTML = process.env.ASSET_PREFIX;
-document.body.appendChild(testPortEl);
+const testEl2 = document.createElement('div');
+testEl2.id = 'test2';
+testEl2.innerHTML = import.meta.env.ASSET_PREFIX;
+document.body.appendChild(testEl2);

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -302,6 +302,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     },
     DefinePlugin {
       "definitions": {
+        "import.meta.env.ASSET_PREFIX": """",
         "import.meta.env.BASE_URL": "\\"/\\"",
         "import.meta.env.DEV": true,
         "import.meta.env.MODE": ""development"",
@@ -662,6 +663,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     },
     DefinePlugin {
       "definitions": {
+        "import.meta.env.ASSET_PREFIX": """",
         "import.meta.env.BASE_URL": "\\"/\\"",
         "import.meta.env.DEV": false,
         "import.meta.env.MODE": ""production"",
@@ -971,6 +973,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     RsbuildCorePlugin {},
     DefinePlugin {
       "definitions": {
+        "import.meta.env.ASSET_PREFIX": """",
         "import.meta.env.BASE_URL": "\\"/\\"",
         "import.meta.env.DEV": false,
         "import.meta.env.MODE": ""production"",
@@ -1263,6 +1266,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     RsbuildCorePlugin {},
     DefinePlugin {
       "definitions": {
+        "import.meta.env.ASSET_PREFIX": """",
         "import.meta.env.BASE_URL": "\\"/\\"",
         "import.meta.env.DEV": false,
         "import.meta.env.MODE": ""production"",

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -67,6 +67,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
   },
   DefinePlugin {
     "definitions": {
+      "import.meta.env.ASSET_PREFIX": """",
       "import.meta.env.BASE_URL": "\\"/\\"",
       "import.meta.env.DEV": false,
       "import.meta.env.MODE": ""none"",

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -9,15 +9,16 @@ export const pluginDefine = (): RsbuildPlugin => ({
       const { config } = environment;
 
       const baseUrl = JSON.stringify(config.server.base);
+      const assetPrefix = JSON.stringify(getPublicPathFromChain(chain, false));
+
       const builtinVars: Define = {
         'import.meta.env.MODE': JSON.stringify(config.mode),
         'import.meta.env.DEV': config.mode === 'development',
         'import.meta.env.PROD': config.mode === 'production',
         'import.meta.env.BASE_URL': baseUrl,
-        'process.env.ASSET_PREFIX': JSON.stringify(
-          getPublicPathFromChain(chain, false),
-        ),
+        'import.meta.env.ASSET_PREFIX': assetPrefix,
         'process.env.BASE_URL': baseUrl,
+        'process.env.ASSET_PREFIX': assetPrefix,
       };
 
       chain

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -359,6 +359,7 @@ exports[`should use rspack as default bundler > apply rspack correctly 1`] = `
     DefinePlugin {
       "_args": [
         {
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": true,
           "import.meta.env.MODE": ""development"",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -359,6 +359,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     DefinePlugin {
       "_args": [
         {
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": true,
           "import.meta.env.MODE": ""development"",
@@ -781,6 +782,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     DefinePlugin {
       "_args": [
         {
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": false,
           "import.meta.env.MODE": ""production"",
@@ -1119,6 +1121,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     DefinePlugin {
       "_args": [
         {
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": true,
           "import.meta.env.MODE": ""development"",
@@ -1521,6 +1524,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     DefinePlugin {
       "_args": [
         {
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": true,
           "import.meta.env.MODE": ""development"",

--- a/packages/core/tests/__snapshots__/define.test.ts.snap
+++ b/packages/core/tests/__snapshots__/define.test.ts.snap
@@ -8,6 +8,7 @@ exports[`plugin-define > should register define plugin correctly 1`] = `
       "_args": [
         {
           "NAME": ""Jack"",
+          "import.meta.env.ASSET_PREFIX": """",
           "import.meta.env.BASE_URL": "\\"/\\"",
           "import.meta.env.DEV": false,
           "import.meta.env.MODE": ""none"",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1698,6 +1698,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       DefinePlugin {
         "_args": [
           {
+            "import.meta.env.ASSET_PREFIX": """",
             "import.meta.env.BASE_URL": "\\"/\\"",
             "import.meta.env.DEV": true,
             "import.meta.env.MODE": ""development"",
@@ -2017,6 +2018,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       DefinePlugin {
         "_args": [
           {
+            "import.meta.env.ASSET_PREFIX": """",
             "import.meta.env.BASE_URL": "\\"/\\"",
             "import.meta.env.DEV": true,
             "import.meta.env.MODE": ""development"",

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -78,6 +78,7 @@ DefinePlugin {
       "__VUE_OPTIONS_API__": true,
       "__VUE_PROD_DEVTOOLS__": false,
       "__VUE_PROD_HYDRATION_MISMATCH_DETAILS__": false,
+      "import.meta.env.ASSET_PREFIX": """",
       "import.meta.env.BASE_URL": "\\"/\\"",
       "import.meta.env.DEV": false,
       "import.meta.env.MODE": ""none"",

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -14,12 +14,13 @@ Rsbuild by default injects the some env variables into the code using [source.de
 - [import.meta.env.DEV](#importmetaenvdev)
 - [import.meta.env.PROD](#importmetaenvprod)
 - [import.meta.env.BASE_URL](#importmetaenvbase_url)
+- [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix)
 
 `process.env` contains these env variables:
 
-- [process.env.NODE_ENV](#processenvnode_env)
-- [process.env.BASE_URL](#importmetaenvbase_url)
+- [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
+- [process.env.NODE_ENV](#processenvnode_env)
 
 ### import.meta.env.MODE
 
@@ -91,16 +92,67 @@ const image = new Image();
 image.src = `${import.meta.env.BASE_URL}/favicon.ico`;
 ```
 
-In the HTML template, you can also use `import.meta.env.BASE_URL` to concatenate the URL:
+### import.meta.env.ASSET_PREFIX
+
+You can use `import.meta.env.ASSET_PREFIX` in the client code to access the URL prefix of static assets.
+
+- In development, it is equivalent to the value set by [dev.assetPrefix](/config/dev/asset-prefix).
+- In production, it is equivalent to the value set by [output.assetPrefix](/config/output/asset-prefix).
+- Rsbuild will automatically remove the trailing slash from `assetPrefix` to make string concatenation easier.
+
+For example, we copy the `static/icon.png` image to the `dist` directory through [output.copy](/config/output/copy) configuration:
+
+```ts
+export default {
+  dev: {
+    assetPrefix: '/',
+  },
+  output: {
+    copy: [{ from: './static', to: 'static' }],
+    assetPrefix: 'https://example.com',
+  },
+};
+```
+
+Then we can access the image URL in the client code:
+
+```jsx
+const Image = <img src={`${import.meta.env.ASSET_PREFIX}/static/icon.png`} />;
+```
+
+In development mode, the above code will be compiled to:
+
+```jsx
+const Image = <img src={`/static/icon.png`} />;
+```
+
+In production mode, the above code will be compiled to:
+
+```jsx
+const Image = <img src={`https://example.com/static/icon.png`} />;
+```
+
+### process.env.BASE_URL
+
+Rsbuild also allows using `process.env.BASE_URL`, which is an alias of [import.meta.env.BASE_URL](#importmetaenvbase_url).
+
+For example, in the HTML template, you can use `process.env.BASE_URL` to concatenate the URL:
 
 ```html title="index.html"
 <!-- Equivalent to "/foo/favicon.ico" -->
-<link rel="icon" href="<%= import.meta.env.BASE_URL %>/favicon.ico" />
+<link rel="icon" href="<%= process.env.BASE_URL %>/favicon.ico" />
 ```
 
-Additionally, you can use the following env variables:
+### process.env.ASSET_PREFIX
 
-- `process.env.BASE_URL`: Equivalent to `import.meta.env.BASE_URL`.
+Rsbuild also allows using `process.env.ASSET_PREFIX`, which is an alias of [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix).
+
+For example, in the HTML template, you can use `process.env.ASSET_PREFIX` to concatenate the URL:
+
+```html title="index.html"
+<!-- Equivalent to "https://example.com/static/icon.png" -->
+<link rel="icon" href="<%= process.env.ASSET_PREFIX %>/static/icon.png" />
+```
 
 ### process.env.NODE_ENV
 
@@ -131,46 +183,6 @@ if (false) {
 ```
 
 During code minification, `if (false) { ... }` will be recognized as invalid code and removed automatically.
-
-### process.env.ASSET_PREFIX
-
-You can use `process.env.ASSET_PREFIX` in the client code to access the URL prefix of static assets.
-
-- In development, it is equivalent to the value set by [dev.assetPrefix](/config/dev/asset-prefix).
-- In production, it is equivalent to the value set by [output.assetPrefix](/config/output/asset-prefix).
-- Rsbuild will automatically remove the trailing slash from `assetPrefix` to make string concatenation easier.
-
-For example, we copy the `static/icon.png` image to the `dist` directory through [output.copy](/config/output/copy) configuration:
-
-```ts
-export default {
-  dev: {
-    assetPrefix: '/',
-  },
-  output: {
-    copy: [{ from: './static', to: 'static' }],
-    assetPrefix: 'https://example.com',
-  },
-};
-```
-
-Then we can access the image URL in the client code:
-
-```jsx
-const Image = <img src={`${process.env.ASSET_PREFIX}/static/icon.png`} />;
-```
-
-In development mode, the above code will be compiled to:
-
-```jsx
-const Image = <img src={`/static/icon.png`} />;
-```
-
-In production mode, the above code will be compiled to:
-
-```jsx
-const Image = <img src={`https://example.com/static/icon.png`} />;
-```
 
 ## `.env` File
 

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -14,12 +14,13 @@ Rsbuild 默认通过 [source.define](#使用-define) 向代码中注入以下环
 - [import.meta.env.DEV](#importmetaenvdev)
 - [import.meta.env.PROD](#importmetaenvprod)
 - [import.meta.env.BASE_URL](#importmetaenvbase_url)
+- [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix)
 
 `process.env` 包含以下环境变量：
 
-- [process.env.NODE_ENV](#processenvnode_env)
-- [process.env.BASE_URL](#importmetaenvbase_url)
+- [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
+- [process.env.NODE_ENV](#processenvnode_env)
 
 ### import.meta.env.MODE
 
@@ -91,16 +92,67 @@ const image = new Image();
 image.src = `${import.meta.env.BASE_URL}/favicon.ico`;
 ```
 
-在 HTML 模板中，也可以使用 `import.meta.env.BASE_URL` 来拼接 URL：
+### import.meta.env.ASSET_PREFIX
+
+你可以在 client 代码中使用 `import.meta.env.ASSET_PREFIX` 来访问静态资源的前缀。
+
+- 在开发模式下，它等同于 [dev.assetPrefix](/config/dev/asset-prefix) 设置的值。
+- 在生产模式下，它等同于 [output.assetPrefix](/config/output/asset-prefix) 设置的值。
+- Rsbuild 会自动移除 `assetPrefix` 尾部的斜线符号，以便于进行字符串拼接。
+
+比如，我们通过 [output.copy](/config/output/copy) 配置，将 `static/icon.png` 图片拷贝到 `dist` 目录下：
+
+```ts
+export default {
+  dev: {
+    assetPrefix: '/',
+  },
+  output: {
+    copy: [{ from: './static', to: 'static' }],
+    assetPrefix: 'https://example.com',
+  },
+};
+```
+
+此时，我们可以在 client 代码中通过以下方式来拼接图片 URL：
+
+```jsx
+const Image = <img src={`${import.meta.env.ASSET_PREFIX}/static/icon.png`} />;
+```
+
+在开发模式，以上代码会被编译为：
+
+```jsx
+const Image = <img src={`/static/icon.png`} />;
+```
+
+在生产模式，以上代码会被编译为：
+
+```jsx
+const Image = <img src={`https://example.com/static/icon.png`} />;
+```
+
+### process.env.BASE_URL
+
+Rsbuild 也允许使用 `process.env.BASE_URL`，它是 [import.meta.env.BASE_URL](#importmetaenvbase_url) 的别名。
+
+例如，在 HTML 模板中，可以使用 `process.env.BASE_URL` 来拼接 URL：
 
 ```html title="index.html"
 <!-- 等价于 "/foo/favicon.ico" -->
-<link rel="icon" href="<%= import.meta.env.BASE_URL %>/favicon.ico" />
+<link rel="icon" href="<%= process.env.BASE_URL %>/favicon.ico" />
 ```
 
-此外，你还可以使用以下环境变量：
+### process.env.ASSET_PREFIX
 
-- `process.env.BASE_URL`：等同于 `import.meta.env.BASE_URL`。
+Rsbuild 也允许使用 `process.env.ASSET_PREFIX`，它是 [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix) 的别名。
+
+例如，在 HTML 模板中，可以使用 `process.env.ASSET_PREFIX` 来拼接 URL：
+
+```html title="index.html"
+<!-- 等价于 "https://example.com/static/icon.png" -->
+<link rel="icon" href="<%= process.env.ASSET_PREFIX %>/static/icon.png" />
+```
 
 ### process.env.NODE_ENV
 
@@ -131,46 +183,6 @@ if (false) {
 ```
 
 在代码压缩过程中，`if (false) { ... }` 会被识别为无效代码，并被自动移除。
-
-### process.env.ASSET_PREFIX
-
-你可以在 client 代码中使用 `process.env.ASSET_PREFIX` 来访问静态资源的前缀。
-
-- 在开发模式下，它等同于 [dev.assetPrefix](/config/dev/asset-prefix) 设置的值。
-- 在生产模式下，它等同于 [output.assetPrefix](/config/output/asset-prefix) 设置的值。
-- Rsbuild 会自动移除 `assetPrefix` 尾部的斜线符号，以便于进行字符串拼接。
-
-比如，我们通过 [output.copy](/config/output/copy) 配置，将 `static/icon.png` 图片拷贝到 `dist` 目录下：
-
-```ts
-export default {
-  dev: {
-    assetPrefix: '/',
-  },
-  output: {
-    copy: [{ from: './static', to: 'static' }],
-    assetPrefix: 'https://example.com',
-  },
-};
-```
-
-此时，我们可以在 client 代码中通过以下方式来拼接图片 URL：
-
-```jsx
-const Image = <img src={`${process.env.ASSET_PREFIX}/static/icon.png`} />;
-```
-
-在开发模式，以上代码会被编译为：
-
-```jsx
-const Image = <img src={`/static/icon.png`} />;
-```
-
-在生产模式，以上代码会被编译为：
-
-```jsx
-const Image = <img src={`https://example.com/static/icon.png`} />;
-```
 
 ## `.env` 文件
 


### PR DESCRIPTION
## Summary

Rsbuild should define `import.meta.env.ASSET_PREFIX` by default to be consistent with `import.meta.env.BASE_URL`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
