### PR TITLE
docs: add decorators version guide for TypeScript

### DIFF
--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -86,3 +86,19 @@ This means:
 
 - You can use the `.js` extension to import `.ts` or `.tsx` files.
 - You can use the `.jsx` extension to import `.tsx` files.
+
+## Decorators version
+
+Rsbuild does not read the `experimentalDecorators` option in `tsconfig.json`, instead, it provides the [decorators.version](/config/source/decorators#decoratorsversion) configuration to specify the decorator version.
+
+By default, Rsbuild uses the `2022-03` version of the decorators, you can also set it to `legacy` to use the legacy decorators:
+
+```ts title="rsbuild.config.ts"
+export default {
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
+};
+```

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -86,3 +86,19 @@ const rspackConfig = {
 
 - 允许使用 `.js` 文件扩展名导入 `.ts` 或 `.tsx` 文件。
 - 允许使用 `.jsx` 文件扩展名导入 `.tsx` 文件。
+
+## 装饰器版本
+
+Rsbuild 不会读取 `tsconfig.json` 中的 `experimentalDecorators` 选项，而是提供了 [decorators.version](/config/source/decorators#decoratorsversion) 配置项来指定装饰器版本。
+
+默认情况下，Rsbuild 会使用 `2022-03` 版本的装饰器，你也可以将其设置为 `legacy` 来使用旧版本装饰器：
+
+```ts title="rsbuild.config.ts"
+export default {
+  source: {
+    decorators: {
+      version: 'legacy',
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

Add the decorators version guide to the TypeScript section.

## Related Links

- https://github.com/web-infra-dev/rspack/issues/9258

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
