### PR TITLE
feat: add `resolve.dedupe` config

### DIFF
--- a/e2e/cases/resolve/dedupe/index.test.ts
+++ b/e2e/cases/resolve/dedupe/index.test.ts
@@ -1,0 +1,36 @@
+import { join } from 'node:path';
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import { outputFileSync } from 'fs-extra';
+
+function writeDuplicatedPackage(flag: string) {
+  const fooPath = join(__dirname, 'node_modules', 'foo');
+  outputFileSync(
+    join(fooPath, 'package.json'),
+    JSON.stringify({ name: 'foo', version: '1.0.0' }),
+  );
+  outputFileSync(
+    join(fooPath, 'index.js'),
+    'import React from "react";export default React;',
+  );
+  outputFileSync(
+    join(fooPath, 'node_modules', 'react', 'package.json'),
+    JSON.stringify({ name: 'react', version: '1.0.0' }),
+  );
+  outputFileSync(
+    join(fooPath, 'node_modules', 'react', 'index.js'),
+    `console.log("${flag}");`,
+  );
+}
+
+test('should dedupe specified packages as expected', async () => {
+  const flag = 'This is fake React';
+  writeDuplicatedPackage(flag);
+
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const { content } = await rsbuild.getIndexFile();
+  expect(content).not.toContain(flag);
+});

--- a/e2e/cases/resolve/dedupe/rsbuild.config.ts
+++ b/e2e/cases/resolve/dedupe/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'all-in-one',
+    },
+  },
+});

--- a/e2e/cases/resolve/dedupe/src/index.js
+++ b/e2e/cases/resolve/dedupe/src/index.js
@@ -1,0 +1,5 @@
+import foo from 'foo';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+console.log(React, ReactDOM, foo);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -196,6 +196,7 @@ const createDefaultConfig = (): RsbuildConfig => ({
   dev: getDefaultDevConfig(),
   server: getDefaultServerConfig(),
   html: getDefaultHtmlConfig(),
+  resolve: {},
   source: getDefaultSourceConfig(),
   output: getDefaultOutputConfig(),
   tools: getDefaultToolsConfig(),

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1395,6 +1395,16 @@ export type NormalizedDevConfig = DevConfig &
     client: NormalizedClientConfig;
   };
 
+export interface ResolveConfig {
+  /**
+   * Force Rsbuild to resolve the specified packages from project root,
+   * which is useful for deduplicating packages and reducing the bundle size.
+   */
+  dedupe?: string[];
+}
+
+export type NormalizedResolveConfig = ResolveConfig;
+
 export type ModuleFederationConfig = {
   options: ModuleFederationPluginOptions;
 };
@@ -1427,6 +1437,10 @@ export interface EnvironmentConfig {
    * Options for the low-level tools.
    */
   tools?: ToolsConfig;
+  /**
+   * Options for configuring module resolving.
+   */
+  resolve?: ResolveConfig;
   /**
    * Options for source code parsing and compilation.
    */
@@ -1500,6 +1514,7 @@ export type MergedEnvironmentConfig = {
   >;
   html: NormalizedHtmlConfig;
   tools: NormalizedToolsConfig;
+  resolve: NormalizedResolveConfig;
   source: NormalizedSourceConfig;
   output: Omit<NormalizedOutputConfig, 'distPath'> & {
     distPath: Omit<Required<DistPathConfig>, 'jsAsync' | 'cssAsync'> & {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -87,6 +87,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
+  "resolve": {},
   "root": "<ROOT>",
   "security": {
     "nonce": "",
@@ -217,6 +218,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
+  "resolve": {},
   "root": "<ROOT>",
   "security": {
     "nonce": "",
@@ -347,6 +349,7 @@ exports[`environment config > should print environment config when inspect confi
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -473,6 +476,7 @@ exports[`environment config > should print environment config when inspect confi
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -619,6 +623,7 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -745,6 +750,7 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -872,6 +878,7 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -1002,6 +1009,7 @@ exports[`environment config > should support modify single environment config by
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -1128,6 +1136,7 @@ exports[`environment config > should support modify single environment config by
       "removeConsole": false,
       "removeMomentLocale": false,
     },
+    "resolve": {},
     "root": "<ROOT>",
     "security": {
       "nonce": "",


### PR DESCRIPTION
## Summary

Introduce a new `resolve.dedupe` config  for deduplication of specified packages.

This is essentially syntactic sugar based on `resolve.alias`, but since it might be frequently needed in real-world projects, we decided to add an option to support it.

Documentation will be added later.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
