### PR TITLE
feat: expose dev server instance for `onBeforeStartDevServer` hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
@@ -1,0 +1,33 @@
+import { dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+test('should run onBeforeStartDevServer hooks and add custom middleware', async ({
+  page,
+}) => {
+  let count = 0;
+
+  const plugin: RsbuildPlugin = {
+    name: 'test-plugin',
+    setup(api) {
+      api.onBeforeStartDevServer(async ({ server }) => {
+        server.middlewares.use((_req, _res, next) => {
+          count++;
+          next();
+        });
+      });
+    },
+  };
+
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      plugins: [plugin],
+    },
+  });
+
+  expect(count).toBeGreaterThanOrEqual(0);
+
+  await rsbuild.close();
+});

--- a/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/src/index.js
+++ b/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -1,8 +1,9 @@
 import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-// HMR will timeout in CI
-test('setupMiddlewares', async ({ page }) => {
+test('should apply custom middleware via `setupMiddlewares`', async ({
+  page,
+}) => {
   // HMR cases will fail in Windows
   if (process.platform === 'win32') {
     test.skip();

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -9,7 +9,7 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
     test.skip();
   }
 
-  let i = 0;
+  let count = 0;
   let reloadFn: undefined | (() => void);
 
   // Only tested to see if it works, not all configurations.
@@ -21,7 +21,7 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
         setupMiddlewares: [
           (middlewares, server) => {
             middlewares.unshift((_req, _res, next) => {
-              i++;
+              count++;
               next();
             });
             reloadFn = () => server.sockWrite('static-changed');
@@ -34,17 +34,17 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
 
-  expect(i).toBeGreaterThanOrEqual(1);
+  expect(count).toBeGreaterThanOrEqual(1);
   expect(reloadFn).toBeDefined();
 
-  i = 0;
+  count = 0;
   reloadFn!();
 
   // check value of `i`
   const maxChecks = 100;
   let checks = 0;
   while (checks < maxChecks) {
-    if (i === 0) {
+    if (count === 0) {
       checks++;
       await new Promise((resolve) => setTimeout(resolve, 50));
     } else {
@@ -52,7 +52,7 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
     }
   }
 
-  expect(i).toBeGreaterThanOrEqual(1);
+  expect(count).toBeGreaterThanOrEqual(1);
 
   await rsbuild.close();
 });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -21,7 +21,11 @@ import {
   getTransformedHtml,
   loadBundle,
 } from './environment';
-import { type CompileMiddlewareAPI, getMiddlewares } from './getDevMiddlewares';
+import {
+  type CompileMiddlewareAPI,
+  type GetMiddlewaresResult,
+  getMiddlewares,
+} from './getDevMiddlewares';
 import {
   type StartServerResult,
   getAddressUrls,
@@ -34,7 +38,7 @@ import { createHttpServer } from './httpServer';
 import { notFoundMiddleware } from './middlewares';
 import { open } from './open';
 import { onBeforeRestartServer, restartDevServer } from './restart';
-import { setupWatchFiles } from './watchFiles';
+import { WatchFilesResult, setupWatchFiles } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 
@@ -116,8 +120,8 @@ export async function createDevServer<
     config,
   });
   const devConfig = formatDevConfig(config.dev, port);
-
   const routes = getRoutes(options.context);
+  const root = options.context.rootPath;
 
   options.context.devServer = {
     hostname: host,
@@ -182,10 +186,6 @@ export async function createDevServer<
   const protocol = https ? 'https' : 'http';
   const urls = getAddressUrls({ protocol, port, host });
 
-  await options.context.hooks.onBeforeStartDevServer.call({
-    environments: options.context.environments,
-  });
-
   const cliShortcutsEnabled = isCliShortcutsEnabled(devConfig);
 
   const printUrls = () =>
@@ -208,9 +208,13 @@ export async function createDevServer<
     });
   };
 
+  // biome-ignore lint/style/useConst: should be declared before use
+  let fileWatcher: WatchFilesResult | undefined;
+  let devMiddlewares: GetMiddlewaresResult | undefined;
+
   const closeServer = async () => {
     await options.context.hooks.onCloseDevServer.call();
-    await Promise.all([devMiddlewares.close(), fileWatcher?.close()]);
+    await Promise.all([devMiddlewares?.close(), fileWatcher?.close()]);
   };
 
   const beforeCreateCompiler = () => {
@@ -237,24 +241,6 @@ export async function createDevServer<
       logger.info(portTip);
     }
   };
-
-  if (runCompile) {
-    // print server url should between listen and beforeCompile
-    options.context.hooks.onBeforeCreateCompiler.tap(beforeCreateCompiler);
-  } else {
-    beforeCreateCompiler();
-  }
-
-  const compileMiddlewareAPI = runCompile ? await startCompile() : undefined;
-
-  const root = options.context.rootPath;
-
-  const fileWatcher = await setupWatchFiles({
-    dev: devConfig,
-    server: config.server,
-    compileMiddlewareAPI,
-    root,
-  });
 
   const readFileSync = (fileName: string) => {
     if ('readFileSync' in outputFileSystem) {
@@ -311,28 +297,8 @@ export async function createDevServer<
     }),
   );
 
-  const devMiddlewares = await getMiddlewares({
-    pwd: root,
-    compileMiddlewareAPI,
-    dev: devConfig,
-    server: config.server,
-    environments: environmentAPI,
-    output: {
-      distPath: options.context.distPath || ROOT_DIST_DIR,
-    },
-    outputFileSystem,
-  });
-
   const { default: connect } = await import('../../compiled/connect/index.js');
   const middlewares = connect();
-
-  for (const item of devMiddlewares.middlewares) {
-    if (Array.isArray(item)) {
-      middlewares.use(...item);
-    } else {
-      middlewares.use(item);
-    }
-  }
 
   const devServerAPI: RsbuildDevServer = {
     port,
@@ -361,7 +327,9 @@ export async function createDevServer<
             }
 
             middlewares.use(notFoundMiddleware);
-            httpServer.on('upgrade', devMiddlewares.onUpgrade);
+            if (devMiddlewares) {
+              httpServer.on('upgrade', devMiddlewares.onUpgrade);
+            }
 
             logger.debug('listen dev server done');
 
@@ -388,12 +356,55 @@ export async function createDevServer<
       });
     },
     connectWebSocket: ({ server }: { server: HTTPServer }) => {
-      server.on('upgrade', devMiddlewares.onUpgrade);
+      if (devMiddlewares) {
+        server.on('upgrade', devMiddlewares.onUpgrade);
+      }
     },
     close: closeServer,
     printUrls,
     open: openPage,
   };
+
+  await options.context.hooks.onBeforeStartDevServer.call({
+    server: devServerAPI,
+    environments: options.context.environments,
+  });
+
+  if (runCompile) {
+    // print server url should between listen and beforeCompile
+    options.context.hooks.onBeforeCreateCompiler.tap(beforeCreateCompiler);
+  } else {
+    beforeCreateCompiler();
+  }
+
+  const compileMiddlewareAPI = runCompile ? await startCompile() : undefined;
+
+  fileWatcher = await setupWatchFiles({
+    dev: devConfig,
+    server: config.server,
+    compileMiddlewareAPI,
+    root,
+  });
+
+  devMiddlewares = await getMiddlewares({
+    pwd: root,
+    compileMiddlewareAPI,
+    dev: devConfig,
+    server: config.server,
+    environments: environmentAPI,
+    output: {
+      distPath: options.context.distPath || ROOT_DIST_DIR,
+    },
+    outputFileSystem,
+  });
+
+  for (const item of devMiddlewares.middlewares) {
+    if (Array.isArray(item)) {
+      middlewares.use(...item);
+    } else {
+      middlewares.use(item);
+    }
+  }
 
   logger.debug('create dev server done');
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -38,7 +38,7 @@ import { createHttpServer } from './httpServer';
 import { notFoundMiddleware } from './middlewares';
 import { open } from './open';
 import { onBeforeRestartServer, restartDevServer } from './restart';
-import { WatchFilesResult, setupWatchFiles } from './watchFiles';
+import { type WatchFilesResult, setupWatchFiles } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -237,13 +237,15 @@ const applyDefaultMiddlewares = async ({
   };
 };
 
-export const getMiddlewares = async (
-  options: RsbuildDevMiddlewareOptions,
-): Promise<{
+export type GetMiddlewaresResult = {
   close: () => Promise<void>;
   onUpgrade: UpgradeEvent;
   middlewares: Middlewares;
-}> => {
+};
+
+export const getMiddlewares = async (
+  options: RsbuildDevMiddlewareOptions,
+): Promise<GetMiddlewaresResult> => {
   const middlewares: Middlewares = [];
   const { environments, compileMiddlewareAPI } = options;
 

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -16,12 +16,13 @@ type WatchFilesOptions = {
   root: string;
 };
 
-export async function setupWatchFiles(options: WatchFilesOptions): Promise<
-  | {
-      close(): Promise<void>;
-    }
-  | undefined
-> {
+export type WatchFilesResult = {
+  close(): Promise<void>;
+};
+
+export async function setupWatchFiles(
+  options: WatchFilesOptions,
+): Promise<WatchFilesResult | undefined> {
   const { dev, server, root, compileMiddlewareAPI } = options;
 
   const { hmr, liveReload } = dev;

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -59,7 +59,13 @@ export type OnDevCompileDoneFn = (params: {
 }) => MaybePromise<void>;
 
 export type OnBeforeStartDevServerFn = (params: {
+  /**
+   * The dev server instance, the same as the return value of `createDevServer`.
+   */
   server: RsbuildDevServer;
+  /**
+   * A read-only object that provides some context information about different environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,5 +1,6 @@
 import type { ChainIdentifier } from '..';
 import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type { RsbuildDevServer } from '../server/devServer';
 import type {
   EnvironmentConfig,
   HtmlBasicTag,
@@ -58,6 +59,7 @@ export type OnDevCompileDoneFn = (params: {
 }) => MaybePromise<void>;
 
 export type OnBeforeStartDevServerFn = (params: {
+  server: RsbuildDevServer;
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -784,8 +784,10 @@ import OnBeforeStartDevServer from '@en/shared/onBeforeStartDevServer.mdx';
 - **Example:**
 
 ```ts
-rsbuild.onBeforeStartDevServer(() => {
-  console.log('before start!');
+rsbuild.onBeforeStartDevServer(({ server, environments }) => {
+  console.log('before starting dev server.');
+  console.log('the server is ', server);
+  console.log('the environments contexts are: ', environments);
 });
 ```
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -659,8 +659,10 @@ import OnBeforeStartDevServer from '@en/shared/onBeforeStartDevServer.mdx';
 ```ts
 const myPlugin = () => ({
   setup: (api) => {
-    api.onBeforeStartDevServer(() => {
-      console.log('before start!');
+    api.onBeforeStartDevServer(({ server, environments }) => {
+      console.log('before starting dev server.');
+      console.log('the server is ', server);
+      console.log('the environments contexts are: ', environments);
     });
   },
 });

--- a/website/docs/en/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/en/shared/onBeforeStartDevServer.mdx
@@ -1,11 +1,20 @@
 Called before starting the dev server.
 
+Use the `server` parameter to get the dev server instance, see [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver) for more information.
+
 - **Type:**
 
 ```ts
-function OnBeforeStartDevServer(
-  callback: (params: {
-    environments: Record<string, EnvironmentContext>;
-  }) => Promise<void> | void,
-): void;
+type OnBeforeStartDevServerFn = (params: {
+  /**
+   * The dev server instance, the same as the return value of `createDevServer`.
+   */
+  server: RsbuildDevServer;
+  /**
+   * A read-only object that provides some context information about different environments.
+   */
+  environments: Record<string, EnvironmentContext>;
+}) => MaybePromise<void>;
+
+function OnBeforeStartDevServer(callback: OnBeforeStartDevServerFn): void;
 ```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -805,8 +805,10 @@ import OnBeforeStartDevServer from '@zh/shared/onBeforeStartDevServer.mdx';
 - **示例：**
 
 ```ts
-rsbuild.onBeforeStartDevServer(() => {
-  console.log('before start!');
+rsbuild.onBeforeStartDevServer(({ server, environments }) => {
+  console.log('before starting dev server.');
+  console.log('the server is ', server);
+  console.log('the environments contexts are: ', environments);
 });
 ```
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -655,8 +655,10 @@ import OnBeforeStartDevServer from '@zh/shared/onBeforeStartDevServer.mdx';
 ```ts
 const myPlugin = () => ({
   setup: (api) => {
-    api.onBeforeStartDevServer(() => {
-      console.log('before start!');
+    api.onBeforeStartDevServer(({ server, environments }) => {
+      console.log('before starting dev server.');
+      console.log('the server is ', server);
+      console.log('the environments contexts are: ', environments);
     });
   },
 });

--- a/website/docs/zh/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/zh/shared/onBeforeStartDevServer.mdx
@@ -1,11 +1,20 @@
 在启动开发服务器前调用。
 
+通过 `server` 参数可以获取到开发服务器实例，参考 [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver) 了解更多。
+
 - **类型：**
 
 ```ts
-function OnBeforeStartDevServer(
-  callback: (params: {
-    environments: Record<string, EnvironmentContext>;
-  }) => Promise<void> | void,
-): void;
+type OnBeforeStartDevServerFn = (params: {
+  /**
+   * The dev server instance, the same as the return value of `createDevServer`.
+   */
+  server: RsbuildDevServer;
+  /**
+   * A read-only object that provides some context information about different environments.
+   */
+  environments: Record<string, EnvironmentContext>;
+}) => MaybePromise<void>;
+
+function OnBeforeStartDevServer(callback: OnBeforeStartDevServerFn): void;
 ```


### PR DESCRIPTION
## Summary

Expose the dev server instance for the  `onBeforeStartDevServer` hook, this makes it easier for the Rsbuild plugins to add a custom middleware.

```js
const myPlugin = {
  setup(api) {
    api.onBeforeStartDevServer(({ server, environments }) => {
      console.log('before starting dev server.');
      console.log('the server is ', server);
      console.log('the environments contexts are: ', environments);
    });
  },
};
```

```js
const myPlugin = {
  name: 'test-plugin',
  setup(api) {
    api.onBeforeStartDevServer({ server }) => {
      server.middlewares.use((_req, _res, next) => {
        count++;
        next();
      });
    });
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
