### PR TITLE
docs: update rspack profile tips

### DIFF
--- a/e2e/cases/rspack-profile/dev.mjs
+++ b/e2e/cases/rspack-profile/dev.mjs
@@ -1,0 +1,28 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRsbuild } from '@rsbuild/core';
+
+process.stdin.isTTY = true;
+delete process.env.CI;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function main() {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        cliShortcuts: true,
+      },
+      output: {
+        distPath: {
+          root: 'dist-dev',
+        },
+      },
+    },
+  });
+
+  await rsbuild.startDevServer();
+}
+
+await main();

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -5,7 +5,7 @@ import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { rspackOnlyTest, waitFor } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest(
+rspackOnlyTest.only(
   'should generator rspack profile as expected in dev',
   async () => {
     const devProcess = exec('RSPACK_PROFILE=ALL node ./dev.mjs', {

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -12,11 +12,12 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    let logs: string[] = [];
+    const logs: string[] = [];
 
     devProcess.stdout?.on('data', (data) => {
       const output = data.toString().trim();
       logs.push(stripAnsi(output));
+      console.log(output);
     });
 
     expect(
@@ -52,11 +53,12 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    let logs: string[] = [];
+    const logs: string[] = [];
 
     buildProcess.stdout?.on('data', (data) => {
       const output = data.toString().trim();
       logs.push(stripAnsi(output));
+      console.log(output);
     });
 
     expect(

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -8,8 +8,7 @@ import { expect } from '@playwright/test';
 rspackOnlyTest(
   'should generator rspack profile as expected in dev',
   async () => {
-    process.env.RSPACK_PROFILE = 'ALL';
-    const devProcess = exec('node ./dev.mjs', {
+    const devProcess = exec('RSPACK_PROFILE=ALL node ./dev.mjs', {
       cwd: __dirname,
     });
 
@@ -43,17 +42,13 @@ rspackOnlyTest(
     ).toBeTruthy();
 
     devProcess.kill();
-
-    delete process.env.RSPACK_PROFILE;
   },
 );
 
 rspackOnlyTest(
   'should generator rspack profile as expected in build',
   async () => {
-    process.env.RSPACK_PROFILE = 'ALL';
-
-    const buildProcess = exec('npx rsbuild build', {
+    const buildProcess = exec('RSPACK_PROFILE=ALL npx rsbuild build', {
       cwd: __dirname,
     });
 
@@ -86,7 +81,5 @@ rspackOnlyTest(
     expect(fs.existsSync(path.join(profileDir!, 'logging.json'))).toBeTruthy();
 
     buildProcess.kill();
-
-    delete process.env.RSPACK_PROFILE;
   },
 );

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -1,0 +1,92 @@
+import { exec } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
+import { rspackOnlyTest, waitFor } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should generator rspack profile as expected in dev',
+  async () => {
+    process.env.RSPACK_PROFILE = 'ALL';
+    const devProcess = exec('node ./dev.mjs', {
+      cwd: __dirname,
+    });
+
+    let logs: string[] = [];
+
+    devProcess.stdout?.on('data', (data) => {
+      const output = data.toString().trim();
+      logs.push(stripAnsi(output));
+    });
+
+    expect(
+      await waitFor(() => logs.some((log) => log.includes('Built in'))),
+    ).toBeTruthy();
+
+    // quit process
+    devProcess.stdin?.write('q\n');
+    expect(
+      await waitFor(() =>
+        logs.some((log) => log.includes('Saved Rspack profile file to')),
+      ),
+    ).toBeTruthy();
+
+    const profileDir = logs
+      .find((log) => log.includes('Saved Rspack profile file to'))
+      ?.split('Saved Rspack profile file to')[1]
+      ?.trim();
+
+    expect(fs.existsSync(path.join(profileDir!, 'trace.json'))).toBeTruthy();
+    expect(
+      fs.existsSync(path.join(profileDir!, 'jscpuprofile.json')),
+    ).toBeTruthy();
+
+    devProcess.kill();
+
+    delete process.env.RSPACK_PROFILE;
+  },
+);
+
+rspackOnlyTest(
+  'should generator rspack profile as expected in build',
+  async () => {
+    process.env.RSPACK_PROFILE = 'ALL';
+
+    const buildProcess = exec('npx rsbuild build', {
+      cwd: __dirname,
+    });
+
+    let logs: string[] = [];
+
+    buildProcess.stdout?.on('data', (data) => {
+      const output = data.toString().trim();
+      logs.push(stripAnsi(output));
+    });
+
+    expect(
+      await waitFor(() => logs.some((log) => log.includes('Built in'))),
+    ).toBeTruthy();
+
+    expect(
+      await waitFor(() =>
+        logs.some((log) => log.includes('Saved Rspack profile file to')),
+      ),
+    ).toBeTruthy();
+
+    const profileDir = logs
+      .find((log) => log.includes('Saved Rspack profile file to'))
+      ?.split('Saved Rspack profile file to')[1]
+      ?.trim();
+
+    expect(fs.existsSync(path.join(profileDir!, 'trace.json'))).toBeTruthy();
+    expect(
+      fs.existsSync(path.join(profileDir!, 'jscpuprofile.json')),
+    ).toBeTruthy();
+    expect(fs.existsSync(path.join(profileDir!, 'logging.json'))).toBeTruthy();
+
+    buildProcess.kill();
+
+    delete process.env.RSPACK_PROFILE;
+  },
+);

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -5,11 +5,15 @@ import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { rspackOnlyTest, waitFor } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest.only(
+rspackOnlyTest(
   'should generator rspack profile as expected in dev',
   async () => {
-    const devProcess = exec('RSPACK_PROFILE=ALL node ./dev.mjs', {
+    const devProcess = exec('node ./dev.mjs', {
       cwd: __dirname,
+      env: {
+        ...process.env,
+        RSPACK_PROFILE: 'ALL',
+      },
     });
 
     const logs: string[] = [];
@@ -17,7 +21,6 @@ rspackOnlyTest.only(
     devProcess.stdout?.on('data', (data) => {
       const output = data.toString().trim();
       logs.push(stripAnsi(output));
-      console.log(output);
     });
 
     expect(
@@ -49,8 +52,12 @@ rspackOnlyTest.only(
 rspackOnlyTest(
   'should generator rspack profile as expected in build',
   async () => {
-    const buildProcess = exec('RSPACK_PROFILE=ALL npx rsbuild build', {
+    const buildProcess = exec('npx rsbuild build', {
       cwd: __dirname,
+      env: {
+        ...process.env,
+        RSPACK_PROFILE: 'ALL',
+      },
     });
 
     const logs: string[] = [];
@@ -58,7 +65,6 @@ rspackOnlyTest(
     buildProcess.stdout?.on('data', (data) => {
       const output = data.toString().trim();
       logs.push(stripAnsi(output));
-      console.log(output);
     });
 
     expect(

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -28,8 +28,12 @@ export const getProviderTest = (
   // @ts-expect-error
   testSkip.fail = test.describe.skip;
   // @ts-expect-error
+  testSkip.only = test.only;
+
+  // @ts-expect-error
   return testSkip as typeof test.skip & {
     describe: typeof test.describe.skip;
+    only: typeof test.only;
   };
 };
 

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -51,7 +51,7 @@ Rsbuild supports the use of the `RSPACK_PROFILE` environment variable for Rspack
 The command will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).
-- `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/).
+- `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/). In development mode, it is generated only when exiting the process through [`h + Enter`](/config/dev/cli-shortcuts).
 - `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development mode yet)
 
 > For more information about Rspack build performance analysis, please refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -51,7 +51,7 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 执行该命令后，会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
 
 - `trace.json`：使用 tracing 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看。
-- `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。
+- `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。开发模式下仅在通过 [`h + Enter`](/config/dev/cli-shortcuts) 退出时生成。
 - `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时（开发模式下暂不支持）。
 
 > 更多 Rspack 构建性能分析用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。


### PR DESCRIPTION
## Summary

Update rspack profile tips: in development mode, the cpu profile is generated only when exiting the process through `h + Enter` shortcut.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/f75f0754-09b9-4545-8b95-ed98fd91326a" />


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
