### PR TITLE
fix: improve compatibility of `source.alias`

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -90,14 +90,8 @@ const getDefaultServerConfig = (): NormalizedServerConfig => ({
 let swcHelpersPath: string;
 
 const getDefaultSourceConfig = (): NormalizedSourceConfig => {
-  if (!swcHelpersPath) {
-    swcHelpersPath = dirname(require.resolve('@swc/helpers/package.json'));
-  }
-
   return {
-    alias: {
-      '@swc/helpers': swcHelpersPath,
-    },
+    alias: {},
     define: {},
     preEntry: [],
     decorators: {
@@ -192,10 +186,18 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   emitAssets: true,
 });
 
-const getDefaultResolveConfig = (): NormalizedResolveConfig => ({
-  alias: {},
-  aliasStrategy: 'prefer-tsconfig',
-});
+const getDefaultResolveConfig = (): NormalizedResolveConfig => {
+  if (!swcHelpersPath) {
+    swcHelpersPath = dirname(require.resolve('@swc/helpers/package.json'));
+  }
+
+  return {
+    alias: {
+      '@swc/helpers': swcHelpersPath,
+    },
+    aliasStrategy: 'prefer-tsconfig',
+  };
+};
 
 const createDefaultConfig = (): RsbuildConfig => ({
   dev: getDefaultDevConfig(),

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -67,25 +67,16 @@ function applyAlias({
   config: NormalizedEnvironmentConfig;
   rootPath: string;
 }) {
+  let mergedAlias = reduceConfigs({
+    initial: {},
+    config: config.resolve.alias,
+  });
+
   // TODO: remove `source.alias` in the next major version
-  const mergedSourceAlias = config.source.alias
-    ? reduceConfigs({
-        initial: {},
-        config: config.source.alias,
-      })
-    : {};
-
-  const mergedResolveAlias = config.resolve.alias
-    ? reduceConfigs({
-        initial: {},
-        config: config.resolve.alias,
-      })
-    : {};
-
-  const mergedAlias = {
-    ...mergedSourceAlias,
-    ...mergedResolveAlias,
-  };
+  mergedAlias = reduceConfigs({
+    initial: mergedAlias,
+    config: config.source.alias,
+  });
 
   if (config.resolve.dedupe) {
     for (const pkgName of config.resolve.dedupe) {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -88,7 +88,10 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "removeMomentLocale": false,
   },
   "resolve": {
-    "alias": {},
+    "alias": {
+      "@common": "./src/common",
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "aliasStrategy": "prefer-tsconfig",
   },
   "root": "<ROOT>",
@@ -109,10 +112,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "strictPort": false,
   },
   "source": {
-    "alias": {
-      "@common": "./src/common",
-      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-    },
+    "alias": {},
     "decorators": {
       "version": "2022-03",
     },
@@ -221,7 +221,10 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "removeMomentLocale": false,
   },
   "resolve": {
-    "alias": {},
+    "alias": {
+      "@common": "./src/common",
+      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+    },
     "aliasStrategy": "prefer-tsconfig",
   },
   "root": "<ROOT>",
@@ -242,10 +245,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "strictPort": false,
   },
   "source": {
-    "alias": {
-      "@common": "./src/common",
-      "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-    },
+    "alias": {},
     "decorators": {
       "version": "2022-03",
     },
@@ -354,7 +354,10 @@ exports[`environment config > should print environment config when inspect confi
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -375,10 +378,7 @@ exports[`environment config > should print environment config when inspect confi
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -483,7 +483,10 @@ exports[`environment config > should print environment config when inspect confi
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -504,10 +507,7 @@ exports[`environment config > should print environment config when inspect confi
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -632,7 +632,10 @@ exports[`environment config > should support modify environment config by api.mo
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -653,10 +656,7 @@ exports[`environment config > should support modify environment config by api.mo
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -761,7 +761,11 @@ exports[`environment config > should support modify environment config by api.mo
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -782,11 +786,7 @@ exports[`environment config > should support modify environment config by api.mo
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@common1": "./src/common1",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -891,7 +891,11 @@ exports[`environment config > should support modify environment config by api.mo
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -912,11 +916,7 @@ exports[`environment config > should support modify environment config by api.mo
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@common1": "./src/common1",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -1024,7 +1024,10 @@ exports[`environment config > should support modify single environment config by
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -1045,10 +1048,7 @@ exports[`environment config > should support modify single environment config by
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },
@@ -1153,7 +1153,11 @@ exports[`environment config > should support modify single environment config by
       "removeMomentLocale": false,
     },
     "resolve": {
-      "alias": {},
+      "alias": {
+        "@common": "./src/common",
+        "@common1": "./src/common1",
+        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
+      },
       "aliasStrategy": "prefer-tsconfig",
     },
     "root": "<ROOT>",
@@ -1174,11 +1178,7 @@ exports[`environment config > should support modify single environment config by
       "strictPort": false,
     },
     "source": {
-      "alias": {
-        "@common": "./src/common",
-        "@common1": "./src/common1",
-        "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
-      },
+      "alias": {},
       "decorators": {
         "version": "2022-03",
       },

--- a/packages/core/tests/environments.test.ts
+++ b/packages/core/tests/environments.test.ts
@@ -38,7 +38,7 @@ describe('environment config', () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common',
           },
@@ -70,14 +70,14 @@ describe('environment config', () => {
             return mergeRsbuildConfig(config, {
               environments: {
                 web: {
-                  source: {
+                  resolve: {
                     alias: {
                       '@common1': './src/common1',
                     },
                   },
                 },
                 web1: {
-                  source: {
+                  resolve: {
                     alias: {
                       '@common1': './src/common1',
                     },
@@ -101,7 +101,7 @@ describe('environment config', () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common',
           },
@@ -136,7 +136,7 @@ describe('environment config', () => {
               }
 
               return mergeEnvironmentConfig(config, {
-                source: {
+                resolve: {
                   alias: {
                     '@common1': './src/common1',
                   },
@@ -163,7 +163,7 @@ describe('environment config', () => {
         api.modifyEnvironmentConfig(
           (config, { name, mergeEnvironmentConfig }) => {
             return mergeEnvironmentConfig(config, {
-              source: {
+              resolve: {
                 alias: {
                   [pluginId]: name,
                 },
@@ -196,7 +196,7 @@ describe('environment config', () => {
       Object.fromEntries(
         Object.entries(environmentConfigs).map(([name, config]) => [
           name,
-          config.source.alias,
+          config.resolve.alias,
         ]),
       ),
     ).toMatchSnapshot();
@@ -242,7 +242,7 @@ describe('environment config', () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common',
           },
@@ -297,7 +297,7 @@ describe('environment config', () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             '@common': './src/common',
           },

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -16,11 +16,11 @@ describe('mergeRsbuildConfig', () => {
   test('should set value when target value is not undefined', () => {
     expect(
       mergeRsbuildConfig(
-        { source: { alias: {} } },
+        { resolve: { alias: {} } },
         { output: { minify: false } },
       ),
     ).toEqual({
-      source: {
+      resolve: {
         alias: {},
       },
       output: {
@@ -32,13 +32,13 @@ describe('mergeRsbuildConfig', () => {
   test('should ignore undefined property', () => {
     const noop = () => ({});
     const config = mergeRsbuildConfig(
-      { source: { alias: {} } },
-      { source: { alias: undefined } },
+      { resolve: { alias: {} } },
+      { resolve: { alias: undefined } },
       { tools: { rspack: noop } },
       { tools: { rspack: undefined } },
     );
     expect(config).toEqual({
-      source: {
+      resolve: {
         alias: {},
       },
       tools: {
@@ -162,7 +162,7 @@ describe('mergeRsbuildConfig', () => {
 
   it('should not modify the original objects when the merged config modified', () => {
     const obj: RsbuildConfig = {
-      source: {
+      resolve: {
         alias: {},
       },
     };
@@ -172,14 +172,17 @@ describe('mergeRsbuildConfig', () => {
     const res = mergeRsbuildConfig(obj, other);
 
     if (!res.source?.entry) {
-      res.source!.entry = {
+      res.source ||= {};
+      res.source.entry = {
         index: './index',
       };
     }
 
     expect(res).toEqual({
-      source: {
+      resolve: {
         alias: {},
+      },
+      source: {
         entry: {
           index: './index',
         },
@@ -187,7 +190,7 @@ describe('mergeRsbuildConfig', () => {
     });
 
     expect(obj).toEqual({
-      source: {
+      resolve: {
         alias: {},
       },
     });

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -38,11 +38,11 @@ describe('plugin-resolve', () => {
     expect(bundlerConfigs[0].resolve?.tsConfig).toBeUndefined();
   });
 
-  it('should allow to use source.alias to config alias', async () => {
+  it('should allow to use resolve.alias to configure alias', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias: {
             foo: 'bar',
           },
@@ -54,11 +54,11 @@ describe('plugin-resolve', () => {
     expect(bundlerConfigs[0].resolve?.alias?.foo).toEqual('bar');
   });
 
-  it('should support source.alias to be a function', async () => {
+  it('should allow resolve.alias to be a function', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
       rsbuildConfig: {
-        source: {
+        resolve: {
           alias() {
             return {
               foo: 'bar',


### PR DESCRIPTION
## Summary

Both of the following usages should work:

```js
export default defineConfig({
  source: {
    alias(config) {
      delete config['@swc/helpers'];
    },
  },
});
```

```js
export default defineConfig({
  resolve: {
    alias(config) {
      delete config['@swc/helpers'];
    },
  },
});
```

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4098

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
