### PR TITLE
release: 1.0.15

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-webpack-swc",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "SWC plugin for Rsbuild webpack provider",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat(webpack-swc): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3726
* feat(assets-retry): use Rslib to bundle by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3727
* feat: add rawPublicVars for `loadEnv` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3732
* feat(plugin-react): allow to disable fast refresh by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3738
* feat(deps): bump rspack 1.0.13 by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3743
### Bug Fixes 🐞
* fix: allow to print URLs when HTML is disabled by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3737
### Document 📖
* docs: add note for destructuring of `process.env` to CRA guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3734
* docs: fix lazy compilation typo by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3736
* docs: add `process.env.NODE_ENV` inject tip by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3744
### Other Changes
* chore(deps): update rspress 1.33.1 by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/3719
* ci: enhance Rsbuild  ecosystem CI by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3712
* ci: should update eco-ci result in comment by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3722
* ci: not run eco-ci when only docs changed by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3735
* chore(deps): update the path-serializer by @SoonIter in https://github.com/web-infra-dev/rsbuild/pull/3739
* chore(deps): update dependency terser to v5.35.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3741
