### PR TITLE
chore: use pnpx to replace npx

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
         run: pnpm run lint
 
       - name: Check Changeset
-        run: npx disallow-major-changeset@latest
+        run: pnpx disallow-major-changeset
 
       - name: Check Dependency Version
         run: pnpm run check-dependency-version

--- a/package.json
+++ b/package.json
@@ -13,23 +13,23 @@
     "build:doc": "cd website && pnpm run build",
     "change": "changeset",
     "changeset": "changeset",
-    "check-dependency-version": "npx check-dependency-version-consistency .",
-    "check-spell": "npx cspell && npx heading-case",
+    "check-dependency-version": "pnpx check-dependency-version-consistency .",
+    "check-spell": "pnpx cspell && heading-case",
     "dev:doc": "cd website && pnpm run dev",
     "e2e": "cd ./e2e && pnpm test",
     "e2e:rspack": "cd ./e2e && pnpm test:rspack",
     "e2e:webpack": "cd ./e2e && pnpm test:webpack",
-    "format": "prettier --write . && npx heading-case --write",
+    "format": "prettier --write . && heading-case --write",
     "lint": "biome check . --diagnostic-level=warn && pnpm run check-spell",
     "prebundle": "nx run-many -t prebundle",
     "prepare": "pnpm run build && simple-git-hooks",
-    "sort-package-json": "npx sort-package-json \"./package.json\" \"packages/*/package.json\" \"packages/compat/*/package.json\"",
+    "sort-package-json": "pnpx sort-package-json \"./package.json\" \"packages/*/package.json\" \"packages/compat/*/package.json\"",
     "test": "pnpm run ut",
     "ut": "vitest run",
     "ut:watch": "vitest"
   },
   "simple-git-hooks": {
-    "pre-commit": "npx nano-staged"
+    "pre-commit": "pnpm exec nano-staged"
   },
   "nano-staged": {
     "*.{md,mdx,json,css,less,scss}": "prettier --write",
@@ -45,6 +45,7 @@
     "@scripts/test-helper": "workspace:*",
     "cross-env": "^7.0.3",
     "cspell-ban-words": "^0.0.4",
+    "heading-case": "^0.1.3",
     "nano-staged": "^0.8.0",
     "nx": "^20.3.1",
     "prettier": "^3.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       cspell-ban-words:
         specifier: ^0.0.4
         version: 0.0.4
+      heading-case:
+        specifier: ^0.1.3
+        version: 0.1.3
       nano-staged:
         specifier: ^0.8.0
         version: 0.8.0
@@ -4406,6 +4409,10 @@ packages:
 
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  heading-case@0.1.3:
+    resolution: {integrity: sha512-iKkeL7fgw+RkMp3ceX00hzY4eyTHXd7En6UzJ1qqSFzhAPXg4HyNvXPyarVje/KAaaA9e+UqN1vrUt8DnNFCiA==}
     hasBin: true
 
   highlight.js@10.7.3:
@@ -10403,6 +10410,8 @@ snapshots:
       space-separated-tokens: 2.0.2
 
   he@1.2.0: {}
+
+  heading-case@0.1.3: {}
 
   highlight.js@10.7.3: {}
 


### PR DESCRIPTION
## Summary

Use pnpx to replace npx because it is faster.

- For remote packages: `pnpx` > `npx`

![Screenshot 2025-01-18 at 17 13 37](https://github.com/user-attachments/assets/2217cf3b-d24f-42d0-8fe6-5d56714a498e)

- For locally installed packages: `pnpm exec` > `npx` > `pnpx`

## Related Links

- https://pnpm.io/cli/exec
- https://pnpm.io/cli/dlx

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
