### PR TITLE
fix: deprecation warning when using proxy with Node 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   },
+  "pnpm": {
+    "patchedDependencies": {
+      "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch"
+    }
+  },
   "packageManager": "pnpm@9.11.0",
   "engines": {
     "node": ">=18.0.0",

--- a/patches/http-proxy@1.18.1.patch
+++ b/patches/http-proxy@1.18.1.patch
@@ -1,0 +1,46 @@
+diff --git a/lib/http-proxy/common.js b/lib/http-proxy/common.js
+index 6513e81d80d5250ea249ea833f819ece67897c7e..486d4c896d65a3bb7cf63307af68facb3ddb886b 100644
+--- a/lib/http-proxy/common.js
++++ b/lib/http-proxy/common.js
+@@ -1,6 +1,5 @@
+ var common   = exports,
+     url      = require('url'),
+-    extend   = require('util')._extend,
+     required = require('requires-port');
+ 
+ var upgradeHeader = /(^|,)\s*upgrade\s*($|,)/i,
+@@ -40,10 +39,10 @@ common.setupOutgoing = function(outgoing, options, req, forward) {
+   );
+ 
+   outgoing.method = options.method || req.method;
+-  outgoing.headers = extend({}, req.headers);
++  outgoing.headers = Object.assign({}, req.headers);
+ 
+   if (options.headers){
+-    extend(outgoing.headers, options.headers);
++    Object.assign(outgoing.headers, options.headers);
+   }
+ 
+   if (options.auth) {
+diff --git a/lib/http-proxy/index.js b/lib/http-proxy/index.js
+index 977a4b3622b9eaac27689f06347ea4c5173a96cd..88b2d0fcfa03c3aafa47c7e6d38e64412c45a7cc 100644
+--- a/lib/http-proxy/index.js
++++ b/lib/http-proxy/index.js
+@@ -1,5 +1,4 @@
+ var httpProxy = module.exports,
+-    extend    = require('util')._extend,
+     parse_url = require('url').parse,
+     EE3       = require('eventemitter3'),
+     http      = require('http'),
+@@ -47,9 +46,9 @@ function createRightProxy(type) {
+         args[cntr] !== res
+       ) {
+         //Copy global options
+-        requestOptions = extend({}, options);
++        requestOptions = Object.assign({}, options);
+         //Overwrite with request options
+-        extend(requestOptions, args[cntr]);
++        Object.assign(requestOptions, args[cntr]);
+ 
+         cntr--;
+       }

--- a/patches/http-proxy@1.18.1.patch
+++ b/patches/http-proxy@1.18.1.patch
@@ -1,3 +1,4 @@
+# ref: https://github.com/web-infra-dev/rsbuild/issues/4344
 diff --git a/lib/http-proxy/common.js b/lib/http-proxy/common.js
 index 6513e81d80d5250ea249ea833f819ece67897c7e..486d4c896d65a3bb7cf63307af68facb3ddb886b 100644
 --- a/lib/http-proxy/common.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  http-proxy@1.18.1:
+    hash: qqiqxx62zlcu62nljjmhlvexni
+    path: patches/http-proxy@1.18.1.patch
+
 importers:
 
   .:
@@ -10564,14 +10569,14 @@ snapshots:
   http-proxy-middleware@2.0.7:
     dependencies:
       '@types/http-proxy': 1.17.15
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni):
     dependencies:
       eventemitter3: 4.0.7
       follow-redirects: 1.15.9

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   http-proxy@1.18.1:
-    hash: qqiqxx62zlcu62nljjmhlvexni
+    hash: rg7rdv5wkqlu467sapxhhl2w2i
     path: patches/http-proxy@1.18.1.patch
 
 importers:
@@ -10569,14 +10569,14 @@ snapshots:
   http-proxy-middleware@2.0.7:
     dependencies:
       '@types/http-proxy': 1.17.15
-      http-proxy: 1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni)
+      http-proxy: 1.18.1(patch_hash=rg7rdv5wkqlu467sapxhhl2w2i)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1(patch_hash=qqiqxx62zlcu62nljjmhlvexni):
+  http-proxy@1.18.1(patch_hash=rg7rdv5wkqlu467sapxhhl2w2i):
     dependencies:
       eventemitter3: 4.0.7
       follow-redirects: 1.15.9


### PR DESCRIPTION
## Summary

The `util._extend` has been deprecated since Node 22. We need to patch `node-http-proxy` before https://github.com/http-party/node-http-proxy/pull/1666 is merged.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/4344

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
