### PR TITLE
chore: avoid using `constructor.name`

### DIFF
--- a/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
+++ b/packages/compat/plugin-webpack-swc/tests/__snapshots__/plugin.test.ts.snap
@@ -145,7 +145,9 @@ exports[`plugin-webpack-swc > output.sourceMap config for swcMinimizerPlugin 1`]
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -265,7 +267,9 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
   {
@@ -376,7 +380,9 @@ exports[`plugin-webpack-swc > should apply multiple environment configs correctl
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -495,7 +501,9 @@ exports[`plugin-webpack-swc > should apply source.include and source.exclude cor
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -1326,7 +1334,9 @@ exports[`plugin-webpack-swc > should set swc-loader 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -1468,7 +1478,9 @@ exports[`plugin-webpack-swc > should use output config 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -247,7 +247,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HotModuleReplacementPlugin {
       "options": {},
     },
@@ -657,7 +659,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
@@ -1070,7 +1074,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     DefinePlugin {
       "definitions": {
         "import.meta.env.ASSET_PREFIX": "\\"\\"",
@@ -1389,7 +1395,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     DefinePlugin {
       "definitions": {
         "import.meta.env.ASSET_PREFIX": "\\"\\"",

--- a/packages/compat/webpack/tests/__snapshots__/environment.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/environment.test.ts.snap
@@ -8,7 +8,9 @@ exports[`environment config > tools.webpack / bundlerChain can be used in enviro
       "filename": "[name].web.js",
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
   {
@@ -17,7 +19,9 @@ exports[`environment config > tools.webpack / bundlerChain can be used in enviro
       "filename": "bundle.js",
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -7,7 +7,9 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "foo": "2",
     },
   },
-  RsbuildCorePlugin {},
+  {
+    "name": "RsbuildCorePlugin",
+  },
   MiniCssExtractPlugin {
     "_sortedModulesCache": WeakMap {},
     "options": {
@@ -124,7 +126,9 @@ exports[`webpackConfig > should allow to use tools.webpackChain to modify config
 {
   "devtool": "eval",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -133,7 +137,9 @@ exports[`webpackConfig > should allow tools.webpack to be an array 1`] = `
 {
   "devtool": "source-map",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -142,7 +148,9 @@ exports[`webpackConfig > should allow tools.webpack to be an object 1`] = `
 {
   "devtool": "eval",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -151,7 +159,9 @@ exports[`webpackConfig > should allow tools.webpack to modify config object 1`] 
 {
   "devtool": "eval-cheap-source-map",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -160,7 +170,9 @@ exports[`webpackConfig > should allow tools.webpack to return config 1`] = `
 {
   "devtool": "eval",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -169,7 +181,9 @@ exports[`webpackConfig > should allow tools.webpackChain to be an array 1`] = `
 {
   "devtool": "source-map",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -178,7 +192,9 @@ exports[`webpackConfig > should provide mergeConfig util in tools.webpack functi
 {
   "devtool": "eval",
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/compat/webpack/tests/default.test.ts
+++ b/packages/compat/webpack/tests/default.test.ts
@@ -95,7 +95,9 @@ describe('bundlerApi', () => {
       {
         "devtool": "hidden-source-map",
         "plugins": [
-          RsbuildCorePlugin {},
+          {
+            "name": "RsbuildCorePlugin",
+          },
         ],
         "target": "node",
       }

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -173,11 +173,4 @@ export default defineConfig({
       },
     },
   ],
-  tools: {
-    swc: {
-      jsc: {
-        keepClassNames: true,
-      },
-    },
-  },
 });

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -333,7 +333,7 @@ export const isMultiCompiler = <
 >(
   compiler: C | M,
 ): compiler is M => {
-  return compiler.constructor.name === 'MultiCompiler';
+  return 'compilers' in compiler && Array.isArray(compiler.compilers);
 };
 
 export function pick<T, U extends keyof T>(

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -169,6 +169,8 @@ export function initPluginAPI({
      * Transform Rsbuild plugin hooks to Rspack plugin hooks
      */
     class RsbuildCorePlugin {
+      name = pluginName;
+
       apply(compiler: Compiler): void {
         compiler.__rsbuildTransformer = transformer;
 

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -167,6 +167,8 @@ function generateLinks(
 export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   readonly options: PreloadOrPreFetchOption;
 
+  name = 'HtmlPreloadOrPrefetchPlugin';
+
   resourceHints: HtmlRspackPlugin.HtmlTagObject[] = [];
 
   type: LinkType;
@@ -187,7 +189,7 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   }
 
   apply(compiler: Compiler): void {
-    compiler.hooks.compilation.tap(this.constructor.name, (compilation) => {
+    compiler.hooks.compilation.tap(this.name, (compilation) => {
       getHTMLPlugin()
         .getHooks(compilation)
         .beforeAssetTagGeneration.tap(

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -118,7 +118,9 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -241,7 +243,9 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -364,7 +368,9 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -487,7 +493,9 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -23,7 +23,9 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -55,7 +57,9 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
   "watchOptions": {
     "aggregateTimeout": 0,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -313,7 +313,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    RsbuildCorePlugin {
+      "name": "RsbuildCorePlugin",
+    },
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },

--- a/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
+++ b/packages/core/tests/__snapshots__/bundleAnalyzer.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
@@ -38,7 +40,9 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin 1`] = `
 exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle analyze is enabled in environments 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {
@@ -73,7 +77,9 @@ exports[`plugin-bundle-analyze > should add bundle analyze plugin when bundle an
 exports[`plugin-bundle-analyze > should enable bundle analyze plugin when performance.profile is enable 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     BundleAnalyzerPlugin {
       "logger": Logger {
         "activeLevels": Set {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -48,7 +48,9 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -91,7 +93,9 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -144,7 +148,9 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -313,7 +313,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },
@@ -764,7 +766,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].[contenthash:8].css",
@@ -1177,7 +1181,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     DefinePlugin {
       "_args": [
         {
@@ -1558,7 +1564,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
     TestPlugin {
       "name": "TestPlugin",
     },
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HotModuleReplacementPlugin {
       "name": "HotModuleReplacementPlugin",
     },

--- a/packages/core/tests/__snapshots__/define.test.ts.snap
+++ b/packages/core/tests/__snapshots__/define.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`plugin-define > should register define plugin correctly 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     DefinePlugin {
       "_args": [
         {

--- a/packages/core/tests/__snapshots__/entry.test.ts.snap
+++ b/packages/core/tests/__snapshots__/entry.test.ts.snap
@@ -9,7 +9,9 @@ exports[`plugin-entry > should apply different environments entry config correct
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
   {
@@ -19,7 +21,9 @@ exports[`plugin-entry > should apply different environments entry config correct
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -34,7 +38,9 @@ exports[`plugin-entry > should apply environments entry config correctly 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
   {
@@ -44,7 +50,9 @@ exports[`plugin-entry > should apply environments entry config correctly 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1590,7 +1590,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "hints": false,
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      RsbuildCorePlugin {
+        "name": "RsbuildCorePlugin",
+      },
       HotModuleReplacementPlugin {
         "name": "HotModuleReplacementPlugin",
       },
@@ -1933,7 +1935,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "hints": false,
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      RsbuildCorePlugin {
+        "name": "RsbuildCorePlugin",
+      },
       DefinePlugin {
         "_args": [
           {

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -11,7 +11,9 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -127,7 +129,9 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -174,7 +178,9 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -230,7 +236,9 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -285,7 +293,9 @@ exports[`plugin-html > should enable minify in production 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -340,7 +350,9 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -395,7 +407,9 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -450,7 +464,9 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,
@@ -506,7 +522,9 @@ exports[`plugin-html > should support environment html config 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
       HtmlRspackPlugin {
         "options": {
           "base": false,
@@ -558,7 +576,9 @@ exports[`plugin-html > should support environment html config 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
       HtmlRspackPlugin {
         "options": {
           "base": false,
@@ -617,7 +637,9 @@ exports[`plugin-html > should support multi entry 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     HtmlRspackPlugin {
       "options": {
         "base": false,

--- a/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
+++ b/packages/core/tests/__snapshots__/moduleFederation.test.ts.snap
@@ -13,7 +13,9 @@ exports[`plugin-module-federation > should set environment module federation con
       "uniqueName": "remote",
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
       _ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -52,7 +54,9 @@ exports[`plugin-module-federation > should set environment module federation con
       },
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -71,7 +75,9 @@ exports[`plugin-module-federation > should set module federation and environment
       "uniqueName": "remote",
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
       _ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -104,7 +110,9 @@ exports[`plugin-module-federation > should set module federation and environment
       "uniqueName": "remote",
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
       _ModuleFederationPlugin {
         "_options": {
           "exposes": {
@@ -144,7 +152,9 @@ exports[`plugin-module-federation > should set module federation config 1`] = `
     "uniqueName": "remote",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     _ModuleFederationPlugin {
       "_options": {
         "exposes": {

--- a/packages/core/tests/__snapshots__/nodeAddons.test.ts.snap
+++ b/packages/core/tests/__snapshots__/nodeAddons.test.ts.snap
@@ -19,7 +19,9 @@ exports[`plugin-node-addons > should add node addons rule properly 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -14,7 +14,9 @@ exports[`plugin-output > output config should works when target is node 1`] = `
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -33,7 +35,9 @@ exports[`plugin-output > should allow to custom server directory with distPath.r
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -49,7 +53,9 @@ exports[`plugin-output > should allow to set distPath.js and distPath.css to emp
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "async/[name].css",
@@ -72,7 +78,9 @@ exports[`plugin-output > should allow to use copy plugin 1`] = `
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CopyRspackPlugin {
       "_args": [
         {
@@ -108,7 +116,9 @@ exports[`plugin-output > should allow to use copy plugin with multiple config 1`
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CopyRspackPlugin {
       "_args": [
         {
@@ -146,7 +156,9 @@ exports[`plugin-output > should allow to use filename.js to modify filename 1`] 
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",
@@ -169,7 +181,9 @@ exports[`plugin-output > should set output correctly 1`] = `
     "publicPath": "/",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",

--- a/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/splitChunks.test.ts.snap
@@ -17,7 +17,9 @@ exports[`plugin-split-chunks > should allow forceSplitting to be an object 1`] =
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -28,7 +30,9 @@ exports[`plugin-split-chunks > should not split chunks when target is node 1`] =
     "splitChunks": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -39,7 +43,9 @@ exports[`plugin-split-chunks > should set all-in-one config 1`] = `
     "splitChunks": false,
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -61,7 +67,9 @@ exports[`plugin-split-chunks > should set custom config 1`] = `
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -77,7 +85,9 @@ exports[`plugin-split-chunks > should set single-size config 1`] = `
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -99,7 +109,9 @@ exports[`plugin-split-chunks > should set single-vendor config 1`] = `
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -124,7 +136,9 @@ exports[`plugin-split-chunks > should set split-by-experience config 1`] = `
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -144,7 +158,9 @@ exports[`plugin-split-chunks > should set split-by-experience config correctly w
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -166,7 +182,9 @@ exports[`plugin-split-chunks > should set split-by-module config 1`] = `
     },
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -102,7 +102,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -230,7 +232,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -756,7 +760,9 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -870,7 +876,9 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -976,7 +984,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -1090,7 +1100,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -1215,7 +1227,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -1341,7 +1355,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -1466,7 +1482,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]
@@ -1572,7 +1590,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
       ],
     },
     "plugins": [
-      RsbuildCorePlugin {},
+      {
+        "name": "RsbuildCorePlugin",
+      },
     ],
   },
 ]

--- a/packages/core/tests/__snapshots__/wasm.test.ts.snap
+++ b/packages/core/tests/__snapshots__/wasm.test.ts.snap
@@ -21,7 +21,9 @@ exports[`plugin-wasm > should add wasm rule properly 1`] = `
     "webassemblyModuleFilename": "static/wasm/[hash].module.wasm",
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -110,7 +110,9 @@ describe('bundlerApi', () => {
       {
         "devtool": "hidden-source-map",
         "plugins": [
-          RsbuildCorePlugin {},
+          {
+            "name": "RsbuildCorePlugin",
+          },
         ],
         "target": "node",
       }
@@ -153,7 +155,9 @@ describe('bundlerApi', () => {
           ],
         },
         "plugins": [
-          RsbuildCorePlugin {},
+          {
+            "name": "RsbuildCorePlugin",
+          },
         ],
       }
     `);
@@ -195,7 +199,9 @@ describe('bundlerApi', () => {
           ],
         },
         "plugins": [
-          RsbuildCorePlugin {},
+          {
+            "name": "RsbuildCorePlugin",
+          },
         ],
       }
     `);

--- a/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
+++ b/packages/plugin-assets-retry/tests/__snapshots__/assetsRetry.test.ts.snap
@@ -3,7 +3,9 @@
 exports[`plugin-assets-retry > should accept user custom options 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     AsyncChunkRetryPlugin {
       "name": "ASYNC_CHUNK_RETRY_PLUGIN",
       "options": {
@@ -50,7 +52,9 @@ exports[`plugin-assets-retry > should accept user custom options 1`] = `
 exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     AsyncChunkRetryPlugin {
       "name": "ASYNC_CHUNK_RETRY_PLUGIN",
       "options": {
@@ -67,7 +71,9 @@ exports[`plugin-assets-retry > should add assets retry plugin 1`] = `
 exports[`plugin-assets-retry > should't add assets retry plugin when target is set to 'node' 1`] = `
 {
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -294,7 +294,9 @@ exports[`plugins/babel > should set babel-loader 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;
@@ -350,7 +352,9 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
 }
 `;

--- a/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-solid/tests/__snapshots__/index.test.ts.snap
@@ -46,7 +46,9 @@ exports[`plugin-solid > should allow to configure solid preset options 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
   "resolve": {
     "alias": {
@@ -99,7 +101,9 @@ exports[`plugin-solid > should apply solid preset correctly 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
   ],
   "resolve": {
     "alias": {

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -24,7 +24,9 @@ exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 1`] = 
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     Plugin {},
   ],
   "resolve": {
@@ -60,7 +62,9 @@ exports[`plugin-vue > should allow to configure vueLoader options 1`] = `
     ],
   },
   "plugins": [
-    RsbuildCorePlugin {},
+    {
+      "name": "RsbuildCorePlugin",
+    },
     Plugin {},
   ],
   "resolve": {


### PR DESCRIPTION
## Summary

Avoid using `constructor.name` as this is an unsafe judgement.

## Related Links

https://github.com/web-infra-dev/rslib/issues/652

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
