### PR TITLE
docs: provides guides for both Tailwind CSS v3 and v4

### DIFF
--- a/website/docs/en/guide/basic/_meta.json
+++ b/website/docs/en/guide/basic/_meta.json
@@ -13,6 +13,7 @@
   "css-modules",
   "typescript",
   "tailwindcss",
+  "tailwindcss-v3",
   "unocss",
   "web-workers",
   "static-deploy",

--- a/website/docs/en/guide/basic/tailwindcss-v3.mdx
+++ b/website/docs/en/guide/basic/tailwindcss-v3.mdx
@@ -1,0 +1,174 @@
+# Use Tailwind CSS v3
+
+[Tailwind CSS](https://v3.tailwindcss.com/) is a CSS framework and design system based on utility class, which can quickly add common styles to components, and support flexible extension of theme styles.
+
+You can integrate Tailwind CSS in Rsbuild via PostCSS plugins.
+
+## Installing Tailwind CSS
+
+Rsbuild has built-in support for PostCSS, you can install `tailwindcss` package to integrate Tailwind CSS:
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add tailwindcss@3 -D" />
+
+## Configuring PostCSS
+
+You can register the `tailwindcss` PostCSS plugin through [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
+
+```js title="postcss.config.cjs"
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+  },
+};
+```
+
+## Configuring Tailwind CSS
+
+Create a `tailwind.config.js` file in the root directory of your project and add the following content:
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+:::tip
+The above configuration is for reference only and can be modified to suit the needs of your project. For example, non-TypeScript projects do not need to include ts and tsx files.
+:::
+
+It should be noted that the `content` option should include the paths to all source files that contain Tailwind class names. For details, please refer to [tailwindcss - Content Configuration](https://v3.tailwindcss.com/docs/content-configuration).
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    '../../lib1/src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+### Other configuration methods
+
+- You can directly pass the Tailwind CSS configuration to `postcss.config.cjs`:
+
+```js title="postcss.config.cjs"
+module.exports = {
+  plugins: {
+    tailwindcss: {
+      content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+      // ...other options
+    },
+  },
+};
+```
+
+- You can also set the Tailwind CSS configuration through [tools.postcss](/config/tools/postcss):
+
+```js title="rsbuild.config.js"
+import tailwindcss from 'tailwindcss';
+
+export default {
+  tools: {
+    postcss: {
+      plugins: [
+        tailwindcss({
+          content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+          // ...other options
+        }),
+      ],
+    },
+  },
+};
+```
+
+But we recommend placing the Tailwind CSS configuration in `tailwind.config.*` because other methods may cause the Tailwind CSS build performance to degrade, refer to [tailwindcss/issues/14229](https://github.com/tailwindlabs/tailwindcss/issues/14229).
+
+## Importing CSS
+
+Add the `@tailwind` directives in your CSS entry file:
+
+```css title="main.css"
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+Depending on your needs, you can selectively import the CSS styles provided by Tailwind CSS. Please refer to the [@tailwind documentation](https://v3.tailwindcss.com/docs/functions-and-directives#tailwind) for detailed usage of the `@tailwind` directives.
+
+## Done
+
+You have now completed all the steps to integrate Tailwind CSS in Rsbuild!
+
+You can use Tailwind's utility classes in any component or HTML, such as:
+
+```html
+<h1 class="text-3xl font-bold underline">Hello world!</h1>
+```
+
+For more usage details, refer to the [Tailwind CSS documentation](https://v3.tailwindcss.com/).
+
+## VS Code extension
+
+Tailwind CSS provides a [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense) plugin for VS Code to automatically complete Tailwind CSS class names, CSS functions, and directives.
+
+You can install this plugin in VS Code to enable the autocompletion feature.
+
+## Optimize build performance
+
+When using Tailwind CSS, if the `content` field in `tailwind.config.js` is not correctly configured, this can lead to poor build performance and HMR performance. This is because Tailwind CSS internally matches files based on the glob defined in `content`. The more files it matches, the greater the performance overhead.
+
+Therefore, we recommend that you specify the paths to be scanned accurately to avoid unnecessary performance overhead. For example, only include HTML or JS files in the project source code that actually contain Tailwind class names, and avoid including irrelevant files or directories, especially the `node_modules` directory.
+
+Here is an bad example of scanning the `node_modules`:
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    // Scanning a large number of files, leading to performance degradation
+    './node_modules/**/*.js',
+  ],
+};
+```
+
+Sometimes, you may accidentally scan the `node_modules` directory, for example, when scanning files in a monorepo:
+
+```js title="tailwind.config.js"
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    // Incorrectly includes the `packages/ui/node_modules` directory
+    // Should be '../../packages/ui/src/**/*.{html,js,ts,jsx,tsx}'
+    '../../packages/ui/**/*.{html,js,ts,jsx,tsx}',
+  ],
+};
+```
+
+## Optimize CSS size
+
+If you need to optimize the size of Tailwind CSS styles, you can try [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss).
+
+This plugin reads the module graph information of Rspack, automatically sets the accurate `content` configuration to generate minimal Tailwind CSS styles.
+
+```ts title="rsbuild.config.ts"
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
+
+export default {
+  plugins: [pluginTailwindCSS()],
+};
+```
+
+> See [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss) for more information.

--- a/website/docs/en/guide/basic/tailwindcss.mdx
+++ b/website/docs/en/guide/basic/tailwindcss.mdx
@@ -1,42 +1,44 @@
-# Use Tailwind CSS
+# Use Tailwind CSS v4
 
 [Tailwind CSS](https://tailwindcss.com/) is a CSS framework and design system based on utility class, which can quickly add common styles to components, and support flexible extension of theme styles.
 
 You can integrate Tailwind CSS in Rsbuild via PostCSS plugins.
 
+## Choosing Tailwind CSS version
+
+This document introduces the integration of Tailwind CSS v4.
+
+Please note that Tailwind CSS v4 uses many modern CSS features, such as [Cascade Layers](https://developer.mozilla.org/zh-CN/docs/Learn_web_development/Core/Styling_basics/Cascade_layers), if your target browser does not support these features, please use Tailwind CSS v3 first, see [Using Tailwind CSS v3](/guide/basic/tailwindcss-v3) for more details.
+
+More information can be found in [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility).
+
 ## Installing Tailwind CSS
 
-Since Rsbuild has built-in support for `postcss` and `autoprefixer`, you only need to install `tailwindcss` and there is no need to install other npm packages:
+Rsbuild has built-in support for PostCSS, you can install `tailwindcss` and `@tailwindcss/postcss` packages to integrate Tailwind CSS:
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add tailwindcss @tailwindcss/postcss postcss -D" />
+<PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
 
 ## Configuring PostCSS
 
-You can register the `tailwindcss` PostCSS plugin through [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
+You can register the Tailwind CSS PostCSS plugin through [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) or [tools.postcss](/config/tools/postcss).
 
 ```js title="postcss.config.mjs"
 export default {
   plugins: {
-    "@tailwindcss/postcss": {},
-  }
-}
+    '@tailwindcss/postcss': {},
+  },
+};
 ```
-
-:::tip
-Rsbuild has built-in [autoprefixer](https://github.com/postcss/autoprefixer), so you only need to register the `tailwindcss` plugin.
-:::
 
 ## Importing CSS
 
-Add the `@tailwind` directives in your CSS entry file:
+Add an `@import` to your CSS entry file that imports Tailwind CSS.
 
-```css title="main.css"
-@tailwind tailwindcss;
+```css title="src/index.css"
+@import 'tailwindcss';
 ```
-
-Depending on your needs, you can selectively import the CSS styles provided by Tailwind CSS. Please refer to the [@tailwind documentation](https://tailwindcss.com/docs/functions-and-directives#tailwind) for detailed usage of the `@tailwind` directives.
 
 ## Done
 

--- a/website/docs/zh/guide/basic/_meta.json
+++ b/website/docs/zh/guide/basic/_meta.json
@@ -13,6 +13,7 @@
   "css-modules",
   "typescript",
   "tailwindcss",
+  "tailwindcss-v3",
   "unocss",
   "web-workers",
   "static-deploy",

--- a/website/docs/zh/guide/basic/tailwindcss-v3.mdx
+++ b/website/docs/zh/guide/basic/tailwindcss-v3.mdx
@@ -1,0 +1,174 @@
+# 使用 Tailwind CSS v3
+
+[Tailwind CSS](https://v3.tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
+
+你可以通过 PostCSS 插件来在 Rsbuild 中接入 Tailwind CSS。
+
+## 安装 Tailwind CSS
+
+Rsbuild 内置支持 PostCSS，你可以安装 `tailwindcss` 包来接入 Tailwind CSS：
+
+import { PackageManagerTabs } from '@theme';
+
+<PackageManagerTabs command="add tailwindcss@3 -D" />
+
+## 配置 PostCSS
+
+你可以通过 [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 `tailwindcss` 的 PostCSS 插件。
+
+```js title="postcss.config.cjs"
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+  },
+};
+```
+
+## 配置 Tailwind CSS
+
+在当前项目的根目录创建 `tailwind.config.js` 文件，并添加以下内容：
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+:::tip
+上述配置仅供参考，你可以根据项目需要进行调整，比如非 TypeScript 项目不需要包含 ts 和 tsx 文件。
+:::
+
+需要注意的是，`content` 选项应包含所有用到 Tailwind 类名的源文件的路径。详情可参考 [tailwindcss - Content 配置](https://v3.tailwindcss.com/docs/content-configuration)。
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    '../../lib1/src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+```
+
+### 其他配置方式
+
+- 你可以在 `postcss.config.cjs` 中直接传入 Tailwind CSS 的配置：
+
+```js title="postcss.config.cjs"
+module.exports = {
+  plugins: {
+    tailwindcss: {
+      content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+      // ...other options
+    },
+  },
+};
+```
+
+- 也可以通过 [tools.postcss](/config/tools/postcss) 来设置 Tailwind CSS 的配置：
+
+```js title="rsbuild.config.js"
+import tailwindcss from 'tailwindcss';
+
+export default {
+  tools: {
+    postcss: {
+      plugins: [
+        tailwindcss({
+          content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
+          // ...other options
+        }),
+      ],
+    },
+  },
+};
+```
+
+但我们建议将 Tailwind CSS 的配置放在 `tailwind.config.*` 中，因为其他方式可能会导致 Tailwind CSS 的构建性能劣化，参考 [tailwindcss/issues/14229](https://github.com/tailwindlabs/tailwindcss/issues/14229)。
+
+## 引入 CSS
+
+在 CSS 入口文件中添加 `@tailwind` 指令：
+
+```css title="main.css"
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+根据需求不同，你可以选择性地导入 Tailwind CSS 提供的 CSS 样式。请参考 [@tailwind 文档](https://v3.tailwindcss.com/docs/functions-and-directives#tailwind) 来了解 `@tailwind` 指令的详细用法。
+
+## 完成
+
+你已经完成了在 Rsbuild 中接入 Tailwind CSS 的全部步骤！
+
+你可以在任意组件或 HTML 中使用 Tailwind 的 utility classes，比如：
+
+```html
+<h1 class="text-3xl font-bold underline">Hello world!</h1>
+```
+
+更多用法请参考 [Tailwind CSS 文档](https://v3.tailwindcss.com/)。
+
+## VS Code 插件
+
+Tailwind CSS 提供了 [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense) 插件，用于在 VS Code 中自动补全 Tailwind CSS 的 class names、CSS functions 和 directives。
+
+你可以在 VS Code 中安装该插件，即可开启自动补全功能。
+
+## 优化构建性能
+
+在使用 Tailwind CSS 时，如果没有正确地配置 `tailwind.config.js` 中的 `content` 字段，可能会导致构建性能和热更新性能下降。这是因为 Tailwind CSS 内部会基于 `content` 定义的 glob 来匹配文件，扫描的文件数量越多，产生的性能开销越大。
+
+因此，我们建议精确地指定需要扫描的路径，以避免不必要的性能开销。例如，仅包括项目源码中实际包含 Tailwind 类名的 HTML 或 JS 文件，避免包含不相关的文件或目录，尤其是 `node_modules` 目录。
+
+下面是一个扫描 `node_modules` 的错误示例：
+
+```js title="tailwind.config.js"
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    // 扫描大量文件，导致性能下降
+    './node_modules/**/*.js',
+  ],
+};
+```
+
+有时，你可能会不小心扫描 `node_modules` 目录，例如在 monorepo 中扫描其他包的文件时：
+
+```js title="tailwind.config.js"
+module.exports = {
+  content: [
+    './src/**/*.{html,js,ts,jsx,tsx}',
+    // 错误地包含了 `packages/ui/node_modules` 目录
+    // 正确写法为 '../../packages/ui/src/**/*.{html,js,ts,jsx,tsx}'
+    '../../packages/ui/**/*.{html,js,ts,jsx,tsx}',
+  ],
+};
+```
+
+## 优化样式体积
+
+如果你需要优化 Tailwind CSS 的样式体积，欢迎尝试 [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss)。
+
+该插件读取了 Rspack 的模块图信息，自动设置准确的 `content` 配置，以生成尽可能少的 Tailwind CSS 样式。
+
+```ts title="rsbuild.config.ts"
+import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
+
+export default {
+  plugins: [pluginTailwindCSS()],
+};
+```
+
+> 参考 [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss) 了解更多。

--- a/website/docs/zh/guide/basic/tailwindcss.mdx
+++ b/website/docs/zh/guide/basic/tailwindcss.mdx
@@ -1,115 +1,44 @@
-# 使用 Tailwind CSS
+# 使用 Tailwind CSS v4
 
 [Tailwind CSS](https://tailwindcss.com/) 是一个以 Utility Class 为基础的 CSS 框架和设计系统，可以快速地为组件添加常用样式，同时支持主题样式的灵活扩展。
 
 你可以通过 PostCSS 插件来在 Rsbuild 中接入 Tailwind CSS。
 
+## 选择 Tailwind CSS 版本
+
+当前文档介绍的是 Tailwind CSS v4 的接入方式。
+
+请注意 Tailwind CSS v4 使用了很多现代 CSS 特性，比如 [Cascade Layers](https://developer.mozilla.org/zh-CN/docs/Learn_web_development/Core/Styling_basics/Cascade_layers)，如果你的目标浏览器不支持这些特性，请优先使用 Tailwind CSS v3，参考 [使用 Tailwind CSS v3](/guide/basic/tailwindcss-v3)。
+
+更多信息请参考 [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility)。
+
 ## 安装 Tailwind CSS
 
-由于 Rsbuild 内置支持了 `postcss` 和 `autoprefixer`，你只需要安装 `tailwindcss`，无须安装其他 npm 包：
+Rsbuild 内置支持 PostCSS，你可以安装 `tailwindcss` 和 `@tailwindcss/postcss` 包来接入 Tailwind CSS：
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add tailwindcss -D" />
+<PackageManagerTabs command="add tailwindcss @tailwindcss/postcss -D" />
 
 ## 配置 PostCSS
 
-你可以通过 [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 `tailwindcss` 的 PostCSS 插件。
+你可以通过 [postcss.config.cjs](https://www.npmjs.com/package/postcss-loader#config) 或 [tools.postcss](/config/tools/postcss) 来注册 Tailwind CSS 的 PostCSS 插件。
 
-```js title="postcss.config.cjs"
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-  },
-};
-```
-
-:::tip
-Rsbuild 内置了 [autoprefixer](https://github.com/postcss/autoprefixer)，因此你只需要注册 `tailwindcss` 插件。
-:::
-
-## 配置 Tailwind CSS
-
-在当前项目的根目录创建 `tailwind.config.js` 文件，并添加以下内容：
-
-```js title="tailwind.config.js"
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-```
-
-:::tip
-上述配置仅供参考，你可以根据项目需要进行调整，比如非 TypeScript 项目不需要包含 ts 和 tsx 文件。
-:::
-
-需要注意的是，`content` 选项应包含所有用到 Tailwind 类名的源文件的路径。详情可参考 [tailwindcss - Content 配置](https://tailwindcss.com/docs/content-configuration)。
-
-```js title="tailwind.config.js"
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    './src/**/*.{html,js,ts,jsx,tsx}',
-    '../../lib1/src/**/*.{js,ts,jsx,tsx}',
-  ],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};
-```
-
-### 其他配置方式
-
-- 你可以在 `postcss.config.cjs` 中直接传入 Tailwind CSS 的配置：
-
-```js title="postcss.config.cjs"
-module.exports = {
-  plugins: {
-    tailwindcss: {
-      content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
-      // ...other options
-    },
-  },
-};
-```
-
-- 也可以通过 [tools.postcss](/config/tools/postcss) 来设置 Tailwind CSS 的配置：
-
-```js title="rsbuild.config.js"
-import tailwindcss from 'tailwindcss';
-
+```js title="postcss.config.mjs"
 export default {
-  tools: {
-    postcss: {
-      plugins: [
-        tailwindcss({
-          content: ['./src/**/*.{html,js,ts,jsx,tsx}'],
-          // ...other options
-        }),
-      ],
-    },
+  plugins: {
+    '@tailwindcss/postcss': {},
   },
 };
 ```
-
-但我们建议将 Tailwind CSS 的配置放在 `tailwind.config.*` 中，因为其他方式可能会导致 Tailwind CSS 的构建性能劣化，参考 [tailwindcss/issues/14229](https://github.com/tailwindlabs/tailwindcss/issues/14229)。
 
 ## 引入 CSS
 
-在 CSS 入口文件中添加 `@tailwind` 指令：
+在 CSS 入口文件中添加 `@import` 指令，引入 Tailwind CSS。
 
-```css title="main.css"
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+```css title="src/index.css"
+@import 'tailwindcss';
 ```
-
-根据需求不同，你可以选择性地导入 Tailwind CSS 提供的 CSS 样式。请参考 [@tailwind 文档](https://tailwindcss.com/docs/functions-and-directives#tailwind) 来了解 `@tailwind` 指令的详细用法。
 
 ## 完成
 
@@ -128,51 +57,3 @@ export default {
 Tailwind CSS 提供了 [Tailwind CSS IntelliSense](https://github.com/tailwindlabs/tailwindcss-intellisense) 插件，用于在 VS Code 中自动补全 Tailwind CSS 的 class names、CSS functions 和 directives。
 
 你可以在 VS Code 中安装该插件，即可开启自动补全功能。
-
-## 优化构建性能
-
-在使用 Tailwind CSS 时，如果没有正确地配置 `tailwind.config.js` 中的 `content` 字段，可能会导致构建性能和热更新性能下降。这是因为 Tailwind CSS 内部会基于 `content` 定义的 glob 来匹配文件，扫描的文件数量越多，产生的性能开销越大。
-
-因此，我们建议精确地指定需要扫描的路径，以避免不必要的性能开销。例如，仅包括项目源码中实际包含 Tailwind 类名的 HTML 或 JS 文件，避免包含不相关的文件或目录，尤其是 `node_modules` 目录。
-
-下面是一个扫描 `node_modules` 的错误示例：
-
-```js title="tailwind.config.js"
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [
-    './src/**/*.{html,js,ts,jsx,tsx}',
-    // 扫描大量文件，导致性能下降
-    './node_modules/**/*.js',
-  ],
-};
-```
-
-有时，你可能会不小心扫描 `node_modules` 目录，例如在 monorepo 中扫描其他包的文件时：
-
-```js title="tailwind.config.js"
-module.exports = {
-  content: [
-    './src/**/*.{html,js,ts,jsx,tsx}',
-    // 错误地包含了 `packages/ui/node_modules` 目录
-    // 正确写法为 '../../packages/ui/src/**/*.{html,js,ts,jsx,tsx}'
-    '../../packages/ui/**/*.{html,js,ts,jsx,tsx}',
-  ],
-};
-```
-
-## 优化样式体积
-
-如果你需要优化 Tailwind CSS 的样式体积，欢迎尝试 [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss)。
-
-该插件读取了 Rspack 的模块图信息，自动设置准确的 `content` 配置，以生成尽可能少的 Tailwind CSS 样式。
-
-```ts title="rsbuild.config.ts"
-import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
-
-export default {
-  plugins: [pluginTailwindCSS()],
-};
-```
-
-> 参考 [rsbuild-plugin-tailwindcss](https://github.com/rspack-contrib/rsbuild-plugin-tailwindcss) 了解更多。


### PR DESCRIPTION
## Summary

This pull request includes updates to the documentation files to add support for Tailwind CSS v3 and v4. The changes include new guides for integrating Tailwind CSS v3 and updates to the existing Tailwind CSS guide to reflect Tailwind CSS v4.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4425

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
