### PR TITLE
perf: enable Node cache before loading modules

### DIFF
--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -1,9 +1,22 @@
 #!/usr/bin/env node
-import { __internalHelper, logger } from '../dist/index.js';
+import nodeModule from 'node:module';
 
-const { runCli, prepareCli } = __internalHelper;
+// enable on-disk code caching of all modules loaded by Node.js
+// requires Nodejs >= 22.8.0
+// @ts-expect-error enableCompileCache is not typed in `@types/node` 18.x
+const { enableCompileCache } = nodeModule;
+if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+  try {
+    enableCompileCache();
+  } catch {
+    // ignore errors
+  }
+}
 
 async function main() {
+  const { __internalHelper, logger } = await import('../dist/index.js');
+  const { runCli, prepareCli } = __internalHelper;
+
   prepareCli();
 
   try {

--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -1,4 +1,3 @@
-import nodeModule from 'node:module';
 import { logger } from '../logger';
 
 function initNodeEnv() {
@@ -12,16 +11,6 @@ function initNodeEnv() {
 
 export function prepareCli(): void {
   initNodeEnv();
-
-  // @ts-expect-error enableCompileCache is not typed yet
-  const { enableCompileCache } = nodeModule;
-  if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
-    try {
-      enableCompileCache();
-    } catch {
-      // ignore errors
-    }
-  }
 
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.


### PR DESCRIPTION
## Summary

Should enable Node cache before loading any modules.

- before:

<img width="865" alt="Screenshot 2024-11-04 at 15 45 57" src="https://github.com/user-attachments/assets/5e726875-b830-48e8-aef2-bb5f9dbd69f0">

- after:

<img width="831" alt="Screenshot 2024-11-04 at 15 44 36" src="https://github.com/user-attachments/assets/bf226918-45cc-4c97-a509-411ed9a30145">


## Related Links

https://github.com/web-infra-dev/rsbuild/pull/3627

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
