### PR TITLE
feat(CLI): close instance after building

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -103,8 +103,12 @@ export function setupCommands(): void {
           watch: options.watch,
         });
 
-        if (options.watch && buildInstance) {
-          onBeforeRestartServer(buildInstance.close);
+        if (buildInstance) {
+          if (options.watch) {
+            onBeforeRestartServer(buildInstance.close);
+          } else {
+            await buildInstance.close();
+          }
         }
       } catch (err) {
         logger.error('Failed to build.');

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@ Called only when running the `rsbuild dev` command or the `rsbuild.startDevServe
 - [onAfterStartDevServer](#onafterstartdevserver): Called after starting the dev server.
 - [onDevCompileDone](#ondevcompiledone): Called after each build in development mode.
 
-Called only when Rsbuild restart or executing the close method of `rsbuild.startDevServer`.
+Called only when Rsbuild is restarted or when the `close()` method of `rsbuild.build()` is executed.
 
 - [onCloseDevServer](#onclosedevserver): Called when the dev server is closed.
 
@@ -36,7 +36,7 @@ Called only when running the `rsbuild build` command or the `rsbuild.build()` me
 - [onBeforeBuild](#onbeforebuild): Called before running the production build.
 - [onAfterBuild](#onafterbuild): Called after running the production build. You can get the build result information.
 
-Called only when Rsbuild restart or executing the close method of `rsbuild.build`.
+Called only when Rsbuild is restarted or when the `close()` method of `rsbuild.build()` is executed.
 
 - [onCloseBuild](#onclosebuild): Called when the build is closed.
 

--- a/website/docs/en/shared/onCloseBuild.mdx
+++ b/website/docs/en/shared/onCloseBuild.mdx
@@ -1,5 +1,7 @@
 Called when closing the build instance. Can be used to perform cleanup operations when the building is closed.
 
+Rsbuild CLI will automatically call this hook after running [rsbuild build](/guide/basic/cli#rsbuild-build), while users of the JavaScript API need to manually call the [rsbuild.close()](/api/javascript-api/instance#rsbuildbuild) method to trigger this hook.
+
 - **Type:**
 
 ```ts

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@
 - [onAfterStartDevServer](#onafterstartdevserver)：在启动开发服务器后调用。
 - [onDevCompileDone](#ondevcompiledone)：在每次开发模式构建结束后调用。
 
-仅在 Rsbuild restart 或执行 `rsbuild.startDevServer` 的 close 方法时调用。
+仅在 Rsbuild restart 时，或是执行 `rsbuild.startDevServer()` 的 `close()` 方法时调用。
 
 - [onCloseDevServer](#onclosedevserver)：在关闭开发服务器时调用。
 
@@ -36,7 +36,7 @@
 - [onBeforeBuild](#onbeforebuild)：在执行生产模式构建前调用。
 - [onAfterBuild](#onafterbuild)：在执行生产模式构建后调用，可以获取到构建结果信息。
 
-仅在 Rsbuild restart 或执行 `rsbuild.build` 的 close 方法时调用。
+仅在 Rsbuild restart 时，或是执行 `rsbuild.build()` 的 `close()` 方法时调用。
 
 - [onCloseBuild](#onclosebuild)：在关闭构建时调用。
 

--- a/website/docs/zh/shared/onCloseBuild.mdx
+++ b/website/docs/zh/shared/onCloseBuild.mdx
@@ -1,5 +1,7 @@
 在关闭构建时调用，可用于在构建关闭时执行清理操作。
 
+Rsbuild CLI 会在执行 [rsbuild build](/guide/basic/cli#rsbuild-build) 完成后自动调用此钩子，使用 JavaScript API 的用户需要手动调用 [rsbuild.close()](/api/javascript-api/instance#rsbuildbuild) 方法来触发此钩子。
+
 - **类型：**
 
 ```ts


### PR DESCRIPTION
## Summary

Close Rsbuild instance after running `rsbuild build` to trigger the `onCloseBuild` hook.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
