### PR TITLE
fix: no need to use extensionAlias when using jsconfig.json

### DIFF
--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -112,7 +112,9 @@ export const pluginResolve = (): RsbuildPlugin => ({
 
         chain.resolve.extensions.merge([...config.resolve.extensions]);
 
-        if (tsconfigPath && !tsconfigPath.endsWith('jsconfig.json')) {
+        const isTsProject =
+          tsconfigPath && !tsconfigPath.endsWith('jsconfig.json');
+        if (isTsProject) {
           // TypeScript allows importing TS files with `.js` extension
           // See: https://github.com/microsoft/TypeScript/blob/c09e2ab4/src/compiler/moduleNameResolver.ts#L2151-L2168
           chain.resolve.extensionAlias.merge({

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -112,7 +112,7 @@ export const pluginResolve = (): RsbuildPlugin => ({
 
         chain.resolve.extensions.merge([...config.resolve.extensions]);
 
-        if (tsconfigPath) {
+        if (tsconfigPath && !tsconfigPath.endsWith('jsconfig.json')) {
           // TypeScript allows importing TS files with `.js` extension
           // See: https://github.com/microsoft/TypeScript/blob/c09e2ab4/src/compiler/moduleNameResolver.ts#L2151-L2168
           chain.resolve.extensionAlias.merge({


### PR DESCRIPTION
## Summary

Rsbuild allows the path alias to be read from `jsconfig.json`, see https://rsbuild.dev/guide/advanced/alias#jsconfigjson

In this case `extensionAlias` should not be used.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
