### PR TITLE
fix(plugin-svelte): `*.svslte.ts` files are transformed twice

### DIFF
--- a/.changeset/pretty-flowers-jog.md
+++ b/.changeset/pretty-flowers-jog.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-svelte': patch
+---
+
+bump

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -247,7 +247,7 @@ export const getHtmlFallbackMiddleware: (params: {
 };
 
 /**
- * Support viewing served files via /rsbuild-dev-server route
+ * Support viewing served files via `/rsbuild-dev-server` route
  */
 export const viewingServedFilesMiddleware: (params: {
   environments: EnvironmentAPI;

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -127,9 +127,13 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
           const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           if (svelte5 && jsRule) {
             const swcUse = jsRule.uses.get(CHAIN_ID.USE.SWC);
+            const regexp = /\.(?:svelte\.js|svelte\.ts)$/;
+
+            jsRule.exclude.add(regexp);
+
             chain.module
               .rule('svelte-js')
-              .test(/\.(?:svelte\.js|svelte\.ts)$/)
+              .test(regexp)
               .use(CHAIN_ID.USE.SVELTE)
               .loader(loaderPath)
               .options(svelteLoaderOptions)

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -1,247 +1,382 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`plugin-svelte > should add svelte loader properly 1`] = `
-{
-  "module": {
-    "rules": [
+exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` as expected 1`] = `
+[
+  {
+    "resolve": {
+      "fullySpecified": false,
+    },
+    "test": /\\\\\\.m\\?js/,
+  },
+  {
+    "exclude": [
+      /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    ],
+    "include": [
       {
-        "test": /\\\\\\.svelte\\$/,
-        "use": [
+        "and": [
+          "<ROOT>/packages/plugin-svelte/tests",
           {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-            "options": {
-              "compilerOptions": {
-                "dev": false,
-              },
-              "emitCss": false,
-              "hotReload": false,
-              "preprocess": {
-                "markup": [Function],
-                "script": [Function],
-                "style": [Function],
-              },
-            },
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
         ],
       },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
     ],
   },
-  "plugins": [
-    RsbuildCorePlugin {},
+  {
+    "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
+      },
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` as expected 2`] = `
+[
+  {
+    "exclude": [
+      /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    ],
+    "include": [
+      {
+        "and": [
+          "<ROOT>/packages/plugin-svelte/tests",
+          {
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+          },
+        ],
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+    ],
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+    ],
+  },
+  {
+    "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
+      },
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-svelte > should add svelte loader and resolve config properly 1`] = `
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
+      },
+    ],
+  },
+]
+`;
+
+exports[`plugin-svelte > should add svelte loader and resolve config properly 2`] = `
+{
+  "alias": {
+    "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+  },
+  "conditionNames": [
+    "svelte",
+    "...",
   ],
-  "resolve": {
-    "conditionNames": [
-      "svelte",
-      "...",
+  "extensionAlias": {
+    ".js": [
+      ".ts",
+      ".tsx",
+      ".js",
     ],
-    "extensions": [
-      ".svelte",
-    ],
-    "mainFields": [
-      "svelte",
-      "...",
+    ".jsx": [
+      ".tsx",
+      ".jsx",
     ],
   },
-  "resolveLoader": {
-    "alias": {
-      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-    },
+  "extensions": [
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".js",
+    ".jsx",
+    ".json",
+    ".svelte",
+  ],
+  "mainFields": [
+    "svelte",
+    "...",
+  ],
+  "tsConfig": {
+    "configFile": "<ROOT>/packages/plugin-svelte/tests/tsconfig.json",
+    "references": "auto",
   },
 }
 `;
 
 exports[`plugin-svelte > should override default svelte-loader options throw options.svelteLoaderOptions 1`] = `
-{
-  "module": {
-    "rules": [
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
       {
-        "test": /\\\\\\.svelte\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-            "options": {
-              "compilerOptions": {
-                "dev": false,
-              },
-              "emitCss": true,
-              "hotReload": false,
-              "preprocess": null,
-            },
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
           },
-        ],
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": null,
+        },
       },
     ],
   },
-  "plugins": [
-    RsbuildCorePlugin {},
-  ],
-  "resolve": {
-    "conditionNames": [
-      "svelte",
-      "...",
-    ],
-    "extensions": [
-      ".svelte",
-    ],
-    "mainFields": [
-      "svelte",
-      "...",
-    ],
-  },
-  "resolveLoader": {
-    "alias": {
-      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-    },
-  },
-}
+]
 `;
 
 exports[`plugin-svelte > should set dev and hotReload to false in production mode 1`] = `
-{
-  "module": {
-    "rules": [
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
       {
-        "test": /\\\\\\.svelte\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-            "options": {
-              "compilerOptions": {
-                "dev": false,
-              },
-              "emitCss": true,
-              "hotReload": false,
-              "preprocess": {
-                "markup": [Function],
-                "script": [Function],
-                "style": [Function],
-              },
-            },
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
           },
-        ],
+          "emitCss": true,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
       },
     ],
   },
-  "plugins": [
-    RsbuildCorePlugin {},
-  ],
-  "resolve": {
-    "conditionNames": [
-      "svelte",
-      "...",
-    ],
-    "extensions": [
-      ".svelte",
-    ],
-    "mainFields": [
-      "svelte",
-      "...",
-    ],
-  },
-  "resolveLoader": {
-    "alias": {
-      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-    },
-  },
-}
+]
 `;
 
 exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
-{
-  "module": {
-    "rules": [
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
       {
-        "test": /\\\\\\.svelte\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-            "options": {
-              "compilerOptions": {
-                "dev": false,
-              },
-              "emitCss": true,
-              "hotReload": false,
-              "preprocess": {
-                "markup": [Function],
-                "script": [Function],
-                "style": [Function],
-              },
-            },
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
           },
-        ],
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
       },
     ],
   },
-  "plugins": [
-    RsbuildCorePlugin {},
-  ],
-  "resolve": {
-    "conditionNames": [
-      "svelte",
-      "...",
-    ],
-    "extensions": [
-      ".svelte",
-    ],
-    "mainFields": [
-      "svelte",
-      "...",
-    ],
-  },
-  "resolveLoader": {
-    "alias": {
-      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-    },
-  },
-}
+]
 `;
 
 exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
-{
-  "module": {
-    "rules": [
+[
+  {
+    "test": /\\\\\\.svelte\\$/,
+    "use": [
       {
-        "test": /\\\\\\.svelte\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-            "options": {
-              "compilerOptions": {
-                "dev": false,
-              },
-              "emitCss": true,
-              "hotReload": false,
-              "preprocess": {
-                "markup": [Function],
-                "script": [Function],
-                "style": [Function],
-              },
-            },
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
           },
-        ],
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
+          },
+        },
       },
     ],
   },
-  "plugins": [
-    RsbuildCorePlugin {},
-  ],
-  "resolve": {
-    "conditionNames": [
-      "svelte",
-      "...",
-    ],
-    "extensions": [
-      ".svelte",
-    ],
-    "mainFields": [
-      "svelte",
-      "...",
-    ],
-  },
-  "resolveLoader": {
-    "alias": {
-      "svelte-loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-    },
-  },
-}
+]
 `;

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -1,80 +1,102 @@
-import { createStubRsbuild } from '@scripts/test-helper';
+import { createRsbuild } from '@rsbuild/core';
+import { matchRules } from '@scripts/test-helper';
 import { pluginSvelte } from '../src';
 
 describe('plugin-svelte', () => {
-  it('should add svelte loader properly', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [pluginSvelte()],
+  it('should add svelte loader and resolve config properly', async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [pluginSvelte()],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
 
-    expect(config).toMatchSnapshot();
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    expect(bundlerConfigs[0].resolve).toMatchSnapshot();
+  });
+
+  it('should add rule for `.svelte.js` and `.svelte.ts` as expected', async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [pluginSvelte()],
+      },
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte.js')).toMatchSnapshot();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte.ts')).toMatchSnapshot();
   });
 
   it('should set dev and hotReload to false in production mode', async () => {
+    const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'production';
-
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [pluginSvelte()],
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [pluginSvelte()],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
+    process.env.NODE_ENV = NODE_ENV;
   });
 
   it('should turn off HMR by hand correctly', async () => {
-    const rsbuild = await createStubRsbuild({
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
       rsbuildConfig: {
         dev: {
           hmr: false,
         },
+        plugins: [pluginSvelte()],
       },
-      plugins: [pluginSvelte()],
     });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 
   it('should override default svelte-loader options throw options.svelteLoaderOptions', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [
-        pluginSvelte({
-          svelteLoaderOptions: {
-            preprocess: null,
-          },
-        }),
-      ],
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [
+          pluginSvelte({
+            svelteLoaderOptions: {
+              preprocess: null,
+            },
+          }),
+        ],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 
   it('should support pass custom preprocess options', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [
-        pluginSvelte({
-          preprocessOptions: {
-            aliases: [
-              ['potato', 'potatoLanguage'],
-              ['pot', 'potatoLanguage'],
-            ],
-            /** Add a custom language preprocessor */
-            potatoLanguage: ({ content }: { content: string }) => {
-              const { code, map } = require('potato-language').render(content);
-              return { code, map };
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [
+          pluginSvelte({
+            preprocessOptions: {
+              aliases: [
+                ['potato', 'potatoLanguage'],
+                ['pot', 'potatoLanguage'],
+              ],
+              /** Add a custom language preprocessor */
+              potatoLanguage: ({ content }: { content: string }) => {
+                const { code, map } =
+                  require('potato-language').render(content);
+                return { code, map };
+              },
             },
-          },
-        }),
-      ],
+          }),
+        ],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.svelte')).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Fix `*.svslte.ts` and `*.svslte.js` files are transformed twice, we should exclude them from the builtin JS/TS rules.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
