### PR TITLE
perf: aggregateTimeout defaults to 0

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -389,6 +389,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -775,6 +776,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -1107,6 +1109,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "target": "node",
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -1428,6 +1431,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -50,9 +50,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
           },
         });
 
-        // Ignore watching files in node_modules to reduce memory usage and make startup faster
         chain.watchOptions({
+          // Ignore watching files in node_modules to reduce memory usage and make startup faster
           ignored: /[\\/](?:\.git|node_modules)[\\/]/,
+          // Remove the delay before rebuilding once the first file changed
+          aggregateTimeout: 0,
         });
 
         // Disable performance hints, these logs are too complex

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -29,6 +29,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
     },
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -57,6 +58,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
     RsbuildCorePlugin {},
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -400,6 +400,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -415,6 +415,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -871,6 +872,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -1222,6 +1224,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "target": "node",
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
@@ -1657,6 +1660,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "es2017",
   ],
   "watchOptions": {
+    "aggregateTimeout": 0,
     "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1527,6 +1527,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "es2017",
     ],
     "watchOptions": {
+      "aggregateTimeout": 0,
       "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
     },
   },
@@ -1856,6 +1857,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     },
     "target": "node",
     "watchOptions": {
+      "aggregateTimeout": 0,
       "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
     },
   },


### PR DESCRIPTION
## Summary

Set `aggregateTimeout` to `0` by default to make HMR a bit faster.

If this change results in an unnecessary rebuild, we can roll it back.

## Related Links

https://github.com/search?q=%22aggregateTimeout%3A+0%22&type=code&p=1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
