### PR TITLE
chore: bump Rspress and remove overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,14 +56,5 @@
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=9.0.0"
-  },
-  "pnpm": {
-    "packageExtensions": {
-      "@rspress/plugin-client-redirects": {
-        "dependencies": {
-          "@rspress/shared": "^1.37.3"
-        }
-      }
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,8 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-packageExtensionsChecksum: 242b46cb3413dd5fe1495d77579faef4
-
 importers:
 
   .:
@@ -1141,11 +1139,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@rspress/plugin-client-redirects':
-        specifier: ^1.37.3
-        version: 1.37.3(@rspress/runtime@1.37.3)
+        specifier: ^1.37.4
+        version: 1.37.4(@rspress/runtime@1.37.4)
       '@rspress/plugin-rss':
         specifier: 1.37.3
-        version: 1.37.3(react@18.3.1)(rspress@1.37.3(webpack@5.96.1))
+        version: 1.37.3(react@18.3.1)(rspress@1.37.4(webpack@5.96.1))
       '@rstack-dev/doc-ui':
         specifier: 1.5.4
         version: 1.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1174,8 +1172,8 @@ importers:
         specifier: 1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
       rspress:
-        specifier: 1.37.3
-        version: 1.37.3(webpack@5.96.1)
+        specifier: 1.37.4
+        version: 1.37.4(webpack@5.96.1)
       rspress-plugin-font-open-sans:
         specifier: 1.0.0
         version: 1.0.0
@@ -2481,13 +2479,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.1.4':
-    resolution: {integrity: sha512-fN13hH6Ag0WgCCDUJErNvGs39hSePr8MTaJu1TjUZbFAY3DtOsUHhEb2V5zCUiaeMLMz7ef+krj7+duAJkizog==}
+  '@rsbuild/core@1.1.7':
+    resolution: {integrity: sha512-YI8qGKa37e5X3av4cB4i06MZv89URW39SrfNqTR6Td7VPznX+n4pHcrYqj86sEM2/XPX57/UL9Hi/Nhu+A003g==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.1.7':
-    resolution: {integrity: sha512-YI8qGKa37e5X3av4cB4i06MZv89URW39SrfNqTR6Td7VPznX+n4pHcrYqj86sEM2/XPX57/UL9Hi/Nhu+A003g==}
+  '@rsbuild/core@1.1.8':
+    resolution: {integrity: sha512-UhP260og3aJcqGWpnRcQXLVapdOZZ09JXaQKY+tE55A7nBw8DQy+qrtTsFZYvVKas1bq8GzhGfLxuglCst4Lnw==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -2623,8 +2621,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@1.37.3':
-    resolution: {integrity: sha512-uebqtPxwARA5ajKJlDs3+9B3bf33P8ErgRTjLebCZdAHUsKt2Fs+5riGUiGE6vuVHQLOt0OpgcNjU7Dl0dhjWw==}
+  '@rspress/core@1.37.4':
+    resolution: {integrity: sha512-Fz8UzogX42Md0zZMY4L4bqxHH+wncfTFBPAK0GjpWAHwVYM4drXypso6CS5/4X0kVTUOJ0ApvCdebwlmUlwQyQ==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.4':
@@ -2679,29 +2677,29 @@ packages:
     resolution: {integrity: sha512-uKAWxA8wY3iKKv+ZSN69iu4wJoa2ZNGOQmbnZskIHPejWa0lbkbbb85SlVhzKnPo04NKG675g6G6rT7REWDieQ==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.37.3':
-    resolution: {integrity: sha512-8PrfUitBCm6PFruMU969Wr5qA+wr0RisEM2iuHwdm2NBQnpwc9Ag73OagCMPwBUYyDod3kXXRyN4Yz/VuQIpDA==}
+  '@rspress/plugin-auto-nav-sidebar@1.37.4':
+    resolution: {integrity: sha512-pk+E31AtBIxXu/a7bowkHHsw9VG5TadlXlKbq3MPvIHhcT2q9got7W2/tJOP/FT/+qI7htiRGxxwN3GFoMxBgA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-client-redirects@1.37.3':
-    resolution: {integrity: sha512-SNlWpNWcV7+ngSK003GVgT74YAl18pv6PZlRVc1a6ozF8XO0fjN66y5AUhxMDSsx1g5jiVmPdL8RSR6fwp9JoA==}
+  '@rspress/plugin-client-redirects@1.37.4':
+    resolution: {integrity: sha512-2q3GtFgdUc+pkEfA+lqTdx/kG48PfklvjGwwIZyysdMqxGyO8X/2gspLDGptsAopx/GI7g8vrnriRcKOn4OQVQ==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.37.3
+      '@rspress/runtime': ^1.37.4
 
-  '@rspress/plugin-container-syntax@1.37.3':
-    resolution: {integrity: sha512-xiGjF2j4QPtD/s6Cmme1KEdr0mHRM/A5bDOmSXAqLssRiQyE7zunPjVIu78sfQndZxzAXWY51lQHbNT8IG5FdA==}
+  '@rspress/plugin-container-syntax@1.37.4':
+    resolution: {integrity: sha512-Fs5/yCRg9W22SSa2h6TOSR/uvx3M2zOHkvJQMFOwG6gOrNMTdlvHdhS/QEhVm0a6yJwUGv+duCAJmdTL5zoyDQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-last-updated@1.37.3':
-    resolution: {integrity: sha512-mKbTP5AF95AcxePye2x6Ssq2JuXApEsj8Kc/XKU35RJjgi2MpaUn8KXoG7b/YAiNnDAyGvmfDRjB94gi9vfBOA==}
+  '@rspress/plugin-last-updated@1.37.4':
+    resolution: {integrity: sha512-G4eC3UQxcnkpO8AUEQqEwqZYjf2gSsqnhxoTe6TT0f/lpRvqRlpV6oh79zEyJsh2PG1wUVD7SvuK7NbwdZa+eg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-medium-zoom@1.37.3':
-    resolution: {integrity: sha512-pnDXKvOMRUSwzrfKc27JAYmvMnTvGQpEMluuNPiWDFNqchfhFBTT1iDF2Rwwh/UfFn5x/A/6g/SwO9nEn1wtVw==}
+  '@rspress/plugin-medium-zoom@1.37.4':
+    resolution: {integrity: sha512-ge3Uon6A09reYKk22eKTABgBnXCKd1Y3ccit2LV5GWkiAk6xhOcWYH4+iN74Ig6LQHlpBrF/d3Pi25c9OqhrCw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.37.3
+      '@rspress/runtime': ^1.37.4
 
   '@rspress/plugin-rss@1.37.3':
     resolution: {integrity: sha512-2Y8fwns5nfYIThGXaY1J9Ny51KXiU/kzTFeTskXYTJklRsxuvO3orgOuRZdNdYEq/DysVeIKuuPTUqAX3dFkeQ==}
@@ -2710,15 +2708,18 @@ packages:
       react: '>=17.0.0'
       rspress: ^1.37.3
 
-  '@rspress/runtime@1.37.3':
-    resolution: {integrity: sha512-6xIOQYihfHejy35m88n69nv7GSEHtJm3xm4YqAsAmAYRk5BH+BWmufzBr3DVnn0dNbv9gZFsqCABH4GD/mMBvg==}
+  '@rspress/runtime@1.37.4':
+    resolution: {integrity: sha512-hyjEu8PcTklSvJEZcmhuk0/TMMuME7VxlAFxU4pTTbAz5bz+GPcMt2vkbVWD5GBBOo1P+dTsurhrF1JJCCXzHw==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/shared@1.37.3':
     resolution: {integrity: sha512-EJV039UJu5fSuodfs7OzXdxKbMLKc3HjOwZOJzxBt1Ywky6AeBHAd9GtkVetE5ud8DI2TloTkSGbkh1lNbq/fw==}
 
-  '@rspress/theme-default@1.37.3':
-    resolution: {integrity: sha512-7Jc6g2bemOUab4Chd2rXgaEeuP6F2dGvhUbsoiWW+p8p8vChAmvRf0/Ku5DLLgM3mgV3WtsFDQeTOzgOwTnRzg==}
+  '@rspress/shared@1.37.4':
+    resolution: {integrity: sha512-HfyzGt3GMx/GlVuJMweYy0VEW7ci52YDosWFmT36uPs9Z+rD8O9+EDUISftU0H7BeMYLEe3BgEfS/Wgr/FL54Q==}
+
+  '@rspress/theme-default@1.37.4':
+    resolution: {integrity: sha512-oqJu8yLUmmCh6qaXb64QVYDZqwXCcYoe0ay/OFcIrpTgKZYC0m1CbRIaHF2OJwp4MzjrM63FfJ1lAiLviA2s1A==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.5.4':
@@ -5637,8 +5638,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@1.37.3:
-    resolution: {integrity: sha512-z3HZoEbMasACHisMOv118kDiKapYhdQgEqnZZWTRP2LvAaGQbb7ZRJRhamK+8twQrMjaV+P2O/Rez/a09EdViQ==}
+  rspress@1.37.4:
+    resolution: {integrity: sha512-qKiD2KZbEt7zgbuX+JNmEcmlyWvsE5XvyUAuDGh8pkXFmheQ4AJeAxVMfEkR/RhN5vCRjcE7W2Vva4b0wtY9mg==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -8080,14 +8081,14 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.3':
     optional: true
 
-  '@rsbuild/core@1.1.4':
+  '@rsbuild/core@1.1.7':
     dependencies:
       '@rspack/core': 1.1.5(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
 
-  '@rsbuild/core@1.1.7':
+  '@rsbuild/core@1.1.8':
     dependencies:
       '@rspack/core': 1.1.5(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
@@ -8118,15 +8119,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.4)':
+  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.8)':
     dependencies:
-      '@rsbuild/core': 1.1.4
+      '@rsbuild/core': 1.1.8
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.4)':
+  '@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.8)':
     dependencies:
-      '@rsbuild/core': 1.1.4
+      '@rsbuild/core': 1.1.8
       '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
       react-refresh: 0.14.2
 
@@ -8137,9 +8138,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-sass@1.1.1(@rsbuild/core@1.1.4)':
+  '@rsbuild/plugin-sass@1.1.1(@rsbuild/core@1.1.8)':
     dependencies:
-      '@rsbuild/core': 1.1.4
+      '@rsbuild/core': 1.1.8
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.49
@@ -8227,23 +8228,23 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.14.2
 
-  '@rspress/core@1.37.3(webpack@5.96.1)':
+  '@rspress/core@1.37.4(webpack@5.96.1)':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.96.1)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.1.4
-      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.4)
-      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.1.4)
-      '@rsbuild/plugin-sass': 1.1.1(@rsbuild/core@1.1.4)
+      '@rsbuild/core': 1.1.8
+      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.8)
+      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.1.8)
+      '@rsbuild/plugin-sass': 1.1.1(@rsbuild/core@1.1.8)
       '@rspress/mdx-rs': 0.6.4
-      '@rspress/plugin-auto-nav-sidebar': 1.37.3
-      '@rspress/plugin-container-syntax': 1.37.3
-      '@rspress/plugin-last-updated': 1.37.3
-      '@rspress/plugin-medium-zoom': 1.37.3(@rspress/runtime@1.37.3)
-      '@rspress/runtime': 1.37.3
-      '@rspress/shared': 1.37.3
-      '@rspress/theme-default': 1.37.3
+      '@rspress/plugin-auto-nav-sidebar': 1.37.4
+      '@rspress/plugin-container-syntax': 1.37.4
+      '@rspress/plugin-last-updated': 1.37.4
+      '@rspress/plugin-medium-zoom': 1.37.4(@rspress/runtime@1.37.4)
+      '@rspress/runtime': 1.37.4
+      '@rspress/shared': 1.37.4
+      '@rspress/theme-default': 1.37.4
       enhanced-resolve: 5.17.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8304,38 +8305,38 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.4
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.4
 
-  '@rspress/plugin-auto-nav-sidebar@1.37.3':
+  '@rspress/plugin-auto-nav-sidebar@1.37.4':
     dependencies:
-      '@rspress/shared': 1.37.3
+      '@rspress/shared': 1.37.4
 
-  '@rspress/plugin-client-redirects@1.37.3(@rspress/runtime@1.37.3)':
+  '@rspress/plugin-client-redirects@1.37.4(@rspress/runtime@1.37.4)':
     dependencies:
-      '@rspress/runtime': 1.37.3
-      '@rspress/shared': 1.37.3
+      '@rspress/runtime': 1.37.4
+      '@rspress/shared': 1.37.4
 
-  '@rspress/plugin-container-syntax@1.37.3':
+  '@rspress/plugin-container-syntax@1.37.4':
     dependencies:
-      '@rspress/shared': 1.37.3
+      '@rspress/shared': 1.37.4
 
-  '@rspress/plugin-last-updated@1.37.3':
+  '@rspress/plugin-last-updated@1.37.4':
     dependencies:
-      '@rspress/shared': 1.37.3
+      '@rspress/shared': 1.37.4
 
-  '@rspress/plugin-medium-zoom@1.37.3(@rspress/runtime@1.37.3)':
+  '@rspress/plugin-medium-zoom@1.37.4(@rspress/runtime@1.37.4)':
     dependencies:
-      '@rspress/runtime': 1.37.3
+      '@rspress/runtime': 1.37.4
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.37.3(react@18.3.1)(rspress@1.37.3(webpack@5.96.1))':
+  '@rspress/plugin-rss@1.37.3(react@18.3.1)(rspress@1.37.4(webpack@5.96.1))':
     dependencies:
       '@rspress/shared': 1.37.3
       feed: 4.2.2
       react: 18.3.1
-      rspress: 1.37.3(webpack@5.96.1)
+      rspress: 1.37.4(webpack@5.96.1)
 
-  '@rspress/runtime@1.37.3':
+  '@rspress/runtime@1.37.4':
     dependencies:
-      '@rspress/shared': 1.37.3
+      '@rspress/shared': 1.37.4
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8351,11 +8352,21 @@ snapshots:
       lodash-es: 4.17.21
       unified: 10.1.2
 
-  '@rspress/theme-default@1.37.3':
+  '@rspress/shared@1.37.4':
+    dependencies:
+      '@rsbuild/core': 1.1.8
+      chalk: 5.3.0
+      execa: 5.1.1
+      fs-extra: 11.2.0
+      gray-matter: 4.0.3
+      lodash-es: 4.17.21
+      unified: 10.1.2
+
+  '@rspress/theme-default@1.37.4':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.37.3
-      '@rspress/shared': 1.37.3
+      '@rspress/runtime': 1.37.4
+      '@rspress/shared': 1.37.4
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -11674,11 +11685,11 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@1.37.3(webpack@5.96.1):
+  rspress@1.37.4(webpack@5.96.1):
     dependencies:
-      '@rsbuild/core': 1.1.4
-      '@rspress/core': 1.37.3(webpack@5.96.1)
-      '@rspress/shared': 1.37.3
+      '@rsbuild/core': 1.1.8
+      '@rspress/core': 1.37.4(webpack@5.96.1)
+      '@rspress/shared': 1.37.4
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0

--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rspress/plugin-client-redirects": "^1.37.3",
+    "@rspress/plugin-client-redirects": "^1.37.4",
     "@rspress/plugin-rss": "1.37.3",
     "@rstack-dev/doc-ui": "1.5.4",
     "@types/node": "^22.10.1",
@@ -21,7 +21,7 @@
     "react-dom": "^18.3.1",
     "rsbuild-plugin-google-analytics": "1.0.3",
     "rsbuild-plugin-open-graph": "1.0.2",
-    "rspress": "1.37.3",
+    "rspress": "1.37.4",
     "rspress-plugin-font-open-sans": "1.0.0",
     "rspress-plugin-sitemap": "^1.1.1"
   }


### PR DESCRIPTION
## Summary

Bump Rspress 1.37.4 and remove temp overrides.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v1.37.4

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
