### PR TITLE
fix(plugin-preact): allow to use Prefresh in IE11

### DIFF
--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -30,6 +30,11 @@ export const pluginPreact = (
       ...userOptions,
     };
 
+    // @rspack/plugin-preact-refresh does not support Windows yet
+    if (process.platform === 'win32') {
+      options.prefreshEnabled = false;
+    }
+
     api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
       const isDev = config.mode === 'development';
       const usePrefresh =
@@ -88,11 +93,7 @@ export const pluginPreact = (
       const usePrefresh =
         isDev && options.prefreshEnabled && config.dev.hmr && target === 'web';
 
-      if (
-        !usePrefresh ||
-        // @rspack/plugin-preact-refresh does not support Windows yet
-        process.platform === 'win32'
-      ) {
+      if (!usePrefresh) {
         return;
       }
 

--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -19,20 +19,28 @@ export type PluginPreactOptions = {
 export const PLUGIN_PREACT_NAME = 'rsbuild:preact';
 
 export const pluginPreact = (
-  options: PluginPreactOptions = {},
+  userOptions: PluginPreactOptions = {},
 ): RsbuildPlugin => ({
   name: PLUGIN_PREACT_NAME,
 
   setup(api) {
-    const { reactAliasesEnabled = true, prefreshEnabled = true } = options;
+    const options = {
+      prefreshEnabled: true,
+      reactAliasesEnabled: true,
+      ...userOptions,
+    };
 
     api.modifyEnvironmentConfig((config, { mergeEnvironmentConfig }) => {
       const isDev = config.mode === 'development';
-      const usingHMR =
-        isDev && config.dev.hmr && config.output.target === 'web';
+      const usePrefresh =
+        isDev &&
+        options.prefreshEnabled &&
+        config.dev.hmr &&
+        config.output.target === 'web';
+
       const reactOptions: Rspack.SwcLoaderTransformConfig['react'] = {
         development: config.mode === 'development',
-        refresh: usingHMR && options.prefreshEnabled,
+        refresh: usePrefresh,
         runtime: 'automatic',
         importSource: 'preact',
       };
@@ -54,8 +62,16 @@ export const pluginPreact = (
         },
       };
 
-      if (reactAliasesEnabled) {
-        extraConfig.source ||= {};
+      extraConfig.source ||= {};
+
+      if (usePrefresh) {
+        // transpile `@prefresh/core` and `@prefresh/utils` to ensure browser compatibility
+        extraConfig.source.include = [
+          /node_modules[\\/]@prefresh[\\/](core|utils)/,
+        ];
+      }
+
+      if (options.reactAliasesEnabled) {
         extraConfig.source.alias = {
           react: 'preact/compat',
           'react-dom/test-utils': 'preact/test-utils',
@@ -67,13 +83,13 @@ export const pluginPreact = (
       return mergeEnvironmentConfig(extraConfig, config);
     });
 
-    api.modifyBundlerChain(async (chain, { isProd, target }) => {
+    api.modifyBundlerChain(async (chain, { isDev, target }) => {
       const config = api.getNormalizedConfig();
-      const usingHMR = !isProd && config.dev.hmr && target === 'web';
+      const usePrefresh =
+        isDev && options.prefreshEnabled && config.dev.hmr && target === 'web';
 
       if (
-        !usingHMR ||
-        !prefreshEnabled ||
+        !usePrefresh ||
         // @rspack/plugin-preact-refresh does not support Windows yet
         process.platform === 'win32'
       ) {


### PR DESCRIPTION
## Summary

From prefresh README:

> If you want to use @prefresh/webpack with IE11, you'll need to transpile the @prefresh/core and @prefresh/utils packages.

## Related Links

https://github.com/preactjs/prefresh?tab=readme-ov-file#usage-in-ie11

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
