### PR TITLE
feat(plugin-sass): mute deprecation warnings of dependencies

### DIFF
--- a/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
+++ b/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
@@ -4,7 +4,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 {
   "plugins": [
     RsbuildCorePlugin {},
-    BundleAnalyzerPlugin {
+    {
       "logger": Logger {
         "activeLevels": Set {
           "info",
@@ -39,7 +39,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle an
 {
   "plugins": [
     RsbuildCorePlugin {},
-    BundleAnalyzerPlugin {
+    {
       "logger": Logger {
         "activeLevels": Set {
           "info",
@@ -74,7 +74,7 @@ exports[`plugin-bundle-analyze > should enable bundle analyze plugin when perfor
 {
   "plugins": [
     RsbuildCorePlugin {},
-    BundleAnalyzerPlugin {
+    {
       "logger": Logger {
         "activeLevels": Set {
           "info",

--- a/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
+++ b/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
@@ -4,7 +4,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 {
   "plugins": [
     RsbuildCorePlugin {},
-    {
+    BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
           "info",
@@ -39,7 +39,7 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle an
 {
   "plugins": [
     RsbuildCorePlugin {},
-    {
+    BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
           "info",
@@ -74,7 +74,7 @@ exports[`plugin-bundle-analyze > should enable bundle analyze plugin when perfor
 {
   "plugins": [
     RsbuildCorePlugin {},
-    {
+    BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
           "info",

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -53,6 +53,10 @@ const getSassLoaderOptions = (
       sourceMap: isUseCssSourceMap,
       api: 'modern-compiler',
       implementation: require.resolve('sass-embedded'),
+      sassOptions: {
+        // mute deprecation warnings of dependencies
+        quietDeps: true,
+      },
     },
     config: userOptions,
     ctx: { addExcludes },

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -49,6 +49,9 @@ exports[`plugin-sass > should add sass-loader 1`] = `
         "options": {
           "api": "modern-compiler",
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+          "sassOptions": {
+            "quietDeps": true,
+          },
           "sourceMap": true,
         },
       },
@@ -106,6 +109,9 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
         "options": {
           "api": "modern-compiler",
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+          "sassOptions": {
+            "quietDeps": true,
+          },
           "sourceMap": true,
         },
       },
@@ -166,6 +172,9 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         "options": {
           "api": "modern-compiler",
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
+          "sassOptions": {
+            "quietDeps": true,
+          },
           "sourceMap": true,
         },
       },
@@ -224,6 +233,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
           "api": "legacy",
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
           "sassOptions": {
+            "quietDeps": true,
             "silenceDeprecations": [
               "legacy-js-api",
             ],

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -53,6 +53,10 @@ const defaultOptions = {
   api: 'modern-compiler',
   implementation: require.resolve('sass-embedded'),
   sourceMap: rsbuildConfig.output.sourceMap.css,
+  sassOptions: {
+    quietDeps: true,
+    silenceDeprecations: api === 'legacy' ? ['legacy-js-api'] : undefined,
+  },
 };
 ```
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -53,6 +53,10 @@ const defaultOptions = {
   api: 'modern-compiler',
   implementation: require.resolve('sass-embedded'),
   sourceMap: rsbuildConfig.output.sourceMap.css,
+  sassOptions: {
+    quietDeps: true,
+    silenceDeprecations: api === 'legacy' ? ['legacy-js-api'] : undefined,
+  },
 };
 ```
 


### PR DESCRIPTION
## Summary

Mute Sass deprecation warnings of dependencies to reduce the noise of Sass logs for daily development:

> If this option is set to true, Sass won’t print warnings that are caused by dependencies. A “dependency” is defined as any file that’s loaded through [loadPaths](https://sass-lang.com/documentation/js-api/interfaces/Options#loadPaths) or [importers](https://sass-lang.com/documentation/js-api/interfaces/Options#importers). Stylesheets that are imported relative to the entrypoint are not considered dependencies. This is useful for silencing deprecation warnings that you can’t fix on your own.

## Related Links

- https://sass-lang.com/documentation/js-api/interfaces/options/#quietDeps
- https://github.com/webpack-contrib/sass-loader/issues/954

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
