### PR TITLE
fix: preserve ansi colors for browser error logs

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -67,21 +67,21 @@ function handleSuccess() {
 }
 
 // Compilation with warnings (e.g. ESLint).
-function handleWarnings(warnings: string[]) {
+function handleWarnings({ text }: { text: string[] }) {
   clearOutdatedErrors();
 
   const isHotUpdate = !isFirstCompilation;
   isFirstCompilation = false;
   hasCompileErrors = false;
 
-  for (let i = 0; i < warnings.length; i++) {
+  for (let i = 0; i < text.length; i++) {
     if (i === 5) {
       console.warn(
         'There were more warnings in other files, you can find a complete log in the terminal.',
       );
       break;
     }
-    console.warn(warnings[i]);
+    console.warn(text[i]);
   }
 
   // Attempt to apply hot updates or reload.
@@ -91,19 +91,19 @@ function handleWarnings(warnings: string[]) {
 }
 
 // Compilation with errors (e.g. syntax error or missing modules).
-function handleErrors(errors: string[]) {
+function handleErrors({ text, html }: { text: string[]; html: string[] }) {
   clearOutdatedErrors();
 
   isFirstCompilation = false;
   hasCompileErrors = true;
 
   // Also log them to the console.
-  for (const error of errors) {
+  for (const error of text) {
     console.error(error);
   }
 
   if (createOverlay) {
-    createOverlay(errors);
+    createOverlay(html);
   }
 }
 

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -294,7 +294,10 @@ export class SocketServer {
       return this.sockWrite({
         type: 'errors',
         compilationId,
-        data: formattedErrors.map((item) => ansiHTML(escapeHtml(item))),
+        data: {
+          text: formattedErrors,
+          html: formattedErrors.map((item) => ansiHTML(escapeHtml(item))),
+        },
       });
     }
 
@@ -307,7 +310,9 @@ export class SocketServer {
       return this.sockWrite({
         type: 'warnings',
         compilationId,
-        data: formattedWarnings.map((item) => ansiHTML(escapeHtml(item))),
+        data: {
+          text: formattedWarnings,
+        },
       });
     }
 


### PR DESCRIPTION
## Summary

Rsbuild should preserve ansi colors for browser error logs.

- before:

<img width="1915" alt="Screenshot 2024-12-25 at 14 47 17" src="https://github.com/user-attachments/assets/5183f8f5-6401-41d5-8974-a81997fb6d0e" />

- after:

![image](https://github.com/user-attachments/assets/295171a3-8a60-405b-b62c-ef233c1a8fb7)


## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/4266

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
