### PR TITLE
chore(examples): use MF Rsbuild plugin

### DIFF
--- a/examples/module-federation-v2/host/package.json
+++ b/examples/module-federation-v2/host/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@module-federation/rspack": "0.7.6",
+    "@module-federation/rsbuild-plugin": "0.7.6",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*"
   }

--- a/examples/module-federation-v2/host/rsbuild.config.ts
+++ b/examples/module-federation-v2/host/rsbuild.config.ts
@@ -1,26 +1,19 @@
-import { ModuleFederationPlugin } from '@module-federation/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'host',
+      remotes: {
+        remote: 'remote@http://localhost:3002/mf-manifest.json',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+  ],
   server: {
     port: 3000,
-  },
-  tools: {
-    rspack: {
-      output: {
-        uniqueName: 'host',
-      },
-      plugins: [
-        new ModuleFederationPlugin({
-          name: 'host',
-          remotes: {
-            remote: 'remote@http://localhost:3002/mf-manifest.json',
-          },
-          shared: ['react', 'react-dom'],
-        }),
-      ],
-    },
   },
 });

--- a/examples/module-federation-v2/remote/package.json
+++ b/examples/module-federation-v2/remote/package.json
@@ -10,7 +10,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@module-federation/rspack": "0.7.6",
+    "@module-federation/rsbuild-plugin": "0.7.6",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*"
   }

--- a/examples/module-federation-v2/remote/rsbuild.config.ts
+++ b/examples/module-federation-v2/remote/rsbuild.config.ts
@@ -1,29 +1,19 @@
-import { ModuleFederationPlugin } from '@module-federation/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'remote',
+      exposes: {
+        './Button': './src/Button',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+  ],
   server: {
     port: 3002,
-  },
-  dev: {
-    assetPrefix: true,
-  },
-  tools: {
-    rspack: {
-      output: {
-        uniqueName: 'remote',
-      },
-      plugins: [
-        new ModuleFederationPlugin({
-          name: 'remote',
-          exposes: {
-            './Button': './src/Button',
-          },
-          shared: ['react', 'react-dom'],
-        }),
-      ],
-    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,9 +286,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@module-federation/rspack':
+      '@module-federation/rsbuild-plugin':
         specifier: 0.7.6
-        version: 0.7.6(typescript@5.6.3)
+        version: 0.7.6(@module-federation/enhanced@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1))(@rsbuild/core@packages+core)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -305,9 +305,9 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@module-federation/rspack':
+      '@module-federation/rsbuild-plugin':
         specifier: 0.7.6
-        version: 0.7.6(typescript@5.6.3)
+        version: 0.7.6(@module-federation/enhanced@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1))(@rsbuild/core@packages+core)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -2131,6 +2131,12 @@ packages:
   '@module-federation/bridge-react-webpack-plugin@0.7.6':
     resolution: {integrity: sha512-eD1JZDQ+h5WLdA58MmAE1DzLwvFaGJeeam3Tswc/sEUb4QGT86X4Fme+dMTBRYRoAq/tRYql3DlVTFhdmrUVzg==}
 
+  '@module-federation/data-prefetch@0.7.6':
+    resolution: {integrity: sha512-AMpfnuIAK/Y5M682BUsnc13ARCEKhEvb0tXF4S+l7jfL08oE9gyo+G/nk0LIzZBO2mLDz5g2AydAERanM6gswQ==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@module-federation/dts-plugin@0.7.6':
     resolution: {integrity: sha512-K8T8+Ip+fCQkTOxAQbAW47drphN36+WcvcOusn/fsIT+1exdhyvqxSCj8V7MLCtjA9kGDi0jHIGN6MN4p2cV0Q==}
     peerDependencies:
@@ -2138,6 +2144,20 @@ packages:
       vue-tsc: '>=1.0.24'
     peerDependenciesMeta:
       vue-tsc:
+        optional: true
+
+  '@module-federation/enhanced@0.7.6':
+    resolution: {integrity: sha512-ivTVuRKhew/25fiblAW22RybYzyacQsvnQG3y9zSNsYbwcj+0u7THWMmsK8vNKxDUpjxuQulCK07BEycDjoB5Q==}
+    peerDependencies:
+      typescript: ^4.9.0 || ^5.0.0
+      vue-tsc: '>=1.0.24'
+      webpack: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+      webpack:
         optional: true
 
   '@module-federation/error-codes@0.7.6':
@@ -2148,6 +2168,13 @@ packages:
 
   '@module-federation/manifest@0.7.6':
     resolution: {integrity: sha512-xBrFwLjDMUjKRnp+P4X29ZNyhgXSsp+SfrBxVsKJpEESOHalDoNClbo6gXvZAvkBZyo9sY3SJhAwduDwNkg04w==}
+
+  '@module-federation/rsbuild-plugin@0.7.6':
+    resolution: {integrity: sha512-aptyTzo6UCBLWlyfNZacqsmhTy9r+JmPb8x12mQjdvfL4TiW4azax41Ux5rl2o9uhU2+etwntmBXBbfW8CGa2Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@module-federation/enhanced': 0.7.6
+      '@rsbuild/core': 1.x
 
   '@module-federation/rspack@0.7.6':
     resolution: {integrity: sha512-alfX85C+2AQLXGrtpa08ImwhHIGwFIkJ/6i/XhxpYL5iFu0mC0xRIJPJUw0tiBWdFpP4p+Ykij3hP3FqfvaiKg==}
@@ -3351,6 +3378,11 @@ packages:
   browserslist@4.24.2:
     resolution: {integrity: sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  btoa@1.2.1:
+    resolution: {integrity: sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==}
+    engines: {node: '>= 0.4.0'}
     hasBin: true
 
   buffer-builder@0.2.0:
@@ -7821,6 +7853,14 @@ snapshots:
       '@types/semver': 7.5.8
       semver: 7.6.3
 
+  '@module-federation/data-prefetch@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@module-federation/runtime': 0.7.6
+      '@module-federation/sdk': 0.7.6
+      fs-extra: 9.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@module-federation/dts-plugin@0.7.6(typescript@5.6.3)':
     dependencies:
       '@module-federation/error-codes': 0.7.6
@@ -7846,6 +7886,29 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  '@module-federation/enhanced@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 0.7.6
+      '@module-federation/data-prefetch': 0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@module-federation/dts-plugin': 0.7.6(typescript@5.6.3)
+      '@module-federation/managers': 0.7.6
+      '@module-federation/manifest': 0.7.6(typescript@5.6.3)
+      '@module-federation/rspack': 0.7.6(typescript@5.6.3)
+      '@module-federation/runtime-tools': 0.7.6
+      '@module-federation/sdk': 0.7.6
+      btoa: 1.2.1
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 5.6.3
+      webpack: 5.96.1
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
   '@module-federation/error-codes@0.7.6': {}
 
   '@module-federation/managers@0.7.6':
@@ -7868,6 +7931,12 @@ snapshots:
       - typescript
       - utf-8-validate
       - vue-tsc
+
+  '@module-federation/rsbuild-plugin@0.7.6(@module-federation/enhanced@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1))(@rsbuild/core@packages+core)':
+    dependencies:
+      '@module-federation/enhanced': 0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1)
+      '@module-federation/sdk': 0.7.6
+      '@rsbuild/core': link:packages/core
 
   '@module-federation/rspack@0.7.6(typescript@5.6.3)':
     dependencies:
@@ -9182,6 +9251,8 @@ snapshots:
       electron-to-chromium: 1.5.50
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
+
+  btoa@1.2.1: {}
 
   buffer-builder@0.2.0: {}
 


### PR DESCRIPTION
## Summary

Use the MF Rsbuild plugin to simplify the MF v2 examples.

## Related Links

https://module-federation.io/guide/basic/rsbuild.html

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
