### PR TITLE
release: @rsbuild/plugin-assets-retry 1.0.5

### DIFF
--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {


### PR DESCRIPTION
## Summary

release: @rsbuild/plugin-assets-retry 1.0.5 

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4025
<!--- Provide links of related issues or pages -->

