### PR TITLE
feat: update building logs

### DIFF
--- a/e2e/cases/javascript-api/custom-logger/index.test.ts
+++ b/e2e/cases/javascript-api/custom-logger/index.test.ts
@@ -8,9 +8,7 @@ rspackOnlyTest('should allow to customize logger', async () => {
     cwd: __dirname,
   });
 
-  expect(
-    logs.find((item) => item.includes('[READY] Compiled in')),
-  ).toBeTruthy();
+  expect(logs.find((item) => item.includes('[READY] Built in'))).toBeTruthy();
 
   restore();
 });

--- a/e2e/cases/progress/index.test.ts
+++ b/e2e/cases/progress/index.test.ts
@@ -26,11 +26,9 @@ webpackOnlyTest('should emit progress log in non-TTY environment', async () => {
   });
 
   expect(
-    infoMsgs.some((message) => message.includes('Compile progress')),
+    infoMsgs.some((message) => message.includes('Build progress')),
   ).toBeTruthy();
-  expect(
-    readyMsgs.some((message) => message.includes('Compiled')),
-  ).toBeTruthy();
+  expect(readyMsgs.some((message) => message.includes('Built'))).toBeTruthy();
 
   process.stdout.isTTY = true;
   logger.info = info;

--- a/packages/compat/webpack/src/progress/ProgressPlugin.ts
+++ b/packages/compat/webpack/src/progress/ProgressPlugin.ts
@@ -83,7 +83,7 @@ export class ProgressPlugin extends webpack.ProgressPlugin {
 
         if (!this.hasCompileErrors) {
           const suffix = this.id ? color.gray(` (${this.id})`) : '';
-          logger.ready(`Compiled in ${this.compileTime} ${suffix}`);
+          logger.ready(`Built in ${this.compileTime} ${suffix}`);
         }
       }
     });

--- a/packages/compat/webpack/src/progress/helpers/nonTty.ts
+++ b/packages/compat/webpack/src/progress/helpers/nonTty.ts
@@ -27,16 +27,16 @@ export function createNonTTYLogger() {
 
       prevPercentage = 100;
       if (hasErrors) {
-        logger.error(`Compile failed in ${compileTime} ${suffix}`);
+        logger.error(`Built failed in ${compileTime} ${suffix}`);
       } else {
-        logger.ready(`Compiled in ${compileTime} ${suffix}`);
+        logger.ready(`Built in ${compileTime} ${suffix}`);
       }
     }
     // print progress when percentage increased by more than 10%
     // because we don't want to spam the console
     else if (current - prevPercentage > 10) {
       prevPercentage = current;
-      logger.info(`Compile progress: ${current.toFixed(0)}% ${suffix}`);
+      logger.info(`Build progress: ${current.toFixed(0)}% ${suffix}`);
     }
   };
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -52,7 +52,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   compiler.hooks.watchRun.tap('rsbuild:compiling', () => {
     logRspackVersion();
     if (!isCompiling) {
-      logger.start('Compiling...');
+      logger.start('Building...');
     }
     isCompiling = true;
   });
@@ -78,7 +78,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
         const time = prettyTime(c.time / 1000);
         const { name } = rspackConfigs[index];
         const suffix = name ? color.gray(` (${name})`) : '';
-        logger.ready(`Compiled in ${time}${suffix}`);
+        logger.ready(`Built in ${time}${suffix}`);
       }
     };
 


### PR DESCRIPTION
## Summary

Update build logs to use `build` instead of `compile`, as this more accurately reflects that Rsbuild is a build tool rather than a compiler.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
