### PR TITLE
feat(CLI): set default `process.title`

### DIFF
--- a/packages/core/src/cli/prepare.ts
+++ b/packages/core/src/cli/prepare.ts
@@ -12,6 +12,9 @@ function initNodeEnv() {
 export function prepareCli(): void {
   initNodeEnv();
 
+  // make it easier to identify the process via activity monitor or other tools
+  process.title = 'rsbuild-node';
+
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.
   const { npm_execpath } = process.env;


### PR DESCRIPTION
## Summary

Set `process.title` to make it easier to identify the process via activity monitor or other tools.

<img width="752" alt="Screenshot 2024-11-28 at 20 45 45" src="https://github.com/user-attachments/assets/643c8015-c913-44fd-8a30-ac3be44f90b1">

## Related Links

https://github.com/web-infra-dev/rspack/issues/8566
https://nodejs.org/api/process.html#processtitle

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
