### PR TITLE
[doc] Fix SSR Node Bundle Usage in Docs

### DIFF
--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -82,8 +82,8 @@ import { createRsbuild, loadConfig } from '@rsbuild/core';
 
 // Implement SSR rendering function
 const serverRender = (serverAPI) => async (_req, res) => {
-  // Load SSR bundle
-  const indexModule = await serverAPI.environments.ssr.loadBundle('index');
+  // Load Node bundle for SSR
+  const indexModule = await serverAPI.environments.node.loadBundle('index');
 
   const markup = indexModule.render();
 


### PR DESCRIPTION
## Summary
Fixes incorrect usage of `ssr` environment in the documentation. Updated to use the correct node bundle for SSR rendering. In this PR used same environment in doc which used in `Create SSR configuration`.

## Related Links
https://rsbuild.dev/guide/advanced/ssr#custom-server

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
