### PR TITLE
docs: correct typo in multi-env title

### DIFF
--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -1,4 +1,4 @@
-# MMulti-environment builds
+# Multi-environment builds
 
 Rsbuild supports building outputs for multiple environments at the same time. You can use [environments](/config/environments) to build multiple environments in parallel and set a different Rsbuild config for each environment.
 


### PR DESCRIPTION
## Summary

Sorry, just a small typo I noticed when reading this part of the docs.

Thanks for the great tooling 👌 

## Related Links

Docs page: https://rsbuild.dev/guide/advanced/environments

## Checklist

<!--- Check and mark with an "x" -->

- [X] Tests updated (or not required).
- [X] Documentation updated (or not required).
