### PR TITLE
feat: reference style modules as URL assets

### DIFF
--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -1,0 +1,49 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to use `new URL` to reference styles as assets',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+
+    const files = await rsbuild.unwrapOutputJSON();
+    const filenames = Object.keys(files);
+
+    const test1 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test1.css'),
+    );
+    const test2 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test2.less'),
+    );
+    const test3 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test3.scss'),
+    );
+    const test4 = filenames.find((filename) =>
+      filename.includes('dist/static/assets/test4.styl'),
+    );
+
+    expect(test1).toBeDefined();
+    expect(test2).toBeDefined();
+    expect(test3).toBeDefined();
+    expect(test4).toBeDefined();
+    expect(files[test1!]).toContain('body{color:red}');
+    expect(files[test2!]).toContain('& .foo');
+    expect(files[test3!]).toContain('& .foo');
+    expect(files[test4!]).toContain('& .foo');
+    expect(await page.evaluate('window.test1')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test1.css`,
+    );
+    expect(await page.evaluate('window.test2')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test2.less`,
+    );
+    expect(await page.evaluate('window.test3')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test3.scss`,
+    );
+    expect(await page.evaluate('window.test4')).toBe(
+      `http://localhost:${rsbuild.port}/static/assets/test4.styl`,
+    );
+  },
+);

--- a/e2e/cases/assets/styles-as-assets/rsbuild.config.ts
+++ b/e2e/cases/assets/styles-as-assets/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginSass } from '@rsbuild/plugin-sass';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default defineConfig({
+  plugins: [pluginLess(), pluginSass(), pluginStylus()],
+  output: {
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/assets/styles-as-assets/src/index.js
+++ b/e2e/cases/assets/styles-as-assets/src/index.js
@@ -1,0 +1,4 @@
+window.test1 = new URL('./test1.css', import.meta.url).href;
+window.test2 = new URL('./test2.less', import.meta.url).href;
+window.test3 = new URL('./test3.scss', import.meta.url).href;
+window.test4 = new URL('./test4.styl', import.meta.url).href;

--- a/e2e/cases/assets/styles-as-assets/src/test1.css
+++ b/e2e/cases/assets/styles-as-assets/src/test1.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/assets/styles-as-assets/src/test2.less
+++ b/e2e/cases/assets/styles-as-assets/src/test2.less
@@ -1,0 +1,5 @@
+body {
+  & .foo {
+    color: blue;
+  }
+}

--- a/e2e/cases/assets/styles-as-assets/src/test3.scss
+++ b/e2e/cases/assets/styles-as-assets/src/test3.scss
@@ -1,0 +1,5 @@
+body {
+  & .foo {
+    color: green;
+  }
+}

--- a/e2e/cases/assets/styles-as-assets/src/test4.styl
+++ b/e2e/cases/assets/styles-as-assets/src/test4.styl
@@ -1,0 +1,5 @@
+body {
+  & .foo {
+    color: yellow;
+  }
+}

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -43,6 +43,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -428,6 +431,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -808,6 +814,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -1135,6 +1144,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -30,6 +30,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -5,6 +5,9 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
   "module": {
     "rules": [
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -55,6 +58,9 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
   "module": {
     "rules": [
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -95,6 +101,9 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
   "module": {
     "rules": [
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -143,6 +152,9 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
 exports[`should ensure isolation of PostCSS config objects between different builds 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -201,6 +213,9 @@ exports[`should ensure isolation of PostCSS config objects between different bui
 exports[`should ensure isolation of PostCSS config objects between different builds 2`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -30,6 +30,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -444,6 +447,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -894,6 +900,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },
@@ -1247,6 +1256,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "test": /\\\\\\.m\\?js/,
       },
       {
+        "dependency": {
+          "not": "url",
+        },
         "resolve": {
           "preferRelative": true,
         },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1199,6 +1199,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "test": /\\\\\\.m\\?js/,
         },
         {
+          "dependency": {
+            "not": "url",
+          },
           "resolve": {
             "preferRelative": true,
           },
@@ -1548,6 +1551,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "test": /\\\\\\.m\\?js/,
         },
         {
+          "dependency": {
+            "not": "url",
+          },
           "resolve": {
             "preferRelative": true,
           },

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -160,9 +160,10 @@ export const pluginLess = (
         rule.exclude.add(pluginOptions.exclude);
       }
 
-      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
-
       // Copy the builtin CSS rules
+      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
+      rule.dependency(cssRule.get('dependency'));
+
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
         const options = loader.get('options') ?? {};

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`plugin-less > should add less-loader 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -58,6 +61,9 @@ exports[`plugin-less > should add less-loader 1`] = `
 exports[`plugin-less > should add less-loader and css-loader when injectStyles 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -113,6 +119,9 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
 exports[`plugin-less > should add less-loader with excludes 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       /node_modules/,
     ],
@@ -171,6 +180,9 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
 exports[`plugin-less > should add less-loader with tools.less 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -226,6 +238,9 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
 exports[`plugin-less > should allow to use Less plugins 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -123,9 +123,10 @@ export const pluginSass = (
         rule.exclude.add(pluginOptions.exclude);
       }
 
-      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
-
       // Copy the builtin CSS rules
+      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
+      rule.dependency(cssRule.get('dependency'));
+
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
         const options = loader.get('options') ?? {};

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`plugin-sass > should add sass-loader 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -63,6 +66,9 @@ exports[`plugin-sass > should add sass-loader 1`] = `
 exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -123,6 +129,9 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
 exports[`plugin-sass > should add sass-loader with excludes 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "exclude": [
       /node_modules/,
     ],
@@ -186,6 +195,9 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
 exports[`plugin-sass > should allow to use legacy API and mute deprecation warnings 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -55,9 +55,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         .resolve.preferRelative(true)
         .end();
 
-      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
-
       // Copy the builtin CSS rules
+      const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);
+      rule.dependency(cssRule.get('dependency'));
+
       for (const id of Object.keys(cssRule.uses.entries())) {
         const loader = cssRule.uses.get(id);
         const options = loader.get('options') ?? {};

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -3,6 +3,9 @@
 exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },
@@ -51,6 +54,9 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
 exports[`plugin-stylus > should allow to configure stylus options 1`] = `
 [
   {
+    "dependency": {
+      "not": "url",
+    },
     "resolve": {
       "preferRelative": true,
     },

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -65,6 +65,15 @@ const fooTs = new URL('./foo.ts', import.meta.url).href;
 console.log(fooTs); // "/static/foo.[hash].ts"
 ```
 
+Similarly, when using `new URL()` to reference `.css` or `.scss` files, they will be treated as URL assets and will not be processed by Rsbuild's built-in CSS loaders.
+
+```tsx
+// foo.css will remain the original content and be output to the dist directory
+const fooCss = new URL('./foo.css', import.meta.url).href;
+
+console.log(fooCss); // "/static/foo.[hash].css"
+```
+
 ## Import Assets in CSS file
 
 In CSS files, you can reference static assets in relative paths:

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -65,6 +65,15 @@ const fooTs = new URL('./foo.ts', import.meta.url).href;
 console.log(fooTs); // "/static/foo.[hash].ts"
 ```
 
+同理，当使用 `new URL()` 引用 `.css` 或 `.scss` 文件时，它们将被视为 URL assets，不会经过 Rsbuild 内置的 CSS loaders 处理。
+
+```tsx
+// foo.css 文件将保持原始内容被输出到产物目录下
+const fooCss = new URL('./foo.css', import.meta.url).href;
+
+console.log(fooCss); // "/static/foo.[hash].css"
+```
+
 ## 在 CSS 文件中引用
 
 在 CSS 文件中，可以引用相对路径下的静态资源：


### PR DESCRIPTION
## Summary

When using `new URL()` to reference `.css` or `.scss` files, they will be treated as URL assets and will not be processed by Rsbuild's built-in CSS loaders.

```tsx
// foo.css will remain the original content and be output to the dist directory
const fooCss = new URL('./foo.css', import.meta.url).href;

console.log(fooCss); // "/static/foo.[hash].css"
```

## Related Links

The same as https://github.com/web-infra-dev/rsbuild/pull/4011

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
