### PR TITLE
chore: remove rspack-chain temporary code

### DIFF
--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -123,7 +123,7 @@ export async function generateWebpackConfig({
 
   const chain = await modifyWebpackChain(context, chainUtils, bundlerChain);
 
-  let webpackConfig = helpers.chainToConfig(chain) as WebpackConfig;
+  let webpackConfig = chain.toConfig() as WebpackConfig;
 
   const configUtils = (await helpers.getConfigUtils(
     webpackConfig as Rspack.Configuration,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.1.2",
     "rslog": "^1.2.3",
-    "rspack-chain": "^1.2.0",
+    "rspack-chain": "^1.2.1",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.0",
     "style-loader": "3.3.4",

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -1,12 +1,7 @@
 import RspackChain from '../compiled/rspack-chain/index.js';
-import { castArray, isPlainObject } from './helpers';
+import { castArray } from './helpers';
 import { logger } from './logger';
-import type {
-  InternalContext,
-  ModifyBundlerChainUtils,
-  RsbuildEntry,
-  Rspack,
-} from './types';
+import type { InternalContext, ModifyBundlerChainUtils } from './types';
 
 export function getBundlerChain(): RspackChain {
   const bundlerChain = new RspackChain();
@@ -37,55 +32,6 @@ export async function modifyBundlerChain(
   logger.debug('modify bundler chain done');
 
   return modifiedBundlerChain;
-}
-
-export function chainToConfig(chain: RspackChain): Rspack.Configuration {
-  const config = chain.toConfig();
-  const { entry } = config;
-
-  if (!isPlainObject(entry)) {
-    return config as Rspack.Configuration;
-  }
-
-  const formattedEntry: RsbuildEntry = {};
-
-  /**
-   * rspack-chain can not handle entry description object correctly,
-   * so we need to format the entry object and correct the entry description object.
-   */
-  for (const [entryName, entryValue] of Object.entries(entry)) {
-    const entryImport: string[] = [];
-    let entryDescription: Rspack.EntryDescription | null = null;
-
-    for (const item of castArray(entryValue)) {
-      if (typeof item === 'string') {
-        entryImport.push(item);
-        continue;
-      }
-
-      if (item.import) {
-        entryImport.push(...castArray(item.import));
-      }
-
-      if (entryDescription) {
-        // merge entry description object
-        Object.assign(entryDescription, item);
-      } else {
-        entryDescription = item;
-      }
-    }
-
-    formattedEntry[entryName] = entryDescription
-      ? {
-          ...entryDescription,
-          import: entryImport,
-        }
-      : entryImport;
-  }
-
-  config.entry = formattedEntry;
-
-  return config as Rspack.Configuration;
 }
 
 export const CHAIN_ID = {

--- a/packages/core/src/provider/helpers.ts
+++ b/packages/core/src/provider/helpers.ts
@@ -13,5 +13,5 @@ export { getHTMLPlugin } from '../pluginHelper';
 export { formatStats, getStatsOptions, prettyTime } from '../helpers';
 export { registerBuildHook, registerDevHook } from '../hooks';
 export { getChainUtils, getConfigUtils } from './rspackConfig';
-export { chainToConfig, modifyBundlerChain } from '../configChain';
+export { modifyBundlerChain } from '../configChain';
 export { createDevServer } from '../server/devServer';

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -1,6 +1,6 @@
 import { rspack } from '@rspack/core';
 import { reduceConfigsAsyncWithContext } from 'reduce-configs';
-import { CHAIN_ID, chainToConfig, modifyBundlerChain } from '../configChain';
+import { CHAIN_ID, modifyBundlerChain } from '../configChain';
 import { castArray, color, getNodeEnv } from '../helpers';
 import { logger } from '../logger';
 import { getHTMLPlugin } from '../pluginHelper';
@@ -179,7 +179,7 @@ export async function generateRspackConfig({
     },
   });
 
-  let rspackConfig = chainToConfig(chain);
+  let rspackConfig = chain.toConfig();
 
   rspackConfig = await modifyRspackConfig(
     context,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -700,8 +700,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       rspack-chain:
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.2.2(@swc/helpers@0.5.15))
@@ -5902,8 +5902,8 @@ packages:
     resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
     engines: {node: '>=14.17.6'}
 
-  rspack-chain@1.2.0:
-    resolution: {integrity: sha512-5J09C2vr1Vl7ig5mp5KDm2l/DA3SS7y6KEzvJkJpmfenun+9a/mcg38NsaowGH1EJTzISZ7acpNA3TGrQLxgrQ==}
+  rspack-chain@1.2.1:
+    resolution: {integrity: sha512-RXix83G+5D9ewhmeAUqsJa6l5QmAVCJU4Q3n7D/9Nt1/dBsg/4rvr3fuTGM4Bi55jCFq8z6m0PvsOrRiEMDhQw==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -12192,7 +12192,7 @@ snapshots:
 
   rslog@1.2.3: {}
 
-  rspack-chain@1.2.0:
+  rspack-chain@1.2.1:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Update rspack-chain to v1.2.1 and remove the entry related temporary code.

## Related Links

- https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.2.1
- https://github.com/rspack-contrib/rspack-chain/pull/36

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
