### PR TITLE
feat(loadConfig): allow to pass a meta data

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -287,6 +287,7 @@ export type ConfigParams = {
   env: string;
   command: string;
   envMode?: string;
+  params?: Record<string, unknown>;
 };
 
 export type RsbuildConfigAsyncFn = (
@@ -387,10 +388,12 @@ export async function loadConfig({
   cwd = process.cwd(),
   path,
   envMode,
+  params,
 }: {
   cwd?: string;
   path?: string;
   envMode?: string;
+  params?: Record<string, any>;
 } = {}): Promise<{ content: RsbuildConfig; filePath: string | null }> {
   const configFilePath = resolveConfigPath(cwd, path);
 
@@ -439,13 +442,14 @@ export async function loadConfig({
   if (typeof configExport === 'function') {
     const command = process.argv[2];
     const nodeEnv = getNodeEnv();
-    const params: ConfigParams = {
+    const configParams: ConfigParams = {
       env: nodeEnv,
       command,
       envMode: envMode || nodeEnv,
+      params,
     };
 
-    const result = await configExport(params);
+    const result = await configExport(configParams);
 
     if (result === undefined) {
       throw new Error('The config function must return a config object.');

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -287,7 +287,7 @@ export type ConfigParams = {
   env: string;
   command: string;
   envMode?: string;
-  params?: Record<string, unknown>;
+  meta?: Record<string, unknown>;
 };
 
 export type RsbuildConfigAsyncFn = (
@@ -388,12 +388,12 @@ export async function loadConfig({
   cwd = process.cwd(),
   path,
   envMode,
-  params,
+  meta,
 }: {
   cwd?: string;
   path?: string;
   envMode?: string;
-  params?: Record<string, any>;
+  meta?: Record<string, unknown>;
 } = {}): Promise<{ content: RsbuildConfig; filePath: string | null }> {
   const configFilePath = resolveConfigPath(cwd, path);
 
@@ -446,7 +446,7 @@ export async function loadConfig({
       env: nodeEnv,
       command,
       envMode: envMode || nodeEnv,
-      params,
+      meta,
     };
 
     const result = await configExport(configParams);


### PR DESCRIPTION
## Summary

Allow to pass a meta data to `defineConfig` function:

```js
await loadConfig({
  meta: {},
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
