### PR TITLE
docs: add `@ng-rsbuild/plugin-angular` to plugins list

### DIFF
--- a/website/docs/en/plugins/list/index.mdx
+++ b/website/docs/en/plugins/list/index.mdx
@@ -49,6 +49,10 @@ Plugins available for the Solid framework:
 
 - [Solid Plugin](/plugins/list/plugin-solid): Provides support for Solid.
 
+### For Angular
+
+[@ng-rsbuild/plugin-angular](https://github.com/Coly010/ng-rspack-build) is a community-maintained Rsbuild plugin that allows you to build Angular applications easily.
+
 ### Common
 
 The following are common framework-agnostic plugins:

--- a/website/docs/zh/plugins/list/index.mdx
+++ b/website/docs/zh/plugins/list/index.mdx
@@ -49,6 +49,10 @@
 
 - [Solid 插件](/plugins/list/plugin-solid)：提供对 Solid 的支持。
 
+### Angular
+
+[@ng-rsbuild/plugin-angular](https://github.com/Coly010/ng-rspack-build) 是一个社区维护的 Rsbuild 插件，允许你轻松直接地构建 Angular 应用程序。
+
 ### 通用插件
 
 以下是与框架无关的通用插件：


### PR DESCRIPTION
## Summary

This pull request includes updates to the documentation to add the Angular plugin to the list of available plugins

## Related Links

https://github.com/Coly010/ng-rspack-build

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
