### PR TITLE
Revert "chore: prepare for v1.2.0 release (#4207)"

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -138,6 +138,7 @@ export default defineConfig({
 0 && (module.exports = {
   PLUGIN_CSS_NAME,
   PLUGIN_SWC_NAME,
+  __internalHelper,
   createRsbuild,
   defineConfig,
   ensureAssetPrefix,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@
  */
 import { rspack } from '@rspack/core';
 import type * as Rspack from '@rspack/core';
+import * as __internalHelper from './internal';
 
 // Core methods
 export { loadEnv } from './loadEnv';
@@ -163,3 +164,11 @@ export type {
   WatchFiles,
 } from './types';
 export type { ChainIdentifier } from './configChain';
+
+export {
+  /**
+   * @private
+   * TODO: remove this in Rspack v1.2.0
+   */
+  __internalHelper,
+};

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -310,7 +310,8 @@ export class RsbuildHtmlPlugin {
 
     compiler.hooks.compilation.tap(this.name, (compilation: Compilation) => {
       getHTMLPlugin()
-        .getCompilationHooks(compilation)
+        // TODO: use getCompilationHooks in minor release
+        .getHooks(compilation)
         .alterAssetTagGroups.tapPromise(this.name, async (data) => {
           const entryName = data.plugin.options?.entryName;
 


### PR DESCRIPTION
This reverts commit ca531354d2348afcfe874ba75b559ff1d592dfee.

## Summary

This allows us to release some `1.1.x` patch versions.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
