### PR TITLE
docs: add license to website footer

### DIFF
--- a/website/theme/components/Copyright.tsx
+++ b/website/theme/components/Copyright.tsx
@@ -5,19 +5,11 @@ export const CopyRight = () => {
     <footer className={styles.copyRight}>
       <div className={styles.copyRightInner}>
         <div className={styles.copyRightText}>
-          <div>Copyright © 2024 ByteDance.</div>
-          <div>
-            Built with{' '}
-            <a
-              target="_blank"
-              rel="noreferrer"
-              style={{ textDecoration: 'underline' }}
-              href="https://github.com/web-infra-dev/rspress"
-            >
-              Rspress
-            </a>
-            .
-          </div>
+          <p className="mb-2">
+            Rsbuild is free and open source software released under the MIT
+            license.
+          </p>
+          <p>© 2023-present ByteDance Inc.</p>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
## Summary

Add Rsbuild license to the footer of Rsbuild website.

## Related Links

https://github.com/web-infra-dev/rspack/pull/8261

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
