### PR TITLE
fix(create-rsbuild): require is not defined

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -28,7 +28,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "1.0.5"
+    "create-rstack": "1.0.6"
   },
   "devDependencies": {
     "@types/node": "18.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -739,8 +739,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.0.5
-        version: 1.0.5
+        specifier: 1.0.6
+        version: 1.0.6
     devDependencies:
       '@types/node':
         specifier: 18.x
@@ -4083,8 +4083,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.0.5:
-    resolution: {integrity: sha512-ShEpRtBDxqQqZ5Tg9hfkRp7razYqdDQtFAYb5hbf/CRek8eaebxU4iC3WnH39Sq7IrwcCc0mIuMbvKHfzy3QRQ==}
+  create-rstack@1.0.6:
+    resolution: {integrity: sha512-eBwYb3jQq6AIYY8dQWZ8UB1MfqxZndEzBZy6DEtwCYpAbMfcX3pujEuNUyj+fobp1MS8eTsRfPq9GOF1GykG7A==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -10842,7 +10842,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.3
 
-  create-rstack@1.0.5: {}
+  create-rstack@1.0.6: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fix `require is not defined` error:

<img width="1208" alt="Screenshot 2024-10-14 at 17 55 43" src="https://github.com/user-attachments/assets/99516795-9d1e-47f7-ba03-be9396d0a0c4">

## Related Links

https://github.com/rspack-contrib/create-rstack/releases/tag/v1.0.6

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
