### PR TITLE
Revert "fix: should copy publicDir to the environment distDir when multiple environments (#4220)"

### DIFF
--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -170,45 +170,6 @@ test('should serve publicDir for preview server correctly', async ({
   await rsbuild.close();
 });
 
-test('should copy publicDir to the environment distDir when multiple environments', async () => {
-  await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
-
-  const rsbuild = await build({
-    cwd,
-    rsbuildConfig: {
-      environments: {
-        web1: {
-          output: {
-            distPath: {
-              root: 'dist-build-web-1',
-            },
-          },
-        },
-        web2: {
-          output: {
-            distPath: {
-              root: 'dist-build-web-2',
-            },
-          },
-        },
-      },
-    },
-  });
-  const files = await rsbuild.unwrapOutputJSON();
-  const filenames = Object.keys(files);
-
-  expect(
-    filenames.some((filename) =>
-      filename.includes('dist-build-web-1/test-temp-file.txt'),
-    ),
-  ).toBeTruthy();
-  expect(
-    filenames.some((filename) =>
-      filename.includes('dist-build-web-2/test-temp-file.txt'),
-    ),
-  ).toBeTruthy();
-});
-
 test('should serve publicDir for preview server with assetPrefix correctly', async ({
   page,
 }) => {

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -23,7 +23,7 @@ export const pluginServer = (): RsbuildPlugin => ({
 
     api.onAfterStartDevServer(onStartServer);
     api.onAfterStartProdServer(onStartServer);
-    api.onBeforeBuild(async ({ isFirstCompile, environments }) => {
+    api.onBeforeBuild(async ({ isFirstCompile }) => {
       if (!isFirstCompile) {
         return;
       }
@@ -45,22 +45,14 @@ export const pluginServer = (): RsbuildPlugin => ({
           continue;
         }
 
-        const distPaths = [
-          ...new Set(Object.values(environments).map((e) => e.distPath)),
-        ];
-
         try {
           // async errors will missing error stack on copy, move
           // https://github.com/jprichardson/node-fs-extra/issues/769
-          await Promise.all(
-            distPaths.map((distPath) =>
-              fs.promises.cp(normalizedPath, distPath, {
-                recursive: true,
-                // dereference symlinks
-                dereference: true,
-              }),
-            ),
-          );
+          await fs.promises.cp(normalizedPath, api.context.distPath, {
+            recursive: true,
+            // dereference symlinks
+            dereference: true,
+          });
         } catch (err) {
           if (err instanceof Error) {
             err.message = `Copy public dir (${normalizedPath}) to dist failed:\n${err.message}`;


### PR DESCRIPTION
This reverts commit 2b5570eb46b0e87aa09aebf4aee1300d3bb32fd0.

## Summary

#4220 introduced a change that was not discussed and broke Rspress.

- fix https://github.com/web-infra-dev/rspress/issues/1684
- fix https://github.com/web-infra-dev/rspress/actions/runs/12454094694/job/34764966986?pr=1685#step:9:406

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/4220

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
