### PR TITLE
feat: add `resolve.alias` and deprecate `source.alias`

### DIFF
--- a/e2e/cases/alias/jsconfig-paths/index.test.ts
+++ b/e2e/cases/alias/jsconfig-paths/index.test.ts
@@ -8,10 +8,12 @@ rspackOnlyTest(
       cwd: __dirname,
       page,
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common2',
           },
+        },
+        source: {
           tsconfigPath: './jsconfig.json',
         },
       },
@@ -31,10 +33,12 @@ rspackOnlyTest(
       cwd: __dirname,
       page,
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@/common': './src/common2',
           },
+        },
+        source: {
           aliasStrategy: 'prefer-alias',
           tsconfigPath: './jsconfig.json',
         },
@@ -42,7 +46,7 @@ rspackOnlyTest(
     });
 
     const foo = page.locator('#foo');
-    await expect(foo).toHaveText('source.alias worked');
+    await expect(foo).toHaveText('resolve.alias worked');
 
     await rsbuild.close();
   },

--- a/e2e/cases/alias/jsconfig-paths/src/common2/test.js
+++ b/e2e/cases/alias/jsconfig-paths/src/common2/test.js
@@ -1,1 +1,1 @@
-export const content = 'source.alias worked';
+export const content = 'resolve.alias worked';

--- a/e2e/cases/alias/legacy-alias/index.test.ts
+++ b/e2e/cases/alias/legacy-alias/index.test.ts
@@ -1,0 +1,20 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to use the legacy `source.alias` config', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const fileNames = Object.keys(files);
+  const webIndex = fileNames.find(
+    (file) => file.includes('static/js') && file.endsWith('index.js'),
+  );
+  const nodeIndex = fileNames.find(
+    (file) => file.includes('server/index') && file.endsWith('index.js'),
+  );
+
+  expect(files[webIndex!]).toContain('for web target');
+  expect(files[nodeIndex!]).toContain('for node target');
+});

--- a/e2e/cases/alias/legacy-alias/rsbuild.config.ts
+++ b/e2e/cases/alias/legacy-alias/rsbuild.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   },
   environments: {
     web: {
-      resolve: {
+      source: {
         alias: {
           '@common': './src/common',
         },
@@ -16,7 +16,7 @@ export default defineConfig({
       },
     },
     node: {
-      resolve: {
+      source: {
         alias: {
           '@common': './src/common2',
         },

--- a/e2e/cases/alias/legacy-alias/src/common/test.js
+++ b/e2e/cases/alias/legacy-alias/src/common/test.js
@@ -1,0 +1,1 @@
+export const content = 'for web target';

--- a/e2e/cases/alias/legacy-alias/src/common2/test.js
+++ b/e2e/cases/alias/legacy-alias/src/common2/test.js
@@ -1,0 +1,1 @@
+export const content = 'for node target';

--- a/e2e/cases/alias/legacy-alias/src/index.js
+++ b/e2e/cases/alias/legacy-alias/src/index.js
@@ -1,0 +1,3 @@
+import { content } from '@common/test';
+
+console.log(content);

--- a/e2e/cases/alias/tsconfig-paths-references/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-references/index.test.ts
@@ -8,7 +8,7 @@ rspackOnlyTest(
       cwd: __dirname,
       page,
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common2',
           },

--- a/e2e/cases/alias/tsconfig-paths-references/src/common2/test.ts
+++ b/e2e/cases/alias/tsconfig-paths-references/src/common2/test.ts
@@ -1,1 +1,1 @@
-export const content = 'source.alias worked';
+export const content = 'resolve.alias worked';

--- a/e2e/cases/alias/tsconfig-paths-specify-config/rsbuild.config.ts
+++ b/e2e/cases/alias/tsconfig-paths-specify-config/rsbuild.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
-  source: {
+  resolve: {
     alias: {
       '@common': './src/common2',
     },
+  },
+  source: {
     tsconfigPath: 'tsconfig.custom.json',
   },
 });

--- a/e2e/cases/alias/tsconfig-paths-specify-config/src/common2/test.ts
+++ b/e2e/cases/alias/tsconfig-paths-specify-config/src/common2/test.ts
@@ -1,1 +1,1 @@
-export const content = 'source.alias worked';
+export const content = 'resolve.alias worked';

--- a/e2e/cases/alias/tsconfig-paths/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths/index.test.ts
@@ -8,7 +8,7 @@ test('tsconfig paths should work and override the alias config', async ({
     cwd: __dirname,
     page,
     rsbuildConfig: {
-      source: {
+      resolve: {
         alias: {
           '@common': './src/common2',
         },
@@ -29,17 +29,19 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
     cwd: __dirname,
     page,
     rsbuildConfig: {
-      source: {
+      resolve: {
         alias: {
           '@/common': './src/common2',
         },
+      },
+      source: {
         aliasStrategy: 'prefer-alias',
       },
     },
   });
 
   const foo = page.locator('#foo');
-  await expect(foo).toHaveText('source.alias worked');
+  await expect(foo).toHaveText('resolve.alias worked');
 
   await rsbuild.close();
 });

--- a/e2e/cases/alias/tsconfig-paths/src/common2/test.ts
+++ b/e2e/cases/alias/tsconfig-paths/src/common2/test.ts
@@ -1,1 +1,1 @@
-export const content = 'source.alias worked';
+export const content = 'resolve.alias worked';

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -7,7 +7,7 @@ rspackOnlyTest('should compile common CSS import correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {
-      source: {
+      resolve: {
         alias: {
           '@': './src',
         },

--- a/e2e/cases/css/resolve-alias/rsbuild.config.ts
+++ b/e2e/cases/css/resolve-alias/rsbuild.config.ts
@@ -4,7 +4,7 @@ import { pluginSass } from '@rsbuild/plugin-sass';
 
 export default {
   plugins: [pluginLess(), pluginSass()],
-  source: {
+  resolve: {
     alias: {
       '@common': path.resolve(__dirname, 'src/common'),
     },

--- a/e2e/cases/source/source.test.ts
+++ b/e2e/cases/source/source.test.ts
@@ -16,10 +16,12 @@ test.describe('source configure multi', () => {
           entry: {
             index: join(fixtures, 'basic/src/index.js'),
           },
+          preEntry: ['./src/pre.js'],
+        },
+        resolve: {
           alias: {
             '@common': './src/common',
           },
-          preEntry: ['./src/pre.js'],
         },
       },
     });

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -110,7 +110,7 @@ const updateConfigForTest = async (
     dev: {
       progressBar: false,
     },
-    source: {
+    resolve: {
       alias: {
         '@assets': join(__dirname, '../assets'),
       },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -44,6 +44,7 @@ import type {
   NormalizedHtmlConfig,
   NormalizedOutputConfig,
   NormalizedPerformanceConfig,
+  NormalizedResolveConfig,
   NormalizedSecurityConfig,
   NormalizedServerConfig,
   NormalizedSourceConfig,
@@ -192,11 +193,15 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   emitAssets: true,
 });
 
+const getDefaultResolveConfig = (): NormalizedResolveConfig => ({
+  alias: {},
+});
+
 const createDefaultConfig = (): RsbuildConfig => ({
   dev: getDefaultDevConfig(),
   server: getDefaultServerConfig(),
   html: getDefaultHtmlConfig(),
-  resolve: {},
+  resolve: getDefaultResolveConfig(),
   source: getDefaultSourceConfig(),
   output: getDefaultOutputConfig(),
   tools: getDefaultToolsConfig(),

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -67,12 +67,25 @@ function applyAlias({
   config: NormalizedEnvironmentConfig;
   rootPath: string;
 }) {
-  const { alias } = config.source;
+  // TODO: remove `source.alias` in the next major version
+  const mergedSourceAlias = config.source.alias
+    ? reduceConfigs({
+        initial: {},
+        config: config.source.alias,
+      })
+    : {};
 
-  const mergedAlias = reduceConfigs({
-    initial: {},
-    config: alias,
-  });
+  const mergedResolveAlias = config.resolve.alias
+    ? reduceConfigs({
+        initial: {},
+        config: config.resolve.alias,
+      })
+    : {};
+
+  const mergedAlias = {
+    ...mergedSourceAlias,
+    ...mergedResolveAlias,
+  };
 
   if (config.resolve.dedupe) {
     for (const pkgName of config.resolve.dedupe) {

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -69,10 +69,6 @@ function applyAlias({
 }) {
   const { alias } = config.source;
 
-  if (!alias) {
-    return;
-  }
-
   const mergedAlias = reduceConfigs({
     initial: {},
     config: alias,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -174,8 +174,8 @@ export type Decorators = {
 
 export interface SourceConfig {
   /**
-   * Create aliases to import or require certain modules,
-   * same as the [resolve.alias](https://rspack.dev/config/resolve) config of Rspack.
+   * @deprecated Use `resolve.alias` instead.
+   * `source.alias` will be removed in v2.0.0.
    */
   alias?: ConfigChain<Alias>;
   /**
@@ -248,6 +248,10 @@ type TransformImportFn = (
 
 export interface NormalizedSourceConfig extends SourceConfig {
   define: Define;
+  /**
+   * @deprecated Use `resolve.alias` instead.
+   * `source.alias` will be removed in v2.0.0.
+   */
   alias: ConfigChain<Alias>;
   aliasStrategy: AliasStrategy;
   preEntry: string[];
@@ -1401,9 +1405,15 @@ export interface ResolveConfig {
    * which is useful for deduplicating packages and reducing the bundle size.
    */
   dedupe?: string[];
+  /**
+   * Create aliases to import or require certain modules,
+   * same as the [resolve.alias](https://rspack.dev/config/resolve) config of Rspack.
+   */
+  alias?: ConfigChain<Alias>;
 }
 
-export type NormalizedResolveConfig = ResolveConfig;
+export type NormalizedResolveConfig = ResolveConfig &
+  Pick<Required<ResolveConfig>, 'alias'>;
 
 export type ModuleFederationConfig = {
   options: ModuleFederationPluginOptions;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -87,7 +87,9 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
-  "resolve": {},
+  "resolve": {
+    "alias": {},
+  },
   "root": "<ROOT>",
   "security": {
     "nonce": "",
@@ -218,7 +220,9 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "removeConsole": false,
     "removeMomentLocale": false,
   },
-  "resolve": {},
+  "resolve": {
+    "alias": {},
+  },
   "root": "<ROOT>",
   "security": {
     "nonce": "",
@@ -349,7 +353,9 @@ exports[`environment config > should print environment config when inspect confi
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -476,7 +482,9 @@ exports[`environment config > should print environment config when inspect confi
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -623,7 +631,9 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -750,7 +760,9 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -878,7 +890,9 @@ exports[`environment config > should support modify environment config by api.mo
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -1009,7 +1023,9 @@ exports[`environment config > should support modify single environment config by
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",
@@ -1136,7 +1152,9 @@ exports[`environment config > should support modify single environment config by
       "removeConsole": false,
       "removeMomentLocale": false,
     },
-    "resolve": {},
+    "resolve": {
+      "alias": {},
+    },
     "root": "<ROOT>",
     "security": {
       "nonce": "",


### PR DESCRIPTION
## Summary

Rename `source.alias` to `resolve.alias`, the renamed API is consistent with Rspack/Vite and more intuitive.

```diff
export default {
- source: {
+ resolve: {
    alias: {}
  },
}
```

`source.alias` is deprecated, but it is still available and we plan to remove it in Rsbuild 2.0.

## Related Links

https://rspack.dev/config/resolve#resolvealias

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
