### PR TITLE
release: 1.2.0-alpha.0

### DIFF
--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.1.6",
+  "version": "1.2.0-alpha.0",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.1.13",
+  "version": "1.2.0-alpha.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.2.0",
+  "version": "1.3.0-alpha.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: hint more unknown file types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4274
* feat: allow to custom manifest JSON by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4289
* feat(deps): bump Rspack 1.2.0-alpha.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4296
* feat: allow `publicDir.copyOnBuild` to be 'auto' by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4299
### Performance 🚀
* perf: move overlay template to server side by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4276
* perf: replace `commander` with `cac` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4284
### Bug Fixes 🐞
* fix: should copy public dir to environment's dist dir by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/4268
* fix: ansi HTML edge cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4279
* fix: overlay renders invalid file path by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4280
* fix: allow `environment` option of `createRsbuild` to be an empty array by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4283
* fix: do not copy public dir for node target by default by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/4281
### Document 📖
* docs: update UnoCSS guide to use `@unocss/webpack` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4287
* docs: add `output.manifest.generate` config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4290
### Other Changes
* chore: prefer to use `static-changed` socket type by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4273
* refactor: rewrite ansiHTML and add test cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4277
* chore(deps): update dependency svelte to ^5.16.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4286
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4292
* chore: prepare for v1.2.0 pre-release by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4297
* chore(deps): update dependency dotenv-expand to v12 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4007
* chore(deps): update playwright monorepo to v1.49.1 - autoclosed by @renovate in https://github.com/web-infra-dev/rsbuild/pull/3342
* ci: fix notify script not found by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/4298
* chore(CI): fix pnpm not found in eco CI by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4300
* chore(CI): fix ecosystem CI failed to get commit sha by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4301


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.1.13...v1.2.0-alpha.0