### PR TITLE
docs: fix grammar in Rsbuild description

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can think of Rsbuild as a modernized version of Create React App or Vue CLI,
 
 ### Vite
 
-Rsbuild shares many similarities with Vite, as they are both aim to improve the frontend development experience. The main differences are:
+Rsbuild shares many similarities with Vite, as they both aim to improve the frontend development experience. The main differences are:
 
 - **Ecosystem compatibility**: Rsbuild is compatible with most webpack plugins and all Rspack plugins, while Vite is compatible with Rollup plugins. If you're currently using more plugins and loaders from the webpack ecosystem, migrating to Rsbuild would be relatively easy.
 - **Production consistency**: Rsbuild uses Rspack for bundling during both the development and production builds, thus ensuring a high level of consistency between the development and production outputs. This is also one of the goals Vite aims to achieve with Rolldown.

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -20,7 +20,7 @@ You can think of Rsbuild as a modernized version of Create React App or Vue CLI,
 
 ### Vite
 
-Rsbuild shares many similarities with Vite, as they are both aim to improve the frontend development experience. The main differences are:
+Rsbuild shares many similarities with Vite, as they both aim to improve the frontend development experience. The main differences are:
 
 - **Production consistency**: Rsbuild uses Rspack for bundling during both the development and production builds, thus ensuring a high level of consistency between the development and production outputs. Vite, on the other hand, uses ESM for module loading during development, which improves the startup speed, but may lead to inconsistencies between the development and production outputs.
 - **Ecosystem compatibility**: Rsbuild is compatible with most webpack plugins and all Rspack plugins, while Vite is compatible with Rollup plugins. If you're currently using more plugins and loaders from the webpack ecosystem, migrating to Rsbuild would be relatively easy.


### PR DESCRIPTION
## Summary

Fixes grammar in the Rsbuild introduction section (which is also included in the project README).

Before:

> Rsbuild shares many similarities with Vite, as they **are** both aim to improve the frontend development experience.

After:

> Rsbuild shares many similarities with Vite, as they both aim to improve the frontend development experience.

## Related Links

<!--- Provide links of related issues or pages -->

* ["Getting Started" -> "Introduction" -> "Comparisons" -> "Vite"](https://rsbuild.dev/guide/start/index#vite)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
