### PR TITLE
docs: only generate stats.json

### DIFF
--- a/website/docs/en/config/performance/bundle-analyze.mdx
+++ b/website/docs/en/config/performance/bundle-analyze.mdx
@@ -107,6 +107,27 @@ export default {
 };
 ```
 
+In the output directory, you will see `stats.json` and `report-web.html` files.
+
+```
+└── dist
+    ├── stats.json
+    └── report-web.html
+```
+
+If you don't need the `report-web.html`, you can set `analyzerMode` to `disabled`.
+
+```js
+export default {
+  performance: {
+    bundleAnalyze: {
+      analyzerMode: 'disabled',
+      generateStatsFile: true,
+    },
+  },
+};
+```
+
 ## Notes
 
 1. Enabling the server mode will cause the `build` process to not exit normally.

--- a/website/docs/zh/config/performance/bundle-analyze.mdx
+++ b/website/docs/zh/config/performance/bundle-analyze.mdx
@@ -107,6 +107,27 @@ export default {
 };
 ```
 
+在产物目录下会生成 `stats.json` 和 `report-web.html` 文件。
+
+```
+└── dist
+    ├── stats.json
+    └── report-web.html
+```
+
+如果你不需要 `report-web.html`，可以设置 `analyzerMode` 为 `disabled`。
+
+```js
+export default {
+  performance: {
+    bundleAnalyze: {
+      analyzerMode: 'disabled',
+      generateStatsFile: true,
+    },
+  },
+};
+```
+
 ## 注意事项
 
 1. 开启 Server 模式会导致 `build` 进程不能正常退出。


### PR DESCRIPTION
## Summary

This pull request includes updates to the `bundle-analyze` documentation. The changes provide instructions on how to disable the `report-web.html` file if it is not needed.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/4338

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
