### PR TITLE
feat: expose httpServer in RsbuildDevServer

### DIFF
--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -49,7 +49,19 @@ type EnvironmentAPI = {
 
 type RsbuildDevServer = {
   /**
-   * Listen the Rsbuild server.
+   * The `connect` app instance.
+   * Can be used to attach custom middlewares to the dev server.
+   */
+  middlewares: Connect.Server /**
+   * The Node.js HTTP server instance.
+   * Will be `Http2SecureServer` if `server.https` config is used.
+   */;
+  httpServer:
+    | import('node:http').Server
+    | import('node:http2').Http2SecureServer
+    | null;
+  /**
+   * Start listening on the Rsbuild dev server.
    * Do not call this method if you are using a custom server.
    */
   listen: () => Promise<{
@@ -68,11 +80,6 @@ type RsbuildDevServer = {
    * By default, Rsbuild server listens on port `3000` and automatically increments the port number if the port is occupied.
    */
   port: number;
-  /**
-   * The `connect` app instance.
-   * Can be used to attach custom middlewares to the dev server.
-   */
-  middlewares: Connect.Server;
   /**
    * Notify that the Rsbuild server has been started.
    * Rsbuild will trigger `onAfterStartDevServer` hook in this stage.

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -49,7 +49,20 @@ type EnvironmentAPI = {
 
 type RsbuildDevServer = {
   /**
-   * 监听 Rsbuild server
+   * `connect` 实例
+   * 可用于向 dev server 附加自定义中间件
+   */
+  middlewares: Connect.Server;
+  /**
+   * Node.js HTTP 服务器实例
+   * 如果使用了 `server.https` 配置，则为 `Http2SecureServer`
+   */
+  httpServer:
+    | import('node:http').Server
+    | import('node:http2').Http2SecureServer
+    | null;
+  /**
+   * 监听 Rsbuild dev server
    * 当你使用自定义 server 时，不需要调用该方法
    */
   listen: () => Promise<{
@@ -68,11 +81,6 @@ type RsbuildDevServer = {
    * 默认情况下，Rsbuild Server 会监听 `3000` 端口，如果端口被占用，则自动递增端口号
    */
   port: number;
-  /**
-   * `connect` 实例
-   * 可用于向 dev server 附加自定义中间件
-   */
-  middlewares: Connect.Server;
   /**
    * 通知 Rsbuild 自定义 Server 已启动
    * Rsbuild 会在此阶段触发 `onAfterStartDevServer` 钩子


### PR DESCRIPTION
## Summary

Expose `httpServer` in RsbuildDevServer, this can be used to set up the Rspack lazy compilation backend server.

Example:

```js
const lazyCompilationServerPlugin = (): RsbuildPlugin => {
  return {
    name: 'lazy-compilation-server-plugin',
    setup(api) {
      let devServer: RsbuildDevServer;

      api.onBeforeStartDevServer(({ server }) => {
        devServer = server;
      });

      api.modifyRspackConfig((config) => {
        const { httpServer } = devServer || {};
        if (!httpServer) {
          return;
        }

        config.experiments ||= {};
        config.experiments.lazyCompilation = {
          backend: {
            server: () => httpServer,
          },
        };
      });
    },
  };
};
```

TODO: Consider adding a new `server.middlewareMode` config to prevent the unnecessary `createHttpServer` call.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
