### PR TITLE
feat: make environment API result cacheable

### DIFF
--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -9,16 +9,16 @@ rspackOnlyTest('support SSR', async ({ page }) => {
     rsbuildConfig: {},
   });
 
-  const url1 = new URL(`http://localhost:${rsbuild.port}`);
+  const url = new URL(`http://localhost:${rsbuild.port}`);
 
-  const res = await page.goto(url1.href);
+  const res = await page.goto(url.href);
 
   expect(await res?.text()).toMatch(/Rsbuild with React/);
 
-  await page.goto(url1.href);
+  await page.goto(url.href);
 
   // bundle result should cacheable and only load once.
-  expect(logs.filter((log) => log.includes('load ssr')).length).toBe(1);
+  expect(logs.filter((log) => log.includes('load SSR')).length).toBe(1);
 
   await rsbuild.close();
 

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -17,6 +17,7 @@ rspackOnlyTest('support SSR', async ({ page }) => {
 
   await page.goto(url1.href);
 
+  // bundle result should cacheable and only load once.
   expect(logs.filter((log) => log.includes('load ssr')).length).toBe(1);
 
   await rsbuild.close();

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -1,7 +1,9 @@
-import { dev, rspackOnlyTest } from '@e2e/helper';
+import { dev, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('support SSR', async ({ page }) => {
+  const { logs, restore } = proxyConsole('log');
+
   const rsbuild = await dev({
     cwd: __dirname,
     rsbuildConfig: {},
@@ -13,7 +15,13 @@ rspackOnlyTest('support SSR', async ({ page }) => {
 
   expect(await res?.text()).toMatch(/Rsbuild with React/);
 
+  await page.goto(url1.href);
+
+  expect(logs.filter((log) => log.includes('load ssr')).length).toBe(1);
+
   await rsbuild.close();
+
+  restore();
 });
 
 rspackOnlyTest('support SSR with esm target', async ({ page }) => {

--- a/e2e/cases/server/ssr/src/index.server.tsx
+++ b/e2e/cases/server/ssr/src/index.server.tsx
@@ -3,7 +3,7 @@ import ReactDOMServer from 'react-dom/server';
 import App from './App';
 import { assert } from './assert.server';
 
-console.log('load ssr');
+console.log('load SSR');
 
 // test dynamic import
 import('./test');

--- a/e2e/cases/server/ssr/src/index.server.tsx
+++ b/e2e/cases/server/ssr/src/index.server.tsx
@@ -3,6 +3,8 @@ import ReactDOMServer from 'react-dom/server';
 import App from './App';
 import { assert } from './assert.server';
 
+console.log('load ssr');
+
 // test dynamic import
 import('./test');
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -16,7 +16,7 @@ import type {
 } from '../types';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
 import { CompilerDevMiddleware } from './compilerDevMiddleware';
-import { getTransformedHtml, loadBundle } from './environment';
+import { cacheableLoadBundle, getTransformedHtml } from './environment';
 import {
   type RsbuildDevMiddlewareOptions,
   getMiddlewares,
@@ -266,6 +266,8 @@ export async function createDevServer<
     }
     return fs.readFileSync(fileName, 'utf-8');
   };
+
+  const loadBundle = cacheableLoadBundle();
 
   const environmentAPI = Object.fromEntries(
     Object.entries(options.context.environments).map(([name, environment]) => {

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -16,7 +16,11 @@ import type {
 } from '../types';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
 import { CompilerDevMiddleware } from './compilerDevMiddleware';
-import { cacheableLoadBundle, getTransformedHtml } from './environment';
+import {
+  createCacheableFunction,
+  getTransformedHtml,
+  loadBundle,
+} from './environment';
 import {
   type RsbuildDevMiddlewareOptions,
   getMiddlewares,
@@ -267,7 +271,10 @@ export async function createDevServer<
     return fs.readFileSync(fileName, 'utf-8');
   };
 
-  const loadBundle = cacheableLoadBundle();
+  const cacheableLoadBundle = createCacheableFunction(loadBundle);
+  const cacheableTransformedHtml = createCacheableFunction<string>(
+    (_stats, entryName, utils) => getTransformedHtml(entryName, utils),
+  );
 
   const environmentAPI = Object.fromEntries(
     Object.entries(options.context.environments).map(([name, environment]) => {
@@ -285,17 +292,25 @@ export async function createDevServer<
           },
           loadBundle: async <T>(entryName: string) => {
             await waitFirstCompileDone;
-            return loadBundle<T>(lastStats[environment.index], entryName, {
-              readFileSync,
-              environment,
-            });
+            return cacheableLoadBundle(
+              lastStats[environment.index],
+              entryName,
+              {
+                readFileSync,
+                environment,
+              },
+            ) as T;
           },
           getTransformedHtml: async (entryName: string) => {
             await waitFirstCompileDone;
-            return getTransformedHtml(entryName, {
-              readFileSync,
-              environment,
-            });
+            return cacheableTransformedHtml(
+              lastStats[environment.index],
+              entryName,
+              {
+                readFileSync,
+                environment,
+              },
+            );
           },
         },
       ];

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -99,14 +99,14 @@ export const createCacheableFunction = <T>(
     utils: ServerUtils,
   ): Promise<T> => {
     const cachedEntries = cache.get(stats);
-    if (cacheEntry?.[entryName]) {
-      return cacheEntry[entryName];
+    if (cachedEntries?.[entryName]) {
+      return cachedEntries[entryName];
     }
 
     const res = await getter(stats, entryName, utils);
 
-    resultCache.set(stats, {
-      ...(cacheEntry || {}),
+    cache.set(stats, {
+      ...(cachedEntries || {}),
       [entryName]: res,
     });
     return res;

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -98,7 +98,7 @@ export const createCacheableFunction = <T>(
     entryName: string,
     utils: ServerUtils,
   ): Promise<T> => {
-    const cacheEntry = resultCache.get(stats);
+    const cachedEntries = cache.get(stats);
     if (cacheEntry?.[entryName]) {
       return cacheEntry[entryName];
     }

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -86,7 +86,7 @@ export const createCacheableFunction = <T>(
     utils: ServerUtils,
   ) => Promise<T>,
 ) => {
-  const resultCache = new WeakMap<
+  const cache = new WeakMap<
     Rspack.Stats,
     {
       [entryName: string]: T;


### PR DESCRIPTION
## Summary

make `loadBundle` and `getTransformedHtml` result cacheable.


## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/4038

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
