### PR TITLE
docs: fix proxy links in features.mdx

### DIFF
--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -55,7 +55,7 @@ Here are all the main features supported by Rsbuild.
 | Features   | Description                                                                    | Links                                                           |
 | ---------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
 | Public Dir | Use the public directory as the directory for serving public assets by default | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul> |
-| Proxy      | Optional feature, proxy requests to the specified service                      | <ul><li>[dev.proxy](/config/dev/proxy)</li></ul>                |
+| Proxy      | Optional feature, proxy requests to the specified service                      | <ul><li>[server.proxy](/config/server/proxy)</li></ul>                |
 | Open page  | Optional feature, automatically open page in browser when starting server      | <ul><li>[server.open](/config/server/open)</li></ul>            |
 | HTTPS      | Optional feature, enable HTTPS server                                          | <ul><li>[server.https](/config/server/https)</li></ul>          |
 

--- a/website/docs/zh/guide/start/features.mdx
+++ b/website/docs/zh/guide/start/features.mdx
@@ -55,7 +55,7 @@
 | 功能        | 描述                                             | 相关链接                                                        |
 | ----------- | ------------------------------------------------ | --------------------------------------------------------------- |
 | Public 目录 | 默认将 public 目录作为静态资源服务的文件夹       | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul> |
-| 请求代理    | 可选功能，将请求代理到指定的服务上               | <ul><li>[dev.proxy](/config/dev/proxy)</li></ul>                |
+| 请求代理    | 可选功能，将请求代理到指定的服务上               | <ul><li>[server.proxy](/config/server/proxy)</li></ul>                |
 | 打开页面    | 可选功能，在启动 server 时自动在浏览器中打开页面 | <ul><li>[server.open](/config/server/open)</li></ul>            |
 | HTTPS       | 可选功能，开启 server 对 HTTPS 的支持            | <ul><li>[server.https](/config/server/https)</li></ul>          |
 


### PR DESCRIPTION
update the [documentation](https://rsbuild.dev/guide/start/features#development-and-preview) from `dev.proxy` to `server.proxy`

## Summary

## Related Links

<!--- Provide links of related issues or pages -->

https://rsbuild.dev/config/dev/proxy

https://rsbuild.dev/config/server/proxy


https://rsbuild.dev/zh/config/dev/proxy

https://rsbuild.dev/zh/config/server/proxy



## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
