### PR TITLE
docs: clarify `swcReactOptions.refresh` option

### DIFF
--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -111,11 +111,11 @@ pluginReact({
 ### swcReactOptions.refresh
 
 - **Type:** `boolean`
-- **Default:** based on [fastRefresh](/config/dev/fast-refresh)
+- **Default:** based on [fastRefresh](#fastrefresh) and [dev.hmr](/config/dev/hmr)
 
-Whether to enable React [Fast Refresh](https://www.npmjs.com/package/react-refresh).
+Whether to enable [React Fast Refresh](https://www.npmjs.com/package/react-refresh).
 
-Most of the time, you should use the plugin's [fastRefresh](/config/dev/fast-refresh) option to enable or disable Fast Refresh.
+Most of the time, you should use the plugin's [fastRefresh](#fastrefresh) option to enable or disable Fast Refresh.
 
 ### splitChunks
 
@@ -234,7 +234,7 @@ pluginReact({
 - **Type:** `boolean`
 - **Default:** `true`
 
-Whether to enable React [Fast Refresh](https://www.npmjs.com/package/react-refresh) in development mode.
+Whether to enable [React Fast Refresh](https://www.npmjs.com/package/react-refresh) in development mode.
 
 If `fastRefresh` is set to `true`, `@rsbuild/plugin-react` will automatically register the [@rspack/plugin-react-refresh](https://www.npmjs.com/package/@rspack/plugin-react-refresh) plugin.
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -108,6 +108,15 @@ pluginReact({
 });
 ```
 
+### swcReactOptions.refresh
+
+- **Type:** `boolean`
+- **Default:** based on [fastRefresh](/config/dev/fast-refresh)
+
+Whether to enable React [Fast Refresh](https://www.npmjs.com/package/react-refresh).
+
+Most of the time, you should use the plugin's [fastRefresh](/config/dev/fast-refresh) option to enable or disable Fast Refresh.
+
 ### splitChunks
 
 When [chunkSplit.strategy](/config/performance/chunk-split) set to `split-by-experience`, Rsbuild will automatically split `react` and `router` related packages into separate chunks by default:
@@ -226,6 +235,8 @@ pluginReact({
 - **Default:** `true`
 
 Whether to enable React [Fast Refresh](https://www.npmjs.com/package/react-refresh) in development mode.
+
+If `fastRefresh` is set to `true`, `@rsbuild/plugin-react` will automatically register the [@rspack/plugin-react-refresh](https://www.npmjs.com/package/@rspack/plugin-react-refresh) plugin.
 
 If you need to disable Fast Refresh, you can set it to `false`:
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -110,6 +110,15 @@ pluginReact({
 });
 ```
 
+### swcReactOptions.refresh
+
+- **类型：** `boolean`
+- **默认值：** 基于 [fastRefresh](/config/dev/fast-refresh)
+
+是否启用 React [Fast Refresh](https://www.npmjs.com/package/react-refresh)。
+
+大多数情况下，你应该使用插件的 [fastRefresh](/config/dev/fast-refresh) 选项来启用或禁用 Fast Refresh。
+
 ### splitChunks
 
 在 [chunkSplit.strategy](/config/performance/chunk-split) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `react` 和 `router` 相关的包拆分为单独的 chunk:
@@ -228,6 +237,8 @@ pluginReact({
 - **默认值：** `true`
 
 是否在开发模式下启用 React [Fast Refresh](https://www.npmjs.com/package/react-refresh)。
+
+当 `fastRefresh` 设置为 `true` 时，`@rsbuild/plugin-react` 会自动注册 [@rspack/plugin-react-refresh](https://www.npmjs.com/package/@rspack/plugin-react-refresh) 插件。
 
 如果你需要禁用 Fast Refresh，可以将其设置为 `false`：
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -113,11 +113,11 @@ pluginReact({
 ### swcReactOptions.refresh
 
 - **类型：** `boolean`
-- **默认值：** 基于 [fastRefresh](/config/dev/fast-refresh)
+- **默认值：** 基于 [fastRefresh](#fastrefresh) 和 [dev.hmr](/config/dev/hmr)
 
-是否启用 React [Fast Refresh](https://www.npmjs.com/package/react-refresh)。
+是否启用 [React Fast Refresh](https://www.npmjs.com/package/react-refresh)。
 
-大多数情况下，你应该使用插件的 [fastRefresh](/config/dev/fast-refresh) 选项来启用或禁用 Fast Refresh。
+大多数情况下，你应该使用插件的 [fastRefresh](#fastrefresh) 选项来启用或禁用 Fast Refresh。
 
 ### splitChunks
 
@@ -236,7 +236,7 @@ pluginReact({
 - **类型：** `boolean`
 - **默认值：** `true`
 
-是否在开发模式下启用 React [Fast Refresh](https://www.npmjs.com/package/react-refresh)。
+是否在开发模式下启用 [React Fast Refresh](https://www.npmjs.com/package/react-refresh)。
 
 当 `fastRefresh` 设置为 `true` 时，`@rsbuild/plugin-react` 会自动注册 [@rspack/plugin-react-refresh](https://www.npmjs.com/package/@rspack/plugin-react-refresh) 插件。
 


### PR DESCRIPTION
## Summary

This pull request includes updates to the documentation for the `pluginReact` plugin, adding details about the `swcReactOptions.refresh` option.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
