### PR TITLE
chore(workflow): merge release PR first

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,5 +216,5 @@ Repository maintainers can publish a new version of changed packages to npm.
 2. Run [changesets](https://github.com/changesets/changesets) to bump changed packages and commit the changes.
 3. Create a pull request, the title should be `release: v1.2.0`.
 4. Run the [release action](https://github.com/web-infra-dev/rsbuild/actions/workflows/release.yml) to publish packages to npm.
-5. Generate the [release notes](https://github.com/web-infra-dev/rsbuild/releases) via GitHub, see [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)
-6. Merge the release pull request to `main`.
+5. Merge the release pull request to `main`.
+6. Generate the [release notes](https://github.com/web-infra-dev/rsbuild/releases) via GitHub, see [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)


### PR DESCRIPTION
## Summary

Update the release workflow: merge release PR before generating the release tag.

## Related Links

https://github.com/web-infra-dev/rslib/blob/main/CONTRIBUTING.md#releasing

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
