### PR TITLE
fix(plugin/assets-retry): make loadScript safer

### DIFF
--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -129,7 +129,7 @@ function getNextRetryUrl(
 }
 
 // shared between ensureChunk and loadScript
-let globalCurrRetrying: Retry | undefined = undefined;
+const globalCurrRetrying: Record<ChunkId, Retry> = {};
 function getCurrentRetry(
   chunkId: string,
   existRetryTimes: number,
@@ -182,7 +182,7 @@ function nextRetry(chunkId: string, existRetryTimes: number): Retry {
   }
 
   retryCollector[chunkId][nextExistRetryTimes] = nextRetry;
-  globalCurrRetrying = nextRetry;
+  globalCurrRetrying[chunkId] = nextRetry;
   return nextRetry;
 }
 
@@ -299,7 +299,7 @@ function loadScript(
   key: string,
   chunkId: ChunkId,
 ) {
-  const retry = globalCurrRetrying;
+  const retry = globalCurrRetrying[chunkId];
   return originalLoadScript(
     retry ? retry.nextRetryUrl : originalUrl,
     done,


### PR DESCRIPTION
## Summary

😂 loadScript in webpack runtime is for all the script, I'd better to scope it for safer

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
