### PR TITLE
fix(plugin/assets-retry): addQuery and switchDomain should work in async css chunk

### DIFF
--- a/e2e/cases/assets/assets-retry/index.test.ts
+++ b/e2e/cases/assets/assets-retry/index.test.ts
@@ -684,7 +684,11 @@ test('should work with addQuery boolean option when retrying async css chunk', a
     logs,
     '/static/css/async/src_AsyncCompTest_tsx.css',
   );
-  expect(blockedAsyncChunkResponseCount).toMatchObject({});
+  expect(blockedAsyncChunkResponseCount).toMatchObject({
+    '/static/css/async/src_AsyncCompTest_tsx.css': 1,
+    '/static/css/async/src_AsyncCompTest_tsx.css?retry=1': 1,
+    '/static/css/async/src_AsyncCompTest_tsx.css?retry=2': 1,
+  });
 
   await rsbuild.close();
   restore();
@@ -897,8 +901,8 @@ test('onRetry and onFail options should work when multiple parallel retrying asy
   await rsbuild.close();
 });
 
-test('should work when the first cdn site is all failed', async ({ page }) => {
-  // this is a real world case
+test('should work when the first, second cdn are all failed and the third is success', async ({ page }) => {
+  // this is a real world case for assets-retry
   const port = await getRandomPort();
   const rsbuild = await createRsbuildWithMiddleware(
     [],

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -104,6 +104,10 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
         '__RUNTIME_GLOBALS_GET_MINI_CSS_EXTRACT_FILENAME__',
         '__webpack_require__.miniCssF',
       )
+      .replaceAll(
+        '__RUNTIME_GLOBALS_RSBUILD_LOAD_STYLESHEET__',
+        '__webpack_require__.rsbuildLoadStyleSheet',
+      )
       .replaceAll('__RUNTIME_GLOBALS_PUBLIC_PATH__', RuntimeGlobals.publicPath)
       .replaceAll('__RUNTIME_GLOBALS_LOAD_SCRIPT__', RuntimeGlobals.loadScript)
       .replaceAll('__RETRY_OPTIONS__', serialize(this.runtimeOptions));
@@ -127,7 +131,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
             (originSource) =>
               originSource.replace(
                 'var fullhref = __webpack_require__.p + href;',
-                'var fullhref = __webpack_require__.rsbuildAsyncCssRetry ? __webpack_require__.rsbuildAsyncCssRetry(href, chunkId) : (__webpack_require__.p + href);',
+                'var fullhref = __webpack_require__.rsbuildLoadStyleSheet ? __webpack_require__.rsbuildLoadStyleSheet(href, chunkId) : (__webpack_require__.p + href);',
               ),
             isRspack,
           );

--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -107,6 +107,15 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
           constructorName === 'PublicPathRuntimeModule' ||
           constructorName === 'AutoPublicPathRuntimeModule';
 
+        if (constructorName.includes('CssLoadingRuntimeModule')) {
+          // @ts-ignore
+          const source = module.source.source.toString();
+          const toCode = source.replace('var fullhref = __webpack_require__.p + href;', 'var fullhref = __webpack_require__.rsbuildAsyncCssRetry ? __webpack_require__.rsbuildAsyncCssRetry(href, chunkId) : (__webpack_require__.p + href);');
+          console.log(toCode, 2222222)
+          // @ts-ignore
+          module.source.source = Buffer.from(toCode, 'utf-8');
+        }
+
         if (!isPublicPathModule) {
           return;
         }

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -260,7 +260,8 @@ function ensureChunk(chunkId: string): Promise<unknown> {
 
   // if __webpack_require__.e is polluted by other runtime codes, fallback to originalEnsureChunk
   if (
-    typeof callingCounter?.count !== 'number' ||
+    !callingCounter ||
+    typeof callingCounter.count !== 'number' ||
     typeof callingCounter.cssFailedCount !== 'number'
   ) {
     return result;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -38,6 +38,7 @@ flexbugs
 fnames
 frontends
 fullhash
+fullhref
 gzipped
 icss
 idents

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -276,7 +276,7 @@ pluginAssetsRetry({
 
 ## Notes
 
-When you use Assets Retry plugin, the Rsbuild injects some runtime code into the HTML and serializes the Assets Retry plugin config, inserting it into the runtime code. Therefore, you need to be aware of the following:
+When you use Assets Retry plugin, the Rsbuild injects some runtime code into the HTML and [Rspack Runtime](https://rspack.dev/misc/glossary#runtime), then serializes the Assets Retry plugin config, inserting it into the runtime code. Therefore, you need to be aware of the following:
 
 - Avoid configuring sensitive information in Assets Retry plugin, such as internal tokens.
 - Avoid referencing variables or methods outside of `onRetry`, `onSuccess`, and `onFail`.

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -276,7 +276,7 @@ pluginAssetsRetry({
 
 ## 注意事项
 
-当你使用 Assets Retry 插件时，Rsbuild 会向 HTML 中注入一段运行时代码，并将 Assets Retry 插件配置的内容序列化，插入到这段代码中，因此你需要注意：
+当你使用 Assets Retry 插件时，Rsbuild 会分别向 HTML 和 [Rspack Runtime](https://rspack.dev/zh/misc/glossary#runtime) 中注入运行时代码，并将 Assets Retry 插件配置的内容序列化后插入到这些代码中，因此你需要注意：
 
 - 避免在 Assets Retry 插件中配置敏感信息，比如内部使用的 token。
 - 避免在 `onRetry`，`onSuccess`，`onFail` 中引用函数外部的变量或方法。


### PR DESCRIPTION
## Summary

fix

```ts
    // At present, we don't consider the switching domain and addQuery of async CSS chunk
    // 1. Async js chunk will be requested first. It is rare for async CSS chunk to fail alone.
    // 2. the code of loading CSS in webpack runtime is complex and it may be modified by cssExtractPlugin, increase the complexity of this plugin.
```

When I implemented this plugin, rsbuild was just switched from `experiment.css` to `cssExtractPlugin` experimentally, I didn't know much about cssExtract.

after this change, it means that `plugin-assets-retry` can only be used together with `rspack.CssExtractPlugin` and MiniCssExtractPlugin in webpack

😂 by the way, it was also not implemented in "eden"

## Related Links

close #4306
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
