### PR TITLE
chore: declare __dirname for Node.js ES modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@changesets/cli": "^2.27.9",
     "@modern-js/module-tools": "^2.60.4",
     "@rsbuild/config": "workspace:*",
-    "@rslib/core": "0.0.0-next-20241012061647",
+    "@rslib/core": "0.0.13",
     "@scripts/test-helper": "workspace:*",
     "check-dependency-version-consistency": "^4.1.0",
     "cross-env": "^7.0.3",

--- a/packages/compat/plugin-webpack-swc/src/plugin.ts
+++ b/packages/compat/plugin-webpack-swc/src/plugin.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { SwcMinimizerPlugin } from './minimizer.js';
 import type {
@@ -11,6 +12,8 @@ import {
   checkUseMinify,
   removeUselessOptions,
 } from './utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
  * In this plugin, we do:

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { type Rspack, rspack } from '@rsbuild/core';
 import serialize from 'serialize-javascript';
 import type { PluginAssetsRetryOptions, RuntimeRetryOptions } from './types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://github.com/web-infra-dev/rspack/pull/5370
 function appendWebpackScript(module: any, appendSource: string) {

--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type {
   EnvironmentContext,
   NormalizedEnvironmentConfig,
@@ -9,6 +10,8 @@ import { ensureAssetPrefix } from '@rsbuild/core';
 import serialize from 'serialize-javascript';
 import { AsyncChunkRetryPlugin } from './AsyncChunkRetryPlugin.js';
 import type { PluginAssetsRetryOptions } from './types.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export type { PluginAssetsRetryOptions };
 

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path, { isAbsolute, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type {
   EnvironmentContext,
   NormalizedEnvironmentConfig,
@@ -11,6 +12,7 @@ import deepmerge from 'deepmerge';
 import { BABEL_JS_RULE, applyUserBabelConfig, castArray } from './helper.js';
 import type { BabelLoaderOptions, PluginBabelOptions } from './types.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 export const PLUGIN_BABEL_NAME = 'rsbuild:babel';

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type {
   ConfigChainWithContext,
   RsbuildPlugin,
@@ -6,6 +7,8 @@ import type {
 } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export const PLUGIN_LESS_NAME = 'rsbuild:less';
 

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -1,11 +1,13 @@
 import { createRequire } from 'node:module';
-import { join } from 'node:path';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 import { getResolveUrlJoinFn, patchCompilerGlobalLocation } from './helpers.js';
 import type { PluginSassOptions, SassLoaderOptions } from './types.js';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 
 export const PLUGIN_SASS_NAME = 'rsbuild:sass';
@@ -123,7 +125,7 @@ export const pluginSass = (
 
       rule
         .use(CHAIN_ID.USE.RESOLVE_URL)
-        .loader(join(__dirname, '../compiled/resolve-url-loader/index.js'))
+        .loader(path.join(__dirname, '../compiled/resolve-url-loader/index.js'))
         .options({
           join: await getResolveUrlJoinFn(),
           // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
@@ -133,7 +135,7 @@ export const pluginSass = (
         })
         .end()
         .use(CHAIN_ID.USE.SASS)
-        .loader(join(__dirname, '../compiled/sass-loader/index.js'))
+        .loader(path.join(__dirname, '../compiled/sass-loader/index.js'))
         .options(options);
     });
   },

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -1,9 +1,12 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { RsbuildPlugin, Rspack } from '@rsbuild/core';
 import { PLUGIN_REACT_NAME } from '@rsbuild/plugin-react';
 import type { Config as SvgrOptions } from '@svgr/core';
 import deepmerge from 'deepmerge';
 import type { Config as SvgoConfig } from 'svgo';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 type SvgoPluginConfig = NonNullable<SvgoConfig['plugins']>[0];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: workspace:*
         version: link:scripts/config
       '@rslib/core':
-        specifier: 0.0.0-next-20241012061647
-        version: 0.0.0-next-20241012061647(typescript@5.6.3)
+        specifier: 0.0.13
+        version: 0.0.13(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:scripts/test-helper
@@ -2823,11 +2823,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.0.13':
-    resolution: {integrity: sha512-YPjd+Aal+lMqAYRt2DGEJc3dI9ZcP5j9kefobYszxs0NlgpoK+y+malXYXW4yVu3s84EqtHp+tSoJzaSK23Txw==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-
   '@rsbuild/core@1.0.15':
     resolution: {integrity: sha512-LIOgs4UzfFeT3sZnPMww1JbqF7zkGNMZdMJ6vV8xEXGOU4t8Z6QAtM5A0FGRfb2mYW5u2+XnMog+JAbo2RrN/A==}
     engines: {node: '>=16.7.0'}
@@ -2890,8 +2885,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.0.0-next-20241012061647':
-    resolution: {integrity: sha512-5uXItTOtczAgv4bcvlw5DOe9wFbzojZshMoPgjH3ZuSwujKeitQmgNu7hmfkIl/jZCiWgAWRk+C8JDPNPFPHaQ==}
+  '@rslib/core@0.0.13':
+    resolution: {integrity: sha512-q0PIEv1snJdiW38sa4bwARhzYbDdbHHVFekiHheLkQwtapvf1/4+n9Ud1mlUhq180wHVAsSJQrRpcW4g7w47OA==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:
@@ -6425,8 +6420,8 @@ packages:
       webpack:
         optional: true
 
-  rsbuild-plugin-dts@0.0.0-next-20241012061647:
-    resolution: {integrity: sha512-+iT1pDvHQzfoYVNvgDyXfDIeJIqoq+Xd0/JXbPiByrYFyuB2ciX0JemqdICN9kB9z0Ky0oNNbRrWUdz57GqItg==}
+  rsbuild-plugin-dts@0.0.13:
+    resolution: {integrity: sha512-coAX6+JiGkyAYsXFGbtExvKgcB2Fn2ZEd8fTWxMImeFpoNxdDL6Ky90c5hSwE4zuxZJ4b0T3KrVzOCxLK0eMQw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -9374,15 +9369,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.1':
     optional: true
 
-  '@rsbuild/core@1.0.13':
-    dependencies:
-      '@rspack/core': 1.0.13(@swc/helpers@0.5.13)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.13
-      core-js: 3.38.1
-    optionalDependencies:
-      fsevents: 2.3.3
-
   '@rsbuild/core@1.0.15':
     dependencies:
       '@rspack/core': 1.0.13(@swc/helpers@0.5.13)
@@ -9471,10 +9457,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rslib/core@0.0.0-next-20241012061647(typescript@5.6.3)':
+  '@rslib/core@0.0.13(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.0.13
-      rsbuild-plugin-dts: 0.0.0-next-20241012061647(@rsbuild/core@1.0.13)(typescript@5.6.3)
+      '@rsbuild/core': 1.0.16
+      rsbuild-plugin-dts: 0.0.13(@rsbuild/core@1.0.16)(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
 
@@ -13685,9 +13671,9 @@ snapshots:
     optionalDependencies:
       webpack: 5.95.0(@swc/core@1.6.13(@swc/helpers@0.5.13))
 
-  rsbuild-plugin-dts@0.0.0-next-20241012061647(@rsbuild/core@1.0.13)(typescript@5.6.3):
+  rsbuild-plugin-dts@0.0.13(@rsbuild/core@1.0.16)(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.0.13
+      '@rsbuild/core': 1.0.16
       fast-glob: 3.3.2
       magic-string: 0.30.12
       picocolors: 1.1.0


### PR DESCRIPTION
## Summary

Declare __dirname for Node.js ES modules as Rslib no longer inject the `__dirname` shim by default.

## Related Links

https://github.com/web-infra-dev/rslib/pull/291
https://stackoverflow.com/questions/46745014/alternative-for-dirname-in-node-js-when-using-es6-modules

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
