### PR TITLE
feat: update the assignment method of host in baseUrl

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -139,6 +139,7 @@ export async function open({
   clearCache?: boolean;
 }): Promise<void> {
   const { targets, before } = normalizeOpenConfig(config);
+  const host = config.server.host || 'localhost';
 
   // Skip open in codesandbox. After being bundled, the `open` package will
   // try to call system xdg-open, which will cause an error on codesandbox.
@@ -154,7 +155,7 @@ export async function open({
 
   const urls: string[] = [];
   const protocol = https ? 'https' : 'http';
-  const baseUrl = `${protocol}://localhost:${port}`;
+  const baseUrl = `${protocol}://${host}:${port}`;
 
   if (!targets.length) {
     if (routes.length) {


### PR DESCRIPTION
## Summary
When local development is allowed and the browser is automatically opened, the host of baseUrl uses the server host configuration by default, instead of directly defaulting to hard-coding localhost
(although it can be specified through open, it is more troublesome for those who use the default open configuration)
## Related Links
![20241112-112748](https://github.com/user-attachments/assets/afcbc64b-3538-4945-82ff-72873e17ccd4)
![20241112-112756](https://github.com/user-attachments/assets/d73a9395-367d-471a-81af-0f56361754ff)
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
