### PR TITLE
docs: link to SWC plugin unmatch FAQ

### DIFF
--- a/website/docs/en/guide/basic/configure-swc.mdx
+++ b/website/docs/en/guide/basic/configure-swc.mdx
@@ -35,22 +35,7 @@ export default {
 
 Please note that the SWC plugin is still an experimental feature, and the SWC Wasm plugin is currently not backward compatible. The version of the SWC plugin is closely tied to the version of `swc_core` that Rspack depends on.
 
-This means that you must to choose an SWC plugin that matches the current version of `swc_core` to ensure that it works properly. If the version of the SWC plugin you are using does not match the version of `swc_core` that Rspack depends on, Rspack will throw the following error during the build process:
-
-```text
-1: failed to run Wasm plugin transform. Please ensure the version of `swc_core`
-   used by the plugin is compatible with the host runtime.
-```
-
-If you encounter the above issues, a common solution is to upgrade both the Rsbuild and SWC plugins to the latest versions.
-
-Alternatively, you can follow these steps to select a suitable SWC plugin version:
-
-1. Check the current version of Rspack you are using, this can be done by enabling [debug mode](/guide/debug/debug-mode).
-2. Visit [plugins.swc.rs](https://plugins.swc.rs/) and select the version of Rspack you are currently using.
-3. The website will list the range of SWC plugin versions that match to your current Rspack version. Then select the matched version of the SWC plugin to use.
-
-If the SWC plugin you are using is not listed on [plugins.swc.rs](https://plugins.swc.rs/), you can find the version information of `swc_core` in the Cargo.toml file within the Rust code repository. For example, in the Rspack repository, you can open [Cargo.toml](https://github.com/web-infra-dev/rspack/blob/main/Cargo.toml) and search for the keyword `swc_core` to find the version. Then read [SWC - Selecting the version](https://swc.rs/docs/plugin/selecting-swc-core) for further guidance.
+This means that you must to choose an SWC plugin that matches the current version of `swc_core` to ensure that it works properly. If the version of the SWC plugin you are using does not match the version of `swc_core` that Rspack depends on, Rspack will throw an error during the build process. Please refer to [Rspack FAQ - SWC Plugin Version Unmatched](https://rspack.dev/errors/swc-plugin-version) for more information.
 
 ### Enable Emotion Support
 

--- a/website/docs/zh/guide/basic/configure-swc.mdx
+++ b/website/docs/zh/guide/basic/configure-swc.mdx
@@ -35,22 +35,7 @@ export default {
 
 请注意，SWC 的插件仍然是一个实验性功能，目前 SWC 的 Wasm 插件是不向后兼容的，SWC 插件的版本与 Rspack 依赖的 `swc_core` 版本存在强耦合关系。
 
-这意味着，你需要选择和当前 `swc_core` 版本匹配的 SWC 插件，才能使它正常执行。如果你使用的 SWC 插件版本与 Rspack 依赖的 `swc_core` 版本不匹配，Rspack 在执行构建时会抛出如下错误：
-
-```text
-1: failed to run Wasm plugin transform. Please ensure the version of `swc_core`
-   used by the plugin is compatible with the host runtime.
-```
-
-如果你遇到了以上问题，通常可行的解决方法是将 Rsbuild 和 SWC 插件都升级到最新版本。
-
-此外，你也可以按照以下步骤来选择合适的 SWC 插件版本：
-
-1. 查看当前使用的 Rspack 版本，你可以通过 [调试模式](/guide/debug/debug-mode) 来查看。
-2. 访问 [plugins.swc.rs](https://plugins.swc.rs/)，选择你当前使用的 Rspack 版本。
-3. 该网站会列出你当前使用的 Rspack 版本所匹配的 SWC 插件版本范围，选择匹配的 SWC 插件版本使用即可。
-
-如果你使用的 SWC 插件未收录到 [plugins.swc.rs](https://plugins.swc.rs/)，可以通过 Rust 代码仓库中的 Cargo.toml 文件来查看 `swc_core` 的版本信息。以 Rspack 仓库为例，你可以打开 [Cargo.toml](https://github.com/web-infra-dev/rspack/blob/main/Cargo.toml)，搜索 `swc_core` 关键字来查看版本，然后参考 [SWC - Selecting the version](https://swc.rs/docs/plugin/selecting-swc-core) 进行选择。
+这意味着，你需要选择和当前 `swc_core` 版本匹配的 SWC 插件，才能使它正常执行。如果你使用的 SWC 插件版本与 Rspack 依赖的 `swc_core` 版本不匹配，Rspack 在执行构建时会抛出错误，请参考 [Rspack 常见问题 - SWC 插件版本不匹配](https://rspack.dev/zh/errors/swc-plugin-version) 进行处理。
 
 ### 启用 Emotion 支持
 


### PR DESCRIPTION
## Summary

Link to Rspack's SWC plugin unmatch FAQ to reduce the maintenance burden.

## Related Links

https://github.com/web-infra-dev/rspack/pull/8829

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
