### PR TITLE
fix: failed to load MF remote modules when using `server.base`

### DIFF
--- a/e2e/cases/module-federation/index.test.ts
+++ b/e2e/cases/module-federation/index.test.ts
@@ -55,6 +55,45 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
+  'should run module federation in development mode with server.base',
+  async ({ page }) => {
+    writeButtonCode();
+
+    const remotePort = await getRandomPort();
+
+    process.env.REMOTE_PORT = remotePort.toString();
+
+    const remoteApp = await dev({
+      cwd: remote,
+      rsbuildConfig: {
+        server: {
+          base: '/remote',
+        },
+      },
+    });
+    const hostApp = await dev({
+      cwd: host,
+      rsbuildConfig: {
+        server: {
+          base: '/host',
+        },
+      },
+    });
+
+    await gotoPage(page, remoteApp);
+    await expect(page.locator('#title')).toHaveText('Remote');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
+
+    await gotoPage(page, hostApp);
+    await expect(page.locator('#title')).toHaveText('Host');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
+
+    await hostApp.close();
+    await remoteApp.close();
+  },
+);
+
+rspackOnlyTest(
   'should allow remote module to perform HMR',
   async ({ page }) => {
     // HMR cases will fail in Windows

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -1,7 +1,6 @@
 import { isRegExp } from 'node:util/types';
 import { rspack } from '@rspack/core';
 import type { RspackPluginInstance } from '@rspack/core';
-import { DEFAULT_ASSET_PREFIX } from '../constants';
 import type { CacheGroup, RsbuildPlugin, Rspack } from '../types';
 
 /**
@@ -115,7 +114,7 @@ export function pluginModuleFederation(): RsbuildPlugin {
           const originalConfig = api.getRsbuildConfig('original');
           if (
             originalConfig.dev?.assetPrefix === undefined &&
-            config.dev.assetPrefix === DEFAULT_ASSET_PREFIX
+            config.dev.assetPrefix === config.server?.base
           ) {
             config.dev.assetPrefix = true;
           }


### PR DESCRIPTION
## Summary

Fix failed to load MF remote modules when using `server.base`.

The default `dev.assetPrefix` is set to the value of `server.base`, and Rsbuild should replace it with `dev.assetPrefix: true` to ensure that the remote module's assets can be requested by consumer apps with the correct URL.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3780

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
