### PR TITLE
feat: support generate preload link with duplicate

### DIFF
--- a/e2e/cases/performance/resource-hints/index.test.ts
+++ b/e2e/cases/performance/resource-hints/index.test.ts
@@ -209,6 +209,46 @@ test('should generate preload link when preload is defined', async () => {
   ).toBeTruthy();
 });
 
+test('should generate preload link with duplicate', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      performance: {
+        preload: {
+          type: 'initial',
+          duplicate: true,
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const initialFileName = Object.keys(files).find(
+    (file) =>
+      file.includes('/static/js/') &&
+      !file.includes('/static/js/async/') &&
+      !file.endsWith('.LICENSE.txt'),
+  )!;
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  expect(
+    content.includes(
+      `<link href="${initialFileName.slice(
+        initialFileName.indexOf('/static/js/'),
+      )}" rel="preload" as="script">`,
+    ),
+  ).toBeTruthy();
+});
+
 test('should generate preload link with crossOrigin', async () => {
   const rsbuild = await build({
     cwd: fixtures,

--- a/e2e/cases/performance/resource-hints/index.test.ts
+++ b/e2e/cases/performance/resource-hints/index.test.ts
@@ -222,7 +222,7 @@ test('should generate preload link with duplicate', async () => {
       performance: {
         preload: {
           type: 'initial',
-          duplicate: true,
+          dedupe: false,
         },
       },
     },

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -35,7 +35,7 @@ import {
 
 const defaultOptions = {
   type: 'async-chunks' as const,
-  duplicate: false,
+  dedupe: true,
 };
 
 type LinkType = 'preload' | 'prefetch';
@@ -215,12 +215,12 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
           (htmlPluginData) => {
             if (this.resourceHints) {
               htmlPluginData.assetTags.styles = [
-                ...(this.options.duplicate
-                  ? this.resourceHints
-                  : filterResourceHints(
+                ...(this.options.dedupe
+                  ? filterResourceHints(
                       this.resourceHints,
                       htmlPluginData.assetTags.scripts,
-                    )),
+                    )
+                  : this.resourceHints),
                 ...htmlPluginData.assetTags.styles,
               ];
             }

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -24,7 +24,7 @@ import type {
 } from '@rspack/core';
 import { ensureAssetPrefix, upperFirst } from '../../helpers';
 import { getHTMLPlugin } from '../../pluginHelper';
-import type { HtmlRspackPlugin, PreloadOrPreFetchOption } from '../../types';
+import type { HtmlRspackPlugin, PreloadOrPrefetchOption } from '../../types';
 import {
   type As,
   type BeforeAssetTagGenerationHtmlPluginData,
@@ -61,7 +61,7 @@ function filterResourceHints(
 }
 
 function generateLinks(
-  options: PreloadOrPreFetchOption,
+  options: PreloadOrPrefetchOption,
   type: LinkType,
   compilation: Compilation,
   htmlPluginData: BeforeAssetTagGenerationHtmlPluginData,
@@ -166,7 +166,7 @@ function generateLinks(
 }
 
 export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
-  readonly options: PreloadOrPreFetchOption;
+  readonly options: PreloadOrPrefetchOption;
 
   name = 'HtmlPreloadOrPrefetchPlugin';
 
@@ -177,7 +177,7 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   HTMLCount: number;
 
   constructor(
-    options: true | PreloadOrPreFetchOption,
+    options: true | PreloadOrPrefetchOption,
     type: LinkType,
     HTMLCount: number,
   ) {

--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -35,6 +35,7 @@ import {
 
 const defaultOptions = {
   type: 'async-chunks' as const,
+  duplicate: false,
 };
 
 type LinkType = 'preload' | 'prefetch';
@@ -214,10 +215,12 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
           (htmlPluginData) => {
             if (this.resourceHints) {
               htmlPluginData.assetTags.styles = [
-                ...filterResourceHints(
-                  this.resourceHints,
-                  htmlPluginData.assetTags.scripts,
-                ),
+                ...(this.options.duplicate
+                  ? this.resourceHints
+                  : filterResourceHints(
+                      this.resourceHints,
+                      htmlPluginData.assetTags.scripts,
+                    )),
                 ...htmlPluginData.assetTags.styles,
               ];
             }

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -17,14 +17,14 @@
  */
 
 import type { Chunk, ChunkGroup, Compilation } from '@rspack/core';
-import type { PreloadOrPreFetchOption } from '../../../types';
+import type { PreloadOrPrefetchOption } from '../../../types';
 import type { BeforeAssetTagGenerationHtmlPluginData } from './type';
 
 interface DoesChunkBelongToHtmlOptions {
   chunk: Chunk;
   compilation?: Compilation;
   htmlPluginData: BeforeAssetTagGenerationHtmlPluginData;
-  pluginOptions?: PreloadOrPreFetchOption;
+  pluginOptions?: PreloadOrPrefetchOption;
 }
 
 function recursiveChunkGroup(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -546,11 +546,11 @@ export interface PreloadOrPreFetchOption {
   type?: PreloadIncludeType;
   include?: Filter;
   exclude?: Filter;
-  duplicate?: boolean;
+  dedupe?: boolean;
 }
 export type PreloadOption = PreloadOrPreFetchOption;
 
-export type PreFetchOption = Omit<PreloadOrPreFetchOption, 'duplicate'>;
+export type PreFetchOption = Omit<PreloadOrPreFetchOption, 'dedupe'>;
 
 export interface PerformanceConfig {
   /**

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -546,7 +546,11 @@ export interface PreloadOrPreFetchOption {
   type?: PreloadIncludeType;
   include?: Filter;
   exclude?: Filter;
+  duplicate?: boolean;
 }
+export type PreloadOption = PreloadOrPreFetchOption;
+
+export type PreFetchOption = Omit<PreloadOrPreFetchOption, 'duplicate'>;
 
 export interface PerformanceConfig {
   /**
@@ -599,7 +603,7 @@ export interface PerformanceConfig {
    *
    * Specifies that the user agent must preemptively fetch and cache the target resource for current navigation.
    */
-  preload?: true | PreloadOrPreFetchOption;
+  preload?: true | PreloadOption;
 
   /**
    * Used to control resource `Prefetch`.
@@ -607,7 +611,7 @@ export interface PerformanceConfig {
    * Specifies that the user agent should preemptively fetch and cache the target resource as it
    * is likely to be required for a followup navigation.
    */
-  prefetch?: true | PreloadOrPreFetchOption;
+  prefetch?: true | PreFetchOption;
 
   /**
    * Whether capture timing information for each module,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -542,15 +542,15 @@ export type PreloadIncludeType =
 
 export type Filter = Array<string | RegExp> | ((filename: string) => boolean);
 
-export interface PreloadOrPreFetchOption {
+export interface PreloadOrPrefetchOption {
   type?: PreloadIncludeType;
   include?: Filter;
   exclude?: Filter;
   dedupe?: boolean;
 }
-export type PreloadOption = PreloadOrPreFetchOption;
+export type PreloadOption = PreloadOrPrefetchOption;
 
-export type PreFetchOption = Omit<PreloadOrPreFetchOption, 'dedupe'>;
+export type PrefetchOption = Omit<PreloadOrPrefetchOption, 'dedupe'>;
 
 export interface PerformanceConfig {
   /**
@@ -611,7 +611,7 @@ export interface PerformanceConfig {
    * Specifies that the user agent should preemptively fetch and cache the target resource as it
    * is likely to be required for a followup navigation.
    */
-  prefetch?: true | PreFetchOption;
+  prefetch?: true | PrefetchOption;
 
   /**
    * Whether capture timing information for each module,

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -11,6 +11,7 @@ interface PreloadOption {
   type?: IncludeType;
   include?: Filter;
   exclude?: Filter;
+  duplicate?: boolean;
 }
 ```
 
@@ -88,16 +89,19 @@ When the value of `performance.preload` is `object` type, the Rsbuild will enabl
 
 ### preload.type
 
+- **Type:** ` 'async-chunks' | 'initial' | 'all-assets' | 'all-chunks'`
+- **Default:** `'async-chunks'`
+
 The `type` field controls which resources will be pre-fetched, and supports secondary filtering of specified resources through `include` and `exclude`.
 
 Currently supported resource types are as follows:
 
 - `async-chunks`: preload all asynchronous resources (on the current page), including asynchronous JS and its associated CSS, image, font and other resources.
-- `initial`: preload all non-async resources (on the current page). It should be noted that if the current script has been added to the HTML template, no additional pre-fetching will be performed.
+- `initial`: preload all non-async resources (on the current page).
 - `all-chunks`: preload all resources (on the current page), including all asynchronous and non-asynchronous resources.
 - `all-assets`: preload all resources, and resources of other pages will be included in the MPA scenario.
 
-### Example
+#### Example
 
 When you want to preload all image resources in png format on the current page, you can configure it as follows:
 
@@ -107,6 +111,25 @@ export default {
     preload: {
       type: 'all-chunks',
       include: [/.*\.png$/],
+    },
+  },
+};
+```
+
+### preload.duplicate
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+Whether to preload script resources that already exist in the current HTML template. By default, if a resource has been added to the current HTML via a script tag, it will not be preloaded additionally.
+
+When set to `true`, Rsbuild will generate preload tags for all eligible resources, even if these resources already exist in the HTML.
+
+```js
+export default {
+  performance: {
+    preload: {
+      duplicate: true,
     },
   },
 };

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -11,7 +11,7 @@ interface PreloadOption {
   type?: IncludeType;
   include?: Filter;
   exclude?: Filter;
-  duplicate?: boolean;
+  dedupe?: boolean;
 }
 ```
 
@@ -116,10 +116,10 @@ export default {
 };
 ```
 
-### preload.duplicate
+### preload.dedupe
 
 - **Type:** `boolean`
-- **Default:** `false`
+- **Default:** `true`
 
 Whether to preload script resources that already exist in the current HTML template. By default, if a resource has been added to the current HTML via a script tag, it will not be preloaded additionally.
 
@@ -129,7 +129,7 @@ When set to `true`, Rsbuild will generate preload tags for all eligible resource
 export default {
   performance: {
     preload: {
-      duplicate: true,
+      dedupe: false,
     },
   },
 };

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -89,8 +89,8 @@ export default {
 
 ### preload.type
 
-- **Type:** ` 'async-chunks' | 'initial' | 'all-assets' | 'all-chunks'`
-- **Default:** `'async-chunks'`
+- **类型：** ` 'async-chunks' | 'initial' | 'all-assets' | 'all-chunks'`
+- **默认值：** `'async-chunks'`
 
 `type` 字段控制了哪些资源会被预加载，同时支持通过 `include` 和 `exclude` 对指定资源进行二次过滤。
 

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -11,6 +11,7 @@ interface PreloadOption {
   type?: IncludeType;
   include?: Filter;
   exclude?: Filter;
+  duplicate?: boolean;
 }
 ```
 
@@ -88,16 +89,19 @@ export default {
 
 ### preload.type
 
+- **Type:** ` 'async-chunks' | 'initial' | 'all-assets' | 'all-chunks'`
+- **Default:** `'async-chunks'`
+
 `type` 字段控制了哪些资源会被预加载，同时支持通过 `include` 和 `exclude` 对指定资源进行二次过滤。
 
 目前支持的资源类型如下：
 
 - `async-chunks`: preload 所有异步资源（当前页面），包含异步 JS 及其关联的 CSS、image、font 等资源。
-- `initial`: preload 所有非异步资源（当前页面）。需要注意的是，如果当前脚本已经被添加到 HTML 模版中，则不会进行额外的预加载。
+- `initial`: preload 所有非异步资源（当前页面）。
 - `all-chunks`: preload 所有资源（当前页面），包含所有异步和非异步资源。
 - `all-assets`: preload 所有资源，MPA 场景下会包含其他页面的资源。
 
-### 示例
+#### 示例
 
 当你希望对当前页面中所有 png 格式的图片资源进行 preload 时，可以配置如下：
 
@@ -107,6 +111,25 @@ export default {
     preload: {
       type: 'all-chunks',
       include: [/.*\.png$/],
+    },
+  },
+};
+```
+
+### preload.duplicate
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+是否对已经在当前 HTML 模版中存在的 script 资源进行预加载。默认情况下，如果某个资源已通过 script 标签添加到当前的 HTML 中，则不会进行额外的预加载。
+
+设置为 `true` 时，Rsbuild 将为所有符合条件的资源生成 preload 标签，即使这些资源已经在 HTML 中存在。
+
+```js
+export default {
+  performance: {
+    preload: {
+      duplicate: true,
     },
   },
 };

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -11,7 +11,7 @@ interface PreloadOption {
   type?: IncludeType;
   include?: Filter;
   exclude?: Filter;
-  duplicate?: boolean;
+  dedupe?: boolean;
 }
 ```
 
@@ -116,10 +116,10 @@ export default {
 };
 ```
 
-### preload.duplicate
+### preload.dedupe
 
 - **类型：** `boolean`
-- **默认值：** `false`
+- **默认值：** `true`
 
 是否对已经在当前 HTML 模版中存在的 script 资源进行预加载。默认情况下，如果某个资源已通过 script 标签添加到当前的 HTML 中，则不会进行额外的预加载。
 
@@ -129,7 +129,7 @@ export default {
 export default {
   performance: {
     preload: {
-      duplicate: true,
+      dedupe: false,
     },
   },
 };


### PR DESCRIPTION
## Summary

By default, if a resource has been added to the current HTML via a script tag, it will not be preloaded additionally.

When set `preload.dedupe` to `false`, Rsbuild will generate preload tags for all eligible resources, even if these resources already exist in the HTML.

```js
export default {
  performance: {
    preload: {
      dedupe: false,
    },
  },
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
