### PR TITLE
fix: configure the default assetPrefix for MF apps correctly

### DIFF
--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -16,7 +16,7 @@ When using Module Federation, it is recommended that you use the `moduleFederati
 When you set the `moduleFederation.options` option, Rsbuild will take the following actions:
 
 - Automatically register the [ModuleFederationPlugin](https://rspack.dev/plugins/webpack/module-federation-plugin) plugin, and pass the value of `options` to the plugin.
-- Set the default value of Rspack's [output.publicPath](https://rspack.dev/config/output#outputpublicpath) configuration to `'auto'`.
+- Set the default value of the provider's [dev.assetPrefix](/config/dev/asset-prefix) configuration to `true`. This will ensure that the static asset URL is correct for remote modules.
 - Set the default value of Rspack's [output.uniqueName](https://rspack.dev/config/output#outputuniquename) configuration to `moduleFederation.options.name`, this allows HMR to work as expected.
 - Turn off the `split-by-experience` rules in Rsbuild's [performance.chunkSplit](/config/performance/chunk-split) as it may conflict with shared modules, refer to [#3161](https://github.com/module-federation/module-federation-examples/issues/3161).
 - Turn off the splitChunks rule of remote entry.

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -16,7 +16,7 @@
 当你设置 `moduleFederation.options` 选项后，Rsbuild 会执行以下操作：
 
 - 自动注册 [ModuleFederationPlugin](https://rspack.dev/zh/plugins/webpack/module-federation-plugin) 插件，并将 `options` 的值透传给插件。
-- 将 Rspack [output.publicPath](https://rspack.dev/config/output#outputpublicpath) 配置的默认值设置为 `'auto'`。
+- 将 provider 的 [dev.assetPrefix](/config/dev/asset-prefix) 配置的默认值设置为 `true`，这可以确保 remote modules 的静态资源 URL 是正确的。
 - 将 Rspack [output.uniqueName](https://rspack.dev/config/output#outputuniquename) 配置的默认值设置为 `moduleFederation.options.name`，使 HMR 可以正常工作。
 - 关闭 Rsbuild [performance.chunkSplit](/config/performance/chunk-split) 中 `split-by-experience` 相关的规则，因为这可能会与 shared modules 冲突，参考 [#3161](https://github.com/module-federation/module-federation-examples/issues/3161)。
 - 关闭 remote entry 的 splitChunks 规则。


### PR DESCRIPTION
## Summary

The default asset prefix has been changed when using `moduleFederation.options`. These changes ensure that the assets of remote modules can be requested by consumer apps with the correct URL, and that the SPA URL fallback works as expected.

- Only change the default asset prefix for MF provider apps.
- Only change the default asset prefix in development mode (via `dev.assetPrefix`).
- The default asset prefix has been changed from `auto` to `true` (equivalent to `localhost:<port>`)
- Always prefer to use the `dev.assetPrefix` value set by user.

@nyqykk please take a look, I suppose these changes should be ported to [@module-federation/rsbuild-plugin](https://github.com/module-federation/core/blob/main/packages/rsbuild-plugin/package.json)

## Related Links

resolve: https://github.com/web-infra-dev/rsbuild/issues/3751

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
