### PR TITLE
feat: add `resolve.aliasStrategy` and deprecate `source.aliasStrategy`

### DIFF
--- a/e2e/cases/alias/jsconfig-paths/index.test.ts
+++ b/e2e/cases/alias/jsconfig-paths/index.test.ts
@@ -37,9 +37,9 @@ rspackOnlyTest(
           alias: {
             '@/common': './src/common2',
           },
+          aliasStrategy: 'prefer-alias',
         },
         source: {
-          aliasStrategy: 'prefer-alias',
           tsconfigPath: './jsconfig.json',
         },
       },

--- a/e2e/cases/alias/tsconfig-paths/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths/index.test.ts
@@ -33,8 +33,6 @@ test('tsconfig paths should not work when aliasStrategy is "prefer-alias"', asyn
         alias: {
           '@/common': './src/common2',
         },
-      },
-      source: {
         aliasStrategy: 'prefer-alias',
       },
     },

--- a/packages/compat/webpack/src/plugin.ts
+++ b/packages/compat/webpack/src/plugin.ts
@@ -66,8 +66,10 @@ export const pluginAdaptor = (
   setup(api) {
     api.modifyBundlerChain(async (chain, { CHAIN_ID, environment, target }) => {
       const { config, tsconfigPath } = environment;
+      const aliasStrategy =
+        config.source.aliasStrategy ?? config.resolve.aliasStrategy;
 
-      if (tsconfigPath && config.source.aliasStrategy === 'prefer-tsconfig') {
+      if (tsconfigPath && aliasStrategy === 'prefer-tsconfig') {
         await applyTsConfigPathsPlugin({
           chain,
           CHAIN_ID,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -99,7 +99,6 @@ const getDefaultSourceConfig = (): NormalizedSourceConfig => {
       '@swc/helpers': swcHelpersPath,
     },
     define: {},
-    aliasStrategy: 'prefer-tsconfig',
     preEntry: [],
     decorators: {
       version: '2022-03',
@@ -195,6 +194,7 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
 
 const getDefaultResolveConfig = (): NormalizedResolveConfig => ({
   alias: {},
+  aliasStrategy: 'prefer-tsconfig',
 });
 
 const createDefaultConfig = (): RsbuildConfig => ({

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -175,11 +175,14 @@ export const pluginResolve = (): RsbuildPlugin => ({
         // In some cases (modern.js), there is an error if the fullySpecified rule is after the js rule
         applyFullySpecified({ chain, config, CHAIN_ID });
 
+        const aliasStrategy =
+          config.source.aliasStrategy ?? config.resolve.aliasStrategy;
+
         if (
           tsconfigPath &&
           // Only Rspack has the tsConfig option
           api.context.bundlerType === 'rspack' &&
-          config.source.aliasStrategy === 'prefer-tsconfig'
+          aliasStrategy === 'prefer-tsconfig'
         ) {
           chain.resolve.tsConfig({
             configFile: tsconfigPath,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -179,8 +179,8 @@ export interface SourceConfig {
    */
   alias?: ConfigChain<Alias>;
   /**
-   * Used to control the priority between the `paths` option in `tsconfig.json`
-   * and the `alias` option in the bundler.
+   * @deprecated Use `resolve.aliasStrategy` instead.
+   * `source.aliasStrategy` will be removed in v2.0.0.
    */
   aliasStrategy?: AliasStrategy;
   /**
@@ -253,7 +253,6 @@ export interface NormalizedSourceConfig extends SourceConfig {
    * `source.alias` will be removed in v2.0.0.
    */
   alias: ConfigChain<Alias>;
-  aliasStrategy: AliasStrategy;
   preEntry: string[];
   decorators: Required<Decorators>;
 }
@@ -1410,10 +1409,16 @@ export interface ResolveConfig {
    * same as the [resolve.alias](https://rspack.dev/config/resolve) config of Rspack.
    */
   alias?: ConfigChain<Alias>;
+  /**
+   * Control the priority between the `paths` option in `tsconfig.json`
+   * and the `resolve.alias` option of Rsbuild.
+   * @default 'prefer-tsconfig'
+   */
+  aliasStrategy?: AliasStrategy;
 }
 
 export type NormalizedResolveConfig = ResolveConfig &
-  Pick<Required<ResolveConfig>, 'alias'>;
+  Pick<Required<ResolveConfig>, 'alias' | 'aliasStrategy'>;
 
 export type ModuleFederationConfig = {
   options: ModuleFederationPluginOptions;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -89,6 +89,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
   },
   "resolve": {
     "alias": {},
+    "aliasStrategy": "prefer-tsconfig",
   },
   "root": "<ROOT>",
   "security": {
@@ -112,7 +113,6 @@ exports[`environment config > should normalize environment config correctly 1`] 
       "@common": "./src/common",
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
-    "aliasStrategy": "prefer-tsconfig",
     "decorators": {
       "version": "2022-03",
     },
@@ -222,6 +222,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
   },
   "resolve": {
     "alias": {},
+    "aliasStrategy": "prefer-tsconfig",
   },
   "root": "<ROOT>",
   "security": {
@@ -245,7 +246,6 @@ exports[`environment config > should normalize environment config correctly 2`] 
       "@common": "./src/common",
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
-    "aliasStrategy": "prefer-tsconfig",
     "decorators": {
       "version": "2022-03",
     },
@@ -355,6 +355,7 @@ exports[`environment config > should print environment config when inspect confi
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -378,7 +379,6 @@ exports[`environment config > should print environment config when inspect confi
         "@common": "./src/common",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -484,6 +484,7 @@ exports[`environment config > should print environment config when inspect confi
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -507,7 +508,6 @@ exports[`environment config > should print environment config when inspect confi
         "@common": "./src/common",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -633,6 +633,7 @@ exports[`environment config > should support modify environment config by api.mo
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -656,7 +657,6 @@ exports[`environment config > should support modify environment config by api.mo
         "@common": "./src/common",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -762,6 +762,7 @@ exports[`environment config > should support modify environment config by api.mo
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -786,7 +787,6 @@ exports[`environment config > should support modify environment config by api.mo
         "@common1": "./src/common1",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -892,6 +892,7 @@ exports[`environment config > should support modify environment config by api.mo
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -916,7 +917,6 @@ exports[`environment config > should support modify environment config by api.mo
         "@common1": "./src/common1",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -1025,6 +1025,7 @@ exports[`environment config > should support modify single environment config by
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -1048,7 +1049,6 @@ exports[`environment config > should support modify single environment config by
         "@common": "./src/common",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },
@@ -1154,6 +1154,7 @@ exports[`environment config > should support modify single environment config by
     },
     "resolve": {
       "alias": {},
+      "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
     "security": {
@@ -1178,7 +1179,6 @@ exports[`environment config > should support modify single environment config by
         "@common1": "./src/common1",
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
-      "aliasStrategy": "prefer-tsconfig",
       "decorators": {
         "version": "2022-03",
       },

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -27,7 +27,7 @@ describe('plugin-resolve', () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
       rsbuildConfig: {
-        source: {
+        resolve: {
           aliasStrategy: 'prefer-alias',
         },
       },

--- a/website/docs/en/config/source/alias-strategy.mdx
+++ b/website/docs/en/config/source/alias-strategy.mdx
@@ -3,7 +3,7 @@
 - **Type:** `'prefer-tsconfig' | 'prefer-alias'`
 - **Default:** `'prefer-tsconfig'`
 
-`source.aliasStrategy` is used to control the priority between the `paths` option in `tsconfig.json` and the `alias` option in the bundler.
+Control the priority between the `paths` option in `tsconfig.json` and the [resolve.alias](/config/source/alias) option of Rsbuild.
 
 ### prefer-tsconfig
 

--- a/website/docs/zh/config/source/alias-strategy.mdx
+++ b/website/docs/zh/config/source/alias-strategy.mdx
@@ -3,7 +3,7 @@
 - **类型：** `'prefer-tsconfig' | 'prefer-alias'`
 - **默认值：** `'prefer-tsconfig'`
 
-`source.aliasStrategy` 用于控制 `tsconfig.json` 中的 `paths` 选项与打包工具的 `alias` 选项的优先级。
+控制 `tsconfig.json` 中的 `paths` 选项与 Rsbuild 的 [resolve.alias](/config/source/alias) 选项的优先级。
 
 ### prefer-tsconfig
 


### PR DESCRIPTION
## Summary

Rename `source.aliasStrategy` to `resolve.aliasStrategy`, align with https://github.com/web-infra-dev/rsbuild/pull/4098.

```diff
export default {
- source: {
+ resolve: {
    aliasStrategy: 'prefer-tsconfig',
  },
}
```

`source.aliasStrategy` is deprecated, but it is still available and we plan to remove it in Rsbuild 2.0.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
