### PR TITLE
feat: optimize `cleanDistPath.keep` RegExp

### DIFF
--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -71,7 +71,7 @@ test('should allow to use `cleanDistPath.keep` to keep some files', async () => 
     rsbuildConfig: {
       output: {
         cleanDistPath: {
-          keep: [/dist[\\/]test.json/, /dist[\\/]foo[\\/]bar[\\/]test.json/],
+          keep: [/dist\/test.json/, /dist\/foo\/bar\/test.json/],
         },
       },
     },

--- a/packages/core/src/helpers/fs.ts
+++ b/packages/core/src/helpers/fs.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { logger } from '../logger';
 import type { Rspack } from '../types';
+import { toPosixPath } from './path';
 
 export const isFileSync = (filePath: string): boolean | undefined => {
   try {
@@ -80,7 +81,7 @@ export async function emptyDir(
     await Promise.all(
       entries.map(async (entry) => {
         const fullPath = path.resolve(dir, entry.name);
-        if (keep.some((reg) => reg.test(fullPath))) {
+        if (keep.some((reg) => reg.test(toPosixPath(fullPath)))) {
           return;
         }
 

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -59,3 +59,15 @@ export const dedupeNestedPaths = (paths: string[]): string[] => {
       return prev.concat(curr);
     }, []);
 };
+
+/**
+ * Convert Windows backslash paths to posix forward slashes
+ * @example
+ * toPosixPath('foo\\bar') // returns 'foo/bar'
+ */
+export const toPosixPath = (filepath: string): string => {
+  if (sep === '/') {
+    return filepath;
+  }
+  return filepath.replace(/\\/g, '/');
+};

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { toPosixPath } from '../helpers/path';
 import type {
   NormalizedEnvironmentConfig,
   RsbuildPlugin,
@@ -80,7 +81,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           // this helps VS Code break points working correctly in monorepo
           chain.output.devtoolModuleFilenameTemplate(
             (info: { absoluteResourcePath: string }) =>
-              path.resolve(info.absoluteResourcePath).replace(/\\/g, '/'),
+              toPosixPath(path.resolve(info.absoluteResourcePath)),
           );
         }
 

--- a/website/docs/en/config/output/clean-dist-path.mdx
+++ b/website/docs/en/config/output/clean-dist-path.mdx
@@ -85,12 +85,8 @@ For example, to keep the `dist/foo.json` file:
 export default {
   output: {
     cleanDistPath: {
-      keep: [/dist[\\/]foo.json/],
+      keep: [/dist\/foo.json/],
     },
   },
 };
 ```
-
-:::tip
-In the regular expression example, we use `[\\/]` to match the path separator because different operating systems use different path separators. Using `[\\/]` ensures that the paths can be matched in macOS, Linux and Windows.
-:::

--- a/website/docs/zh/config/output/clean-dist-path.mdx
+++ b/website/docs/zh/config/output/clean-dist-path.mdx
@@ -85,12 +85,8 @@ export default {
 export default {
   output: {
     cleanDistPath: {
-      keep: [/dist[\\/]foo.json/],
+      keep: [/dist\/foo.json/],
     },
   },
 };
 ```
-
-:::tip
-在正则表达式的例子中，我们使用 `[\\/]` 来匹配路径分隔符，这是因为不同的操作系统使用了不同的路径分隔符，使用 `[\\/]` 可以保证 macOS、Linux 和 Windows 的路径都被匹配到。
-:::


### PR DESCRIPTION
## Summary

This pull request updates the path handling for `cleanDistPath.keep` to use POSIX-style paths and removes outdated documentation hints.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
