### PR TITLE
feat: allow `output.sourceMap` to be boolean value

### DIFF
--- a/e2e/cases/source-map/index.test.ts
+++ b/e2e/cases/source-map/index.test.ts
@@ -113,6 +113,50 @@ test('should not generate source map by default in production build', async () =
   expect(cssMapFiles.length).toEqual(0);
 });
 
+test('should generate source map if `output.sourceMap` is true', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    rsbuildConfig: {
+      output: {
+        sourceMap: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON(false);
+
+  const jsMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapFiles.length).toBeGreaterThan(0);
+  expect(cssMapFiles.length).toBeGreaterThan(0);
+});
+
+test('should not generate source map if `output.sourceMap` is false', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    rsbuildConfig: {
+      output: {
+        sourceMap: false,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON(false);
+
+  const jsMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapFiles.length).toEqual(0);
+  expect(cssMapFiles.length).toEqual(0);
+});
+
 test('should generate source map correctly in development build', async ({
   page,
 }) => {

--- a/packages/compat/plugin-webpack-swc/src/minimizer.ts
+++ b/packages/compat/plugin-webpack-swc/src/minimizer.ts
@@ -85,7 +85,7 @@ export class SwcMinimizerPlugin {
 
   private name = 'swc-minimizer-plugin';
 
-  private rsbuildSourceMapConfig: NormalizedEnvironmentConfig['output']['sourceMap'];
+  private sourceMapConfig: NormalizedEnvironmentConfig['output']['sourceMap'];
 
   constructor(options: {
     jsMinify?: boolean | JsMinifyOptions;
@@ -93,7 +93,7 @@ export class SwcMinimizerPlugin {
     getEnvironmentConfig: () => NormalizedEnvironmentConfig;
   }) {
     const rsbuildConfig = options.getEnvironmentConfig();
-    this.rsbuildSourceMapConfig = rsbuildConfig.output.sourceMap;
+    this.sourceMapConfig = rsbuildConfig.output.sourceMap;
     this.minifyOptions = {
       jsMinify: options.jsMinify
         ? deepmerge<JsMinifyOptions>(
@@ -129,24 +129,22 @@ export class SwcMinimizerPlugin {
       const { devtool } = compilation.options;
       const { jsMinify, cssMinify } = this.minifyOptions;
 
-      const enableMinify =
-        typeof devtool === 'string'
-          ? devtool.includes('source-map')
-          : Boolean(devtool);
+      const enableSourceMap = Boolean(devtool);
       const inlineSourceContent =
         typeof devtool === 'string' && devtool.includes('inline');
 
       if (jsMinify) {
-        const userSourceMapJS = this.rsbuildSourceMapConfig.js;
-        jsMinify.sourceMap =
-          userSourceMapJS === undefined ? enableMinify : !!userSourceMapJS;
+        jsMinify.sourceMap = enableSourceMap;
         jsMinify.inlineSourcesContent = inlineSourceContent;
       }
 
       if (cssMinify) {
-        const userSourceMapCss = this.rsbuildSourceMapConfig.css;
+        const userSourceMapCss =
+          typeof this.sourceMapConfig === 'boolean'
+            ? this.sourceMapConfig
+            : this.sourceMapConfig.css;
         cssMinify.sourceMap =
-          userSourceMapCss === undefined ? enableMinify : !!userSourceMapCss;
+          userSourceMapCss === undefined ? enableSourceMap : !!userSourceMapCss;
         cssMinify.inlineSourceContent = inlineSourceContent;
       }
 

--- a/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -126,7 +126,7 @@ exports[`plugin-webpack-swc > output.sourceMap config for swcMinimizerPlugin 1`]
             },
           },
           "name": "swc-minimizer-plugin",
-          "rsbuildSourceMapConfig": {
+          "sourceMapConfig": {
             "css": false,
             "js": "cheap-source-map",
           },
@@ -137,7 +137,7 @@ exports[`plugin-webpack-swc > output.sourceMap config for swcMinimizerPlugin 1`]
             "jsMinify": undefined,
           },
           "name": "swc-minimizer-plugin",
-          "rsbuildSourceMapConfig": {
+          "sourceMapConfig": {
             "css": false,
             "js": "cheap-source-map",
           },
@@ -960,7 +960,7 @@ exports[`plugin-webpack-swc > should set SWC minimizer in production 1`] = `
         },
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -971,7 +971,7 @@ exports[`plugin-webpack-swc > should set SWC minimizer in production 1`] = `
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -995,7 +995,7 @@ exports[`plugin-webpack-swc > should set correct SWC minimizer options in produc
         },
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -1006,7 +1006,7 @@ exports[`plugin-webpack-swc > should set correct SWC minimizer options in produc
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -1030,7 +1030,7 @@ exports[`plugin-webpack-swc > should set correct SWC minimizer options using raw
         },
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -1041,7 +1041,7 @@ exports[`plugin-webpack-swc > should set correct SWC minimizer options using raw
         "jsMinify": undefined,
       },
       "name": "swc-minimizer-plugin",
-      "rsbuildSourceMapConfig": {
+      "sourceMapConfig": {
         "css": false,
         "js": undefined,
       },
@@ -1460,7 +1460,7 @@ exports[`plugin-webpack-swc > should use output config 1`] = `
             },
           },
           "name": "swc-minimizer-plugin",
-          "rsbuildSourceMapConfig": {
+          "sourceMapConfig": {
             "css": false,
             "js": undefined,
           },

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -1,10 +1,24 @@
 import path from 'node:path';
-import type { NormalizedEnvironmentConfig, RsbuildPlugin } from '../types';
+import type {
+  NormalizedEnvironmentConfig,
+  RsbuildPlugin,
+  Rspack,
+} from '../types';
 
-const getJsSourceMap = (config: NormalizedEnvironmentConfig) => {
+const getJsSourceMap = (
+  config: NormalizedEnvironmentConfig,
+): Rspack.DevTool => {
   const { sourceMap } = config.output;
+  const isProd = config.mode === 'production';
+
+  if (sourceMap === false) {
+    return false;
+  }
+  if (sourceMap === true) {
+    return isProd ? 'source-map' : 'cheap-module-source-map';
+  }
   if (sourceMap.js === undefined) {
-    return config.mode === 'production' ? false : 'cheap-module-source-map';
+    return isProd ? false : 'cheap-module-source-map';
   }
   return sourceMap.js;
 };

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -72,6 +72,11 @@ const clonePostCSSConfig = (config: PostCSSOptions) => ({
   plugins: config.plugins ? [...config.plugins] : undefined,
 });
 
+const getCSSSourceMap = (config: NormalizedEnvironmentConfig): boolean => {
+  const { sourceMap } = config.output;
+  return typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css;
+};
+
 async function loadUserPostcssrc(root: string): Promise<PostCSSOptions> {
   const cached = userPostcssrcCache.get(root);
 
@@ -128,7 +133,7 @@ const getPostcssLoaderOptions = async ({
   const defaultOptions: PostCSSLoaderOptions = {
     implementation: getCompiledPath('postcss'),
     postcssOptions: userOptions,
-    sourceMap: config.output.sourceMap.css,
+    sourceMap: getCSSSourceMap(config),
   };
 
   const finalOptions = reduceConfigsWithContext({
@@ -209,7 +214,7 @@ const getCSSLoaderOptions = ({
       ...cssModules,
       localIdentName,
     },
-    sourceMap: config.output.sourceMap.css,
+    sourceMap: getCSSSourceMap(config),
   };
 
   const mergedCssLoaderOptions = reduceConfigs({

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -919,7 +919,7 @@ export interface OutputConfig {
    * };
    * ```
    */
-  sourceMap?: SourceMap;
+  sourceMap?: boolean | SourceMap;
   /**
    * Whether to add filename hash after production build.
    * @default true
@@ -974,10 +974,12 @@ export interface NormalizedOutputConfig extends OutputConfig {
   distPath: Omit<Required<DistPathConfig>, 'jsAsync' | 'cssAsync' | 'js'> &
     Pick<DistPathConfig, 'jsAsync' | 'cssAsync' | 'js'>;
   polyfill: Polyfill;
-  sourceMap: {
-    js?: Rspack.Configuration['devtool'];
-    css: boolean;
-  };
+  sourceMap:
+    | boolean
+    | {
+        js?: Rspack.Configuration['devtool'];
+        css: boolean;
+      };
   filenameHash: boolean | string;
   assetPrefix: string;
   dataUriLimit: number | NormalizedDataUriLimit;

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -146,9 +146,10 @@ export const pluginLess = (
         .resolve.preferRelative(true)
         .end();
 
+      const { sourceMap } = config.output;
       const { excludes, options } = getLessLoaderOptions(
         pluginOptions.lessLoaderOptions,
-        config.output.sourceMap.css,
+        typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css,
         api.context.rootPath,
       );
 

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -40,9 +40,10 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
     api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
+      const { sourceMap } = config.output;
       const mergedOptions = reduceConfigs({
         initial: {
-          sourceMap: config.output.sourceMap.css,
+          sourceMap: typeof sourceMap === 'boolean' ? sourceMap : sourceMap.css,
         },
         config: options,
         mergeFn: deepmerge,

--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -3,17 +3,19 @@
 - **Type:**
 
 ```ts
-type SourceMap = {
-  js?: Rspack.Configuration['devtool'];
-  css?: boolean;
-};
+type SourceMap =
+  | boolean
+  | {
+      js?: Rspack.Configuration['devtool'];
+      css?: boolean;
+    };
 ```
 
 - **Default:**
 
 ```ts
 const defaultSourceMap = {
-  js: isDev ? 'cheap-module-source-map' : false,
+  js: mode === 'development' ? 'cheap-module-source-map' : false,
   css: false,
 };
 ```
@@ -30,6 +32,34 @@ By default, the source map generation rules for Rsbuild are as follows:
 
 - In development mode, source maps for JS files are generated for development debugging, while source maps for CSS files are not generated.
 - In production mode, no source maps for JS and CSS files are generated to improve build performance.
+
+## Boolean value
+
+If `output.sourceMap` is `true`, the source map will be generated according to the [mode](/config/mode), equivalent to:
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: mode === 'development' ? 'cheap-module-source-map' : 'source-map',
+      css: true,
+    },
+  },
+};
+```
+
+If `output.sourceMap` is `false`, no source map will be generated, equivalent to:
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: false,
+      css: false,
+    },
+  },
+};
+```
 
 ## JS Source Map
 

--- a/website/docs/zh/config/output/source-map.mdx
+++ b/website/docs/zh/config/output/source-map.mdx
@@ -3,17 +3,19 @@
 - **类型：**
 
 ```ts
-type SourceMap = {
-  js?: Rspack.Configuration['devtool'];
-  css?: boolean;
-};
+type SourceMap =
+  | boolean
+  | {
+      js?: Rspack.Configuration['devtool'];
+      css?: boolean;
+    };
 ```
 
 - **默认值：**
 
 ```ts
 const defaultSourceMap = {
-  js: isDev ? 'cheap-module-source-map' : false,
+  js: mode === 'development' ? 'cheap-module-source-map' : false,
   css: false,
 };
 ```
@@ -30,6 +32,34 @@ source map 是保存源代码映射关系的信息文件，它记录了编译后
 
 - 在开发模式构建时，会生成 JS 文件的 source map，便于进行开发调试；不会生成 CSS 文件的 source map。
 - 在生产模式构建时，不会生成 JS 和 CSS 文件的 source map，以提供最佳的构建性能。
+
+## 布尔值
+
+如果 `output.sourceMap` 为 `true`，则会根据 [mode](/config/mode) 生成 JS 和 CSS 文件的 source map，等价于：
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: mode === 'development' ? 'cheap-module-source-map' : 'source-map',
+      css: true,
+    },
+  },
+};
+```
+
+如果 `output.sourceMap` 为 `false`，则不会生成 JS 和 CSS 文件的 source map，等价于：
+
+```js
+export default {
+  output: {
+    sourceMap: {
+      js: false,
+      css: false,
+    },
+  },
+};
+```
 
 ## JS Source Map
 


### PR DESCRIPTION
## Summary

Allow `output.sourceMap` to be boolean value to simplify source map configuration.

## Related Links

https://github.com/web-infra-dev/rslib/discussions/467

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
