### PR TITLE
release: v1.1.2

### DIFF
--- a/.changeset/brown-books-sort.md
+++ b/.changeset/brown-books-sort.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-webpack-swc': patch
----
-
-bump

--- a/.changeset/popular-roses-learn.md
+++ b/.changeset/popular-roses-learn.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-stylus': patch
----
-
-bump

--- a/.changeset/proud-trains-dance.md
+++ b/.changeset/proud-trains-dance.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/plugin-vue': patch
----
-
-bump

--- a/.changeset/sixty-pets-hide.md
+++ b/.changeset/sixty-pets-hide.md
@@ -1,5 +1,0 @@
----
-'@rsbuild/webpack': patch
----
-
-bump

--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-webpack-swc",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "SWC plugin for Rsbuild webpack provider",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: add new `output.emitCss` config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3967
* feat: support restart build in build watch mode by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3974
### Performance 🚀
* perf: bump chokidar to v4 and remove fsevents dependency by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3960
* perf(build): custom Rslib minify options for Node output by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3966
### Bug Fixes 🐞
* fix: `watchFiles.type` not work as expected by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3963
* fix(plugin-vue): should transpile all Vue SFC by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3964
* fix: close API does not actually close the build by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/3969
* fix(plugin-stylus): `stylusOptions.import` should be an array by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3972
### Document 📖
* docs: remove npm packages page by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3970
### Other Changes
* test: replace strip-ansi with Node.js builtin util by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3976
* chore: clean up unused internal helpers by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3977
* refactor: move internal helpers to provider parameters by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/3978


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.1.1...v1.1.2