### PR TITLE
chore(CI): fix ecosystem CI failed to get commit sha

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           script: |
             await github.rest.repos.createCommitComment({
-              commit_sha: github.sha,
+              commit_sha: context.sha,
               owner: 'web-infra-dev',
               repo: 'rsbuild',
               body: ${{ steps.eco-ci-result.outputs.result }}


### PR DESCRIPTION
## Summary

Fix ecosystem CI failed to get commit sha:

![image](https://github.com/user-attachments/assets/e2502ff2-c1f9-4b91-9c16-85f523927640)

## Related Links

- https://github.com/web-infra-dev/rsbuild/actions/runs/12547473767/job/34985012119#step:9:17

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
