### PR TITLE
chore: move `runCLI` from internal helpers to index export

### DIFF
--- a/packages/core/bin/rsbuild.js
+++ b/packages/core/bin/rsbuild.js
@@ -13,16 +13,8 @@ if (enableCompileCache) {
 }
 
 async function main() {
-  const { __internalHelper, logger } = await import('../dist/index.js');
-  const { runCli, prepareCli } = __internalHelper;
-
-  prepareCli();
-
-  try {
-    runCli();
-  } catch (err) {
-    logger.error(err);
-  }
+  const { runCLI } = await import('../dist/index.js');
+  runCLI();
 }
 
 main();

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -74,7 +74,7 @@ export default defineConfig({
     externals,
   },
   lib: [
-    // Node / ESM
+    // Node / ESM / index
     {
       format: 'esm',
       syntax: 'es2021',

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -63,7 +63,7 @@ const applyServerOptions = (command: Command) => {
     .option('--host <host>', 'specify the host that the server listens to');
 };
 
-export function runCli(): void {
+export function setupCommands(): void {
   program.name('rsbuild').usage('<command> [options]').version(RSBUILD_VERSION);
 
   const devCommand = program.command('dev');

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,0 +1,14 @@
+import { logger } from '../logger';
+import { setupCommands } from './commands';
+import { prepareCli } from './prepare';
+
+export async function runCLI(): Promise<void> {
+  prepareCli();
+
+  try {
+    setupCommands();
+  } catch (err) {
+    logger.error('Failed to start Rsbuild CLI.');
+    logger.error(err);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ import * as __internalHelper from './internal';
 export { loadEnv } from './loadEnv';
 export { createRsbuild } from './createRsbuild';
 export { loadConfig, defineConfig } from './config';
+export { runCLI } from './cli';
 
 // Rsbuild version
 export const version: string = RSBUILD_VERSION;

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -3,7 +3,4 @@
  * Some internal methods of Rsbuild.
  * Please do not use them in your Rsbuild project or plugins.
  */
-
-export { runCli } from './cli/commands';
-export { prepareCli } from './cli/prepare';
 export { setHTMLPlugin } from './pluginHelper';


### PR DESCRIPTION
## Summary

Move `runCLI` from internal helpers to index export.

Motivations:

- To remove all internal helpers.
- `runCLI` now can be used as a public API, it is still undocumented, but users can use it. So we will keep it stable and simple.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
