### PR TITLE
chore(CI): update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     inputs:
       npm_tag:
         type: choice
-        description: 'Specify npm tag (latest, alpha, beta, rc)'
+        description: 'Specify npm tag'
         required: true
         default: 'latest'
         options:
+          - latest
           - alpha
           - beta
           - rc
-          - latest
+          - canary
       branch:
         description: 'Release Branch (confirm release branch)'
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,15 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      version:
+      npm_tag:
         type: choice
-        description: 'Release Version (next, beta, alpha, latest)'
+        description: 'Specify npm tag (latest, alpha, beta, rc)'
         required: true
-        default: 'next'
+        default: 'latest'
         options:
-          - next
-          - beta
           - alpha
+          - beta
+          - rc
           - latest
       branch:
         description: 'Release Branch (confirm release branch)'
@@ -31,6 +31,7 @@ jobs:
     name: Release
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Run Ecosystem CI
         if: inputs.run_eco_ci == true
@@ -39,14 +40,14 @@ jobs:
           owner: "rspack-contrib"
           repo: "rsbuild-ecosystem-ci"
           workflow_file_name: "ecosystem-ci-selected.yml"
-          github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
+          github_token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN }}
           ref: "main"
           client_payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
 
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 25
+          fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
@@ -61,15 +62,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
-      - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          version: ${{ github.event.inputs.version }}
-          branch: ${{ github.event.inputs.branch }}
-          type: 'release'
-          tools: 'changeset'
+      - name: Publish to npm
+        run: pnpm -r publish --tag ${{ github.event.inputs.npm_tag }}
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          REF: ${{ github.ref }}
+          NODE_AUTH_TOKEN: ${{ secrets.RSBUILD_NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Update release workflow:

- use `pnpm -r publish` to publish
- rename some tokens
- require less tokens
- add `environment: production`

## Related Links

https://pnpm.io/cli/publish

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
