### PR TITLE
fix(plugin-sass): mute import deprecation warning

### DIFF
--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -63,13 +63,16 @@ const getSassLoaderOptions = (
     mergeFn,
   });
 
-  if (
-    mergedOptions.api === 'legacy' &&
-    !mergedOptions.sassOptions?.silenceDeprecations
-  ) {
-    // mute the noisy legacy API deprecation warnings
-    mergedOptions.sassOptions ||= {};
-    mergedOptions.sassOptions.silenceDeprecations = ['legacy-js-api'];
+  mergedOptions.sassOptions ||= {};
+
+  if (!mergedOptions.sassOptions.silenceDeprecations) {
+    // `import` is widely used and will not be removed within two years
+    mergedOptions.sassOptions.silenceDeprecations = ['import'];
+
+    if (mergedOptions.api === 'legacy') {
+      // mute the noisy legacy API deprecation warnings
+      mergedOptions.sassOptions.silenceDeprecations.push('legacy-js-api');
+    }
   }
 
   return {

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -54,6 +54,9 @@ exports[`plugin-sass > should add sass-loader 1`] = `
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
           "sassOptions": {
             "quietDeps": true,
+            "silenceDeprecations": [
+              "import",
+            ],
           },
           "sourceMap": true,
         },
@@ -117,6 +120,9 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
           "sassOptions": {
             "quietDeps": true,
+            "silenceDeprecations": [
+              "import",
+            ],
           },
           "sourceMap": true,
         },
@@ -183,6 +189,9 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
           "implementation": "<ROOT>/node_modules/<PNPM_INNER>/sass-embedded/dist/lib/index.js",
           "sassOptions": {
             "quietDeps": true,
+            "silenceDeprecations": [
+              "import",
+            ],
           },
           "sourceMap": true,
         },
@@ -247,6 +256,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
           "sassOptions": {
             "quietDeps": true,
             "silenceDeprecations": [
+              "import",
               "legacy-js-api",
             ],
           },

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -55,7 +55,7 @@ const defaultOptions = {
   sourceMap: rsbuildConfig.output.sourceMap.css,
   sassOptions: {
     quietDeps: true,
-    silenceDeprecations: api === 'legacy' ? ['legacy-js-api'] : undefined,
+    silenceDeprecations: ['legacy-js-api', 'import'],
   },
 };
 ```
@@ -167,7 +167,7 @@ More info and automated migrator: https://sass-lang.com/d/import
  0 | @import './b.scss';
 ```
 
-You can suppress the `@import` warning with the following configuration:
+`@rsbuild/plugin-sass` adds the following configuration by default to silence the `@import` warning, if you need to silence other deprecated warnings, you can use the same method.
 
 ```ts
 pluginSass({

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -55,7 +55,7 @@ const defaultOptions = {
   sourceMap: rsbuildConfig.output.sourceMap.css,
   sassOptions: {
     quietDeps: true,
-    silenceDeprecations: api === 'legacy' ? ['legacy-js-api'] : undefined,
+    silenceDeprecations: ['legacy-js-api', 'import'],
   },
 };
 ```
@@ -167,7 +167,7 @@ More info and automated migrator: https://sass-lang.com/d/import
  0 | @import './b.scss';
 ```
 
-可以通过如下的配置来忽略 `@import` 的警告：
+`@rsbuild/plugin-sass` 默认添加了如下配置来忽略 `@import` 的警告，如果你需要忽略其他废弃警告，可以使用同样的方式。
 
 ```ts
 pluginSass({


### PR DESCRIPTION
## Summary

`import` is widely used and will not be removed within two years, so I prefer to mute import deprecation warning.

> As previously announced, given the size of this change, we expect to wait at least a two years after this deprecation before we remove @import from the language. While we plan to release Dart Sass 2.0.0 soon with other, smaller breaking changes, that release will not include any changes to @import. Instead, we expect @import to be removed in Dart Sass 3.0.0.

## Related Links

https://sass-lang.com/blog/import-is-deprecated/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
