### PR TITLE
feat(plugin-sass): add `useOriginalUrlResolver` option to disable `resolve-url-loader`

### DIFF
--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -55,4 +55,9 @@ export type PluginSassOptions = {
    * Exclude some `.scss` or `.sass` files, they will not be transformed by sass-loader.
    */
   exclude?: Rspack.RuleSetCondition;
+
+  /**
+   * Use original url resolver instead of resolve-url-loader.
+   */
+  useOriginalUrlResolver?: boolean;
 };

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -115,6 +115,14 @@ pluginSass({
 });
 ```
 
+### useOriginalUrlResolver
+
+- **Type:** `boolean`
+- **Default:** `undefined`
+- **Version:** `>= 1.2.0`
+
+Use the original resolver instead of `resolve-url-loader` when resolving urls
+
 ## Practices
 
 ### Modify Sass implementation


### PR DESCRIPTION
## Summary

Adds new `useOriginalUrlResolver` option to disable `resolve-url-loader`

## Related Links

Relative url usage like [this](https://github.com/junhea/rsbuild-sass-issue-sample/blob/2f5df5922c2161fdff50fb1bbec18b1a5a9360fb/src/assets/partials/_foo.scss#L2) should build

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
