### PR TITLE
fix: skip clean in dev mode when writeToDisk is false

### DIFF
--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { build, proxyConsole } from '@e2e/helper';
+import { build, dev, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import fse from 'fs-extra';
 
@@ -16,7 +16,37 @@ test('should clean dist path by default', async () => {
   });
 
   expect(fs.existsSync(testDistFile)).toBeFalsy();
+});
+
+test('should not clean dist path in dev mode when writeToDisk is false', async () => {
+  await fse.outputFile(testDistFile, `{ "test": 1 }`);
+
+  await dev({
+    cwd,
+    rsbuildConfig: {
+      dev: {
+        writeToDisk: false,
+      },
+    },
+  });
+
+  expect(fs.existsSync(testDistFile)).toBeTruthy();
   fs.rmSync(testDistFile, { force: true });
+});
+
+test('should clean dist path in dev mode when writeToDisk is true', async () => {
+  await fse.outputFile(testDistFile, `{ "test": 1 }`);
+
+  await dev({
+    cwd,
+    rsbuildConfig: {
+      dev: {
+        writeToDisk: true,
+      },
+    },
+  });
+
+  expect(fs.existsSync(testDistFile)).toBeFalsy();
 });
 
 test('should not clean dist path if it is outside root', async () => {

--- a/website/docs/en/config/output/clean-dist-path.mdx
+++ b/website/docs/en/config/output/clean-dist-path.mdx
@@ -8,13 +8,14 @@ type CleanDistPath = boolean | 'auto' | CleanDistPathObject;
 
 - **Default:** `'auto'`
 
-Whether to clean up all files under the output directory before the build starts (the output directory defaults to `dist`).
+Whether to clean up all files under the output directory before the build starts, the output directory is the value of [output.distPath.root](/config/output/dist-path).
 
 ## Default behavior
 
-The default value of `output.cleanDistPath` is `'auto'`. If the output directory is a subdir of the project root path, Rsbuild will automatically clean all files under the output directory.
+The default value of `output.cleanDistPath` is `'auto'`:
 
-When [output.distPath.root](/config/output/dist-path) is an external directory, or equals to the project root directory, `cleanDistPath` is not enabled by default, to avoid accidentally deleting files from other directories.
+- In development mode, if the value of [dev.writeToDisk](/config/dev/write-to-disk) is `false`, Rsbuild will not perform cleanup.
+- In any mode, if [output.distPath.root](/config/output/dist-path) is an external directory or equals to the project root directory, Rsbuild will not perform cleanup to avoid accidentally deleting files from other directories.
 
 ```js
 export default {

--- a/website/docs/zh/config/output/clean-dist-path.mdx
+++ b/website/docs/zh/config/output/clean-dist-path.mdx
@@ -8,13 +8,14 @@ type CleanDistPath = boolean | 'auto' | CleanDistPathObject;
 
 - **默认值：** `'auto'`
 
-是否在构建开始前清理产物目录下的所有文件（产物目录默认为 `dist`）。
+是否在构建开始前清理产物目录下的所有文件，产物目录为 [output.distPath.root](/config/output/dist-path) 的值。
 
 ## 默认行为
 
-`output.cleanDistPath` 的默认值为 `'auto'`。如果产物目录是项目根路径的子目录，Rsbuild 会自动清空产物目录下的文件。
+`output.cleanDistPath` 的默认值为 `'auto'`：
 
-当 [output.distPath.root](/config/output/dist-path) 为外部目录，或等于项目根目录时，`cleanDistPath` 不会默认开启，这是为了避免误删其他目录的文件。
+- 在开发模式下，如果 [dev.writeToDisk](/config/dev/write-to-disk) 的值为 `false`，则 Rsbuild 不会执行清理。
+- 在任意模式下，如果 [output.distPath.root](/config/output/dist-path) 为外部目录，或等于项目根目录时，Rsbuild 不会执行清理，这是为了避免误删其他目录的文件。
 
 ```js
 export default {


### PR DESCRIPTION
## Summary

In development mode, if the value of `dev.writeToDisk` is `false`, Rsbuild will no longer clean up the output directory.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4481

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
