### PR TITLE
feat: add rawPublicVars for `loadEnv`

### DIFF
--- a/e2e/cases/javascript-api/load-env/index.test.ts
+++ b/e2e/cases/javascript-api/load-env/index.test.ts
@@ -28,6 +28,12 @@ rspackOnlyTest('should load env files correctly', () => {
     'process.env.REACT_VERSION': '"18"',
   });
 
+  expect(env.rawPublicVars).toEqual({
+    REACT_EMPTY_STRING: '',
+    REACT_NAME: 'react',
+    REACT_VERSION: '18',
+  });
+
   expect(env.filePaths.find((item) => item.endsWith('.env'))).toBeTruthy();
   expect(
     env.filePaths.find((item) => item.endsWith('.env.staging')),

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -82,7 +82,7 @@ Load the `.env` file and return all environment variables starting with the spec
 
 - **Type:**
 
-```ts
+````ts
 type LoadEnvOptions = {
   /**
    * The root path to load the env file
@@ -107,12 +107,35 @@ function loadEnv(options: LoadEnvOptions): {
   parsed: Record<string, string>;
   /** The absolute paths to all env files */
   filePaths: string[];
-  /** Environment variables that start with prefixes */
+  /**
+   * Env variables that start with prefixes.
+   *
+   * @example
+   * ```ts
+   * {
+   *   PUBLIC_FOO: 'bar',
+   * }
+   * ```
+   **/
+  rawPublicVars: Record<string, string | undefined>;
+  /**
+   * Formatted env variables that start with prefixes.
+   * The keys contain the prefixes `process.env.*` and `import.meta.env.*`.
+   * The values are processed by `JSON.stringify`.
+   *
+   * @example
+   * ```ts
+   * {
+   *   'process.env.PUBLIC_FOO': '"bar"',
+   *   'import.meta.env.PUBLIC_FOO': '"bar"',
+   * }
+   * ```
+   **/
   publicVars: Record<string, string>;
   /** Clear the environment variables mounted on `process.env` */
   cleanup: () => void;
 };
-```
+````
 
 - **Example:**
 

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -103,7 +103,7 @@ type LoadEnvOptions = {
 };
 
 function loadEnv(options: LoadEnvOptions): {
-  /** All environment variables in the .env file */
+  /** All env variables in the .env file */
   parsed: Record<string, string>;
   /** The absolute paths to all env files */
   filePaths: string[];
@@ -132,7 +132,7 @@ function loadEnv(options: LoadEnvOptions): {
    * ```
    **/
   publicVars: Record<string, string>;
-  /** Clear the environment variables mounted on `process.env` */
+  /** Clear the env variables mounted on `process.env` */
   cleanup: () => void;
 };
 ````

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -82,7 +82,7 @@ const rsbuild = await createRsbuild({
 
 - **类型：**
 
-```ts
+````ts
 type LoadEnvOptions = {
   /**
    * 加载 env 文件的根路径
@@ -107,12 +107,35 @@ function loadEnv(options: LoadEnvOptions): {
   parsed: Record<string, string>;
   /** 所有 env 文件的绝对路径 */
   filePaths: string[];
-  /** 以 prefixes 开头的环境变量 */
+  /**
+   * 以 prefixes 开头的环境变量
+   *
+   * @example
+   * ```ts
+   * {
+   *   PUBLIC_FOO: 'bar',
+   * }
+   * ```
+   **/
+  rawPublicVars: Record<string, string | undefined>;
+  /**
+   * 以 prefix 开头的环境变量，并经过格式化。
+   * key 包含前缀 `process.env.*` 和 `import.meta.env.*`。
+   * value 经过 `JSON.stringify` 处理。
+   *
+   * @example
+   * ```ts
+   * {
+   *   'process.env.PUBLIC_FOO': '"bar"',
+   *   'import.meta.env.PUBLIC_FOO': '"bar"',
+   * }
+   * ```
+   **/
   publicVars: Record<string, string>;
   /** 从 `process.env` 上清除挂载的环境变量 */
   cleanup: () => void;
 };
-```
+````
 
 - **示例：**
 


### PR DESCRIPTION
## Summary

Add a new `rawPublicVars` return value for the `loadEnv` JS API:

- Can be used to define the `process.env` object, see https://github.com/web-infra-dev/rsbuild/issues/3718
- Align the return value of Vite's `loadEnv` method, see https://vite.dev/guide/api-javascript.html#loadenv

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
