### PR TITLE
docs: add `importModule` for `api.transform`

### DIFF
--- a/.github/workflows/issue-close-require.yml
+++ b/.github/workflows/issue-close-require.yml
@@ -5,12 +5,11 @@ on:
     - cron: '0 0 * * *'
 
 permissions:
+  issues: write
   contents: read
 
 jobs:
   issue-close-require:
-    permissions:
-      issues: write
     runs-on: ubuntu-latest
     if: github.repository == 'web-infra-dev/rsbuild'
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,6 @@ on:
         required: false
         default: true
 
-permissions:
-  id-token: write
-
 jobs:
   release:
     name: Release

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -275,12 +275,8 @@ type TransformContext = {
   resourceQuery: string;
   environment: EnvironmentContext;
   addDependency: (file: string) => void;
-  emitFile: (
-    name: string,
-    content: string | Buffer,
-    sourceMap?: string,
-    assetInfo?: Record<string, any>,
-  ) => void;
+  emitFile: Rspack.LoaderContext['emitFile'];
+  importModule: Rspack.LoaderContext['importModule'];
 };
 
 type TransformResult =
@@ -304,6 +300,7 @@ The `handler` function provides the following params:
 - `environment`: The [environment context](/api/javascript-api/environment-api#environment-context) for current build.
 - `addDependency`: Add an additional file as the dependency. The file will be watched and changes to the file will trigger rebuild. The same as Rspack loader's [this.addDependency](https://rspack.dev/api/loader-api/context#thisadddependency).
 - `emitFile`: Emits a file to the build output. The same as Rspack loader's [this.emitFile](https://rspack.dev/api/loader-api/context#thisemitfile).
+- `importModule`: Compile and execute a module at the build time. The same as Rspack loader's [this.importModule](https://rspack.dev/api/loader-api/context#thisimportmodule).
 
 For example:
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -273,12 +273,8 @@ type TransformContext = {
   resourceQuery: string;
   environment: EnvironmentContext;
   addDependency: (file: string) => void;
-  emitFile: (
-    name: string,
-    content: string | Buffer,
-    sourceMap?: string,
-    assetInfo?: Record<string, any>,
-  ) => void;
+  emitFile: Rspack.LoaderContext['emitFile'];
+  importModule: Rspack.LoaderContext['importModule'];
 };
 
 type TransformResult =
@@ -301,7 +297,8 @@ handler 函数提供以下参数：
 - `resourceQuery`：模块路径上的 query。
 - `environment`: 当前构建的 [environment 上下文](/api/javascript-api/environment-api#environment-context).
 - `addDependency`：添加一个额外的文件作为依赖。该文件将被监听，并在发生变更时触发重新构建。与 Rspack loader 的 [this.addDependency](https://rspack.dev/api/loader-api/context#thisadddependency) 相同。
-- `emitFile`：将一个文件输出到构建结果中。与 Rspack loader 的 [this.emitFile](https://rspack.dev/api/loader-api/context#thisemitfile) 相同。
+- `emitFile`：将一个文件输出到构建结果中。与 Rspack loader 的 [this.emitFile](https://rspack.dev/zh/api/loader-api/context#thisemitfile) 相同。
+- `importModule`：在构建时编译并执行一个模块。与 Rspack loader 的 [this.importModule](https://rspack.dev/zh/api/loader-api/context#thisimportmodule) 相同。
 
 比如：
 


### PR DESCRIPTION
## Summary

Updating permissions in workflow files and adding the `importModule` methods to the `TransformContext` type.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4217

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
