### PR TITLE
docs: correct `rsbuild.addPlugins` typing

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -128,10 +128,12 @@ export type PluginManager = {
   addPlugins: (
     plugins: Array<RsbuildPlugin | Falsy>,
     options?: {
+      /**
+       * Insert before the specified plugin.
+       */
       before?: string;
       /**
        * Add a plugin for the specified environment.
-       *
        * If environment is not specified, it will be registered as a global plugin (effective in all environments)
        */
       environment?: string;

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -528,7 +528,7 @@ This method needs to be called before compiling. If it is called after compiling
 - **Type:**
 
 ```ts
-type AddPluginsOptions = { before?: string } | { after?: string };
+type AddPluginsOptions = { before?: string; environment?: string };
 
 function AddPlugins(
   plugins: Array<RsbuildPlugin | Falsy>,
@@ -544,8 +544,8 @@ rsbuild.addPlugins([pluginFoo(), pluginBar()]);
 // Insert before the bar plugin
 rsbuild.addPlugins([pluginFoo()], { before: 'bar' });
 
-// Insert after the bar plugin
-rsbuild.addPlugins([pluginFoo()], { after: 'bar' });
+// Add plugin for node environment
+rsbuild.addPlugins([pluginFoo()], { environment: 'node' });
 ```
 
 ## rsbuild.getPlugins

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -549,7 +549,7 @@ const compiler = await rsbuild.createCompiler();
 - **类型：**
 
 ```ts
-type AddPluginsOptions = { before?: string } | { after?: string };
+type AddPluginsOptions = { before?: string; environment?: string };
 
 function AddPlugins(
   plugins: Array<RsbuildPlugin | Falsy>,
@@ -565,8 +565,8 @@ rsbuild.addPlugins([pluginFoo(), pluginBar()]);
 // 在 bar 插件之前插入
 rsbuild.addPlugins([pluginFoo()], { before: 'bar' });
 
-// 在 bar 插件之后插入
-rsbuild.addPlugins([pluginFoo()], { after: 'bar' });
+// 为 node 环境添加插件
+rsbuild.addPlugins([pluginFoo()], { environment: 'node' });
 ```
 
 ## rsbuild.getPlugins


### PR DESCRIPTION
## Summary

Correct `rsbuild.addPlugins` typing, align with the implementation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
