### PR TITLE
fix: prebundle breaks RspackChain type

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -93,6 +93,7 @@ export default {
       },
       ignoreDts: true,
       afterBundle(task) {
+        // copy types to dist because prebundle will break the types
         fs.cpSync(
           join(task.depPath, 'types/index.d.ts'),
           join(task.distPath, 'index.d.ts'),

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -91,6 +91,13 @@ export default {
       externals: {
         '@rspack/core': '@rspack/core',
       },
+      ignoreDts: true,
+      afterBundle(task) {
+        fs.cpSync(
+          join(task.depPath, 'types/index.d.ts'),
+          join(task.distPath, 'index.d.ts'),
+        );
+      },
     },
     {
       name: 'http-proxy-middleware',


### PR DESCRIPTION
## Summary

Fix prebundle breaks RspackChain type when setting `"moduleResolution": "Node16"` in tsconfig.json.

<img width="762" alt="Screenshot 2024-10-14 at 11 46 50" src="https://github.com/user-attachments/assets/2f0709b1-5d20-4bd5-8439-86e77eed24df">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
