### PR TITLE
fix(plugin-less): lessLoaderOptions.lessOptions.plugins has lose it's prototype.

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -16,7 +16,12 @@ export {
 } from './config';
 export type { InternalContext } from './types';
 export { setHTMLPlugin, getHTMLPlugin } from './pluginHelper';
-export { formatStats, getStatsOptions, prettyTime } from './helpers';
+export {
+  formatStats,
+  getStatsOptions,
+  prettyTime,
+  isPlainObject,
+} from './helpers';
 export { registerBuildHook, registerDevHook, onCompileDone } from './hooks';
 export { getChainUtils, getConfigUtils } from './provider/rspackConfig';
 export { chainToConfig, modifyBundlerChain } from './configChain';

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -5,6 +5,7 @@ import type {
   RsbuildPlugin,
   Rspack,
 } from '@rsbuild/core';
+import { __internalHelper } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 
@@ -75,7 +76,9 @@ const getLessLoaderOptions = (
   ): LessLoaderOptions => {
     const getLessOptions = () => {
       if (defaults.lessOptions && userOptions.lessOptions) {
-        return deepmerge(defaults.lessOptions, userOptions.lessOptions);
+        return deepmerge(defaults.lessOptions, userOptions.lessOptions, {
+          isMergeableObject: __internalHelper.isPlainObject,
+        });
       }
       return userOptions.lessOptions || defaults.lessOptions;
     };

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -63,4 +63,30 @@ describe('plugin-less', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
   });
+
+  it('should add less-loader with plugins', async () => {
+    class MockPlugin {
+      options?: any;
+      constructor(options?: any) {
+        this.options = options;
+      }
+      install(less: any, pluginManager: any) {}
+    }
+    const mockPlugin = new MockPlugin();
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginLess({
+            lessLoaderOptions: {
+              lessOptions: {
+                plugins: [mockPlugin],
+              },
+            },
+          }),
+        ],
+      },
+    });
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.less')).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
## Summary

fix the `deepmerge` to judge whether is an plain object.

## Related Links

#3810 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
