### PR TITLE
chore(plugin-preact): use `resolve.alias`

### DIFF
--- a/packages/plugin-preact/src/index.ts
+++ b/packages/plugin-preact/src/index.ts
@@ -87,6 +87,7 @@ export const pluginPreact = (
       };
 
       extraConfig.source ||= {};
+      extraConfig.resolve ||= {};
 
       if (usePrefresh) {
         // transpile `@prefresh/core` and `@prefresh/utils` to ensure browser compatibility
@@ -96,7 +97,7 @@ export const pluginPreact = (
       }
 
       if (options.reactAliasesEnabled) {
-        extraConfig.source.alias = {
+        extraConfig.resolve.alias = {
           react: 'preact/compat',
           'react-dom/test-utils': 'preact/test-utils',
           'react-dom': 'preact/compat',


### PR DESCRIPTION
## Summary

Use `resolve.alias` in plugin-preact.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4098

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
