### PR TITLE
feat: make it easier to remove the built-in alias

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -330,6 +330,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     },
   ],
   "resolve": {
+    "alias": {
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -692,6 +695,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     },
   ],
   "resolve": {
+    "alias": {
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -1003,6 +1009,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
   ],
   "resolve": {
+    "alias": {
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "extensions": [
       ".ts",
       ".tsx",
@@ -1297,6 +1306,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
   ],
   "resolve": {
+    "alias": {
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "extensions": [
       ".ts",
       ".tsx",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,5 +1,5 @@
 import fs from 'node:fs';
-import { isAbsolute, join } from 'node:path';
+import { dirname, isAbsolute, join } from 'node:path';
 import type { WatchOptions } from 'chokidar';
 import color from 'picocolors';
 import RspackChain from 'rspack-chain';
@@ -80,15 +80,25 @@ const getDefaultServerConfig = (): NormalizedServerConfig => ({
   strictPort: false,
 });
 
-const getDefaultSourceConfig = (): NormalizedSourceConfig => ({
-  alias: {},
-  define: {},
-  aliasStrategy: 'prefer-tsconfig',
-  preEntry: [],
-  decorators: {
-    version: '2022-03',
-  },
-});
+let swcHelpersPath: string;
+
+const getDefaultSourceConfig = (): NormalizedSourceConfig => {
+  if (!swcHelpersPath) {
+    swcHelpersPath = dirname(require.resolve('@swc/helpers/package.json'));
+  }
+
+  return {
+    alias: {
+      '@swc/helpers': swcHelpersPath,
+    },
+    define: {},
+    aliasStrategy: 'prefer-tsconfig',
+    preEntry: [],
+    decorators: {
+      version: '2022-03',
+    },
+  };
+};
 
 const getDefaultHtmlConfig = (): NormalizedHtmlConfig => ({
   meta: {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -123,13 +123,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
         applyTransformImport(swcConfig, config.source.transformImport);
         applySwcDecoratorConfig(swcConfig, config);
 
-        if (swcConfig.jsc?.externalHelpers) {
-          chain.resolve.alias.set(
-            '@swc/helpers',
-            path.dirname(require.resolve('@swc/helpers/package.json')),
-          );
-        }
-
         // apply polyfill
         if (isWebTarget(target)) {
           const polyfillMode = config.output.polyfill;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -106,6 +106,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
   "source": {
     "alias": {
       "@common": "./src/common",
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
     "aliasStrategy": "prefer-tsconfig",
     "decorators": {
@@ -234,6 +235,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
   "source": {
     "alias": {
       "@common": "./src/common",
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
     "aliasStrategy": "prefer-tsconfig",
     "decorators": {
@@ -397,6 +399,7 @@ exports[`environment config > should print environment config when inspect confi
     "source": {
       "alias": {
         "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -556,6 +559,7 @@ exports[`environment config > should print environment config when inspect confi
     "source": {
       "alias": {
         "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -582,10 +586,12 @@ exports[`environment config > should print environment config when inspect confi
 exports[`environment config > should support add single environment plugin 1`] = `
 {
   "ssr": {
+    "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     "global": "ssr",
     "ssr": "ssr",
   },
   "web": {
+    "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     "global": "web",
     "web": "web",
   },
@@ -734,6 +740,7 @@ exports[`environment config > should support modify environment config by api.mo
     "source": {
       "alias": {
         "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -895,6 +902,7 @@ exports[`environment config > should support modify environment config by api.mo
       "alias": {
         "@common": "./src/common",
         "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -1056,6 +1064,7 @@ exports[`environment config > should support modify environment config by api.mo
       "alias": {
         "@common": "./src/common",
         "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -1219,6 +1228,7 @@ exports[`environment config > should support modify single environment config by
     "source": {
       "alias": {
         "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {
@@ -1380,6 +1390,7 @@ exports[`environment config > should support modify single environment config by
       "alias": {
         "@common": "./src/common",
         "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
       "decorators": {

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -99,11 +99,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -227,11 +222,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -735,11 +725,6 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -849,11 +834,6 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -955,11 +935,6 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -1069,11 +1044,6 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -1194,11 +1164,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -1320,11 +1285,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -1445,11 +1405,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;
@@ -1551,11 +1506,6 @@ exports[`plugin-swc > should has correct core-js 2`] = `
     "plugins": [
       RsbuildCorePlugin {},
     ],
-    "resolve": {
-      "alias": {
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
-    },
   },
 ]
 `;

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -51,9 +51,7 @@ describe('plugin-resolve', () => {
     });
     const bundlerConfigs = await rsbuild.initConfigs();
 
-    expect(bundlerConfigs[0].resolve?.alias).toEqual({
-      foo: 'bar',
-    });
+    expect(bundlerConfigs[0].resolve?.alias?.foo).toEqual('bar');
   });
 
   it('should support source.alias to be a function', async () => {

--- a/website/docs/en/config/source/alias.mdx
+++ b/website/docs/en/config/source/alias.mdx
@@ -6,7 +6,13 @@
 type Alias = Record<string, string | false | (string | false)[]> | Function;
 ```
 
-- **Default:** `undefined`
+- **Default:**
+
+```ts
+const defaultAlias = {
+  '@swc/helpers': path.dirname(require.resolve('@swc/helpers/package.json')),
+};
+```
 
 Create aliases to import or require certain modules, same as the [resolve.alias](https://rspack.dev/config/resolve#resolvealias) config of Rspack.
 
@@ -44,7 +50,19 @@ export default {
 };
 ```
 
-You can also return a new object as the final result in the function, which will replace the previous alias object.
+If you need to remove the built-in `@swc/helpers` alias, you can delete it in the function:
+
+```js
+export default {
+  source: {
+    alias: (alias) => {
+      delete alias['@swc/helpers'];
+    },
+  },
+};
+```
+
+You can also return a new object as the final result in the function, which will replace the preset alias object.
 
 ```js
 export default {

--- a/website/docs/zh/config/source/alias.mdx
+++ b/website/docs/zh/config/source/alias.mdx
@@ -6,7 +6,13 @@
 type Alias = Record<string, string | false | (string | false)[]> | Function;
 ```
 
-- **默认值：** `undefined`
+- **默认值：**
+
+```ts
+const defaultAlias = {
+  '@swc/helpers': path.dirname(require.resolve('@swc/helpers/package.json')),
+};
+```
 
 设置文件引用的别名，对应 Rspack 的 [resolve.alias](https://rspack.dev/zh/config/resolve#resolvealias) 配置。
 
@@ -44,7 +50,19 @@ export default {
 };
 ```
 
-也可以在函数中返回一个新对象作为最终结果，新对象会覆盖预设的 alias 对象。
+如果你需要移除 Rsbuild 内置的 `@swc/helpers` 别名，可以在函数中删除它：
+
+```js
+export default {
+  source: {
+    alias: (alias) => {
+      delete alias['@swc/helpers'];
+    },
+  },
+};
+```
+
+你也可以在函数中返回一个新对象作为最终结果，新对象会覆盖预设的 alias 对象。
 
 ```js
 export default {


### PR DESCRIPTION
## Summary

Make it easier to remove the built-in alias:

```js
export default {
  source: {
    alias: (alias) => {
      delete alias['@swc/helpers'];
    },
  },
};
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/3711

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
