### PR TITLE
fix: watchOptions.ignored use array glob instead of regexp

### DIFF
--- a/.changeset/sharp-bikes-shout.md
+++ b/.changeset/sharp-bikes-shout.md
@@ -1,0 +1,5 @@
+---
+'@rsbuild/core': patch
+---
+
+fix: watchOptions.ignored use array glob instead of regexp

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -390,7 +390,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -777,7 +780,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -1110,7 +1116,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "target": "node",
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -1432,7 +1441,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -52,7 +52,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         chain.watchOptions({
           // Ignore watching files in node_modules to reduce memory usage and make startup faster
-          ignored: /[\\/](?:\.git|node_modules)[\\/]/,
+          ignored: ['**/.git/**', '**/node_modules/**'],
           // Remove the delay before rebuilding once the first file changed
           aggregateTimeout: 0,
         });

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -30,7 +30,10 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -59,7 +62,10 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -401,7 +401,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -416,7 +416,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -873,7 +876,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -1225,7 +1231,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "target": "node",
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;
@@ -1661,7 +1670,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+    "ignored": [
+      "**/.git/**",
+      "**/node_modules/**",
+    ],
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1528,7 +1528,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     ],
     "watchOptions": {
       "aggregateTimeout": 0,
-      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+      "ignored": [
+        "**/.git/**",
+        "**/node_modules/**",
+      ],
     },
   },
   {
@@ -1858,7 +1861,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "target": "node",
     "watchOptions": {
       "aggregateTimeout": 0,
-      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
+      "ignored": [
+        "**/.git/**",
+        "**/node_modules/**",
+      ],
     },
   },
 ]


### PR DESCRIPTION
## Summary

Both Webpack and Rspack have the watchOptions.ignore type as `Regexp | string | string[]` , if the internal configuration is Regexp , it's difficult for users to expand this config, so recommend to use array instead.

before 

```ts
const rsbuildConfig = watchOptions.ignored;
watchOptions.ignored = [ transform(rsbuildConfig), userConfig ]
```

after
```ts
const rsbuildConfig = watchOptions.ignored;
watchOptions.ignored = [ ...rsbuildConfig, userConfig ]
```

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
