### PR TITLE
release: 1.0.18

### DIFF
--- a/.changeset/afraid-beers-train.md
+++ b/.changeset/afraid-beers-train.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-preact': minor
----
-
-bump

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: improve JSDoc for `output` and `html` configurations by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3804
* feat: add new `source.assetsInclude` config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3808
* feat: allow to configure `dataUriLimit` for extended assets by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3826
* feat(plugin-preact): support for prefresh by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/2469
* feat(plugin-preact): add `include` and `exclude` options by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3835
### Bug Fixes 🐞
* fix: allow Rsbuild plugin to be registered times by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3818
* fix(plugin-less): lessLoaderOptions.lessOptions.plugins has lose it's prototype. by @Sang-Sang33 in https://github.com/web-infra-dev/rsbuild/pull/3815
* fix(plugin-preact): allow to use Prefresh in IE11 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3831
### Document 📖
* docs: update vite.mdx to fix npm command reference by @adammark in https://github.com/web-infra-dev/rsbuild/pull/3802
* docs: add guide for using Web Workers by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3795
* docs: add guide for worker-loader by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3809
* docs: update guide for additional asset types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3811
* docs: add how to import absolute path in CSS files by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/3816
* docs: correct `rsbuild.addPlugins` typing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3817
* docs(plugin-prefresh): add `prefreshEnabled` option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3829
* docs: update example in transform-import.mdx by @wangi4myself in https://github.com/web-infra-dev/rsbuild/pull/3825
### Other Changes
* chore(renovate): bump Rslib separately by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3807
* test: group e2e test cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3806
* chore(deps): update rspress to v1.35.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3812
* chore: extract `isTTY` helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3821
* test(plugin-less): fix plugin snapshot by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3822
* chore: simplify `isPlainObject` helper by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3823
* chore: correct some cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3830
* test(e2e): avoid writing temp files to git by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3832
* chore(deps): update babel to ^7.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3833

## New Contributors
* @adammark made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3802
* @Sang-Sang33 made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3815
* @wangi4myself made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/3825

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.0.17...v1.0.18