### PR TITLE
fix: correct `rsbuild.createCompiler` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,7 +42,6 @@ export type {
   ConfigChainWithContext,
   ConsoleType,
   CreateCompiler,
-  CreateCompilerOptions,
   CreateRsbuildOptions,
   CrossOrigin,
   CSSLoaderOptions,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -10,8 +10,6 @@ import type { WebpackConfig } from './thirdParty';
 
 export type Bundler = 'rspack' | 'webpack';
 
-export type CreateCompilerOptions = { watch?: boolean };
-
 export type StartDevServerOptions = {
   /**
    * Using a custom Rspack Compiler object.
@@ -96,9 +94,8 @@ export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {
   };
 };
 
-export type CreateCompiler =
-  // Allow user to manually narrow Compiler type
-  <C = Compiler | MultiCompiler>(options?: CreateCompilerOptions) => Promise<C>;
+// Allow user to manually narrow Compiler type
+export type CreateCompiler = <C = Compiler | MultiCompiler>() => Promise<C>;
 
 export type CreateRsbuildOptions = {
   /** The root path of current project. */

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -28,7 +28,7 @@ const rsbuild = await createRsbuild({
 
 ### options
 
-The first parameter of `createRsbuild` is a options object, you can pass in the following options:
+The first parameter of `createRsbuild` is an `options` object, you can pass in the following options:
 
 ```ts
 type CreateRsbuildOptions = {

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -18,7 +18,7 @@ type Version = string;
 
 ### context.rootPath
 
-The root path of current build, corresponding to the `cwd` option of `createRsbuild` method.
+The root path of current build, corresponding to the `cwd` option of [createRsbuild](/api/javascript-api/core#creatersbuild) method.
 
 - **Type:**
 
@@ -489,9 +489,7 @@ await server.close();
 
 ## rsbuild.createCompiler
 
-Create a Compiler object.
-
-When the `target` option of `createRsbuild` contains only one value, the return value is `Compiler`; when `target` contains multiple values, the return value is `MultiCompiler`.
+Create an Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) instance. If there are multiple [environments](/config/environments) for this build, the return value is `MultiCompiler`.
 
 - **Type:**
 
@@ -505,7 +503,7 @@ function CreateCompiler(): Promise<Compiler | MultiCompiler>;
 const compiler = await rsbuild.createCompiler();
 ```
 
-> In most scenarios, you do not need to use this API unless you need to custom the dev server or other advanced scenarios.
+> You do not need to use this API unless you need to custom the dev server or other advanced scenarios.
 
 ## rsbuild.addPlugins
 

--- a/website/docs/en/api/start/index.mdx
+++ b/website/docs/en/api/start/index.mdx
@@ -16,7 +16,7 @@ import { PackageManagerTabs } from '@theme';
 
 ### 2. Create an Rsbuild Instance
 
-You can call the `createRsbuild` method to create an Rsbuild instance:
+You can call the [createRsbuild](/api/javascript-api/core#creatersbuild) method to create an Rsbuild instance:
 
 ```ts
 import { createRsbuild } from '@rsbuild/core';

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -28,7 +28,7 @@ const rsbuild = await createRsbuild({
 
 ### options
 
-`createRsbuild` 的第一个参数是一个配置对象，你可以传入以下选项：
+`createRsbuild` 的第一个参数是一个 `options` 对象，你可以传入以下选项：
 
 ```ts
 type CreateRsbuildOptions = {

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -18,7 +18,7 @@ type Version = string;
 
 ### context.rootPath
 
-当前执行构建的根路径，对应调用 `createRsbuild` 时传入的 `cwd` 选项。
+当前执行构建的根路径，对应调用 [createRsbuild](/api/javascript-api/core#creatersbuild) 时传入的 `cwd` 选项。
 
 - **类型：**
 
@@ -510,9 +510,7 @@ await server.close();
 
 ## rsbuild.createCompiler
 
-创建一个 compiler 对象。
-
-当 `createRsbuild` 的 `target` 选项包含一个值时，返回值为 `Compiler`；当 `target` 包含多个值时，返回值为 `MultiCompiler`。
+创建一个 Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) 实例；如果本次构建存在多个 [environments](/config/environments)，则返回值为 `MultiCompiler`。
 
 - **类型：**
 
@@ -526,7 +524,7 @@ function CreateCompiler(): Promise<Compiler | MultiCompiler>;
 const compiler = await rsbuild.createCompiler();
 ```
 
-> 大部分场景下，不需要使用该 API，除非需要进行自定义 dev server 等高级操作。
+> 大部分场景下，你不需要使用该 API，除非需要进行自定义 dev server 等高级操作。
 
 ## rsbuild.addPlugins
 

--- a/website/docs/zh/api/start/index.mdx
+++ b/website/docs/zh/api/start/index.mdx
@@ -16,7 +16,7 @@ import { PackageManagerTabs } from '@theme';
 
 ### 2. 创建 Rsbuild 实例
 
-你可以调用 `createRsbuild` 方法来创建一个 Rsbuild 实例对象：
+你可以调用 [createRsbuild](/api/javascript-api/core#creatersbuild) 方法来创建一个 Rsbuild 实例对象：
 
 ```ts
 import { createRsbuild } from '@rsbuild/core';


### PR DESCRIPTION
## Summary

Correct type and documentation for `rsbuild.createCompiler`, remove the unused `CreateCompilerOptions` type.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
