### PR TITLE
feat: exclude `.d.ts` files from file size reporting

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -23,9 +23,11 @@ async function gzipSize(input: Buffer) {
   return data.length;
 }
 
+const EXCLUDE_ASSET_REGEX = /\.(?:map|LICENSE\.txt|d\.ts)$/;
+
 /** Exclude source map and license files by default */
 export const excludeAsset = (asset: PrintFileSizeAsset): boolean =>
-  /\.(?:map|LICENSE\.txt)$/.test(asset.name);
+  EXCLUDE_ASSET_REGEX.test(asset.name);
 
 const getAssetColor = (size: number) => {
   if (size > 300 * 1000) {

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -170,11 +170,11 @@ export default {
 type Exclude = (asset: PrintFileSizeAsset) => boolean;
 ```
 
-- **Default:** `(asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)`
+- **Default:** `(asset) => /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name)`
 
 A filter function to determine which static assets to exclude. If both `include` and `exclude` are set, `exclude` will take precedence.
 
-Rsbuild defaults to excluding source map and license files, as these files do not affect page load performance.
+Rsbuild defaults to excluding source map, license files, and `.d.ts` type files, as these files do not affect page load performance.
 
 For example, exclude `.html` files in addition to the default:
 

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -170,11 +170,11 @@ export default {
 type Exclude = (asset: PrintFileSizeAsset) => boolean;
 ```
 
-- **默认值：** `(asset) => /\.(?:map|LICENSE\.txt)$/.test(asset.name)`
+- **默认值：** `(asset) => /\.(?:map|LICENSE\.txt|d\.ts)$/.test(asset.name)`
 
 一个过滤函数，用于确定哪些静态资源需要被排除。如果同时设置了 `include` 和 `exclude`，则 `exclude` 优先级更高。
 
-Rsbuild 默认排除 source map 和 license 文件，因为这些文件不会影响页面加载的性能。
+Rsbuild 默认排除 source map、许可证文件和 `.d.ts` 类型文件，因为这些文件不会影响页面加载的性能。
 
 例如，额外再排除 `.html` 文件：
 


### PR DESCRIPTION
## Summary

Exclude `.d.ts` type files from file size reporting as they do not affect the page load performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
