### PR TITLE
docs: upgrade to React 19 and fix peer issues

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -38,6 +38,7 @@
     "@rsbuild/plugin-vue": "workspace:*",
     "@rsbuild/plugin-vue-jsx": "^1.0.1",
     "@rsbuild/webpack": "workspace:*",
+    "@module-federation/enhanced": "0.8.1",
     "@module-federation/rsbuild-plugin": "0.8.1",
     "@scripts/test-helper": "workspace:*",
     "@types/fs-extra": "^11.0.4",

--- a/examples/module-federation-v2/host/package.json
+++ b/examples/module-federation-v2/host/package.json
@@ -10,6 +10,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@module-federation/enhanced": "0.8.1",
     "@module-federation/rsbuild-plugin": "0.8.1",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*"

--- a/examples/module-federation-v2/remote/package.json
+++ b/examples/module-federation-v2/remote/package.json
@@ -10,6 +10,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@module-federation/enhanced": "0.8.1",
     "@module-federation/rsbuild-plugin": "0.8.1",
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-react": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,12 @@ importers:
       '@e2e/helper':
         specifier: workspace:*
         version: link:scripts
+      '@module-federation/enhanced':
+        specifier: 0.8.1
+        version: 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)
       '@module-federation/rsbuild-plugin':
         specifier: 0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
       '@playwright/test':
         specifier: 1.44.1
         version: 1.44.1
@@ -286,9 +289,12 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
     devDependencies:
+      '@module-federation/enhanced':
+        specifier: 0.8.1
+        version: 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)
       '@module-federation/rsbuild-plugin':
         specifier: 0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -305,9 +311,12 @@ importers:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
     devDependencies:
+      '@module-federation/enhanced':
+        specifier: 0.8.1
+        version: 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)
       '@module-federation/rsbuild-plugin':
         specifier: 0.8.1
-        version: 0.8.1(@module-federation/enhanced@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
+        version: 0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -1139,14 +1148,14 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@rspress/plugin-client-redirects':
-        specifier: ^1.37.4
-        version: 1.37.4(@rspress/runtime@1.37.4)
+        specifier: ^1.38.0
+        version: 1.38.0(@rspress/runtime@1.38.0)
       '@rspress/plugin-rss':
-        specifier: 1.37.4
-        version: 1.37.4(react@18.3.1)(rspress@1.37.4(webpack@5.97.1))
+        specifier: ^1.38.0
+        version: 1.38.0(react@19.0.0)(rspress@1.38.0(webpack@5.97.1))
       '@rstack-dev/doc-ui':
         specifier: 1.5.4
-        version: 1.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.5.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/node':
         specifier: ^22.10.1
         version: 22.10.1
@@ -1160,22 +1169,22 @@ importers:
         specifier: ^3.3.2
         version: 3.3.2
       react:
-        specifier: ^18.3.1
-        version: 18.3.1
+        specifier: ^19.0.0
+        version: 19.0.0
       react-dom:
-        specifier: ^18.3.1
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.0.0
+        version: 19.0.0(react@19.0.0)
       rsbuild-plugin-google-analytics:
-        specifier: 1.0.3
+        specifier: ^1.0.3
         version: 1.0.3(@rsbuild/core@packages+core)
       rsbuild-plugin-open-graph:
-        specifier: 1.0.2
+        specifier: ^1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
       rspress:
-        specifier: 1.37.4
-        version: 1.37.4(webpack@5.97.1)
+        specifier: ^1.38.0
+        version: 1.38.0(webpack@5.97.1)
       rspress-plugin-font-open-sans:
-        specifier: 1.0.0
+        specifier: ^1.0.0
         version: 1.0.0
       rspress-plugin-sitemap:
         specifier: ^1.1.1
@@ -2122,17 +2131,17 @@ packages:
       '@swc/helpers':
         optional: true
 
-  '@module-federation/bridge-react-webpack-plugin@0.7.6':
-    resolution: {integrity: sha512-eD1JZDQ+h5WLdA58MmAE1DzLwvFaGJeeam3Tswc/sEUb4QGT86X4Fme+dMTBRYRoAq/tRYql3DlVTFhdmrUVzg==}
+  '@module-federation/bridge-react-webpack-plugin@0.8.1':
+    resolution: {integrity: sha512-5yCk16gdD0Mqqn4ExCu/VhnEJVA7UvCIHl9PDoiVqzM9uXMOlhwgwOeLTRlSfKmF5p8Xz7/8GM7aaquU/lkhJQ==}
 
-  '@module-federation/data-prefetch@0.7.6':
-    resolution: {integrity: sha512-AMpfnuIAK/Y5M682BUsnc13ARCEKhEvb0tXF4S+l7jfL08oE9gyo+G/nk0LIzZBO2mLDz5g2AydAERanM6gswQ==}
+  '@module-federation/data-prefetch@0.8.1':
+    resolution: {integrity: sha512-KkMmTO1Xp6OboLMcqSHGcAC6SxzMsXuzwBr62iteuBgxxl0jJJVKwbr7kyQh5TwV0H/KPZRTbkvsa2EWFNMRHg==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@module-federation/dts-plugin@0.7.6':
-    resolution: {integrity: sha512-K8T8+Ip+fCQkTOxAQbAW47drphN36+WcvcOusn/fsIT+1exdhyvqxSCj8V7MLCtjA9kGDi0jHIGN6MN4p2cV0Q==}
+  '@module-federation/dts-plugin@0.8.1':
+    resolution: {integrity: sha512-XGyuMLFE2NoDwXzdAJOp/YpQSe1hTkOWnfjSvsrpmnBJiRKL9WRik4LN9chGxbgCX2AsaMWhOOdX+ICcPlxnMg==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -2140,8 +2149,8 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/enhanced@0.7.6':
-    resolution: {integrity: sha512-ivTVuRKhew/25fiblAW22RybYzyacQsvnQG3y9zSNsYbwcj+0u7THWMmsK8vNKxDUpjxuQulCK07BEycDjoB5Q==}
+  '@module-federation/enhanced@0.8.1':
+    resolution: {integrity: sha512-gRHrmOXEvGLt4N31oDIolKs6GrTlgsG80yddl43iOHJVZHnx1QGFKDBkIlZLeWC8CMMU4U4GtRjY9Nv0CKqEPg==}
     peerDependencies:
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
@@ -2154,14 +2163,14 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/error-codes@0.7.6':
-    resolution: {integrity: sha512-XVzX/sRFj1h5JvOOVMoFppxq0t1t3o/AlEICHgWX+dybIwJgz9g4gihZOWVZfz5/xsKGcUwdH5X7Z2nkuYhJEw==}
+  '@module-federation/error-codes@0.8.1':
+    resolution: {integrity: sha512-Uq6c6WoA2cWSSGUwyVNy6g7sYlh2nDYsLIBPxsDJmF6oBe5FtD3QJcAawMKGV0TFb6HSWbJXVbNmpAeJMIIh+Q==}
 
-  '@module-federation/managers@0.7.6':
-    resolution: {integrity: sha512-NW0LJ6TL13oN004D9e50EalcGZyTYHHgyaeKOc90Omb/HMeHxjyhHx7wl1TLRwVN2E5Rk+IO0JrwgrdlNMfAzg==}
+  '@module-federation/managers@0.8.1':
+    resolution: {integrity: sha512-anr1744RUIUjeb1cwuQkC851ZPIYo1hxapY0N7V9sJaQdP5V2CwMFu2F+innqVa12jF32pVuV5L/yJp/Nsm72A==}
 
-  '@module-federation/manifest@0.7.6':
-    resolution: {integrity: sha512-xBrFwLjDMUjKRnp+P4X29ZNyhgXSsp+SfrBxVsKJpEESOHalDoNClbo6gXvZAvkBZyo9sY3SJhAwduDwNkg04w==}
+  '@module-federation/manifest@0.8.1':
+    resolution: {integrity: sha512-uMZUrL31uJkRolC/JvzdLMKx96kn/N+zd99fnSz3bt8ySPu7PHFY8YdK/TZfO43CLA6ZEN4n+wCZE85ppHZblQ==}
 
   '@module-federation/rsbuild-plugin@0.8.1':
     resolution: {integrity: sha512-/JU/VDA225U1EbJdn1VLFER8Y/Swg+uU+Jpo2JHDqkCx+tpFONN+mdBOd183kFlChUPnlRpH9ayXsl/t+V2WPg==}
@@ -2170,9 +2179,10 @@ packages:
       '@module-federation/enhanced': 0.8.1
       '@rsbuild/core': 1.x
 
-  '@module-federation/rspack@0.7.6':
-    resolution: {integrity: sha512-alfX85C+2AQLXGrtpa08ImwhHIGwFIkJ/6i/XhxpYL5iFu0mC0xRIJPJUw0tiBWdFpP4p+Ykij3hP3FqfvaiKg==}
+  '@module-federation/rspack@0.8.1':
+    resolution: {integrity: sha512-nTkfEoIfGqYqxvh6E0wFR19xK9yPduE3ZhBYxdw9vCAmxzERjr6rVr7Fu2XVmZg6GTHmugm7oge4xqzLtXa1yA==}
     peerDependencies:
+      '@rspack/core': '>=0.7'
       typescript: ^4.9.0 || ^5.0.0
       vue-tsc: '>=1.0.24'
     peerDependenciesMeta:
@@ -2184,32 +2194,29 @@ packages:
   '@module-federation/runtime-tools@0.5.1':
     resolution: {integrity: sha512-nfBedkoZ3/SWyO0hnmaxuz0R0iGPSikHZOAZ0N/dVSQaIzlffUo35B5nlC2wgWIc0JdMZfkwkjZRrnuuDIJbzg==}
 
-  '@module-federation/runtime-tools@0.7.6':
-    resolution: {integrity: sha512-SvokF6gn2sNrTEPG51H0LrowHnf3iNfznO2PzKpxAhZOBdb1pm0wJPwWSMHYrjMdDpjr7bzaqAywnkHdA6lqeQ==}
+  '@module-federation/runtime-tools@0.8.1':
+    resolution: {integrity: sha512-kr5u0wrdhjY2NbOoINXwZARGGADZayA8sLPsEi1EiKrSn22IR7O0pBIptV5X5uR/s4tsLbGClfl8pFOzvbSVEg==}
 
   '@module-federation/runtime@0.5.1':
     resolution: {integrity: sha512-xgiMUWwGLWDrvZc9JibuEbXIbhXg6z2oUkemogSvQ4LKvrl/n0kbqP1Blk669mXzyWbqtSp6PpvNdwaE1aN5xQ==}
 
-  '@module-federation/runtime@0.7.6':
-    resolution: {integrity: sha512-TEEDbGwaohZ2dMa+Sk/Igq8XpcyfjqJfbL20mdAZeifSFVZYRSCaTd/xIXP7pEw8+5BaCMc4YfCf/XcjFAUrVA==}
+  '@module-federation/runtime@0.8.1':
+    resolution: {integrity: sha512-aiQnczuEMDk1oyBN9JS3zbhg7zyXasCux/OntqEcXn+JgYat4e6rZ6c2qxI1YE1hYHsIGuiRsIRMKT9Om54bNg==}
 
   '@module-federation/sdk@0.5.1':
     resolution: {integrity: sha512-exvchtjNURJJkpqjQ3/opdbfeT2wPKvrbnGnyRkrwW5o3FH1LaST1tkiNviT6OXTexGaVc2DahbdniQHVtQ7pA==}
 
-  '@module-federation/sdk@0.7.6':
-    resolution: {integrity: sha512-MFE+RtsHnutZOCp2eKpa3A/yzZ8tOPmjX7QRdVnB2qqR9JA2SH3ZP5+cYq76tzFQZvU1BCWAQVNMvqGOW2yVZQ==}
-
   '@module-federation/sdk@0.8.1':
     resolution: {integrity: sha512-wFaD/gm83fJEeU90KwkRNxU9+tG0j/2HVRzLY2TLXXxvIo8IqvWZKqetexELaIV0KQmzHOoG5cZSefouActoYw==}
 
-  '@module-federation/third-party-dts-extractor@0.7.6':
-    resolution: {integrity: sha512-JME76/rgr41AKXG6kUTQXdQJiMCypN3qHOgPv4VuIag10UdLo/0gdeN6PYronvYmvPOQMfYev80GcEwl4l531A==}
+  '@module-federation/third-party-dts-extractor@0.8.1':
+    resolution: {integrity: sha512-U9bX/r1yFJUUuuhvKgHWEULNbP/ORZhAEHLGyMJBm06i/V8Tk4qgp0fh6s9fYIqA/IfS3cxkGEteYaBKtElmVg==}
 
   '@module-federation/webpack-bundler-runtime@0.5.1':
     resolution: {integrity: sha512-mMhRFH0k2VjwHt3Jol9JkUsmI/4XlrAoBG3E0o7HoyoPYv1UFOWyqAflfANcUPgbYpvqmyLzDcO+3IT36LXnrA==}
 
-  '@module-federation/webpack-bundler-runtime@0.7.6':
-    resolution: {integrity: sha512-kB9hQ0BfwNAcQWGskDEOxYP2z2bB/1ABXKr8MDomCFl2mbW3vvfYMQrb8UhJmJvE3rbGI/iXhJUdgBLNREnjUg==}
+  '@module-federation/webpack-bundler-runtime@0.8.1':
+    resolution: {integrity: sha512-c56+zyQ9tTJwGP2/HbXNx/nL+VAqTV37wOkDQhxGc1mkendUqSYFXl/e3BOXeGV9vch3W1cdPynrgp09w6zMNw==}
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -2484,6 +2491,11 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
+  '@rsbuild/core@1.1.9':
+    resolution: {integrity: sha512-mHZveEwlTtW9nxWa+T0xUm6ssm+HkDYZ0NENLfWMUmsL0LjMJrpQzRlbD+p5+9Uf+KXUo3Dbtv0ScA+p7cuGTg==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.3':
     resolution: {integrity: sha512-3S/ykXv7KRo0FxVpkjoHFUwB04nKINIET1kuv4xiRaDmeww1Tp0wl9h4u8a7d7gU/4FllyoUflY8TVhci/o05g==}
     peerDependencies:
@@ -2502,8 +2514,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x
 
-  '@rsbuild/plugin-react@1.0.7':
-    resolution: {integrity: sha512-t7T/GqDwodusTAnxGpqVRnQ/G+HYh98zk71qIg19WkjVJJGv57AC1Ppx0/6zzbZAbxU60bfK8TeEEXjhXCdSxA==}
+  '@rsbuild/plugin-react@1.1.0':
+    resolution: {integrity: sha512-uqdRoV2V91G1XIA14dAmxqYTlTDVf0ktpE7TgwG29oQ2j+DerF1kh29WPHK9HvGE34JTfaBrsme2Zmb6bGD0cw==}
     peerDependencies:
       '@rsbuild/core': 1.x
 
@@ -2515,8 +2527,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-sass@1.1.1':
-    resolution: {integrity: sha512-5yAclxBMUGlbnJ/xrX28QsDdE/7Qgd3erJBUeZRfFclxrKaN6NbTSOag72b8RpVmnKQViY16DHKC/L5DtlIeZg==}
+  '@rsbuild/plugin-sass@1.1.2':
+    resolution: {integrity: sha512-h/7WZbRloMxAAt/X52Pbyy3cNEIAKSSl39WG1VSoIBx6agW9qSLRx7zhRf1YlNt3C5G0n1pgDLpvtJSynqZ8OQ==}
     peerDependencies:
       '@rsbuild/core': 1.x
 
@@ -2616,8 +2628,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@1.37.4':
-    resolution: {integrity: sha512-Fz8UzogX42Md0zZMY4L4bqxHH+wncfTFBPAK0GjpWAHwVYM4drXypso6CS5/4X0kVTUOJ0ApvCdebwlmUlwQyQ==}
+  '@rspress/core@1.38.0':
+    resolution: {integrity: sha512-CVppLH1sxp5TSRW6Fl+2t4VHOdCm7W7wI8+12bUIyrGWv8P+wezkyIrbEEoqGeUI6F+CjEIaV+WfKHFTPErj9w==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.4':
@@ -2672,46 +2684,46 @@ packages:
     resolution: {integrity: sha512-uKAWxA8wY3iKKv+ZSN69iu4wJoa2ZNGOQmbnZskIHPejWa0lbkbbb85SlVhzKnPo04NKG675g6G6rT7REWDieQ==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.37.4':
-    resolution: {integrity: sha512-pk+E31AtBIxXu/a7bowkHHsw9VG5TadlXlKbq3MPvIHhcT2q9got7W2/tJOP/FT/+qI7htiRGxxwN3GFoMxBgA==}
+  '@rspress/plugin-auto-nav-sidebar@1.38.0':
+    resolution: {integrity: sha512-D/lLElfCEQzxFHyzXU/+btzzw5Aor4FFtyJi6AugOZq3P9lFkP4xmpFH6f2FajvkUuMFUQ5iRwrSqdMjrLQ+bg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-client-redirects@1.37.4':
-    resolution: {integrity: sha512-2q3GtFgdUc+pkEfA+lqTdx/kG48PfklvjGwwIZyysdMqxGyO8X/2gspLDGptsAopx/GI7g8vrnriRcKOn4OQVQ==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      '@rspress/runtime': ^1.37.4
-
-  '@rspress/plugin-container-syntax@1.37.4':
-    resolution: {integrity: sha512-Fs5/yCRg9W22SSa2h6TOSR/uvx3M2zOHkvJQMFOwG6gOrNMTdlvHdhS/QEhVm0a6yJwUGv+duCAJmdTL5zoyDQ==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-last-updated@1.37.4':
-    resolution: {integrity: sha512-G4eC3UQxcnkpO8AUEQqEwqZYjf2gSsqnhxoTe6TT0f/lpRvqRlpV6oh79zEyJsh2PG1wUVD7SvuK7NbwdZa+eg==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-medium-zoom@1.37.4':
-    resolution: {integrity: sha512-ge3Uon6A09reYKk22eKTABgBnXCKd1Y3ccit2LV5GWkiAk6xhOcWYH4+iN74Ig6LQHlpBrF/d3Pi25c9OqhrCw==}
+  '@rspress/plugin-client-redirects@1.38.0':
+    resolution: {integrity: sha512-zNEuHKyFa+DYofIl791YOseZYQhyb+ftCMKv0xzy6scMBTbsOt4ZcWFs8B42vnUCaEQEDUtlOoEiRZXZcffT5w==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.37.4
+      '@rspress/runtime': ^1.38.0
 
-  '@rspress/plugin-rss@1.37.4':
-    resolution: {integrity: sha512-n8R73Ty2pJbQc5m9wGrirGHi7KYcGFW/r9XziyybC7hUEM4siuzGUyO29Sch9FcSWN3HAX+J09mRvSG1ZfzO+Q==}
+  '@rspress/plugin-container-syntax@1.38.0':
+    resolution: {integrity: sha512-8LPoZTO904ZI3hRYl3f9zPFDbY6Ztp71fOVT2V1t7wcT0R5YaLM1rk5TWNtqmUf0Lt5KXpwM0edCL0Lb4L6kfQ==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-last-updated@1.38.0':
+    resolution: {integrity: sha512-nFCNIWoh3xd6xptLMoAUxIasJe3E3ipen2wq4jqf9w5iBEYUQle1peuyfLaYdgxnt2aZAU7BtsVnq+8K9+QLIA==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-medium-zoom@1.38.0':
+    resolution: {integrity: sha512-HUBcankFKu1eKhhW3YPvRXAkM783TASfH64OaHZ8i0HfKEIHDR8EZjGfQa0BlwK76+T6j+WgmeIX8WoF8LdQaA==}
+    engines: {node: '>=14.17.6'}
+    peerDependencies:
+      '@rspress/runtime': ^1.38.0
+
+  '@rspress/plugin-rss@1.38.0':
+    resolution: {integrity: sha512-rUue3DZlD9ZQoc+4ZDa6Lyx/PKYdnVdJbttqESc7f+y/mIUzolUcJLI2SveDNTjeqJ2Kfy5+HjjUxaXcbMG/hg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: ^1.37.4
+      rspress: ^1.38.0
 
-  '@rspress/runtime@1.37.4':
-    resolution: {integrity: sha512-hyjEu8PcTklSvJEZcmhuk0/TMMuME7VxlAFxU4pTTbAz5bz+GPcMt2vkbVWD5GBBOo1P+dTsurhrF1JJCCXzHw==}
+  '@rspress/runtime@1.38.0':
+    resolution: {integrity: sha512-VJlUMBZvmM/VJJ+Q15hdpiT3SJQnontIt60dG4LY5TpMVNaVLxiYL6XjlmfS9OvOoaVMdh7nQp+venaDJO8TFQ==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.37.4':
-    resolution: {integrity: sha512-HfyzGt3GMx/GlVuJMweYy0VEW7ci52YDosWFmT36uPs9Z+rD8O9+EDUISftU0H7BeMYLEe3BgEfS/Wgr/FL54Q==}
+  '@rspress/shared@1.38.0':
+    resolution: {integrity: sha512-PnyjsZ/zKVTy8FyG6LauinQ4hUeI/09rUdL1pM3MO2PRJ4KMieaUcybRbY8Yf+LOcQZyDLoonKflRgsg+iaHWQ==}
 
-  '@rspress/theme-default@1.37.4':
-    resolution: {integrity: sha512-oqJu8yLUmmCh6qaXb64QVYDZqwXCcYoe0ay/OFcIrpTgKZYC0m1CbRIaHF2OJwp4MzjrM63FfJ1lAiLviA2s1A==}
+  '@rspress/theme-default@1.38.0':
+    resolution: {integrity: sha512-+u+EQwXKdwWMpwQRpZzovQLPa7SBObtKbI7c+UNX5c8SDNHeOgXNW0GDv5DJN7UXxsGzm5cxKjMlN5q3+/6pdw==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.5.4':
@@ -4025,12 +4037,12 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  framer-motion@11.11.11:
-    resolution: {integrity: sha512-tuDH23ptJAKUHGydJQII9PhABNJBpB+z0P1bmgKK9QFIssHGlfPd6kxMq00LSKwE27WFsb2z0ovY0bpUyMvfRw==}
+  framer-motion@11.13.5:
+    resolution: {integrity: sha512-rArI0zPU9VkpS3Wt0J7dmRxAFUWtzPWoSofNQAP0UO276CmJ+Xlf5xN19GMw3w2QsdrS2sU+0+Q2vtuz4IEZaw==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -4908,6 +4920,12 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
+  motion-dom@11.13.0:
+    resolution: {integrity: sha512-Oc1MLGJQ6nrvXccXA89lXtOqFyBmvHtaDcTRGT66o8Czl7nuA8BeHAd9MQV1pQKX0d2RHFBFaw5g3k23hQJt0w==}
+
+  motion-utils@11.13.0:
+    resolution: {integrity: sha512-lq6TzXkH5c/ysJQBxgLXgM01qwBH1b4goTPh57VvZWJbVJZF/0SB31UWEn4EIqbVPf3au88n2rvK17SpDTja1A==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -5382,10 +5400,6 @@ packages:
   react-lazy-with-preload@2.2.1:
     resolution: {integrity: sha512-ONSb8gizLE5jFpdHAclZ6EAAKuFX2JydnFXPPPjoUImZlLjGtKzyBS8SJgJq7CpLgsGKh9QCZdugJyEEOVC16Q==}
 
-  react-refresh@0.14.2:
-    resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
-    engines: {node: '>=0.10.0'}
-
   react-refresh@0.16.0:
     resolution: {integrity: sha512-FPvF2XxTSikpJxcr+bHut2H4gJ17+18Uy20D5/F+SKzFap62R3cM5wH6b8WN3LyGSYeQilLEcJcR1fjBSI2S1A==}
     engines: {node: '>=0.10.0'}
@@ -5627,8 +5641,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@1.37.4:
-    resolution: {integrity: sha512-qKiD2KZbEt7zgbuX+JNmEcmlyWvsE5XvyUAuDGh8pkXFmheQ4AJeAxVMfEkR/RhN5vCRjcE7W2Vva4b0wtY9mg==}
+  rspress@1.38.0:
+    resolution: {integrity: sha512-QU1PdC8bcH6/6HJ1ohUO75uPS+TZSysNNi64hR+wBUv6jklQVXjv6z8w6Xbndg+whSebuAZtmS0ox6C7h0tX5w==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -7745,26 +7759,26 @@ snapshots:
       '@modern-js/swc-plugins-win32-x64-msvc': 0.6.11
       '@swc/helpers': 0.5.15
 
-  '@module-federation/bridge-react-webpack-plugin@0.7.6':
+  '@module-federation/bridge-react-webpack-plugin@0.8.1':
     dependencies:
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/sdk': 0.8.1
       '@types/semver': 7.5.8
       semver: 7.6.3
 
-  '@module-federation/data-prefetch@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@module-federation/data-prefetch@0.8.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      '@module-federation/runtime': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/runtime': 0.8.1
+      '@module-federation/sdk': 0.8.1
       fs-extra: 9.1.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  '@module-federation/dts-plugin@0.7.6(typescript@5.7.2)':
+  '@module-federation/dts-plugin@0.8.1(typescript@5.7.2)':
     dependencies:
-      '@module-federation/error-codes': 0.7.6
-      '@module-federation/managers': 0.7.6
-      '@module-federation/sdk': 0.7.6
-      '@module-federation/third-party-dts-extractor': 0.7.6
+      '@module-federation/error-codes': 0.8.1
+      '@module-federation/managers': 0.8.1
+      '@module-federation/sdk': 0.8.1
+      '@module-federation/third-party-dts-extractor': 0.8.1
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
       axios: 1.7.7
@@ -7784,22 +7798,23 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)':
+  '@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.7.6
-      '@module-federation/data-prefetch': 0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@module-federation/dts-plugin': 0.7.6(typescript@5.7.2)
-      '@module-federation/managers': 0.7.6
-      '@module-federation/manifest': 0.7.6(typescript@5.7.2)
-      '@module-federation/rspack': 0.7.6(typescript@5.7.2)
-      '@module-federation/runtime-tools': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/bridge-react-webpack-plugin': 0.8.1
+      '@module-federation/data-prefetch': 0.8.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@module-federation/dts-plugin': 0.8.1(typescript@5.7.2)
+      '@module-federation/managers': 0.8.1
+      '@module-federation/manifest': 0.8.1(typescript@5.7.2)
+      '@module-federation/rspack': 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(typescript@5.7.2)
+      '@module-federation/runtime-tools': 0.8.1
+      '@module-federation/sdk': 0.8.1
       btoa: 1.2.1
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.7.2
       webpack: 5.97.1
     transitivePeerDependencies:
+      - '@rspack/core'
       - bufferutil
       - debug
       - react
@@ -7807,19 +7822,19 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/error-codes@0.7.6': {}
+  '@module-federation/error-codes@0.8.1': {}
 
-  '@module-federation/managers@0.7.6':
+  '@module-federation/managers@0.8.1':
     dependencies:
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/sdk': 0.8.1
       find-pkg: 2.0.0
       fs-extra: 9.1.0
 
-  '@module-federation/manifest@0.7.6(typescript@5.7.2)':
+  '@module-federation/manifest@0.8.1(typescript@5.7.2)':
     dependencies:
-      '@module-federation/dts-plugin': 0.7.6(typescript@5.7.2)
-      '@module-federation/managers': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/dts-plugin': 0.8.1(typescript@5.7.2)
+      '@module-federation/managers': 0.8.1
+      '@module-federation/sdk': 0.8.1
       chalk: 3.0.0
       find-pkg: 2.0.0
     transitivePeerDependencies:
@@ -7830,20 +7845,21 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.8.1(@module-federation/enhanced@0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)':
+  '@module-federation/rsbuild-plugin@0.8.1(@module-federation/enhanced@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1))(@rsbuild/core@packages+core)':
     dependencies:
-      '@module-federation/enhanced': 0.7.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)
+      '@module-federation/enhanced': 0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.7.2)(webpack@5.97.1)
       '@module-federation/sdk': 0.8.1
       '@rsbuild/core': link:packages/core
 
-  '@module-federation/rspack@0.7.6(typescript@5.7.2)':
+  '@module-federation/rspack@0.8.1(@rspack/core@1.1.6(@swc/helpers@0.5.15))(typescript@5.7.2)':
     dependencies:
-      '@module-federation/bridge-react-webpack-plugin': 0.7.6
-      '@module-federation/dts-plugin': 0.7.6(typescript@5.7.2)
-      '@module-federation/managers': 0.7.6
-      '@module-federation/manifest': 0.7.6(typescript@5.7.2)
-      '@module-federation/runtime-tools': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/bridge-react-webpack-plugin': 0.8.1
+      '@module-federation/dts-plugin': 0.8.1(typescript@5.7.2)
+      '@module-federation/managers': 0.8.1
+      '@module-federation/manifest': 0.8.1(typescript@5.7.2)
+      '@module-federation/runtime-tools': 0.8.1
+      '@module-federation/sdk': 0.8.1
+      '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
     optionalDependencies:
       typescript: 5.7.2
     transitivePeerDependencies:
@@ -7857,31 +7873,27 @@ snapshots:
       '@module-federation/runtime': 0.5.1
       '@module-federation/webpack-bundler-runtime': 0.5.1
 
-  '@module-federation/runtime-tools@0.7.6':
+  '@module-federation/runtime-tools@0.8.1':
     dependencies:
-      '@module-federation/runtime': 0.7.6
-      '@module-federation/webpack-bundler-runtime': 0.7.6
+      '@module-federation/runtime': 0.8.1
+      '@module-federation/webpack-bundler-runtime': 0.8.1
 
   '@module-federation/runtime@0.5.1':
     dependencies:
       '@module-federation/sdk': 0.5.1
 
-  '@module-federation/runtime@0.7.6':
+  '@module-federation/runtime@0.8.1':
     dependencies:
-      '@module-federation/error-codes': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/error-codes': 0.8.1
+      '@module-federation/sdk': 0.8.1
 
   '@module-federation/sdk@0.5.1': {}
-
-  '@module-federation/sdk@0.7.6':
-    dependencies:
-      isomorphic-rslog: 0.0.6
 
   '@module-federation/sdk@0.8.1':
     dependencies:
       isomorphic-rslog: 0.0.6
 
-  '@module-federation/third-party-dts-extractor@0.7.6':
+  '@module-federation/third-party-dts-extractor@0.8.1':
     dependencies:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
@@ -7892,10 +7904,10 @@ snapshots:
       '@module-federation/runtime': 0.5.1
       '@module-federation/sdk': 0.5.1
 
-  '@module-federation/webpack-bundler-runtime@0.7.6':
+  '@module-federation/webpack-bundler-runtime@0.8.1':
     dependencies:
-      '@module-federation/runtime': 0.7.6
-      '@module-federation/sdk': 0.7.6
+      '@module-federation/runtime': 0.8.1
+      '@module-federation/sdk': 0.8.1
 
   '@napi-rs/wasm-runtime@0.2.4':
     dependencies:
@@ -8082,6 +8094,13 @@ snapshots:
       '@swc/helpers': 0.5.15
       core-js: 3.39.0
 
+  '@rsbuild/core@1.1.9':
+    dependencies:
+      '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      core-js: 3.39.0
+
   '@rsbuild/plugin-babel@1.0.3(@rsbuild/core@packages+core)':
     dependencies:
       '@babel/core': 7.26.0
@@ -8106,17 +8125,17 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.8)':
+  '@rsbuild/plugin-less@1.1.0(@rsbuild/core@1.1.9)':
     dependencies:
-      '@rsbuild/core': 1.1.8
+      '@rsbuild/core': 1.1.9
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-react@1.0.7(@rsbuild/core@1.1.8)':
+  '@rsbuild/plugin-react@1.1.0(@rsbuild/core@1.1.9)':
     dependencies:
-      '@rsbuild/core': 1.1.8
-      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.14.2)
-      react-refresh: 0.14.2
+      '@rsbuild/core': 1.1.9
+      '@rspack/plugin-react-refresh': 1.0.0(react-refresh@0.16.0)
+      react-refresh: 0.16.0
 
   '@rsbuild/plugin-rem@1.0.2(@rsbuild/core@packages+core)':
     dependencies:
@@ -8125,9 +8144,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-sass@1.1.1(@rsbuild/core@1.1.8)':
+  '@rsbuild/plugin-sass@1.1.2(@rsbuild/core@1.1.9)':
     dependencies:
-      '@rsbuild/core': 1.1.8
+      '@rsbuild/core': 1.1.9
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.4.49
@@ -8208,13 +8227,6 @@ snapshots:
       '@prefresh/core': 1.5.3(preact@10.25.1)
       '@prefresh/utils': 1.2.0
 
-  '@rspack/plugin-react-refresh@1.0.0(react-refresh@0.14.2)':
-    dependencies:
-      error-stack-parser: 2.1.4
-      html-entities: 2.5.2
-    optionalDependencies:
-      react-refresh: 0.14.2
-
   '@rspack/plugin-react-refresh@1.0.0(react-refresh@0.16.0)':
     dependencies:
       error-stack-parser: 2.1.4
@@ -8222,23 +8234,23 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.16.0
 
-  '@rspress/core@1.37.4(webpack@5.97.1)':
+  '@rspress/core@1.38.0(webpack@5.97.1)':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.97.1)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.1.8
-      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.8)
-      '@rsbuild/plugin-react': 1.0.7(@rsbuild/core@1.1.8)
-      '@rsbuild/plugin-sass': 1.1.1(@rsbuild/core@1.1.8)
+      '@rsbuild/core': 1.1.9
+      '@rsbuild/plugin-less': 1.1.0(@rsbuild/core@1.1.9)
+      '@rsbuild/plugin-react': 1.1.0(@rsbuild/core@1.1.9)
+      '@rsbuild/plugin-sass': 1.1.2(@rsbuild/core@1.1.9)
       '@rspress/mdx-rs': 0.6.4
-      '@rspress/plugin-auto-nav-sidebar': 1.37.4
-      '@rspress/plugin-container-syntax': 1.37.4
-      '@rspress/plugin-last-updated': 1.37.4
-      '@rspress/plugin-medium-zoom': 1.37.4(@rspress/runtime@1.37.4)
-      '@rspress/runtime': 1.37.4
-      '@rspress/shared': 1.37.4
-      '@rspress/theme-default': 1.37.4
+      '@rspress/plugin-auto-nav-sidebar': 1.38.0
+      '@rspress/plugin-container-syntax': 1.38.0
+      '@rspress/plugin-last-updated': 1.38.0
+      '@rspress/plugin-medium-zoom': 1.38.0(@rspress/runtime@1.38.0)
+      '@rspress/runtime': 1.38.0
+      '@rspress/shared': 1.38.0
+      '@rspress/theme-default': 1.38.0
       enhanced-resolve: 5.17.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8299,46 +8311,46 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.4
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.4
 
-  '@rspress/plugin-auto-nav-sidebar@1.37.4':
+  '@rspress/plugin-auto-nav-sidebar@1.38.0':
     dependencies:
-      '@rspress/shared': 1.37.4
+      '@rspress/shared': 1.38.0
 
-  '@rspress/plugin-client-redirects@1.37.4(@rspress/runtime@1.37.4)':
+  '@rspress/plugin-client-redirects@1.38.0(@rspress/runtime@1.38.0)':
     dependencies:
-      '@rspress/runtime': 1.37.4
-      '@rspress/shared': 1.37.4
+      '@rspress/runtime': 1.38.0
+      '@rspress/shared': 1.38.0
 
-  '@rspress/plugin-container-syntax@1.37.4':
+  '@rspress/plugin-container-syntax@1.38.0':
     dependencies:
-      '@rspress/shared': 1.37.4
+      '@rspress/shared': 1.38.0
 
-  '@rspress/plugin-last-updated@1.37.4':
+  '@rspress/plugin-last-updated@1.38.0':
     dependencies:
-      '@rspress/shared': 1.37.4
+      '@rspress/shared': 1.38.0
 
-  '@rspress/plugin-medium-zoom@1.37.4(@rspress/runtime@1.37.4)':
+  '@rspress/plugin-medium-zoom@1.38.0(@rspress/runtime@1.38.0)':
     dependencies:
-      '@rspress/runtime': 1.37.4
+      '@rspress/runtime': 1.38.0
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.37.4(react@18.3.1)(rspress@1.37.4(webpack@5.97.1))':
+  '@rspress/plugin-rss@1.38.0(react@19.0.0)(rspress@1.38.0(webpack@5.97.1))':
     dependencies:
-      '@rspress/shared': 1.37.4
+      '@rspress/shared': 1.38.0
       feed: 4.2.2
-      react: 18.3.1
-      rspress: 1.37.4(webpack@5.97.1)
+      react: 19.0.0
+      rspress: 1.38.0(webpack@5.97.1)
 
-  '@rspress/runtime@1.37.4':
+  '@rspress/runtime@1.38.0':
     dependencies:
-      '@rspress/shared': 1.37.4
+      '@rspress/shared': 1.38.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@rspress/shared@1.37.4':
+  '@rspress/shared@1.38.0':
     dependencies:
-      '@rsbuild/core': 1.1.8
+      '@rsbuild/core': 1.1.9
       chalk: 5.3.0
       execa: 5.1.1
       fs-extra: 11.2.0
@@ -8346,11 +8358,11 @@ snapshots:
       lodash-es: 4.17.21
       unified: 10.1.2
 
-  '@rspress/theme-default@1.37.4':
+  '@rspress/theme-default@1.38.0':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.37.4
-      '@rspress/shared': 1.37.4
+      '@rspress/runtime': 1.38.0
+      '@rspress/shared': 1.38.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -8362,9 +8374,9 @@ snapshots:
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-syntax-highlighter: 15.6.1(react@18.3.1)
 
-  '@rstack-dev/doc-ui@1.5.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@rstack-dev/doc-ui@1.5.4(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
-      framer-motion: 11.11.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      framer-motion: 11.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -9749,12 +9761,14 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  framer-motion@11.11.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@11.13.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
+      motion-dom: 11.13.0
+      motion-utils: 11.13.0
       tslib: 2.8.1
     optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   fresh@0.5.2: {}
 
@@ -10917,6 +10931,10 @@ snapshots:
 
   moment@2.30.1: {}
 
+  motion-dom@11.13.0: {}
+
+  motion-utils@11.13.0: {}
+
   mri@1.2.0: {}
 
   mrmime@2.0.0: {}
@@ -11385,8 +11403,6 @@ snapshots:
 
   react-lazy-with-preload@2.2.1: {}
 
-  react-refresh@0.14.2: {}
-
   react-refresh@0.16.0: {}
 
   react-router-dom@6.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -11667,11 +11683,11 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@1.37.4(webpack@5.97.1):
+  rspress@1.38.0(webpack@5.97.1):
     dependencies:
-      '@rsbuild/core': 1.1.8
-      '@rspress/core': 1.37.4(webpack@5.97.1)
-      '@rspress/shared': 1.37.4
+      '@rsbuild/core': 1.1.9
+      '@rspress/core': 1.38.0(webpack@5.97.1)
+      '@rspress/shared': 1.38.0
       cac: 6.7.14
       chalk: 5.3.0
       chokidar: 3.6.0

--- a/website/package.json
+++ b/website/package.json
@@ -10,19 +10,19 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rspress/plugin-client-redirects": "^1.37.4",
-    "@rspress/plugin-rss": "1.37.4",
+    "@rspress/plugin-client-redirects": "^1.38.0",
+    "@rspress/plugin-rss": "^1.38.0",
     "@rstack-dev/doc-ui": "1.5.4",
     "@types/node": "^22.10.1",
     "@types/react": "^19.0.1",
     "@types/react-dom": "^19.0.1",
     "fast-glob": "^3.3.2",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "rsbuild-plugin-google-analytics": "1.0.3",
-    "rsbuild-plugin-open-graph": "1.0.2",
-    "rspress": "1.37.4",
-    "rspress-plugin-font-open-sans": "1.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "rsbuild-plugin-google-analytics": "^1.0.3",
+    "rsbuild-plugin-open-graph": "^1.0.2",
+    "rspress": "^1.38.0",
+    "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.1.1"
   }
 }


### PR DESCRIPTION
## Summary

Upgrade website to React 19 and fix peer dependency issues.

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v1.38.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
