### PR TITLE
chore(workflow): exclude dist folders from search result

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "search.exclude": {
     "**/.git": true,
     "**/dist": true,
-    "**/dist-types": true,
+    "**/dist-*": true,
     "**/coverage": true,
     "**/compiled": true,
     "**/doc_build": true,


### PR DESCRIPTION
## Summary

Our E2E cases will create some dist-* folders and these should be excluded from the VS Code search.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
