### PR TITLE
fix: no need for checking NODE_DISABLE_COMPILE_CACHE

### DIFF
--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -3,9 +3,8 @@ import nodeModule from 'node:module';
 
 // enable on-disk code caching of all modules loaded by Node.js
 // requires Nodejs >= 22.8.0
-// @ts-expect-error enableCompileCache is not typed in `@types/node` 18.x
 const { enableCompileCache } = nodeModule;
-if (enableCompileCache && !process.env.NODE_DISABLE_COMPILE_CACHE) {
+if (enableCompileCache) {
   try {
     enableCompileCache();
   } catch {


### PR DESCRIPTION
## Summary

No need for checking NODE_DISABLE_COMPILE_CACHE, Node.js will check it. See https://nodejs.org/api/cli.html#node_disable_compile_cache1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
