### PR TITLE
feat: check output folder when using preview JS API

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -1,6 +1,8 @@
+import { join } from 'node:path';
 import { getRandomPort, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
+import { outputFile } from 'fs-extra';
 
 const createPlugin = () => {
   const names: string[] = [];
@@ -152,11 +154,16 @@ rspackOnlyTest(
       },
     });
 
+    await rsbuild.initConfigs();
+    await outputFile(join(rsbuild.context.distPath, 'index.html'), '');
+
     const result = await rsbuild.preview();
 
     expect(names).toEqual([
       'ModifyRsbuildConfig',
       'ModifyEnvironmentConfig',
+      'ModifyBundlerChain',
+      'ModifyBundlerConfig',
       'BeforeStartProdServer',
       'AfterStartProdServer',
     ]);

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,7 +1,4 @@
-import { existsSync } from 'node:fs';
 import { type Command, program } from 'commander';
-import color from 'picocolors';
-import { isEmptyDir } from '../helpers';
 import { logger } from '../logger';
 import type { RsbuildMode } from '../types';
 import { init } from './init';
@@ -114,27 +111,6 @@ export function runCli(): void {
       try {
         const rsbuild = await init({ cliOptions: options });
         await rsbuild?.initConfigs();
-
-        if (rsbuild) {
-          const { distPath } = rsbuild.context;
-
-          if (!existsSync(distPath)) {
-            throw new Error(
-              `The output directory ${color.yellow(
-                distPath,
-              )} does not exist, please build the project before previewing.`,
-            );
-          }
-
-          if (isEmptyDir(distPath)) {
-            throw new Error(
-              `The output directory ${color.yellow(
-                distPath,
-              )} is empty, please build the project before previewing.`,
-            );
-          }
-        }
-
         await rsbuild?.preview();
       } catch (err) {
         logger.error('Failed to start preview server.');

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -1,6 +1,8 @@
+import { existsSync } from 'node:fs';
 import { isPromise } from 'node:util/types';
+import color from 'picocolors';
 import { createContext } from './createContext';
-import { getNodeEnv, pick, setNodeEnv } from './helpers';
+import { getNodeEnv, isEmptyDir, pick, setNodeEnv } from './helpers';
 import { initPluginAPI } from './initPlugins';
 import { initRsbuildConfig } from './internal';
 import { logger } from './logger';
@@ -142,6 +144,25 @@ export async function createRsbuild(
     if (!getNodeEnv()) {
       setNodeEnv('production');
     }
+
+    const { distPath } = context;
+
+    if (!existsSync(distPath)) {
+      throw new Error(
+        `The output directory ${color.yellow(
+          distPath,
+        )} does not exist, please build the project before previewing.`,
+      );
+    }
+
+    if (isEmptyDir(distPath)) {
+      throw new Error(
+        `The output directory ${color.yellow(
+          distPath,
+        )} is empty, please build the project before previewing.`,
+      );
+    }
+
     const { startProdServer } = await import('./server/prodServer');
     const config = await initRsbuildConfig({ context, pluginManager });
     return startProdServer(context, config, options);

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -27,6 +27,10 @@ export type CreateDevServerOptions = StartDevServerOptions & {
 };
 
 export type PreviewServerOptions = {
+  /**
+   * Whether to get port silently
+   * @default false
+   */
   getPortSilently?: boolean;
 };
 


### PR DESCRIPTION
## Summary

Check output folder when using the `rsbuild.preview()` JS API.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
