### PR TITLE
test(e2e): fix unsable CORS cases

### DIFF
--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -10,7 +10,7 @@ test('should include CORS headers by default for dev server', async ({
     page,
   });
 
-  const response = await request.get(`http://localhost:${rsbuild.port}`);
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
   expect(response.headers()['access-control-allow-origin']).toEqual('*');
 
   await rsbuild.close();
@@ -25,7 +25,7 @@ test('should include CORS headers by default for preview server', async ({
     page,
   });
 
-  const response = await request.get(`http://localhost:${rsbuild.port}`);
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
   expect(response.headers()['access-control-allow-origin']).toEqual('*');
 
   await rsbuild.close();
@@ -42,7 +42,7 @@ test('should allow to disable CORS', async ({ page, request }) => {
     },
   });
 
-  const response = await request.get(`http://localhost:${rsbuild.port}`);
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
   expect(response.headers()).not.toHaveProperty('access-control-allow-origin');
 
   await rsbuild.close();
@@ -61,7 +61,7 @@ test('should allow to configure CORS', async ({ page, request }) => {
     },
   });
 
-  const response = await request.get(`http://localhost:${rsbuild.port}`);
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
   expect(response.headers()['access-control-allow-origin']).toEqual(
     'https://example.com',
   );


### PR DESCRIPTION
## Summary

The CORS e2e cases are unstable in the Windows CI:

```bash
    Error: apiRequestContext.get: connect ECONNREFUSED ::1:24257
    Call log:
      - → GET http://localhost:24257/
      -   user-agent: Playwright/1.44.1 (x64; windows 10.0) node/22.12 CI/1
      -   accept: */*
      -   accept-encoding: gzip,deflate,br


        at D:\a\rsbuild\rsbuild\e2e\apiRequestContext.get: connect ECONNREFUSED ::1:24257
        at D:\a\rsbuild\rsbuild\e2e\cases\server\cors\index.test.ts:45:34
```

Possible solution: https://stackoverflow.com/questions/74567328/api-get-request-test-using-playwright

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/12328244091/job/34411201012?pr=4194#step:7:1838

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
