### PR TITLE
refactor(core): simplify CacheGroups types

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,8 +39,6 @@ export type {
   Build,
   BuildOptions,
   BundlerPluginInstance,
-  CacheGroup,
-  CacheGroups,
   Charset,
   ClientConfig,
   CliShortcut,

--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -1,13 +1,15 @@
 import assert from 'node:assert';
 import { NODE_MODULES_REGEX } from '../constants';
 import type {
-  CacheGroups,
   ForceSplitting,
   Polyfill,
   RsbuildChunkSplit,
   RsbuildPlugin,
+  Rspack,
   SplitChunks,
 } from '../types';
+
+type CacheGroups = Record<string, Rspack.OptimizationSplitChunksCacheGroup>;
 
 // We expose three layers to specify Rspack chunk-split config:
 // 1. By strategy. Some best practices strategies.

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -616,24 +616,6 @@ export type SplitChunks = Configuration extends {
   ? P
   : never;
 
-export type CacheGroups = Configuration extends {
-  optimization?: {
-    splitChunks?:
-      | {
-          cacheGroups?: infer P;
-        }
-      | false;
-  };
-}
-  ? P
-  : never;
-
-export type CacheGroup = CacheGroups extends {
-  [key: string]: infer P;
-}
-  ? P
-  : null;
-
 export type ForceSplitting = RegExp[] | Record<string, RegExp>;
 
 export interface BaseSplitRules {

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -1,4 +1,4 @@
-import type { CacheGroups, RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
+import type { RsbuildPluginAPI, Rspack, SplitChunks } from '@rsbuild/core';
 import type { SplitReactChunkOptions } from './index.js';
 
 const isPlainObject = (obj: unknown): obj is Record<string, any> =>
@@ -24,7 +24,10 @@ export const applySplitChunksRule = (
       return;
     }
 
-    const extraGroups: CacheGroups = {};
+    const extraGroups: Record<
+      string,
+      Rspack.OptimizationSplitChunksCacheGroup
+    > = {};
 
     if (options.react) {
       extraGroups.react = {

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -1,4 +1,4 @@
-import type { CacheGroups, RsbuildPluginAPI, SplitChunks } from '@rsbuild/core';
+import type { RsbuildPluginAPI, Rspack, SplitChunks } from '@rsbuild/core';
 import type { SplitVueChunkOptions } from './index.js';
 
 const isPlainObject = (obj: unknown): obj is Record<string, any> =>
@@ -24,7 +24,10 @@ export const applySplitChunksRule = (
       return;
     }
 
-    const extraGroups: CacheGroups = {};
+    const extraGroups: Record<
+      string,
+      Rspack.OptimizationSplitChunksCacheGroup
+    > = {};
 
     if (options.vue) {
       extraGroups.vue = {


### PR DESCRIPTION
## Summary

This PR improves the handling and type definitions related to split chunks and cache groups. The most important changes include removing the `CacheGroup` and `CacheGroups` types, and updating related type references to use `Rspack.*`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
