### PR TITLE
feat: support for `importModule` in `api.transform`

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
@@ -1,0 +1,18 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow plugin to transform code and call `importModule`',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+
+    const files = await rsbuild.unwrapOutputJSON();
+    const indexCss = Object.keys(files).find(
+      (file) => file.includes('index') && file.endsWith('.css'),
+    );
+
+    expect(files[indexCss!].includes('#00f')).toBeTruthy();
+  },
+);

--- a/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
@@ -7,7 +7,6 @@ export const myPlugin: RsbuildPlugin = {
     api.transform({ test: /\.css$/ }, async ({ code, importModule }) => {
       // @ts-expect-error TODO: Rspack type issue
       const { foo } = await importModule(join(__dirname, './src/foo.ts'));
-      console.log('foo', foo);
       return code.replace('red', foo);
     });
   },

--- a/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/myPlugin.ts
@@ -1,0 +1,14 @@
+import { join } from 'node:path';
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.transform({ test: /\.css$/ }, async ({ code, importModule }) => {
+      // @ts-expect-error TODO: Rspack type issue
+      const { foo } = await importModule(join(__dirname, './src/foo.ts'));
+      console.log('foo', foo);
+      return code.replace('red', foo);
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-import-module/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { myPlugin } from './myPlugin';
+
+export default {
+  plugins: [myPlugin],
+};

--- a/e2e/cases/plugin-api/plugin-transform-import-module/src/foo.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/src/foo.ts
@@ -1,0 +1,1 @@
+export const foo = 'blue';

--- a/e2e/cases/plugin-api/plugin-transform-import-module/src/index.css
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/plugin-api/plugin-transform-import-module/src/index.js
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+console.log('hello');

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -1,5 +1,5 @@
 import type { LoaderContext } from '@rspack/core';
-import type { EnvironmentContext, Rspack, TransformContext } from '../types';
+import type { EnvironmentContext, Rspack } from '../types';
 
 export type TransformLoaderOptions = {
   id: string;
@@ -31,7 +31,8 @@ export default async function transform(
     resourceQuery: this.resourceQuery,
     environment: getEnvironment(),
     addDependency: this.addDependency,
-    emitFile: this.emitFile as TransformContext['emitFile'],
+    importModule: this.importModule.bind(this),
+    emitFile: this.emitFile,
   });
 
   if (result === null || result === undefined) {

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -30,9 +30,9 @@ export default async function transform(
     resourcePath: this.resourcePath,
     resourceQuery: this.resourceQuery,
     environment: getEnvironment(),
-    addDependency: this.addDependency,
+    addDependency: this.addDependency.bind(this),
+    emitFile: this.emitFile.bind(this),
     importModule: this.importModule.bind(this),
-    emitFile: this.emitFile,
   });
 
   if (result === null || result === undefined) {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -263,12 +263,11 @@ export type TransformContext = {
    * @param sourceMap source map of the asset
    * @param assetInfo additional asset information
    */
-  emitFile: (
-    name: string,
-    content: string | Buffer,
-    sourceMap?: string,
-    assetInfo?: Record<string, any>,
-  ) => void;
+  emitFile: Rspack.LoaderContext['emitFile'];
+  /**
+   * Compile and execute a module at the build time.
+   */
+  importModule: Rspack.LoaderContext['importModule'];
 };
 
 export type TransformHandler = (


### PR DESCRIPTION
## Summary

This is the same as Rspack's `loaderContext.importModule`.

```ts
const myPlugin: RsbuildPlugin = {
  name: 'my-plugin',
  setup(api) {
    api.transform({ test: /\.css$/ }, async ({ code, importModule }) => {
      const { foo } = await importModule(join(__dirname, './src/foo.ts'));
      console.log('foo', foo);
      return code.replace('red', foo);
    });
  },
};
```

Documentation will be added later as Rspack also lacks the documentation for this API.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4186

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
