### PR TITLE
chore(plugin-sass): rename unreleased option

### DIFF
--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -110,6 +110,8 @@ export const pluginSass = (
         true,
       );
 
+      const { rewriteUrls = true } = pluginOptions;
+
       const ruleId = findRuleId(chain, CHAIN_ID.RULE.SASS);
       const rule = chain.module
         .rule(ruleId)
@@ -137,8 +139,9 @@ export const pluginSass = (
 
         if (id === CHAIN_ID.USE.CSS) {
           // add resolve-url-loader
-          if (!pluginOptions.useOriginalUrlResolver)
+          if (rewriteUrls) {
             clonedOptions.importLoaders += 1;
+          }
           // add sass-loader
           clonedOptions.importLoaders += 1;
         }
@@ -146,8 +149,8 @@ export const pluginSass = (
         rule.use(id).loader(loader.get('loader')).options(clonedOptions);
       }
 
-      // use resolve-url-loader if useOriginalResolver is not set
-      if (!pluginOptions.useOriginalUrlResolver)
+      // use `resolve-url-loader` to rewrite urls
+      if (rewriteUrls)
         rule
           .use(CHAIN_ID.USE.RESOLVE_URL)
           .loader(

--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -57,7 +57,8 @@ export type PluginSassOptions = {
   exclude?: Rspack.RuleSetCondition;
 
   /**
-   * Use original url resolver instead of resolve-url-loader.
+   * Whether to use `resolve-url-loader` to rewrite urls.
+   * @default true
    */
-  useOriginalUrlResolver?: boolean;
+  rewriteUrls?: boolean;
 };

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -115,13 +115,13 @@ pluginSass({
 });
 ```
 
-### useOriginalUrlResolver
+### rewriteUrls
 
 - **Type:** `boolean`
-- **Default:** `undefined`
+- **Default:** `true`
 - **Version:** `>= 1.2.0`
 
-Use the original resolver instead of `resolve-url-loader` when resolving urls
+Whether to use `resolve-url-loader` to rewrite urls.
 
 ## Practices
 


### PR DESCRIPTION
## Summary

Rename the unreleased `useOriginalUrlResolver` option to `rewriteUrls`, which can more clearly express the role of resolve-url-loader.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/4389 
- https://github.com/bholloway/resolve-url-loader/blob/v5/packages/resolve-url-loader/README.md
- https://webpack.js.org/loaders/sass-loader/#problems-with-url
- https://github.com/sass/sass/issues/2535

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
