### PR TITLE
fix: set default command for `createCompiler()`

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -44,6 +44,7 @@ import { rspackProvider } from './provider/provider';
 import { startProdServer } from './server/prodServer';
 import type {
   Build,
+  CreateCompiler,
   CreateDevServer,
   CreateRsbuildOptions,
   Falsy,
@@ -212,10 +213,18 @@ export async function createRsbuild(
     return providerInstance.createDevServer(...args);
   };
 
+  const createCompiler: CreateCompiler = (...args) => {
+    if (!context.command) {
+      context.command = getNodeEnv() === 'development' ? 'dev' : 'build';
+    }
+    return providerInstance.createCompiler(...args);
+  };
+
   const rsbuild = {
     build,
     preview,
     startDevServer,
+    createCompiler,
     createDevServer,
     ...pick(pluginManager, [
       'addPlugins',
@@ -240,11 +249,7 @@ export async function createRsbuild(
       'getRsbuildConfig',
       'getNormalizedConfig',
     ]),
-    ...pick(providerInstance, [
-      'initConfigs',
-      'inspectConfig',
-      'createCompiler',
-    ]),
+    ...pick(providerInstance, ['initConfigs', 'inspectConfig']),
   };
 
   const getFlattenedPlugins = async (pluginOptions: RsbuildPlugins) => {


### PR DESCRIPTION
## Summary

When calling the `rsbuild.createCompiler()` method, if `context.command` does not exist, we should assign a default value based on `process.env.NODE_ENV` to ensure dev and build hooks work as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
