### PR TITLE
docs: correct some cases

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,12 +45,12 @@ or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
+not aligned to this code of conduct, and will communicate reasons for moderation
 decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
+This code of conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
 Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
@@ -68,7 +68,7 @@ reporter of any incident.
 ## Enforcement guidelines
 
 Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+the consequences for any action they deem in violation of this code of conduct:
 
 ### 1. Correction
 
@@ -86,7 +86,7 @@ of actions.
 
 **Consequence**: A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
+those enforcing the code of conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
 like social media. Violating these terms may lead to a temporary or
 permanent ban.
@@ -99,7 +99,7 @@ sustained inappropriate behavior.
 **Consequence**: A temporary ban from any sort of interaction or public
 communication with the community for a specified period of time. No public or
 private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
+with those enforcing the code of conduct, is allowed during this period.
 Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent ban
@@ -113,7 +113,7 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This code of conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following diagram illustrates the relationship between Rsbuild and other too
 
 ## 📚 Getting started
 
-To get started with Rsbuild, see the [Quick Start](https://rsbuild.dev/guide/start/quick-start).
+To get started with Rsbuild, see the [Quick start](https://rsbuild.dev/guide/start/quick-start).
 
 ## 🦀 Links
 
@@ -140,7 +140,7 @@ Please read the [Contributing Guide](https://github.com/web-infra-dev/rsbuild/bl
 
 ### Code of conduct
 
-This repo has adopted the ByteDance Open Source Code of Conduct. Please check [Code of Conduct](./CODE_OF_CONDUCT.md) for more details.
+This repo has adopted the ByteDance open source code of conduct. Please check [Code of conduct](./CODE_OF_CONDUCT.md) for more details.
 
 ## 🧑‍💻 Community
 

--- a/website/docs/en/community/releases/v1-0.mdx
+++ b/website/docs/en/community/releases/v1-0.mdx
@@ -80,7 +80,7 @@ As shown, the API style of the Rsbuild plugin is similar to esbuild, it can be d
 
 ## How to use 1.0
 
-- If you haven't used Rsbuild before, you can experience it through the [CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example) or refer to the [Quick Start](https://rsbuild.dev/guide/start/quick-start) to use Rsbuild.
+- If you haven't used Rsbuild before, you can experience it through the [CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example) or refer to the [Quick start](https://rsbuild.dev/guide/start/quick-start) to use Rsbuild.
 - If you are using Rsbuild 0.7 or earlier, please note that 1.0 includes some breaking changes. You can refer to the [Migrating from 0.x](https://rsbuild.dev/guide/migration/rsbuild-0-x) document to upgrade.
 - Rsbuild also provides migration guides for projects that use webpack, CRA, Vue CLI, etc. See [Migrate from Existing Projects](https://rsbuild.dev/guide/start/quick-start#migrate-from-existing-projects).
 

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -85,12 +85,12 @@ import Step from '@components/Step';
 <NextSteps>
   <Step
     href="/guide/start/quick-start"
-    title="Quick Start"
+    title="Quick start"
     description="Learn how to use Rsbuild"
   />
   <Step
     href="/guide/start/features"
-    title="All Features"
+    title="All features"
     description="Learn all features of Rsbuild"
   />
   <Step

--- a/website/i18n.json
+++ b/website/i18n.json
@@ -4,7 +4,7 @@
     "zh": "介绍"
   },
   "quickStart": {
-    "en": "Quick Start",
+    "en": "Quick start",
     "zh": "快速上手"
   },
   "subtitle": {


### PR DESCRIPTION
## Summary

This pull request includes several documentation updates to ensure consistent capitalization and terminology usage across files. The changes primarily focus on standardizing the capitalization of "code of conduct" and "quick start."

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
