### PR TITLE
feat: support `buildCache.buildDependencies` configuration

### DIFF
--- a/e2e/cases/cache/index.test.ts
+++ b/e2e/cases/cache/index.test.ts
@@ -72,9 +72,7 @@ test('`buildCache.buildDependencies` should work as expected', async () => {
         performance: {
           buildCache: {
             cacheDirectory,
-            buildDependencies: {
-              deps: [testDepsPath],
-            },
+            buildDependencies: [testDepsPath],
           },
         },
       } as RsbuildConfig,

--- a/e2e/cases/cache/index.test.ts
+++ b/e2e/cases/cache/index.test.ts
@@ -47,6 +47,55 @@ test('`buildCache.cacheDigest` should work as expected', async () => {
   ).toBeTruthy();
 });
 
+test('`buildCache.buildDependencies` should work as expected', async () => {
+  const cacheDirectory = path.resolve(
+    __dirname,
+    './node_modules/.cache/test-cache-build-dependencies',
+  );
+
+  const testDepsPath = path.resolve(__dirname, './test-temp-deps.js');
+
+  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+  const getBuildConfig = (input: string) => {
+    fs.writeFileSync(testDepsPath, input);
+    return {
+      cwd: __dirname,
+      rsbuildConfig: {
+        tools: {
+          bundlerChain: (chain) => {
+            if (input === 'foo') {
+              chain.resolve.extensions.prepend('.test.js');
+            }
+          },
+        },
+        performance: {
+          buildCache: {
+            cacheDirectory,
+            buildDependencies: {
+              deps: [testDepsPath],
+            },
+          },
+        },
+      } as RsbuildConfig,
+    };
+  };
+
+  // first build without cache
+  let rsbuild = await build(getBuildConfig(''));
+
+  expect(
+    (await rsbuild.getIndexFile()).content.includes('222222'),
+  ).toBeTruthy();
+
+  rsbuild = await build(getBuildConfig('foo'));
+
+  // extension '.test.js' should work
+  expect(
+    (await rsbuild.getIndexFile()).content.includes('111111'),
+  ).toBeTruthy();
+});
+
 webpackOnlyTest(
   'should save the buildDependencies to cache directory and hit cache',
   async () => {

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -71,6 +71,7 @@ async function getBuildDependencies(
   context: Readonly<RsbuildContext>,
   config: NormalizedEnvironmentConfig,
   environmentContext: EnvironmentContext,
+  userBuildDependencies: Record<string, string[]>,
 ) {
   const rootPackageJson = join(context.rootPath, 'package.json');
   const browserslistConfig = join(context.rootPath, '.browserslistrc');
@@ -104,7 +105,10 @@ async function getBuildDependencies(
     buildDependencies.tailwindcss = [tailwindConfig];
   }
 
-  return buildDependencies;
+  return {
+    ...buildDependencies,
+    ...userBuildDependencies,
+  };
 }
 
 export const pluginCache = (): RsbuildPlugin => ({
@@ -135,6 +139,7 @@ export const pluginCache = (): RsbuildPlugin => ({
         context,
         config,
         environment,
+        cacheConfig.buildDependencies || {},
       );
 
       if (bundlerType === 'webpack') {

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -139,7 +139,11 @@ export const pluginCache = (): RsbuildPlugin => ({
         context,
         config,
         environment,
-        cacheConfig.buildDependencies || {},
+        cacheConfig.buildDependencies
+          ? {
+              userBuildDependencies: cacheConfig.buildDependencies,
+            }
+          : {},
       );
 
       if (bundlerType === 'webpack') {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -468,6 +468,11 @@ export type BuildCacheOptions = {
    * @default undefined
    */
   cacheDigest?: Array<string | undefined>;
+  /**
+   * An object of arrays of additional code dependencies for the build.
+   * Rspack will use the hash of each of these files to invalidate the persistent cache.
+   */
+  buildDependencies?: Record<string, string[]>;
 };
 
 export type PrintFileSizeAsset = {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -469,10 +469,10 @@ export type BuildCacheOptions = {
    */
   cacheDigest?: Array<string | undefined>;
   /**
-   * An object of arrays of additional code dependencies for the build.
+   * An array of files containing build dependencies.
    * Rspack will use the hash of each of these files to invalidate the persistent cache.
    */
-  buildDependencies?: Record<string, string[]>;
+  buildDependencies?: string[];
 };
 
 export type PrintFileSizeAsset = {

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -8,7 +8,7 @@ type BuildCacheConfig =
   | {
       cacheDirectory?: string;
       cacheDigest?: Array<string | undefined>;
-      buildDependencies?: Record<string, string[]>;
+      buildDependencies?: string[];
     };
 ```
 
@@ -91,10 +91,10 @@ export default defineConfig({
 
 ### buildDependencies
 
-- **Type:** `Record<string, string[]>`
+- **Type:** `string[]`
 - **Default:** `undefined`
 
-`buildDependencies` is an object of arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
+`buildDependencies` is an arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
 
 By default, Rsbuild will use your `packageJson`, `tsconfig`, `rsbuildConfig`, `browserslistrc`, and `tailwindcss` configuration files as build dependencies.
 
@@ -102,9 +102,7 @@ By default, Rsbuild will use your `packageJson`, `tsconfig`, `rsbuildConfig`, `b
 export default defineConfig({
   performance: {
     buildCache: {
-      buildDependencies: {
-        configFile: [__filename],
-      },
+      buildDependencies: [__filename],
     },
   },
 });

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -8,6 +8,7 @@ type BuildCacheConfig =
   | {
       cacheDirectory?: string;
       cacheDigest?: Array<string | undefined>;
+      buildDependencies?: Record<string, string[]>;
     };
 ```
 
@@ -83,6 +84,27 @@ export default defineConfig({
   performance: {
     buildCache: {
       cacheDigest: [process.env.SOME_ENV],
+    },
+  },
+});
+```
+
+### buildDependencies
+
+- **Type:** `Record<string, string[]>`
+- **Default:** `undefined`
+
+`buildDependencies` is an object of arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
+
+By default, Rsbuild will add the configuration file paths of the current project's `packageJson`, `tsconfig`, `rsbuildConfig`, `browserslistrc`, and `tailwindcss` to `buildDependencies`.
+
+```ts title="rsbuild.config.ts"
+export default defineConfig({
+  performance: {
+    buildCache: {
+      buildDependencies: {
+        configFile: [__filename],
+      },
     },
   },
 });

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -96,7 +96,15 @@ export default defineConfig({
 
 `buildDependencies` is an arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
 
-By default, Rsbuild will use your `package.json`, `tsconfig.json`, `rsbuild.config.*`, `.browserslistrc`, and `tailwindcss.config.*` configuration files as the build dependencies.
+Rsbuild will use the following configuration files as the default build dependencies:
+
+- `package.json`
+- `tsconfig.json`
+- `rsbuild.config.*`
+- `.browserslistrc`
+- `tailwindcss.config.*`
+
+When you add other build dependencies, Rsbuild merges these custom dependencies with the default dependencies and passes them to Rspack.
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -96,7 +96,7 @@ export default defineConfig({
 
 `buildDependencies` is an object of arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
 
-By default, Rsbuild will add the configuration file paths of the current project's `packageJson`, `tsconfig`, `rsbuildConfig`, `browserslistrc`, and `tailwindcss` to `buildDependencies`.
+By default, Rsbuild will use your `packageJson`, `tsconfig`, `rsbuildConfig`, `browserslistrc`, and `tailwindcss` configuration files as build dependencies.
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -96,7 +96,7 @@ export default defineConfig({
 
 `buildDependencies` is an arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.
 
-By default, Rsbuild will use your `packageJson`, `tsconfig`, `rsbuildConfig`, `browserslistrc`, and `tailwindcss` configuration files as build dependencies.
+By default, Rsbuild will use your `package.json`, `tsconfig.json`, `rsbuild.config.*`, `.browserslistrc`, and `tailwindcss.config.*` configuration files as the build dependencies.
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -8,7 +8,7 @@ type BuildCacheConfig =
   | {
       cacheDirectory?: string;
       cacheDigest?: Array<string | undefined>;
-      buildDependencies?: Record<string, string[]>;
+      buildDependencies?: string[];
     };
 ```
 
@@ -91,10 +91,10 @@ export default defineConfig({
 
 ### buildDependencies
 
-- **类型：** `Record<string, string[]>`
+- **类型：** `string[]`
 - **默认值：** `undefined`
 
-`buildDependencies` 是一个包含构建依赖的文件数组的对象，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
+`buildDependencies` 是一个包含构建依赖的文件数组，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
 
 默认情况下，Rsbuild 会把你的 `packageJson`、`tsconfig`、`rsbuildConfig`、`browserslistrc`、`tailwindcss` 的配置文件作为构建依赖。
 
@@ -102,9 +102,7 @@ export default defineConfig({
 export default defineConfig({
   performance: {
     buildCache: {
-      buildDependencies: {
-        configFile: [__filename],
-      },
+      buildDependencies: [__filename],,
     },
   },
 });

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -96,7 +96,7 @@ export default defineConfig({
 
 `buildDependencies` 是一个包含构建依赖的文件数组，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
 
-默认情况下，Rsbuild 会把你的 `packageJson`、`tsconfig`、`rsbuildConfig`、`browserslistrc`、`tailwindcss` 的配置文件作为构建依赖。
+默认情况下，Rsbuild 会把你的 `package.json`、`tsconfig.json`、`rsbuild.config.*`、`.browserslistrc`、`tailwindcss.config.*` 配置文件作为构建依赖。
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -102,7 +102,7 @@ export default defineConfig({
 export default defineConfig({
   performance: {
     buildCache: {
-      buildDependencies: [__filename],,
+      buildDependencies: [__filename],
     },
   },
 });

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -96,7 +96,7 @@ export default defineConfig({
 
 `buildDependencies` 是一个包含构建依赖的文件数组的对象，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
 
-默认情况下，Rsbuild 会把你的 `packageJson`、`tsconfig`、`rsbuildConfig`、`browserslistrc`、`tailwindcss` 的配置文件路径加到 `buildDependencies` 中。
+默认情况下，Rsbuild 会把你的 `packageJson`、`tsconfig`、`rsbuildConfig`、`browserslistrc`、`tailwindcss` 的配置文件作为构建依赖。
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -8,6 +8,7 @@ type BuildCacheConfig =
   | {
       cacheDirectory?: string;
       cacheDigest?: Array<string | undefined>;
+      buildDependencies?: Record<string, string[]>;
     };
 ```
 
@@ -83,6 +84,27 @@ export default defineConfig({
   performance: {
     buildCache: {
       cacheDigest: [process.env.SOME_ENV],
+    },
+  },
+});
+```
+
+### buildDependencies
+
+- **类型：** `Record<string, string[]>`
+- **默认值：** `undefined`
+
+`buildDependencies` 是一个包含构建依赖的文件数组的对象，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
+
+默认情况下，Rsbuild 会把你的 `packageJson`、`tsconfig`、`rsbuildConfig`、`browserslistrc`、`tailwindcss` 的配置文件路径加到 `buildDependencies` 中。
+
+```ts title="rsbuild.config.ts"
+export default defineConfig({
+  performance: {
+    buildCache: {
+      buildDependencies: {
+        configFile: [__filename],
+      },
     },
   },
 });

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -96,7 +96,15 @@ export default defineConfig({
 
 `buildDependencies` 是一个包含构建依赖的文件数组，Rspack 将使用其中每个文件的哈希值来判断持久化缓存是否失效。
 
-默认情况下，Rsbuild 会把你的 `package.json`、`tsconfig.json`、`rsbuild.config.*`、`.browserslistrc`、`tailwindcss.config.*` 配置文件作为构建依赖。
+Rsbuild 会将以下配置文件作为默认的构建依赖：
+
+- `package.json`
+- `tsconfig.json`
+- `rsbuild.config.*`
+- `.browserslistrc`
+- `tailwindcss.config.*`
+
+当你添加其他构建依赖时，Rsbuild 会将这些自定义依赖与默认依赖合并，并传递给 Rspack。
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({


### PR DESCRIPTION
## Summary

`buildDependencies` is an arrays of additional code dependencies for the build. Rspack will use a hash of each of these items and all dependencies to invalidate the filesystem cache.

https://rspack.dev/config/experiments#cachebuilddependencies

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
