### PR TITLE
chore(renovate): pin GitHub Action digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: ['config:recommended', 'schedule:weekly'],
+  extends: ['config:recommended', 'schedule:weekly', 'helpers:pinGitHubActionDigests'],
   ignorePaths: ['**/tests/**', '**/node_modules/**'],
   packageRules: [
     // Use chore as semantic commit type for commit messages


### PR DESCRIPTION
## Summary

Add `helpers:pinGitHubActionDigests` to let renovate automatically pin action digests. This change should fix all the `Unpinned tag for a non-immutable Action in workflow` alerts in https://github.com/web-infra-dev/rsbuild/security/code-scanning.

## Related Links

- https://docs.renovatebot.com/modules/manager/github-actions/#additional-information

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
