### PR TITLE
fix(core): failed to register environment plugin

### DIFF
--- a/e2e/cases/stylus/basic/index.test.ts
+++ b/e2e/cases/stylus/basic/index.test.ts
@@ -1,30 +1,9 @@
-import fs from 'node:fs';
-import { join, resolve } from 'node:path';
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import { pluginStylus } from '@rsbuild/plugin-stylus';
-
-const fixtures = __dirname;
-
-const generatorTempDir = async (testDir: string) => {
-  fs.rmSync(testDir, { recursive: true, force: true });
-  await fs.promises.cp(join(fixtures, 'src'), testDir, { recursive: true });
-
-  return () => fs.promises.rm(testDir, { force: true, recursive: true });
-};
 
 rspackOnlyTest('should compile stylus correctly', async () => {
-  const testDir = join(fixtures, 'test-temp-src-1');
-  const clear = await generatorTempDir(testDir);
-
   const rsbuild = await build({
     cwd: __dirname,
-    plugins: [pluginStylus()],
-    rsbuildConfig: {
-      source: {
-        entry: { index: resolve(testDir, 'index.js') },
-      },
-    },
   });
   const files = await rsbuild.unwrapOutputJSON();
 
@@ -34,6 +13,4 @@ rspackOnlyTest('should compile stylus correctly', async () => {
   expect(content).toMatch(
     /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,
   );
-
-  await clear();
 });

--- a/e2e/cases/stylus/basic/rsbuild.config.ts
+++ b/e2e/cases/stylus/basic/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default defineConfig({
+  plugins: [pluginStylus()],
+});

--- a/e2e/cases/stylus/environment/index.test.ts
+++ b/e2e/cases/stylus/environment/index.test.ts
@@ -1,0 +1,19 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to configure Stylus plugin for specific environment',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+    const files = await rsbuild.unwrapOutputJSON();
+
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+
+    expect(content).toMatch(
+      /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,
+    );
+  },
+);

--- a/e2e/cases/stylus/environment/rsbuild.config.ts
+++ b/e2e/cases/stylus/environment/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default defineConfig({
+  environments: {
+    web: {
+      plugins: [pluginStylus()],
+    },
+  },
+});

--- a/e2e/cases/stylus/environment/src/a.styl
+++ b/e2e/cases/stylus/environment/src/a.styl
@@ -1,0 +1,3 @@
+body
+  color red
+  font 14px Arial, sans-serif

--- a/e2e/cases/stylus/environment/src/b.module.styl
+++ b/e2e/cases/stylus/environment/src/b.module.styl
@@ -1,0 +1,2 @@
+.title-class
+  font-size: 14px;

--- a/e2e/cases/stylus/environment/src/index.js
+++ b/e2e/cases/stylus/environment/src/index.js
@@ -1,0 +1,4 @@
+import './a.styl';
+import style from './b.module.styl';
+
+console.log(style);

--- a/e2e/cases/stylus/rem/index.test.ts
+++ b/e2e/cases/stylus/rem/index.test.ts
@@ -1,12 +1,9 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import { pluginRem } from '@rsbuild/plugin-rem';
-import { pluginStylus } from '@rsbuild/plugin-stylus';
 
 rspackOnlyTest('should compile stylus and rem correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
-    plugins: [pluginStylus(), pluginRem()],
   });
   const files = await rsbuild.unwrapOutputJSON();
 

--- a/e2e/cases/stylus/rem/rsbuild.config.ts
+++ b/e2e/cases/stylus/rem/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginRem } from '@rsbuild/plugin-rem';
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default defineConfig({
+  plugins: [pluginStylus(), pluginRem()],
+});

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -272,15 +272,22 @@ export async function createRsbuild(
   if (rsbuildConfig.environments) {
     await Promise.all(
       Object.entries(rsbuildConfig.environments).map(async ([name, config]) => {
-        const isEnvironmentEnabled =
-          !rsbuildOptions.environment ||
-          rsbuildOptions.environment.includes(name);
-        if (config.plugins && isEnvironmentEnabled) {
-          const plugins = await getFlattenedPlugins(config.plugins);
-          rsbuild.addPlugins(plugins, {
-            environment: name,
-          });
+        if (!config.plugins) {
+          return;
         }
+
+        // The current environment is not specified, skip it
+        if (
+          context.specifiedEnvironments &&
+          !context.specifiedEnvironments.includes(name)
+        ) {
+          return;
+        }
+
+        const plugins = await getFlattenedPlugins(config.plugins);
+        rsbuild.addPlugins(plugins, {
+          environment: name,
+        });
       }),
     );
   }

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -285,11 +285,9 @@ export function initPluginAPI({
           if (descriptor.issuerLayer) {
             rule.issuerLayer(descriptor.issuerLayer);
           }
-
           if (descriptor.issuer) {
             rule.issuer(descriptor.issuer);
           }
-
           if (descriptor.with) {
             rule.with(descriptor.with);
           }


### PR DESCRIPTION
## Summary

Fix failed to register environment plugin.

Since https://github.com/web-infra-dev/rsbuild/pull/4283, `rsbuildOptions.environment` will be empty array by default, and we should use `context.specifiedEnvironments` to filter environments.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4435

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
