### PR TITLE
fix: `dev.assetPrefix: true` not work with `server.base`

### DIFF
--- a/e2e/cases/server/base-url/index.test.ts
+++ b/e2e/cases/server/base-url/index.test.ts
@@ -49,6 +49,31 @@ test('server.base when dev', async ({ page }) => {
   await rsbuild.close();
 });
 
+test('server.base with dev.assetPrefix: true', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      server: {
+        base: '/base',
+      },
+      dev: {
+        assetPrefix: true,
+      },
+    },
+  });
+
+  // should visit base url correctly
+  await page.goto(`http://localhost:${rsbuild.port}/base`);
+  await expect(page.locator('#test')).toHaveText('Hello Rsbuild!');
+
+  // should visit public dir correctly with base prefix
+  await page.goto(`http://localhost:${rsbuild.port}/base/aaa.txt`);
+  expect(await page.content()).toContain('aaaa');
+
+  await rsbuild.close();
+});
+
 test('server.base when build & preview', async ({ page }) => {
   const { logs, restore } = proxyConsole('log');
 

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -159,7 +159,7 @@ export const getPublicPathFromCompiler = (
   return DEFAULT_ASSET_PREFIX;
 };
 
-const urlJoin = (base: string, path: string) => {
+export const urlJoin = (base: string, path: string) => {
   const [urlProtocol, baseUrl] = base.split('://');
   return `${urlProtocol}://${posix.join(baseUrl, path)}`;
 };

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -5,7 +5,7 @@ import {
   DEFAULT_DEV_HOST,
   DEFAULT_PORT,
 } from '../constants';
-import { formatPublicPath, getFilename } from '../helpers';
+import { formatPublicPath, getFilename, urlJoin } from '../helpers';
 import { getCssExtractPlugin } from '../pluginHelper';
 import { replacePortPlaceholder } from '../server/open';
 import type {
@@ -24,7 +24,7 @@ function getPublicPath({
   config: NormalizedEnvironmentConfig;
   context: RsbuildContext;
 }) {
-  const { dev, output } = config;
+  const { dev, output, server } = config;
 
   let publicPath = DEFAULT_ASSET_PREFIX;
   const port = context.devServer?.port || DEFAULT_PORT;
@@ -38,6 +38,7 @@ function getPublicPath({
   } else if (dev.assetPrefix === true) {
     const protocol = context.devServer?.https ? 'https' : 'http';
     const hostname = context.devServer?.hostname || DEFAULT_DEV_HOST;
+
     if (hostname === DEFAULT_DEV_HOST) {
       const localHostname = 'localhost';
       // If user not specify the hostname, it would use 0.0.0.0
@@ -47,6 +48,10 @@ function getPublicPath({
       publicPath = `${protocol}://${localHostname}:<port>/`;
     } else {
       publicPath = `${protocol}://${hostname}:<port>/`;
+    }
+
+    if (server.base && server.base !== '/') {
+      publicPath = urlJoin(publicPath, server.base);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix `dev.assetPrefix: true` not work with `server.base` config.

```js
{
  server: {
    base: '/base',
  },
  dev: {
    assetPrefix: true,
  },
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
