### PR TITLE
fix(server): remove `.mjs` suffix check when loading ESM module in runner

### DIFF
--- a/e2e/cases/server/ssr-type-module/index.test.ts
+++ b/e2e/cases/server/ssr-type-module/index.test.ts
@@ -1,0 +1,17 @@
+import { dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('support SSR load esm with type module', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {},
+  });
+
+  const url1 = new URL(`http://localhost:${rsbuild.port}`);
+
+  const res = await page.goto(url1.href);
+
+  expect(await res?.text()).toMatch(/Rsbuild with React/);
+
+  await rsbuild.close();
+});

--- a/e2e/cases/server/ssr-type-module/index.test.ts
+++ b/e2e/cases/server/ssr-type-module/index.test.ts
@@ -1,7 +1,17 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('support SSR load esm with type module', async ({ page }) => {
+  const distPath = path.join(__dirname, './dist');
+  if (!fs.existsSync(distPath)) {
+    fs.mkdirSync(distPath);
+  }
+  fs.writeFileSync(
+    path.join(distPath, './package.json'),
+    JSON.stringify({ type: 'module' }),
+  );
   const rsbuild = await dev({
     cwd: __dirname,
     rsbuildConfig: {},

--- a/e2e/cases/server/ssr-type-module/index.test.ts
+++ b/e2e/cases/server/ssr-type-module/index.test.ts
@@ -1,17 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('support SSR load esm with type module', async ({ page }) => {
-  const distPath = path.join(__dirname, './dist');
-  if (!fs.existsSync(distPath)) {
-    fs.mkdirSync(distPath);
-  }
-  fs.writeFileSync(
-    path.join(distPath, './package.json'),
-    JSON.stringify({ type: 'module' }),
-  );
   const rsbuild = await dev({
     cwd: __dirname,
     rsbuildConfig: {},
@@ -24,6 +14,4 @@ rspackOnlyTest('support SSR load esm with type module', async ({ page }) => {
   expect(await res?.text()).toMatch(/Rsbuild with React/);
 
   await rsbuild.close();
-
-  fs.rmSync(path.join(distPath, './package.json'));
 });

--- a/e2e/cases/server/ssr-type-module/index.test.ts
+++ b/e2e/cases/server/ssr-type-module/index.test.ts
@@ -24,4 +24,6 @@ rspackOnlyTest('support SSR load esm with type module', async ({ page }) => {
   expect(await res?.text()).toMatch(/Rsbuild with React/);
 
   await rsbuild.close();
+
+  fs.rmSync(path.join(distPath, './package.json'));
 });

--- a/e2e/cases/server/ssr-type-module/package.json
+++ b/e2e/cases/server/ssr-type-module/package.json
@@ -2,7 +2,6 @@
   "private": true,
   "name": "@e2e/custom-server-ssr-type-module",
   "version": "1.0.0",
-  "type": "module",
   "scripts": {
     "dev": "cross-env NODE_OPTIONS=--experimental-vm-modules npx rsbuild dev"
   }

--- a/e2e/cases/server/ssr-type-module/package.json
+++ b/e2e/cases/server/ssr-type-module/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "name": "@e2e/custom-server-ssr-type-module",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "cross-env NODE_OPTIONS=--experimental-vm-modules npx rsbuild dev"
+  }
+}

--- a/e2e/cases/server/ssr-type-module/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-type-module/rsbuild.config.ts
@@ -1,0 +1,95 @@
+import {
+  type RequestHandler,
+  type SetupMiddlewaresServer,
+  defineConfig,
+  logger,
+} from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export const serverRender =
+  (serverAPI: SetupMiddlewaresServer): RequestHandler =>
+  async (_req, res, _next) => {
+    const indexModule = await serverAPI.environments.node.loadBundle<{
+      render: () => string;
+    }>('index');
+
+    const markup = indexModule.render();
+
+    const template =
+      await serverAPI.environments.web.getTransformedHtml('index');
+
+    const html = template.replace('<!--app-content-->', markup);
+
+    res.writeHead(200, {
+      'Content-Type': 'text/html',
+    });
+    res.end(html);
+  };
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  dev: {
+    setupMiddlewares: [
+      ({ unshift }, serverAPI) => {
+        const serverRenderMiddleware = serverRender(serverAPI);
+
+        unshift(async (req, res, next) => {
+          if (req.method === 'GET' && req.url === '/') {
+            try {
+              await serverRenderMiddleware(req, res, next);
+            } catch (err) {
+              logger.error('SSR render error, downgrade to CSR...\n', err);
+              next();
+            }
+          } else {
+            next();
+          }
+        });
+      },
+    ],
+  },
+  environments: {
+    web: {
+      output: {
+        target: 'web',
+      },
+      source: {
+        entry: {
+          index: './src/index',
+        },
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+      source: {
+        entry: {
+          index: './src/index.server',
+        },
+      },
+      tools: {
+        rspack: (config) => {
+          return {
+            ...config,
+            experiments: {
+              ...config.experiments,
+              outputModule: true,
+            },
+            output: {
+              ...config.output,
+              chunkFormat: 'module',
+              chunkLoading: 'import',
+              library: {
+                type: 'module',
+              },
+            },
+          };
+        },
+      },
+    },
+  },
+  html: {
+    template: './template.html',
+  },
+});

--- a/e2e/cases/server/ssr-type-module/src/App.css
+++ b/e2e/cases/server/ssr-type-module/src/App.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  color: #fff;
+  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  background-image: linear-gradient(to bottom, #020917, #101725);
+}
+
+.content {
+  display: flex;
+  min-height: 100vh;
+  line-height: 1.1;
+  text-align: center;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.content h1 {
+  font-size: 3.6rem;
+  font-weight: 700;
+}
+
+.content p {
+  font-size: 1.2rem;
+  font-weight: 400;
+  opacity: 0.5;
+}

--- a/e2e/cases/server/ssr-type-module/src/App.tsx
+++ b/e2e/cases/server/ssr-type-module/src/App.tsx
@@ -1,0 +1,12 @@
+import './App.css';
+
+const App = () => {
+  return (
+    <div className="content">
+      <h1>Rsbuild with React</h1>
+      <p>Start building amazing things with Rsbuild.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/e2e/cases/server/ssr-type-module/src/env.d.ts
+++ b/e2e/cases/server/ssr-type-module/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/e2e/cases/server/ssr-type-module/src/index.server.tsx
+++ b/e2e/cases/server/ssr-type-module/src/index.server.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import App from './App';
+
+console.log('load SSR');
+
+// test dynamic import
+import('./test');
+
+export function render() {
+  return ReactDOMServer.renderToString(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}

--- a/e2e/cases/server/ssr-type-module/src/index.server.tsx
+++ b/e2e/cases/server/ssr-type-module/src/index.server.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import App from './App';
 
-console.log('load SSR');
-
 // test dynamic import
 import('./test');
 

--- a/e2e/cases/server/ssr-type-module/src/index.tsx
+++ b/e2e/cases/server/ssr-type-module/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.hydrateRoot(
+  document.getElementById('root')!,
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/e2e/cases/server/ssr-type-module/src/test.ts
+++ b/e2e/cases/server/ssr-type-module/src/test.ts
@@ -1,0 +1,3 @@
+export const getA = () => {
+  return 'A';
+};

--- a/e2e/cases/server/ssr-type-module/template.html
+++ b/e2e/cases/server/ssr-type-module/template.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Rsbuild + React + TS</title>
+  </head>
+  <body>
+    <div id="root"><!--app-content--></div>
+  </body>
+</html>

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -25,12 +25,69 @@ rspackOnlyTest('support SSR', async ({ page }) => {
   restore();
 });
 
+rspackOnlyTest('support SSR with external', async ({ page }) => {
+  const { logs, restore } = proxyConsole('log');
+
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        externals: {
+          react: 'react',
+          'react-dom': 'react-dom',
+        },
+      },
+    },
+  });
+
+  const url = new URL(`http://localhost:${rsbuild.port}`);
+
+  const res = await page.goto(url.href);
+
+  expect(await res?.text()).toMatch(/Rsbuild with React/);
+
+  await page.goto(url.href);
+
+  // bundle result should cacheable and only load once.
+  expect(logs.filter((log) => log.includes('load SSR')).length).toBe(1);
+
+  await rsbuild.close();
+
+  restore();
+});
+
 rspackOnlyTest('support SSR with esm target', async ({ page }) => {
   process.env.TEST_ESM_LIBRARY = '1';
 
   const rsbuild = await dev({
     cwd: __dirname,
     rsbuildConfig: {},
+  });
+
+  const url1 = new URL(`http://localhost:${rsbuild.port}`);
+
+  const res = await page.goto(url1.href);
+
+  expect(await res?.text()).toMatch(/Rsbuild with React/);
+
+  await rsbuild.close();
+
+  delete process.env.TEST_ESM_LIBRARY;
+});
+
+rspackOnlyTest('support SSR with esm target & external', async ({ page }) => {
+  process.env.TEST_ESM_LIBRARY = '1';
+
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        externals: {
+          react: 'react',
+          'react-dom': 'react-dom',
+        },
+      },
+    },
   });
 
   const url1 = new URL(`http://localhost:${rsbuild.port}`);

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pnpm test:rspack && pnpm test:webpack",
-    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
+    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules --no-warnings EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
     "test:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pnpm test:rspack && pnpm test:webpack",
-    "test:rspack": "cross-env NODE_OPTIONS=--experimental-vm-modules --no-warnings EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
+    "test:rspack": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
     "test:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -50,10 +50,8 @@ export const loadBundle = async <T>(
   }
 
   const allChunkFiles =
-    chunks
-      ?.map((c) => c.files)
-      .flat()
-      .map((file) => join(outputPath!, file!)) || [];
+    chunks?.flatMap((c) => c.files).map((file) => join(outputPath!, file!)) ||
+    [];
 
   const res = await run<T>({
     bundlePath: files[0],

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -49,12 +49,19 @@ export const loadBundle = async <T>(
     );
   }
 
-  const res = await run<T>(
-    files[0],
-    outputPath!,
-    stats.compilation.options,
-    utils.readFileSync,
-  );
+  const allChunkFiles =
+    chunks
+      ?.map((c) => c.files)
+      .flat()
+      .map((file) => join(outputPath!, file!)) || [];
+
+  const res = await run<T>({
+    bundlePath: files[0],
+    dist: outputPath!,
+    compilerOptions: stats.compilation.options,
+    readFileSync: utils.readFileSync,
+    isBundleOutput: (modulePath: string) => allChunkFiles.includes(modulePath),
+  });
 
   return res;
 };

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -80,6 +80,11 @@ export abstract class BasicRunner implements Runner {
     file: BasicRunnerFile,
   ): BasicModuleScope;
 
+  /**
+   * Get the file information for a given module path.
+   *
+   * @returns An object containing the file path, content, and subPath, or null if the module path is not relative (not rspack chunk file).
+   */
   protected getFile(
     modulePath: string[] | string,
     currentDirectory: string,
@@ -95,6 +100,11 @@ export abstract class BasicRunner implements Runner {
         subPath: '',
       };
     }
+    /**
+     * only proxy chunk files. eg:
+     * - installChunk(require("./" + __webpack_require__.u(chunkId)));
+     * - import("./" + __webpack_require__.u(chunkId))
+     */
     if (isRelativePath(modulePath)) {
       const p = path.join(currentDirectory, modulePath);
       return {

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -84,7 +84,7 @@ export abstract class BasicRunner implements Runner {
   /**
    * Get the file information for a given module path.
    *
-   * @returns An object containing the file path, content, and subPath, or null if the module path is not relative (not rspack chunk file).
+   * @returns An object containing the file path, content, and subPath, or null if the module is not an rspack output.
    */
   protected getFile(
     modulePath: string[] | string,

--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -75,10 +75,12 @@ export class CommonJsRunner extends BasicRunner {
   protected createMissRequirer(): RunnerRequirer {
     return (_currentDirectory, modulePath, _context = {}) => {
       const modulePathStr = modulePath as string;
+      const resolvedPath = require.resolve(modulePathStr, {
+        paths: [_currentDirectory],
+      });
+
       return require(
-        modulePathStr.startsWith('node:')
-          ? modulePathStr.slice(5)
-          : modulePathStr,
+        resolvedPath.startsWith('node:') ? resolvedPath.slice(5) : resolvedPath,
       );
     };
   }

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -13,9 +13,8 @@ function findPackageJson(startDir: string) {
     const pkgFile = path.join(dir, 'package.json');
     if (fs.existsSync(pkgFile)) {
       return pkgFile;
-    } else {
-      dir = path.join(dir, '..');
     }
+    dir = path.join(dir, '..');
   } while (dir !== path.resolve(dir, '..'));
   return null;
 }
@@ -40,10 +39,9 @@ function determineModuleType(filePath: string) {
       if (JSON.parse(fs.readFileSync(packageJson, 'utf8')).type === 'module') {
         ModuleTypeMap.set(packageJson, 'ESM');
         return 'ESM';
-      } else {
-        ModuleTypeMap.set(packageJson, 'CJS');
-        return 'CJS';
       }
+      ModuleTypeMap.set(packageJson, 'CJS');
+      return 'CJS';
     }
   } catch (e) {}
 

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -19,7 +19,7 @@ function findPackageJson(startDir: string) {
   return null;
 }
 
-const ModuleTypeMap = new Map<string, 'ESM' | 'CJS'>();
+const moduleTypeMap = new Map<string, 'ESM' | 'CJS'>();
 
 function determineModuleType(filePath: string) {
   const ext = path.extname(filePath);
@@ -33,14 +33,14 @@ function determineModuleType(filePath: string) {
   try {
     const packageJson = findPackageJson(path.dirname(filePath));
     if (packageJson) {
-      if (ModuleTypeMap.get(packageJson)) {
-        return ModuleTypeMap.get(packageJson);
+      if (moduleTypeMap.get(packageJson)) {
+        return moduleTypeMap.get(packageJson);
       }
       if (JSON.parse(fs.readFileSync(packageJson, 'utf8')).type === 'module') {
-        ModuleTypeMap.set(packageJson, 'ESM');
+        moduleTypeMap.set(packageJson, 'ESM');
         return 'ESM';
       }
-      ModuleTypeMap.set(packageJson, 'CJS');
+      moduleTypeMap.set(packageJson, 'CJS');
       return 'CJS';
     }
   } catch (e) {}

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -55,16 +55,16 @@ export class EsmRunner extends CommonJsRunner {
     super.createRunner();
     this.requirers.set('cjs', this.getRequire());
     this.requirers.set('esm', this.createEsmRequirer());
+
+    const supportEsm = this._options.compilerOptions.experiments?.outputModule;
+
     this.requirers.set('entry', (currentDirectory, modulePath, context) => {
       const file = this.getFile(modulePath, currentDirectory);
       if (!file) {
         return this.requirers.get('miss')!(currentDirectory, modulePath);
       }
 
-      if (
-        this._options.compilerOptions.experiments?.outputModule &&
-        determineModuleType(file.path) === 'ESM'
-      ) {
+      if (supportEsm && determineModuleType(file.path) === 'ESM') {
         return this.requirers.get('esm')!(currentDirectory, modulePath, {
           ...context,
           file,

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -12,7 +12,7 @@ export class EsmRunner extends CommonJsRunner {
     this.requirers.set('cjs', this.getRequire());
     this.requirers.set('esm', this.createEsmRequirer());
 
-    const isEsmOutputs =
+    const outputModule =
       this._options.compilerOptions.experiments?.outputModule;
 
     this.requirers.set('entry', (currentDirectory, modulePath, context) => {
@@ -21,7 +21,7 @@ export class EsmRunner extends CommonJsRunner {
         return this.requirers.get('miss')!(currentDirectory, modulePath);
       }
 
-      if (isEsmOutputs && !file.path.endsWith('.cjs')) {
+      if (outputModule && !file.path.endsWith('.cjs')) {
         return this.requirers.get('esm')!(currentDirectory, modulePath, {
           ...context,
           file,

--- a/packages/core/src/server/runner/index.ts
+++ b/packages/core/src/server/runner/index.ts
@@ -4,31 +4,22 @@
  * TODO: should be extracted as a separate bundle-runner pkg
  */
 import { EsmRunner } from './esm';
-import type { CompilerOptions, Runner, RunnerFactory } from './type';
+import type { Runner, RunnerFactory, RunnerFactoryOptions } from './type';
 
 export class BasicRunnerFactory implements RunnerFactory {
   constructor(protected name: string) {}
 
-  create(
-    compilerOptions: CompilerOptions,
-    dist: string,
-    readFileSync: (path: string) => string,
-  ): Runner {
-    const runner = this.createRunner(compilerOptions, dist, readFileSync);
+  create(options: RunnerFactoryOptions): Runner {
+    const runner = this.createRunner(options);
     return runner;
   }
 
-  protected createRunner(
-    compilerOptions: CompilerOptions,
-    dist: string,
-    readFileSync: (path: string) => string,
-  ): Runner {
+  protected createRunner(options: RunnerFactoryOptions): Runner {
     const runnerOptions = {
       name: this.name,
-      dist,
-      compilerOptions,
-      readFileSync,
+      ...options,
     };
+    const { compilerOptions } = options;
     if (
       compilerOptions.target === 'web' ||
       compilerOptions.target === 'webworker'
@@ -41,18 +32,14 @@ export class BasicRunnerFactory implements RunnerFactory {
   }
 }
 
-export const run = async <T>(
-  bundlePath: string,
-  outputPath: string,
-  compilerOptions: CompilerOptions,
-  readFileSync: (path: string) => string,
-): Promise<T> => {
+export const run = async <T>({
+  bundlePath,
+  ...runnerFactoryOptions
+}: RunnerFactoryOptions & {
+  bundlePath: string;
+}): Promise<T> => {
   const runnerFactory = new BasicRunnerFactory(bundlePath);
-  const runner = runnerFactory.create(
-    compilerOptions,
-    outputPath,
-    readFileSync,
-  );
+  const runner = runnerFactory.create(runnerFactoryOptions);
   const mod = runner.run(bundlePath);
 
   return mod as T;

--- a/packages/core/src/server/runner/index.ts
+++ b/packages/core/src/server/runner/index.ts
@@ -1,7 +1,6 @@
 /**
  * The following code is modified based on @rspack/test-tools/runner
  *
- * TODO: should be extracted as a separate bundle-runner pkg
  */
 import { EsmRunner } from './esm';
 import type { Runner, RunnerFactory, RunnerFactoryOptions } from './type';

--- a/packages/core/src/server/runner/type.ts
+++ b/packages/core/src/server/runner/type.ts
@@ -42,10 +42,13 @@ export interface Runner {
   getRequire(): RunnerRequirer;
 }
 
+export type RunnerFactoryOptions = {
+  dist: string;
+  compilerOptions: CompilerOptions;
+  readFileSync: (path: string) => string;
+  isBundleOutput: (modulePath: string) => boolean;
+};
+
 export interface RunnerFactory {
-  create(
-    compilerOptions: CompilerOptions,
-    dist: string,
-    readFileSync: (fileName: string) => string,
-  ): Runner;
+  create(options: RunnerFactoryOptions): Runner;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,6 +249,8 @@ importers:
 
   e2e/cases/server/ssr: {}
 
+  e2e/cases/server/ssr-type-module: {}
+
   e2e/cases/svelte:
     dependencies:
       svelte:


### PR DESCRIPTION
## Summary

Only rspack outputs require proxy import, so only [experiments.outputModule](https://rspack.dev/config/experiments#experimentsoutputmodule) is required for loading rspack esm outputs in runner, no `.mjs` suffix is ​​required.


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
