### PR TITLE
chore(CI): specify pnpm publish branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
         type: choice
         description: 'Specify npm tag'
         required: true
-        default: 'latest'
+        default: 'alpha'
         options:
           - latest
           - alpha
@@ -64,6 +64,6 @@ jobs:
         run: pnpm install
 
       - name: Publish to npm
-        run: pnpm -r publish --tag ${{ github.event.inputs.npm_tag }}
+        run: pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.RSBUILD_NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ on:
         required: true
         default: 'alpha'
         options:
-          - latest
           - alpha
           - beta
           - rc
           - canary
+          - latest
       branch:
         description: 'Release Branch (confirm release branch)'
         required: true


### PR DESCRIPTION
## Summary

Specify pnpm publish branch in the release workflow, by default pnpm only allows `main` and `master` branches.

## Related Links

https://github.com/web-infra-dev/rsbuild/actions/runs/12445341903/job/34746555603#step:8:7

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
