### PR TITLE
fix(plugin-svelte): require is not defined in computing sveltePath variable

### DIFF
--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -1,10 +1,11 @@
 import { promises } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { logger } from '@rsbuild/core';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { sveltePreprocess } from 'svelte-preprocess';
 import type { CompileOptions } from 'svelte/compiler';
-import { createRequire } from 'node:module';
+
 const require = createRequire(import.meta.url);
 
 export type AutoPreprocessOptions = NonNullable<

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -4,6 +4,8 @@ import { logger } from '@rsbuild/core';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { sveltePreprocess } from 'svelte-preprocess';
 import type { CompileOptions } from 'svelte/compiler';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 export type AutoPreprocessOptions = NonNullable<
   Parameters<typeof sveltePreprocess>[0]


### PR DESCRIPTION
fix require is not defined in computing sveltePath variable

## Summary

## Related Links

no open issue, just a fix

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
