### PR TITLE
fix: validate `server.base` config

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -471,7 +471,7 @@ export async function loadConfig({
 
   let configExport: RsbuildConfigExport;
 
-  if (/\.(?:js|mjs|cjs)$/.test(configFilePath) || loader === 'native') {
+  if (loader === 'native' || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
     try {
       const exportModule = await import(`${configFilePath}?t=${Date.now()}`);
       configExport = exportModule.default ? exportModule.default : exportModule;

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -151,6 +151,14 @@ const initEnvironmentConfigs = (
   };
 };
 
+const validateRsbuildConfig = (config: NormalizedConfig) => {
+  if (config.server.base && !config.server.base.startsWith('/')) {
+    throw new Error(
+      `[rsbuild:config] The "server.base" option should start with a slash, for example: "/base"`,
+    );
+  }
+};
+
 export async function initRsbuildConfig({
   context,
   pluginManager,
@@ -215,6 +223,7 @@ export async function initRsbuildConfig({
 
   await updateEnvironmentContext(context, environments);
   updateContextByNormalizedConfig(context);
+  validateRsbuildConfig(context.normalizedConfig);
 
   return context.normalizedConfig;
 }


### PR DESCRIPTION
## Summary

Adding a validation for the `server.base` configuration:

<img width="1192" alt="Screenshot 2025-02-06 at 21 33 14" src="https://github.com/user-attachments/assets/c392b7d6-b6ec-42e6-95df-898dbfb84684" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
