### PR TITLE
feat: add `cliShortcuts.help` option

### DIFF
--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -10,12 +10,14 @@ export const isCliShortcutsEnabled = (
 ): boolean => devConfig.cliShortcuts && isTTY('stdin');
 
 export function setupCliShortcuts({
+  help = true,
   openPage,
   closeServer,
   printUrls,
   restartServer,
   customShortcuts,
 }: {
+  help?: boolean;
   openPage: () => Promise<void>;
   closeServer: () => Promise<void>;
   printUrls: () => void;
@@ -68,9 +70,11 @@ export function setupCliShortcuts({
     }
   }
 
-  logger.log(
-    `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`,
-  );
+  if (help) {
+    logger.log(
+      `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`,
+    );
+  }
 
   const rl = readline.createInterface({
     input: process.stdin,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -220,15 +220,18 @@ export async function createDevServer<
     printUrls();
 
     if (cliShortcutsEnabled) {
+      const shortcutsOptions =
+        typeof devConfig.cliShortcuts === 'boolean'
+          ? {}
+          : devConfig.cliShortcuts;
+
       setupCliShortcuts({
         openPage,
         closeServer,
         printUrls,
         restartServer: () => restartDevServer({ clear: false }),
-        customShortcuts:
-          typeof devConfig.cliShortcuts === 'boolean'
-            ? undefined
-            : devConfig.cliShortcuts.custom,
+        help: shortcutsOptions.help,
+        customShortcuts: shortcutsOptions.custom,
       });
     }
 

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -233,14 +233,17 @@ export async function startProdServer(
         printUrls();
 
         if (cliShortcutsEnabled) {
+          const shortcutsOptions =
+            typeof config.dev.cliShortcuts === 'boolean'
+              ? {}
+              : config.dev.cliShortcuts;
+
           setupCliShortcuts({
             openPage,
             closeServer,
             printUrls,
-            customShortcuts:
-              typeof config.dev.cliShortcuts === 'boolean'
-                ? undefined
-                : config.dev.cliShortcuts.custom,
+            help: shortcutsOptions.help,
+            customShortcuts: shortcutsOptions.custom,
           });
         }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1310,6 +1310,11 @@ export interface DevConfig {
          * @returns - The customized CLI shortcuts.
          */
         custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
+        /**
+         * Whether to print the help hint when the server is started.
+         * @default true
+         */
+        help?: boolean;
       };
   /**
    * Provides the ability to execute a custom function and apply custom middlewares.

--- a/website/docs/en/config/dev/cli-shortcuts.mdx
+++ b/website/docs/en/config/dev/cli-shortcuts.mdx
@@ -6,6 +6,7 @@
 type CliShortcuts =
   | boolean
   | {
+      help?: boolean;
       custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
     };
 ```
@@ -50,19 +51,9 @@ export default {
 };
 ```
 
-- Disable some shortcuts:
+## Custom Shortcuts
 
-```js
-export default {
-  dev: {
-    cliShortcuts: {
-      custom: (shortcuts) => {
-        return shortcuts.filter((shortcut) => shortcut.key !== 'o');
-      },
-    },
-  },
-};
-```
+`custom` option can be used to custom shortcuts, the value is a function that receives the default shortcuts array and returns a new shortcuts array.
 
 - Add custom shortcuts:
 
@@ -82,6 +73,40 @@ export default {
           },
         ];
       },
+    },
+  },
+};
+```
+
+- Disable some shortcuts:
+
+```js
+export default {
+  dev: {
+    cliShortcuts: {
+      custom: (shortcuts) => {
+        return shortcuts.filter((shortcut) => shortcut.key !== 'o');
+      },
+    },
+  },
+};
+```
+
+## Print Help
+
+`help` option can be used to control whether to print the help hint when the server is started:
+
+```bash
+  ➜ press h + enter to show shortcuts
+```
+
+- Disable:
+
+```js
+export default {
+  dev: {
+    cliShortcuts: {
+      help: false,
     },
   },
 };

--- a/website/docs/zh/config/dev/cli-shortcuts.mdx
+++ b/website/docs/zh/config/dev/cli-shortcuts.mdx
@@ -6,6 +6,7 @@
 type CliShortcuts =
   | boolean
   | {
+      help?: boolean;
       custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
     };
 ```
@@ -50,19 +51,9 @@ export default {
 };
 ```
 
-- 禁用部分快捷键：
+## 自定义快捷键
 
-```js
-export default {
-  dev: {
-    cliShortcuts: {
-      custom: (shortcuts) => {
-        return shortcuts.filter((shortcut) => shortcut.key !== 'o');
-      },
-    },
-  },
-};
-```
+`custom` 选项可以自定义快捷键，`custom` 的值是一个函数，接收默认的 shortcuts 列表，并返回一个新的 shortcuts 列表。
 
 - 添加自定义快捷键：
 
@@ -82,6 +73,40 @@ export default {
           },
         ];
       },
+    },
+  },
+};
+```
+
+- 禁用部分快捷键：
+
+```js
+export default {
+  dev: {
+    cliShortcuts: {
+      custom: (shortcuts) => {
+        return shortcuts.filter((shortcut) => shortcut.key !== 'o');
+      },
+    },
+  },
+};
+```
+
+## 打印帮助
+
+`help` 选项可以控制是否在启动服务器时打印帮助提示：
+
+```bash
+  ➜ press h + enter to show shortcuts
+```
+
+- 禁用：
+
+```js
+export default {
+  dev: {
+    cliShortcuts: {
+      help: false,
     },
   },
 };


### PR DESCRIPTION
## Summary

Add `cliShortcuts.help` option to allow disable the help hint.

```js
export default {
  dev: {
    cliShortcuts: {
      help: false,
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
