### PR TITLE
feat(assets-retry): use Rslib to bundle

### DIFF
--- a/packages/plugin-assets-retry/modern.config.ts
+++ b/packages/plugin-assets-retry/modern.config.ts
@@ -1,3 +1,0 @@
-import { configForSeparateTypesPackage } from '@rsbuild/config/modern.config.ts';
-
-export default configForSeparateTypesPackage;

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -12,23 +12,19 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist-types/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "types": "./dist-types/index.d.ts",
+  "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "dist-types"
+    "dist"
   ],
   "scripts": {
-    "build": "modern build && node scripts/postCompile.mjs",
-    "dev": "modern build --watch"
-  },
-  "dependencies": {
-    "serialize-javascript": "^6.0.2"
+    "build": "rslib build && node scripts/postCompile.mjs",
+    "dev": "rslib build --watch"
   },
   "devDependencies": {
     "@babel/core": "^7.25.8",
@@ -36,6 +32,7 @@
     "@babel/preset-typescript": "^7.25.7",
     "@rsbuild/core": "workspace:*",
     "@types/serialize-javascript": "^5.0.4",
+    "serialize-javascript": "^6.0.2",
     "terser": "5.34.1",
     "typescript": "^5.6.3"
   },

--- a/packages/plugin-assets-retry/rslib.config.ts
+++ b/packages/plugin-assets-retry/rslib.config.ts
@@ -1,0 +1,12 @@
+import { dualPackage } from '@rsbuild/config/rslib.config.ts';
+import { defineConfig } from '@rslib/core';
+import pkgJson from './package.json';
+
+export default defineConfig({
+  ...dualPackage,
+  source: {
+    define: {
+      RSBUILD_VERSION: JSON.stringify(pkgJson.version.replace(/\./g, '-')),
+    },
+  },
+});

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { type Rspack, rspack } from '@rsbuild/core';
 import serialize from 'serialize-javascript';
-import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types';
+import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types.js';
 
 // https://github.com/web-infra-dev/rspack/pull/5370
 function appendWebpackScript(module: any, appendSource: string) {

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -6,7 +6,9 @@ import type {
   RsbuildPlugin,
 } from '@rsbuild/core';
 import { ensureAssetPrefix } from '@rsbuild/core';
-import type { PluginAssetsRetryOptions } from './types';
+import serialize from 'serialize-javascript';
+import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin.js';
+import type { PluginAssetsRetryOptions } from './types.js';
 
 export type { PluginAssetsRetryOptions };
 
@@ -15,7 +17,6 @@ export const PLUGIN_ASSETS_RETRY_NAME = 'rsbuild:assets-retry';
 async function getRetryCode(
   options: PluginAssetsRetryOptions,
 ): Promise<string> {
-  const { default: serialize } = await import('serialize-javascript');
   const filename = 'initialChunkRetry';
   const { minify, inlineScript: _, ...restOptions } = options;
 
@@ -106,7 +107,6 @@ export const pluginAssetsRetry = (
         return;
       }
 
-      const { AsyncChunkRetryPlugin } = await import('./AsyncChunkRetryPlugin');
       const options = formatOptions(config);
       const isRspack = api.context.bundlerType === 'rspack';
 

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -1,5 +1,5 @@
 // rsbuild/runtime/async-chunk-retry
-import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types';
+import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types.js';
 
 type ChunkId = string; // e.g: src_AsyncCompTest_tsx
 type ChunkFilename = string; // e.g: static/js/async/src_AsyncCompTest_tsx.js

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -1,6 +1,6 @@
 // rsbuild/runtime/initial-chunk-retry
 import type { CrossOrigin } from '@rsbuild/core';
-import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types';
+import type { AssetsRetryHookContext, RuntimeRetryOptions } from '../types.js';
 
 interface ScriptElementAttributes {
   url: string;

--- a/packages/plugin-assets-retry/tsconfig.json
+++ b/packages/plugin-assets-retry/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@rsbuild/config/tsconfig",
+  "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
     "baseUrl": "./",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,10 +750,6 @@ importers:
         version: 5.6.3
 
   packages/plugin-assets-retry:
-    dependencies:
-      serialize-javascript:
-        specifier: ^6.0.2
-        version: 6.0.2
     devDependencies:
       '@babel/core':
         specifier: ^7.25.8
@@ -770,6 +766,9 @@ importers:
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
+      serialize-javascript:
+        specifier: ^6.0.2
+        version: 6.0.2
       terser:
         specifier: 5.34.1
         version: 5.34.1


### PR DESCRIPTION
## Summary

Use Rslib to bundle `@rsbuild/plugin-assets-retry`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
