### PR TITLE
fix(core): ensure that  keep url original

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -160,9 +160,8 @@ export const getPublicPathFromCompiler = (
 };
 
 const urlJoin = (base: string, path: string) => {
-  const fullUrl = new URL(base);
-  fullUrl.pathname = posix.join(fullUrl.pathname, path);
-  return fullUrl.toString();
+  const [urlProtocol, baseUrl] = base.split('://');
+  return `${urlProtocol}://${posix.join(baseUrl, path)}`;
 };
 
 // Can be replaced with URL.canParse when we drop support for Node.js 16

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -121,6 +121,7 @@ it('normalizeUrl', () => {
 
 describe('ensureAssetPrefix', () => {
   const ASSET_PREFIX = 'https://www.example.com/static/';
+  const CAPITAL_ASSET_PREFIX = 'https://www.{{CDN}}.com/{{CDN_PATH}}/';
 
   it('should handle relative url', () => {
     expect(ensureAssetPrefix('foo/bar.js', ASSET_PREFIX)).toBe(
@@ -156,6 +157,15 @@ describe('ensureAssetPrefix', () => {
     );
     expect(ensureAssetPrefix('//foo.com/bar.js', '/')).toBe('//foo.com/bar.js');
     expect(ensureAssetPrefix('/bar.js', '//foo.com')).toBe('//foo.com/bar.js');
+  });
+
+  it('should keep url original', () => {
+    expect(ensureAssetPrefix('foo/bar.js', CAPITAL_ASSET_PREFIX)).toBe(
+      'https://www.{{CDN}}.com/{{CDN_PATH}}/foo/bar.js',
+    );
+    expect(ensureAssetPrefix('/foo/bar.js', CAPITAL_ASSET_PREFIX)).toBe(
+      'https://www.{{CDN}}.com/{{CDN_PATH}}/foo/bar.js',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
When customize `html.publicPath` with url and using `performance.prefetch` changed the parameters what I set.

Eg:
`publicPath: 'https://{{CDN_HOST}}/{{CDN_PATH_PREFIX}}'`, output is  `<link href="https://{{cdn_host}}/%7B%7BCDN_PATH_PREFIX%7D%7D/static/js/async/318.1e5b1319.js" rel="prefetch">`
Because `urlJoin`  use `new URL` changed `publicPath`.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ x ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
