### PR TITLE
docs(plugin-svgr): explain base64 URL

### DIFF
--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -42,7 +42,7 @@ import Logo from './logo.svg?react';
 export const App = () => <Logo />;
 ```
 
-If the imported path does not contain the `?react` suffix, then the SVG will be treated as a normal static asset and you will get a URL string or base64 URL, refer to [Import Static Assets](/guide/basic/static-assets).
+If the imported path does not contain the `?react` suffix, then the SVG will be treated as a normal static asset and you will get a URL string or base64 URL, see [Import Static Assets](/guide/basic/static-assets).
 
 ```js
 import logoURL from './static/logo.svg';

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -42,7 +42,7 @@ import Logo from './logo.svg?react';
 export const App = () => <Logo />;
 ```
 
-If the imported path does not contain the `?react` suffix, then the SVG will be treated as a normal static asset and you will get a URL:
+If the imported path does not contain the `?react` suffix, then the SVG will be treated as a normal static asset and you will get a URL string or base64 URL, refer to [Import Static Assets](/guide/basic/static-assets).
 
 ```js
 import logoURL from './static/logo.svg';

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -42,7 +42,7 @@ import Logo from './logo.svg?react';
 export const App = () => <Logo />;
 ```
 
-如果导入的路径不包含 `?react` 后缀，那么 SVG 会被当做普通的静态资源来处理，你会得到一个 URL 字符串：
+如果导入的路径不包含 `?react` 后缀，那么 SVG 会被当做普通的静态资源来处理，你会得到一个 URL 字符串或 base64 URL，参考 [引用静态资源](/guide/basic/static-assets)。
 
 ```js
 import logoURL from './static/logo.svg';


### PR DESCRIPTION
## Summary

This pull request includes updates to the documentation for the `plugin-svgr`. The changes clarify the behavior when importing SVG files without the `?react` suffix.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4167

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
