### PR TITLE
fix: allow Rsbuild plugin to be registered times

### DIFF
--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -79,17 +79,7 @@ export function createPluginManager(): PluginManager {
 
       validatePlugin(newPlugin);
 
-      const existPlugin = plugins.find(
-        (item) =>
-          item.instance.name === newPlugin.name &&
-          item.environment === environment,
-      );
-
-      if (existPlugin) {
-        logger.warn(
-          `Rsbuild plugin "${newPlugin.name}" registered multiple times.`,
-        );
-      } else if (before) {
+      if (before) {
         const index = plugins.findIndex(
           (item) => item.instance.name === before,
         );


### PR DESCRIPTION
## Summary

Allow Rsbuild plugin to be registered times. This gives plugins more flexibility in designing their APIs, and allows multiple registrations with different options.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3814

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
