### PR TITLE
fix(webpack): avoid duplicate import core package

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,6 +7,7 @@
       "!{projectRoot}/**/*.{md,mdx}",
       "{projectRoot}/tsconfig.json",
       "{projectRoot}/package.json",
+      "{projectRoot}/rslib.config.*",
       "{projectRoot}/modern.config.*",
       "{projectRoot}/scripts/**/*"
     ],

--- a/packages/compat/webpack/rslib.config.ts
+++ b/packages/compat/webpack/rslib.config.ts
@@ -1,15 +1,30 @@
-import path from 'node:path';
-import { pureEsmPackage } from '@rsbuild/config/rslib.config.ts';
+import {
+  cjsConfig,
+  dualPackage,
+  esmConfig,
+} from '@rsbuild/config/rslib.config.ts';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  ...pureEsmPackage,
-  output: {
-    ...pureEsmPackage.output,
-    copy: [
-      {
-        from: path.resolve(__dirname, 'src/index.cjs'),
+  ...dualPackage,
+  lib: [
+    esmConfig,
+    {
+      ...cjsConfig,
+      output: {
+        target: 'node',
+        externals: {
+          webpack: 'import webpack',
+          'copy-webpack-plugin': 'import copy-webpack-plugin',
+          'mini-css-extract-plugin': 'import mini-css-extract-plugin',
+          'tsconfig-paths-webpack-plugin':
+            'import tsconfig-paths-webpack-plugin',
+        },
       },
-    ],
-  },
+      footer: {
+        js: `// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = { webpackProvider: exports.webpackProvider });`,
+      },
+    },
+  ],
 });

--- a/packages/compat/webpack/rslib.config.ts
+++ b/packages/compat/webpack/rslib.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
       ...cjsConfig,
       output: {
         target: 'node',
+        // TODO https://github.com/web-infra-dev/rslib/issues/287
         externals: {
           webpack: 'import webpack',
           'copy-webpack-plugin': 'import copy-webpack-plugin',
@@ -22,6 +23,7 @@ export default defineConfig({
         },
       },
       footer: {
+        // TODO https://github.com/web-infra-dev/rslib/issues/351
         js: `// Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = { webpackProvider: exports.webpackProvider });`,
       },

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -27,8 +27,3 @@ export const dualPackage = defineConfig({
     },
   },
 });
-
-export const pureEsmPackage = defineConfig({
-  ...dualPackage,
-  lib: [esmConfig],
-});


### PR DESCRIPTION
## Summary

In https://github.com/web-infra-dev/rsbuild/pull/3713, `@rsbuild/webpack` has been changed to a pure ESM package (with a CJS shim wrapper).

But this change introduces the dual package hazard: `@rsbuild/core` will be loaded twice times when `@rsbuild/webpack` is used by a CommonJS package (like Modern.js).

This PR reverts `@rsbuild/webpack` to a dual package to avoid this problem.

## Related Links

- https://github.com/nodejs/package-examples?tab=readme-ov-file#dual-package-hazard
- https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/11608094993/job/32322683762

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
