### PR TITLE
fix: print wrong URLs with custom dist path in windows

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -300,3 +300,48 @@ test('should print server urls when HTML is disabled but printUrls is a custom f
   await rsbuild.close();
   restore();
 });
+
+test('should get posix route correctly', async ({ page }) => {
+  const { logs, restore } = proxyConsole('log');
+
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        printUrls: ({ routes }) => {
+          expect(routes[0].pathname).toBe('/dist/');
+          expect(routes[1].pathname).toBe('/.dist/web1/');
+        },
+      },
+      environments: {
+        web: {},
+        web1: {
+          output: {
+            distPath: {
+              root: '.dist/web1',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  const webLog = logs.find(
+    (log) =>
+      log.includes('Local:') &&
+      log.includes(`http://localhost${rsbuild.port}/dist/`),
+  );
+  const web1Log = logs.find(
+    (log) =>
+      log.includes('Local:') &&
+      log.includes(`http://localhost${rsbuild.port}/.dist1/web1/`),
+  );
+
+  expect(webLog).toBeTruthy();
+  expect(web1Log).toBeTruthy();
+
+  await rsbuild.close();
+  restore();
+});

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -308,14 +308,20 @@ test('should get posix route correctly', async ({ page }) => {
     cwd,
     rsbuildConfig: {
       server: {
-        printUrls: ({ routes }) => {
+        printUrls: ({ urls, routes }) => {
           expect(routes[0].pathname).toBe('/dist/');
-          expect(routes[1].pathname).toBe('/.dist/web1/');
+          expect(routes[1].pathname).toBe('/.dist/web1/index1');
+          return urls;
         },
       },
       environments: {
         web: {},
         web1: {
+          source: {
+            entry: {
+              index1: './src/index.js',
+            },
+          },
           output: {
             distPath: {
               root: '.dist/web1',
@@ -328,15 +334,11 @@ test('should get posix route correctly', async ({ page }) => {
 
   await page.goto(`http://localhost:${rsbuild.port}`);
 
-  const webLog = logs.find(
-    (log) =>
-      log.includes('Local:') &&
-      log.includes(`http://localhost${rsbuild.port}/dist/`),
+  const webLog = logs.find((log) =>
+    log.includes(`http://localhost:${rsbuild.port}/dist/`),
   );
-  const web1Log = logs.find(
-    (log) =>
-      log.includes('Local:') &&
-      log.includes(`http://localhost${rsbuild.port}/.dist1/web1/`),
+  const web1Log = logs.find((log) =>
+    log.includes(`http://localhost:${rsbuild.port}/.dist/web1/index1`),
   );
 
   expect(webLog).toBeTruthy();

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -3,7 +3,7 @@ import type { Http2SecureServer } from 'node:http2';
 import net from 'node:net';
 import type { Socket } from 'node:net';
 import os from 'node:os';
-import { posix } from 'node:path';
+import { posix, relative, sep } from 'node:path';
 import { DEFAULT_DEV_HOST, DEFAULT_PORT } from '../constants';
 import {
   addTrailingSlash,
@@ -86,7 +86,9 @@ export const getRoutes = (context: InternalContext): Routes => {
   return Object.values(context.environments).reduce<Routes>(
     (prev, environmentContext) => {
       const { distPath, config } = environmentContext;
-      const distPrefix = posix.relative(context.distPath, distPath);
+      const distPrefix = relative(context.distPath, distPath)
+        .split(sep)
+        .join('/');
 
       const routes = formatRoutes(
         environmentContext.htmlPaths,


### PR DESCRIPTION
## Summary
fix: print wrong URLs with custom dist path in windows
<img width="761" alt="image" src="https://github.com/user-attachments/assets/81bc41d1-9aa6-4b5f-a106-634bae5387f8">


## Related Links

fix https://github.com/web-infra-dev/rsbuild/issues/3996


<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
