### PR TITLE
feat: support print error module traces

### DIFF
--- a/e2e/cases/config/stats-module-trace/index.test.ts
+++ b/e2e/cases/config/stats-module-trace/index.test.ts
@@ -1,0 +1,17 @@
+import { build, proxyConsole } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should log error module trace when enable moduleTrace', async () => {
+  const { restore, logs } = proxyConsole();
+
+  await expect(
+    build({
+      cwd: __dirname,
+      rsbuildConfig: {},
+    }),
+  ).rejects.toThrowError('build failed');
+
+  expect(logs.some((log) => log.includes('@ ./src/index.tsx'))).toBeTruthy();
+
+  restore();
+});

--- a/e2e/cases/config/stats-module-trace/rsbuild.config.ts
+++ b/e2e/cases/config/stats-module-trace/rsbuild.config.ts
@@ -1,0 +1,14 @@
+export default {
+  tools: {
+    rspack: {
+      stats: {
+        moduleTrace: true,
+      },
+    },
+    webpack: {
+      stats: {
+        moduleTrace: true,
+      },
+    },
+  },
+};

--- a/e2e/cases/config/stats-module-trace/src/index.tsx
+++ b/e2e/cases/config/stats-module-trace/src/index.tsx
@@ -1,0 +1,1 @@
+import './test';

--- a/e2e/cases/config/stats-module-trace/src/test.tsx
+++ b/e2e/cases/config/stats-module-trace/src/test.tsx
@@ -1,0 +1,1 @@
+import './test1';

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -13,7 +13,7 @@ test('should log warning by default', async () => {
     logs.some((log) =>
       log.includes('Using / for division outside of calc() is deprecated'),
     ),
-  );
+  ).toBeTruthy();
 
   restore();
 });

--- a/packages/core/src/client/format.ts
+++ b/packages/core/src/client/format.ts
@@ -20,6 +20,20 @@ function resolveFileName(stats: StatsError) {
   return file ? `File: ${file}\n` : '';
 }
 
+function resolveModuleTrace(stats: StatsError) {
+  let traceStr = '';
+  if (stats.moduleTrace) {
+    for (const trace of stats.moduleTrace) {
+      if (trace.originName) {
+        // TODO: missing moduleTrace.dependencies[].loc in rspack
+        traceStr += `\n @ ${trace.originName}`;
+      }
+    }
+  }
+
+  return traceStr;
+}
+
 function hintUnknownFiles(message: string): string {
   const hint = 'You may need an appropriate loader to handle this file type.';
 
@@ -61,8 +75,9 @@ function formatMessage(stats: StatsError | string, verbose?: boolean) {
     const details =
       verbose && stats.details ? `\nDetails: ${stats.details}\n` : '';
     const stack = verbose && stats.stack ? `\n${stats.stack}` : '';
+    const moduleTrace = resolveModuleTrace(stats);
 
-    message = `${fileName}${mainMessage}${details}${stack}`;
+    message = `${fileName}${mainMessage}${details}${stack}${moduleTrace}`;
   } else {
     message = stats;
   }

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -2,7 +2,11 @@ import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
 import { parse } from 'node:querystring';
 import type Ws from 'ws';
-import { getAllStatsErrors, getAllStatsWarnings } from '../helpers';
+import {
+  getAllStatsErrors,
+  getAllStatsWarnings,
+  getStatsOptions,
+} from '../helpers';
 import { logger } from '../logger';
 import type { DevConfig, Rspack } from '../types';
 import { getCompilationId } from './helper';
@@ -203,7 +207,16 @@ export class SocketServer {
       children: true,
     };
 
-    return curStats.toJson(defaultStats);
+    const statsOptions = getStatsOptions(curStats.compilation.compiler);
+
+    const userOptions =
+      typeof statsOptions === 'string'
+        ? { preset: statsOptions }
+        : typeof statsOptions === 'object'
+          ? statsOptions
+          : {};
+
+    return curStats.toJson({ ...defaultStats, ...userOptions });
   }
 
   // determine what message should send by stats


### PR DESCRIPTION
## Summary
support print error module traces when `stats.moduleTrace` is enabled.

Maybe we can enable moduleTrace by default, because it is enabled by default in [preset: 'errors-only'](https://github.com/web-infra-dev/rspack/blob/f420048ee32b47007b5482b9a6a43721302dcb83/packages/rspack/src/Stats.ts#L186)

```file=rsbuild.config.ts
export default {
  tools: {
    rspack: {
      stats: {
        moduleTrace: true,
      },
    },
};
```
<img width="862" alt="image" src="https://github.com/user-attachments/assets/630d8012-9cf1-49a3-8a9f-1911f36548ee">


## Related Links

<!--- Provide links of related issues or pages -->
resolve: https://github.com/web-infra-dev/rsbuild/issues/3983

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
