### PR TITLE
fix(plugin/assets-retry): calculate the times independently in each retry

### DIFF
--- a/e2e/cases/assets/assets-retry/index.test.ts
+++ b/e2e/cases/assets/assets-retry/index.test.ts
@@ -117,9 +117,7 @@ async function createRsbuildWithMiddleware(
   return rsbuild;
 }
 
-test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index.js', async ({
-  page,
-}) => {
+test('should work when blocking initial chunk index.js', async ({ page }) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
   const blockedMiddleware = createBlockMiddleware({
@@ -138,7 +136,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking initial chunk index
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking initial chunk index.js', async ({
+test('should work with minified runtime code when blocking initial chunk index.js', async ({
   page,
 }) => {
   logger.level = 'verbose';
@@ -161,9 +159,7 @@ test('@rsbuild/plugin-assets-retry should work with minified runtime code when b
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', async ({
-  page,
-}) => {
+test('should work when blocking async chunk', async ({ page }) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
   const blockedMiddleware = createBlockMiddleware({
@@ -185,9 +181,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking async chunk`', asyn
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should work when blocking async CSS chunk`', async ({
-  page,
-}) => {
+test('should work when blocking async css chunk`', async ({ page }) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
   const blockedMiddleware = createBlockMiddleware({
@@ -210,7 +204,7 @@ test('@rsbuild/plugin-assets-retry should work when blocking async CSS chunk`', 
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should work with minified runtime code when blocking async chunk', async ({
+test('should work with minified runtime code when blocking async chunk', async ({
   page,
 }) => {
   logger.level = 'verbose';
@@ -236,7 +230,7 @@ test('@rsbuild/plugin-assets-retry should work with minified runtime code when b
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should catch error by react ErrorBoundary when all retries failed', async ({
+test('react ErrorBoundary should catch error when all retries failed', async ({
   page,
 }) => {
   logger.level = 'verbose';
@@ -313,7 +307,7 @@ async function proxyPageConsole(page: Page, port: number) {
   };
 }
 
-test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying initial chunk', async ({
+test('onRetry and onSuccess options should work when retrying initial chunk successfully', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -383,7 +377,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await rsbuild.close();
 });
 
-test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in successfully retrying async chunk', async ({
+test('onRetry and onSuccess options should work when retrying async chunk successfully', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -454,7 +448,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onSuccess options should work in 
   await rsbuild.close();
 });
 
-test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying initial chunk', async ({
+test('onRetry and onFail options should work when retrying initial chunk failed', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -530,7 +524,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await rsbuild.close();
 });
 
-test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in failed retrying async chunk', async ({
+test('onRetry and onFail options should work when retrying async chunk failed', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -610,9 +604,7 @@ test('@rsbuild/plugin-assets-retry onRetry and onFail options should work in fai
   await rsbuild.close();
 });
 
-test('@rsbuild/plugin-assets-retry should work with addQuery boolean option', async ({
-  page,
-}) => {
+test('should work with addQuery boolean option', async ({ page }) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
   const initialChunkBlockedMiddleware = createBlockMiddleware({
@@ -663,9 +655,7 @@ test('@rsbuild/plugin-assets-retry should work with addQuery boolean option', as
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should work with addQuery function type option', async ({
-  page,
-}) => {
+test('should work with addQuery function type option', async ({ page }) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
   const initialChunkBlockedMiddleware = createBlockMiddleware({
@@ -720,7 +710,7 @@ test('@rsbuild/plugin-assets-retry should work with addQuery function type optio
   logger.level = 'log';
 });
 
-test('@rsbuild/plugin-assets-retry should preserve users query when set addQuery option', async ({
+test('should preserve users query when set addQuery option', async ({
   page,
 }) => {
   logger.level = 'verbose';
@@ -768,4 +758,105 @@ test('@rsbuild/plugin-assets-retry should preserve users query when set addQuery
   await rsbuild.close();
   restore();
   logger.level = 'log';
+});
+
+test('onRetry and onFail options should work when multiple parallel retrying async chunk', async ({
+  page,
+}) => {
+  const blockedMiddleware = createBlockMiddleware({
+    blockNum: 100,
+    urlPrefix: '/static/js/async/src_AsyncCompTest_tsx.js',
+  });
+
+  const rsbuild = await createRsbuildWithMiddleware(
+    blockedMiddleware,
+    {
+      minify: true,
+      onRetry(context) {
+        console.info('onRetry', context);
+      },
+      onSuccess(context) {
+        console.info('onSuccess', context);
+      },
+      onFail(context) {
+        console.info('onFail', context);
+      },
+    },
+    './src/testParallelRetryEntry.js',
+  );
+
+  const { onRetryContextList, onFailContextList, onSuccessContextList } =
+    await proxyPageConsole(page, rsbuild.port);
+
+  await gotoPage(page, rsbuild);
+  await delay();
+
+  expect({
+    onRetryContextList,
+    onFailContextList,
+    onSuccessContextList,
+  }).toMatchObject({
+    onRetryContextList: [
+      {
+        times: 0,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+      {
+        times: 0,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+      {
+        times: 1,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+      {
+        times: 1,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+      {
+        times: 2,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+      {
+        times: 2,
+        domain: '<ORIGIN>',
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+        tagName: 'script',
+        isAsyncChunk: true,
+      },
+    ],
+    onFailContextList: [
+      {
+        domain: '<ORIGIN>',
+        isAsyncChunk: true,
+        tagName: 'script',
+        times: 3,
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+      },
+      {
+        domain: '<ORIGIN>',
+        isAsyncChunk: true,
+        tagName: 'script',
+        times: 3,
+        url: '<ORIGIN>/static/js/async/src_AsyncCompTest_tsx.js',
+      },
+    ],
+    onSuccessContextList: [],
+  });
+  await rsbuild.close();
 });

--- a/e2e/cases/assets/assets-retry/src/testParallelRetryEntry.js
+++ b/e2e/cases/assets/assets-retry/src/testParallelRetryEntry.js
@@ -1,0 +1,2 @@
+import('./AsyncCompTest');
+import('./AsyncCompTest');

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -218,7 +218,7 @@ function ensureChunk(
 
   return result.catch((error: Error) => {
     // the first calling is not retry
-    // if the error request is 4 in network panel, the first one is the normal request, and existRetryTimes is 3, retried 3 times
+    // if the failed request is 4 in network panel, callingCounter.count === 4, the first one is the normal request, and existRetryTimes is 3, retried 3 times
     const existRetryTimes = callingCounter.count - 1;
     const { originalSrcUrl, nextRetryUrl, nextDomain } = nextRetry(
       chunkId,

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -170,7 +170,11 @@ function nextRetry(chunkId: string, existRetryTimes: number): Retry {
 
     nextRetry = {
       nextDomain,
-      nextRetryUrl: getNextRetryUrl(nextExistRetryTimes, nextDomain, originalSrcUrl),
+      nextRetryUrl: getNextRetryUrl(
+        nextExistRetryTimes,
+        nextDomain,
+        originalSrcUrl,
+      ),
 
       originalScriptFilename,
       originalSrcUrl,
@@ -272,10 +276,9 @@ function ensureChunk(
 
     const nextPromise = ensureChunk(chunkId, callingCounter);
     return nextPromise.then((result) => {
-      if (
-        typeof config.onSuccess === 'function' &&
-        callingCounter.count === existRetryTimes + 2
-      ) {
+      // when after retrying 3 times aka "ensureChunk(chunkId, 2)", the callingCounter.count is 4
+      const isLastSuccessRetry = callingCounter.count === existRetryTimes + 2;
+      if (typeof config.onSuccess === 'function' && isLastSuccessRetry) {
         const context = createContext(existRetryTimes + 1);
         config.onSuccess(context);
       }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -241,7 +241,9 @@ function ensureChunk(
     const context = createContext(existRetryTimes);
 
     if (existRetryTimes >= maxRetries) {
-      error.message = `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
+      error.message = Boolean(error.message?.includes('retries:'))
+        ? error.message
+        : `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
       if (typeof config.onFail === 'function') {
         config.onFail(context);
       }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -280,7 +280,9 @@ function ensureChunk(
 
     const nextPromise = ensureChunk(chunkId, callingCounter);
     return nextPromise.then((result) => {
-      // when after retrying the third time, that is after "ensureChunk(chunkId, 2)", the callingCounter.count is 4
+      // when after retrying the third time
+      // "ensureChunk(chunkId, { count: 3 })"
+      // callingCounter.count is 4
       const isLastSuccessRetry = callingCounter.count === existRetryTimes + 2;
       if (typeof config.onSuccess === 'function' && isLastSuccessRetry) {
         const context = createContext(existRetryTimes + 1);

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -281,8 +281,8 @@ function ensureChunk(
     const nextPromise = ensureChunk(chunkId, callingCounter);
     return nextPromise.then((result) => {
       // when after retrying the third time
-      // "ensureChunk(chunkId, { count: 3 })"
-      // callingCounter.count is 4
+      // ensureChunk(chunkId, { count: 3 }), at that time, existRetryTimes === 2
+      // after all, callingCounter.count is 4
       const isLastSuccessRetry = callingCounter.count === existRetryTimes + 2;
       if (typeof config.onSuccess === 'function' && isLastSuccessRetry) {
         const context = createContext(existRetryTimes + 1);

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -217,7 +217,9 @@ function ensureChunk(
   callingCounter.count += 1;
 
   return result.catch((error: Error) => {
-    const existRetryTimes = callingCounter.count - 1; // the first calling is not retry
+    // the first calling is not retry
+    // if the error request is 4 in network panel, the first one is the normal request, and existRetryTimes is 3, retried 3 times
+    const existRetryTimes = callingCounter.count - 1;
     const { originalSrcUrl, nextRetryUrl, nextDomain } = nextRetry(
       chunkId,
       existRetryTimes,
@@ -278,7 +280,7 @@ function ensureChunk(
 
     const nextPromise = ensureChunk(chunkId, callingCounter);
     return nextPromise.then((result) => {
-      // when after retrying 3 times aka "ensureChunk(chunkId, 2)", the callingCounter.count is 4
+      // when after retrying the third time, that is after "ensureChunk(chunkId, 2)", the callingCounter.count is 4
       const isLastSuccessRetry = callingCounter.count === existRetryTimes + 2;
       if (typeof config.onSuccess === 'function' && isLastSuccessRetry) {
         const context = createContext(existRetryTimes + 1);

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -241,7 +241,7 @@ function ensureChunk(
     const context = createContext(existRetryTimes);
 
     if (existRetryTimes >= maxRetries) {
-      error.message = Boolean(error.message?.includes('retries:'))
+      error.message = error.message?.includes('retries:')
         ? error.message
         : `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
       if (typeof config.onFail === 'function') {


### PR DESCRIPTION
## Summary

each retry should be independent.

### before this pull request, 

when two `"max": 3` retries are parallel, the result may be that one is `1, 3`, the other is `2`, so number of times of each retry is not fixed.

### after this pull request,

`first: 1 2 3` 
`second: 1 2 3`

every request retried three times




## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
