### PR TITLE
fix: allow to only generate source map for CSS files

### DIFF
--- a/e2e/cases/output/source-map/index.test.ts
+++ b/e2e/cases/output/source-map/index.test.ts
@@ -186,3 +186,28 @@ test('should generate source map correctly in development build', async ({
 
   await rsbuild.close();
 });
+
+test('should allow to only generate source map for CSS files', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        sourceMap: {
+          js: false,
+          css: true,
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON(false);
+
+  const jsMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.js.map'),
+  );
+  const cssMapFiles = Object.keys(files).filter((files) =>
+    files.endsWith('.css.map'),
+  );
+  expect(jsMapFiles.length).toEqual(0);
+  expect(cssMapFiles.length).toBeGreaterThan(0);
+});

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -105,6 +105,7 @@ export async function generateWebpackConfig({
     DefinePlugin,
     IgnorePlugin,
     ProvidePlugin,
+    SourceMapDevToolPlugin,
     HotModuleReplacementPlugin,
   } = webpack;
 
@@ -115,6 +116,7 @@ export async function generateWebpackConfig({
       DefinePlugin,
       IgnorePlugin,
       ProvidePlugin,
+      SourceMapDevToolPlugin,
       HotModuleReplacementPlugin,
     },
   });

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -163,6 +163,7 @@ export async function generateRspackConfig({
     DefinePlugin,
     IgnorePlugin,
     ProvidePlugin,
+    SourceMapDevToolPlugin,
     HotModuleReplacementPlugin,
   } = rspack;
 
@@ -173,6 +174,7 @@ export async function generateRspackConfig({
       DefinePlugin,
       IgnorePlugin,
       ProvidePlugin,
+      SourceMapDevToolPlugin,
       HotModuleReplacementPlugin,
     },
   });

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -192,6 +192,7 @@ export type ModifyBundlerChainUtils = ModifyChainUtils & {
     DefinePlugin: PluginInstance;
     IgnorePlugin: PluginInstance;
     ProvidePlugin: PluginInstance;
+    SourceMapDevToolPlugin: PluginInstance;
     HotModuleReplacementPlugin: PluginInstance;
   };
 };

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -405,11 +405,7 @@ type ModifyBundlerChainUtils = {
   CHAIN_ID: ChainIdentifier;
   HtmlPlugin: typeof import('html-rspack-plugin');
   bundler: {
-    BannerPlugin: rspack.BannerPlugin;
-    DefinePlugin: rspack.DefinePlugin;
-    IgnorePlugin: rspack.IgnorePlugin;
-    ProvidePlugin: rspack.ProvidePlugin;
-    HotModuleReplacementPlugin: rspack.HotModuleReplacementPlugin;
+    // some Rspack built-in plugins
   };
 };
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -401,11 +401,7 @@ type ModifyBundlerChainUtils = {
   CHAIN_ID: ChainIdentifier;
   HtmlPlugin: typeof import('html-rspack-plugin');
   bundler: {
-    BannerPlugin: rspack.BannerPlugin;
-    DefinePlugin: rspack.DefinePlugin;
-    IgnorePlugin: rspack.IgnorePlugin;
-    ProvidePlugin: rspack.ProvidePlugin;
-    HotModuleReplacementPlugin: rspack.HotModuleReplacementPlugin;
+    // some Rspack built-in plugins
   };
 };
 


### PR DESCRIPTION
## Summary

When JS source map is disabled, but CSS source map is enabled, we should add the `SourceMapDevToolPlugin` to let Rspack generate CSS source map.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/4397
- https://rspack.dev/plugins/webpack/source-map-dev-tool-plugin#host-source-maps-externally

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
