### PR TITLE
perf: no need to init Rspack config before preview

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -110,7 +110,6 @@ export function runCli(): void {
     .action(async (options: PreviewOptions) => {
       try {
         const rsbuild = await init({ cliOptions: options });
-        await rsbuild?.initConfigs();
         await rsbuild?.preview();
       } catch (err) {
         logger.error('Failed to start preview server.');

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -145,6 +145,7 @@ export async function createRsbuild(
       setNodeEnv('production');
     }
 
+    const config = await initRsbuildConfig({ context, pluginManager });
     const { distPath } = context;
 
     if (!existsSync(distPath)) {
@@ -164,7 +165,6 @@ export async function createRsbuild(
     }
 
     const { startProdServer } = await import('./server/prodServer');
-    const config = await initRsbuildConfig({ context, pluginManager });
     return startProdServer(context, config, options);
   };
 


### PR DESCRIPTION
## Summary

No need to init the Rspack config before `rsbuild preview`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
