### PR TITLE
feat: warn when using Rspack devServer config

### DIFF
--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -123,6 +123,31 @@ export function getChainUtils(
   };
 }
 
+function validateRspackConfig(config: Rspack.Configuration) {
+  // validate plugins
+  if (config.plugins) {
+    for (const plugin of config.plugins) {
+      if (
+        plugin &&
+        plugin.apply === undefined &&
+        'name' in plugin &&
+        'setup' in plugin
+      ) {
+        const name = color.bold(color.yellow(plugin.name));
+        throw new Error(
+          `[rsbuild:plugin] "${name}" appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
+        );
+      }
+    }
+  }
+
+  if (config.devServer) {
+    logger.warn(
+      `[rsbuild:config] Find invalid Rspack config: "${color.yellow('devServer')}". Note that Rspack's "devServer" config is not supported by Rsbuild. You can use Rsbuild's "dev" config to configure the Rsbuild dev server.`,
+    );
+  }
+}
+
 export async function generateRspackConfig({
   target,
   context,
@@ -160,22 +185,7 @@ export async function generateRspackConfig({
     await getConfigUtils(rspackConfig, chainUtils),
   );
 
-  // validate plugins
-  if (rspackConfig.plugins) {
-    for (const plugin of rspackConfig.plugins) {
-      if (
-        plugin &&
-        plugin.apply === undefined &&
-        'name' in plugin &&
-        'setup' in plugin
-      ) {
-        const name = color.bold(color.yellow(plugin.name));
-        throw new Error(
-          `[rsbuild:plugin] "${name}" appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
-        );
-      }
-    }
-  }
+  validateRspackConfig(rspackConfig);
 
   return rspackConfig;
 }


### PR DESCRIPTION
## Summary

Warn when using Rspack devServer config:

![image](https://github.com/user-attachments/assets/c0c9801b-ccd8-470c-87da-ad177acdff74)

## Related Links

- https://rspack.dev/config/dev-server

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
