### PR TITLE
test(e2e): enable MF v2 HMR case

### DIFF
--- a/e2e/cases/module-federation-v2/host/rsbuild.config.ts
+++ b/e2e/cases/module-federation-v2/host/rsbuild.config.ts
@@ -1,26 +1,19 @@
-import { ModuleFederationPlugin } from '@module-federation/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'host',
+      remotes: {
+        remote: `remote@http://localhost:${process.env.REMOTE_PORT || 3002}/mf-manifest.json`,
+      },
+      shared: ['react', 'react-dom'],
+    }),
+  ],
   dev: {
     writeToDisk: true,
-  },
-  tools: {
-    rspack: {
-      output: {
-        uniqueName: 'host',
-      },
-      plugins: [
-        new ModuleFederationPlugin({
-          name: 'host',
-          remotes: {
-            remote: `remote@http://localhost:${process.env.REMOTE_PORT || 3002}/mf-manifest.json`,
-          },
-          shared: ['react', 'react-dom'],
-        }),
-      ],
-    },
   },
 });

--- a/e2e/cases/module-federation-v2/index.test.ts
+++ b/e2e/cases/module-federation-v2/index.test.ts
@@ -60,40 +60,44 @@ rspackOnlyTest(
   },
 );
 
-// TODO support for remote HMR
-test.skip('should allow remote module to perform HMR', async ({ page }) => {
-  // HMR cases will fail in Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
+rspackOnlyTest(
+  'should allow remote module to perform HMR',
+  async ({ page }) => {
+    // HMR cases will fail in Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
 
-  writeButtonCode();
+    writeButtonCode();
 
-  const remotePort = await getRandomPort();
+    const remotePort = await getRandomPort();
 
-  process.env.REMOTE_PORT = remotePort.toString();
+    process.env.REMOTE_PORT = remotePort.toString();
 
-  const remoteApp = await dev({
-    cwd: remote,
-  });
-  const hostApp = await dev({
-    cwd: host,
-  });
+    const remoteApp = await dev({
+      cwd: remote,
+    });
+    const hostApp = await dev({
+      cwd: host,
+    });
 
-  await gotoPage(page, remoteApp);
-  await expect(page.locator('#title')).toHaveText('Remote');
-  await expect(page.locator('#button')).toHaveText('Button from remote');
+    await gotoPage(page, remoteApp);
+    await expect(page.locator('#title')).toHaveText('Remote');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
 
-  await gotoPage(page, hostApp);
-  await expect(page.locator('#title')).toHaveText('Host');
-  await expect(page.locator('#button')).toHaveText('Button from remote');
+    await gotoPage(page, hostApp);
+    await expect(page.locator('#title')).toHaveText('Host');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
 
-  writeButtonCode('Button from remote (HMR)');
-  await expect(page.locator('#button')).toHaveText('Button from remote (HMR)');
+    writeButtonCode('Button from remote (HMR)');
+    await expect(page.locator('#button')).toHaveText(
+      'Button from remote (HMR)',
+    );
 
-  await hostApp.close();
-  await remoteApp.close();
-});
+    await hostApp.close();
+    await remoteApp.close();
+  },
+);
 
 // TODO downgrade syntax
 test.skip('should transform module federation runtime with SWC', async () => {

--- a/e2e/cases/module-federation-v2/remote/rsbuild.config.ts
+++ b/e2e/cases/module-federation-v2/remote/rsbuild.config.ts
@@ -1,30 +1,22 @@
-import { ModuleFederationPlugin } from '@module-federation/rspack';
+import { pluginModuleFederation } from '@module-federation/rsbuild-plugin';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
+  plugins: [
+    pluginReact(),
+    pluginModuleFederation({
+      name: 'remote',
+      exposes: {
+        './Button': './src/test-temp-Button',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+  ],
   server: {
     port: Number(process.env.REMOTE_PORT) || 3002,
   },
   dev: {
     writeToDisk: true,
-    assetPrefix: true,
-  },
-  tools: {
-    rspack: {
-      output: {
-        uniqueName: 'remote',
-      },
-      plugins: [
-        new ModuleFederationPlugin({
-          name: 'remote',
-          exposes: {
-            './Button': './src/test-temp-Button',
-          },
-          shared: ['react', 'react-dom'],
-        }),
-      ],
-    },
   },
 });

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,7 +38,7 @@
     "@rsbuild/plugin-vue": "workspace:*",
     "@rsbuild/plugin-vue-jsx": "^1.0.1",
     "@rsbuild/webpack": "workspace:*",
-    "@module-federation/rspack": "0.7.6",
+    "@module-federation/rsbuild-plugin": "0.7.6",
     "@scripts/test-helper": "workspace:*",
     "@types/fs-extra": "^11.0.4",
     "@types/lodash": "^4.17.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,9 @@ importers:
       '@e2e/helper':
         specifier: workspace:*
         version: link:scripts
-      '@module-federation/rspack':
+      '@module-federation/rsbuild-plugin':
         specifier: 0.7.6
-        version: 0.7.6(typescript@5.6.3)
+        version: 0.7.6(@module-federation/enhanced@0.7.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.6.3)(webpack@5.96.1))(@rsbuild/core@packages+core)
       '@playwright/test':
         specifier: 1.44.1
         version: 1.44.1


### PR DESCRIPTION
## Summary

Switch to `@module-federation/rsbuild-plugin` and it supports MF v2 HMR out-of-the-box, so we can enable the MF v2 HMR test case.

## Related Links

https://module-federation.io/guide/basic/rsbuild.html

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
