### PR TITLE
chore(workflow): remove duplicated issue label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.en-US.yml
@@ -2,7 +2,6 @@ name: '🐞 Bug Report'
 description: Report a Bug to Rsbuild
 title: '[Bug]: '
 type: Bug
-labels: ['🐞 bug']
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.en-US.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.en-US.yml
@@ -2,7 +2,6 @@ name: '💡 Feature Request'
 description: Submit a new feature request to Rsbuild
 title: '[Feature]: '
 type: Enhancement
-labels: ['💡 feature']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## Summary

The GitHub issue types work well and we can remove the issue label to reduce duplicated information.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4171

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
