### PR TITLE
docs: tip for style-loader source map

### DIFF
--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -109,3 +109,18 @@ export default {
   },
 };
 ```
+
+In production builds, it is not recommended to enable both [output.injectStyles](/config/output/inject-styles) and `output.sourceMap.css`, as `style-loader` will inject the source map into the JS bundles, which will increase the file size and slow down the page loading speed.
+
+You can only enable the CSS file source map in the development mode:
+
+```js
+export default {
+  output: {
+    injectStyles: true,
+    sourceMap: {
+      css: process.env.NODE_ENV === 'development',
+    },
+  },
+};
+```

--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -110,7 +110,7 @@ export default {
 };
 ```
 
-In production builds, it is not recommended to enable both [output.injectStyles](/config/output/inject-styles) and `output.sourceMap.css`, as `style-loader` will inject the source map into the JS bundles, which will increase the file size and slow down the page loading speed.
+In production builds, it is not recommended to enable both [output.injectStyles](/config/output/inject-styles) and `output.sourceMap.css`, as `output.injectStyles` will inject the source map into the JS bundles, which will increase the file size and slow down the page loading speed.
 
 You can only enable the CSS file source map in the development mode:
 

--- a/website/docs/zh/config/output/source-map.mdx
+++ b/website/docs/zh/config/output/source-map.mdx
@@ -109,3 +109,18 @@ export default {
   },
 };
 ```
+
+在生产构建时，我们不推荐同时开启 [output.injectStyles](/config/output/inject-styles) 和 `output.sourceMap.css`，因为 `style-loader` 会将 source map 注入到 JS 文件中，这会增加文件的体积并导致页面加载变慢。
+
+你可以仅在开发模式下开启 CSS 文件的 source map：
+
+```js
+export default {
+  output: {
+    injectStyles: true,
+    sourceMap: {
+      css: process.env.NODE_ENV === 'development',
+    },
+  },
+};
+```

--- a/website/docs/zh/config/output/source-map.mdx
+++ b/website/docs/zh/config/output/source-map.mdx
@@ -110,7 +110,7 @@ export default {
 };
 ```
 
-在生产构建时，我们不推荐同时开启 [output.injectStyles](/config/output/inject-styles) 和 `output.sourceMap.css`，因为 `style-loader` 会将 source map 注入到 JS 文件中，这会增加文件的体积并导致页面加载变慢。
+在生产构建时，我们不推荐同时开启 [output.injectStyles](/config/output/inject-styles) 和 `output.sourceMap.css`，因为 `output.injectStyles` 会将 source map 注入到 JS 文件中，这会增加文件的体积并导致页面加载变慢。
 
 你可以仅在开发模式下开启 CSS 文件的 source map：
 


### PR DESCRIPTION
## Summary

Adds a recommendation against enabling both `output.injectStyles` and `output.sourceMap.css` in production builds, explaining the potential performance impact.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
