### PR TITLE
chore(CI): fix pnpm not found in eco CI

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -34,12 +34,17 @@ jobs:
         uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
+
+      - name: Install Pnpm
+        run: corepack enable
+
       - name: Setup Node.js
         if: steps.eco_ci.outcome == 'failure'
         uses: actions/setup-node@v4.1.0
         with:
           node-version: 22
           cache: 'pnpm'
+
       - name: Send Failure Notification
         if: steps.eco_ci.outcome == 'failure'
         shell: bash


### PR DESCRIPTION
## Summary

Fix pnpm not found in eco CI:

![image](https://github.com/user-attachments/assets/13f0bb7e-7a8f-4093-8171-b1fa9d0e85f9)

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/4298
- https://github.com/web-infra-dev/rsbuild/actions/runs/12545829437/job/34980655176#step:5:9

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
