### PR TITLE
perf(build): custom Rslib minify options for Node output

### DIFF
--- a/packages/compat/webpack/rslib.config.ts
+++ b/packages/compat/webpack/rslib.config.ts
@@ -3,14 +3,14 @@ import {
   dualPackage,
   esmConfig,
 } from '@rsbuild/config/rslib.config.ts';
+import { mergeRsbuildConfig } from '@rsbuild/core';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   ...dualPackage,
   lib: [
     esmConfig,
-    {
-      ...cjsConfig,
+    mergeRsbuildConfig(cjsConfig, {
       output: {
         // TODO https://github.com/web-infra-dev/rslib/issues/287
         externals: {
@@ -26,6 +26,6 @@ export default defineConfig({
         js: `// Annotate the CommonJS export names for ESM import in node:
 0 && (module.exports = { webpackProvider: exports.webpackProvider });`,
       },
-    },
+    }),
   ],
 });

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { pluginCleanTscCache } from '@rsbuild/config/rslib.config';
+import {
+  nodeMinifyConfig,
+  pluginCleanTscCache,
+} from '@rsbuild/config/rslib.config';
 import { defineConfig } from '@rslib/core';
 import type { Configuration } from '@rspack/core';
 import pkgJson from './package.json';
@@ -85,6 +88,9 @@ export default defineConfig({
       dts: {
         build: true,
       },
+      output: {
+        minify: nodeMinifyConfig,
+      },
     },
     // Node / CJS
     {
@@ -97,6 +103,9 @@ export default defineConfig({
           transformLoader: './src/loader/transformLoader.ts',
           transformRawLoader: './src/loader/transformRawLoader.ts',
         },
+      },
+      output: {
+        minify: nodeMinifyConfig,
       },
       footer: {
         // TODO https://github.com/web-infra-dev/rslib/issues/351

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -1,12 +1,24 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { RsbuildPlugin } from '@rsbuild/core';
+import type { Minify, RsbuildPlugin } from '@rsbuild/core';
 import { type LibConfig, defineConfig } from '@rslib/core';
 
 export const commonExternals: Array<string | RegExp> = [
   'webpack',
   /[\\/]compiled[\\/]/,
 ];
+
+export const nodeMinifyConfig: Minify = {
+  js: true,
+  css: false,
+  jsOptions: {
+    minimizerOptions: {
+      mangle: false,
+      minify: false,
+      compress: true,
+    },
+  },
+};
 
 // Clean tsc cache to ensure the dts files can be generated correctly
 export const pluginCleanTscCache: RsbuildPlugin = {
@@ -31,11 +43,17 @@ export const esmConfig: LibConfig = {
     build: true,
   },
   plugins: [pluginCleanTscCache],
+  output: {
+    minify: nodeMinifyConfig,
+  },
 };
 
 export const cjsConfig: LibConfig = {
   format: 'cjs',
   syntax: 'es2021',
+  output: {
+    minify: nodeMinifyConfig,
+  },
 };
 
 export const dualPackage = defineConfig({

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -13,6 +13,7 @@ export const nodeMinifyConfig: Minify = {
   css: false,
   jsOptions: {
     minimizerOptions: {
+      // preserve variable name and disable minify for easier debugging
       mangle: false,
       minify: false,
       compress: true,


### PR DESCRIPTION
## Summary

Custom Rslib minify options for Node output, Rsbuild packages can enable the `compress` options of SWC minimizer to reduce the size of Node bundles. This can reduce memory usage and make the startup a little faster.

- before:

<img width="774" alt="Screenshot 2024-11-14 at 10 13 36" src="https://github.com/user-attachments/assets/13ed873c-fbcf-4f34-bac0-a653fa722115">

- after:

<img width="786" alt="Screenshot 2024-11-14 at 10 36 23" src="https://github.com/user-attachments/assets/fc89cd81-c723-4159-ae4a-cad561086bbc">


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
