### PR TITLE
docs: add explanation to .env

### DIFF
--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -186,7 +186,7 @@ During code minification, `if (false) { ... }` will be recognized as invalid cod
 
 ## `.env` File
 
-When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these env variables and add them to the current Node.js process.
+When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these env variables and add them to the current Node.js process, The [Public Variables](#public-variables) will be exposed in the client code.
 
 You can access these env variables through `import.meta.env.[name]` or `process.env.[name]`.
 
@@ -280,6 +280,7 @@ If you are not using the Rsbuild CLI and are using the Rsbuild [JavaScript API](
 ```ts
 import { loadEnv, mergeRsbuildConfig } from '@rsbuild/core';
 
+// Here publicVars is the PUBLIC_ prefixed variable read by default.
 const { parsed, publicVars } = loadEnv();
 
 const mergedConfig = mergeRsbuildConfig(

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -186,7 +186,7 @@ During code minification, `if (false) { ... }` will be recognized as invalid cod
 
 ## `.env` File
 
-When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these env variables and add them to the current Node.js process, The [Public Variables](#public-variables) will be exposed in the client code.
+When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these env variables and add them to the current Node.js process. The [Public Variables](#public-variables) will be exposed in the client code.
 
 You can access these env variables through `import.meta.env.[name]` or `process.env.[name]`.
 
@@ -280,7 +280,7 @@ If you are not using the Rsbuild CLI and are using the Rsbuild [JavaScript API](
 ```ts
 import { loadEnv, mergeRsbuildConfig } from '@rsbuild/core';
 
-// Here publicVars is the PUBLIC_ prefixed variable read by default.
+// By default, `publicVars` are variables prefixed with `PUBLIC_`
 const { parsed, publicVars } = loadEnv();
 
 const mergedConfig = mergeRsbuildConfig(

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -186,7 +186,7 @@ if (false) {
 
 ## `.env` 文件
 
-当项目根目录存在 `.env` 文件时，Rsbuild CLI 会自动使用 [dotenv](https://npmjs.com/package/dotenv) 来加载这些环境变量，并添加到当前 Node.js 进程中。
+当项目根目录存在 `.env` 文件时，Rsbuild CLI 会自动使用 [dotenv](https://npmjs.com/package/dotenv) 来加载这些环境变量，并添加到当前 Node.js 进程中，其中的 [public 变量](#public-变量) 会被暴露在`client`代码中。
 
 你可以通过 `import.meta.env.[name]` 或 `process.env.[name]` 来访问这些环境变量。
 
@@ -280,6 +280,7 @@ console.log(process.env.BAR); // '2'
 ```ts
 import { loadEnv, mergeRsbuildConfig } from '@rsbuild/core';
 
+// 此处 publicVars 为默认方式读取的 PUBLIC_ 前缀的变量
 const { parsed, publicVars } = loadEnv();
 
 const mergedConfig = mergeRsbuildConfig(

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -186,7 +186,7 @@ if (false) {
 
 ## `.env` 文件
 
-当项目根目录存在 `.env` 文件时，Rsbuild CLI 会自动使用 [dotenv](https://npmjs.com/package/dotenv) 来加载这些环境变量，并添加到当前 Node.js 进程中，其中的 [public 变量](#public-变量) 会被暴露在`client`代码中。
+当项目根目录存在 `.env` 文件时，Rsbuild CLI 会自动使用 [dotenv](https://npmjs.com/package/dotenv) 来加载这些环境变量，并添加到当前 Node.js 进程中，其中的 [public 变量](#public-变量) 会被暴露在 `client` 代码中。
 
 你可以通过 `import.meta.env.[name]` 或 `process.env.[name]` 来访问这些环境变量。
 
@@ -280,7 +280,7 @@ console.log(process.env.BAR); // '2'
 ```ts
 import { loadEnv, mergeRsbuildConfig } from '@rsbuild/core';
 
-// 此处 publicVars 为默认方式读取的 PUBLIC_ 前缀的变量
+// 默认情况下，`publicVars` 是以 `PUBLIC_` 为前缀的变量
 const { parsed, publicVars } = loadEnv();
 
 const mergedConfig = mergeRsbuildConfig(


### PR DESCRIPTION
## Summary
I think the variables that the client can access should be stated at the beginning of .env.
![image](https://github.com/user-attachments/assets/450c2970-6b08-45e6-ba22-e483c70159e6)
Where the .env file is loaded manually, our example will pass publicVars to source.define. The default value of publicVars should also be briefly commented to avoid misleading people.
![image](https://github.com/user-attachments/assets/1073336a-1222-473a-b2c4-3512564362cf)


## Related Links

https://github.com/web-infra-dev/rsbuild/issues/3975

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
