### PR TITLE
docs: set Open Graph images based on page routes

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -133,6 +133,17 @@ export default defineConfig({
       },
     ],
   },
+  head: [
+    ({ routePath }) => {
+      const getOgImage = () => {
+        if (routePath.endsWith('releases/v1-0')) {
+          return 'assets/rsbuild-og-image-v1-0.png';
+        }
+        return 'rsbuild-og-image.png';
+      };
+      return `<meta property="og:image" content="https://assets.rspack.dev/rsbuild/${getOgImage()}">`;
+    },
+  ],
   builderConfig: {
     dev: {
       lazyCompilation: true,
@@ -144,8 +155,6 @@ export default defineConfig({
         title: 'Rsbuild',
         type: 'website',
         url: siteUrl,
-        image:
-          'https://assets.rspack.dev/rsbuild/assets/rsbuild-og-image-v1-0.png',
         description: 'The Rspack-based build tool',
         twitter: {
           site: '@rspack_dev',


### PR DESCRIPTION
## Summary

This pull request includes changes to the `website/rspress.config.ts` file to dynamically generate Open Graph images based on the route path. The most important changes include adding a function to determine the appropriate Open Graph image and removing the hardcoded image URL.

## Related Links

- https://rspress.dev/api/config/config-basic#head

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
