### PR TITLE
fix(plugin-react): allow to override builtin split chunks

### DIFF
--- a/e2e/cases/react/split-chunk/index.test.ts
+++ b/e2e/cases/react/split-chunk/index.test.ts
@@ -34,3 +34,28 @@ test('should not split react chunks when strategy is `all-in-one`', async () => 
   expect(filesNames.find((file) => file.includes('lib-react'))).toBeFalsy();
   expect(filesNames.find((file) => file.includes('lib-router'))).toBeFalsy();
 });
+
+test('should not override user defined cache groups', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      performance: {
+        chunkSplit: {
+          override: {
+            cacheGroups: {
+              react: {
+                name: 'my-react',
+                test: /react/,
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filesNames = Object.keys(files);
+  expect(filesNames.find((file) => file.includes('my-react'))).toBeTruthy();
+});

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -51,8 +51,9 @@ export const applySplitChunksRule = (
     chain.optimization.splitChunks({
       ...currentConfig,
       cacheGroups: {
-        ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
+        // user defined cache groups take precedence
         ...extraGroups,
+        ...(currentConfig as Exclude<SplitChunks, false>).cacheGroups,
       },
     });
   });


### PR DESCRIPTION
## Summary

Allow to override builtin split chunks for `@rsbuild/plugin-react`.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3786

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
