### PR TITLE
perf(assets-retry): reduce nullish coalescing operator

### DIFF
--- a/e2e/cases/assets/assets-retry/index.test.ts
+++ b/e2e/cases/assets/assets-retry/index.test.ts
@@ -77,7 +77,7 @@ async function createRsbuildWithMiddleware(
   options: PluginAssetsRetryOptions,
   entry?: string,
   port?: number,
-  assetPrefix?: string
+  assetPrefix?: string,
 ) {
   const rsbuild = await dev({
     cwd: __dirname,
@@ -94,9 +94,11 @@ async function createRsbuildWithMiddleware(
             middlewares.unshift(...addMiddleWares);
           },
         ],
-        ...(assetPrefix ? {
-          assetPrefix
-        }: {})
+        ...(assetPrefix
+          ? {
+              assetPrefix,
+            }
+          : {}),
       },
       ...(port
         ? {
@@ -111,10 +113,7 @@ async function createRsbuildWithMiddleware(
           }
         : {}),
       output: {
-        sourceMap: {
-          css: false,
-          js: false,
-        },
+        sourceMap: false,
       },
     },
   });
@@ -465,7 +464,11 @@ test('domain, onRetry and onFail options should work when retrying initial chunk
     blockedMiddleware,
     {
       minify: true,
-      domain: [`http://localhost:${port}`, 'http://a.com/foo-path', 'http://b.com'],
+      domain: [
+        `http://localhost:${port}`,
+        'http://a.com/foo-path',
+        'http://b.com',
+      ],
       onRetry(context) {
         console.info('onRetry', context);
       },
@@ -541,7 +544,11 @@ test('domain, onRetry and onFail options should work when retrying async chunk f
     blockedMiddleware,
     {
       minify: true,
-      domain: [`http://localhost:${port}`, 'http://a.com/foo-path', 'http://b.com'],
+      domain: [
+        `http://localhost:${port}`,
+        'http://a.com/foo-path',
+        'http://b.com',
+      ],
       onRetry(context) {
         console.info('onRetry', context);
       },
@@ -659,7 +666,9 @@ test('should work with addQuery boolean option', async ({ page }) => {
   logger.level = 'log';
 });
 
-test('should work with addQuery boolean option when retrying async css chunk', async ({ page }) => {
+test('should work with addQuery boolean option when retrying async css chunk', async ({
+  page,
+}) => {
   logger.level = 'verbose';
   const { logs, restore } = proxyConsole();
 
@@ -678,7 +687,10 @@ test('should work with addQuery boolean option when retrying async css chunk', a
   await gotoPage(page, rsbuild);
   const asyncCompTestElement = page.locator('#async-comp-test');
   await expect(asyncCompTestElement).toHaveText('Hello AsyncCompTest');
-  await expect(asyncCompTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
+  await expect(asyncCompTestElement).toHaveCSS(
+    'background-color',
+    'rgb(0, 0, 139)',
+  );
 
   const blockedAsyncChunkResponseCount = count404ResponseByUrl(
     logs,
@@ -901,14 +913,20 @@ test('onRetry and onFail options should work when multiple parallel retrying asy
   await rsbuild.close();
 });
 
-test('should work when the first, second cdn are all failed and the third is success', async ({ page }) => {
+test('should work when the first, second cdn are all failed and the third is success', async ({
+  page,
+}) => {
   // this is a real world case for assets-retry
   const port = await getRandomPort();
   const rsbuild = await createRsbuildWithMiddleware(
     [],
     {
       minify: true,
-      domain: ['http://a.com/foo-path', 'http://b.com', `http://localhost:${port}`],
+      domain: [
+        'http://a.com/foo-path',
+        'http://b.com',
+        `http://localhost:${port}`,
+      ],
       addQuery: true,
       onRetry(context) {
         console.info('onRetry', context);
@@ -922,11 +940,11 @@ test('should work when the first, second cdn are all failed and the third is suc
     },
     undefined,
     port,
-    'http://a.com/foo-path'
+    'http://a.com/foo-path',
   );
 
   await gotoPage(page, rsbuild);
   const compTestElement = page.locator('#async-comp-test');
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
   await expect(compTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
-})
+});

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -237,7 +237,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
 
   // if the initial request is "/static/js/async/src_Hello_tsx.js?q=1", retry url would be "/static/js/async/src_Hello_tsx.js?q=1&retry=1"
   const originalQuery =
-    target.dataset.rsbuildOriginalQuery || getQueryFromUrl(url);
+    target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
 
   // this function is the same as async chunk retry
   function getUrlRetryQuery(existRetryTimes: number): string {

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -20,11 +20,11 @@ declare global {
 }
 
 // this function is the same as async chunk retry
-function findCurrentDomain(url: string, domainList: string[]) {
+function findCurrentDomain(url: string, domains: string[]) {
   let domain = '';
-  for (let i = 0; i < domainList.length; i++) {
-    if (url.indexOf(domainList[i]) !== -1) {
-      domain = domainList[i];
+  for (let i = 0; i < domains.length; i++) {
+    if (url.indexOf(domains[i]) !== -1) {
+      domain = domains[i];
       break;
     }
   }
@@ -32,10 +32,10 @@ function findCurrentDomain(url: string, domainList: string[]) {
 }
 
 // this function is the same as async chunk retry
-function findNextDomain(url: string, domainList: string[]) {
-  const currentDomain = findCurrentDomain(url, domainList);
-  const index = domainList.indexOf(currentDomain);
-  return domainList[(index + 1) % domainList.length] || url;
+function findNextDomain(url: string, domains: string[]) {
+  const currentDomain = findCurrentDomain(url, domains);
+  const index = domains.indexOf(currentDomain);
+  return domains[(index + 1) % domains.length] || url;
 }
 
 function getRequestUrl(element: HTMLElement) {
@@ -56,7 +56,7 @@ function validateTargetInfo(
   e: Event,
 ): { target: HTMLElement; tagName: string; url: string } | false {
   const target: HTMLElement = e.target as HTMLElement;
-  const tagName = target.tagName?.toLocaleLowerCase();
+  const tagName = target.tagName.toLocaleLowerCase();
   const allowTags = config.type!;
   const url = getRequestUrl(target);
   if (
@@ -237,7 +237,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
 
   // if the initial request is "/static/js/async/src_Hello_tsx.js?q=1", retry url would be "/static/js/async/src_Hello_tsx.js?q=1&retry=1"
   const originalQuery =
-    target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
+    target.dataset.rsbuildOriginalQuery || getQueryFromUrl(url);
 
   // this function is the same as async chunk retry
   function getUrlRetryQuery(existRetryTimes: number): string {


### PR DESCRIPTION
## Summary

The nullish coalescing operator is very useful in modern JS code, but it generates some extra code when it is transpiled to ES5.

This PR uses `||` to replace `??` because they are equivalent in the assets retry runtime code.

- `initialChunkRetry.min.js`: 3,980 bytes -> 3,946 bytes
- `asyncChunkRetry.min.js`: 3,778 bytes -> 3,575 byte

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
