### PR TITLE
fix: do not copy public dir for node target by default

### DIFF
--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -191,6 +191,14 @@ test('should copy publicDir to the environment distDir when multiple environment
             },
           },
         },
+        node: {
+          output: {
+            target: 'node',
+            distPath: {
+              root: 'dist-build-node',
+            },
+          },
+        },
       },
     },
   });
@@ -205,6 +213,44 @@ test('should copy publicDir to the environment distDir when multiple environment
   expect(
     filenames.some((filename) =>
       filename.includes('dist-build-web-2/test-temp-file.txt'),
+    ),
+  ).toBeTruthy();
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-node/test-temp-file.txt'),
+    ),
+  ).toBeFalsy();
+});
+
+test('should copy publicDir to the node distDir when copyOnBuild is specified as true', async () => {
+  await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
+
+  const rsbuild = await build({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        publicDir: {
+          copyOnBuild: true,
+        },
+      },
+      environments: {
+        node: {
+          output: {
+            target: 'node',
+            distPath: {
+              root: 'dist-build-node-1',
+            },
+          },
+        },
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+  const filenames = Object.keys(files);
+
+  expect(
+    filenames.some((filename) =>
+      filename.includes('dist-build-node-1/test-temp-file.txt'),
     ),
   ).toBeTruthy();
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -679,16 +679,18 @@ export function stringifyConfig(config: unknown, verbose?: boolean): string {
   return stringify(config, { verbose });
 }
 
+type NormalizePublicDirOptions = PublicDirOptions &
+  Required<Omit<PublicDirOptions, 'copyOnBuild'>>;
+
 export const normalizePublicDirs = (
   publicDir?: PublicDir,
-): Required<PublicDirOptions>[] => {
+): NormalizePublicDirOptions[] => {
   if (publicDir === false) {
     return [];
   }
 
-  const defaultConfig: Required<PublicDirOptions> = {
+  const defaultConfig: NormalizePublicDirOptions = {
     name: 'public',
-    copyOnBuild: true,
     watch: false,
   };
 

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -34,7 +34,7 @@ export const pluginServer = (): RsbuildPlugin => ({
       for (const publicDir of publicDirs) {
         const { name, copyOnBuild } = publicDir;
 
-        if (!copyOnBuild || !name) {
+        if (copyOnBuild === false || !name) {
           continue;
         }
 
@@ -47,7 +47,11 @@ export const pluginServer = (): RsbuildPlugin => ({
         }
 
         const distPaths = dedupeNestedPaths(
-          Object.values(environments).map((e) => e.distPath),
+          Object.values(environments)
+            .filter(
+              (e) => copyOnBuild === true || e.config.output.target !== 'node',
+            )
+            .map((e) => e.distPath),
         );
 
         try {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -322,7 +322,7 @@ export type PublicDirOptions = {
   name?: string;
   /**
    * Whether to copy files from the publicDir to the distDir on production build
-   * @default true
+   * @default target !== 'node'
    */
   copyOnBuild?: boolean;
   /**

--- a/website/docs/en/config/server/public-dir.mdx
+++ b/website/docs/en/config/server/public-dir.mdx
@@ -16,7 +16,7 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: true,
+  copyOnBuild: target !== 'node',
 };
 ```
 
@@ -62,7 +62,7 @@ export default {
 ### copyOnBuild
 
 - **Type:** `boolean`
-- **Default:** `true`
+- **Default:** `target !== 'node'`
 
 Whether to copy files from the publicDir to the distDir on production build.
 
@@ -79,6 +79,18 @@ export default {
 ```
 
 Note that setting the value of `copyOnBuild` to false means that when you run `rsbuild preview` for a production preview, you will not be able to access the corresponding static resources.
+
+By default, the public directory is not copied in the node target environment. If you need to copy files from the public directory to the distDir in the node target environment, you can manually enable `copyOnBuild`:
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      copyOnBuild: true,
+    },
+  },
+};
+```
 
 :::tip
 During dev builds, if you need to copy some static assets to the output directory, you can use the [output.copy](/config/output/copy) option instead.

--- a/website/docs/zh/config/server/public-dir.mdx
+++ b/website/docs/zh/config/server/public-dir.mdx
@@ -16,7 +16,7 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: true,
+  copyOnBuild: target !== 'node',
   watch: false,
 };
 ```
@@ -63,7 +63,7 @@ export default {
 ### copyOnBuild
 
 - **类型：** `boolean`
-- **默认值：** `true`
+- **默认值：** `target !== 'node'`
 
 在生产构建时，是否将文件从 public 目录复制到构建产物目录。
 
@@ -80,6 +80,18 @@ export default {
 ```
 
 需要注意的是，将 `copyOnBuild` 的值为 false 后，如果执行 `rsbuild preview` 进行生产环境预览，将无法访问对应的静态资源文件。
+
+默认情况下，node 环境下不会进行复制。如果你需要在 node 环境下将文件从 public 目录复制到构建产物目录，可手动开启 `copyOnBuild`：
+
+```ts
+export default {
+  server: {
+    publicDir: {
+      copyOnBuild: true,
+    },
+  },
+};
+```
 
 :::tip
 在 dev 构建时，如果你需要拷贝一些静态资源到构建产物目录，可以使用 [output.copy](/config/output/copy) 选项代替。


### PR DESCRIPTION
## Summary

Do not copy public dir for node target by default. Update `publicDir.copyOnBuild` default value from `true` to `target !== 'node'` as publicDir is not normally used for node target .

Note 🔴  : This modification may cause breaking changes for some users who use publicDir in node target.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
