### PR TITLE
chore(CI): specify minimal permissions for issue-labeler

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -6,6 +6,10 @@ on:
       - opened
       - edited
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   change-labeling:
     name: Labeling for changes


### PR DESCRIPTION
## Summary

Specify minimal permissions for the `issue-labeler` action.

## Related Links

https://github.com/github/issue-labeler?tab=readme-ov-file#create-workflow

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
