### PR TITLE
fix: `watchFiles.type` not work as expected

### DIFF
--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -4,16 +4,19 @@ import path from 'node:path';
 import { awaitFileExists, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
+const dist = path.join(__dirname, 'dist');
 const tempConfigPath = './test-temp-config.ts';
+const tempOutputFile = path.join(__dirname, 'test-temp-file.txt');
+const extraConfigFile = path.join(__dirname, tempConfigPath);
+
+test.beforeEach(() => {
+  fs.rmSync(dist, { recursive: true, force: true });
+  fs.rmSync(tempOutputFile, { force: true });
+  fs.rmSync(extraConfigFile, { force: true });
+  fs.writeFileSync(extraConfigFile, 'export default 1;');
+});
 
 test('should restart dev server when extra config file changed', async () => {
-  const dist = path.join(__dirname, 'dist');
-  const extraConfigFile = path.join(__dirname, tempConfigPath);
-
-  fs.rmSync(extraConfigFile, { force: true });
-  fs.rmSync(dist, { recursive: true, force: true });
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
-
   const childProcess = exec('npx rsbuild dev', {
     cwd: __dirname,
     env: {
@@ -23,27 +26,21 @@ test('should restart dev server when extra config file changed', async () => {
     },
   });
 
+  // the first build
   await awaitFileExists(dist);
 
-  fs.rmSync(dist, { recursive: true });
-  // temp config changed
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 2 };');
+  fs.rmSync(tempOutputFile, { force: true });
+  // temp config changed and trigger rebuild
+  fs.writeFileSync(extraConfigFile, 'export default 2;');
 
   // rebuild and generate dist files
-  await awaitFileExists(dist);
-  expect(fs.existsSync(path.join(dist, 'temp.txt')));
+  await awaitFileExists(tempOutputFile);
+  expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('2');
 
   childProcess.kill();
 });
 
 test('should not restart dev server if `watchFiles.type` is `reload-page`', async () => {
-  const dist = path.join(__dirname, 'dist');
-  const extraConfigFile = path.join(__dirname, tempConfigPath);
-
-  fs.rmSync(extraConfigFile, { force: true });
-  fs.rmSync(dist, { recursive: true, force: true });
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
-
   const childProcess = exec('npx rsbuild dev', {
     cwd: __dirname,
     env: {
@@ -57,22 +54,15 @@ test('should not restart dev server if `watchFiles.type` is `reload-page`', asyn
 
   fs.rmSync(dist, { recursive: true });
   // temp config changed
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 2 };');
+  fs.writeFileSync(extraConfigFile, 'export default 2;');
 
   await new Promise((resolve) => setTimeout(resolve, 300));
-  expect(fs.existsSync(path.join(dist, 'temp.txt'))).toBeFalsy();
+  expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
 
   childProcess.kill();
 });
 
 test('should not restart dev server if `watchFiles.type` is not set', async () => {
-  const dist = path.join(__dirname, 'dist');
-  const extraConfigFile = path.join(__dirname, tempConfigPath);
-
-  fs.rmSync(extraConfigFile, { force: true });
-  fs.rmSync(dist, { recursive: true, force: true });
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
-
   const childProcess = exec('npx rsbuild dev', {
     cwd: __dirname,
     env: {
@@ -85,10 +75,10 @@ test('should not restart dev server if `watchFiles.type` is not set', async () =
 
   fs.rmSync(dist, { recursive: true });
   // temp config changed
-  fs.writeFileSync(extraConfigFile, 'export default { foo: 2 };');
+  fs.writeFileSync(extraConfigFile, 'export default 2;');
 
   await new Promise((resolve) => setTimeout(resolve, 300));
-  expect(fs.existsSync(path.join(dist, 'temp.txt'))).toBeFalsy();
+  expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
 
   childProcess.kill();
 });

--- a/e2e/cases/cli/watch-files/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files/rsbuild.config.ts
@@ -6,9 +6,9 @@ import content from './test-temp-config';
 const testPlugin: RsbuildPlugin = {
   name: 'test-plugin',
   setup(api) {
-    api.onBeforeBuild(() => {
+    api.onBeforeCreateCompiler(() => {
       fse.outputFileSync(
-        path.join(api.context.distPath, 'temp.txt'),
+        path.join(__dirname, 'test-temp-file.txt'),
         JSON.stringify(content),
       );
     });

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -54,7 +54,7 @@ export async function init({
 
       if (config.dev?.watchFiles) {
         for (const watchFilesConfig of castArray(config.dev.watchFiles)) {
-          if (watchFilesConfig.type === 'reload-page') {
+          if (watchFilesConfig.type !== 'reload-server') {
             continue;
           }
 

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -104,11 +104,14 @@ function prepareWatchOptions(
 }
 
 async function startWatchFiles(
-  { paths, options, type }: ReturnType<typeof prepareWatchOptions>,
+  {
+    paths,
+    options,
+    type = 'reload-page',
+  }: ReturnType<typeof prepareWatchOptions>,
   compileMiddlewareAPI: CompileMiddlewareAPI,
 ) {
-  // If `type` is 'reload-server', skip it.
-  if (type === 'reload-server') {
+  if (type !== 'reload-page') {
     return;
   }
 


### PR DESCRIPTION
## Summary

If `watchFiles.type` is `undefined`, the default type should be `reload-page` as documented.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
