### PR TITLE
fix: close API does not actually close the build

### DIFF
--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -31,7 +31,7 @@ export const build = async (
   });
 
   if (watch) {
-    const watching = compiler.watch({}, (err) => {
+    compiler.watch({}, (err) => {
       if (err) {
         logger.error(err);
       }
@@ -39,7 +39,7 @@ export const build = async (
     return {
       close: () =>
         new Promise((resolve) => {
-          watching.close(() => {
+          compiler.close(() => {
             resolve();
           });
         }),
@@ -73,8 +73,11 @@ export const build = async (
 
   return {
     stats,
-    // This close method is a noop in non-watch mode
-    // In watch mode, it's defined above to stop watching
-    close: async () => {},
+    close: () =>
+      new Promise((resolve) => {
+        compiler.close(() => {
+          resolve();
+        });
+      }),
   };
 };


### PR DESCRIPTION
## Summary

The build is not actually closed when `close()` is called, only watcher was closed before.

## Related Links

https://github.com/web-infra-dev/rspack/blob/8f75992e608d0e317ce94078f1b830d2d44121e6/packages/rspack/src/Compiler.ts#L646

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
