### PR TITLE
test: run e2e cases with Rspack incremental

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,8 +3,9 @@
   "name": "@rsbuild/e2e",
   "version": "1.0.0",
   "scripts": {
-    "test": "pnpm test:rspack && pnpm test:webpack",
+    "test": "pnpm test:rspack && pnpm test:rspack:incremental && pnpm test:webpack",
     "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules playwright test",
+    "test:rspack:incremental": "cross-env NODE_OPTIONS=--experimental-vm-modules EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
     "test:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -90,6 +90,14 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // improve kill process performance
         // https://github.com/web-infra-dev/rspack/pull/5486
         process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
+
+        // This is temporary, we will remove it after Rspack incremental is stable
+        if (process.env.EXPERIMENTAL_RSPACK_INCREMENTAL) {
+          chain.experiments({
+            ...chain.get('experiments'),
+            incremental: isDev,
+          });
+        }
       },
     );
   },


### PR DESCRIPTION
## Summary

Add a temporary `process.env.EXPERIMENTAL_RSPACK_INCREMENTAL` env var for testing Rspack's new incremental implementation.

Now Rsbuild's e2e tests will run twice, one of which is enabled with incremental.

We will remove it after Rspack incremental is stable.

## Related Links

https://rspack.dev/config/experiments#experimentsincremental

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
