### PR TITLE
docs: add reload-server tip

### DIFF
--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -106,6 +106,8 @@ export default {
 };
 ```
 
+It should be noted that the reload-server functionality is provided by Rsbuild CLI. If you are using a custom server or an upper-layer framework based on the Rsbuild, this configuration may not be supported.
+
 ## options
 
 - **Type:** `WatchOptions`

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -106,7 +106,7 @@ export default {
 };
 ```
 
-It should be noted that the reload-server functionality is provided by Rsbuild CLI. If you are using a custom server or an upper-layer framework based on the Rsbuild, this configuration may not be supported.
+It should be noted that the reload-server functionality is provided by Rsbuild CLI. If you are using a custom server or an upper-layer framework based on the Rsbuild, this configuration is currently not supported.
 
 ## options
 

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -106,7 +106,7 @@ export default {
 };
 ```
 
-需要注意的是，reload-server 功能由 Rsbuild CLI 提供。如果你使用的是自定义 server 或基于 Rsbuild 封装的上层框架，可能不支持此配置。
+需要注意的是，reload-server 功能由 Rsbuild CLI 提供。如果你使用的是自定义 server 或基于 Rsbuild 封装的上层框架，目前暂不支持此配置。
 
 ## options
 

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -106,6 +106,8 @@ export default {
 };
 ```
 
+需要注意的是，reload-server 功能由 Rsbuild CLI 提供。如果你使用的是自定义 server 或基于 Rsbuild 封装的上层框架，可能不支持此配置。
+
 ## options
 
 - **类型：** `WatchOptions`


### PR DESCRIPTION
## Summary

`reload-server` functionality is provided by Rsbuild CLI. This configuration may not be supported when using a custom server or an upper-layer framework based on the Rsbuild.

## Related Links

https://github.com/web-infra-dev/modern.js/pull/6336

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
