### PR TITLE
test: fix overlay-type-errors case timeout

### DIFF
--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -17,7 +17,7 @@ test('should display type errors on overlay correctly', async ({ page }) => {
     page,
     plugins: [
       {
-        name: 'remove-pre-ts-check',
+        name: 'remove-pre-ts-check-plugin',
         remove: [pluginTypeCheck.name],
         setup() {},
       },

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, proxyConsole } from '@e2e/helper';
+import { dev, gotoPage, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
 
@@ -14,7 +14,6 @@ test('should display type errors on overlay correctly', async ({ page }) => {
 
   const rsbuild = await dev({
     cwd,
-    page,
     plugins: [
       {
         name: 'remove-pre-ts-check-plugin',
@@ -37,6 +36,7 @@ test('should display type errors on overlay correctly', async ({ page }) => {
 
   await waitTsCheckDone;
 
+  await gotoPage(page, rsbuild);
   const errorOverlay = page.locator('rsbuild-error-overlay');
 
   await expect(errorOverlay.locator('.title')).toHaveText('Build failed');

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -15,11 +15,6 @@ test('should display type errors on overlay correctly', async ({ page }) => {
   const rsbuild = await dev({
     cwd,
     plugins: [
-      {
-        name: 'remove-pre-ts-check-plugin',
-        remove: [pluginTypeCheck.name],
-        setup() {},
-      },
       pluginTypeCheck({
         forkTsCheckerOptions: {
           logger: {

--- a/e2e/cases/server/overlay-type-errors/rsbuild.config.ts
+++ b/e2e/cases/server/overlay-type-errors/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
+
+export default defineConfig({
+  plugins: [pluginTypeCheck()],
+});

--- a/e2e/cases/server/overlay-type-errors/rsbuild.config.ts
+++ b/e2e/cases/server/overlay-type-errors/rsbuild.config.ts
@@ -1,6 +1,0 @@
-import { defineConfig } from '@rsbuild/core';
-import { pluginTypeCheck } from '@rsbuild/plugin-type-check';
-
-export default defineConfig({
-  plugins: [pluginTypeCheck()],
-});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -27,6 +27,7 @@ darkgrey
 datauri
 deepmerge
 docgen
+domcontentloaded
 dppx
 envinfo
 estree


### PR DESCRIPTION
## Summary

Should gotoPage after ts check done. Because ts check is asynced in dev, and  reports issues after Rspack's compilation is done.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
