### PR TITLE
perf: no need to calc gzipped size for Node bundles

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -263,7 +263,7 @@ export const pluginFileSize = (): RsbuildPlugin => ({
           const defaultConfig: PrintFileSizeOptions = {
             total: true,
             detail: true,
-            // print compressed size only in the browser environment by default
+            // print compressed size for the browser targets by default
             compressed: environment.config.output.target !== 'node',
           };
 

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -263,7 +263,8 @@ export const pluginFileSize = (): RsbuildPlugin => ({
           const defaultConfig: PrintFileSizeOptions = {
             total: true,
             detail: true,
-            compressed: true,
+            // print compressed size only in the browser environment by default
+            compressed: environment.config.output.target !== 'node',
           };
 
           const mergedConfig =

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -86,7 +86,7 @@ export default {
 ### compressed
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `false` when [output.target](/config/output/target) is `node`, otherwise `true`
 
 Whether to output the gzip-compressed size of each static asset.
 

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -86,7 +86,7 @@ export default {
 ### compressed
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** 当 [output.target](/config/output/target) 为 `node` 时为 `false`，否则为 `true`
 
 是否输出 gzip 压缩后的体积。
 


### PR DESCRIPTION
## Summary

Print compressed size only for the browser targets by default, which can make Node bundles building faster.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
