### PR TITLE
chore: prefer to use `static-changed` socket type

### DIFF
--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -23,7 +23,7 @@ test('setupMiddlewares', async ({ page }) => {
               i++;
               next();
             });
-            reloadFn = () => server.sockWrite('content-changed');
+            reloadFn = () => server.sockWrite('static-changed');
           },
         ],
       },

--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -163,7 +163,7 @@ export class CompilerDevMiddleware {
         // reload page when HTML template changed
         if (typeof fileName === 'string' && HTML_REGEX.test(fileName)) {
           this.socketServer.sockWrite({
-            type: 'content-changed',
+            type: 'static-changed',
             compilationId,
           });
           return;

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -260,7 +260,7 @@ export class SocketServer {
 
     if (shouldReload) {
       return this.sockWrite({
-        type: 'content-changed',
+        type: 'static-changed',
         compilationId,
       });
     }

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -58,7 +58,7 @@ In the `setupMiddlewares` function, you can access the `server` object, which pr
 
 `sockWrite` allows middlewares to send some message to HMR client, and then the HMR client will take different actions depending on the message type.
 
-For example, if you send a `'content-changed'` message, the page will reload.
+For example, if you send a `'static-changed'` message, the page will reload.
 
 ```js
 export default {
@@ -66,13 +66,15 @@ export default {
     setupMiddlewares: [
       (middlewares, server) => {
         if (someCondition) {
-          server.sockWrite('content-changed');
+          server.sockWrite('static-changed');
         }
       },
     ],
   },
 };
 ```
+
+> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.
 
 ### environments
 

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -58,7 +58,7 @@ export default {
 
 `sockWrite` 允许中间件向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
 
-例如，如果你发送一个 `'content-changed'` 的消息，页面将会重新加载。
+例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
 
 ```js
 export default {
@@ -66,13 +66,15 @@ export default {
     setupMiddlewares: [
       (middlewares, server) => {
         if (someCondition) {
-          server.sockWrite('content-changed');
+          server.sockWrite('static-changed');
         }
       },
     ],
   },
 };
 ```
+
+> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。
 
 ### environments
 


### PR DESCRIPTION
## Summary

Prefer to use `static-changed` instead of `content-changed` as the socket type.

This change aims to align with webpack-dev-server v5, see https://github.com/webpack/webpack-dev-server/pull/4679.

`content-changed` is deprecated, we may will remove it in Rsbuild 2.0.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
