### PR TITLE
fix: should not trigger dev hooks when building

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -105,6 +105,39 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
+  'should run plugin hooks correctly when running build and mode is development',
+  async () => {
+    const { plugin, names } = createPlugin();
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        mode: 'development',
+        plugins: [plugin],
+      },
+    });
+
+    const buildInstance = await rsbuild.build();
+
+    await buildInstance.close();
+
+    expect(names).toEqual([
+      'ModifyRsbuildConfig',
+      'ModifyEnvironmentConfig',
+      'ModifyBundlerChain',
+      'ModifyBundlerConfig',
+      'BeforeCreateCompiler',
+      'AfterCreateCompiler',
+      'BeforeBuild',
+      'BeforeEnvironmentCompile',
+      'ModifyHTMLTags',
+      'AfterEnvironmentCompile',
+      'AfterBuild',
+      'OnCloseBuild',
+    ]);
+  },
+);
+
+rspackOnlyTest(
   'should run plugin hooks correctly when running startDevServer',
   async ({ page }) => {
     process.env.NODE_ENV = 'development';

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -46,7 +46,7 @@ export async function createCompiler(options: InitConfigsOptions) {
     done(stats as Rspack.Stats);
   });
 
-  if (context.normalizedConfig?.mode === 'development') {
+  if (context.command === 'dev') {
     helpers.registerDevHook({
       compiler,
       context,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -144,6 +144,8 @@ export async function createRsbuild(
   });
 
   const preview = async (options: PreviewOptions = {}) => {
+    context.command = 'preview';
+
     if (!getNodeEnv()) {
       setNodeEnv('production');
     }
@@ -174,9 +176,12 @@ export async function createRsbuild(
   };
 
   const build: Build = async (...args) => {
+    context.command = 'build';
+
     if (!getNodeEnv()) {
       setNodeEnv('production');
     }
+
     const buildInstance = await providerInstance.build(...args);
     return {
       ...buildInstance,
@@ -188,16 +193,22 @@ export async function createRsbuild(
   };
 
   const startDevServer: StartDevServer = (...args) => {
+    context.command = 'dev';
+
     if (!getNodeEnv()) {
       setNodeEnv('development');
     }
+
     return providerInstance.startDevServer(...args);
   };
 
   const createDevServer: CreateDevServer = (...args) => {
+    context.command = 'dev';
+
     if (!getNodeEnv()) {
       setNodeEnv('development');
     }
+
     return providerInstance.createDevServer(...args);
   };
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -57,7 +57,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     isCompiling = true;
   });
 
-  if (context.normalizedConfig?.mode === 'production') {
+  if (context.command === 'build') {
     compiler.hooks.run.tap('rsbuild:run', logRspackVersion);
   }
 
@@ -113,7 +113,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     },
   );
 
-  if (context.normalizedConfig?.mode === 'development') {
+  if (context.command === 'dev') {
     registerDevHook({
       context,
       compiler,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -44,4 +44,12 @@ export type InternalContext = RsbuildContext & {
   environments: Record<string, EnvironmentContext>;
   /** Only build specified environment. */
   specifiedEnvironments?: string[];
+  /**
+   * The command type.
+   *
+   * - dev: `rsbuild dev` or `rsbuild.startDevServer()`
+   * - build: `rsbuild build` or `rsbuild.build()`
+   * - preview: `rsbuild preview` or `rsbuild.preview()`
+   */
+  command?: 'dev' | 'build' | 'preview';
 };


### PR DESCRIPTION
## Summary

- Should not trigger dev hooks when building.
- Added `command` property to the internal context.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4164

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
