### PR TITLE
feat(plugin-babel): use Rslib to bundle

### DIFF
--- a/packages/plugin-babel/modern.config.ts
+++ b/packages/plugin-babel/modern.config.ts
@@ -1,3 +1,0 @@
-import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
-
-export default configForSeparateTypesPackage;

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -11,21 +11,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist-types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist-types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "compiled",
-    "dist-types"
+    "compiled"
   ],
   "scripts": {
-    "build": "modern build",
-    "dev": "modern build --watch",
+    "build": "rslib build",
+    "dev": "rslib build --watch",
     "prebundle": "prebundle"
   },
   "dependencies": {

--- a/packages/plugin-babel/rslib.config.ts
+++ b/packages/plugin-babel/rslib.config.ts
@@ -1,0 +1,3 @@
+import { dualPackage } from '@rsbuild/config/rslib.config.ts';
+
+export default dualPackage;

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -11,7 +11,7 @@ import type {
   PluginBabelOptions,
   PresetEnvOptions,
   PresetReactOptions,
-} from './types';
+} from './types.js';
 
 export const BABEL_JS_RULE = 'babel-js';
 

--- a/packages/plugin-babel/src/index.ts
+++ b/packages/plugin-babel/src/index.ts
@@ -2,8 +2,8 @@ export {
   pluginBabel,
   getDefaultBabelOptions,
   PLUGIN_BABEL_NAME,
-} from './plugin';
-export { getBabelUtils, modifyBabelLoaderOptions } from './helper';
+} from './plugin.js';
+export { getBabelUtils, modifyBabelLoaderOptions } from './helper.js';
 export type {
   PresetEnvOptions,
   PresetEnvTargets,
@@ -11,4 +11,4 @@ export type {
   BabelConfigUtils,
   BabelTransformOptions,
   PluginBabelOptions,
-} from './types';
+} from './types.js';

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path, { isAbsolute, join } from 'node:path';
 import type {
   EnvironmentContext,
@@ -7,8 +8,10 @@ import type {
   RsbuildPlugin,
 } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
-import { BABEL_JS_RULE, applyUserBabelConfig, castArray } from './helper';
-import type { BabelLoaderOptions, PluginBabelOptions } from './types';
+import { BABEL_JS_RULE, applyUserBabelConfig, castArray } from './helper.js';
+import type { BabelLoaderOptions, PluginBabelOptions } from './types.js';
+
+const require = createRequire(import.meta.url);
 
 export const PLUGIN_BABEL_NAME = 'rsbuild:babel';
 const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -5,6 +5,8 @@
     "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -1,12 +1,10 @@
 {
-  "extends": "@rsbuild/config/tsconfig",
+  "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
     "isolatedDeclarations": true
   },
   "references": [


### PR DESCRIPTION
## Summary

Use Rslib to bundle `@rsbuild/plugin-babel`.

## Related Links

https://github.com/web-infra-dev/rslib/issues/283

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
