### PR TITLE
fix(plugin-assets-retry): support `output.assetPrefix` with absolute url

### DIFF
--- a/e2e/cases/assets/assets-retry/index.test.ts
+++ b/e2e/cases/assets/assets-retry/index.test.ts
@@ -244,7 +244,7 @@ test('react ErrorBoundary should catch error when all retries failed', async ({
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
   await expect(compTestElement).toHaveText(
-    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from "static\/js\/async\/src_AsyncCompTest_tsx\.js" failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   const blockedResponseCount = count404Response(
     logs,
@@ -448,7 +448,7 @@ test('onRetry and onSuccess options should work when retrying async chunk succes
   await rsbuild.close();
 });
 
-test('onRetry and onFail options should work when retrying initial chunk failed', async ({
+test('domain, onRetry and onFail options should work when retrying initial chunk failed', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -461,7 +461,7 @@ test('onRetry and onFail options should work when retrying initial chunk failed'
     blockedMiddleware,
     {
       minify: true,
-      domain: [`http://localhost:${port}`, 'http://a.com', 'http://b.com'],
+      domain: [`http://localhost:${port}`, 'http://a.com/foo-path', 'http://b.com'],
       onRetry(context) {
         console.info('onRetry', context);
       },
@@ -497,8 +497,8 @@ test('onRetry and onFail options should work when retrying initial chunk failed'
       },
       {
         times: 1,
-        domain: 'http://a.com',
-        url: 'http://a.com/static/js/index.js',
+        domain: 'http://a.com/foo-path',
+        url: 'http://a.com/foo-path/static/js/index.js',
         tagName: 'script',
         isAsyncChunk: false,
       },
@@ -524,7 +524,7 @@ test('onRetry and onFail options should work when retrying initial chunk failed'
   await rsbuild.close();
 });
 
-test('onRetry and onFail options should work when retrying async chunk failed', async ({
+test('domain, onRetry and onFail options should work when retrying async chunk failed', async ({
   page,
 }) => {
   const blockedMiddleware = createBlockMiddleware({
@@ -537,7 +537,7 @@ test('onRetry and onFail options should work when retrying async chunk failed', 
     blockedMiddleware,
     {
       minify: true,
-      domain: [`http://localhost:${port}`, 'http://a.com', 'http://b.com'],
+      domain: [`http://localhost:${port}`, 'http://a.com/foo-path', 'http://b.com'],
       onRetry(context) {
         console.info('onRetry', context);
       },
@@ -558,7 +558,7 @@ test('onRetry and onFail options should work when retrying async chunk failed', 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test-error');
   await expect(compTestElement).toHaveText(
-    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from \/static\/js\/async\/src_AsyncCompTest_tsx\.js failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
+    /ChunkLoadError: Loading chunk src_AsyncCompTest_tsx from "static\/js\/async\/src_AsyncCompTest_tsx\.js" failed after 3 retries: "Loading chunk src_AsyncCompTest_tsx failed.*/,
   );
   await delay();
 
@@ -577,8 +577,8 @@ test('onRetry and onFail options should work when retrying async chunk failed', 
       },
       {
         times: 1,
-        domain: 'http://a.com',
-        url: 'http://a.com/static/js/async/src_AsyncCompTest_tsx.js',
+        domain: 'http://a.com/foo-path',
+        url: 'http://a.com/foo-path/static/js/async/src_AsyncCompTest_tsx.js',
         tagName: 'script',
         isAsyncChunk: true,
       },

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -104,10 +104,11 @@ function getNextRetryUrl(
   domain: string,
   nextDomain: string,
   existRetryTimes: number,
+  originalSrcUrl: string, // to get originalQuery
 ) {
   return (
     cleanUrl(currRetryUrl.replace(domain, nextDomain)) +
-    getUrlRetryQuery(existRetryTimes + 1, getQueryFromUrl(currRetryUrl))
+    getUrlRetryQuery(existRetryTimes + 1, getQueryFromUrl(originalSrcUrl))
   );
 }
 
@@ -128,7 +129,7 @@ function initRetry(chunkId: string): Retry {
     ? window.origin + originalPublicPath + originalScriptFilename
     : originalPublicPath + originalScriptFilename;
 
-  const existRetryTimes = 1;
+  const existRetryTimes = 0;
   const nextDomain = config.domain?.[0] ?? window.origin;
 
   return {
@@ -138,6 +139,7 @@ function initRetry(chunkId: string): Retry {
       nextDomain,
       nextDomain,
       existRetryTimes,
+      originalSrcUrl,
     ),
 
     originalScriptFilename,
@@ -165,6 +167,7 @@ function nextRetry(chunkId: string, existRetryTimes: number): Retry {
         currRetry.nextDomain,
         nextDomain,
         existRetryTimes,
+        originalSrcUrl,
       ),
 
       originalScriptFilename,
@@ -244,13 +247,13 @@ function ensureChunk(
     // the first calling is not retry
     // if the failed request is 4 in network panel, callingCounter.count === 4, the first one is the normal request, and existRetryTimes is 3, retried 3 times
     const existRetryTimes = callingCounter.count - 1;
-    let originalSrcUrl: string;
+    let originalScriptFilename: string;
     let nextRetryUrl: string;
     let nextDomain: string;
 
     try {
       const retryResult = nextRetry(chunkId, existRetryTimes);
-      originalSrcUrl = retryResult.originalSrcUrl;
+      originalScriptFilename = retryResult.originalScriptFilename;
       nextRetryUrl = retryResult.nextRetryUrl;
       nextDomain = retryResult.nextDomain;
     } catch (e) {
@@ -278,7 +281,7 @@ function ensureChunk(
     if (existRetryTimes >= maxRetries) {
       error.message = error.message?.includes('retries:')
         ? error.message
-        : `Loading chunk ${chunkId} from ${originalSrcUrl} failed after ${maxRetries} retries: "${error.message}"`;
+        : `Loading chunk ${chunkId} from "${originalScriptFilename}" failed after ${maxRetries} retries: "${error.message}"`;
       if (typeof config.onFail === 'function') {
         config.onFail(context);
       }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -105,7 +105,7 @@ function getNextRetryUrl(
   domain: string,
   nextDomain: string,
   existRetryTimes: number,
-  originalQuery: string, // to get originalQuery
+  originalQuery: string,
 ) {
   return (
     cleanUrl(currRetryUrl.replace(domain, nextDomain)) +

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -10,6 +10,7 @@ type Retry = {
   nextRetryUrl: ChunkSrcUrl;
   originalScriptFilename: ChunkFilename;
   originalSrcUrl: ChunkSrcUrl;
+  originalQuery: string;
 };
 
 type RetryCollector = Record<ChunkId, Record<number, Retry>>;
@@ -104,11 +105,11 @@ function getNextRetryUrl(
   domain: string,
   nextDomain: string,
   existRetryTimes: number,
-  originalSrcUrl: string, // to get originalQuery
+  originalQuery: string, // to get originalQuery
 ) {
   return (
     cleanUrl(currRetryUrl.replace(domain, nextDomain)) +
-    getUrlRetryQuery(existRetryTimes + 1, getQueryFromUrl(originalSrcUrl))
+    getUrlRetryQuery(existRetryTimes + 1, originalQuery)
   );
 }
 
@@ -128,6 +129,7 @@ function initRetry(chunkId: string): Retry {
   const originalSrcUrl = originalPublicPath.startsWith('/')
     ? window.origin + originalPublicPath + originalScriptFilename
     : originalPublicPath + originalScriptFilename;
+  const originalQuery = getQueryFromUrl(originalSrcUrl);
 
   const existRetryTimes = 0;
   const nextDomain = config.domain?.[0] ?? window.origin;
@@ -139,11 +141,12 @@ function initRetry(chunkId: string): Retry {
       nextDomain,
       nextDomain,
       existRetryTimes,
-      originalSrcUrl,
+      originalQuery,
     ),
 
     originalScriptFilename,
     originalSrcUrl,
+    originalQuery,
   };
 }
 
@@ -157,7 +160,7 @@ function nextRetry(chunkId: string, existRetryTimes: number): Retry {
     nextRetry = initRetry(chunkId);
     retryCollector[chunkId] = [];
   } else {
-    const { originalScriptFilename, originalSrcUrl } = currRetry;
+    const { originalScriptFilename, originalSrcUrl, originalQuery } = currRetry;
     const nextDomain = findNextDomain(currRetry.nextDomain);
 
     nextRetry = {
@@ -167,11 +170,12 @@ function nextRetry(chunkId: string, existRetryTimes: number): Retry {
         currRetry.nextDomain,
         nextDomain,
         existRetryTimes,
-        originalSrcUrl,
+        originalQuery,
       ),
 
       originalScriptFilename,
       originalSrcUrl,
+      originalQuery,
     };
   }
 

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -247,7 +247,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   const originalQuery =
     target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
 
-  // this function is same with async chunk retry
+  // this function is the same as async chunk retry
   function getUrlRetryQuery(
     existRetryTimes: number,
     originalQuery: string,
@@ -263,12 +263,13 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     return '';
   }
 
-  // this function is same with async chunk retry
+  // this function is the same as async chunk retry
   function getNextRetryUrl(
     currRetryUrl: string,
     domain: string,
     nextDomain: string,
     existRetryTimes: number,
+    originalQuery: string, // to get originalQuery
   ) {
     return (
       cleanUrl(currRetryUrl.replace(domain, nextDomain)) +
@@ -282,7 +283,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     (target as HTMLScriptElement).defer;
 
   const attributes: ScriptElementAttributes = {
-    url: getNextRetryUrl(url, domain, nextDomain, existRetryTimes),
+    url: getNextRetryUrl(url, domain, nextDomain, existRetryTimes, originalQuery),
     times: existRetryTimes + 1,
     crossOrigin: config.crossOrigin,
     isAsync,

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -22,6 +22,7 @@ declare global {
   var __RB_ASYNC_CHUNKS__: Record<string, boolean>;
 }
 
+// this function is the same as async chunk retry
 function findCurrentDomain(url: string, domainList: string[]) {
   let domain = '';
   for (let i = 0; i < domainList.length; i++) {
@@ -33,6 +34,7 @@ function findCurrentDomain(url: string, domainList: string[]) {
   return domain || window.origin;
 }
 
+// this function is the same as async chunk retry
 function findNextDomain(url: string, domainList: string[]) {
   const currentDomain = findCurrentDomain(url, domainList);
   const index = domainList.indexOf(currentDomain);
@@ -248,10 +250,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
 
   // this function is the same as async chunk retry
-  function getUrlRetryQuery(
-    existRetryTimes: number,
-    originalQuery: string,
-  ): string {
+  function getUrlRetryQuery(existRetryTimes: number): string {
     if (config.addQuery === true) {
       return originalQuery !== ''
         ? `${originalQuery}&retry=${existRetryTimes}`
@@ -269,11 +268,10 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     domain: string,
     nextDomain: string,
     existRetryTimes: number,
-    originalQuery: string,
   ) {
     return (
       cleanUrl(currRetryUrl.replace(domain, nextDomain)) +
-      getUrlRetryQuery(existRetryTimes + 1, originalQuery)
+      getUrlRetryQuery(existRetryTimes + 1)
     );
   }
 
@@ -283,7 +281,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     (target as HTMLScriptElement).defer;
 
   const attributes: ScriptElementAttributes = {
-    url: getNextRetryUrl(url, domain, nextDomain, existRetryTimes, originalQuery),
+    url: getNextRetryUrl(url, domain, nextDomain, existRetryTimes),
     times: existRetryTimes + 1,
     crossOrigin: config.crossOrigin,
     isAsync,

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -272,7 +272,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   ) {
     return (
       cleanUrl(currRetryUrl.replace(domain, nextDomain)) +
-      getUrlRetryQuery(existRetryTimes + 1, getQueryFromUrl(currRetryUrl))
+      getUrlRetryQuery(existRetryTimes + 1, originalQuery)
     );
   }
 

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -269,7 +269,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
     domain: string,
     nextDomain: string,
     existRetryTimes: number,
-    originalQuery: string, // to get originalQuery
+    originalQuery: string,
   ) {
     return (
       cleanUrl(currRetryUrl.replace(domain, nextDomain)) +


### PR DESCRIPTION
## Summary

let async-retry url calculating aligned with initial-retry

#### Before

only support

```ts
domain: ['https://a.com', 'https://b.com']

// or

domain: ['https://a.com/path-foo', 'https://b.com/path-foo']
```

if you uses below

```ts
domain: ['https://a.com/path-foo', 'https://b.com'],
max: 3

output: {
	assetPrefix: 'https://a.com/path-foo'
}
```

the retry contexts: 

```
0. https://a.com/path-foo/static/js/main.js

1. https://a.com/path-foo/static/js/main.js

2. https://b.com/path-foo/static/js/main.js

3. https://a.com/path-foo/static/js/main.js
```


#### after

```ts
domains: ['https://a.com/path-foo', 'https://b.com'],
max: 3

output: {
	assetPrefix: 'https://a.com/path-foo'
}
```

```
0. https://a.com/path-foo/static/js/main.js

1. https://a.com/path-foo/static/js/main.js

2. https://b.com/static/js/main.js

3. https://a.com/path-foo/static/js/main.js
```

