### PR TITLE
fix(webpack): move Rslib to devDependencies

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@modern-js/swc-plugins": "0.6.11",
-    "@rslib/core": "0.0.18",
     "@swc/helpers": "^0.5.15",
     "core-js": "~3.39.0",
     "deepmerge": "^4.3.1",
@@ -38,6 +37,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
+    "@rslib/core": "0.0.18",
     "@types/lodash": "^4.17.13",
     "@types/semver": "^7.5.8",
     "typescript": "^5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -478,9 +478,6 @@ importers:
       '@modern-js/swc-plugins':
         specifier: 0.6.11
         version: 0.6.11(@swc/helpers@0.5.15)
-      '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
       '@swc/helpers':
         specifier: ^0.5.15
         version: 0.5.15
@@ -506,6 +503,9 @@ importers:
       '@rsbuild/webpack':
         specifier: workspace:*
         version: link:../webpack
+      '@rslib/core':
+        specifier: 0.0.18
+        version: 0.0.18(typescript@5.6.3)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13


### PR DESCRIPTION
## Summary

Avoid installing Rslib as dependencies of `@rsbuild/plugin-webpack-swc`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [ ] Documentation updated (or **not required**).
