### PR TITLE
chore(CI): reduce playwright install time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm install && cd ./e2e && npx playwright install --with-deps chromium
+        run: pnpm install && cd ./e2e && npx playwright install chromium
 
       - name: E2E Test
         if: steps.changes.outputs.changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm install && cd ./e2e && npx playwright install
+        run: pnpm install && cd ./e2e && npx playwright install --with-deps chromium
 
       - name: E2E Test
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Reduce playwright install time, only `chromium` is required.

## Related Issue

https://playwright.dev/docs/browsers#install-system-dependencies

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
