### PR TITLE
fix(core): `output.assetsInclude` adds a rule but not exposes public api

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -99,6 +99,8 @@ export const CHAIN_ID = {
     IMAGE: 'image',
     /** Rule for media */
     MEDIA: 'media',
+    /** Rule for additional asset */
+    ADDITIONAL: 'additional',
     /** Rule for js */
     JS: 'js',
     /** Rule for data uri encoded javascript */

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -99,8 +99,8 @@ export const CHAIN_ID = {
     IMAGE: 'image',
     /** Rule for media */
     MEDIA: 'media',
-    /** Rule for additional asset */
-    ADDITIONAL: 'additional',
+    /** Rule for additional assets */
+    ADDITIONAL_ASSETS: 'additional-assets',
     /** Rule for js */
     JS: 'js',
     /** Rule for data uri encoded javascript */

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -131,7 +131,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
       const { assetsInclude } = config.source;
       if (assetsInclude) {
         const { dataUriLimit } = config.output;
-        const rule = chain.module.rule('additional-assets').test(assetsInclude);
+        const rule = chain.module.rule('additional').test(assetsInclude);
         const maxSize =
           typeof dataUriLimit === 'number' ? dataUriLimit : dataUriLimit.assets;
 

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { GeneratorOptionsByModuleType } from '@rspack/core';
+import { CHAIN_ID } from '../configChain';
 import {
   AUDIO_EXTENSIONS,
   FONT_EXTENSIONS,
@@ -85,7 +86,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
       };
 
       const createAssetRule = (
-        assetType: 'svg' | 'font' | 'image' | 'media',
+        assetType: 'svg' | 'font' | 'image' | 'media' | 'assets',
         exts: string[],
         emit: boolean,
       ) => {
@@ -109,17 +110,17 @@ export const pluginAsset = (): RsbuildPlugin => ({
       const { emitAssets } = config.output;
 
       // image
-      createAssetRule('image', IMAGE_EXTENSIONS, emitAssets);
+      createAssetRule(CHAIN_ID.RULE.IMAGE, IMAGE_EXTENSIONS, emitAssets);
       // svg
-      createAssetRule('svg', ['svg'], emitAssets);
+      createAssetRule(CHAIN_ID.RULE.SVG, ['svg'], emitAssets);
       // media
       createAssetRule(
-        'media',
+        CHAIN_ID.RULE.MEDIA,
         [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS],
         emitAssets,
       );
       // font
-      createAssetRule('font', FONT_EXTENSIONS, emitAssets);
+      createAssetRule(CHAIN_ID.RULE.FONT, FONT_EXTENSIONS, emitAssets);
       // assets
       const assetsFilename = getMergedFilename('assets');
       chain.output.assetModuleFilename(assetsFilename);
@@ -131,7 +132,9 @@ export const pluginAsset = (): RsbuildPlugin => ({
       const { assetsInclude } = config.source;
       if (assetsInclude) {
         const { dataUriLimit } = config.output;
-        const rule = chain.module.rule('additional').test(assetsInclude);
+        const rule = chain.module
+          .rule(CHAIN_ID.RULE.ADDITIONAL_ASSETS)
+          .test(assetsInclude);
         const maxSize =
           typeof dataUriLimit === 'number' ? dataUriLimit : dataUriLimit.assets;
 
@@ -140,7 +143,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
           rule,
           maxSize,
           filename: assetsFilename,
-          assetType: 'additional',
+          assetType: 'additional-assets',
         });
       }
     });

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -86,7 +86,7 @@ export const pluginAsset = (): RsbuildPlugin => ({
       };
 
       const createAssetRule = (
-        assetType: 'svg' | 'font' | 'image' | 'media' | 'assets',
+        assetType: 'svg' | 'font' | 'image' | 'media',
         exts: string[],
         emit: boolean,
       ) => {


### PR DESCRIPTION
## Summary

not regular


<img width="400" alt="image" src="https://github.com/user-attachments/assets/a2885fe0-c539-4196-a52c-2bdcdafe92a8" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/ebb9233c-7b96-49dc-9fa8-3ba1e3970f95" />


should be `${type}-asset-url`

```
font  font-asset-url
additional  additional-asset-url
```

## Related Links

for Rslib Asset
https://github.com/web-infra-dev/rslib/pull/684

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
