### PR TITLE
docs: configure alias via jsconfig.json

### DIFF
--- a/website/docs/en/guide/advanced/alias.mdx
+++ b/website/docs/en/guide/advanced/alias.mdx
@@ -4,12 +4,16 @@ Path aliases allow developers to define aliases for modules, making it easier to
 
 For example, if you frequently reference the `src/common/request.ts` module in your project, you can define an alias for it as `@request` and then use `import request from '@request'` in your code instead of writing the full relative path every time. This also allows you to move the module to a different location without needing to update all the import statements in your code.
 
+```ts title="src/index.ts"
+import request from '@request'; // resolve to `src/common/request.ts`
+```
+
 In Rsbuild, there are two ways to set up path aliases:
 
-- Through the `paths` configuration in `tsconfig.json`.
-- Through the [resolve.alias](/config/resolve/alias) configuration.
+- Use the `paths` configuration in [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html).
+- Use the [resolve.alias](/config/resolve/alias) configuration.
 
-## Using `tsconfig.json`'s `paths` Configuration
+## `paths` in tsconfig.json
 
 You can configure aliases through the `paths` configuration in `tsconfig.json`, which is the recommended approach in TypeScript projects as it also resolves the TS type issues related to path aliases.
 
@@ -31,7 +35,21 @@ After configuring, if you reference `@common/Foo.tsx` in your code, it will be m
 You can refer to the [TypeScript - paths](https://typescriptlang.org/tsconfig#paths) documentation for more details.
 :::
 
-## Use `resolve.alias` Configuration
+## jsconfig.json
+
+In non-TypeScript projects, if you need to set path aliases through the `paths` field in [jsconfig.json](https://code.visualstudio.com/docs/languages/jsconfig), you can use the [source.tsconfigPath](/config/source/tsconfig-path) option to set it.
+
+After adding the following configuration, Rsbuild will recognize the `paths` field in `jsconfig.json`.
+
+```js title="rsbuild.config.mjs"
+export default {
+  source: {
+    tsconfigPath: './jsconfig.json',
+  },
+};
+```
+
+## `resolve.alias` Configuration
 
 Rsbuild provides the [resolve.alias](/config/resolve/alias) configuration option, which corresponds to the webpack/Rspack native [resolve.alias](https://rspack.dev/config/resolve#resolvealias) configuration. You can configure this option using an object or a function.
 

--- a/website/docs/en/guide/migration/cra.mdx
+++ b/website/docs/en/guide/migration/cra.mdx
@@ -279,15 +279,7 @@ module.exports = {
 
 In non-TypeScript projects, CRA supports reading the `paths` field in jsconfig.json as the path alias.
 
-If you want to use this feature in Rsbuild, you can set the [source.tsconfigPath](/config/source/tsconfig-path) option, so that Rsbuild can recognize the `paths` field in jsconfig.json.
-
-```js title="rsbuild.config.mjs"
-export default {
-  source: {
-    tsconfigPath: './jsconfig.json',
-  },
-};
-```
+If you want to use this feature in Rsbuild, you can refer to the [Path Alias - jsconfig.json](/guide/advanced/alias#jsconfigjson).
 
 ## CRACO Migration
 

--- a/website/docs/zh/guide/advanced/alias.mdx
+++ b/website/docs/zh/guide/advanced/alias.mdx
@@ -2,14 +2,18 @@
 
 路径别名（alias）允许开发者为模块定义别名，以便于在代码中更方便的引用它们。当你想要使用一个简短、易于记忆的名称来代替冗长复杂的路径时，这将非常有用。
 
-例如，假如你在项目中经常引用 `src/common/request.ts` 模块，你可以为它定义一个别名 `@request`，然后在代码中通过 `import request from '@request'` 来引用它，而不需要每次都写出完整的相对路径。同时，这也允许你将模块移动到不同的位置，而不需要更新代码中的所有 import 语法。
+例如，假如你在项目中经常引用 `src/common/request.ts` 模块，你可以为它定义一个别名 `@request`，然后在代码中通过 `import request from '@request'` 来引用它，而不需要每次都写出完整的相对路径。这也允许你将模块移动到不同的位置，而不需要更新代码中的所有 import 语法。
+
+```ts title="src/index.ts"
+import request from '@request'; // 解析为 `src/common/request.ts`
+```
 
 在 Rsbuild 中，你有两种方式可以设置路径别名:
 
-- 通过 `tsconfig.json` 中的 `paths` 配置。
-- 通过 [resolve.alias](/config/resolve/alias) 配置。
+- 使用 [tsconfig.json](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) 中的 `paths` 选项。
+- 使用 [resolve.alias](/config/resolve/alias) 配置。
 
-## 通过 `tsconfig.json` 的 `paths` 配置
+## `tsconfig.json` 的 `paths` 选项
 
 你可以通过 `tsconfig.json` 中的 `paths` 来配置别名，这是我们在 TypeScript 项目中推荐使用的方式，因为它可以解决路径别名的 TS 类型问题。
 
@@ -31,7 +35,21 @@
 你可以阅读 [TypeScript - paths](https://typescriptlang.org/tsconfig#paths) 文档来了解更多用法。
 :::
 
-## 通过 `resolve.alias` 配置
+## jsconfig.json
+
+在非 TypeScript 项目中，如果你需要通过 [jsconfig.json](https://code.visualstudio.com/docs/languages/jsconfig) 中的 `paths` 字段来设置路径别名，可以使用 [source.tsconfigPath](/config/source/tsconfig-path) 选项来设置。
+
+添加以下配置后，Rsbuild 会识别 `jsconfig.json` 中的 `paths` 字段。
+
+```js title="rsbuild.config.mjs"
+export default {
+  source: {
+    tsconfigPath: './jsconfig.json',
+  },
+};
+```
+
+## `resolve.alias` 配置
 
 Rsbuild 提供了 [resolve.alias](/config/resolve/alias) 配置项，对应 Rspack 原生的 [resolve.alias](https://rspack.dev/zh/config/resolve#resolvealias) 配置，你可以通过对象或者函数的方式来配置这个选项。
 

--- a/website/docs/zh/guide/migration/cra.mdx
+++ b/website/docs/zh/guide/migration/cra.mdx
@@ -279,15 +279,7 @@ module.exports = {
 
 在非 TypeScript 项目中，CRA 支持读取 jsconfig.json 中的 `paths` 字段作为路径别名。
 
-如果你需要在 Rsbuild 中使用该特性，可以使用 [source.tsconfigPath](/config/source/tsconfig-path) 选项，使 Rsbuild 能够识别 jsconfig.json 中的 `paths` 字段。
-
-```js title="rsbuild.config.mjs"
-export default {
-  source: {
-    tsconfigPath: './jsconfig.json',
-  },
-};
-```
+如果你需要在 Rsbuild 中使用该特性，可以参考 [路径别名 - jsconfig.json](/guide/advanced/alias#jsconfigjson)。
 
 ## CRACO 迁移
 


### PR DESCRIPTION
## Summary

This pull request includes updates to the documentation for configuring path aliases in Rsbuild. The most important changes involve adding examples and clarifying the use of `tsconfig.json` and `jsconfig.json` for setting up path aliases.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4228

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
