### PR TITLE
fix(plugin-less): missing `lessOptions` type with TS node16 resolution

### DIFF
--- a/packages/plugin-less/prebundle.config.mjs
+++ b/packages/plugin-less/prebundle.config.mjs
@@ -1,14 +1,5 @@
-import fs from 'node:fs';
 // @ts-check
-import { join } from 'node:path';
-
-function replaceFileContent(filePath, replaceFn) {
-  const content = fs.readFileSync(filePath, 'utf-8');
-  const newContent = replaceFn(content);
-  if (newContent !== content) {
-    fs.writeFileSync(filePath, newContent);
-  }
-}
+import fs from 'node:fs';
 
 /** @type {import('prebundle').Config} */
 export default {

--- a/packages/plugin-less/prebundle.config.mjs
+++ b/packages/plugin-less/prebundle.config.mjs
@@ -21,17 +21,6 @@ export default {
         // needle is an optional dependency and no need to bundle it.
         needle: 'needle',
       },
-      // bundle namespace child (hoisting) not supported yet
-      beforeBundle: () => {
-        replaceFileContent(
-          join(process.cwd(), 'node_modules/@types/less/index.d.ts'),
-          (content) =>
-            `${content.replace(
-              /declare module "less" {\s+export = less;\s+}/,
-              'export = Less;',
-            )}`,
-        );
-      },
     },
     // prebundle less-loader to make it works in Node 16
     {

--- a/packages/plugin-less/prebundle.config.mjs
+++ b/packages/plugin-less/prebundle.config.mjs
@@ -1,5 +1,4 @@
 // @ts-check
-import fs from 'node:fs';
 
 /** @type {import('prebundle').Config} */
 export default {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -6,12 +6,11 @@ import type {
 } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
-import type Less from '../compiled/less';
 
 export const PLUGIN_LESS_NAME = 'rsbuild:less';
 
 export type LessLoaderOptions = {
-  lessOptions?: Less.Options;
+  lessOptions?: import('../compiled/less/index.js').default.Options;
   additionalData?:
     | string
     | ((


### PR DESCRIPTION
## Summary

Fix missing `lessOptions` type with TS node16 resolution

<img width="594" alt="Screenshot 2024-10-12 at 16 50 08" src="https://github.com/user-attachments/assets/0452f3bd-d2f4-45c7-b15b-0739c6c48b56">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
