### PR TITLE
fix(webpack): use html-webpack-plugin by default

### DIFF
--- a/.changeset/chilled-falcons-fetch.md
+++ b/.changeset/chilled-falcons-fetch.md
@@ -1,0 +1,6 @@
+---
+'@rsbuild/webpack': patch
+'@rsbuild/core': patch
+---
+
+fix(webpack): use html-webpack-plugin

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -1,7 +1,7 @@
-import { build, normalizeNewlines } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, normalizeNewlines, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should inject tags with function usage correctly', async () => {
+rspackOnlyTest('should inject tags with function usage correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, normalizeNewlines } from '@e2e/helper';
+import { build, normalizeNewlines, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
@@ -32,7 +32,7 @@ test('injection script order should be as expected', async () => {
   expect(html.indexOf('/js/index')).toBe(html.lastIndexOf('/js/index'));
 });
 
-test('should set inject via function correctly', async () => {
+rspackOnlyTest('should set inject via function correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,23 +1,25 @@
-import { build, normalizeNewlines } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, normalizeNewlines, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should not inject charset meta if template already contains it', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    rsbuildConfig: {
-      html: {
-        template: './src/index.html',
+rspackOnlyTest(
+  'should not inject charset meta if template already contains it',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      rsbuildConfig: {
+        html: {
+          template: './src/index.html',
+        },
+        output: {
+          filenameHash: false,
+        },
       },
-      output: {
-        filenameHash: false,
-      },
-    },
-  });
-  const files = await rsbuild.unwrapOutputJSON();
+    });
+    const files = await rsbuild.unwrapOutputJSON();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
-  expect(normalizeNewlines(html)).toEqual(`<!doctype html>
+    const html =
+      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    expect(normalizeNewlines(html)).toEqual(`<!doctype html>
 <html>
   <head>
     <title>Page Title</title>
@@ -28,4 +30,5 @@ test('should not inject charset meta if template already contains it', async () 
   </body>
 </html>
 `);
-});
+  },
+);

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,8 +1,7 @@
-import path from 'node:path';
-import { build } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should apply defer by default', async () => {
+rspackOnlyTest('should apply defer by default', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });

--- a/e2e/cases/javascript-api/build/index.test.ts
+++ b/e2e/cases/javascript-api/build/index.test.ts
@@ -1,17 +1,21 @@
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
+import { rspackOnlyTest } from 'scripts';
 
-test('should allow to call `build` and get stats object', async () => {
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
+rspackOnlyTest(
+  'should allow to call `build` and get stats object',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
 
-  const { stats, close } = await rsbuild.build();
+    const { stats, close } = await rsbuild.build();
 
-  await close();
+    await close();
 
-  const result = stats?.toJson({ all: true })!;
+    const result = stats?.toJson({ all: true })!;
 
-  expect(result.name).toBe('web');
-  expect(result.assets?.length).toBeGreaterThan(0);
-});
+    expect(result.name).toBe('web');
+    expect(result.assets?.length).toBeGreaterThan(0);
+  },
+);

--- a/e2e/cases/nonce/basic/index.test.ts
+++ b/e2e/cases/nonce/basic/index.test.ts
@@ -1,7 +1,7 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should apply nonce to script and style tags', async () => {
+rspackOnlyTest('should apply nonce to script and style tags', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
@@ -12,7 +12,7 @@ test('should apply nonce to script and style tags', async () => {
   expect(html).toContain(`<style nonce="CSP_NONCE_PLACEHOLDER">body{`);
 });
 
-test('should apply environment nonce', async () => {
+rspackOnlyTest('should apply environment nonce', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {

--- a/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
@@ -1,7 +1,7 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should allow plugin to modify HTML tags', async () => {
+rspackOnlyTest('should allow plugin to modify HTML tags', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });

--- a/e2e/cases/sri/algotithm/index.test.ts
+++ b/e2e/cases/sri/algotithm/index.test.ts
@@ -1,25 +1,28 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('generate integrity using sha512 algorithm', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'generate integrity using sha512 algorithm',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const files = await rsbuild.unwrapOutputJSON();
+    const html =
+      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
-  expect(html).toMatch(
-    /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+\/=]+"/,
-  );
+    expect(html).toMatch(
+      /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+\/=]+"/,
+    );
 
-  expect(html).toMatch(
-    /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+\/=]+"/,
-  );
+    expect(html).toMatch(
+      /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha512-[A-Za-z0-9+\/=]+"/,
+    );
 
-  const testEl = page.locator('#root');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
-  await rsbuild.close();
-});
+    const testEl = page.locator('#root');
+    await expect(testEl).toHaveText('Hello Rsbuild!');
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/sri/basic/index.test.ts
+++ b/e2e/cases/sri/basic/index.test.ts
@@ -1,30 +1,31 @@
-import { build, dev } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('generate integrity for script and style tags in prod build', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'generate integrity for script and style tags in prod build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const files = await rsbuild.unwrapOutputJSON();
+    const html =
+      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
-  expect(html).toMatch(
-    /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha384-[A-Za-z0-9+\/=]+"/,
-  );
+    expect(html).toMatch(
+      /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha384-[A-Za-z0-9+\/=]+"/,
+    );
 
-  expect(html).toMatch(
-    /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha384-[A-Za-z0-9+\/=]+"/,
-  );
+    expect(html).toMatch(
+      /link href="\/static\/css\/index\.\w{8}\.css" rel="stylesheet" integrity="sha384-[A-Za-z0-9+\/=]+"/,
+    );
 
-  const testEl = page.locator('#root');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
-  await rsbuild.close();
-});
+    const testEl = page.locator('#root');
+    await expect(testEl).toHaveText('Hello Rsbuild!');
+    await rsbuild.close();
+  },
+);
 
 test('do not generate integrity for script and style tags in dev build', async ({
   page,

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "copy-webpack-plugin": "11.0.0",
+    "html-webpack-plugin": "^5.6.3",
     "mini-css-extract-plugin": "2.9.2",
     "picocolors": "^1.1.1",
     "reduce-configs": "^1.1.0",

--- a/packages/compat/webpack/src/provider.ts
+++ b/packages/compat/webpack/src/provider.ts
@@ -14,6 +14,13 @@ export const webpackProvider: RsbuildProvider<'webpack'> = async ({
   const { default: cssExtractPlugin } = await import('mini-css-extract-plugin');
   helpers.setCssExtractPlugin(cssExtractPlugin);
 
+  if (helpers.setHTMLPlugin) {
+    const { default: htmlPlugin } = await import('html-webpack-plugin');
+    helpers.setHTMLPlugin(
+      htmlPlugin as unknown as Parameters<typeof helpers.setHTMLPlugin>[0],
+    );
+  }
+
   const createCompiler = (async () => {
     const result = await baseCreateCompiler({
       context,

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -266,7 +266,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "linkType": "text/css",
       },
     },
-    HtmlRspackPlugin {
+    HtmlWebpackPlugin {
       "options": {
         "base": false,
         "cache": true,
@@ -287,6 +287,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
+        "minify": "auto",
         "publicPath": "auto",
         "scriptLoading": "defer",
         "showErrors": true,
@@ -296,7 +297,26 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "title": "Rsbuild App",
         "xhtml": false,
       },
-      "version": 6,
+      "userOptions": {
+        "chunks": [
+          "index",
+        ],
+        "entryName": "index",
+        "filename": "index.html",
+        "inject": "head",
+        "meta": {
+          "charset": {
+            "charset": "UTF-8",
+          },
+          "viewport": "width=device-width, initial-scale=1.0",
+        },
+        "scriptLoading": "defer",
+        "template": "",
+        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
+        "templateParameters": [Function],
+        "title": "Rsbuild App",
+      },
+      "version": 5,
     },
     RsbuildHtmlPlugin {
       "getEnvironment": [Function],
@@ -653,7 +673,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "linkType": "text/css",
       },
     },
-    HtmlRspackPlugin {
+    HtmlWebpackPlugin {
       "options": {
         "base": false,
         "cache": true,
@@ -674,6 +694,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           },
           "viewport": "width=device-width, initial-scale=1.0",
         },
+        "minify": "auto",
         "publicPath": "auto",
         "scriptLoading": "defer",
         "showErrors": true,
@@ -683,7 +704,26 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "title": "Rsbuild App",
         "xhtml": false,
       },
-      "version": 6,
+      "userOptions": {
+        "chunks": [
+          "index",
+        ],
+        "entryName": "index",
+        "filename": "index.html",
+        "inject": "head",
+        "meta": {
+          "charset": {
+            "charset": "UTF-8",
+          },
+          "viewport": "width=device-width, initial-scale=1.0",
+        },
+        "scriptLoading": "defer",
+        "template": "",
+        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
+        "templateParameters": [Function],
+        "title": "Rsbuild App",
+      },
+      "version": 5,
     },
     RsbuildHtmlPlugin {
       "getEnvironment": [Function],

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -23,7 +23,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "linkType": "text/css",
     },
   },
-  HtmlRspackPlugin {
+  HtmlWebpackPlugin {
     "options": {
       "base": false,
       "cache": true,
@@ -44,6 +44,7 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
         },
         "viewport": "width=device-width, initial-scale=1.0",
       },
+      "minify": "auto",
       "publicPath": "auto",
       "scriptLoading": "defer",
       "showErrors": true,
@@ -53,7 +54,26 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "title": "Rsbuild App",
       "xhtml": false,
     },
-    "version": 6,
+    "userOptions": {
+      "chunks": [
+        "index",
+      ],
+      "entryName": "index",
+      "filename": "index.html",
+      "inject": "head",
+      "meta": {
+        "charset": {
+          "charset": "UTF-8",
+        },
+        "viewport": "width=device-width, initial-scale=1.0",
+      },
+      "scriptLoading": "defer",
+      "template": "",
+      "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
+      "templateParameters": [Function],
+      "title": "Rsbuild App",
+    },
+    "version": 5,
   },
   RsbuildHtmlPlugin {
     "getEnvironment": [Function],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,7 @@ export type { ChainIdentifier } from './configChain';
 export {
   /**
    * @private
+   * TODO: remove this in Rspack v1.2.0
    */
   __internalHelper,
 };

--- a/packages/core/src/provider/helpers.ts
+++ b/packages/core/src/provider/helpers.ts
@@ -2,7 +2,7 @@
  * Helpers for `@rsbuild/webpack`.
  */
 
-export { setCssExtractPlugin } from '../pluginHelper';
+export { setCssExtractPlugin, setHTMLPlugin } from '../pluginHelper';
 export { initRsbuildConfig } from './initConfigs';
 export {
   stringifyConfig,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       copy-webpack-plugin:
         specifier: 11.0.0
         version: 11.0.0(webpack@5.97.1)
+      html-webpack-plugin:
+        specifier: ^5.6.3
+        version: 5.6.3(@rspack/core@1.1.6(@swc/helpers@0.5.15))(webpack@5.97.1)
       mini-css-extract-plugin:
         specifier: 2.9.2
         version: 2.9.2(webpack@5.97.1)
@@ -2873,6 +2876,9 @@ packages:
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
 
+  '@types/html-minifier-terser@6.1.0':
+    resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
+
   '@types/http-proxy@1.17.15':
     resolution: {integrity: sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==}
 
@@ -3492,6 +3498,10 @@ packages:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
 
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
 
@@ -3591,6 +3601,9 @@ packages:
         optional: true
       webpack:
         optional: true
+
+  css-select@4.3.0:
+    resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -3720,6 +3733,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-converter@0.2.0:
+    resolution: {integrity: sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==}
 
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
@@ -4200,6 +4216,10 @@ packages:
   hastscript@8.0.0:
     resolution: {integrity: sha512-dMOtzCEd3ABUeSIISmrETiKuyydk1w0pa+gE/uormcTpSYuaNJPbX1NU3JLyscSLjwAQM8bWMhhIlnCqnRvDTw==}
 
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
@@ -4225,6 +4245,11 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
 
+  html-minifier-terser@6.1.0:
+    resolution: {integrity: sha512-YXxSlJBZTP7RS3tWnQw74ooKa6L9b9i9QYXY21eUEvhZ3u9XLfv6OnFsQq6RxkhHygsaUMvYsZRV5rU/OVNZxw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   html-minifier-terser@7.2.0:
     resolution: {integrity: sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -4246,6 +4271,18 @@ packages:
   html-to-text@9.0.5:
     resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
     engines: {node: '>=14'}
+
+  html-webpack-plugin@5.6.3:
+    resolution: {integrity: sha512-QSf1yjtSAsmf7rYBV7XX86uua4W/vkhIt0xNXKbsi2foEeW7vjJQz4bhnpL3xH+l1ryl1680uNv968Z+X6jSYg==}
+    engines: {node: '>=10.13.0'}
+    peerDependencies:
+      '@rspack/core': 0.x || 1.x
+      webpack: ^5.20.0
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      webpack:
+        optional: true
 
   htmlparser2@6.1.0:
     resolution: {integrity: sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==}
@@ -5328,6 +5365,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-error@4.0.0:
+    resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5523,6 +5563,9 @@ packages:
 
   remark@14.0.3:
     resolution: {integrity: sha512-bfmJW1dmR2LvaMJuAnE88pZP9DktIFYXazkTfOIKZzi3Knk9lT0roItIA24ydOucI3bV/g/tXBA6hzqq3FV9Ew==}
+
+  renderkid@3.0.0:
+    resolution: {integrity: sha512-q/7VIQA8lmM1hF+jn+sFSPWGlMkSAeNYcPLmDQx2zzuiDfaLrOmumR8iaUKlenFgh0XRPIUeSPlH3A+AW3Z5pg==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -6379,6 +6422,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utila@0.4.0:
+    resolution: {integrity: sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==}
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -8552,6 +8598,8 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/html-minifier-terser@6.1.0': {}
+
   '@types/http-proxy@1.17.15':
     dependencies:
       '@types/node': 22.10.1
@@ -9232,6 +9280,8 @@ snapshots:
 
   commander@7.2.0: {}
 
+  commander@8.3.0: {}
+
   common-path-prefix@3.0.0: {}
 
   connect-history-api-fallback@2.0.0: {}
@@ -9336,6 +9386,14 @@ snapshots:
       '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
       webpack: 5.97.1
 
+  css-select@4.3.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 4.3.1
+      domutils: 2.8.0
+      nth-check: 2.1.1
+
   css-select@5.1.0:
     dependencies:
       boolbase: 1.0.0
@@ -9426,6 +9484,10 @@ snapshots:
       path-type: 4.0.0
 
   dlv@1.1.3: {}
+
+  dom-converter@0.2.0:
+    dependencies:
+      utila: 0.4.0
 
   dom-serializer@1.4.1:
     dependencies:
@@ -9970,6 +10032,8 @@ snapshots:
       property-information: 6.5.0
       space-separated-tokens: 2.0.2
 
+  he@1.2.0: {}
+
   highlight.js@10.7.3: {}
 
   highlightjs-vue@1.0.0: {}
@@ -9989,6 +10053,16 @@ snapshots:
       html-minifier-terser: 7.2.0
       parse5: 7.2.1
       webpack: 5.97.1
+
+  html-minifier-terser@6.1.0:
+    dependencies:
+      camel-case: 4.1.2
+      clean-css: 5.3.3
+      commander: 8.3.0
+      he: 1.2.0
+      param-case: 3.0.4
+      relateurl: 0.2.7
+      terser: 5.37.0
 
   html-minifier-terser@7.2.0:
     dependencies:
@@ -10015,6 +10089,17 @@ snapshots:
       dom-serializer: 2.0.0
       htmlparser2: 8.0.2
       selderee: 0.11.0
+
+  html-webpack-plugin@5.6.3(@rspack/core@1.1.6(@swc/helpers@0.5.15))(webpack@5.97.1):
+    dependencies:
+      '@types/html-minifier-terser': 6.1.0
+      html-minifier-terser: 6.1.0
+      lodash: 4.17.21
+      pretty-error: 4.0.0
+      tapable: 2.2.1
+    optionalDependencies:
+      '@rspack/core': 1.1.6(@swc/helpers@0.5.15)
+      webpack: 5.97.1
 
   htmlparser2@6.1.0:
     dependencies:
@@ -11335,6 +11420,11 @@ snapshots:
 
   prettier@3.4.2: {}
 
+  pretty-error@4.0.0:
+    dependencies:
+      lodash: 4.17.21
+      renderkid: 3.0.0
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -11565,6 +11655,14 @@ snapshots:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
+
+  renderkid@3.0.0:
+    dependencies:
+      css-select: 4.3.0
+      dom-converter: 0.2.0
+      htmlparser2: 6.1.0
+      lodash: 4.17.21
+      strip-ansi: 6.0.1
 
   require-directory@2.1.1: {}
 
@@ -12373,6 +12471,8 @@ snapshots:
       file-loader: 6.2.0(webpack@5.97.1)
 
   util-deprecate@1.0.2: {}
+
+  utila@0.4.0: {}
 
   utils-merge@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Use `html-webpack-plugin` in `@rsbuild/webpack` by default.

This allows us to:

- Remove `__internalHelper` from `@rsbuild/core`. We no longer need to export the helper for Modern.js
- `@rsbuild/core` can switch to the Rust [HtmlRspackPlugin](https://rspack.dev/plugins/rspack/html-rspack-plugin) in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
