### PR TITLE
docs: fix missing admonition end indicator on inline-assets doc

### DIFF
--- a/website/docs/en/guide/optimization/inline-assets.mdx
+++ b/website/docs/en/guide/optimization/inline-assets.mdx
@@ -79,6 +79,7 @@ When you reference a static asset in your CSS file, you can also force the asset
 
 :::tip Do you really need to exclude assets from inlining?
 Excluding assets from inlining will increase the number of assets that the Web App needs to load. This will reduce the efficiency of loading assets in a weak network environment or in scenarios where HTTP2 is not enabled. Please use force no Inline with caution.
+:::
 
 ## Inline JS files
 


### PR DESCRIPTION
## Summary

Due to the missing `:::` in markdown, _Inline JS files section_ is included _Do you really need to exclude assets from inlining?_ info part of _Force no Inlining_ section.

![image](https://github.com/user-attachments/assets/9cad1f0b-d91c-47e7-adbd-53147ea48de3)


## Related Links

<!--- Provide links of related issues or pages -->

https://rsbuild.dev/guide/optimization/inline-assets#inline-js-files

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
