### PR TITLE
fix(plugin-vue): should transpile all Vue SFC

### DIFF
--- a/.changeset/proud-trains-dance.md
+++ b/.changeset/proud-trains-dance.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-vue': patch
+---
+
+bump

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should build Vue sfc correctly', async () => {
+rspackOnlyTest('should build Vue SFC correctly', async () => {
   execSync('npx rsbuild build', {
     cwd: __dirname,
   });

--- a/e2e/cases/vue/sfc-basic/index.test.ts
+++ b/e2e/cases/vue/sfc-basic/index.test.ts
@@ -1,7 +1,7 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should build basic Vue sfc correctly', async ({ page }) => {
+rspackOnlyTest('should build basic Vue SFC correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
     page,

--- a/e2e/cases/vue/sfc-css-modules/index.test.ts
+++ b/e2e/cases/vue/sfc-css-modules/index.test.ts
@@ -2,7 +2,7 @@ import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
-  'should build Vue sfc with CSS Modules correctly in dev build',
+  'should build Vue SFC with CSS Modules correctly in dev build',
   async ({ page }) => {
     const rsbuild = await dev({
       cwd: __dirname,
@@ -22,7 +22,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
-  'should build Vue sfc with CSS Modules correctly in prod build',
+  'should build Vue SFC with CSS Modules correctly in prod build',
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,

--- a/e2e/cases/vue/sfc-in-node-modules/index.test.ts
+++ b/e2e/cases/vue/sfc-in-node-modules/index.test.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import fse from 'fs-extra';
+
+rspackOnlyTest(
+  'should transpile Vue SFC in node_modules correctly',
+  async () => {
+    fse.outputFileSync(
+      path.resolve(__dirname, 'node_modules/foo/package.json'),
+      JSON.stringify({
+        name: 'foo',
+        version: '1.0.0',
+        main: 'index.vue',
+      }),
+    );
+    fse.outputFileSync(
+      path.resolve(__dirname, 'node_modules/foo/index.vue'),
+      '<template><div :test="window?.foo" /></template>',
+    );
+
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+
+    const { content } = await rsbuild.getIndexFile();
+    expect(content).not.toContain('window?.foo');
+    // should transpile optional chaining
+    expect(content).toContain('test:null===');
+  },
+);

--- a/e2e/cases/vue/sfc-in-node-modules/rsbuild.config.ts
+++ b/e2e/cases/vue/sfc-in-node-modules/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+});

--- a/e2e/cases/vue/sfc-in-node-modules/src/A.vue
+++ b/e2e/cases/vue/sfc-in-node-modules/src/A.vue
@@ -1,0 +1,7 @@
+<template>
+  <Foo />
+</template>
+
+<script setup>
+import Foo from 'foo';
+</script>

--- a/e2e/cases/vue/sfc-in-node-modules/src/index.js
+++ b/e2e/cases/vue/sfc-in-node-modules/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import A from './A.vue';
+
+createApp(A).mount('#root');

--- a/e2e/cases/vue/sfc-lang-pcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-pcss/index.test.ts
@@ -2,7 +2,7 @@ import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
-  'should build Vue sfc with lang="postcss" correctly',
+  'should build Vue SFC with lang="postcss" correctly',
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,

--- a/e2e/cases/vue/sfc-lang-postcss/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-postcss/index.test.ts
@@ -2,7 +2,7 @@ import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
-  'should build Vue sfc with lang="postcss" correctly',
+  'should build Vue SFC with lang="postcss" correctly',
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,

--- a/e2e/cases/vue/sfc-lang-ts/index.test.ts
+++ b/e2e/cases/vue/sfc-lang-ts/index.test.ts
@@ -2,7 +2,7 @@ import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
-  'should build Vue sfc with lang="ts" correctly',
+  'should build Vue SFC with lang="ts" correctly',
   async ({ page }) => {
     const rsbuild = await build({
       cwd: __dirname,

--- a/e2e/cases/vue/sfc-style/index.test.ts
+++ b/e2e/cases/vue/sfc-style/index.test.ts
@@ -1,7 +1,7 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should build Vue sfc style correctly', async ({ page }) => {
+rspackOnlyTest('should build Vue SFC style correctly', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
     page,

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -49,6 +49,8 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
               __VUE_PROD_DEVTOOLS__: false,
               __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: false,
             },
+            // should transpile all scripts from Vue SFC
+            include: [/\.vue.js$/],
           },
         };
 


### PR DESCRIPTION
## Summary

By default, Rsbuild only compiles JavaScript files in the current directory and TypeScript and JSX files in all directories. It does not compile JavaScript files under node_modules.

But the scripts from Vue SFC should be always transpiled, adding `/\.vue.js$/` to `source.include` can fix this.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3956

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
