### PR TITLE
chore(CI): fix eco-ci ref & release checkout branch

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -7,6 +7,11 @@ on:
   merge_group:
 
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch of the Ecosystem CI run'
+        required: true
+        default: 'main'
 
 jobs:
   ecosystem_ci_notify:
@@ -56,5 +61,5 @@ jobs:
           repo: "rsbuild-ecosystem-ci"
           workflow_file_name: "ecosystem-ci-selected.yml"
           github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
-          ref: ${{ github.event.inputs.branch }}
+          ref: "main"
           client_payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,14 @@ jobs:
           repo: "rsbuild-ecosystem-ci"
           workflow_file_name: "ecosystem-ci-selected.yml"
           github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
-          ref: ${{ github.event.inputs.branch }}
+          ref: "main"
           client_payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 25
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
         run: corepack enable


### PR DESCRIPTION
## Summary

- fix eco-ci ref: should use eco-ci  main brach instead of rsbuild target branch.
- fix release checkout branch: should use selected branch

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
