### PR TITLE
feat: add `resolve.extensions` config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -196,6 +196,15 @@ const getDefaultResolveConfig = (): NormalizedResolveConfig => {
       '@swc/helpers': swcHelpersPath,
     },
     aliasStrategy: 'prefer-tsconfig',
+    extensions: [
+      // most projects are using TypeScript, resolve .ts(x) files first to reduce resolve time.
+      '.ts',
+      '.tsx',
+      '.mjs',
+      '.js',
+      '.jsx',
+      '.json',
+    ],
   };
 };
 

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -9,6 +9,7 @@ const OVERRIDE_PATHS = [
   'output.overrideBrowserslist',
   'server.open',
   'server.printUrls',
+  'resolve.extensions',
   'provider',
 ];
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1415,10 +1415,16 @@ export interface ResolveConfig {
    * @default 'prefer-tsconfig'
    */
   aliasStrategy?: AliasStrategy;
+  /**
+   * Automatically resolve file extensions when importing modules.
+   * This means you can import files without explicitly writing their extensions.
+   * @default ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json']
+   */
+  extensions?: string[];
 }
 
 export type NormalizedResolveConfig = ResolveConfig &
-  Pick<Required<ResolveConfig>, 'alias' | 'aliasStrategy'>;
+  Pick<Required<ResolveConfig>, 'alias' | 'aliasStrategy' | 'extensions'>;
 
 export type ModuleFederationConfig = {
   options: ModuleFederationPluginOptions;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -93,6 +93,14 @@ exports[`environment config > should normalize environment config correctly 1`] 
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
     "aliasStrategy": "prefer-tsconfig",
+    "extensions": [
+      ".ts",
+      ".tsx",
+      ".mjs",
+      ".js",
+      ".jsx",
+      ".json",
+    ],
   },
   "root": "<ROOT>",
   "security": {
@@ -226,6 +234,14 @@ exports[`environment config > should normalize environment config correctly 2`] 
       "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
     },
     "aliasStrategy": "prefer-tsconfig",
+    "extensions": [
+      ".ts",
+      ".tsx",
+      ".mjs",
+      ".js",
+      ".jsx",
+      ".json",
+    ],
   },
   "root": "<ROOT>",
   "security": {
@@ -359,6 +375,14 @@ exports[`environment config > should print environment config when inspect confi
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -488,6 +512,14 @@ exports[`environment config > should print environment config when inspect confi
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -637,6 +669,14 @@ exports[`environment config > should support modify environment config by api.mo
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -767,6 +807,14 @@ exports[`environment config > should support modify environment config by api.mo
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -897,6 +945,14 @@ exports[`environment config > should support modify environment config by api.mo
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -1029,6 +1085,14 @@ exports[`environment config > should support modify single environment config by
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {
@@ -1159,6 +1223,14 @@ exports[`environment config > should support modify single environment config by
         "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
       },
       "aliasStrategy": "prefer-tsconfig",
+      "extensions": [
+        ".ts",
+        ".tsx",
+        ".mjs",
+        ".js",
+        ".jsx",
+        ".json",
+      ],
     },
     "root": "<ROOT>",
     "security": {

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -23,6 +23,20 @@ describe('plugin-resolve', () => {
     ).toBeDefined();
   });
 
+  it('should allow to customize extensions', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginResolve()],
+      rsbuildConfig: {
+        resolve: {
+          extensions: ['.ts', '.js'],
+        },
+      },
+    });
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(bundlerConfigs[0].resolve?.extensions).toEqual(['.ts', '.js']);
+  });
+
   it('should not apply tsConfigPath when aliasStrategy is "prefer-alias"', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],


### PR DESCRIPTION
## Summary

Add new `resolve.extensions` config:

```js
export default {
  resolve: {
    extensions: ['.ts', '.js'],
  },
};
```

## Related Links

https://rspack.dev/config/resolve#resolveextensions

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
