### PR TITLE
fix: gzipped total file size calculation

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -106,10 +106,8 @@ async function printFileSizes(
     const fileName = asset.name.split('?')[0];
     const contents = await fs.promises.readFile(path.join(distPath, fileName));
     const size = contents.length;
-    const gzippedSize =
-      options.compressed && isCompressible(fileName)
-        ? await gzipSize(contents)
-        : null;
+    const compressible = options.compressed && isCompressible(fileName);
+    const gzippedSize = compressible ? await gzipSize(contents) : null;
     const gzipSizeLabel = gzippedSize
       ? getAssetColor(gzippedSize)(calcFileSize(gzippedSize))
       : null;
@@ -200,8 +198,8 @@ async function printFileSizes(
 
     totalSize += asset.size;
 
-    if (asset.gzippedSize) {
-      totalGzipSize += asset.gzippedSize;
+    if (options.compressed) {
+      totalGzipSize += asset.gzippedSize ?? asset.size;
     }
 
     if (options.detail !== false) {

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -107,7 +107,10 @@ export default {
 ```
 
 :::tip
-This data is only for reference to the size after gzip compression. Rsbuild does not enable gzip compression for static assets. Usually, you need to enable gzip compression on the server side, for example, using the [gzip module](https://nginx.org/en/docs/http/ngx_http_gzip_module.html) of nginx.
+
+- This data is only for reference to the size after gzip compression. Rsbuild does not enable gzip compression for static assets. Usually, you need to enable gzip compression on the server side, for example, using the [gzip module](https://nginx.org/en/docs/http/ngx_http_gzip_module.html) of nginx.
+- For non-compressible assets (such as images), the gzip size will not be shown in the detailed list, but their original size will be included in the total gzip size calculation.
+
 :::
 
 ### include

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -107,7 +107,10 @@ export default {
 ```
 
 :::tip
-该数据仅用于参考 gzip 压缩后的体积，Rsbuild 并不会对静态资源开启 gzip 压缩。通常，你需要在服务器端开启 gzip 压缩，例如使用 [nginx 的 gzip 模块](https://nginx.org/en/docs/http/ngx_http_gzip_module.html)。
+
+- 该数据仅用于参考 gzip 压缩后的体积，Rsbuild 并不会对静态资源开启 gzip 压缩。通常，你需要在服务器端开启 gzip 压缩，例如使用 [nginx 的 gzip 模块](https://nginx.org/en/docs/http/ngx_http_gzip_module.html)。
+- 对于不适合 gzip 压缩的静态资源（如图片文件），在详细列表中不会显示其 gzip 体积，但在计算 gzip 后的总体积时会包含这些资源的原始大小。
+
 :::
 
 ### include


### PR DESCRIPTION
## Summary

For non-compressible assets (such as images), the gzip size will not be shown in the detailed list, but their original size should be included in the total gzip size calculation.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/4537

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
