### PR TITLE
fix(plugin-stylus): `stylusOptions.import` should be an array

### DIFF
--- a/.changeset/popular-roses-learn.md
+++ b/.changeset/popular-roses-learn.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-stylus': patch
+---
+
+bump

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -11,7 +11,12 @@ type StylusOptions = {
   use?: string[];
   define?: [string, any, boolean?];
   include?: string[];
-  import?: string;
+  /**
+   * Import the specified Stylus files/paths, can not be relative path.
+   * @example import: ["nib", path.join(__dirname, "src/styl/mixins")],
+   * @default []
+   */
+  import?: string[];
   resolveURL?: boolean;
   lineNumbers?: boolean;
   hoistAtrules?: boolean;

--- a/website/docs/en/plugins/list/plugin-stylus.mdx
+++ b/website/docs/en/plugins/list/plugin-stylus.mdx
@@ -69,7 +69,7 @@ type StylusOptions = {
   use?: string[];
   define?: [string, any, boolean?];
   include?: string[];
-  import?: string;
+  import?: string[];
   resolveURL?: boolean;
   lineNumbers?: boolean;
   hoistAtrules?: boolean;

--- a/website/docs/zh/plugins/list/plugin-stylus.mdx
+++ b/website/docs/zh/plugins/list/plugin-stylus.mdx
@@ -69,7 +69,7 @@ type StylusOptions = {
   use?: string[];
   define?: [string, any, boolean?];
   include?: string[];
-  import?: string;
+  import?: string[];
   resolveURL?: boolean;
   lineNumbers?: boolean;
   hoistAtrules?: boolean;


### PR DESCRIPTION
## Summary

`stylusOptions.import` should be `string[]` instead of `string`, see https://github.com/webpack-contrib/stylus-loader?tab=readme-ov-file#object

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/3971

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
