### PR TITLE
chore(deps): replace fast-glob with tinyglobby

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -46,7 +46,7 @@
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
     "create-rsbuild": "workspace:*",
-    "fast-glob": "^3.3.2",
+    "tinyglobby": "^0.2.9",
     "fs-extra": "^11.2.0",
     "playwright": "1.44.1",
     "strip-ansi": "6.0.1",

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,10 +1,9 @@
 import fs from 'node:fs';
-import { platform } from 'node:os';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
 import type { ConsoleType } from '@rsbuild/core';
 import stripAnsi from 'strip-ansi';
-import { type GlobOptions, convertPathToPattern, glob } from 'tinyglobby';
+import { type GlobOptions, glob } from 'tinyglobby';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 
@@ -33,17 +32,8 @@ export const getProviderTest = (
 export const webpackOnlyTest = getProviderTest(['webpack']);
 export const rspackOnlyTest = getProviderTest(['rspack']);
 
-// fast-glob only accepts posix path
-// https://github.com/mrmlnc/fast-glob#convertpathtopatternpath
-const convertPath = (path: string) => {
-  if (platform() === 'win32') {
-    return convertPathToPattern(path);
-  }
-  return path;
-};
-
 export const globContentJSON = async (path: string, options?: GlobOptions) => {
-  const files = await glob(convertPath(join(path, '**/*')), {
+  const files = await glob(join(path, '**/*'), {
     absolute: true,
     ...options,
   });

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -3,11 +3,8 @@ import { platform } from 'node:os';
 import { join } from 'node:path';
 import { test } from '@playwright/test';
 import type { ConsoleType } from '@rsbuild/core';
-import glob, {
-  convertPathToPattern,
-  type Options as GlobOptions,
-} from 'fast-glob';
 import stripAnsi from 'strip-ansi';
+import { type GlobOptions, convertPathToPattern, glob } from 'tinyglobby';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 
@@ -46,7 +43,10 @@ const convertPath = (path: string) => {
 };
 
 export const globContentJSON = async (path: string, options?: GlobOptions) => {
-  const files = await glob(convertPath(join(path, '**/*')), options);
+  const files = await glob(convertPath(join(path, '**/*')), {
+    absolute: true,
+    ...options,
+  });
   const ret: Record<string, string> = {};
 
   await Promise.all(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       create-rsbuild:
         specifier: workspace:*
         version: link:../packages/create-rsbuild
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       fs-extra:
         specifier: ^11.2.0
         version: 11.2.0
@@ -180,6 +177,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.13
         version: 3.4.13
+      tinyglobby:
+        specifier: ^0.2.9
+        version: 0.2.9
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -1123,9 +1123,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.3.1
         version: 18.3.1
-      fast-glob:
-        specifier: ^3.3.2
-        version: 3.3.2
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -1147,6 +1144,9 @@ importers:
       rspress-plugin-sitemap:
         specifier: ^1.1.1
         version: 1.1.1
+      tinyglobby:
+        specifier: ^0.2.9
+        version: 0.2.9
 
 packages:
 
@@ -4534,6 +4534,14 @@ packages:
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
 
+  fdir@6.4.2:
+    resolution: {integrity: sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   feed@4.2.2:
     resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
     engines: {node: '>=0.4.0'}
@@ -5974,6 +5982,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
@@ -7112,6 +7124,10 @@ packages:
 
   tinyexec@0.3.0:
     resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+
+  tinyglobby@0.2.9:
+    resolution: {integrity: sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@1.0.0:
     resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
@@ -11336,6 +11352,10 @@ snapshots:
     dependencies:
       format: 0.2.2
 
+  fdir@6.4.2(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
   feed@4.2.2:
     dependencies:
       xml-js: 1.6.11
@@ -13157,6 +13177,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pify@2.3.0: {}
 
   pify@4.0.1: {}
@@ -14373,6 +14395,11 @@ snapshots:
   tinybench@2.9.0: {}
 
   tinyexec@0.3.0: {}
+
+  tinyglobby@0.2.9:
+    dependencies:
+      fdir: 6.4.2(picomatch@4.0.2)
+      picomatch: 4.0.2
 
   tinypool@1.0.0: {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -62,8 +62,8 @@ mYbzBtlg6o
 napi
 nolyfill
 nosources
-nuxt
 ntqry
+nuxt
 oklab
 onclosetag
 onopentag
@@ -109,13 +109,14 @@ subdir
 subpage
 subresource
 subresources
-svgr
 sveltejs
+svgr
 swcrc
 systemjs
 tailwindcss
 taze
 templating
+tinyglobby
 transpiling
 treeshaking
 tsbuildinfo

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@types/node": "18.x",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.1",
-    "fast-glob": "^3.3.2",
+    "tinyglobby": "^0.2.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rsbuild-plugin-google-analytics": "1.0.3",

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import type { RsbuildPlugin } from '@rsbuild/core';
-import glob from 'fast-glob';
+import { glob } from 'tinyglobby';
 import type { Group } from './components/Overview';
 
 const camelCase = (input: string): string =>
@@ -13,7 +13,7 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
     const root = path.join(__dirname, '../docs/en/config/');
     const globPath = path.join(root, '**/*.{mdx,md}');
 
-    const files = await glob(globPath);
+    const files = await glob(globPath, { absolute: true });
     const groups: Group[] = [
       {
         name: 'top level',


### PR DESCRIPTION
## Summary

Tinyglobby is a fast and minimal alternative to globby and fast-glob.

## Related Links

https://github.com/SuperchupuDev/tinyglobby?tab=readme-ov-file#api

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
