### PR TITLE
perf: bump chokidar to v4 and remove fsevents dependency

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,7 +73,6 @@
     // require Node 18
     'copy-webpack-plugin',
     // major version contains breaking changes
-    'chokidar',
     'style-loader',
     'http-proxy-middleware',
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,12 +60,13 @@
     "@rslib/core": "0.0.18",
     "@types/connect": "3.4.38",
     "@types/fs-extra": "^11.0.4",
+    "@types/is-glob": "^4.0.4",
     "@types/node": "^22.9.0",
     "@types/on-finished": "2.3.4",
     "@types/webpack-bundle-analyzer": "4.7.0",
     "@types/ws": "^8.5.13",
     "browserslist-load-config": "1.0.0",
-    "chokidar": "3.6.0",
+    "chokidar": "^4.0.1",
     "commander": "^12.1.0",
     "connect": "3.7.0",
     "connect-history-api-fallback": "^2.0.0",
@@ -76,6 +77,7 @@
     "fs-extra": "^11.2.0",
     "html-rspack-plugin": "6.0.2",
     "http-proxy-middleware": "^2.0.6",
+    "is-glob": "^4.0.3",
     "jiti": "^1.21.6",
     "launch-editor-middleware": "^2.9.1",
     "mrmime": "^2.0.0",
@@ -94,14 +96,12 @@
     "rspack-manifest-plugin": "5.0.2",
     "sirv": "^3.0.0",
     "style-loader": "3.3.4",
+    "tinyglobby": "^0.2.10",
     "typescript": "^5.6.3",
     "webpack": "^5.96.1",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-merge": "6.0.1",
     "ws": "^8.18.0"
-  },
-  "optionalDependencies": {
-    "fsevents": "~2.3.3"
   },
   "engines": {
     "node": ">=16.7.0"

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -40,12 +40,7 @@ export default {
     'html-rspack-plugin',
     'mrmime',
     'tinyglobby',
-    {
-      name: 'chokidar',
-      externals: {
-        fsevents: 'fsevents',
-      },
-    },
+    'chokidar',
     {
       name: 'picocolors',
       beforeBundle({ depPath }) {

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -39,6 +39,7 @@ export default {
     'webpack-merge',
     'html-rspack-plugin',
     'mrmime',
+    'tinyglobby',
     {
       name: 'chokidar',
       externals: {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -60,14 +60,14 @@ export async function init({
 
           const paths = castArray(watchFilesConfig.paths);
           if (watchFilesConfig.options) {
-            watchFilesForRestart(paths, watchFilesConfig.options);
+            watchFilesForRestart(paths, root, watchFilesConfig.options);
           } else {
             files.push(...paths);
           }
         }
       }
 
-      watchFilesForRestart(files);
+      watchFilesForRestart(files, root);
     }
 
     config.source ||= {};

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join } from 'node:path';
-import type { WatchOptions } from '../compiled/chokidar/index.js';
+import type { ChokidarOptions } from '../compiled/chokidar/index.js';
 import RspackChain from '../compiled/rspack-chain/index.js';
 import {
   ASSETS_DIST_DIR,
@@ -33,6 +33,7 @@ import {
 import { logger } from './logger';
 import { mergeRsbuildConfig } from './mergeConfig';
 import { restartDevServer } from './server/restart';
+import { createChokidar } from './server/watchFiles.js';
 import type {
   InspectConfigOptions,
   InspectConfigResult,
@@ -348,14 +349,14 @@ const resolveConfigPath = (root: string, customConfig?: string) => {
 
 export async function watchFilesForRestart(
   files: string[],
-  watchOptions?: WatchOptions,
+  root: string,
+  watchOptions?: ChokidarOptions,
 ): Promise<void> {
   if (!files.length) {
     return;
   }
 
-  const chokidar = await import('../compiled/chokidar/index.js');
-  const watcher = chokidar.watch(files, {
+  const watcher = await createChokidar(files, root, {
     // do not trigger add for initial files
     ignoreInitial: true,
     // If watching fails due to read permissions, the errors will be suppressed silently.

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -249,13 +249,14 @@ export async function createDevServer<
 
   const compileMiddlewareAPI = runCompile ? await startCompile() : undefined;
 
+  const root = options.context.rootPath;
+
   const fileWatcher = await setupWatchFiles({
     dev: devConfig,
     server: config.server,
     compileMiddlewareAPI,
+    root,
   });
-
-  const pwd = options.context.rootPath;
 
   const readFileSync = (fileName: string) => {
     if ('readFileSync' in outputFileSystem) {
@@ -298,7 +299,7 @@ export async function createDevServer<
   );
 
   const devMiddlewares = await getMiddlewares({
-    pwd,
+    pwd: root,
     compileMiddlewareAPI,
     dev: devConfig,
     server: config.server,

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -117,7 +117,7 @@ function prepareWatchOptions(
 }
 
 export async function createChokidar(
-  pathsOrGlobs: string[],
+  pathOrGlobs: string[],
   root: string,
   options: ChokidarOptions,
 ): Promise<FSWatcher> {
@@ -125,11 +125,11 @@ export async function createChokidar(
 
   const watchFiles: Set<string> = new Set();
 
-  const globPatterns = pathsOrGlobs.filter((pathsOrGlob) => {
-    if (isGlob(pathsOrGlob)) {
+  const globPatterns = pathOrGlobs.filter((pathOrGlob) => {
+    if (isGlob(pathOrGlob)) {
       return true;
     }
-    watchFiles.add(pathsOrGlob);
+    watchFiles.add(pathOrGlob);
     return false;
   });
 

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -134,10 +134,10 @@ export async function createChokidar(
   });
 
   if (globPatterns.length) {
-    const { default: tinyglobby } = await import(
-      '../../compiled/tinyglobby/index.js'
-    );
-    const files = await tinyglobby.glob(globPatterns, {
+    const tinyglobby = await import('../../compiled/tinyglobby/index.js');
+    // interop default to make both CJS and ESM work
+    const { glob } = tinyglobby.default || tinyglobby;
+    const files = await glob(globPatterns, {
       cwd: root,
       absolute: true,
     });

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -1,8 +1,9 @@
+import isGlob from 'is-glob';
 import type { FSWatcher } from '../../compiled/chokidar/index.js';
 import { normalizePublicDirs } from '../config';
 import { castArray } from '../helpers';
 import type {
-  ChokidarWatchOptions,
+  ChokidarOptions,
   DevConfig,
   ServerConfig,
   WatchFiles,
@@ -13,6 +14,7 @@ type WatchFilesOptions = {
   dev: DevConfig;
   server: ServerConfig;
   compileMiddlewareAPI?: CompileMiddlewareAPI;
+  root: string;
 };
 
 export async function setupWatchFiles(options: WatchFilesOptions): Promise<
@@ -21,17 +23,22 @@ export async function setupWatchFiles(options: WatchFilesOptions): Promise<
     }
   | undefined
 > {
-  const { dev, server, compileMiddlewareAPI } = options;
+  const { dev, server, root, compileMiddlewareAPI } = options;
 
   const { hmr, liveReload } = dev;
   if ((!hmr && !liveReload) || !compileMiddlewareAPI) {
     return;
   }
 
-  const closeDevFilesWatcher = await watchDevFiles(dev, compileMiddlewareAPI);
+  const closeDevFilesWatcher = await watchDevFiles(
+    dev,
+    compileMiddlewareAPI,
+    root,
+  );
   const serverFilesWatcher = await watchServerFiles(
     server,
     compileMiddlewareAPI,
+    root,
   );
 
   return {
@@ -47,6 +54,7 @@ export async function setupWatchFiles(options: WatchFilesOptions): Promise<
 async function watchDevFiles(
   devConfig: DevConfig,
   compileMiddlewareAPI: CompileMiddlewareAPI,
+  root: string,
 ) {
   const { watchFiles } = devConfig;
   if (!watchFiles) {
@@ -57,7 +65,11 @@ async function watchDevFiles(
 
   for (const { paths, options, type } of castArray(watchFiles)) {
     const watchOptions = prepareWatchOptions(paths, options, type);
-    const watcher = await startWatchFiles(watchOptions, compileMiddlewareAPI);
+    const watcher = await startWatchFiles(
+      watchOptions,
+      compileMiddlewareAPI,
+      root,
+    );
     if (watcher) {
       watchers.push(watcher);
     }
@@ -73,6 +85,7 @@ async function watchDevFiles(
 function watchServerFiles(
   serverConfig: ServerConfig,
   compileMiddlewareAPI: CompileMiddlewareAPI,
+  root: string,
 ) {
   const publicDirs = normalizePublicDirs(serverConfig.publicDir);
   if (!publicDirs.length) {
@@ -88,12 +101,12 @@ function watchServerFiles(
   }
 
   const watchOptions = prepareWatchOptions(watchPaths);
-  return startWatchFiles(watchOptions, compileMiddlewareAPI);
+  return startWatchFiles(watchOptions, compileMiddlewareAPI, root);
 }
 
 function prepareWatchOptions(
   paths: string | string[],
-  options: ChokidarWatchOptions = {},
+  options: ChokidarOptions = {},
   type?: WatchFiles['type'],
 ) {
   return {
@@ -103,17 +116,50 @@ function prepareWatchOptions(
   };
 }
 
+export async function createChokidar(
+  pathsOrGlobs: string[],
+  root: string,
+  options: ChokidarOptions,
+): Promise<FSWatcher> {
+  const chokidar = await import('../../compiled/chokidar/index.js');
+
+  const watchFiles: Set<string> = new Set();
+
+  const globPatterns = pathsOrGlobs.filter((pathsOrGlob) => {
+    if (isGlob(pathsOrGlob)) {
+      return true;
+    }
+    watchFiles.add(pathsOrGlob);
+    return false;
+  });
+
+  if (globPatterns.length) {
+    const { default: tinyglobby } = await import(
+      '../../compiled/tinyglobby/index.js'
+    );
+    const files = await tinyglobby.glob(globPatterns, {
+      cwd: root,
+      absolute: true,
+    });
+    for (const file of files) {
+      watchFiles.add(file);
+    }
+  }
+
+  return chokidar.watch(Array.from(watchFiles), options);
+}
+
 async function startWatchFiles(
   { paths, options, type }: ReturnType<typeof prepareWatchOptions>,
   compileMiddlewareAPI: CompileMiddlewareAPI,
+  root: string,
 ) {
   // If `type` is 'reload-server', skip it.
   if (type === 'reload-server') {
     return;
   }
 
-  const chokidar = await import('../../compiled/chokidar/index.js');
-  const watcher = chokidar.watch(paths, options);
+  const watcher = await createChokidar(paths, root, options);
 
   watcher.on('change', () => {
     compileMiddlewareAPI.sockWrite('static-changed');

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -12,7 +12,7 @@ import type {
   SwcLoaderOptions,
   rspack,
 } from '@rspack/core';
-import type { WatchOptions } from '../../compiled/chokidar/index.js';
+import type { ChokidarOptions } from '../../compiled/chokidar/index.js';
 import type {
   Options as HttpProxyOptions,
   Filter as ProxyFilter,
@@ -1253,11 +1253,11 @@ export type ClientConfig = {
 export type NormalizedClientConfig = Pick<ClientConfig, 'protocol'> &
   Omit<Required<ClientConfig>, 'protocol'>;
 
-export type ChokidarWatchOptions = WatchOptions;
+export type { ChokidarOptions };
 
 export type WatchFiles = {
   paths: string | string[];
-  options?: WatchOptions;
+  options?: ChokidarOptions;
   type?: 'reload-page' | 'reload-server';
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,10 +582,6 @@ importers:
       core-js:
         specifier: ~3.39.0
         version: 3.39.0
-    optionalDependencies:
-      fsevents:
-        specifier: ~2.3.3
-        version: 2.3.3
     devDependencies:
       '@rslib/core':
         specifier: 0.0.18
@@ -596,6 +592,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/is-glob':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
@@ -612,8 +611,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       chokidar:
-        specifier: 3.6.0
-        version: 3.6.0
+        specifier: ^4.0.1
+        version: 4.0.1
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -644,6 +643,9 @@ importers:
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.7
+      is-glob:
+        specifier: ^4.0.3
+        version: 4.0.3
       jiti:
         specifier: ^1.21.6
         version: 1.21.6
@@ -698,6 +700,9 @@ importers:
       style-loader:
         specifier: 3.3.4
         version: 3.3.4(webpack@5.96.1)
+      tinyglobby:
+        specifier: ^0.2.10
+        version: 0.2.10
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -2908,6 +2913,9 @@ packages:
 
   '@types/http-proxy@1.17.15':
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
+
+  '@types/is-glob@4.0.4':
+    resolution: {integrity: sha512-3mFBtIPQ0TQetKRDe94g8YrxJZxdMillMGegyv6zRBXvq4peRRhf2wLZ/Dl53emtTsC29dQQBwYvovS20yXpiQ==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -8683,6 +8691,8 @@ snapshots:
   '@types/http-proxy@1.17.15':
     dependencies:
       '@types/node': 22.9.0
+
+  '@types/is-glob@4.0.4': {}
 
   '@types/json-schema@7.0.15': {}
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -62,8 +62,8 @@ mYbzBtlg6o
 napi
 nolyfill
 nosources
-nuxt
 ntqry
+nuxt
 oklab
 onclosetag
 onopentag
@@ -109,13 +109,14 @@ subdir
 subpage
 subresource
 subresources
-svgr
 sveltejs
+svgr
 swcrc
 systemjs
 tailwindcss
 taze
 templating
+tinyglobby
 transpiling
 treeshaking
 tsbuildinfo

--- a/website/docs/en/config/dev/watch-files.mdx
+++ b/website/docs/en/config/dev/watch-files.mdx
@@ -7,7 +7,7 @@ type WatchFiles = {
   paths: string | string[];
   type?: 'reload-page' | 'reload-server';
   // watch options for chokidar
-  options?: WatchOptions;
+  options?: ChokidarOptions;
 };
 
 type WatchFilesConfig = WatchFiles | WatchFiles[];
@@ -110,10 +110,10 @@ It should be noted that the reload-server functionality is provided by Rsbuild C
 
 ## options
 
-- **Type:** `WatchOptions`
+- **Type:** `ChokidarOptions`
 - **Default:** `undefined`
 
-`watchFiles` is implemented based on [chokidar v3](https://github.com/paulmillr/chokidar#api), and you can pass chokidar options through `options`.
+`watchFiles` is implemented based on [chokidar v4](https://github.com/paulmillr/chokidar#api), and you can pass chokidar options through `options`.
 
 ```js
 export default {

--- a/website/docs/zh/config/dev/watch-files.mdx
+++ b/website/docs/zh/config/dev/watch-files.mdx
@@ -7,7 +7,7 @@ type WatchFilesOptions = {
   paths: string | string[];
   type?: 'reload-page' | 'reload-server';
   //  chokidar 选项
-  options?: WatchOptions;
+  options?: ChokidarOptions;
 };
 
 type WatchFilesConfig = WatchFiles | WatchFiles[];
@@ -110,10 +110,10 @@ export default {
 
 ## options
 
-- **类型：** `WatchOptions`
+- **类型：** `ChokidarOptions`
 - **默认值：** `undefined`
 
-`watchFiles` 是基于 [chokidar v3](https://github.com/paulmillr/chokidar#api) 实现的，你可以通过 `options` 传入 chokidar 的选项。
+`watchFiles` 是基于 [chokidar v4](https://github.com/paulmillr/chokidar#api) 实现的，你可以通过 `options` 传入 chokidar 的选项。
 
 ```js
 export default {


### PR DESCRIPTION
## Summary

- Bump chokidar to [v4](https://github.com/paulmillr/chokidar/releases) and remove fsevents dependency.
- Use [tinyglobby](https://github.com/SuperchupuDev/tinyglobby) to support glob paths and avoid introducing break change.

The dev startup is now 4ms faster.

- before:

<img width="480" alt="Screenshot 2024-11-13 at 17 10 40" src="https://github.com/user-attachments/assets/6853e20b-1668-422f-9c0f-1a3d90304864">

- after:

<img width="486" alt="Screenshot 2024-11-13 at 17 11 58" src="https://github.com/user-attachments/assets/3a5c7f02-4b8b-4b26-ac91-21b84a5e5147">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
