### PR TITLE
fix: type infer for plugin hooks

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -47,7 +47,10 @@ export type HookDescriptor<T extends (...args: any[]) => any> = {
   order: HookOrder;
 };
 
-export type EnvironmentAsyncHook<Callback extends (...args: any[]) => any> = {
+export type EnvironmentAsyncHook<
+  Callback extends (...args: any[]) => T,
+  T = any,
+> = {
   /**
    * Registers a callback function to be executed when the hook is triggered.
    * The callback can be a plain function or a HookDescriptor that includes execution order.
@@ -90,7 +93,7 @@ export type EnvironmentAsyncHook<Callback extends (...args: any[]) => any> = {
    * Each callback receives the original parameters, and their results don't affect subsequent callbacks.
    * @returns A promise that resolves with an array containing the results of all callbacks
    */
-  callBatch: <T = unknown>(params: {
+  callBatch: (params: {
     /**
      * Specify the environment for filtering callbacks.
      */
@@ -99,10 +102,10 @@ export type EnvironmentAsyncHook<Callback extends (...args: any[]) => any> = {
      * The parameters to pass to each callback
      */
     args: Parameters<Callback>;
-  }) => Promise<T[]>;
+  }) => Promise<Awaited<ReturnType<Callback>>[]>;
 };
 
-export type AsyncHook<Callback extends (...args: any[]) => any> = {
+export type AsyncHook<Callback extends (...args: any[]) => T, T = any> = {
   /**
    * Registers a callback function to be executed when the hook is triggered.
    * The callback can be a plain function or a HookDescriptor that includes execution order.
@@ -123,7 +126,9 @@ export type AsyncHook<Callback extends (...args: any[]) => any> = {
    * @param params The parameters to pass to each callback
    * @returns A promise that resolves with an array containing the results of all callbacks
    */
-  callBatch: <T = unknown>(...args: Parameters<Callback>) => Promise<T[]>;
+  callBatch: (
+    ...args: Parameters<Callback>
+  ) => Promise<Awaited<ReturnType<Callback>>[]>;
 };
 
 export type ModifyRspackConfigFn = (


### PR DESCRIPTION
## Summary

This pull request includes changes to improve type definitions for hooks.  This ensures that the return type of `callBatch` is automatically inferred.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
