### PR TITLE
docs: add example for accessing dev server in plugin hooks

### DIFF
--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -668,6 +668,33 @@ const myPlugin = () => ({
 });
 ```
 
+If you need to access `server` in other hooks, you can store the `server` instance through `api.onBeforeStartDevServer`, and then access it in the hooks executed later. Note that you cannot access `server` in hooks that are executed earlier than `onBeforeStartDevServer`.
+
+```ts
+import type { RsbuildDevServer } from '@rsbuild/core';
+
+const myPlugin = () => ({
+  setup(api) {
+    let devServer: RsbuildDevServer | null = null;
+
+    api.onBeforeStartDevServer(({ server, environments }) => {
+      devServer = server;
+    });
+
+    api.transform({ test: /\.foo$/ }, ({ code }) => {
+      if (devServer) {
+        // access server API
+      }
+      return code;
+    });
+
+    api.onCloseDevServer(() => {
+      devServer = null;
+    });
+  },
+});
+```
+
 ### onAfterStartDevServer
 
 import OnAfterStartDevServer from '@en/shared/onAfterStartDevServer.mdx';

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -664,6 +664,33 @@ const myPlugin = () => ({
 });
 ```
 
+如果你需要在其他 hooks 中访问 `server`，可以通过 `onBeforeStartDevServer` 来存储 `server` 实例，并在执行后续的 hooks 时访问它。注意你不能在执行时机早于 `onBeforeStartDevServer` 的 hooks 中访问 `server`。
+
+```ts
+import type { RsbuildDevServer } from '@rsbuild/core';
+
+const myPlugin = () => ({
+  setup(api) {
+    let devServer: RsbuildDevServer | null = null;
+
+    api.onBeforeStartDevServer(({ server, environments }) => {
+      devServer = server;
+    });
+
+    api.transform({ test: /\.foo$/ }, ({ code }) => {
+      if (devServer) {
+        // access server API
+      }
+      return code;
+    });
+
+    api.onCloseDevServer(() => {
+      devServer = null;
+    });
+  },
+});
+```
+
 ### onAfterStartDevServer
 
 import OnAfterStartDevServer from '@zh/shared/onAfterStartDevServer.mdx';


### PR DESCRIPTION
## Summary

Add example on how to access the `server` instance in other plugin hooks by storing it through `api.onBeforeStartDevServer`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
