### PR TITLE
fix: prevent some hook return values from affecting other hooks

### DIFF
--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -7,7 +7,7 @@ export async function createCompiler(options: InitConfigsOptions) {
   const { helpers, context } = options;
   const { webpackConfigs } = await initConfigs(options);
 
-  await context.hooks.onBeforeCreateCompiler.call({
+  await context.hooks.onBeforeCreateCompiler.callBatch({
     bundlerConfigs: webpackConfigs as Rspack.Configuration[],
     environments: context.environments,
   });
@@ -55,7 +55,7 @@ export async function createCompiler(options: InitConfigsOptions) {
     });
   }
 
-  await context.hooks.onAfterCreateCompiler.call({
+  await context.hooks.onAfterCreateCompiler.callBatch({
     compiler,
     environments: context.environments,
   });

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -21,11 +21,10 @@ async function modifyWebpackChain(
 ): Promise<RspackChain> {
   logger.debug('modify webpack chain');
 
-  const [modifiedChain] =
-    await context.hooks.modifyWebpackChain.callInEnvironment({
-      environment: utils.environment.name,
-      args: [chain, utils],
-    });
+  const [modifiedChain] = await context.hooks.modifyWebpackChain.callChain({
+    environment: utils.environment.name,
+    args: [chain, utils],
+  });
 
   if (utils.environment.config.tools?.webpackChain) {
     for (const item of castArray(utils.environment.config.tools.webpackChain)) {
@@ -44,11 +43,10 @@ async function modifyWebpackConfig(
   utils: ModifyWebpackConfigUtils,
 ): Promise<WebpackConfig> {
   logger.debug('modify webpack config');
-  let [modifiedConfig] =
-    await context.hooks.modifyWebpackConfig.callInEnvironment({
-      environment: utils.environment.name,
-      args: [webpackConfig, utils],
-    });
+  let [modifiedConfig] = await context.hooks.modifyWebpackConfig.callChain({
+    environment: utils.environment.name,
+    args: [webpackConfig, utils],
+  });
 
   if (utils.environment.config.tools?.webpack) {
     modifiedConfig = reduceConfigsWithContext({

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -18,7 +18,7 @@ export async function modifyBundlerChain(
   const bundlerChain = getBundlerChain();
 
   const [modifiedBundlerChain] =
-    await context.hooks.modifyBundlerChain.callInEnvironment({
+    await context.hooks.modifyBundlerChain.callChain({
       environment: utils.environment.name,
       args: [bundlerChain, utils],
     });

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -75,7 +75,7 @@ async function applyDefaultPlugins(
     pluginCleanOutput(),
     pluginAsset(),
     pluginHtml((environment: string) => async (...args) => {
-      const result = await context.hooks.modifyHTMLTags.callInEnvironment({
+      const result = await context.hooks.modifyHTMLTags.callChain({
         environment,
         args,
       });
@@ -190,7 +190,7 @@ export async function createRsbuild(
     return {
       ...buildInstance,
       close: async () => {
-        await context.hooks.onCloseBuild.call();
+        await context.hooks.onCloseBuild.callBatch();
         await buildInstance.close();
       },
     };

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -71,7 +71,7 @@ export function createEnvironmentAsyncHook<
     }
   };
 
-  const callInEnvironment = async ({
+  const callChain = async ({
     environment,
     args: params,
   }: {
@@ -100,11 +100,39 @@ export function createEnvironmentAsyncHook<
     return params;
   };
 
+  const callBatch = async <T = unknown>({
+    environment,
+    args: params,
+  }: {
+    environment?: string;
+    args: Parameters<Callback>;
+  }) => {
+    const callbacks = [...preGroup, ...defaultGroup, ...postGroup];
+    const results: T[] = [];
+
+    for (const callback of callbacks) {
+      // If this callback is not a global callback, the environment info should match
+      if (
+        callback.environment &&
+        environment &&
+        !isPluginMatchEnvironment(callback.environment, environment)
+      ) {
+        continue;
+      }
+
+      const result = await callback.handler(...params);
+      results.push(result);
+    }
+
+    return results;
+  };
+
   return {
     tapEnvironment,
     tap: (handler: Callback | HookDescriptor<Callback>) =>
       tapEnvironment({ handler }),
-    callInEnvironment,
+    callChain,
+    callBatch,
   };
 }
 
@@ -127,7 +155,7 @@ export function createAsyncHook<
     }
   };
 
-  const call = async (...params: Parameters<Callback>) => {
+  const callChain = async (...params: Parameters<Callback>) => {
     const callbacks = [...preGroup, ...defaultGroup, ...postGroup];
 
     for (const callback of callbacks) {
@@ -141,9 +169,22 @@ export function createAsyncHook<
     return params;
   };
 
+  const callBatch = async <T = unknown>(...params: Parameters<Callback>) => {
+    const callbacks = [...preGroup, ...defaultGroup, ...postGroup];
+    const results: T[] = [];
+
+    for (const callback of callbacks) {
+      const result = await callback(...params);
+      results.push(result);
+    }
+
+    return results;
+  };
+
   return {
     tap,
-    call,
+    callChain,
+    callBatch,
   };
 }
 
@@ -345,7 +386,7 @@ export const registerBuildHook = ({
   }, []);
 
   const beforeCompile = async () =>
-    await context.hooks.onBeforeBuild.call({
+    await context.hooks.onBeforeBuild.callBatch({
       bundlerConfigs,
       environments: context.environments,
       isWatch,
@@ -353,7 +394,7 @@ export const registerBuildHook = ({
     });
 
   const beforeEnvironmentCompiler = async (buildIndex: number) =>
-    await context.hooks.onBeforeEnvironmentCompile.callInEnvironment({
+    await context.hooks.onBeforeEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {
@@ -366,7 +407,7 @@ export const registerBuildHook = ({
     });
 
   const onDone = async (stats: Rspack.Stats | Rspack.MultiStats) => {
-    const p = context.hooks.onAfterBuild.call({
+    const p = context.hooks.onAfterBuild.callBatch({
       isFirstCompile,
       stats,
       environments: context.environments,
@@ -377,7 +418,7 @@ export const registerBuildHook = ({
   };
 
   const onEnvironmentDone = async (buildIndex: number, stats: Rspack.Stats) => {
-    await context.hooks.onAfterEnvironmentCompile.callInEnvironment({
+    await context.hooks.onAfterEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {
@@ -426,7 +467,7 @@ export const registerDevHook = ({
   }, []);
 
   const beforeEnvironmentCompiler = async (buildIndex: number) =>
-    await context.hooks.onBeforeEnvironmentCompile.callInEnvironment({
+    await context.hooks.onBeforeEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {
@@ -439,7 +480,7 @@ export const registerDevHook = ({
     });
 
   const onDone = async (stats: Rspack.Stats | Rspack.MultiStats) => {
-    const p = context.hooks.onDevCompileDone.call({
+    const p = context.hooks.onDevCompileDone.callBatch({
       isFirstCompile,
       stats,
       environments: context.environments,
@@ -449,7 +490,7 @@ export const registerDevHook = ({
   };
 
   const onEnvironmentDone = async (buildIndex: number, stats: Rspack.Stats) => {
-    await context.hooks.onAfterEnvironmentCompile.callInEnvironment({
+    await context.hooks.onAfterEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -323,7 +323,7 @@ export function initPluginAPI({
   const onExit: typeof hooks.onExit.tap = (cb) => {
     if (!onExitListened) {
       process.on('exit', () => {
-        hooks.onExit.call();
+        hooks.onExit.callBatch();
       });
       onExitListened = true;
     }

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -21,7 +21,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   const { context } = options;
   const { rspackConfigs } = await initConfigs(options);
 
-  await context.hooks.onBeforeCreateCompiler.call({
+  await context.hooks.onBeforeCreateCompiler.callBatch({
     bundlerConfigs: rspackConfigs,
     environments: context.environments,
   });
@@ -122,7 +122,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     });
   }
 
-  await context.hooks.onAfterCreateCompiler.call({
+  await context.hooks.onAfterCreateCompiler.callBatch({
     compiler,
     environments: context.environments,
   });

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -25,7 +25,7 @@ import { generateRspackConfig } from './rspackConfig';
 
 async function modifyRsbuildConfig(context: InternalContext) {
   logger.debug('modify Rsbuild config');
-  const [modified] = await context.hooks.modifyRsbuildConfig.call(
+  const [modified] = await context.hooks.modifyRsbuildConfig.callChain(
     context.config,
     { mergeRsbuildConfig },
   );
@@ -41,18 +41,17 @@ async function modifyEnvironmentConfig(
 ) {
   logger.debug(`modify Rsbuild environment(${name}) config`);
 
-  const [modified] =
-    await context.hooks.modifyEnvironmentConfig.callInEnvironment({
-      environment: name,
-      args: [
-        config,
-        {
-          name,
-          mergeEnvironmentConfig:
-            mergeRsbuildConfig<MergedEnvironmentConfig> as ModifyEnvironmentConfigUtils['mergeEnvironmentConfig'],
-        },
-      ],
-    });
+  const [modified] = await context.hooks.modifyEnvironmentConfig.callChain({
+    environment: name,
+    args: [
+      config,
+      {
+        name,
+        mergeEnvironmentConfig:
+          mergeRsbuildConfig<MergedEnvironmentConfig> as ModifyEnvironmentConfigUtils['mergeEnvironmentConfig'],
+      },
+    ],
+  });
 
   logger.debug(`modify Rsbuild environment(${name}) config done`);
 

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -19,11 +19,10 @@ async function modifyRspackConfig(
   utils: ModifyRspackConfigUtils,
 ) {
   logger.debug('modify Rspack config');
-  let [modifiedConfig] =
-    await context.hooks.modifyRspackConfig.callInEnvironment({
-      environment: utils.environment.name,
-      args: [rspackConfig, utils],
-    });
+  let [modifiedConfig] = await context.hooks.modifyRspackConfig.callChain({
+    environment: utils.environment.name,
+    args: [rspackConfig, utils],
+  });
 
   if (utils.environment.config.tools?.rspack) {
     modifiedConfig = await reduceConfigsAsyncWithContext({

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -213,7 +213,7 @@ export async function createDevServer<
   let devMiddlewares: GetMiddlewaresResult | undefined;
 
   const closeServer = async () => {
-    await options.context.hooks.onCloseDevServer.call();
+    await options.context.hooks.onCloseDevServer.callBatch();
     await Promise.all([devMiddlewares?.close(), fileWatcher?.close()]);
   };
 
@@ -349,7 +349,7 @@ export async function createDevServer<
       });
     },
     afterListen: async () => {
-      await options.context.hooks.onAfterStartDevServer.call({
+      await options.context.hooks.onAfterStartDevServer.callBatch({
         port,
         routes,
         environments: options.context.environments,
@@ -365,7 +365,7 @@ export async function createDevServer<
     open: openPage,
   };
 
-  await options.context.hooks.onBeforeStartDevServer.call({
+  await options.context.hooks.onBeforeStartDevServer.callBatch({
     server: devServerAPI,
     environments: options.context.environments,
   });

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -187,7 +187,7 @@ export async function startProdServer(
     middlewares,
   );
 
-  await context.hooks.onBeforeStartProdServer.call();
+  await context.hooks.onBeforeStartProdServer.callBatch();
 
   const httpServer = await createHttpServer({
     serverConfig,
@@ -205,7 +205,7 @@ export async function startProdServer(
       },
       async () => {
         const routes = getRoutes(context);
-        await context.hooks.onAfterStartProdServer.call({
+        await context.hooks.onAfterStartProdServer.callBatch({
           port,
           routes,
           environments: context.environments,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -48,27 +48,82 @@ export type HookDescriptor<T extends (...args: any[]) => any> = {
 };
 
 export type EnvironmentAsyncHook<Callback extends (...args: any[]) => any> = {
+  /**
+   * Registers a callback function to be executed when the hook is triggered.
+   * The callback can be a plain function or a HookDescriptor that includes execution order.
+   * The callback will be executed in all environments by default.
+   * If you need to specify the environment, please use `tapEnvironment`
+   * @param cb The callback function or hook descriptor to register
+   */
+  tap: (cb: Callback | HookDescriptor<Callback>) => void;
+  /**
+   * Registers a callback function to be executed when the hook is triggered.
+   * The callback will only be executed under the specified environment.
+   */
   tapEnvironment: (params: {
     /**
-     * Specify that the callback will only be executed under the specified environment
+     * Specify the environment that the callback will be executed under.
      */
     environment?: string;
+    /**
+     * The callback function or hook descriptor to register
+     */
     handler: Callback | HookDescriptor<Callback>;
   }) => void;
   /**
-   *  Triggered in all environments by default.
-   *  If you need to specify the environment, please use `tapEnvironment`
+   * Executes callbacks in sequence independently and collects all their results into an array.
+   * Each callback receives the original parameters, and their results don't affect subsequent callbacks.
+   * @returns A promise that resolves with an array containing the results of all callbacks
    */
-  tap: (cb: Callback | HookDescriptor<Callback>) => void;
-  callInEnvironment: (params: {
+  callChain: (params: {
+    /**
+     * Specify the environment for filtering callbacks.
+     */
     environment?: string;
+    /**
+     * The parameters to pass to each callback
+     */
     args: Parameters<Callback>;
   }) => Promise<Parameters<Callback>>;
+  /**
+   * Executes callbacks in sequence independently and collects all their results into an array.
+   * Each callback receives the original parameters, and their results don't affect subsequent callbacks.
+   * @returns A promise that resolves with an array containing the results of all callbacks
+   */
+  callBatch: <T = unknown>(params: {
+    /**
+     * Specify the environment for filtering callbacks.
+     */
+    environment?: string;
+    /**
+     * The parameters to pass to each callback
+     */
+    args: Parameters<Callback>;
+  }) => Promise<T[]>;
 };
 
 export type AsyncHook<Callback extends (...args: any[]) => any> = {
+  /**
+   * Registers a callback function to be executed when the hook is triggered.
+   * The callback can be a plain function or a HookDescriptor that includes execution order.
+   * @param cb The callback function or hook descriptor to register
+   */
   tap: (cb: Callback | HookDescriptor<Callback>) => void;
-  call: (...args: Parameters<Callback>) => Promise<Parameters<Callback>>;
+  /**
+   * Executes callbacks in sequence, passing the result of each callback as the first argument
+   * to the next callback in the chain. If a callback returns undefined, the original arguments
+   * will be passed to the next callback.
+   * @param params The initial parameters to pass to the first callback
+   * @returns A promise that resolves with the final parameters after all callbacks have executed
+   */
+  callChain: (...args: Parameters<Callback>) => Promise<Parameters<Callback>>;
+  /**
+   * Executes callbacks in sequence independently and collects all their results into an array.
+   * Each callback receives the original parameters, and their results don't affect subsequent callbacks.
+   * @param params The parameters to pass to each callback
+   * @returns A promise that resolves with an array containing the results of all callbacks
+   */
+  callBatch: <T = unknown>(...args: Parameters<Callback>) => Promise<T[]>;
 };
 
 export type ModifyRspackConfigFn = (

--- a/packages/core/tests/hooks.test.ts
+++ b/packages/core/tests/hooks.test.ts
@@ -21,12 +21,12 @@ describe('initHooks', () => {
       },
     });
 
-    await hookA.callInEnvironment({
+    await hookA.callChain({
       environment: 'a',
       args: ['call in a'],
     });
 
-    await hookA.callInEnvironment({
+    await hookA.callChain({
       environment: 'b',
       args: ['call in b'],
     });


### PR DESCRIPTION
## Summary

This PR distinguishes the `call` method of Rsbuild's internal hook into `callBatch` and `callChain` to prevent some hook return values from affecting other hooks.

- `callBatch`: Each callback receives the original parameters, and their results don't affect subsequent callbacks. For example, `onBeforeBuild` and `onAfterBuild` hooks.
- `callChain`: Passing the result of each callback as the first argument to the next callback in the chain. If a callback returns undefined, the original arguments will be passed to the next callback. For example, `modifyRspackConfig` and `modifyRsbuildConfig` hooks.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
