### PR TITLE
feat: export `PreviewOptions` type and correct doc

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -15,7 +15,7 @@ import type {
   Falsy,
   InternalContext,
   PluginManager,
-  PreviewServerOptions,
+  PreviewOptions,
   ResolvedCreateRsbuildOptions,
   RsbuildInstance,
   RsbuildPlugin,
@@ -140,7 +140,7 @@ export async function createRsbuild(
     setCssExtractPlugin,
   });
 
-  const preview = async (options?: PreviewServerOptions) => {
+  const preview = async (options?: PreviewOptions) => {
     if (!getNodeEnv()) {
       setNodeEnv('production');
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,7 @@ export type {
   Polyfill,
   PostCSSLoaderOptions,
   PostCSSPlugin,
+  PreviewOptions,
   PreconnectOption,
   ProxyConfig,
   ProxyOptions,

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -6,7 +6,7 @@ import { logger } from '../logger';
 import type {
   InternalContext,
   NormalizedConfig,
-  PreviewServerOptions,
+  PreviewOptions,
   RequestHandler,
   ServerConfig,
 } from '../types';
@@ -152,7 +152,7 @@ export class RsbuildProdServer {
 export async function startProdServer(
   context: InternalContext,
   config: NormalizedConfig,
-  { getPortSilently }: PreviewServerOptions = {},
+  { getPortSilently }: PreviewOptions = {},
 ): Promise<StartServerResult> {
   const { port, host, https, portTip } = await getServerConfig({
     config,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -26,7 +26,7 @@ export type CreateDevServerOptions = StartDevServerOptions & {
   runCompile?: boolean;
 };
 
-export type PreviewServerOptions = {
+export type PreviewOptions = {
   /**
    * Whether to get port silently
    * @default false
@@ -148,7 +148,7 @@ export type RsbuildInstance = {
   isPluginExists: PluginManager['isPluginExists'];
 
   build: ProviderInstance['build'];
-  preview: (options?: PreviewServerOptions) => Promise<StartServerResult>;
+  preview: (options?: PreviewOptions) => Promise<StartServerResult>;
   initConfigs: ProviderInstance['initConfigs'];
   inspectConfig: ProviderInstance['inspectConfig'];
   createCompiler: ProviderInstance['createCompiler'];

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -412,18 +412,28 @@ rsbuildServer.connectWebSocket({ server: httpServer });
 
 ## rsbuild.preview
 
-Start a server to preview the production build locally. This method should be executed after `rsbuild.build`.
+Start a server to preview the production build locally. This method should be executed after [rsbuild.build](#rsbuildbuild).
 
 - **Type:**
 
 ```ts
+type PreviewOptions = {
+  /**
+   * Whether to get port silently
+   * @default false
+   */
+  getPortSilently?: boolean;
+};
+
 type StartServerResult = {
   urls: string[];
   port: number;
-  server: Server;
+  server: {
+    close: () => Promise<void>;
+  };
 };
 
-function server(): Promise<StartServerResult>;
+function preview(options?: PreviewOptions): Promise<StartServerResult>;
 ```
 
 - **Example:**

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -433,18 +433,28 @@ rsbuildServer.connectWebSocket({ server: httpServer });
 
 ## rsbuild.preview
 
-在本地启动 Server 来预览生产模式构建的产物，需要在 `rsbuild.build` 方法之后执行。
+在本地启动 server 来预览生产模式构建的产物，需要在 [rsbuild.build](#rsbuildbuild) 方法之后执行。
 
 - **类型：**
 
 ```ts
+type PreviewOptions = {
+  /**
+   * Whether to get port silently
+   * @default false
+   */
+  getPortSilently?: boolean;
+};
+
 type StartServerResult = {
   urls: string[];
   port: number;
-  server: Server;
+  server: {
+    close: () => Promise<void>;
+  };
 };
 
-function server(): Promise<StartServerResult>;
+function preview(options?: PreviewOptions): Promise<StartServerResult>;
 ```
 
 - **示例：**


### PR DESCRIPTION
## Summary

Export the `PreviewOptions` type and correct `rsbuild.preview` documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
