### PR TITLE
docs: React Compiler for React 17 and 18

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -88,7 +88,7 @@ Before you start using React Compiler, it's recommended to read the [React Compi
 
 The steps to use React Compiler in Rsbuild:
 
-1. Upgrade versions of `react` and `react-dom` to 19.
+1. Upgrade versions of `react` and `react-dom` to 19. If you are unable to upgrade, you can install the extra [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) package which will allow the compiled code to run on versions prior to 19.
 2. React Compiler currently only provides a Babel plugin, you need to install [@rsbuild/plugin-babel](/plugins/list/plugin-babel) and [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler).
 3. Register the Babel plugin in your Rsbuild config file:
 
@@ -114,7 +114,7 @@ export default defineConfig({
 
 ### Configuration
 
-Set the config for React Compiler as follows
+Set the config for React Compiler as follows:
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';
@@ -139,6 +139,14 @@ export default defineConfig({
     }),
   ],
 });
+```
+
+For React 17 and 18 projects, you need to install [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime) and specify the `target`:
+
+```ts title="rsbuild.config.ts"
+const ReactCompilerConfig = {
+  target: '18', // '17' | '18' | '19'
+};
 ```
 
 ## Router

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -82,7 +82,7 @@ export default MyComponent;
 
 React Compiler 是 React 19 引入的一个实验性编译器，它可以自动优化你的 React 代码。
 
-在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://react.dev/learn/react-compiler)，以了解 React Compiler 的功能、当前状态和使用方法。
+在开始使用 React Compiler 之前，建议阅读 [React Compiler 文档](https://zh-hans.react.dev/learn/react-compiler)，以了解 React Compiler 的功能、当前状态和使用方法。
 
 ### 如何使用
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -88,7 +88,7 @@ React Compiler 是 React 19 引入的一个实验性编译器，它可以自动�
 
 在 Rsbuild 中使用 React Compiler 的步骤如下：
 
-1. 升级 `react` 和 `react-dom` 版本到 19。
+1. 升级 `react` 和 `react-dom` 版本到 19。如果你暂时无法升级，可以在 React 17 或 18 项目中安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，以允许编译后的代码在 19 之前的版本上运行。
 2. 目前 React Compiler 仅提供了 Babel 插件，你需要安装 [@rsbuild/plugin-babel](/plugins/list/plugin-babel) 和 [babel-plugin-react-compiler](https://www.npmjs.com/package/babel-plugin-react-compiler)。
 3. 在你的 Rsbuild 配置文件中注册 Babel 插件：
 
@@ -139,6 +139,14 @@ export default defineConfig({
     }),
   ],
 });
+```
+
+对于 React 17 和 18 的项目，除了安装 [react-compiler-runtime](https://www.npmjs.com/package/react-compiler-runtime)，还需要指定 `target`：
+
+```ts title="rsbuild.config.ts"
+const ReactCompilerConfig = {
+  target: '18', // '17' | '18' | '19'
+};
 ```
 
 ## Router


### PR DESCRIPTION
## Summary

Provide additional instructions for using the React Compiler with React versions prior to 19 by installing the `react-compiler-runtime` package and specifying the `target` in the configuration.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/4197

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
