### PR TITLE
perf(assets-retry): use shorter namespace prefix

### DIFF
--- a/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
+++ b/packages/plugin-assets-retry/src/AsyncChunkRetryPlugin.ts
@@ -106,7 +106,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
       )
       .replaceAll(
         '__RUNTIME_GLOBALS_RSBUILD_LOAD_STYLESHEET__',
-        '__webpack_require__.rsbuildLoadStyleSheet',
+        '__webpack_require__.rbLoadStyleSheet',
       )
       .replaceAll('__RUNTIME_GLOBALS_PUBLIC_PATH__', RuntimeGlobals.publicPath)
       .replaceAll('__RUNTIME_GLOBALS_LOAD_SCRIPT__', RuntimeGlobals.loadScript)
@@ -131,7 +131,7 @@ class AsyncChunkRetryPlugin implements Rspack.RspackPluginInstance {
             (originSource) =>
               originSource.replace(
                 'var fullhref = __webpack_require__.p + href;',
-                'var fullhref = __webpack_require__.rsbuildLoadStyleSheet ? __webpack_require__.rsbuildLoadStyleSheet(href, chunkId) : (__webpack_require__.p + href);',
+                'var fullhref = __webpack_require__.rbLoadStyleSheet ? __webpack_require__.rbLoadStyleSheet(href, chunkId) : (__webpack_require__.p + href);',
               ),
             isRspack,
           );

--- a/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/asyncChunkRetry.ts
@@ -43,7 +43,7 @@ declare global {
     | undefined;
   // RuntimeGlobals.loadScript
   var __RUNTIME_GLOBALS_LOAD_SCRIPT__: LoadScript;
-  // __webpack_require__.rsbuildLoadStyleSheet
+  // __webpack_require__.rbLoadStyleSheet
   var __RUNTIME_GLOBALS_RSBUILD_LOAD_STYLESHEET__: LoadStyleSheet;
   // RuntimeGlobals.publicPath
   var __RUNTIME_GLOBALS_PUBLIC_PATH__: string;

--- a/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
+++ b/packages/plugin-assets-retry/src/runtime/initialChunkRetry.ts
@@ -89,13 +89,13 @@ function createElement(
     attributes.crossOrigin === true ? 'anonymous' : attributes.crossOrigin;
   const crossOriginAttr = crossOrigin ? `crossorigin="${crossOrigin}"` : '';
   const retryTimesAttr = attributes.times
-    ? `data-rsbuild-retry-times="${attributes.times}"`
+    ? `data-rb-retry-times="${attributes.times}"`
     : '';
 
   const originalQueryAttr = attributes.originalQuery
-    ? `data-rsbuild-original-query="${attributes.originalQuery}"`
+    ? `data-rb-original-query="${attributes.originalQuery}"`
     : '';
-  const isAsyncAttr = attributes.isAsync ? 'data-rsbuild-async' : '';
+  const isAsyncAttr = attributes.isAsync ? 'data-rb-async' : '';
 
   if (origin instanceof HTMLScriptElement) {
     const script = document.createElement('script');
@@ -104,13 +104,13 @@ function createElement(
       script.crossOrigin = crossOrigin;
     }
     if (attributes.times) {
-      script.dataset.rsbuildRetryTimes = String(attributes.times);
+      script.dataset.rbRetryTimes = String(attributes.times);
     }
     if (attributes.isAsync) {
-      script.dataset.rsbuildAsync = '';
+      script.dataset.rbAsync = '';
     }
     if (attributes.originalQuery !== undefined) {
-      script.dataset.rsbuildOriginalQuery = attributes.originalQuery;
+      script.dataset.rbOriginalQuery = attributes.originalQuery;
     }
 
     return {
@@ -135,10 +135,10 @@ function createElement(
       link.crossOrigin = crossOrigin;
     }
     if (attributes.times) {
-      link.dataset.rsbuildRetryTimes = String(attributes.times);
+      link.dataset.rbRetryTimes = String(attributes.times);
     }
     if (attributes.originalQuery !== undefined) {
-      link.dataset.rsbuildOriginalQuery = attributes.originalQuery;
+      link.dataset.rbOriginalQuery = attributes.originalQuery;
     }
     return {
       element: link,
@@ -170,8 +170,8 @@ function reloadElementResource(
 
   if (origin instanceof HTMLImageElement) {
     origin.src = attributes.url;
-    origin.dataset.rsbuildRetryTimes = String(attributes.times);
-    origin.dataset.rsbuildOriginalQuery = String(attributes.originalQuery);
+    origin.dataset.rbRetryTimes = String(attributes.times);
+    origin.dataset.rbOriginalQuery = String(attributes.originalQuery);
   }
 }
 
@@ -217,7 +217,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   }
 
   // If the retry times has exceeded the maximum, fail
-  const existRetryTimes = Number(target.dataset.rsbuildRetryTimes) || 0;
+  const existRetryTimes = Number(target.dataset.rbRetryTimes) || 0;
   if (existRetryTimes === config.max!) {
     if (typeof config.onFail === 'function') {
       const context: AssetsRetryHookContext = {
@@ -236,8 +236,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   const nextDomain = findNextDomain(domain, config.domain!);
 
   // if the initial request is "/static/js/async/src_Hello_tsx.js?q=1", retry url would be "/static/js/async/src_Hello_tsx.js?q=1&retry=1"
-  const originalQuery =
-    target.dataset.rsbuildOriginalQuery ?? getQueryFromUrl(url);
+  const originalQuery = target.dataset.rbOriginalQuery ?? getQueryFromUrl(url);
 
   // this function is the same as async chunk retry
   function getUrlRetryQuery(existRetryTimes: number): string {
@@ -266,7 +265,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
   }
 
   const isAsync =
-    Boolean(target.dataset.rsbuildAsync) ||
+    Boolean(target.dataset.rbAsync) ||
     (target as HTMLScriptElement).async ||
     (target as HTMLScriptElement).defer;
 
@@ -280,7 +279,7 @@ function retry(config: RuntimeRetryOptions, e: Event) {
 
   const element = createElement(target, attributes)!;
 
-  if (config.onRetry && typeof config.onRetry === 'function') {
+  if (typeof config.onRetry === 'function') {
     const context: AssetsRetryHookContext = {
       times: existRetryTimes,
       domain,
@@ -301,7 +300,7 @@ function load(config: RuntimeRetryOptions, e: Event) {
   }
   const { target, tagName, url } = targetInfo;
   const domain = findCurrentDomain(url, config.domain!);
-  const retryTimes = Number(target.dataset.rsbuildRetryTimes) || 0;
+  const retryTimes = Number(target.dataset.rbRetryTimes) || 0;
   if (retryTimes === 0) {
     return;
   }


### PR DESCRIPTION
## Summary

Use shorter namespace prefix to reduce bundle size.

- `initialChunkRetry.min.js`: 3,946 bytes -> 3,865 bytes

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
