### PR TITLE
Introducing Rsbuild Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://npmcharts.com/compare/@rsbuild/core?minimal=true"><img src="https://img.shields.io/npm/dm/@rsbuild/core.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="downloads" /></a>
   <a href="https://nodejs.org/en/about/previous-releases"><img src="https://img.shields.io/node/v/@rsbuild/core.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="node version"></a>
   <a href="https://github.com/web-infra-dev/rsbuild/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
+   <a href="https://gurubase.io/g/rsbuild"><img src="https://img.shields.io/badge/Gurubase-Ask%20Rsbuild%20Guru-blue?style=flat-square&colorA=564341&colorB=EDED91" alt="gurubase" /></a>
 </p>
 
 English | [Portuguese](./README.pt-BR.md) | [简体中文](./README.zh-CN.md)


### PR DESCRIPTION
Hello Rsbuild team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Rsbuild Guru](https://gurubase.io/g/rsbuild) to Gurubase. Rsbuild Guru uses the data from this repo and data from the [docs](https://rsbuild.dev/guide/start/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Rsbuild Guru" badge, which highlights that Rsbuild now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Rsbuild Guru in Gurubase, just let me know that's totally fine.