### PR TITLE
chore(core): use Rslib to bundle client code

### DIFF
--- a/packages/core/modern.config.ts
+++ b/packages/core/modern.config.ts
@@ -109,26 +109,6 @@ export default defineConfig({
         return options;
       },
     },
-    // Client / ESM
-    {
-      format: 'esm',
-      input: {
-        hmr: 'src/client/hmr.ts',
-        overlay: 'src/client/overlay.ts',
-      },
-      target: BUILD_TARGET.client,
-      dts: false,
-      externals: ['./hmr'],
-      outDir: './dist/client',
-      autoExtension: true,
-      externalHelpers: true,
-      // Skip esbuild transform and only use SWC to transform,
-      // because esbuild will transform `import.meta`.
-      esbuildOptions: (options) => {
-        options.target = undefined;
-        return options;
-      },
-    },
     // Types
     {
       externals,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@modern-js/module-tools": "^2.61.0",
-    "@rslib/core": "^0.0.16",
+    "@rslib/core": "0.0.16",
     "@types/connect": "3.4.38",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "18.x",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,8 @@
     "types.d.ts"
   ],
   "scripts": {
-    "build": "modern build && tsc-alias -p tsconfig.json",
+    "build": "modern build && rslib build && tsc-alias -p tsconfig.json",
+    "build:rslib": "rslib build",
     "dev": "modern build --watch",
     "prebundle": "prebundle"
   },
@@ -58,6 +59,7 @@
   },
   "devDependencies": {
     "@modern-js/module-tools": "^2.61.0",
+    "@rslib/core": "^0.0.16",
     "@types/connect": "3.4.38",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "18.x",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@rslib/core';
+
+export default defineConfig({
+  lib: [
+    // Client / ESM
+    {
+      format: 'esm',
+      syntax: 'es2017',
+      source: {
+        entry: {
+          hmr: 'src/client/hmr.ts',
+          overlay: 'src/client/overlay.ts',
+        },
+        define: {
+          WEBPACK_HASH: '__webpack_hash__',
+        },
+      },
+      output: {
+        target: 'web',
+        externals: ['./hmr'],
+        distPath: {
+          root: './dist/client',
+        },
+      },
+    },
+  ],
+});

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -120,7 +120,7 @@ function handleErrors(errors: Rspack.StatsError[]) {
 
 // __webpack_hash__ is the hash of the current compilation.
 // It's a global variable injected by Rspack.
-const isUpdateAvailable = () => lastCompilationHash !== __webpack_hash__;
+const isUpdateAvailable = () => lastCompilationHash !== WEBPACK_HASH;
 
 // Attempt to update code on the fly, fall back to a hard reload.
 function tryApplyUpdates() {

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,7 +1,9 @@
 declare const RSBUILD_VERSION;
 
-declare let RSBUILD_CLIENT_CONFIG: ClientConfig;
+declare const WEBPACK_HASH: string;
 
-declare let RSBUILD_DEV_LIVE_RELOAD: boolean;
+declare const RSBUILD_CLIENT_CONFIG: ClientConfig;
 
-declare let RSBUILD_COMPILATION_NAME: string;
+declare const RSBUILD_DEV_LIVE_RELOAD: boolean;
+
+declare const RSBUILD_COMPILATION_NAME: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -590,6 +590,9 @@ importers:
       '@modern-js/module-tools':
         specifier: ^2.61.0
         version: 2.61.0(typescript@5.6.3)
+      '@rslib/core':
+        specifier: ^0.0.16
+        version: 0.0.16(typescript@5.6.3)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,7 +591,7 @@ importers:
         specifier: ^2.61.0
         version: 2.61.0(typescript@5.6.3)
       '@rslib/core':
-        specifier: ^0.0.16
+        specifier: 0.0.16
         version: 0.0.16(typescript@5.6.3)
       '@types/connect':
         specifier: 3.4.38


### PR DESCRIPTION
## Summary

I'm gradually switching @rsbuild/core's build tool from Modern.js Module to Rslib, and this is the first PR for it.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
