### PR TITLE
fix: do not open browser when open parameter is set to false

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -107,11 +107,15 @@ export function resolveUrl(str: string, base: string): string {
 
 const normalizeOpenConfig = (
   config: NormalizedConfig,
-): { targets: string[]; before?: () => Promise<void> | void } => {
+): {
+  targets: string[];
+  before?: () => Promise<void> | void;
+  skip?: boolean;
+} => {
   const { open } = config.server;
 
   if (typeof open === 'boolean') {
-    return { targets: [] };
+    return { targets: [], skip: !open };
   }
   if (typeof open === 'string') {
     return { targets: [open] };
@@ -139,7 +143,10 @@ export async function open({
   config: NormalizedConfig;
   clearCache?: boolean;
 }): Promise<void> {
-  const { targets, before } = normalizeOpenConfig(config);
+  const { targets, before, skip } = normalizeOpenConfig(config);
+  if (skip) {
+    return;
+  }
 
   // Skip open in codesandbox. After being bundled, the `open` package will
   // try to call system xdg-open, which will cause an error on codesandbox.

--- a/packages/core/tests/open.test.ts
+++ b/packages/core/tests/open.test.ts
@@ -1,4 +1,5 @@
-import { replacePortPlaceholder, resolveUrl } from '../src/server/open';
+import type { NormalizedConfig, NormalizedServerConfig } from '../dist-types';
+import { open, replacePortPlaceholder, resolveUrl } from '../src/server/open';
 
 describe('plugin-open', () => {
   it('#replacePortPlaceholder - should replace port number correctly', () => {

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -73,6 +73,16 @@ export default {
 };
 ```
 
+- Do not open any browser at all:
+
+```js
+export default {
+  server: {
+    open: false,
+  },
+};
+```
+
 ## Port placeholder
 
 The port number that Rsbuild server listens on may change. For example, if the port is in use, Rsbuild will automatically increment the port number until it finds an available port.


### PR DESCRIPTION
## Summary

Allows to disable browser opening by setting the open parameter to false.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
