### PR TITLE
chore(server): replace deprecated `url.parse()`

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,4 +1,5 @@
 import { posix } from 'node:path';
+import { URL } from 'node:url';
 import deepmerge from 'deepmerge';
 import type {
   Compiler as WebpackCompiler,

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -162,6 +162,14 @@ export const canParse = (url: string): boolean => {
   }
 };
 
+export const parseUrl = (url: string): URL | null => {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+};
+
 export const ensureAssetPrefix = (
   url: string,
   assetPrefix: Rspack.PublicPath = DEFAULT_ASSET_PREFIX,

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, join } from 'node:path';
 import { URL } from 'node:url';
 import { normalizePublicDirs } from '../config';
+import { parseUrl } from '../helpers';
 import { logger } from '../logger';
 import type {
   DevConfig,
@@ -93,7 +94,7 @@ const applyDefaultMiddlewares = async ({
   middlewares.push((req, res, next) => {
     // allow HMR request cross-domain, because the user may use global proxy
     res.setHeader('Access-Control-Allow-Origin', '*');
-    const path = req.url ? new URL(req.url).pathname : '';
+    const path = req.url ? parseUrl(req.url)?.pathname : '';
     if (path?.includes('hot-update')) {
       res.setHeader('Access-Control-Allow-Credentials', 'false');
     }

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join } from 'node:path';
-import url from 'node:url';
+import { URL } from 'node:url';
 import { normalizePublicDirs } from '../config';
 import { logger } from '../logger';
 import type {
@@ -93,7 +93,7 @@ const applyDefaultMiddlewares = async ({
   middlewares.push((req, res, next) => {
     // allow HMR request cross-domain, because the user may use global proxy
     res.setHeader('Access-Control-Allow-Origin', '*');
-    const path = req.url ? url.parse(req.url).pathname : '';
+    const path = req.url ? new URL(req.url).pathname : '';
     if (path?.includes('hot-update')) {
       res.setHeader('Access-Control-Allow-Credentials', 'false');
     }

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,5 +1,4 @@
 import { isAbsolute, join } from 'node:path';
-import { URL } from 'node:url';
 import { normalizePublicDirs } from '../config';
 import { parseUrl } from '../helpers';
 import { logger } from '../logger';


### PR DESCRIPTION
## Summary

Using the `URL` class instead of the deprecated `url.parse` method.

## Related Links

https://nodejs.org/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
