### PR TITLE
fix: remove unused if condition

### DIFF
--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -69,10 +69,6 @@ function applyAlias({
 }) {
   const { alias } = config.source;
 
-  if (!alias) {
-    return;
-  }
-
   const mergedAlias = reduceConfigs({
     initial: {},
     config: alias,


### PR DESCRIPTION
## Summary

`source.alias` has a default value `{}`, remove unused if condition.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
