### PR TITLE
feat: allow `publicDir.copyOnBuild` to be 'auto'

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -679,18 +679,16 @@ export function stringifyConfig(config: unknown, verbose?: boolean): string {
   return stringify(config, { verbose });
 }
 
-type NormalizePublicDirOptions = PublicDirOptions &
-  Required<Omit<PublicDirOptions, 'copyOnBuild'>>;
-
 export const normalizePublicDirs = (
   publicDir?: PublicDir,
-): NormalizePublicDirOptions[] => {
+): Required<PublicDirOptions>[] => {
   if (publicDir === false) {
     return [];
   }
 
-  const defaultConfig: NormalizePublicDirOptions = {
+  const defaultConfig: Required<PublicDirOptions> = {
     name: 'public',
+    copyOnBuild: 'auto',
     watch: false,
   };
 

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -49,9 +49,11 @@ export const pluginServer = (): RsbuildPlugin => ({
         const distPaths = dedupeNestedPaths(
           Object.values(environments)
             .filter(
-              (e) => copyOnBuild === true || e.config.output.target !== 'node',
+              ({ config }) =>
+                copyOnBuild === true ||
+                (copyOnBuild === 'auto' && config.output.target !== 'node'),
             )
-            .map((e) => e.distPath),
+            .map(({ distPath }) => distPath),
         );
 
         try {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -324,7 +324,7 @@ export type PublicDirOptions = {
    * Whether to copy files from the public directory to the dist directory on production build.
    * - `true`: copy files
    * - `false`: do not copy files
-   * - `'auto'`: if `output.target` is not `'node'`, copy files, otherwise do not copy.
+   * - `'auto'`: if `output.target` is not `'node'`, copy files, otherwise do not copy
    * @default 'auto'
    */
   copyOnBuild?: boolean | 'auto';

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -324,7 +324,7 @@ export type PublicDirOptions = {
    * Whether to copy files from the public directory to the dist directory on production build.
    * - `true`: copy files
    * - `false`: do not copy files
-   * - `'auto'`: copy files only if `output.target` is not `'node'`
+   * - `'auto'`: if `output.target` is not `'node'`, copy files, otherwise do not copy.
    * @default 'auto'
    */
   copyOnBuild?: boolean | 'auto';

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -321,10 +321,13 @@ export type PublicDirOptions = {
    */
   name?: string;
   /**
-   * Whether to copy files from the publicDir to the distDir on production build
-   * @default target !== 'node'
+   * Whether to copy files from the public directory to the dist directory on production build.
+   * - `true`: copy files
+   * - `false`: do not copy files
+   * - `'auto'`: copy files only if `output.target` is not `'node'`
+   * @default 'auto'
    */
-  copyOnBuild?: boolean;
+  copyOnBuild?: boolean | 'auto';
   /**
    * whether to watch the public directory and reload the page when the files change
    * @default false

--- a/website/docs/en/config/server/public-dir.mdx
+++ b/website/docs/en/config/server/public-dir.mdx
@@ -5,7 +5,7 @@
 ```ts
 type PublicDirOptions = {
   name?: string;
-  copyOnBuild?: boolean;
+  copyOnBuild?: boolean | 'auto';
   watch?: boolean;
 };
 type PublicDir = false | PublicDirOptions | PublicDirOptions[];
@@ -16,7 +16,8 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: target !== 'node',
+  copyOnBuild: 'auto',
+  watch: false,
 };
 ```
 
@@ -61,10 +62,20 @@ export default {
 
 ### copyOnBuild
 
-- **Type:** `boolean`
-- **Default:** `target !== 'node'`
+- **Type:** `boolean | 'auto'`
+- **Default:** `'auto'`
 
-Whether to copy files from the publicDir to the distDir on production build.
+Whether to copy files from the public directory to the dist directory on production build.
+
+- `true`: copy files.
+- `false`: do not copy files.
+- `'auto'`: if [output.target](/config/output/target) is not `'node'`, copy files, otherwise do not copy.
+
+:::tip
+During dev builds, if you need to copy some static assets to the output directory, you can use the [output.copy](/config/output/copy) option instead.
+:::
+
+#### Disable
 
 For example, disable `copyOnBuild`:
 
@@ -80,10 +91,17 @@ export default {
 
 Note that setting the value of `copyOnBuild` to false means that when you run `rsbuild preview` for a production preview, you will not be able to access the corresponding static resources.
 
-By default, the public directory is not copied in the node target environment. If you need to copy files from the public directory to the distDir in the node target environment, you can manually enable `copyOnBuild`:
+#### Node Target
+
+By default, when [output.target](/config/output/target) is `'node'`, Rsbuild will not copy files from the public directory.
+
+You can set `copyOnBuild` to `true` to copy files for the `node` target:
 
 ```ts
 export default {
+  output: {
+    target: 'node',
+  },
   server: {
     publicDir: {
       copyOnBuild: true,
@@ -91,10 +109,6 @@ export default {
   },
 };
 ```
-
-:::tip
-During dev builds, if you need to copy some static assets to the output directory, you can use the [output.copy](/config/output/copy) option instead.
-:::
 
 #### Multiple environments
 

--- a/website/docs/zh/config/server/public-dir.mdx
+++ b/website/docs/zh/config/server/public-dir.mdx
@@ -5,7 +5,7 @@
 ```ts
 type PublicDirOptions = {
   name?: string;
-  copyOnBuild?: boolean;
+  copyOnBuild?: boolean | 'auto';
   watch?: boolean;
 };
 type PublicDir = false | PublicDirOptions | PublicDirOptions[];
@@ -16,7 +16,7 @@ type PublicDir = false | PublicDirOptions | PublicDirOptions[];
 ```js
 const defaultValue = {
   name: 'public',
-  copyOnBuild: target !== 'node',
+  copyOnBuild: 'auto',
   watch: false,
 };
 ```
@@ -62,10 +62,20 @@ export default {
 
 ### copyOnBuild
 
-- **类型：** `boolean`
-- **默认值：** `target !== 'node'`
+- **类型：** `boolean | 'auto'`
+- **默认值：** `'auto'`
 
 在生产构建时，是否将文件从 public 目录复制到构建产物目录。
+
+- `true`: 复制文件。
+- `false`: 不复制文件。
+- `'auto'`: 当 [output.target](/config/output/target) 不是 `'node'` 时，会复制文件，否则不复制。
+
+:::tip
+在 dev 构建时，如果你需要拷贝一些静态资源到构建产物目录，可以使用 [output.copy](/config/output/copy) 选项代替。
+:::
+
+#### 禁用
 
 比如关闭 `copyOnBuild`：
 
@@ -81,10 +91,17 @@ export default {
 
 需要注意的是，将 `copyOnBuild` 的值为 false 后，如果执行 `rsbuild preview` 进行生产环境预览，将无法访问对应的静态资源文件。
 
-默认情况下，node 环境下不会进行复制。如果你需要在 node 环境下将文件从 public 目录复制到构建产物目录，可手动开启 `copyOnBuild`：
+#### Node Target
+
+默认情况下，当 [output.target](/config/output/target) 为 `'node'` 时，Rsbuild 不会复制 public 目录下的文件。
+
+你可以将 `copyOnBuild` 设置为 `true` 来为 `node` target 复制文件：
 
 ```ts
 export default {
+  output: {
+    target: 'node',
+  },
   server: {
     publicDir: {
       copyOnBuild: true,
@@ -92,10 +109,6 @@ export default {
   },
 };
 ```
-
-:::tip
-在 dev 构建时，如果你需要拷贝一些静态资源到构建产物目录，可以使用 [output.copy](/config/output/copy) 选项代替。
-:::
 
 #### 多环境
 


### PR DESCRIPTION
## Summary

In https://github.com/web-infra-dev/rsbuild/pull/4281, we have changed the default value of `publicDir.copyOnBuild`.

This PR adds the `auto` value to `publicDir.copyOnBuild` to make the default behavior clearer.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
