### PR TITLE
docs: improve `server.port`

### DIFF
--- a/website/docs/en/config/server/port.mdx
+++ b/website/docs/en/config/server/port.mdx
@@ -5,18 +5,32 @@
 
 Specify a port number for Rsbuild Server to listen.
 
-By default, Rsbuild Server listens on port `3000` and automatically increments the port number when the port is occupied.
+By default, Rsbuild Server listens on port `3000` and automatically increments the port number when the port is occupied. If you enable the [server.strictPort](/config/server/strict-port) config, Rsbuild Server will throw an error instead of incrementing the port number when the port is occupied.
 
-You can use `server.port` or the `--port` CLI param to set the port number (The priority of `--port` option is higher than `server.port`).
+Rsbuild CLI provides the [--port](/guide/basic/cli#rsbuild-dev) option to set the port number, and the `--port` option has higher priority than `server.port` config.
+
+```bash
+npx rsbuild dev --port 8080
+```
 
 ## Example
 
-Set the port to `3000`:
+Set the port to `8080`:
 
 ```ts
 export default {
   server: {
-    port: 3000,
+    port: 8080,
+  },
+};
+```
+
+Set different port numbers for development and preview servers:
+
+```ts
+export default {
+  server: {
+    port: process.env.NODE_ENV === 'development' ? 3000 : 8080,
   },
 };
 ```

--- a/website/docs/zh/config/server/port.mdx
+++ b/website/docs/zh/config/server/port.mdx
@@ -5,18 +5,32 @@
 
 设置 Rsbuild Server 监听的端口号。
 
-默认情况下，Rsbuild Server 会监听 3000 端口，并在端口被占用时自动递增端口号。
+默认情况下，Rsbuild Server 会监听 3000 端口，并在端口被占用时自动递增端口号。当你开启 [server.strictPort](/config/server/strict-port) 配置时，如果端口被占用，Rsbuild Server 会抛出异常，而不是递增端口号。
 
-你可以使用 `server.port` 配置或 `--port` 参数来设置端口号 (`--port` 参数的优先级高于 `server.port` 配置)。
+Rsbuild CLI 提供了 [--port](/guide/basic/cli#rsbuild-dev) 选项来设置端口号，`--port` 选项的优先级高于 `server.port` 配置。
+
+```bash
+npx rsbuild dev --port 8080
+```
 
 ## 示例
 
-将端口设置为 `3000`：
+将端口设置为 `8080`：
 
 ```ts
 export default {
   server: {
-    port: 3000,
+    port: 8080,
+  },
+};
+```
+
+为开发服务器和预览服务器设置不同的端口号：
+
+```ts
+export default {
+  server: {
+    port: process.env.NODE_ENV === 'development' ? 3000 : 8080,
   },
 };
 ```


### PR DESCRIPTION
## Summary

Clarify the behavior of the server when the port is occupied and provide examples for setting the port using both configuration files and CLI parameters.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
