### PR TITLE
chore: pin Rslib 0.1.0 to fix unstable CI

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/lodash": "^4.17.13",
     "@types/semver": "^7.5.8",
     "typescript": "^5.7.2",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "ansi-escapes": "4.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -57,7 +57,7 @@
     "core-js": "~3.39.0"
   },
   "devDependencies": {
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/connect": "3.4.38",
     "@types/node": "^22.10.1",
     "@types/on-finished": "2.3.4",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -31,7 +31,7 @@
     "create-rstack": "1.0.9"
   },
   "devDependencies": {
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.10.1",
     "typescript": "^5.7.2"
   },

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-typescript": "^7.26.0",
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/serialize-javascript": "^5.0.4",
     "serialize-javascript": "^6.0.2",
     "terser": "5.36.0",

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "babel-loader": "9.2.1",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.7",
     "less": "^4.2.1",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.10.1",
     "preact": "^10.25.0",
     "typescript": "^5.7.2"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "typescript": "^5.7.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "@types/sass-loader": "^8.0.9",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "typescript": "^5.7.2"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "typescript": "^5.7.2"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "svelte": "^5.3.1",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "file-loader": "6.2.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.10.1",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,8 +504,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/lodash':
         specifier: ^4.17.13
         version: 4.17.13
@@ -544,8 +544,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../../scripts/test-helper
@@ -581,8 +581,8 @@ importers:
         version: 3.39.0
     devDependencies:
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -708,8 +708,8 @@ importers:
         version: 1.0.9
     devDependencies:
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/node':
         specifier: ^22.10.1
         version: 22.10.1
@@ -732,8 +732,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/serialize-javascript':
         specifier: ^5.0.4
         version: 5.0.4
@@ -778,8 +778,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -809,8 +809,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -849,8 +849,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/node':
         specifier: ^22.10.1
         version: 22.10.1
@@ -874,8 +874,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -908,8 +908,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -948,8 +948,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -979,8 +979,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1004,8 +1004,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1044,8 +1044,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1081,8 +1081,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1102,8 +1102,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
       '@types/node':
         specifier: ^22.10.1
         version: 22.10.1
@@ -1130,8 +1130,8 @@ importers:
         version: 2.0.1
     devDependencies:
       '@rslib/core':
-        specifier: 0.1.1
-        version: 0.1.1(typescript@5.7.2)
+        specifier: 0.1.0
+        version: 0.1.0(typescript@5.7.2)
 
   website:
     devDependencies:
@@ -2530,8 +2530,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rslib/core@0.1.1':
-    resolution: {integrity: sha512-D/zCLzhNNM7DkuR/XNVFyB9er8OpmBpSJZQYeQgjuShg+JtXTWYX/DbmTniHpeO9B0ydMFS84WFO9ZAzGlDd6A==}
+  '@rslib/core@0.1.0':
+    resolution: {integrity: sha512-CGtHgTgj8BSWdQB7yCpGjr5dd37Y7jj/IH6rAtrYbTJR0/o7dm4QqygdwjR8MHBlD9fYTGu7uWbKRdh6qYXPTw==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     peerDependencies:
@@ -5568,8 +5568,8 @@ packages:
       webpack:
         optional: true
 
-  rsbuild-plugin-dts@0.1.1:
-    resolution: {integrity: sha512-pm0tVPioQGaF8O50S9j51oAjIVfM0Sn0+BteZ1TIv5t3cBdQmI9dmd15YJERrwsZAAUPAtuwIWM1TmEGH2m4zQ==}
+  rsbuild-plugin-dts@0.1.0:
+    resolution: {integrity: sha512-8HE2aGkseyrkNSPmJLVEgqIvaTDWGJYE5l6Hfrf94mFzAFcbtHOrYTr4aR/zw90x+BY3sMfE3bMBj/wR9AnxiA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8142,10 +8142,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@rslib/core@0.1.1(typescript@5.7.2)':
+  '@rslib/core@0.1.0(typescript@5.7.2)':
     dependencies:
       '@rsbuild/core': 1.1.7
-      rsbuild-plugin-dts: 0.1.1(@rsbuild/core@1.1.7)(typescript@5.7.2)
+      rsbuild-plugin-dts: 0.1.0(@rsbuild/core@1.1.7)(typescript@5.7.2)
       tinyglobby: 0.2.10
     optionalDependencies:
       typescript: 5.7.2
@@ -11614,7 +11614,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.96.1
 
-  rsbuild-plugin-dts@0.1.1(@rsbuild/core@1.1.7)(typescript@5.7.2):
+  rsbuild-plugin-dts@0.1.0(@rsbuild/core@1.1.7)(typescript@5.7.2):
     dependencies:
       '@rsbuild/core': 1.1.7
       magic-string: 0.30.14

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.1.1",
+    "@rslib/core": "0.1.0",
     "@types/node": "^22.10.1",
     "typescript": "^5.7.2"
   }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -32,7 +32,7 @@
     "upath": "2.0.1"
   },
   "devDependencies": {
-    "@rslib/core": "0.1.1"
+    "@rslib/core": "0.1.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Pin Rslib 0.1.0 to fix unstable CI.

![image](https://github.com/user-attachments/assets/3d258c8c-64fd-47c0-8bfc-6da03ecd4dab)

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/12116056090/job/33775821740?pr=4109

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
