### PR TITLE
test(e2e): run Rspack with incremental flag

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,9 +3,8 @@
   "name": "@rsbuild/e2e",
   "version": "1.0.0",
   "scripts": {
-    "test": "pnpm test:rspack && pnpm test:rspack:incremental && pnpm test:webpack",
-    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules playwright test",
-    "test:rspack:incremental": "cross-env NODE_OPTIONS=--experimental-vm-modules EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
+    "test": "pnpm test:rspack && pnpm test:webpack",
+    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
     "test:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

After bumping Rspack 1.2.0, Rsbuild's E2E testing takes longer and become unstable (We are still investigating the cause).

This PR reduced the number of cases that need to be run to make CI relatively stable.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
