### PR TITLE
perf: ignore watching files in node_modules

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -388,6 +388,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -771,6 +774,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -1100,6 +1106,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     ],
   },
   "target": "node",
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -1418,5 +1427,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "webworker",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -50,6 +50,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
           },
         });
 
+        // Ignore watching files in node_modules to reduce memory usage and make startup faster
+        chain.watchOptions({
+          ignored: /[\\/](?:\.git|node_modules)[\\/]/,
+        });
+
         // Disable performance hints, these logs are too complex
         chain.performance.hints(false);
 

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -28,6 +28,9 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
       "name": "HotModuleReplacementPlugin",
     },
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -53,5 +56,8 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "plugins": [
     RsbuildCorePlugin {},
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -399,5 +399,8 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -414,6 +414,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -867,6 +870,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -1215,6 +1221,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
   },
   "target": "node",
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;
 
@@ -1647,5 +1656,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "web",
     "es2017",
   ],
+  "watchOptions": {
+    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+  },
 }
 `;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1526,6 +1526,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "web",
       "es2017",
     ],
+    "watchOptions": {
+      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    },
   },
   {
     "context": "<ROOT>",
@@ -1852,6 +1855,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       ],
     },
     "target": "node",
+    "watchOptions": {
+      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    },
   },
 ]
 `;


### PR DESCRIPTION
## Summary

Update the default `watchOptions` configuration to improve performance by ignoring node_modules.

This will not affect symlinked resources in monorepo, as symlinked resources are resolved to their real path by default.

## Benchmark

Using the benchmark repo for testing: https://github.com/rspack-contrib/build-tools-performance

- Memory usage reduced by 120MB
- dev startup speed increased by 40%
- HMR speed increased by 20~30%

![20241126-104609](https://github.com/user-attachments/assets/c46ba5f4-2104-4bb3-9584-ae6d78eb57cd)

## Related Links

- Next.js does not watch node_modules by default: https://github.com/vercel/next.js/blob/56b28ce8f814273b3a991e878731384fb0ebe025/packages/next/src/build/webpack-config.ts#L141
- Vite does not watch node_modules by default: https://vite.dev/config/server-options.html#server-watch
- Twitter votes: https://x.com/rspack_dev/status/1861223088001819115
- https://github.com/web-infra-dev/rspack/issues/8511

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).

I will update the doc in another PR.
