### PR TITLE
feat: enable CLI shortcuts by default when using Rsbuild CLI

### DIFF
--- a/examples/react/rsbuild.config.ts
+++ b/examples/react/rsbuild.config.ts
@@ -3,7 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  dev: {
-    cliShortcuts: true,
-  },
 });

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -100,6 +100,12 @@ export async function init({
       config.server.port = commonOpts.port;
     }
 
+    // enable CLI shortcuts by default when using Rsbuild CLI
+    if (config.dev?.cliShortcuts === undefined) {
+      config.dev ||= {};
+      config.dev.cliShortcuts = true;
+    }
+
     return createRsbuild({
       cwd: root,
       rsbuildConfig: config,


### PR DESCRIPTION
## Summary

Enable CLI shortcuts by default when using Rsbuild CLI.

When using Rsbuild's JS API, the CLI shortcuts can be manually enabled via `dev.cliShortcuts`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/2991

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
