### PR TITLE
chore: prepare for v1.2.0 release

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -138,7 +138,6 @@ export default defineConfig({
 0 && (module.exports = {
   PLUGIN_CSS_NAME,
   PLUGIN_SWC_NAME,
-  __internalHelper,
   createRsbuild,
   defineConfig,
   ensureAssetPrefix,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@
  */
 import { rspack } from '@rspack/core';
 import type * as Rspack from '@rspack/core';
-import * as __internalHelper from './internal';
 
 // Core methods
 export { loadEnv } from './loadEnv';
@@ -164,11 +163,3 @@ export type {
   WatchFiles,
 } from './types';
 export type { ChainIdentifier } from './configChain';
-
-export {
-  /**
-   * @private
-   * TODO: remove this in Rspack v1.2.0
-   */
-  __internalHelper,
-};

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -310,8 +310,7 @@ export class RsbuildHtmlPlugin {
 
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
       getHTMLPlugin()
-        // TODO: use getCompilationHooks in minor release
-        .getHooks(compilation)
+        .getCompilationHooks(compilation)
         .alterAssetTagGroups.tapPromise(this.name, async (data) => {
           const entryName = data.plugin.options?.entryName;
 


### PR DESCRIPTION
## Summary

This PR includes some planned changes in preparation for the v1.2.0 release.

Rspack & Rsbuild will be releasing the 1.2.0 pre-release this week.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
