### PR TITLE
docs: fix return value of `rsbuild.rspackConfigs()`

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -618,7 +618,7 @@ function InitConfigs(): Promise<{
 - **Example:**
 
 ```ts
-const { rspackConfigs } = await rsbuild.initConfigs();
+const rspackConfigs = await rsbuild.initConfigs();
 
 console.log(rspackConfigs);
 ```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -639,7 +639,7 @@ function InitConfigs(): Promise<{
 - **示例：**
 
 ```ts
-const { rspackConfigs } = await rsbuild.initConfigs();
+const rspackConfigs = await rsbuild.initConfigs();
 
 console.log(rspackConfigs);
 ```


### PR DESCRIPTION
## Summary

Fix return value of `rsbuild.rspackConfigs()`, should be `rspackConfigs`.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4463

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
