### PR TITLE
docs: correct CSS Modules named import example

### DIFF
--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -277,6 +277,6 @@ console.log(foo);
 console.log(styles.foo);
 ```
 
-```tip
+:::tip
 When `namedExport` is set to true, the `default` class exported by CSS Modules will be automatically renamed to `_default` class because `default` is a reserved word in ECMA modules.
-```
+:::

--- a/website/docs/en/guide/basic/css-modules.mdx
+++ b/website/docs/en/guide/basic/css-modules.mdx
@@ -13,7 +13,7 @@ The following style files are considered CSS Modules:
 - `*.module.styl`
 - `*.module.stylus`
 
-## Example
+## Usage Example
 
 - Write style:
 
@@ -33,7 +33,21 @@ export default () => {
 };
 ```
 
-- You can also reference class names through named imports:
+## Named Import
+
+If you prefer to use named imports in CSS Modules, you can enable it through the [output.cssModules.namedExport](/config/output/css-modules#cssmodulesnamedexport) config.
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    cssModules: {
+      namedExport: true,
+    },
+  },
+};
+```
+
+If enabled, you can reference class names using named imports:
 
 ```tsx title="Button.tsx"
 import { red } from './button.module.css';

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -281,6 +281,6 @@ console.log(foo);
 console.log(styles.foo);
 ```
 
-```tip
+:::tip
 当 namedExport 为 true 时，CSS Modules 导出的 `default` class 会被自动重命名为 `_default` class，因为 default 是 ECMA modules 的保留字。
-```
+:::

--- a/website/docs/zh/guide/basic/css-modules.mdx
+++ b/website/docs/zh/guide/basic/css-modules.mdx
@@ -13,7 +13,7 @@ Rsbuild 默认支持使用 CSS Modules，无需添加额外的配置。我们约
 - `*.module.styl`
 - `*.module.stylus`
 
-## 示例
+## 用法示例
 
 - 编写样式：
 
@@ -33,7 +33,21 @@ export default () => {
 };
 ```
 
-- 你也可以通过具名导入来引用类名：
+## 具名导入
+
+如果你倾向于在 CSS Modules 中使用具名导入，可以通过 [output.cssModules.namedExport](/config/output/css-modules#cssmodulesnamedexport) 配置项来开启。
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    cssModules: {
+      namedExport: true,
+    },
+  },
+};
+```
+
+开启后，你可以通过具名导入来引用类名：
 
 ```tsx title="Button.tsx"
 import { red } from './button.module.css';


### PR DESCRIPTION
## Summary

Correct CSS Modules named import example, `output.cssModules.namedExport` should be enabled.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
