### PR TITLE
fix: should await inspect config in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
   <a href="https://github.com/web-infra-dev/rsbuild/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
 </p>
 
+1
+
 English | [Portuguese](./README.pt-BR.md) | [简体中文](./README.zh-CN.md)
 
 Rsbuild is a high-performance build tool powered by Rspack. It provides a set of thoughtfully designed default build configs, offering an out-of-the-box development experience and can fully unleash the performance advantages of Rspack.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
   <a href="https://github.com/web-infra-dev/rsbuild/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square&colorA=564341&colorB=EDED91" alt="license" /></a>
 </p>
 
-1
-
 English | [Portuguese](./README.pt-BR.md) | [简体中文](./README.zh-CN.md)
 
 Rsbuild is a high-performance build tool powered by Rspack. It provides a set of thoughtfully designed default build configs, offering an out-of-the-box development experience and can fully unleash the performance advantages of Rspack.

--- a/packages/compat/webpack/src/initConfigs.ts
+++ b/packages/compat/webpack/src/initConfigs.ts
@@ -43,12 +43,12 @@ export async function initConfigs({
 
   // write Rsbuild config and webpack config to disk in debug mode
   if (logger.level === 'verbose') {
-    const inspect = () => {
+    const inspect = async () => {
       const inspectOptions: InspectConfigOptions = {
         verbose: true,
         writeToDisk: true,
       };
-      inspectConfig({
+      await inspectConfig({
         context,
         pluginManager,
         inspectOptions,
@@ -59,9 +59,9 @@ export async function initConfigs({
     };
 
     // run inspect later to avoid cleaned by cleanOutput plugin
-    context.hooks.onBeforeBuild.tap(({ isFirstCompile }) => {
+    context.hooks.onBeforeBuild.tap(async ({ isFirstCompile }) => {
       if (isFirstCompile) {
-        inspect();
+        await inspect();
       }
     });
     context.hooks.onAfterStartDevServer.tap(inspect);

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -240,12 +240,12 @@ export async function initConfigs({
 
   // write Rsbuild config and Rspack config to disk in debug mode
   if (isDebug()) {
-    const inspect = () => {
+    const inspect = async () => {
       const inspectOptions: InspectConfigOptions = {
         verbose: true,
         writeToDisk: true,
       };
-      inspectConfig({
+      await inspectConfig({
         context,
         pluginManager,
         inspectOptions,
@@ -255,9 +255,9 @@ export async function initConfigs({
     };
 
     // run inspect later to avoid cleaned by cleanOutput plugin
-    context.hooks.onBeforeBuild.tap(({ isFirstCompile }) => {
+    context.hooks.onBeforeBuild.tap(async ({ isFirstCompile }) => {
       if (isFirstCompile) {
-        inspect();
+        await inspect();
       }
     });
     context.hooks.onAfterStartDevServer.tap(inspect);


### PR DESCRIPTION
## Summary

This pull request includes changes to the `initConfigs` function to ensure async operations are properly awaited.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
