### PR TITLE
test(e2e): fix failed Module Federation test case

### DIFF
--- a/e2e/cases/module-federation-v2/index.test.ts
+++ b/e2e/cases/module-federation-v2/index.test.ts
@@ -100,7 +100,7 @@ rspackOnlyTest(
   },
 );
 
-rspackOnlyTest('should handle syntax issues as expected', async () => {
+rspackOnlyTest('should downgrade syntax as expected', async () => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();

--- a/e2e/cases/module-federation-v2/index.test.ts
+++ b/e2e/cases/module-federation-v2/index.test.ts
@@ -100,7 +100,7 @@ rspackOnlyTest(
   },
 );
 
-test('should transform module federation runtime with SWC', async () => {
+rspackOnlyTest('should handle syntax issues as expected', async () => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();

--- a/e2e/cases/module-federation-v2/index.test.ts
+++ b/e2e/cases/module-federation-v2/index.test.ts
@@ -8,6 +8,7 @@ import {
   rspackOnlyTest,
 } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
 const host = join(__dirname, 'host');
@@ -99,45 +100,42 @@ rspackOnlyTest(
   },
 );
 
-// TODO downgrade syntax
-test.skip('should transform module federation runtime with SWC', async () => {
+test('should transform module federation runtime with SWC', async () => {
   writeButtonCode();
 
   const remotePort = await getRandomPort();
 
   process.env.REMOTE_PORT = remotePort.toString();
 
+  const rsbuildConfig: RsbuildConfig = {
+    output: {
+      sourceMap: true,
+      overrideBrowserslist: ['Chrome >= 51'],
+    },
+    performance: {
+      chunkSplit: {
+        strategy: 'all-in-one',
+      },
+    },
+    plugins: [
+      pluginCheckSyntax({
+        // MF runtime contains dynamic import, which can not pass syntax checking
+        exclude: [/@module-federation[\\/]runtime/],
+      }),
+    ],
+  };
+
   await expect(
     build({
       cwd: remote,
-      rsbuildConfig: {
-        output: {
-          overrideBrowserslist: ['Chrome >= 51'],
-        },
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-        plugins: [pluginCheckSyntax()],
-      },
+      rsbuildConfig,
     }),
   ).resolves.toBeTruthy();
 
   await expect(
     build({
       cwd: host,
-      rsbuildConfig: {
-        output: {
-          overrideBrowserslist: ['Chrome >= 51'],
-        },
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-        plugins: [pluginCheckSyntax()],
-      },
+      rsbuildConfig,
     }),
   ).resolves.toBeTruthy();
 });

--- a/e2e/cases/module-federation/index.test.ts
+++ b/e2e/cases/module-federation/index.test.ts
@@ -8,6 +8,7 @@ import {
   rspackOnlyTest,
 } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
 const host = join(__dirname, 'host');
@@ -141,37 +142,29 @@ rspackOnlyTest(
 
     process.env.REMOTE_PORT = remotePort.toString();
 
+    const rsbuildConfig: RsbuildConfig = {
+      output: {
+        overrideBrowserslist: ['Chrome >= 51'],
+      },
+      performance: {
+        chunkSplit: {
+          strategy: 'all-in-one',
+        },
+      },
+      plugins: [pluginCheckSyntax()],
+    };
+
     await expect(
       build({
         cwd: remote,
-        rsbuildConfig: {
-          output: {
-            overrideBrowserslist: ['Chrome >= 51'],
-          },
-          performance: {
-            chunkSplit: {
-              strategy: 'all-in-one',
-            },
-          },
-          plugins: [pluginCheckSyntax()],
-        },
+        rsbuildConfig,
       }),
     ).resolves.toBeTruthy();
 
     await expect(
       build({
         cwd: host,
-        rsbuildConfig: {
-          output: {
-            overrideBrowserslist: ['Chrome >= 51'],
-          },
-          performance: {
-            chunkSplit: {
-              strategy: 'all-in-one',
-            },
-          },
-          plugins: [pluginCheckSyntax()],
-        },
+        rsbuildConfig,
       }),
     ).resolves.toBeTruthy();
   },


### PR DESCRIPTION
## Summary

Fix failed Module Federation test case. MF runtime contains dynamic import, which can not pass syntax checking, we need to configure `exclude` for it.

## Related Links

https://github.com/sk-pub/module-federation-core/blob/7199bd346980d08270f5620967b8bc7eb4729e73/packages/runtime/src/utils/load.ts#L28

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
