### PR TITLE
test(e2e): fix unstable plugin hooks case

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks/environments.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/environments.test.ts
@@ -73,6 +73,7 @@ const createPlugin = () => {
 rspackOnlyTest(
   'should run plugin hooks correctly when running build with multiple environments',
   async () => {
+    process.env.NODE_ENV = 'production';
     const { plugin, names } = createPlugin();
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -121,6 +122,8 @@ rspackOnlyTest(
       'AfterEnvironmentCompile node',
       'AfterBuild',
     ]);
+
+    process.env.NODE_ENV = 'test';
   },
 );
 


### PR DESCRIPTION
## Summary

Fix unstable plugin hooks case:

<img width="1276" alt="Screenshot 2024-12-10 at 15 32 26" src="https://github.com/user-attachments/assets/c8c31541-def3-4e5d-8cc9-30851ba52c75">

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
