### PR TITLE
语法存在问题

### DIFF
--- a/website/docs/zh/config/html/title.mdx
+++ b/website/docs/zh/config/html/title.mdx
@@ -45,7 +45,7 @@ type TitleFunction = ({ value: string; entryName: string }) => string | void;
 ```js
 export default {
   html: {
-    title({ entryName }) {
+    title({ entryName }) =>{
       const titles = {
         foo: 'Foo Page',
         bar: 'Bar Page',


### PR DESCRIPTION
({ entryName })  {
      const titles = {
        foo: "Foo Page",
        bar: "Bar Page",
      };
      return titles[entryName] || "Other Page";
    },这应该是一个箭头函数，但少了=>

## Summary

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
