### PR TITLE
chore: remove unused internal.ts

### DIFF
--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -1,6 +1,0 @@
-/**
- * @private
- * Some internal methods of Rsbuild.
- * Please do not use them in your Rsbuild project or plugins.
- */
-export { setHTMLPlugin } from './pluginHelper';


### PR DESCRIPTION
## Summary

`internal.ts` is no longer used since https://github.com/web-infra-dev/rsbuild/pull/4297.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
