### PR TITLE
chore(CI): declare permissions for eco CI comments

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -11,6 +11,12 @@ on:
         required: true
         default: 'main'
 
+permissions:
+  # Allow commenting on commits
+  contents: write
+  # Allow commenting on issues
+  issues: write
+
 jobs:
   ecosystem_ci_notify:
     name: Run Ecosystem CI With Notify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ on:
 permissions:
   # Provenance generation in GitHub Actions requires "write" access to the "id-token"
   id-token: write
+  # Allow commenting on issues
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Declare `GitHUB_TOKEN` permissions for eco CI comments.

## Related Links

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
