### PR TITLE
chore(renovate): group sass packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,9 +31,9 @@
       matchPackageNames: ['/rslib/'],
     },
     {
-      groupName: 'modern-js',
-      groupSlug: 'modern-js',
-      matchPackageNames: ['/modern-js/'],
+      groupName: 'sass',
+      groupSlug: 'sass',
+      matchPackageNames: ['/sass/'],
     },
     {
       groupName: 'eslint',


### PR DESCRIPTION
## Summary

Update renovate config: group `sass` packages and remove `modern-js` group.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
