### PR TITLE
feat: reference script modules as URL assets

### DIFF
--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -1,0 +1,47 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+function isIncludeFile(filenames: string[], includeFilename: string) {
+  return filenames.some((filename) => filename.includes(includeFilename));
+}
+
+test('should allow to use `new URL` to reference script as assets', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  const test1 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test1.js'),
+  );
+  const test2 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test2.ts'),
+  );
+  const test3 = filenames.find((filename) =>
+    filename.includes('dist/static/assets/test3.mjs'),
+  );
+
+  expect(test1).toBeDefined();
+  expect(test2).toBeDefined();
+  expect(test3).toBeDefined();
+
+  expect(files[test1!]).toEqual('export const test="test1";');
+  expect(files[test2!]).toEqual(`export const test2: string = 'test2';
+`);
+  expect(files[test3!]).toEqual('export const test="test3";');
+
+  expect(await page.evaluate('window.test1')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test1.js`,
+  );
+  expect(await page.evaluate('window.test2')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test2.ts`,
+  );
+  expect(await page.evaluate('window.test3')).toBe(
+    `http://localhost:${rsbuild.port}/static/assets/test3.mjs`,
+  );
+});

--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -1,47 +1,44 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-function isIncludeFile(filenames: string[], includeFilename: string) {
-  return filenames.some((filename) => filename.includes(includeFilename));
-}
+rspackOnlyTest(
+  'should allow to use `new URL` to reference script as assets',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-test('should allow to use `new URL` to reference script as assets', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+    const files = await rsbuild.unwrapOutputJSON();
+    const filenames = Object.keys(files);
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const filenames = Object.keys(files);
+    const test1 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test1.js'),
+    );
+    const test2 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test2.ts'),
+    );
+    const test3 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test3.mjs'),
+    );
 
-  const test1 = filenames.find((filename) =>
-    filename.includes('dist/static/assets/test1.js'),
-  );
-  const test2 = filenames.find((filename) =>
-    filename.includes('dist/static/assets/test2.ts'),
-  );
-  const test3 = filenames.find((filename) =>
-    filename.includes('dist/static/assets/test3.mjs'),
-  );
+    expect(test1).toBeDefined();
+    expect(test2).toBeDefined();
+    expect(test3).toBeDefined();
 
-  expect(test1).toBeDefined();
-  expect(test2).toBeDefined();
-  expect(test3).toBeDefined();
-
-  expect(files[test1!]).toEqual('export const test="test1";');
-  expect(files[test2!]).toEqual(`export const test2: string = 'test2';
+    expect(files[test1!]).toEqual('export const test="test1";');
+    expect(files[test2!]).toEqual(`export const test2: string = 'test2';
 `);
-  expect(files[test3!]).toEqual('export const test="test3";');
+    expect(files[test3!]).toEqual('export const test="test3";');
 
-  expect(await page.evaluate('window.test1')).toBe(
-    `http://localhost:${rsbuild.port}/static/assets/test1.js`,
-  );
-  expect(await page.evaluate('window.test2')).toBe(
-    `http://localhost:${rsbuild.port}/static/assets/test2.ts`,
-  );
-  expect(await page.evaluate('window.test3')).toBe(
-    `http://localhost:${rsbuild.port}/static/assets/test3.mjs`,
-  );
-});
+    expect(await page.evaluate('window.test1')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test1.js`,
+    );
+    expect(await page.evaluate('window.test2')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test2.ts`,
+    );
+    expect(await page.evaluate('window.test3')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test3.mjs`,
+    );
+  },
+);

--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -27,8 +27,7 @@ rspackOnlyTest(
     expect(test3).toBeDefined();
 
     expect(files[test1!]).toEqual('export const test="test1";');
-    expect(files[test2!]).toEqual(`export const test2: string = 'test2';
-`);
+    expect(files[test2!]).toContain(`export const test2: string = 'test2';`);
     expect(files[test3!]).toEqual('export const test="test3";');
 
     expect(await page.evaluate('window.test1')).toBe(

--- a/e2e/cases/assets/script-as-assets/rsbuild.config.ts
+++ b/e2e/cases/assets/script-as-assets/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/assets/script-as-assets/src/index.js
+++ b/e2e/cases/assets/script-as-assets/src/index.js
@@ -1,0 +1,7 @@
+const test1 = new URL('./test1.js', import.meta.url).href;
+const test2 = new URL('./test2.ts', import.meta.url).href;
+const test3 = new URL('./test3.mjs', import.meta.url).href;
+
+window.test1 = test1;
+window.test2 = test2;
+window.test3 = test3;

--- a/e2e/cases/assets/script-as-assets/src/test1.js
+++ b/e2e/cases/assets/script-as-assets/src/test1.js
@@ -1,0 +1,1 @@
+export const test = 'test1';

--- a/e2e/cases/assets/script-as-assets/src/test2.ts
+++ b/e2e/cases/assets/script-as-assets/src/test2.ts
@@ -1,0 +1,1 @@
+export const test2: string = 'test2';

--- a/e2e/cases/assets/script-as-assets/src/test3.mjs
+++ b/e2e/cases/assets/script-as-assets/src/test3.mjs
@@ -1,0 +1,1 @@
+export const test = 'test3';

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -70,6 +70,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -452,6 +455,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -830,6 +836,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -1154,6 +1163,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -104,7 +104,10 @@ export const pluginSwc = (): RsbuildPlugin => ({
         const rule = chain.module
           .rule(CHAIN_ID.RULE.JS)
           .test(SCRIPT_REGEX)
-          .type('javascript/auto');
+          .type('javascript/auto')
+          // When using `new URL('./path/to/foo.js', import.meta.url)`,
+          // the module should be treated as an asset module rather than a JS module.
+          .dependency({ not: 'url' });
 
         const dataUriRule = chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -68,6 +68,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -68,6 +68,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -479,6 +482,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -916,6 +922,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [
@@ -1276,6 +1285,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
         ],
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "include": [
           {
             "and": [

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1237,6 +1237,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -1573,6 +1576,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -11,6 +11,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -116,6 +119,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -233,6 +239,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
 exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       {
         "and": [
@@ -284,6 +293,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
 exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader options 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       {
         "and": [
@@ -381,6 +393,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
 exports[`plugin-swc > should apply environment config correctly 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       "src/example",
     ],
@@ -507,6 +522,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
 exports[`plugin-swc > should apply environment config correctly 2`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       "src/example1",
     ],
@@ -621,6 +639,9 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -752,6 +773,9 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -863,6 +887,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -966,6 +993,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -1078,6 +1108,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -1199,6 +1232,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -1323,6 +1359,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [
@@ -1444,6 +1483,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
     "module": {
       "rules": [
         {
+          "dependency": {
+            "not": "url",
+          },
           "include": [
             {
               "and": [

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -2,6 +2,9 @@
 
 exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] = `
 {
+  "dependency": {
+    "not": "url",
+  },
   "exclude": [
     "src/example",
   ],
@@ -85,6 +88,9 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
 
 exports[`plugins/babel > should apply environment config correctly 1`] = `
 {
+  "dependency": {
+    "not": "url",
+  },
   "exclude": [
     "src/example",
   ],
@@ -167,6 +173,9 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
 
 exports[`plugins/babel > should apply environment config correctly 2`] = `
 {
+  "dependency": {
+    "not": "url",
+  },
   "exclude": [
     "src/example1",
   ],

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -9,6 +9,9 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
     "test": /\\\\\\.m\\?js/,
   },
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       {
         "and": [
@@ -89,6 +92,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     "test": /\\\\\\.m\\?js/,
   },
   {
+    "dependency": {
+      "not": "url",
+    },
     "include": [
       {
         "and": [

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -9,6 +9,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     "test": /\\\\\\.m\\?js/,
   },
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
     ],
@@ -116,6 +119,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
 exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` as expected 2`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
     ],

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -29,6 +29,8 @@ In JS files, you can import static assets with relative paths:
 // Import the logo.png image in the static directory
 import logo from './static/logo.png';
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
 ```
 
@@ -37,15 +39,30 @@ Import with [alias](/guide/advanced/alias) is also available:
 ```tsx
 import logo from '@/static/logo.png';
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
 ```
 
-You can also combine [URL](https://developer.mozilla.org/docs/Web/API/URL) with [import.meta.url](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta) which are native ESM features to import static assets.
+### URL assets
+
+Rsbuild supports using JavaScript's native [URL](https://developer.mozilla.org/docs/Web/API/URL) and [import.meta.url](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta) to import static assets.
 
 ```tsx
 const logo = new URL('./static/logo.png', import.meta.url).href;
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
+```
+
+If you use `new URL()` to reference `.js` or `.ts` files, they will be treated as URL assets and will not be processed by Rsbuild's built-in `swc-loader`.
+
+```tsx
+// foo.ts will remain the original content and be output to the dist directory
+const fooTs = new URL('./foo.ts', import.meta.url).href;
+
+console.log(fooTs); // "/static/foo.[hash].ts"
 ```
 
 ## Import Assets in CSS file

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -122,7 +122,7 @@ The result of importing static assets depends on the file size:
 import largeImage from './static/largeImage.png';
 import smallImage from './static/smallImage.png';
 
-console.log(largeImage); // "/static/largeImage.6c12aba3.png"
+console.log(largeImage); // "/static/largeImage.[hash].png"
 console.log(smallImage); // "data:image/png;base64,iVBORw0KGgo..."
 ```
 
@@ -149,7 +149,7 @@ For example, you can set `output.assetPrefix` to `https://example.com`:
 ```js
 import logo from './static/logo.png';
 
-console.log(logo); // "https://example.com/static/logo.6c12aba3.png"
+console.log(logo); // "https://example.com/static/logo.[hash].png"
 ```
 
 ## Public Folder
@@ -258,7 +258,7 @@ After adding the above configuration, you can import `*.pdf` files in your code,
 ```js
 import myFile from './static/myFile.pdf';
 
-console.log(myFile); // "/static/myFile.6c12aba3.pdf"
+console.log(myFile); // "/static/myFile.[hash].pdf"
 ```
 
 ### Use `tools.rspack`

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -12,7 +12,7 @@ Rsbuild supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/)
 
 ### Node.js
 
-Before getting started, you will need to install Node.js >= version 16, it is recommended to use the Node.js LTS version.
+For Node.js, you will need to install Node.js >= version 16, it is recommended to use the Node.js LTS version.
 
 Check the current Node.js version with the following command:
 

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -29,6 +29,8 @@ SVG 图片是一种特殊情况，Rsbuild 提供了 SVG 转 React 组件的能�
 // 引用 static 目录下的 logo.png 图片
 import logo from './static/logo.png';
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
 ```
 
@@ -37,15 +39,30 @@ export default = () => <img src={logo} />;
 ```tsx
 import logo from '@/static/logo.png';
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
 ```
 
-也支持使用 ESM 原生功能中的 [URL](https://developer.mozilla.org/docs/Web/API/URL) 和 [import.meta.url](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta) 相配合，来引用静态资源。
+### URL assets
+
+Rsbuild 支持使用 JavaScript 原生的 [URL](https://developer.mozilla.org/docs/Web/API/URL) 和 [import.meta.url](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/import.meta) 相配合，来引用静态资源。
 
 ```tsx
 const logo = new URL('./static/logo.png', import.meta.url).href;
 
+console.log(logo); // "/static/logo.[hash].png"
+
 export default = () => <img src={logo} />;
+```
+
+如果你使用 `new URL()` 引用 `.js` 或 `.ts` 文件，它们将被视为 URL assets，不会经过 Rsbuild 内置的 `swc-loader` 处理。
+
+```tsx
+// foo.ts 文件将保持原始内容被输出到产物目录下
+const fooTs = new URL('./foo.ts', import.meta.url).href;
+
+console.log(fooTs); // "/static/foo.[hash].ts"
 ```
 
 ## 在 CSS 文件中引用
@@ -105,7 +122,7 @@ export default {
 import largeImage from './static/largeImage.png';
 import smallImage from './static/smallImage.png';
 
-console.log(largeImage); // "/static/largeImage.6c12aba3.png"
+console.log(largeImage); // "/static/largeImage.[hash].png"
 console.log(smallImage); // "data:image/png;base64,iVBORw0KGgo..."
 ```
 
@@ -132,7 +149,7 @@ console.log(smallImage); // "data:image/png;base64,iVBORw0KGgo..."
 ```js
 import logo from './static/logo.png';
 
-console.log(logo); // "https://example.com/static/logo.6c12aba3.png"
+console.log(logo); // "https://example.com/static/logo.[hash].png"
 ```
 
 ## public 目录
@@ -241,7 +258,7 @@ export default {
 ```js
 import myFile from './static/myFile.pdf';
 
-console.log(myFile); // "/static/myFile.6c12aba3.pdf"
+console.log(myFile); // "/static/myFile.[hash].pdf"
 ```
 
 ### 使用 `tools.rspack`

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -17,7 +17,7 @@ Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 
 
 ### Node.js
 
-在开始使用前，你需要安装 Node.js >= 16 版本，推荐使用 Node.js LTS 版本。
+对于 Node.js，请安装 Node.js >= 16 版本，推荐使用 Node.js LTS 版本。
 
 通过以下命令检查当前使用的 Node.js 版本：
 


### PR DESCRIPTION
## Summary

If we use `new URL()` to reference `.js` or `.ts` files, they will be treated as URL assets and will not be processed by Rsbuild's built-in `swc-loader`.

```tsx
// foo.ts will remain the original content and be output to the dist directory
const fooTs = new URL('./foo.ts', import.meta.url).href;

console.log(fooTs); // "/static/foo.[hash].ts"
```

## Related Links

see https://github.com/web-infra-dev/rsbuild/issues/3953

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
