### PR TITLE
test: split webpack E2E test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,4 +102,49 @@ jobs:
 
       - name: E2E Test
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm run e2e
+        run: pnpm run e2e:rspack
+
+  # ======== e2e-webpack ========
+  e2e-webpack:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 1
+
+      - name: Install Pnpm
+        run: |
+          npm install -g corepack@latest --force
+          corepack enable
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          predicate-quantifier: 'every'
+          filters: |
+            changed:
+              - "!**/*.md"
+              - "!**/*.mdx"
+              - "!**/_meta.json"
+              - "!**/dictionary.txt"
+
+      - name: Setup Node.js
+        if: steps.changes.outputs.changed == 'true'
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        if: steps.changes.outputs.changed == 'true'
+        run: pnpm install && cd ./e2e && npx playwright install chromium
+
+      - name: E2E Test
+        if: steps.changes.outputs.changed == 'true'
+        run: pnpm run e2e:webpack


### PR DESCRIPTION
## Summary

Most of the E2E tests in Rsbuild are run by both Rspack and webpack at the same time. This is to check that the functionality of Rspack is correctly aligned with webpack.

This PR splits the webpack E2E testing into an independent workflow to speed up the CI.

We may remove all the webpack related E2E cases in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
