### PR TITLE
docs(javascript-api): fix defineConfig parameters in English documentation

### DIFF
--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -110,7 +110,7 @@ const { content } = await loadConfig({
 In the `defineConfig` configuration function, you can access the `foo` variable through the `meta` object:
 
 ```ts title="rsbuild.config.ts"
-export default defineConfig((config, { meta }) => {
+export default defineConfig(({ meta }) => {
   console.log(meta.foo); // bar
   return config;
 });


### PR DESCRIPTION
## Summary

Fix defineConfig parameters in English documentation.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4412

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
