### PR TITLE
fix(plugin-assets-retry): avoid __webpack_require__.e pollution and add some try catch to be safer

### DIFF
--- a/.changeset/cyan-flies-destroy.md
+++ b/.changeset/cyan-flies-destroy.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/plugin-assets-retry': patch
+---
+
+fix(plugin-assets-retry): avoid **webpack_require**.e pollution


### PR DESCRIPTION
## Summary

if apps use preload, `__webpack_require__.e` would have other arguments `fetchPriority`, that would cause the error

![img_v3_02gr_f9b96642-8ffb-48e1-ba46-d83d7d37763g](https://github.com/user-attachments/assets/e1dbfb10-c939-49fc-8688-46a6ff542ee4)

1. add args placeholder to avoid other runtime code overrides the `__webpack_require__.e`  with some args
2. add some `try catch` logic to make safer

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
