### PR TITLE
ci(corepack): fix corepack key id mismatch

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -42,7 +42,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js
         if: steps.eco_ci.outcome == 'failure'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,9 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - uses: dorny/paths-filter@v3.0.2
         id: changes
@@ -69,7 +71,9 @@ jobs:
           fetch-depth: 1
 
       - name: Install Pnpm
-        run: corepack enable
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
 
       - uses: dorny/paths-filter@v3.0.2
         id: changes


### PR DESCRIPTION
## Summary

Add `npm install -g corepack@latest --force` before `corepack enable` to fix corepack key id mismatch issue.

> `--force` to prevent windows install error

![image](https://github.com/user-attachments/assets/47a73c6c-240e-4c15-bf7b-1e23f8b1c54d)

## Related Links

https://github.com/nodejs/corepack/issues/612

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
