### PR TITLE
chore(build): enable Rslib's `dts.build`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,9 +46,8 @@
     "types.d.ts"
   ],
   "scripts": {
-    "build": "pnpm run build:types && rslib build",
-    "build:types": "rimraf ./dist-types && tsc --build --force --emitDeclarationOnly",
-    "dev": "pnpm run build:types && rslib build --watch",
+    "build": "rslib build",
+    "dev": "rslib build --watch",
     "prebundle": "prebundle"
   },
   "dependencies": {

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { pluginCleanTscCache } from '@rsbuild/config/rslib.config';
 import { defineConfig } from '@rslib/core';
 import type { Configuration } from '@rspack/core';
 import pkgJson from './package.json';
@@ -81,7 +82,7 @@ export default defineConfig({
           __dirname: true,
         },
       },
-      plugins: [pluginFixDtsTypes],
+      plugins: [pluginFixDtsTypes, pluginCleanTscCache],
       dts: {
         build: true,
       },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -127,6 +127,7 @@ export default defineConfig({
           overlay: 'src/client/overlay.ts',
         },
         define: {
+          // use define to avoid compile time evaluation of __webpack_hash__
           WEBPACK_HASH: '__webpack_hash__',
         },
       },

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -82,6 +82,9 @@ export default defineConfig({
         },
       },
       plugins: [pluginFixDtsTypes],
+      dts: {
+        build: true,
+      },
     },
     // Node / CJS
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,6 +1111,12 @@ importers:
 
   scripts/config:
     devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@rslib/core':
+        specifier: 0.0.16
+        version: 0.0.16(typescript@5.6.3)
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.1",
   "private": true,
   "devDependencies": {
+    "@rsbuild/core": "workspace:*",
+    "@rslib/core": "0.0.16",
     "@types/node": "^22.9.0",
     "typescript": "^5.6.3"
   }

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { RsbuildPlugin } from '@rsbuild/core';
 import { type LibConfig, defineConfig } from '@rslib/core';
 
 export const commonExternals: Array<string | RegExp> = [
@@ -5,10 +8,28 @@ export const commonExternals: Array<string | RegExp> = [
   /[\\/]compiled[\\/]/,
 ];
 
+export const pluginCleanTscCache: RsbuildPlugin = {
+  name: 'plugin-clean-tsc-cache',
+  setup(api) {
+    api.onBeforeBuild(() => {
+      const tsbuildinfo = path.join(
+        api.context.rootPath,
+        'tsconfig.tsbuildinfo',
+      );
+      if (fs.existsSync(tsbuildinfo)) {
+        fs.rmSync(tsbuildinfo);
+      }
+    });
+  },
+};
+
 export const esmConfig: LibConfig = {
   format: 'esm',
   syntax: 'es2021',
-  dts: { build: true },
+  dts: {
+    build: true,
+  },
+  plugins: [pluginCleanTscCache],
 };
 
 export const cjsConfig: LibConfig = {

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -8,7 +8,7 @@ export const commonExternals: Array<string | RegExp> = [
 export const esmConfig: LibConfig = {
   format: 'esm',
   syntax: 'es2021',
-  dts: { bundle: false },
+  dts: { build: true },
 };
 
 export const cjsConfig: LibConfig = {

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -8,6 +8,7 @@ export const commonExternals: Array<string | RegExp> = [
   /[\\/]compiled[\\/]/,
 ];
 
+// Clean tsc cache to ensure the dts files can be generated correctly
 export const pluginCleanTscCache: RsbuildPlugin = {
   name: 'plugin-clean-tsc-cache',
   setup(api) {


### PR DESCRIPTION
## Summary

Enable Rslib's `dts.build` for incremental building project references.

## Related Links

https://github.com/web-infra-dev/rslib/pull/337

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
