### PR TITLE
fix: correct extension alias order to align with Node.js

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -362,13 +362,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -769,13 +769,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -1105,13 +1105,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -1424,13 +1424,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -116,8 +116,8 @@ export const pluginResolve = (): RsbuildPlugin => ({
           // TypeScript allows importing TS files with `.js` extension
           // See: https://github.com/microsoft/TypeScript/blob/c09e2ab4/src/compiler/moduleNameResolver.ts#L2151-L2168
           chain.resolve.extensionAlias.merge({
-            '.js': ['.ts', '.tsx', '.js'],
-            '.jsx': ['.tsx', '.jsx'],
+            '.js': ['.js', '.ts', '.tsx'],
+            '.jsx': ['.jsx', '.tsx'],
           });
         }
 

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -388,13 +388,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -845,13 +845,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -1200,13 +1200,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [
@@ -1633,13 +1633,13 @@ exports[`tools.rspack > should match snapshot 1`] = `
     },
     "extensionAlias": {
       ".js": [
+        ".js",
         ".ts",
         ".tsx",
-        ".js",
       ],
       ".jsx": [
-        ".tsx",
         ".jsx",
+        ".tsx",
       ],
     },
     "extensions": [

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -262,13 +262,13 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 2`
   ],
   "extensionAlias": {
     ".js": [
+      ".js",
       ".ts",
       ".tsx",
-      ".js",
     ],
     ".jsx": [
-      ".tsx",
       ".jsx",
+      ".tsx",
     ],
   },
   "extensions": [

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -75,8 +75,8 @@ Rsbuild supports this feature through Rspack's [extensionAlias](https://rspack.d
 const rspackConfig = {
   resolve: {
     extensionAlias: {
-      '.js': ['.ts', '.tsx', '.js'],
-      '.jsx': ['.tsx', '.jsx'],
+      '.js': ['.js', '.ts', '.tsx'],
+      '.jsx': ['.jsx', '.tsx'],
     },
   },
 };

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -75,8 +75,8 @@ Rsbuild 通过 Rspack 的 [extensionAlias](https://rspack.dev/config/resolve#res
 const rspackConfig = {
   resolve: {
     extensionAlias: {
-      '.js': ['.ts', '.tsx', '.js'],
-      '.jsx': ['.tsx', '.jsx'],
+      '.js': ['.js', '.ts', '.tsx'],
+      '.jsx': ['.jsx', '.tsx'],
     },
   },
 };


### PR DESCRIPTION
## Summary

When importing `./foo.js` in a TypeScript file, if there are both `foo.ts` and `foo.js`, Node.js and TypeScript have different resolution orders:

- TypeScript will resolve `foo.ts` first.
- Node.js will resolve `foo.js` first.

Rsbuild should match the behavior of Node.js, because:

1. It maintains consistency with Node.js runtime behavior, avoiding potential surprises when the code runs in production
2. It follows the explicit intent when developers specifically write `.js` in their import statements

This PR fixes this issue from Discord:

![image](https://github.com/user-attachments/assets/1c993f45-bfa9-4849-86c2-ba70ad87d715)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
