### PR TITLE
fix: line breaks ` \n` in error overlay messages

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -179,7 +179,7 @@ class ErrorOverlay extends HTMLElement {
     const root = this.attachShadow({ mode: 'open' });
     root.innerHTML = overlayTemplate;
 
-    linkedText(root, '.content', stripAnsi(message.join('/n')).trim());
+    linkedText(root, '.content', stripAnsi(message.join('\n')).trim());
 
     root.querySelector('.close')?.addEventListener('click', this.close);
 


### PR DESCRIPTION
换行符设置错误，导致 overlay 显示的信息，折行不正确
