### PR TITLE
chore(deps): bump Rslib v0.1.0

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/lodash": "^4.17.13",
     "@types/semver": "^7.5.8",
     "typescript": "^5.6.3",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "ansi-escapes": "4.3.2",

--- a/packages/compat/webpack/rslib.config.ts
+++ b/packages/compat/webpack/rslib.config.ts
@@ -11,16 +11,6 @@ export default defineConfig({
   lib: [
     esmConfig,
     mergeRsbuildConfig(cjsConfig, {
-      output: {
-        // TODO https://github.com/web-infra-dev/rslib/issues/287
-        externals: {
-          webpack: 'import webpack',
-          'copy-webpack-plugin': 'import copy-webpack-plugin',
-          'mini-css-extract-plugin': 'import mini-css-extract-plugin',
-          'tsconfig-paths-webpack-plugin':
-            'import tsconfig-paths-webpack-plugin',
-        },
-      },
       footer: {
         // TODO https://github.com/web-infra-dev/rslib/issues/351
         js: `// Annotate the CommonJS export names for ESM import in node:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "core-js": "~3.39.0"
   },
   "devDependencies": {
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/connect": "3.4.38",
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^22.9.1",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -31,7 +31,7 @@
     "create-rstack": "1.0.9"
   },
   "devDependencies": {
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.9.1",
     "typescript": "^5.6.3"
   },

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/serialize-javascript": "^5.0.4",
     "serialize-javascript": "^6.0.2",
     "terser": "5.36.0",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "babel-loader": "9.2.1",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.7",
     "less": "^4.2.0",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.9.1",
     "preact": "^10.24.3",
     "typescript": "^5.6.3"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "typescript": "^5.6.3"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "@types/sass-loader": "^8.0.9",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "typescript": "^5.6.3"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "typescript": "^5.6.3"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "svelte": "^5.2.4",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "file-loader": "6.2.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.9.1",
     "typescript": "^5.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,8 +504,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -544,8 +544,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../../scripts/test-helper
@@ -581,8 +581,8 @@ importers:
         version: 3.39.0
     devDependencies:
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -717,8 +717,8 @@ importers:
         version: 1.0.9
     devDependencies:
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/node':
         specifier: ^22.9.1
         version: 22.9.1
@@ -741,8 +741,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
@@ -787,8 +787,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -818,8 +818,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -858,8 +858,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/node':
         specifier: ^22.9.1
         version: 22.9.1
@@ -883,8 +883,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -917,8 +917,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -957,8 +957,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -988,8 +988,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1013,8 +1013,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1053,8 +1053,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1090,8 +1090,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1111,8 +1111,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
       '@types/node':
         specifier: ^22.9.1
         version: 22.9.1
@@ -1139,8 +1139,8 @@ importers:
         version: 2.0.1
     devDependencies:
       '@rslib/core':
-        specifier: 0.0.18
-        version: 0.0.18(typescript@5.6.3)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.6.3)
 
   website:
     devDependencies:
@@ -2482,11 +2482,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.1.0':
-    resolution: {integrity: sha512-SyQlJjWgR1VwLt4nuiY0g6L9INv2koH232TeDZuopvNgbRytskD3kJ8bbGWBBXsQjZjtqBEh5ishqf8CIfF8dQ==}
-    engines: {node: '>=16.7.0'}
-    hasBin: true
-
   '@rsbuild/core@1.1.4':
     resolution: {integrity: sha512-fN13hH6Ag0WgCCDUJErNvGs39hSePr8MTaJu1TjUZbFAY3DtOsUHhEb2V5zCUiaeMLMz7ef+krj7+duAJkizog==}
     engines: {node: '>=16.7.0'}
@@ -2536,8 +2531,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.0.18':
-    resolution: {integrity: sha512-TN3WOgpX5FvHDA5oWm/5vG+sQQhzkUiHx0YjgEQHA0IiRUJNwaqDvSyRyQkBqWrQw5o6WpVet9kM/P6+rm4RSw==}
+  '@rslib/core@0.1.0':
+    resolution: {integrity: sha512-CGtHgTgj8BSWdQB7yCpGjr5dd37Y7jj/IH6rAtrYbTJR0/o7dm4QqygdwjR8MHBlD9fYTGu7uWbKRdh6qYXPTw==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:
@@ -5594,8 +5589,8 @@ packages:
       webpack:
         optional: true
 
-  rsbuild-plugin-dts@0.0.18:
-    resolution: {integrity: sha512-svOrOUi3INkEEhUShMtUBqpBKNdco6qY8BmvO7wAHzU736p3bemlf79ubxDpWFR1WbML9ahv6MqrIQunu3aDNg==}
+  rsbuild-plugin-dts@0.1.0:
+    resolution: {integrity: sha512-8HE2aGkseyrkNSPmJLVEgqIvaTDWGJYE5l6Hfrf94mFzAFcbtHOrYTr4aR/zw90x+BY3sMfE3bMBj/wR9AnxiA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8083,15 +8078,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.3':
     optional: true
 
-  '@rsbuild/core@1.1.0':
-    dependencies:
-      '@rspack/core': 1.1.2(@swc/helpers@0.5.15)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.15
-      core-js: 3.39.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
   '@rsbuild/core@1.1.4':
     dependencies:
       '@rspack/core': 1.1.2(@swc/helpers@0.5.15)
@@ -8162,10 +8148,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rslib/core@0.0.18(typescript@5.6.3)':
+  '@rslib/core@0.1.0(typescript@5.6.3)':
     dependencies:
-      '@rsbuild/core': 1.1.0
-      rsbuild-plugin-dts: 0.0.18(@rsbuild/core@1.1.0)(typescript@5.6.3)
+      '@rsbuild/core': 1.1.4
+      rsbuild-plugin-dts: 0.1.0(@rsbuild/core@1.1.4)(typescript@5.6.3)
       tinyglobby: 0.2.10
     optionalDependencies:
       typescript: 5.6.3
@@ -11687,9 +11673,9 @@ snapshots:
     optionalDependencies:
       webpack: 5.96.1
 
-  rsbuild-plugin-dts@0.0.18(@rsbuild/core@1.1.0)(typescript@5.6.3):
+  rsbuild-plugin-dts@0.1.0(@rsbuild/core@1.1.4)(typescript@5.6.3):
     dependencies:
-      '@rsbuild/core': 1.1.0
+      '@rsbuild/core': 1.1.4
       magic-string: 0.30.12
       picocolors: 1.1.1
       tinyglobby: 0.2.10

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.0.18",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.9.1",
     "typescript": "^5.6.3"
   }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -32,7 +32,7 @@
     "upath": "2.0.1"
   },
   "devDependencies": {
-    "@rslib/core": "0.0.18"
+    "@rslib/core": "0.1.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Bump Rslib v0.1.0, remove unused config.

## Related Links

https://github.com/web-infra-dev/rslib/releases/tag/v0.1.0
close https://github.com/web-infra-dev/rsbuild/pull/4029

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
