### PR TITLE
docs: add `process.env.NODE_ENV` inject tip

### DIFF
--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild by default injects the some env variables into the code using [source.de
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env) (This capability is supported by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv))
+- [process.env.NODE_ENV](#processenvnode_env) (This capability is supported by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/config/optimization#optimizationnodeenv))
 
 ### import.meta.env.MODE
 

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild by default injects the some env variables into the code using [source.de
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env)
+- [process.env.NODE_ENV](#processenvnode_env) (This capability is supported by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv))
 
 ### import.meta.env.MODE
 

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild by default injects the some env variables into the code using [source.de
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env) (This capability is supported by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/config/optimization#optimizationnodeenv))
+- [process.env.NODE_ENV](#processenvnode_env): This variable is injected by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/config/optimization#optimizationnodeenv))
 
 ### import.meta.env.MODE
 

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild 默认通过 [source.define](#使用-define) 向代码中注入以下环
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env)
+- [process.env.NODE_ENV](#processenvnode_env)（该能力由 Rspack 提供支持，如需关闭或修改，可参考 [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv)）
 
 ### import.meta.env.MODE
 

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild 默认通过 [source.define](#使用-define) 向代码中注入以下环
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env)（该能力由 Rspack 提供支持，如需关闭或修改，可参考 [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv)）
+- [process.env.NODE_ENV](#processenvnode_env)：该变量由 Rspack 注入，如需关闭或修改，可参考 [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv)
 
 ### import.meta.env.MODE
 


### PR DESCRIPTION
## Summary

`process.env.NODE_ENV` injection capability is supported by Rspack, not injected via rsbuild `source.define`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
