### PR TITLE
test(e2e): proxy logs to avoid redundant e2e outputs

### DIFF
--- a/e2e/cases/config/inspect-config/debug.test.ts
+++ b/e2e/cases/config/inspect-config/debug.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { build, dev, gotoPage } from '@e2e/helper';
+import { build, dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { logger } from '@rsbuild/core';
 
@@ -18,6 +18,7 @@ test('should generate config files when build (with DEBUG)', async () => {
   logger.level = 'verbose';
 
   const distRoot = 'dist-1';
+  const { logs, restore } = proxyConsole();
 
   await build({
     cwd: __dirname,
@@ -34,8 +35,16 @@ test('should generate config files when build (with DEBUG)', async () => {
   expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
+  expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
+  expect(logs.some((log) => log.includes('create compiler'))).toBeTruthy();
+
   delete process.env.DEBUG;
   logger.level = 'log';
+
+  restore();
 });
 
 test('should generate config files when dev (with DEBUG)', async ({ page }) => {
@@ -43,6 +52,7 @@ test('should generate config files when dev (with DEBUG)', async ({ page }) => {
   logger.level = 'verbose';
 
   const distRoot = 'dist-2';
+  const { logs, restore } = proxyConsole();
 
   const rsbuild = await dev({
     cwd: __dirname,
@@ -63,8 +73,16 @@ test('should generate config files when dev (with DEBUG)', async ({ page }) => {
   expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
+  expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
+  expect(logs.some((log) => log.includes('create compiler'))).toBeTruthy();
+
   delete process.env.DEBUG;
   logger.level = 'log';
 
   await rsbuild.close();
+
+  restore();
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRsbuild, rspackOnlyTest } from '@e2e/helper';
+import { createRsbuild, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const rsbuildConfig = path.resolve(
@@ -22,6 +22,8 @@ const bundlerNodeConfig = path.resolve(
 );
 
 test('should generate config files when writeToDisk is true', async () => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
   });
@@ -32,11 +34,19 @@ test('should generate config files when writeToDisk is true', async () => {
   expect(fs.existsSync(bundlerConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
+  expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
   fs.rmSync(rsbuildConfig, { force: true });
   fs.rmSync(bundlerConfig, { force: true });
+
+  restore();
 });
 
 test('should generate config files correctly when output is specified', async () => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
   });
@@ -58,11 +68,19 @@ test('should generate config files correctly when output is specified', async ()
   expect(fs.existsSync(bundlerConfig)).toBeTruthy();
   expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
+  expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
   fs.rmSync(rsbuildConfig, { force: true });
   fs.rmSync(bundlerConfig, { force: true });
+
+  restore();
 });
 
 test('should generate bundler config for node when target contains node', async () => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
     rsbuildConfig: {
@@ -88,10 +106,16 @@ test('should generate bundler config for node when target contains node', async 
   expect(fs.existsSync(bundlerConfig)).toBeTruthy();
   expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
 
+  expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
   fs.rmSync(rsbuildConfig, { force: true });
   fs.rmSync(rsbuildNodeConfig, { force: true });
   fs.rmSync(bundlerConfig, { force: true });
   fs.rmSync(bundlerNodeConfig, { force: true });
+
+  restore();
 });
 
 test('should not generate config files when writeToDisk is false', async () => {
@@ -107,6 +131,8 @@ test('should not generate config files when writeToDisk is false', async () => {
 });
 
 rspackOnlyTest('should allow to specify absolute output path', async () => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await createRsbuild({
     cwd: __dirname,
   });
@@ -118,8 +144,14 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
   });
 
   expect(
+    logs.some((log) => log.includes('Inspect config succeed')),
+  ).toBeTruthy();
+
+  expect(
     fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
   ).toBeTruthy();
 
   fs.rmSync(rsbuildConfig, { force: true });
+
+  restore();
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { createRsbuild, proxyConsole, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const rsbuildConfig = path.resolve(
   __dirname,
@@ -21,114 +21,126 @@ const bundlerNodeConfig = path.resolve(
   `./dist/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.node.mjs`,
 );
 
-test('should generate config files when writeToDisk is true', async () => {
-  const { logs, restore } = proxyConsole();
+rspackOnlyTest(
+  'should generate config files when writeToDisk is true',
+  async () => {
+    const { logs, restore } = proxyConsole();
 
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
-  await rsbuild.inspectConfig({
-    writeToDisk: true,
-  });
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+    await rsbuild.inspectConfig({
+      writeToDisk: true,
+    });
 
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+    expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
-  expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
-  ).toBeTruthy();
+    expect(
+      logs.some((log) => log.includes('Inspect config succeed')),
+    ).toBeTruthy();
 
-  fs.rmSync(rsbuildConfig, { force: true });
-  fs.rmSync(bundlerConfig, { force: true });
+    fs.rmSync(rsbuildConfig, { force: true });
+    fs.rmSync(bundlerConfig, { force: true });
 
-  restore();
-});
+    restore();
+  },
+);
 
-test('should generate config files correctly when output is specified', async () => {
-  const { logs, restore } = proxyConsole();
+rspackOnlyTest(
+  'should generate config files correctly when output is specified',
+  async () => {
+    const { logs, restore } = proxyConsole();
 
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
-  await rsbuild.inspectConfig({
-    writeToDisk: true,
-    outputPath: 'foo',
-  });
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+    await rsbuild.inspectConfig({
+      writeToDisk: true,
+      outputPath: 'foo',
+    });
 
-  const bundlerConfig = path.resolve(
-    __dirname,
-    `./dist/foo/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
-  );
+    const bundlerConfig = path.resolve(
+      __dirname,
+      `./dist/foo/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
+    );
 
-  const rsbuildConfig = path.resolve(
-    __dirname,
-    './dist/foo/rsbuild.config.mjs',
-  );
+    const rsbuildConfig = path.resolve(
+      __dirname,
+      './dist/foo/rsbuild.config.mjs',
+    );
 
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-  expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
+    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+    expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
-  expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
-  ).toBeTruthy();
+    expect(
+      logs.some((log) => log.includes('Inspect config succeed')),
+    ).toBeTruthy();
 
-  fs.rmSync(rsbuildConfig, { force: true });
-  fs.rmSync(bundlerConfig, { force: true });
+    fs.rmSync(rsbuildConfig, { force: true });
+    fs.rmSync(bundlerConfig, { force: true });
 
-  restore();
-});
+    restore();
+  },
+);
 
-test('should generate bundler config for node when target contains node', async () => {
-  const { logs, restore } = proxyConsole();
+rspackOnlyTest(
+  'should generate bundler config for node when target contains node',
+  async () => {
+    const { logs, restore } = proxyConsole();
 
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    rsbuildConfig: {
-      environments: {
-        web: {
-          output: {
-            target: 'web',
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        environments: {
+          web: {
+            output: {
+              target: 'web',
+            },
           },
-        },
-        node: {
-          output: {
-            target: 'node',
+          node: {
+            output: {
+              target: 'node',
+            },
           },
         },
       },
-    },
-  });
-  await rsbuild.inspectConfig({
-    writeToDisk: true,
-  });
+    });
+    await rsbuild.inspectConfig({
+      writeToDisk: true,
+    });
 
-  expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
-  expect(fs.existsSync(bundlerConfig)).toBeTruthy();
-  expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
+    expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
+    expect(fs.existsSync(bundlerConfig)).toBeTruthy();
+    expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
 
-  expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
-  ).toBeTruthy();
+    expect(
+      logs.some((log) => log.includes('Inspect config succeed')),
+    ).toBeTruthy();
 
-  fs.rmSync(rsbuildConfig, { force: true });
-  fs.rmSync(rsbuildNodeConfig, { force: true });
-  fs.rmSync(bundlerConfig, { force: true });
-  fs.rmSync(bundlerNodeConfig, { force: true });
+    fs.rmSync(rsbuildConfig, { force: true });
+    fs.rmSync(rsbuildNodeConfig, { force: true });
+    fs.rmSync(bundlerConfig, { force: true });
+    fs.rmSync(bundlerNodeConfig, { force: true });
 
-  restore();
-});
+    restore();
+  },
+);
 
-test('should not generate config files when writeToDisk is false', async () => {
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
-  await rsbuild.inspectConfig({
-    writeToDisk: false,
-  });
+rspackOnlyTest(
+  'should not generate config files when writeToDisk is false',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+    await rsbuild.inspectConfig({
+      writeToDisk: false,
+    });
 
-  expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
-  expect(fs.existsSync(bundlerConfig)).toBeFalsy();
-});
+    expect(fs.existsSync(rsbuildConfig)).toBeFalsy();
+    expect(fs.existsSync(bundlerConfig)).toBeFalsy();
+  },
+);
 
 rspackOnlyTest('should allow to specify absolute output path', async () => {
   const { logs, restore } = proxyConsole();

--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -1,10 +1,12 @@
 import { join } from 'node:path';
-import { build, dev, globContentJSON } from '@e2e/helper';
+import { build, dev, globContentJSON, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should emit bundle analyze report correctly when dev', async ({
   page,
 }) => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await dev({
     cwd: __dirname,
   });
@@ -19,10 +21,18 @@ test('should emit bundle analyze report correctly when dev', async ({
   );
   expect(filePaths.length).toBe(1);
 
+  expect(
+    logs.some((log) => log.includes('Webpack Bundle Analyzer saved report to')),
+  ).toBeTruthy();
+
   await rsbuild.close();
+
+  restore();
 });
 
 test('should emit bundle analyze report correctly when build', async () => {
+  const { logs, restore } = proxyConsole();
+
   const rsbuild = await build({
     cwd: __dirname,
   });
@@ -32,5 +42,11 @@ test('should emit bundle analyze report correctly when build', async () => {
     file.endsWith('report-web.html'),
   );
 
+  expect(
+    logs.some((log) => log.includes('Webpack Bundle Analyzer saved report to')),
+  ).toBeTruthy();
+
   expect(filePaths.length).toBe(1);
+
+  restore();
 });

--- a/e2e/cases/server/ssr/rsbuild.config.ts
+++ b/e2e/cases/server/ssr/rsbuild.config.ts
@@ -97,7 +97,6 @@ export default defineConfig({
                 runtimeChunk: true,
                 splitChunks: {
                   chunks: 'all',
-                  enforceSizeThreshold: 50000,
                   minSize: 0,
                   cacheGroups: {
                     'lib-react': {


### PR DESCRIPTION
## Summary

Proxy logs to avoid redundant e2e outputs, such as:

<img width="1221" alt="Screenshot 2024-12-23 at 22 47 28" src="https://github.com/user-attachments/assets/92deaff2-db4c-4b04-a9e4-1b2416f311d5" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
