### PR TITLE
fix: allow to print URLs when HTML is disabled

### DIFF
--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -7,6 +7,7 @@ import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
 } from 'fast-glob';
+import stripAnsi from 'strip-ansi';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 
@@ -91,6 +92,7 @@ export const awaitFileExists = async (dir: string) => {
 
 export const proxyConsole = (
   types: ConsoleType | ConsoleType[] = ['log', 'warn', 'info', 'error'],
+  keepAnsi = false,
 ) => {
   const logs: string[] = [];
   const restores: Array<() => void> = [];
@@ -103,7 +105,7 @@ export const proxyConsole = (
     });
 
     console[type] = (log) => {
-      logs.push(log);
+      logs.push(keepAnsi ? log : stripAnsi(log));
     };
   }
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -127,12 +127,13 @@ function getURLMessages(
   urls: Array<{ url: string; label: string }>,
   routes: Routes,
 ) {
-  if (routes.length === 1) {
+  if (routes.length <= 1) {
+    const pathname = routes.length ? routes[0].pathname : '';
     return urls
       .map(({ label, url }) => {
-        const pathname = normalizeUrl(`${url}${routes[0].pathname}`);
+        const normalizedPathname = normalizeUrl(`${url}${pathname}`);
         const prefix = `➜ ${color.dim(label.padEnd(10))}`;
-        return `  ${prefix}${color.cyan(pathname)}\n`;
+        return `  ${prefix}${color.cyan(normalizedPathname)}\n`;
       })
       .join('');
   }
@@ -175,8 +176,9 @@ export function printServerURLs({
   }
 
   let urls = originalUrls;
+  const useCustomUrl = isFunction(printUrls);
 
-  if (isFunction(printUrls)) {
+  if (useCustomUrl) {
     const newUrls = printUrls({
       urls: urls.map((item) => item.url),
       port,
@@ -200,7 +202,13 @@ export function printServerURLs({
     }));
   }
 
-  if (urls.length === 0 || routes.length === 0) {
+  // If no urls, skip printing
+  if (urls.length === 0) {
+    return null;
+  }
+
+  // If no routes and not use custom url, skip printing
+  if (routes.length === 0 && !useCustomUrl) {
     return null;
   }
 

--- a/website/docs/en/config/server/print-urls.mdx
+++ b/website/docs/en/config/server/print-urls.mdx
@@ -20,7 +20,7 @@ type PrintUrls =
 
 - **Default:** `true`
 
-Whether to print the server's urls.
+Whether to print the server's URLs.
 
 By default, when you start the dev server or preview server, Rsbuild will print the following logs:
 
@@ -41,7 +41,7 @@ If the `printUrls` function returns an URLs array, Rsbuild prints these URLs to 
 export default {
   server: {
     printUrls({ urls }) {
-      return urls.map((url) => `${url}/base`);
+      return urls.map((url) => `${url}/base/`);
     },
   },
 };
@@ -94,7 +94,7 @@ export default {
 
 ## Disable Output
 
-Setting `server.printUrls` to `false` will prevent Rsbuild from printing the server urls.
+Setting `server.printUrls` to `false` will prevent Rsbuild from printing the server URLs.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -102,4 +102,27 @@ export default {
     printUrls: false,
   },
 };
+```
+
+### HTML Disabled
+
+If [tools.htmlPlugin](/config/tools/html-plugin) is set to `false`, Rsbuild will not generate HTML files or output the server URL.
+
+However, you can still print the server URLs using the `server.printUrls` function, which has a higher priority.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    htmlPlugin: false,
+  },
+  server: {
+    printUrls: ({ port }) => [`http://localhost:${port}`],
+  },
+};
+```
+
+Output:
+
+```
+  ➜ Local:    http://localhost:3000
 ```

--- a/website/docs/zh/config/server/print-urls.mdx
+++ b/website/docs/zh/config/server/print-urls.mdx
@@ -41,7 +41,7 @@ type PrintUrls =
 export default {
   server: {
     printUrls({ urls }) {
-      return urls.map((url) => `${url}/base`);
+      return urls.map((url) => `${url}/base/`);
     },
   },
 };
@@ -102,4 +102,27 @@ export default {
     printUrls: false,
   },
 };
+```
+
+### 禁用 HTML
+
+当 [tools.htmlPlugin](/config/tools/html-plugin) 被设置为 `false` 时，Rsbuild 不会生成 HTML 文件，也不会输出 server 的 URL 地址。
+
+但你仍然可以通过 `server.printUrls` 函数来输出 URL 地址，它具有更高的优先级。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    htmlPlugin: false,
+  },
+  server: {
+    printUrls: ({ port }) => [`http://localhost:${port}`],
+  },
+};
+```
+
+输出：
+
+```
+  ➜ Local:    http://localhost:3000
 ```


### PR DESCRIPTION
## Summary

Allow to print URLs via the `printUrls` function when HTML is disabled.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3731

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
