### PR TITLE
chore: use pnpm patch instead of custom scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
   },
   "pnpm": {
     "patchedDependencies": {
-      "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch"
+      "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch",
+      "postcss-loader@8.1.1": "patches/postcss-loader@8.1.1.patch",
+      "css-loader@7.1.2": "patches/css-loader@7.1.2.patch"
     }
   },
   "packageManager": "pnpm@9.11.0",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -1,7 +1,4 @@
 // @ts-check
-/**
- * Tip: please add the prebundled packages to `tsconfig.json#paths`.
- */
 import fs from 'node:fs';
 import { join } from 'node:path';
 
@@ -12,14 +9,6 @@ function replaceFileContent(filePath, replaceFn) {
     fs.writeFileSync(filePath, newContent);
   }
 }
-
-// postcss-loader and css-loader use `semver` to compare PostCSS ast version,
-// Rsbuild uses the same PostCSS version and do not need the comparison.
-const skipSemver = (task) => {
-  replaceFileContent(join(task.depPath, 'dist/index.js'), (content) =>
-    content.replaceAll('require("semver")', '({ satisfies: () => true })'),
-  );
-};
 
 /** @type {import('prebundle').Config} */
 export default {
@@ -85,9 +74,6 @@ export default {
     },
     {
       name: 'rspack-chain',
-      externals: {
-        '@rspack/core': '@rspack/core',
-      },
       ignoreDts: true,
       afterBundle(task) {
         // copy types to dist because prebundle will break the types
@@ -131,8 +117,6 @@ export default {
       },
     },
     {
-      // The webpack-bundle-analyzer version was locked to v4.9.0 to be compatible with Rspack
-      // If we need to upgrade the version, please check if the chunk detail can be displayed correctly
       name: 'webpack-bundle-analyzer',
     },
     {
@@ -164,27 +148,16 @@ export default {
       name: 'css-loader',
       ignoreDts: true,
       externals: {
-        semver: './semver',
         postcss: '../postcss',
       },
-      beforeBundle: skipSemver,
     },
     {
       name: 'postcss-loader',
       externals: {
         jiti: '../jiti',
-        semver: './semver',
         postcss: '../postcss',
       },
       ignoreDts: true,
-      beforeBundle(task) {
-        replaceFileContent(join(task.depPath, 'dist/utils.js'), (content) =>
-          // Rsbuild uses `postcss-load-config` and no need to use `cosmiconfig`.
-          // the ralevent code will never be executed, so we can replace it with an empty object.
-          content.replaceAll('require("cosmiconfig")', '{}'),
-        );
-        skipSemver(task);
-      },
     },
     {
       name: 'postcss-load-config',

--- a/patches/css-loader@7.1.2.patch
+++ b/patches/css-loader@7.1.2.patch
@@ -1,0 +1,34 @@
+# postcss-loader and css-loader use `semver` to compare PostCSS ast version,
+# Rsbuild uses the same PostCSS version and do not need the comparison.
+diff --git a/dist/index.js b/dist/index.js
+index 11afa0f317e59dd940048aa732aa8d3a0c336370..b638b4d7758273ac55654f2b188b780f095dc6fa 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -5,9 +5,6 @@ Object.defineProperty(exports, "__esModule", {
+ });
+ exports.default = loader;
+ var _postcss = _interopRequireDefault(require("postcss"));
+-var _package = _interopRequireDefault(require("postcss/package.json"));
+-var _semver = require("semver");
+-var _options = _interopRequireDefault(require("./options.json"));
+ var _plugins = require("./plugins");
+ var _utils = require("./utils");
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+@@ -17,7 +14,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
+ */
+ 
+ async function loader(content, map, meta) {
+-  const rawOptions = this.getOptions(_options.default);
++  const rawOptions = this.getOptions();
+   const callback = this.async();
+   if (this._compiler && this._compiler.options && this._compiler.options.experiments && this._compiler.options.experiments.css && this._module && (this._module.type === "css" || this._module.type === "css/auto" || this._module.type === "css/global" || this._module.type === "css/module")) {
+     this.emitWarning(new Error('You can\'t use `experiments.css` (`experiments.futureDefaults` enable built-in CSS support by default) and `css-loader` together, please set `experiments.css` to `false` or set `{ type: "javascript/auto" }` for rules with `css-loader` in your webpack config (now css-loader does nothing).'));
+@@ -98,7 +95,7 @@ async function loader(content, map, meta) {
+     const {
+       ast
+     } = meta;
+-    if (ast && ast.type === "postcss" && (0, _semver.satisfies)(ast.version, `^${_package.default.version}`)) {
++    if (ast && ast.type === "postcss" ) {
+       // eslint-disable-next-line no-param-reassign
+       content = ast.root;
+     }

--- a/patches/postcss-loader@8.1.1.patch
+++ b/patches/postcss-loader@8.1.1.patch
@@ -1,0 +1,48 @@
+# postcss-loader and css-loader use `semver` to compare PostCSS ast version,
+# Rsbuild uses the same PostCSS version and do not need the comparison.
+diff --git a/dist/index.js b/dist/index.js
+index c71ab296e023491323a8abaff050ca906ae36f0c..fa7679761159a21ce210604d74dc9c34dee7000b 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -5,8 +5,6 @@ Object.defineProperty(exports, "__esModule", {
+ });
+ exports.default = loader;
+ var _path = _interopRequireDefault(require("path"));
+-var _package = _interopRequireDefault(require("postcss/package.json"));
+-var _options = _interopRequireDefault(require("./options.json"));
+ var _utils = require("./utils");
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ let hasExplicitDependencyOnPostCSS = false;
+@@ -25,7 +23,7 @@ let hasExplicitDependencyOnPostCSS = false;
+  * @return {callback} callback Result
+  */
+ async function loader(content, sourceMap, meta) {
+-  const options = this.getOptions(_options.default);
++  const options = this.getOptions();
+   const callback = this.async();
+   const configOption = typeof options.postcssOptions === "undefined" || typeof options.postcssOptions.config === "undefined" ? true : options.postcssOptions.config;
+   let implementation;
+@@ -66,9 +64,7 @@ async function loader(content, sourceMap, meta) {
+   let root;
+ 
+   // Reuse PostCSS AST from other loaders
+-  if (meta && meta.ast && meta.ast.type === "postcss" &&
+-  // eslint-disable-next-line global-require
+-  require("semver").satisfies(meta.ast.version, `^${_package.default.version}`)) {
++  if (meta && meta.ast && meta.ast.type === "postcss") {
+     ({
+       root
+     } = meta.ast);
+diff --git a/dist/utils.js b/dist/utils.js
+index 218f597ff2220b4381f9df37b1d5377835c631d6..b5a870957098ef0d971a2ff9f6be3cde9a1fbfb5 100644
+--- a/dist/utils.js
++++ b/dist/utils.js
+@@ -15,7 +15,7 @@ exports.warningFactory = warningFactory;
+ var _path = _interopRequireDefault(require("path"));
+ var _url = _interopRequireDefault(require("url"));
+ var _module = _interopRequireDefault(require("module"));
+-var _cosmiconfig = require("cosmiconfig");
++var _cosmiconfig = {};
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ const parentModule = module;
+ const stat = (inputFileSystem, filePath) => new Promise((resolve, reject) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  css-loader@7.1.2:
+    hash: hgmoyq6bbvmxg74vxs5gi6q7sa
+    path: patches/css-loader@7.1.2.patch
   http-proxy@1.18.1:
     hash: rg7rdv5wkqlu467sapxhhl2w2i
     path: patches/http-proxy@1.18.1.patch
+  postcss-loader@8.1.1:
+    hash: vfmtcjxhomso2wgrjs2ahhjxfy
+    path: patches/postcss-loader@8.1.1.patch
 
 importers:
 
@@ -632,7 +638,7 @@ importers:
         version: 2.8.5
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15)))
+        version: 7.1.2(patch_hash=hgmoyq6bbvmxg74vxs5gi6q7sa)(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15)))
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -674,7 +680,7 @@ importers:
         version: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(yaml@2.6.0)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15)))
+        version: 8.1.1(patch_hash=vfmtcjxhomso2wgrjs2ahhjxfy)(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15)))
       prebundle:
         specifier: 1.2.5
         version: 1.2.5(typescript@5.7.2)
@@ -9800,7 +9806,7 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-loader@7.1.2(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15))):
+  css-loader@7.1.2(patch_hash=hgmoyq6bbvmxg74vxs5gi6q7sa)(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.49)
       postcss: 8.4.49
@@ -11778,7 +11784,7 @@ snapshots:
       postcss: 8.4.49
       yaml: 2.6.0
 
-  postcss-loader@8.1.1(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15))):
+  postcss-loader@8.1.1(patch_hash=vfmtcjxhomso2wgrjs2ahhjxfy)(@rspack/core@1.2.0-beta.0(@swc/helpers@0.5.15))(postcss@8.4.49)(typescript@5.7.2)(webpack@5.97.1(@swc/core@1.10.4(@swc/helpers@0.5.15))):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.2)
       jiti: 1.21.7


### PR DESCRIPTION
## Summary

Use `pnpm patch` to patch `css-loader` and `postcss`, so we don't have to maintain additional scripts to replace the code.

## Related Links

- https://pnpm.io/cli/patch

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
