### PR TITLE
feat: support for `resolve` and `context` in `api.transform`

### DIFF
--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -26,6 +26,7 @@ export default async function transform(
 
   const result = await transform({
     code: source,
+    context: this.context,
     resource: this.resource,
     resourcePath: this.resourcePath,
     resourceQuery: this.resourceQuery,
@@ -33,6 +34,7 @@ export default async function transform(
     addDependency: this.addDependency.bind(this),
     emitFile: this.emitFile.bind(this),
     importModule: this.importModule.bind(this),
+    resolve: this.resolve.bind(this),
   });
 
   if (result === null || result === undefined) {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -232,6 +232,11 @@ export type TransformContext = {
    */
   code: string;
   /**
+   * The directory path of the currently processed module,
+   * which changes with the location of each processed module.
+   */
+  context: string | null;
+  /**
    * The absolute path of the module, including the query.
    * @example '/home/user/project/src/index.js?foo=123'
    */
@@ -268,6 +273,10 @@ export type TransformContext = {
    * Compile and execute a module at the build time.
    */
   importModule: Rspack.LoaderContext['importModule'];
+  /**
+   * Resolve a module specifier.
+   */
+  resolve: Rspack.LoaderContext['resolve'];
 };
 
 export type TransformHandler = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -274,6 +274,7 @@ The handler param is a transformation function that takes the current module cod
 ```ts
 type TransformContext = {
   code: string;
+  context: string | null;
   resource: string;
   resourcePath: string;
   resourceQuery: string;
@@ -281,6 +282,7 @@ type TransformContext = {
   addDependency: (file: string) => void;
   emitFile: Rspack.LoaderContext['emitFile'];
   importModule: Rspack.LoaderContext['importModule'];
+  resolve: Rspack.LoaderContext['resolve'];
 };
 
 type TransformResult =
@@ -298,6 +300,8 @@ type TransformHandler = (
 The `handler` function provides the following params:
 
 - `code`: The code of the module.
+- `context`: The directory path of the currently processed module.
+- `resolve`: Resolve a module specifier. The same as Rspack loader's [this.resolve](https://rspack.dev/api/loader-api/context#thisresolve).
 - `resource`: The absolute path of the module, including the query.
 - `resourcePath`: The absolute path of the module, without the query.
 - `resourceQuery`: The query of the module.

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -300,7 +300,7 @@ type TransformHandler = (
 The `handler` function provides the following params:
 
 - `code`: The code of the module.
-- `context`: The directory path of the currently processed module.
+- `context`: The directory path of the currently processed module. The same as Rspack loader's [this.context](https://rspack.dev/api/loader-api/context#thiscontext).
 - `resolve`: Resolve a module specifier. The same as Rspack loader's [this.resolve](https://rspack.dev/api/loader-api/context#thisresolve).
 - `resource`: The absolute path of the module, including the query.
 - `resourcePath`: The absolute path of the module, without the query.

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -272,6 +272,7 @@ handler 参数是一个转换函数，接收模块当前的代码，并返回转
 ```ts
 type TransformContext = {
   code: string;
+  context: string | null;
   resource: string;
   resourcePath: string;
   resourceQuery: string;
@@ -279,6 +280,7 @@ type TransformContext = {
   addDependency: (file: string) => void;
   emitFile: Rspack.LoaderContext['emitFile'];
   importModule: Rspack.LoaderContext['importModule'];
+  resolve: Rspack.LoaderContext['resolve'];
 };
 
 type TransformResult =
@@ -296,6 +298,8 @@ type TransformHandler = (
 handler 函数提供以下参数：
 
 - `code`：模块的代码。
+- `context`：当前被处理的模块所在的目录路径。
+- `resolve`：解析一个模块标识符。与 Rspack loader 的 [this.resolve](https://rspack.dev/zh/api/loader-api/context#thisresolve) 相同。
 - `resource`：模块的绝对路径，包含 query。
 - `resourcePath`：模块的绝对路径，不包含 query。
 - `resourceQuery`：模块路径上的 query。

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -298,7 +298,7 @@ type TransformHandler = (
 handler 函数提供以下参数：
 
 - `code`：模块的代码。
-- `context`：当前被处理的模块所在的目录路径。
+- `context`：当前被处理的模块所在的目录路径。与 Rspack loader 的 [this.context](https://rspack.dev/zh/api/loader-api/context#thiscontext) 相同。
 - `resolve`：解析一个模块标识符。与 Rspack loader 的 [this.resolve](https://rspack.dev/zh/api/loader-api/context#thisresolve) 相同。
 - `resource`：模块的绝对路径，包含 query。
 - `resourcePath`：模块的绝对路径，不包含 query。


### PR DESCRIPTION
## Summary

Support for `resolve` and `context` in `api.transform`, same as rspack loader api.

```js
    api.transform(
      { test: /index\.js$/ },
      async ({ code, resolve, context, resource }) => {
        resolve(context!, '@foo', (err, res) => {
          console.log('resolved', res);
        });
      },
    );
```
https://rspack.dev/api/loader-api/context
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
