### PR TITLE
chore(CI): correct permissions for issue labeler

### DIFF
--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -6,11 +6,11 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   reply-labeled:
-    permissions:
-      issues: write
+    name: Reply need reproduction
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild'
     steps:

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -7,7 +7,7 @@ on:
       - edited
 
 permissions:
-  issues: write
+  pull-requests: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary

Since the `pr-labeler` workflow adds labels to pull requests, it needs the `pull-requests: write` permission.

![image](https://github.com/user-attachments/assets/72577dba-728f-464a-b567-201f5510daca)

## Related Links

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
