### PR TITLE
feat: add `printFileSize.exclude` option

### DIFF
--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -224,4 +224,23 @@ test.describe('should print file size correctly', async () => {
     expect(logs.some((log) => log.includes('.js'))).toBeTruthy();
     expect(logs.some((log) => log.includes('.css'))).toBeFalsy();
   });
+
+  test('should allow to custom exclude function', async () => {
+    await build({
+      cwd,
+      rsbuildConfig: {
+        performance: {
+          printFileSize: {
+            exclude: (asset) =>
+              /\.(?:map|LICENSE\.txt)$/.test(asset.name) ||
+              /\.html$/.test(asset.name),
+          },
+        },
+      },
+    });
+
+    expect(logs.some((log) => log.includes('index.html'))).toBeFalsy();
+    expect(logs.some((log) => log.includes('.js'))).toBeTruthy();
+    expect(logs.some((log) => log.includes('.css'))).toBeTruthy();
+  });
 });

--- a/e2e/cases/print-file-size/basic/src/App.css
+++ b/e2e/cases/print-file-size/basic/src/App.css
@@ -1,0 +1,3 @@
+.foo {
+  color: red;
+}

--- a/e2e/cases/print-file-size/basic/src/App.jsx
+++ b/e2e/cases/print-file-size/basic/src/App.jsx
@@ -1,3 +1,5 @@
+import './App.css';
+
 const App = () => <div id="test">Hello Rsbuild!</div>;
 
 export default App;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -478,6 +478,12 @@ export type PrintFileSizeOptions = {
    * @default undefined
    */
   include?: (asset: PrintFileSizeAsset) => boolean;
+  /**
+   * A filter function to exclude static assets from the total size or detailed size.
+   * If both `include` and `exclude` are set, `exclude` will take precedence.
+   * @default (asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)
+   */
+  exclude?: (asset: PrintFileSizeAsset) => boolean;
 };
 
 export interface PreconnectOption {

--- a/packages/core/tests/fileSize.test.ts
+++ b/packages/core/tests/fileSize.test.ts
@@ -1,13 +1,17 @@
-import { filterAsset } from '../src/plugins/fileSize';
+import { excludeAsset } from '../src/plugins/fileSize';
 
 describe('plugin-file-size', () => {
-  it('#filterAsset - should filter asset correctly', () => {
-    expect(filterAsset('dist/a.js')).toBeTruthy();
-    expect(filterAsset('dist/a.css')).toBeTruthy();
-    expect(filterAsset('dist/a.js.map')).toBeFalsy();
-    expect(filterAsset('dist/b.css.map')).toBeFalsy();
-    expect(filterAsset('dist/a.js.LICENSE.txt')).toBeFalsy();
-    expect(filterAsset('dist/b.css.LICENSE.txt')).toBeFalsy();
-    expect(filterAsset('dist/a.png')).toBeTruthy();
+  it('#excludeAsset - should exclude asset correctly', () => {
+    expect(excludeAsset({ name: 'dist/a.js', size: 1000 })).toBeFalsy();
+    expect(excludeAsset({ name: 'dist/a.css', size: 1000 })).toBeFalsy();
+    expect(excludeAsset({ name: 'dist/a.js.map', size: 1000 })).toBeTruthy();
+    expect(excludeAsset({ name: 'dist/b.css.map', size: 1000 })).toBeTruthy();
+    expect(
+      excludeAsset({ name: 'dist/a.js.LICENSE.txt', size: 1000 }),
+    ).toBeTruthy();
+    expect(
+      excludeAsset({ name: 'dist/b.css.LICENSE.txt', size: 1000 }),
+    ).toBeTruthy();
+    expect(excludeAsset({ name: 'dist/a.png', size: 1000 })).toBeFalsy();
   });
 });

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -139,13 +139,41 @@ export default {
 };
 ```
 
-Or only output `.js` files:
+Or only output `.js` files larger than 10kB:
 
 ```ts
 export default {
   performance: {
     printFileSize: {
-      include: (asset) => /\.js$/.test(asset.name),
+      include: (asset) => /\.js$/.test(asset.name) && asset.size > 10 * 1000,
+    },
+  },
+};
+```
+
+### exclude
+
+- **Type:**
+
+```ts
+type Exclude = (asset: PrintFileSizeAsset) => boolean;
+```
+
+- **Default:** `(asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)`
+
+A filter function to determine which static assets to exclude. If both `include` and `exclude` are set, `exclude` will take precedence.
+
+Rsbuild defaults to excluding source map and license files, as these files do not affect page load performance.
+
+For example, exclude `.html` files in addition to the default:
+
+```ts
+export default {
+  performance: {
+    printFileSize: {
+      exclude: (asset) =>
+        /\.(?:map|LICENSE\.txt)$/.test(asset.name) ||
+        /\.html$/.test(asset.name),
     },
   },
 };

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -139,13 +139,41 @@ export default {
 };
 ```
 
-或者只输出 `.js` 文件：
+或者只输出体积大于 10kB 的 `.js` 文件：
 
 ```ts
 export default {
   performance: {
     printFileSize: {
-      include: (asset) => /\.js$/.test(asset.name),
+      include: (asset) => /\.js$/.test(asset.name) && asset.size > 10 * 1000,
+    },
+  },
+};
+```
+
+### exclude
+
+- **类型：**
+
+```ts
+type Exclude = (asset: PrintFileSizeAsset) => boolean;
+```
+
+- **默认值：** `(asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)`
+
+一个过滤函数，用于确定哪些静态资源需要被排除。如果同时设置了 `include` 和 `exclude`，则 `exclude` 优先级更高。
+
+Rsbuild 默认排除 source map 和 license 文件，因为这些文件不会影响页面加载的性能。
+
+例如，额外再排除 `.html` 文件：
+
+```ts
+export default {
+  performance: {
+    printFileSize: {
+      exclude: (asset) =>
+        /\.(?:map|LICENSE\.txt)$/.test(asset.name) ||
+        /\.html$/.test(asset.name),
     },
   },
 };


### PR DESCRIPTION
## Summary

Add new `printFileSize.exclude` option to determine which static assets to exclude.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4041Ï

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
