### PR TITLE
feat: validate Rspack plugins configuration

### DIFF
--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -1,4 +1,5 @@
 import { rspack } from '@rspack/core';
+import color from 'picocolors';
 import { reduceConfigsAsyncWithContext } from 'reduce-configs';
 import { CHAIN_ID, chainToConfig, modifyBundlerChain } from '../configChain';
 import { castArray, getNodeEnv } from '../helpers';
@@ -148,6 +149,21 @@ export async function generateRspackConfig({
     rspackConfig,
     await getConfigUtils(rspackConfig, chainUtils),
   );
+
+  // validate plugins
+  if (rspackConfig.plugins) {
+    for (const plugin of rspackConfig.plugins) {
+      if (!plugin || plugin.apply !== undefined) {
+        continue;
+      }
+      if ('name' in plugin && 'setup' in plugin) {
+        const name = color.bold(color.yellow(plugin.name));
+        throw new Error(
+          `${name} appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
+        );
+      }
+    }
+  }
 
   return rspackConfig;
 }

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -153,10 +153,12 @@ export async function generateRspackConfig({
   // validate plugins
   if (rspackConfig.plugins) {
     for (const plugin of rspackConfig.plugins) {
-      if (!plugin || plugin.apply !== undefined) {
-        continue;
-      }
-      if ('name' in plugin && 'setup' in plugin) {
+      if (
+        plugin &&
+        plugin.apply === undefined &&
+        'name' in plugin &&
+        'setup' in plugin
+      ) {
         const name = color.bold(color.yellow(plugin.name));
         throw new Error(
           `${name} appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,


### PR DESCRIPTION
## Summary

Validate Rspack plugins and recognize Rsbuild plugins:

![image](https://github.com/user-attachments/assets/2bbcba29-b715-42b9-aeca-9514606861d1)

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3621

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
