### PR TITLE
feat: add `layer` option to `api.transform()`

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -277,6 +277,9 @@ export function initPluginAPI({
           if (descriptor.resourceQuery) {
             rule.resourceQuery(descriptor.resourceQuery);
           }
+          if (descriptor.layer) {
+            rule.layer(descriptor.layer);
+          }
 
           const loaderName = descriptor.raw
             ? 'transformRawLoader.cjs'

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -300,6 +300,12 @@ export type TransformDescriptor = {
    * @see https://rspack.dev/api/loader-api/examples#raw-loader
    */
   raw?: boolean;
+  /**
+   * Used to mark the layer of the matching module.
+   * A group of modules could be united in one layer which could then be used in
+   * split chunks, stats or entry options.
+   */
+  layer?: string;
 };
 
 export type TransformFn = (

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -304,6 +304,7 @@ export type TransformDescriptor = {
    * Used to mark the layer of the matching module.
    * A group of modules could be united in one layer which could then be used in
    * split chunks, stats or entry options.
+   * @see https://rspack.dev/config/module#rulelayer
    */
   layer?: string;
 };

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -212,6 +212,7 @@ type TransformDescriptor = {
   environments?: string[];
   resourceQuery?: RuleSetCondition;
   raw?: boolean;
+  layer?: string;
 };
 ```
 
@@ -256,6 +257,8 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
   // ...
 });
 ```
+
+- `layer`: the same as Rspack's [Rule.layer](https://rspack.dev/config/module#rulelayer).
 
 ### Handler Param
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -210,6 +210,7 @@ type TransformDescriptor = {
   environments?: string[];
   resourceQuery?: RuleSetCondition;
   raw?: boolean;
+  layer?: string;
 };
 ```
 
@@ -254,6 +255,8 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
   // ...
 });
 ```
+
+- `layer`：等同于 Rspack 的 [Rule.layer](https://rspack.dev/config/module#rulelayer)。
 
 ### handler 参数
 


### PR DESCRIPTION
## Summary

Allow to specify `layer` when using `api.transform()`.

## Related Links

https://rspack.dev/config/module#rulelayer

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
