### PR TITLE
fix!: disable `server.cors` by default for security reasons

### DIFF
--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -1,13 +1,18 @@
 import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should include CORS headers by default for dev server', async ({
+test('should include CORS headers for dev server if `cors` is `true`', async ({
   page,
   request,
 }) => {
   const rsbuild = await dev({
     cwd: __dirname,
     page,
+    rsbuildConfig: {
+      server: {
+        cors: true,
+      },
+    },
   });
 
   const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
@@ -16,13 +21,18 @@ test('should include CORS headers by default for dev server', async ({
   await rsbuild.close();
 });
 
-test('should include CORS headers by default for preview server', async ({
+test('should include CORS headers for preview server if `cors` is `true`', async ({
   page,
   request,
 }) => {
   const rsbuild = await build({
     cwd: __dirname,
     page,
+    rsbuildConfig: {
+      server: {
+        cors: true,
+      },
+    },
   });
 
   const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -85,7 +85,7 @@ const getDefaultServerConfig = (): NormalizedServerConfig => ({
   compress: true,
   printUrls: true,
   strictPort: false,
-  cors: true,
+  cors: false,
 });
 
 let swcHelpersPath: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -394,7 +394,7 @@ export interface ServerConfig {
    * - true: enable CORS with default options.
    * - false: disable CORS.
    * - object: enable CORS with the specified options.
-   * @default true
+   * @default false
    * @link https://github.com/expressjs/cors
    */
   cors?: boolean | cors.CorsOptions;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -112,7 +112,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
   "server": {
     "base": "/",
     "compress": true,
-    "cors": true,
+    "cors": false,
     "host": "0.0.0.0",
     "htmlFallback": "index",
     "open": false,
@@ -254,7 +254,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
   "server": {
     "base": "/",
     "compress": true,
-    "cors": true,
+    "cors": false,
     "host": "0.0.0.0",
     "htmlFallback": "index",
     "open": false,
@@ -396,7 +396,7 @@ exports[`environment config > should print environment config when inspect confi
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -534,7 +534,7 @@ exports[`environment config > should print environment config when inspect confi
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -692,7 +692,7 @@ exports[`environment config > should support modify environment config by api.mo
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -831,7 +831,7 @@ exports[`environment config > should support modify environment config by api.mo
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -970,7 +970,7 @@ exports[`environment config > should support modify environment config by api.mo
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -1111,7 +1111,7 @@ exports[`environment config > should support modify single environment config by
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,
@@ -1250,7 +1250,7 @@ exports[`environment config > should support modify single environment config by
     "server": {
       "base": "/",
       "compress": true,
-      "cors": true,
+      "cors": false,
       "host": "0.0.0.0",
       "htmlFallback": "index",
       "open": false,

--- a/website/docs/en/config/server/cors.mdx
+++ b/website/docs/en/config/server/cors.mdx
@@ -1,7 +1,7 @@
 # server.cors
 
 - **Type:** `boolean | import('cors').CorsOptions`
-- **Default:** `true`
+- **Default:** `false`
 - **Version:** `>= 1.1.11`
 
 Configure [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) options for the dev server or preview server, based on the [cors](https://github.com/expressjs/cors) middleware.
@@ -10,14 +10,25 @@ Configure [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) options
 - `false`：Disable CORS.
 - `object`：Enable CORS with the specified options.
 
+:::tip
+Although `cors` can be set to `true`, we recommend setting a specified `origin` option to prevent untrusted origins from accessing your dev server.
+:::
+
 ## Example
 
 Only enable CORS for the dev server:
 
 ```ts
+const isDev = process.env.NODE_ENV === 'development';
+
 export default {
   server: {
-    cors: process.env.NODE_ENV === 'development',
+    cors: isDev
+      ? {
+          // Configures the `Access-Control-Allow-Origin` CORS response header
+          origin: 'https://example.com',
+        }
+      : false,
   },
 };
 ```

--- a/website/docs/zh/config/server/cors.mdx
+++ b/website/docs/zh/config/server/cors.mdx
@@ -1,7 +1,7 @@
 # server.cors
 
 - **类型：** `boolean | import('cors').CorsOptions`
-- **默认值：** `true`
+- **默认值：** `false`
 - **版本：** `>= 1.1.11`
 
 为开发服务器和预览服务器配置 [CORS](https://developer.mozilla.org/zh-CN/docs/Web/HTTP/CORS) 选项，基于 [cors](https://github.com/expressjs/cors) 中间件实现。
@@ -10,14 +10,25 @@
 - `false`：禁用 CORS。
 - `object`：启用 CORS 并使用指定的选项。
 
+:::tip
+虽然 `cors` 可以设置为 `true`，但我们建议设置一个指定的 `origin` 选项，以防止不受信任的 origin 访问你的开发服务器。
+:::
+
 ## 示例
 
 仅为开发服务器启用 CORS：
 
 ```ts
+const isDev = process.env.NODE_ENV === 'development';
+
 export default {
   server: {
-    cors: process.env.NODE_ENV === 'development',
+    cors: isDev
+      ? {
+          // 配置 `Access-Control-Allow-Origin` CORS 响应头
+          origin: 'https://example.com',
+        }
+      : false,
   },
 };
 ```


### PR DESCRIPTION
## Summary

This PR follows Vite's security patches to disallow fetching from untrusted origins.

Although this is a breaking change, considering that `server.cors` was newly added in version [v1.1.11](https://github.com/web-infra-dev/rsbuild/releases/tag/v1.1.11), it's unlikely that many users are relying on this behavior.

See:

- [GHSA-vg6x-rcgg-rjx6](https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6)
- https://github.com/vitejs/vite/commit/b09572acc939351f4e4c50ddf793017a92c678b1

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
