### PR TITLE
fix: should copy publicDir to the environment distDir when multiple environments

### DIFF
--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -170,6 +170,131 @@ test('should serve publicDir for preview server correctly', async ({
   await rsbuild.close();
 });
 
+test('should copy publicDir to the environment distDir when multiple environments', async () => {
+  await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
+
+  const rsbuild = await build({
+    cwd,
+    rsbuildConfig: {
+      environments: {
+        web1: {
+          output: {
+            distPath: {
+              root: 'dist-build-web-1',
+            },
+          },
+        },
+        web2: {
+          output: {
+            distPath: {
+              root: 'dist-build-web-2',
+            },
+          },
+        },
+        node: {
+          output: {
+            target: 'node',
+            distPath: {
+              root: 'dist-build-node',
+            },
+          },
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-web-1/test-temp-file.txt'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-web-2/test-temp-file.txt'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-node/test-temp-file.txt'),
+    ),
+  ).toBeFalsy();
+});
+
+test('should copy publicDir to the node environment distDir when copyOnBuild is specified as true', async () => {
+  await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
+
+  const rsbuild = await build({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        publicDir: {
+          copyOnBuild: true,
+        },
+      },
+      environments: {
+        node: {
+          output: {
+            target: 'node',
+            distPath: {
+              root: 'dist-build-node-1',
+            },
+          },
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-node-1/test-temp-file.txt'),
+    ),
+  ).toBeTruthy();
+});
+
+test('should copy publicDir to root dist when environment dist path has a parent-child relationship', async () => {
+  await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
+  fse.removeSync(join(__dirname, 'dist-build-web'));
+
+  const rsbuild = await build({
+    cwd,
+    rsbuildConfig: {
+      environments: {
+        web1: {
+          output: {
+            distPath: {
+              root: 'dist-build-web/1',
+            },
+          },
+        },
+        web2: {
+          output: {
+            distPath: {
+              root: 'dist-build-web',
+            },
+          },
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-web/test-temp-file.txt'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-web/1/test-temp-file.txt'),
+    ),
+  ).toBeFalsy();
+});
+
 test('should serve publicDir for preview server with assetPrefix correctly', async ({
   page,
 }) => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -679,16 +679,18 @@ export function stringifyConfig(config: unknown, verbose?: boolean): string {
   return stringify(config, { verbose });
 }
 
+type NormalizePublicDirOptions = PublicDirOptions &
+  Required<Omit<PublicDirOptions, 'copyOnBuild'>>;
+
 export const normalizePublicDirs = (
   publicDir?: PublicDir,
-): Required<PublicDirOptions>[] => {
+): NormalizePublicDirOptions[] => {
   if (publicDir === false) {
     return [];
   }
 
-  const defaultConfig: Required<PublicDirOptions> = {
+  const defaultConfig: NormalizePublicDirOptions = {
     name: 'public',
-    copyOnBuild: true,
     watch: false,
   };
 

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -45,3 +45,17 @@ export const pathnameParse = (publicPath: string): string => {
     return publicPath;
   }
 };
+
+/** dedupe and remove nested paths */
+export const dedupeNestedPaths = (paths: string[]): string[] => {
+  return paths
+    .sort((p1, p2) => (p2.length > p1.length ? -1 : 1))
+    .reduce<string[]>((prev, curr) => {
+      const isSub = prev.find((p) => curr.startsWith(p) || curr === p);
+      if (isSub) {
+        return prev;
+      }
+
+      return prev.concat(curr);
+    }, []);
+};

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { normalizePublicDirs } from '../config';
+import { dedupeNestedPaths } from '../helpers';
 import { open } from '../server/open';
 import type { OnAfterStartDevServerFn, RsbuildPlugin } from '../types';
 
@@ -23,7 +24,7 @@ export const pluginServer = (): RsbuildPlugin => ({
 
     api.onAfterStartDevServer(onStartServer);
     api.onAfterStartProdServer(onStartServer);
-    api.onBeforeBuild(async ({ isFirstCompile }) => {
+    api.onBeforeBuild(async ({ isFirstCompile, environments }) => {
       if (!isFirstCompile) {
         return;
       }
@@ -33,7 +34,7 @@ export const pluginServer = (): RsbuildPlugin => ({
       for (const publicDir of publicDirs) {
         const { name, copyOnBuild } = publicDir;
 
-        if (!copyOnBuild || !name) {
+        if (copyOnBuild === false || !name) {
           continue;
         }
 
@@ -45,14 +46,26 @@ export const pluginServer = (): RsbuildPlugin => ({
           continue;
         }
 
+        const distPaths = dedupeNestedPaths(
+          Object.values(environments)
+            .filter(
+              (e) => copyOnBuild === true || e.config.output.target !== 'node',
+            )
+            .map((e) => e.distPath),
+        );
+
         try {
           // async errors will missing error stack on copy, move
           // https://github.com/jprichardson/node-fs-extra/issues/769
-          await fs.promises.cp(normalizedPath, api.context.distPath, {
-            recursive: true,
-            // dereference symlinks
-            dereference: true,
-          });
+          await Promise.all(
+            distPaths.map((distPath) =>
+              fs.promises.cp(normalizedPath, distPath, {
+                recursive: true,
+                // dereference symlinks
+                dereference: true,
+              }),
+            ),
+          );
         } catch (err) {
           if (err instanceof Error) {
             err.message = `Copy public dir (${normalizedPath}) to dist failed:\n${err.message}`;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -322,7 +322,7 @@ export type PublicDirOptions = {
   name?: string;
   /**
    * Whether to copy files from the publicDir to the distDir on production build
-   * @default true
+   * @default target !== 'node'
    */
   copyOnBuild?: boolean;
   /**

--- a/website/docs/en/config/server/public-dir.mdx
+++ b/website/docs/en/config/server/public-dir.mdx
@@ -16,7 +16,7 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: true,
+  copyOnBuild: target !== 'node',
 };
 ```
 
@@ -62,7 +62,7 @@ export default {
 ### copyOnBuild
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `target !== 'node'`
 
 Whether to copy files from the publicDir to the distDir on production build.
 
@@ -80,9 +80,28 @@ export default {
 
 Note that setting the value of `copyOnBuild` to false means that when you run `rsbuild preview` for a production preview, you will not be able to access the corresponding static resources.
 
+By default, the public directory is not copied in the node target environment. If you need to copy files from the public directory to the distDir in the node target environment, you can manually enable `copyOnBuild`:
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      copyOnBuild: true,
+    },
+  },
+};
+```
+
 :::tip
 During dev builds, if you need to copy some static assets to the output directory, you can use the [output.copy](/config/output/copy) option instead.
 :::
+
+#### Multiple environments
+
+When there are multiple environment builds, the files will be copied from the public directory to their respective distDir. When distDir are nested, they are only copied to their parent directory. For example:
+
+- The distDir of the `web` environment is `dist`, and the distDir of the `web1` environment is `dist/web1`. Due to the nested relationship between `dist` and `dist/web1`, at this time, the public directory files are only copied to the `dist` directory.
+- The distDir of the `esm` environment is `dist/esm`, and the distDir of the `cjs` environment is `dist/cjs`. Since there is no nesting relationship between `dist/esm` and `dist/cjs`, at this time, the public directory files will be copied to the `dist/esm` and `dist/cjs` directories respectively.
 
 ### watch
 

--- a/website/docs/zh/config/server/public-dir.mdx
+++ b/website/docs/zh/config/server/public-dir.mdx
@@ -16,7 +16,7 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: true,
+  copyOnBuild: target !== 'node',
   watch: false,
 };
 ```
@@ -63,7 +63,7 @@ export default {
 ### copyOnBuild
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** `target !== 'node'`
 
 在生产构建时，是否将文件从 public 目录复制到构建产物目录。
 
@@ -81,9 +81,28 @@ export default {
 
 需要注意的是，将 `copyOnBuild` 的值为 false 后，如果执行 `rsbuild preview` 进行生产环境预览，将无法访问对应的静态资源文件。
 
+默认情况下，node 环境下不会进行复制。如果你需要在 node 环境下将文件从 public 目录复制到构建产物目录，可手动开启 `copyOnBuild`：
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      copyOnBuild: true,
+    },
+  },
+};
+```
+
 :::tip
 在 dev 构建时，如果你需要拷贝一些静态资源到构建产物目录，可以使用 [output.copy](/config/output/copy) 选项代替。
 :::
+
+#### 多环境
+
+当存在多个环境构建时，会将文件从 public 目录复制到各自的构建产物目录下。当构建产物目录存在嵌套的情况时，仅复制到构建产物父目录下。如：
+
+- `web` 环境的构建产物目录设置为 `dist`，`web1` 环境的构建产物目录设置为 `dist/web1`。由于 `dist` 和 `dist/web1` 存在嵌套关系，此时，public 目录文件仅复制到 `dist` 目录下。
+- `esm` 环境的构建产物目录设置为 `dist/esm`，`cjs` 环境的构建产物目录设置为 `dist/cjs`。由于 `dist/esm` 和 `dist/cjs` 不存在嵌套关系，此时，public 目录文件将分别复制到 `dist/esm` 和 `dist/cjs` 目录下。
 
 ### watch
 


### PR DESCRIPTION
## Summary

- Should copy publicDir to the environment distDir when multiple environments, except for nested dist directories.
- The public directory is not copied in the node target environment by default.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
