### PR TITLE
fix: proxy type error

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -116,6 +116,22 @@ export default {
             )}`,
         );
       },
+      afterBundle(task) {
+        replaceFileContent(
+          join(task.distPath, 'index.d.ts'),
+          (content) =>
+            // TODO: Due to the breaking change of http-proxy-middleware, it needs to be upgraded in rsbuild 2.0
+            // https://github.com/chimurai/http-proxy-middleware/pull/730
+            `${content
+              .replace('express.Request', 'http.IncomingMessage')
+              .replace('express.Response', 'http.ServerResponse')
+              .replace(
+                'extends express.RequestHandler {',
+                `{
+  (req: Request, res: Response, next?: (err?: any) => void): void | Promise<void>;`,
+              )}`,
+        );
+      },
     },
     {
       // The webpack-bundle-analyzer version was locked to v4.9.0 to be compatible with Rspack


### PR DESCRIPTION
## Summary

The proxy type of `http-proxy-middleware` refers to express, but express is not actually used in rsbuild.

This problem will be temporarily fixed in the prebundle. To completely fix this problem I think we need to upgrade to `http-proxy-middleware` v3 (maybe rsbuild v2)

## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/3924

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
