### PR TITLE
fix: should writeToDisk correctly when environment writeToDisk configuration same

### DIFF
--- a/e2e/cases/server/write-to-disk-environments/index.test.ts
+++ b/e2e/cases/server/write-to-disk-environments/index.test.ts
@@ -57,7 +57,7 @@ test('multiple environments writeToDisk should work correctly', async ({
   await rsbuild.close();
 });
 
-test('writeToDisk correctly when environment writeToDisk configurations same', async ({
+test('writeToDisk correctly when environment writeToDisk configuration same', async ({
   page,
 }) => {
   const rsbuild = await dev({

--- a/e2e/cases/server/write-to-disk-environments/index.test.ts
+++ b/e2e/cases/server/write-to-disk-environments/index.test.ts
@@ -57,13 +57,16 @@ test('multiple environments writeToDisk should work correctly', async ({
   await rsbuild.close();
 });
 
-test('writeToDisk correctly when environment writeToDisk configuration same', async ({
+test('should writeToDisk correctly when environment writeToDisk configuration same', async ({
   page,
 }) => {
   const rsbuild = await dev({
     cwd,
     page,
     rsbuildConfig: {
+      dev: {
+        writeToDisk: false,
+      },
       environments: {
         web: {
           output: {

--- a/e2e/cases/server/write-to-disk-environments/index.test.ts
+++ b/e2e/cases/server/write-to-disk-environments/index.test.ts
@@ -56,3 +56,44 @@ test('multiple environments writeToDisk should work correctly', async ({
 
   await rsbuild.close();
 });
+
+test('writeToDisk correctly when environment writeToDisk configurations same', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd,
+    page,
+    rsbuildConfig: {
+      environments: {
+        web: {
+          output: {
+            distPath: {
+              root: 'dist-same',
+            },
+          },
+          dev: {
+            writeToDisk: true,
+          },
+        },
+        web1: {
+          output: {
+            distPath: {
+              root: 'dist-same-1',
+            },
+          },
+          dev: {
+            writeToDisk: true,
+          },
+        },
+      },
+    },
+  });
+
+  const test = page.locator('#test');
+  await expect(test).toHaveText('Hello Rsbuild!');
+
+  expect(fs.existsSync(join(cwd, 'dist-same/index.html'))).toBeTruthy();
+  expect(fs.existsSync(join(cwd, 'dist-same-1/index.html'))).toBeTruthy();
+
+  await rsbuild.close();
+});

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -43,7 +43,10 @@ const formatDevConfig = (
     (env) => env.config.dev.writeToDisk,
   );
   if (new Set(writeToDiskValues).size === 1) {
-    return config;
+    return {
+      ...config,
+      writeToDisk: writeToDiskValues[0],
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary
 
should writeToDisk correctly when the environment `writeToDisk` configuration is the same

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
