### PR TITLE
fix: print file size should ends with a new line

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -229,12 +229,10 @@ async function printFileSizes(
       log += color.dim(` (gzip: ${calcFileSize(totalGzipSize)})`);
     }
 
-    // log += ` ${color.dim(`(${environmentName})`)}`;
-
-    log += '\n';
-
     logs.push(log);
   }
+
+  logs.push('');
 
   return logs;
 }


### PR DESCRIPTION
## Summary

Print file size should always ends with a new line.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
