### PR TITLE
docs: improve `output.filename` function type

### DIFF
--- a/e2e/cases/filename-function/index.test.ts
+++ b/e2e/cases/filename-function/index.test.ts
@@ -20,4 +20,16 @@ test('should allow to custom filename by function', async () => {
       filename.includes('dist/static/js/async/some-path/foo.js'),
     ),
   ).toBeTruthy();
+
+  // CSS
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/css/my-index.css'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist/static/css/async/some-path/foo.css'),
+    ),
+  ).toBeTruthy();
 });

--- a/website/docs/en/config/output/filename.mdx
+++ b/website/docs/en/config/output/filename.mdx
@@ -7,8 +7,16 @@ type FilenameConfig = {
   html?: string;
   js?:
     | string
-    | ((pathData: Rspack.PathData, assetInfo: Rspack.JsAssetInfo) => string);
-  css?: string;
+    | ((
+        pathData: Rspack.PathData,
+        assetInfo: Rspack.JsAssetInfo | undefined,
+      ) => string);
+  css?:
+    | string
+    | ((
+        pathData: Rspack.PathData,
+        assetInfo: Rspack.JsAssetInfo | undefined,
+      ) => string);
   svg?: string;
   font?: string;
   image?: string;

--- a/website/docs/zh/config/output/filename.mdx
+++ b/website/docs/zh/config/output/filename.mdx
@@ -7,10 +7,16 @@ type FilenameConfig = {
   html?: string;
   js?:
     | string
-    | ((pathData: Rspack.PathData, assetInfo: Rspack.JsAssetInfo) => string);
+    | ((
+        pathData: Rspack.PathData,
+        assetInfo: Rspack.JsAssetInfo | undefined,
+      ) => string);
   css?:
     | string
-    | ((pathData: Rspack.PathData, assetInfo: Rspack.JsAssetInfo) => string);
+    | ((
+        pathData: Rspack.PathData,
+        assetInfo: Rspack.JsAssetInfo | undefined,
+      ) => string);
   svg?: string;
   font?: string;
   image?: string;


### PR DESCRIPTION
## Summary

Improve `output.filename.js` and `output.filename.css` function type, align with the Rspack configuration types.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
