### PR TITLE
fix: allow `environment` option of `createRsbuild` to be an empty array

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -192,6 +192,11 @@ export async function createContext(
   const rsbuildConfig = await withDefaultConfig(rootPath, userConfig);
   const cachePath = join(rootPath, 'node_modules', '.cache');
 
+  const specifiedEnvironments =
+    options.environment && options.environment.length > 0
+      ? options.environment
+      : undefined;
+
   return {
     version: RSBUILD_VERSION,
     rootPath,
@@ -202,6 +207,6 @@ export async function createContext(
     hooks: initHooks(),
     config: { ...rsbuildConfig },
     originalConfig: userConfig,
-    specifiedEnvironments: options.environment,
+    specifiedEnvironments,
   };
 }

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -99,6 +99,8 @@ export type CreateRsbuildOptions = {
   cwd?: string;
   /**
    * Only build specified environments.
+   * For example, passing `['web']` will only build the `web` environment.
+   * If not specified or passing an empty array, all environments will be built.
    */
   environment?: string[];
   /**

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -39,7 +39,7 @@ type CreateRsbuildOptions = {
 ```
 
 - `cwd`: The root path of the current build, defaults to `process.cwd()`.
-- `environment`: Only build specified [environments](/guide/advanced/environments).
+- `environment`: Only build specified [environments](/guide/advanced/environments). If not specified or passing an empty array, all environments will be built.
 - `rsbuildConfig`: Rsbuild configuration object. Refer to [Configuration Overview](/config/) for all available configuration options.
 
 ## loadConfig

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -39,7 +39,7 @@ type CreateRsbuildOptions = {
 ```
 
 - `cwd`：当前执行构建的根路径，默认值为 `process.cwd()`
-- `environment`：只构建指定的 [environments](/guide/advanced/environments)。
+- `environment`：只构建指定的 [environments](/guide/advanced/environments)，如果未指定或传入空数组，则构建所有环境。
 - `rsbuildConfig`：Rsbuild 配置对象。参考 [配置总览](/config/) 查看所有可用的配置项。
 
 ## loadConfig


### PR DESCRIPTION
## Summary

Allow the `environment` option of `createRsbuild` to be an empty array.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
