### PR TITLE
feat(plugin-solid): use Rslib to bundle

### DIFF
--- a/packages/plugin-solid/modern.config.ts
+++ b/packages/plugin-solid/modern.config.ts
@@ -1,3 +1,0 @@
-import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
-
-export default configForSeparateTypesPackage;

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -12,20 +12,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist-types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist-types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "dist-types"
+    "dist"
   ],
   "scripts": {
-    "build": "modern build",
-    "dev": "modern build --watch"
+    "build": "rslib build",
+    "dev": "rslib build --watch"
   },
   "dependencies": {
     "@rsbuild/plugin-babel": "workspace:*",

--- a/packages/plugin-solid/rslib.config.ts
+++ b/packages/plugin-solid/rslib.config.ts
@@ -1,0 +1,3 @@
+import { dualPackage } from '@rsbuild/config/rslib.config.ts';
+
+export default dualPackage;

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { modifyBabelLoaderOptions } from '@rsbuild/plugin-babel';
-import type { SolidPresetOptions } from './types';
+import type { SolidPresetOptions } from './types.js';
+
+const require = createRequire(import.meta.url);
 
 export type PluginSolidOptions = {
   /**

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/tsconfig",
+  "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/scripts/config/tsconfig-node16.json
+++ b/scripts/config/tsconfig-node16.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16"
+  }
+}


### PR DESCRIPTION
## Summary

- Use Rslib to bundle `@rsbuild/plugin-solid`.
- Add a tsconfig file for Node 16 resolution.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
