### PR TITLE
fix(cache): error handling for buildDependencies JSON parsing

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -20,7 +20,7 @@ async function validateCache(
   if (await isFileExists(configFile)) {
     const rawConfigFile = await fs.promises.readFile(configFile, 'utf-8');
 
-    let prevBuildDependencies = {};
+    let prevBuildDependencies: Record<string, string[]> | null = null;
     try {
       prevBuildDependencies = JSON.parse(rawConfigFile);
     } catch (e) {

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -2,6 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { findExists, isFileExists } from '../helpers';
+import { logger } from '../logger';
 import type {
   BuildCacheOptions,
   EnvironmentContext,
@@ -18,7 +19,13 @@ async function validateCache(
 
   if (await isFileExists(configFile)) {
     const rawConfigFile = await fs.promises.readFile(configFile, 'utf-8');
-    const prevBuildDependencies = JSON.parse(rawConfigFile);
+
+    let prevBuildDependencies = {};
+    try {
+      prevBuildDependencies = JSON.parse(rawConfigFile);
+    } catch (e) {
+      logger.debug('Failed to parse the previous buildDependencies.json', e);
+    }
 
     if (
       JSON.stringify(prevBuildDependencies) ===


### PR DESCRIPTION
## Summary

The `buildDependencies.json` may be an invalid JSON in abnormal cases. This PR adds `try catch` to improve error handling for buildDependencies JSON parsing. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
