### PR TITLE
fix: `resolve.dedupe` may set incorrect path

### DIFF
--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -113,7 +113,8 @@ function applyAlias({
             paths: [rootPath],
           });
 
-          const trailing = sep === '/' ? pkgName : pkgName.split('/').join(sep);
+          // Ensure the package path is `node_modules/@scope/package-name`
+          const trailing = ['node_modules', ...pkgName.split('/')].join(sep);
           while (
             !pkgPath.endsWith(trailing) &&
             pkgPath.includes('node_modules')


### PR DESCRIPTION
## Summary

Fix `resolve.dedupe` may set incorrect path.

For example, a `foo` package exports `node_modules/foo/foo/index.js` module.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
