### PR TITLE
perf(assets-retry): normalize options on the server side

### DIFF
--- a/packages/plugin-assets-retry/src/index.ts
+++ b/packages/plugin-assets-retry/src/index.ts
@@ -17,6 +17,33 @@ export type { PluginAssetsRetryOptions };
 
 export const PLUGIN_ASSETS_RETRY_NAME = 'rsbuild:assets-retry';
 
+function getRuntimeOptions(userOptions: PluginAssetsRetryOptions) {
+  const defaultOptions: RuntimeRetryOptions = {
+    max: 3,
+    type: ['link', 'script', 'img'],
+    domain: [],
+    crossOrigin: false,
+  };
+
+  const result: RuntimeRetryOptions = {
+    ...defaultOptions,
+    ...userOptions,
+  };
+
+  // Normalize config
+  if (!Array.isArray(result.type) || result.type.length === 0) {
+    result.type = defaultOptions.type;
+  }
+  if (!Array.isArray(result.domain) || result.domain.length === 0) {
+    result.domain = defaultOptions.domain;
+  }
+  if (Array.isArray(result.domain)) {
+    result.domain = result.domain.filter(Boolean);
+  }
+
+  return result;
+}
+
 async function getRetryCode(
   options: PluginAssetsRetryOptions,
 ): Promise<string> {
@@ -29,10 +56,11 @@ async function getRetryCode(
     minify ? `${filename}.min.js` : `${filename}.js`,
   );
   const runtimeCode = await fs.promises.readFile(runtimeFilePath, 'utf-8');
+  const runtimeOptions = getRuntimeOptions(restOptions);
 
   return `(function(){${runtimeCode}})()`.replace(
     '__RUNTIME_GLOBALS_OPTIONS__',
-    serialize(restOptions),
+    serialize(runtimeOptions),
   );
 }
 

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -12,7 +12,6 @@ const TAG_TYPE: { [propName: string]: new () => HTMLElement } = {
   script: HTMLScriptElement,
   img: HTMLImageElement,
 };
-const TYPES = Object.keys(TAG_TYPE);
 
 declare global {
   // global variables shared with async chunk
@@ -51,13 +50,6 @@ function getRequestUrl(element: HTMLElement) {
   }
   return null;
 }
-
-const defaultConfig: RuntimeRetryOptions = {
-  max: 3,
-  type: TYPES,
-  domain: [],
-  crossOrigin: false,
-};
 
 function validateTargetInfo(
   config: RuntimeRetryOptions,
@@ -352,37 +344,13 @@ function resourceMonitor(
   }
 }
 
-const config: RuntimeRetryOptions = {};
-const options = __RUNTIME_GLOBALS_OPTIONS__;
-
-for (const key in defaultConfig) {
-  // @ts-ignore
-  config[key] = defaultConfig[key];
-}
-
-for (const key in options) {
-  // @ts-ignore
-  config[key] = options[key];
-}
-
-// Normalize config
-if (!Array.isArray(config.type) || config.type.length === 0) {
-  config.type = defaultConfig.type;
-}
-if (!Array.isArray(config.domain) || config.domain.length === 0) {
-  config.domain = defaultConfig.domain;
-}
-
-if (Array.isArray(config.domain)) {
-  config.domain = config.domain.filter(Boolean);
-}
-
 // init global variables shared with async chunk
 if (typeof window !== 'undefined' && !window.__RB_ASYNC_CHUNKS__) {
   window.__RB_ASYNC_CHUNKS__ = {};
 }
 // Bind event in window
 try {
+  const config = __RUNTIME_GLOBALS_OPTIONS__;
   resourceMonitor(
     (e: Event) => {
       try {


### PR DESCRIPTION
## Summary

Normalize runtime options on the server side, this can reduce the client side code:

- initialChunkRetry.min.js: `4,275 bytes` -> `3,980 bytes`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
