### PR TITLE
fix: remove RC version from peer dependencies

### DIFF
--- a/.changeset/fast-crabs-sin.md
+++ b/.changeset/fast-crabs-sin.md
@@ -1,0 +1,16 @@
+---
+'@rsbuild/plugin-webpack-swc': patch
+'@rsbuild/plugin-assets-retry': patch
+'@rsbuild/plugin-preact': patch
+'@rsbuild/plugin-stylus': patch
+'@rsbuild/plugin-svelte': patch
+'@rsbuild/plugin-babel': patch
+'@rsbuild/plugin-react': patch
+'@rsbuild/plugin-solid': patch
+'@rsbuild/plugin-less': patch
+'@rsbuild/plugin-sass': patch
+'@rsbuild/plugin-svgr': patch
+'@rsbuild/plugin-vue': patch
+---
+
+bump

--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -43,7 +43,7 @@
     "webpack": "^5.95.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -42,7 +42,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -38,7 +38,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -39,7 +39,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -37,7 +37,7 @@
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -46,7 +46,7 @@
     "url-loader": "4.1.1"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -38,7 +38,7 @@
     "webpack": "^5.95.0"
   },
   "peerDependencies": {
-    "@rsbuild/core": "1.x || ^1.0.1-rc.0"
+    "@rsbuild/core": "1.x"
   },
   "publishConfig": {
     "access": "public",

--- a/website/docs/en/guide/basic/css-usage.mdx
+++ b/website/docs/en/guide/basic/css-usage.mdx
@@ -18,8 +18,6 @@ Rsbuild uses Rspack's built-in [lightningcss-loader](https://www.rspack.dev/guid
 - Lightning CSS automatically downgrades CSS syntax, allowing you to use modern CSS features such as CSS nesting and custom media queries in your code without worrying about browser compatibility issues.
 - You can use [tools.lightningcssLoader](/config/tools/lightningcss-loader) to customize the options for `lightningcss-loader`.
 
-> Rsbuild has enabled Lightning CSS by default since version `1.0.1-beta.7`.
-
 ### Disabling Lightning CSS
 
 If Lightning CSS does not meet your needs, you can disable Lightning CSS and use [PostCSS](#using-postcss) to transform your CSS code.

--- a/website/docs/zh/guide/basic/css-usage.mdx
+++ b/website/docs/zh/guide/basic/css-usage.mdx
@@ -18,8 +18,6 @@ Rsbuild 使用 Rspack 内置的 [lightningcss-loader](https://www.rspack.dev/gui
 - Lightning CSS 会自动将 CSS 语法降级，这允许你在代码中使用现代的 CSS 特性，比如 CSS nesting，custom media queries 等，而无需担心浏览器兼容性问题。
 - 你可以使用 [tools.lightningcssLoader](/config/tools/lightningcss-loader) 来自定义 `lightningcss-loader` 的选项。
 
-> Rsbuild 从 `1.0.1-beta.7` 版本开始默认启用 Lightning CSS。
-
 ### 禁用 Lightning CSS
 
 如果 Lightning CSS 无法满足你的需求，你也可以禁用 Lightning CSS，并使用 [PostCSS](#使用-postcss) 来转换 CSS 代码。


### PR DESCRIPTION
## Summary

Remove the RC version from the peer dependencies, as we recommend using the stable version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
