### PR TITLE
chore: simplify `isPlainObject` helper

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -35,26 +35,12 @@ export const isFunction = (func: unknown): func is (...args: any[]) => any =>
 export const isObject = (obj: unknown): obj is Record<string, any> =>
   Object.prototype.toString.call(obj) === '[object Object]';
 
-export const isPlainObject = (o: unknown): o is Record<string, any> => {
-  if (isObject(o) === false) return false;
-
-  // If has modified constructor
-  const ctor = (o as Record<string, any>).constructor;
-  if (ctor === undefined) return true;
-
-  // If has modified prototype
-  const prot = ctor.prototype;
-  if (isObject(prot) === false) return false;
-
-  // If constructor does not have an Object-specific method
-
-  // biome-ignore lint/suspicious/noPrototypeBuiltins: <explanation>
-  if (prot.hasOwnProperty('isPrototypeOf') === false) {
-    return false;
-  }
-
-  // Most likely a plain Object
-  return true;
+export const isPlainObject = (obj: unknown): obj is Record<string, any> => {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    Object.getPrototypeOf(obj) === Object.prototype
+  );
 };
 
 export const castArray = <T>(arr?: T | T[]): T[] => {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -5,11 +5,18 @@ import type {
   RsbuildPlugin,
   Rspack,
 } from '@rsbuild/core';
-import { __internalHelper } from '@rsbuild/core';
 import deepmerge from 'deepmerge';
 import { reduceConfigsWithContext } from 'reduce-configs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const isPlainObject = (obj: unknown): obj is Record<string, any> => {
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    Object.getPrototypeOf(obj) === Object.prototype
+  );
+};
 
 export const PLUGIN_LESS_NAME = 'rsbuild:less';
 
@@ -77,7 +84,7 @@ const getLessLoaderOptions = (
     const getLessOptions = () => {
       if (defaults.lessOptions && userOptions.lessOptions) {
         return deepmerge(defaults.lessOptions, userOptions.lessOptions, {
-          isMergeableObject: __internalHelper.isPlainObject,
+          isMergeableObject: isPlainObject,
         });
       }
       return userOptions.lessOptions || defaults.lessOptions;


### PR DESCRIPTION
## Summary

- Use modern JavaScript features to write `isPlainObject` more concisely
- Let pluginLess no longer depend on the internal helper of `@rsbuild/core`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
