### PR TITLE
feat: add `issuerLayer` option to `api.transform()`

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -280,6 +280,9 @@ export function initPluginAPI({
           if (descriptor.layer) {
             rule.layer(descriptor.layer);
           }
+          if (descriptor.issuerLayer) {
+            rule.issuerLayer(descriptor.issuerLayer);
+          }
 
           const loaderName = descriptor.raw
             ? 'transformRawLoader.cjs'

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -286,17 +286,20 @@ export type TransformDescriptor = {
    */
   resourceQuery?: Rspack.RuleSetCondition;
   /**
-   * Match based on the Rsbuild targets and only apply the transform to certain targets.
+   * Match based on the Rsbuild targets and only apply the transform to
+   * certain targets.
    * @see https://rsbuild.dev/config/output/target
    */
   targets?: RsbuildTarget[];
   /**
-   * Match based on the Rsbuild environment names and only apply the transform to certain environments.
+   * Match based on the Rsbuild environment names and only apply the transform
+   * to certain environments.
    * @see https://rsbuild.dev/config/environments
    */
   environments?: string[];
   /**
-   * If raw is `true`, the transform handler will receive the Buffer type code instead of the string type.
+   * If raw is `true`, the transform handler will receive the Buffer type code
+   * instead of the string type.
    * @see https://rspack.dev/api/loader-api/examples#raw-loader
    */
   raw?: boolean;
@@ -307,6 +310,12 @@ export type TransformDescriptor = {
    * @see https://rspack.dev/config/module#rulelayer
    */
   layer?: string;
+  /**
+   * Matches all modules that match this resource, and will match against layer of
+   * the module that issued the current module.
+   * @see https://rspack.dev/config/module#ruleissuerlayer
+   */
+  issuerLayer?: string;
 };
 
 export type TransformFn = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -259,6 +259,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 ```
 
 - `layer`: the same as Rspack's [Rule.layer](https://rspack.dev/config/module#rulelayer).
+- `issuerLayer`: the same as Rspack's [Rule.issuerLayer](https://rspack.dev/config/module#ruleissuerlayer).
 
 ### Handler Param
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -257,6 +257,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 ```
 
 - `layer`：等同于 Rspack 的 [Rule.layer](https://rspack.dev/config/module#rulelayer)。
+- `issuerLayer`：等同于 Rspack 的 [Rule.issuerLayer](https://rspack.dev/config/module#ruleissuerlayer)。
 
 ### handler 参数
 


### PR DESCRIPTION
## Summary

Allow to specify `issuerLayer` when using `api.transform()`.

## Related Links

https://rspack.dev/config/module#ruleissuerlayer

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
