### PR TITLE
feat(cache): add experimental cache logging

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { findExists, isFileExists } from '../helpers';
+import { color, findExists, isFileExists } from '../helpers';
 import { logger } from '../logger';
 import type {
   BuildCacheOptions,
@@ -111,6 +111,8 @@ export const pluginCache = (): RsbuildPlugin => ({
   name: 'rsbuild:cache',
 
   setup(api) {
+    let cacheEnabled = false;
+
     api.modifyBundlerChain(async (chain, { environment, env }) => {
       const { config } = environment;
       const { bundlerType } = api.context;
@@ -123,6 +125,8 @@ export const pluginCache = (): RsbuildPlugin => ({
       if (buildCache === false) {
         return;
       }
+
+      cacheEnabled = true;
 
       const { context } = api;
       const cacheConfig = typeof buildCache === 'boolean' ? {} : buildCache;
@@ -164,6 +168,15 @@ export const pluginCache = (): RsbuildPlugin => ({
           cacheDirectory,
           buildDependencies,
         });
+      }
+    });
+
+    api.onAfterCreateCompiler(() => {
+      // Tell user that the cache is enabled and it's experimental
+      if (cacheEnabled && api.context.bundlerType === 'rspack') {
+        logger.info(
+          `Rspack persistent cache enabled ${color.dim('(experimental)')}`,
+        );
       }
     });
   },


### PR DESCRIPTION
## Summary

Rspack's persistent cache is still experimental, this PR adds a log to make that clear.

<img width="717" alt="Screenshot 2025-02-09 at 10 42 04" src="https://github.com/user-attachments/assets/52d9f382-a0ee-4564-b53a-072a6b4f5d92" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
