### PR TITLE
fix: correct `cliShortcuts.custom` typing

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1361,7 +1361,7 @@ export interface DevConfig {
          * @param shortcuts - The default CLI shortcuts.
          * @returns - The customized CLI shortcuts.
          */
-        custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
+        custom?: (shortcuts: CliShortcut[]) => CliShortcut[];
         /**
          * Whether to print the help hint when the server is started.
          * @default true

--- a/website/docs/en/config/dev/cli-shortcuts.mdx
+++ b/website/docs/en/config/dev/cli-shortcuts.mdx
@@ -7,7 +7,7 @@ type CliShortcuts =
   | boolean
   | {
       help?: boolean;
-      custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
+      custom?: (shortcuts: CliShortcut[]) => CliShortcut[];
     };
 ```
 

--- a/website/docs/zh/config/dev/cli-shortcuts.mdx
+++ b/website/docs/zh/config/dev/cli-shortcuts.mdx
@@ -7,7 +7,7 @@ type CliShortcuts =
   | boolean
   | {
       help?: boolean;
-      custom?: (shortcuts?: CliShortcut[]) => CliShortcut[];
+      custom?: (shortcuts: CliShortcut[]) => CliShortcut[];
     };
 ```
 


### PR DESCRIPTION
## Summary

Correct `cliShortcuts.custom` typing, `shortcuts` will not be undefined.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
