### PR TITLE
fix: failed to use native config loader on Windows

### DIFF
--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,14 +1,9 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest('should use Node.js native loader to load config', async () => {
-  // TODO: fix this test on Windows
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   execSync('npx rsbuild build --config-loader native', {
     cwd: __dirname,
     env: {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { ChokidarOptions } from '../compiled/chokidar/index.js';
 import RspackChain from '../compiled/rspack-chain/index.js';
 import {
@@ -472,7 +473,8 @@ export async function loadConfig({
 
   if (loader === 'native' || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
     try {
-      const exportModule = await import(`${configFilePath}?t=${Date.now()}`);
+      const configFileURL = pathToFileURL(configFilePath).href;
+      const exportModule = await import(`${configFileURL}?t=${Date.now()}`);
       configExport = exportModule.default ? exportModule.default : exportModule;
     } catch (err) {
       if (loader === 'native') {


### PR DESCRIPTION
## Summary

Fix failed to use native config loader in Windows.

On Windows, absolute path must be valid `file://` URLs, we should use `pathToFileURL` to process the file path.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
