### PR TITLE
test(e2e): simplify stylus code

### DIFF
--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -32,7 +32,7 @@ rspackOnlyTest(
     expect(files[test1!]).toContain('body{color:red}');
     expect(files[test2!]).toContain('& .foo');
     expect(files[test3!]).toContain('& .foo');
-    expect(files[test4!]).toContain('& .foo');
+    expect(files[test4!]).toContain('color yellow');
     expect(await page.evaluate('window.test1')).toBe(
       `http://localhost:${rsbuild.port}/static/assets/test1.css`,
     );

--- a/e2e/cases/assets/styles-as-assets/src/test4.styl
+++ b/e2e/cases/assets/styles-as-assets/src/test4.styl
@@ -1,5 +1,3 @@
-body {
-  & .foo {
-    color: yellow;
-  }
-}
+body
+  .foo
+    color yellow

--- a/e2e/cases/solid/stylus/src/App.styl
+++ b/e2e/cases/solid/stylus/src/App.styl
@@ -1,8 +1,8 @@
-color = #ff3e00;
+color = #ff3e00
 
 .main
   h1
-    color: color
-    text-transform: uppercase
-    font-size: 4em
-    font-weight: 100
+    color color
+    text-transform uppercase
+    font-size 4em
+    font-weight 100

--- a/e2e/cases/stylus/basic/src/b.module.styl
+++ b/e2e/cases/stylus/basic/src/b.module.styl
@@ -1,2 +1,2 @@
 .title-class
-  font-size: 14px;
+  font-size 14px

--- a/e2e/cases/stylus/environment/src/b.module.styl
+++ b/e2e/cases/stylus/environment/src/b.module.styl
@@ -1,2 +1,2 @@
 .title-class
-  font-size: 14px;
+  font-size 14px

--- a/e2e/cases/stylus/rem/src/b.module.styl
+++ b/e2e/cases/stylus/rem/src/b.module.styl
@@ -1,2 +1,2 @@
 .title-class
-  font-size: 14px;
+  font-size 14px

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -276,7 +276,7 @@ export async function createRsbuild(
           return;
         }
 
-        // The current environment is not specified, skip it
+        // If the current environment is not specified, skip it
         if (
           context.specifiedEnvironments &&
           !context.specifiedEnvironments.includes(name)


### PR DESCRIPTION
## Summary

Adopt the recommendations in https://github.com/web-infra-dev/rsbuild/pull/4437.

Stylus supports omitting symbols such as `&` and `;`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
