### PR TITLE
fix: should close compiler when dev closed

### DIFF
--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -59,9 +59,6 @@ const formatDevConfig = (
     },
   };
 };
-const noop = () => {
-  // noop
-};
 
 function getClientPaths(devConfig: DevConfig) {
   const clientPaths: string[] = [];
@@ -118,10 +115,24 @@ export class CompilerDevMiddleware {
     this.socketServer.upgrade(req, sock, head);
   }
 
-  public close(): void {
+  public async close(): Promise<void> {
     // socketServer close should before app close
     this.socketServer.close();
-    this.middleware?.close(noop);
+
+    if (this.middleware) {
+      await new Promise<void>((resolve) => {
+        this.middleware.close(() => {
+          resolve();
+        });
+      });
+    }
+
+    // middleware close only stop watching for file changes.
+    await new Promise<void>((resolve) => {
+      this.compiler.close(() => {
+        resolve();
+      });
+    });
   }
 
   public sockWrite(

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -127,7 +127,7 @@ export class CompilerDevMiddleware {
       });
     }
 
-    // middleware close only stop watching for file changes.
+    // `middleware.close()` only stop watching for file changes, compiler should also be closed.
     await new Promise<void>((resolve) => {
       this.compiler.close(() => {
         resolve();

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -26,7 +26,7 @@ export type CompileMiddlewareAPI = {
   middleware: RequestHandler;
   sockWrite: SetupMiddlewaresServer['sockWrite'];
   onUpgrade: UpgradeEvent;
-  close: () => void;
+  close: () => Promise<void>;
 };
 
 export type RsbuildDevMiddlewareOptions = {
@@ -260,7 +260,7 @@ export const getMiddlewares = async (
 
   return {
     close: async () => {
-      compileMiddlewareAPI?.close();
+      await compileMiddlewareAPI?.close();
     },
     onUpgrade,
     middlewares,


### PR DESCRIPTION
## Summary

Should close compiler when dev closed. According to `webpack-dev-middleware` doc, middleware close only stop watching for file changes.

https://github.com/webpack/webpack-dev-middleware?tab=readme-ov-file#closecallback

It is expected that the relevant memory can be GC when the compiler closed, however currently this part of the memory cannot be fully GC due to unknown reasons.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
