### PR TITLE
chore: extract `isTTY` helper

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -370,3 +370,13 @@ export const prettyTime = (seconds: number): string => {
   const minutes = seconds / 60;
   return `${format(minutes.toFixed(2))} m`;
 };
+
+/**
+ * Check if running in a TTY context
+ */
+export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
+  return (
+    (type === 'stdin' ? process.stdin.isTTY : process.stdout.isTTY) &&
+    !process.env.CI
+  );
+};

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -1,12 +1,13 @@
 import readline from 'node:readline';
 import color from 'picocolors';
+import { isTTY } from '../helpers';
 import { logger } from '../logger';
 import type { CliShortcut, NormalizedDevConfig } from '../types/config';
 import { onBeforeRestartServer } from './restart';
 
 export const isCliShortcutsEnabled = (
   devConfig: NormalizedDevConfig,
-): boolean => devConfig.cliShortcuts && process.stdin.isTTY && !process.env.CI;
+): boolean => devConfig.cliShortcuts && isTTY('stdin');
 
 export function setupCliShortcuts({
   openPage,

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import color from 'picocolors';
 import { init } from '../cli/init';
+import { isTTY } from '../helpers';
 import { logger } from '../logger';
 
 type Cleaner = () => Promise<unknown> | unknown;
@@ -15,7 +16,7 @@ export const onBeforeRestartServer = (cleaner: Cleaner): void => {
 };
 
 const clearConsole = () => {
-  if (process.stdout.isTTY && !process.env.DEBUG) {
+  if (isTTY() && !process.env.DEBUG) {
     process.stdout.write('\x1B[H\x1B[2J');
   }
 };


### PR DESCRIPTION
## Summary

Extract `isTTY` helper to check if running in a TTY context.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
