### PR TITLE
test: replace strip-ansi with Node.js builtin util

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,7 +63,6 @@
     'loader-utils',
     // pure ESM packages can not be used now
     'open',
-    'strip-ansi',
     'ansi-escapes',
     'cli-truncate',
     'patch-console',

--- a/e2e/cases/assets/assets-retry/index.test.ts
+++ b/e2e/cases/assets/assets-retry/index.test.ts
@@ -1,10 +1,10 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { dev, getRandomPort, gotoPage, proxyConsole } from '@e2e/helper';
 import { type Page, expect, test } from '@playwright/test';
 import { type RequestHandler, logger } from '@rsbuild/core';
 import { pluginAssetsRetry } from '@rsbuild/plugin-assets-retry';
 import type { PluginAssetsRetryOptions } from '@rsbuild/plugin-assets-retry';
 import { pluginReact } from '@rsbuild/plugin-react';
-import stripAnsi from 'strip-ansi';
 
 // TODO: write a common testMiddleware instead of collect DEBUG logger
 

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@playwright/test';
 import { waitFor } from 'scripts';
-import stripAnsi from 'strip-ansi';
 
 test('should display shortcuts as expected in dev', async () => {
   const devProcess = exec('node ./dev.mjs', {

--- a/e2e/cases/config/rspack-config-validate/index.test.ts
+++ b/e2e/cases/config/rspack-config-validate/index.test.ts
@@ -1,7 +1,7 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { build, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
-import stripAnsi from 'strip-ansi';
 
 rspackOnlyTest('should validate Rspack config by default', async () => {
   try {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -49,7 +49,6 @@
     "fast-glob": "^3.3.2",
     "fs-extra": "^11.2.0",
     "playwright": "1.44.1",
-    "strip-ansi": "6.0.1",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3"
   }

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -1,13 +1,13 @@
 import fs from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { test } from '@playwright/test';
 import type { ConsoleType } from '@rsbuild/core';
 import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
 } from 'fast-glob';
-import stripAnsi from 'strip-ansi';
 
 export const providerType = process.env.PROVIDE_TYPE || 'rspack';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       playwright:
         specifier: 1.44.1
         version: 1.44.1
-      strip-ansi:
-        specifier: 6.0.1
-        version: 6.0.1
       tailwindcss:
         specifier: ^3.4.14
         version: 3.4.14


### PR DESCRIPTION
## Summary

Use the Node.js builtin util `stripVTControlCharacters` to replace `strip-ansi`

## Related Links

https://nodejs.org/api/util.html#utilstripvtcontrolcharactersstr

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
