### PR TITLE
feat: allow onBeforeStartDevServer hook to return post callback

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -374,10 +374,12 @@ export async function createDevServer<
     open: openPage,
   };
 
-  await options.context.hooks.onBeforeStartDevServer.callBatch({
-    server: devServerAPI,
-    environments: options.context.environments,
-  });
+  const postCallbacks = (
+    await options.context.hooks.onBeforeStartDevServer.callBatch({
+      server: devServerAPI,
+      environments: options.context.environments,
+    })
+  ).filter((item) => typeof item === 'function');
 
   if (runCompile) {
     // print server url should between listen and beforeCompile
@@ -405,6 +407,7 @@ export async function createDevServer<
       distPath: options.context.distPath || ROOT_DIST_DIR,
     },
     outputFileSystem,
+    postCallbacks,
   });
 
   for (const item of devMiddlewares.middlewares) {

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -39,6 +39,10 @@ export type RsbuildDevMiddlewareOptions = {
   output: {
     distPath: string;
   };
+  /**
+   * Callbacks registered through the `onBeforeStartDevServer` hook.
+   */
+  postCallbacks: (() => void)[];
 };
 
 const applySetupMiddlewares = (
@@ -79,6 +83,7 @@ const applyDefaultMiddlewares = async ({
   pwd,
   outputFileSystem,
   environments,
+  postCallbacks,
 }: RsbuildDevMiddlewareOptions & {
   middlewares: Middlewares;
 }): Promise<{
@@ -184,6 +189,15 @@ const applyDefaultMiddlewares = async ({
     });
 
     middlewares.push(assetMiddleware);
+  }
+
+  // Execute callbacks registered through the `onBeforeStartDevServer` hook.
+  // This is the ideal place for users to add custom middlewares because:
+  // 1. It runs after most of the default middlewares
+  // 2. It runs before fallback middlewares
+  // This ensures custom middleware can intercept requests before any fallback handling
+  for (const callback of postCallbacks) {
+    callback();
   }
 
   if (compileMiddlewareAPI) {

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -40,7 +40,7 @@ export type RsbuildDevMiddlewareOptions = {
     distPath: string;
   };
   /**
-   * Callbacks registered through the `onBeforeStartDevServer` hook.
+   * Callbacks returned by the `onBeforeStartDevServer` hook.
    */
   postCallbacks: (() => void)[];
 };

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -191,7 +191,7 @@ const applyDefaultMiddlewares = async ({
     middlewares.push(assetMiddleware);
   }
 
-  // Execute callbacks registered through the `onBeforeStartDevServer` hook.
+  // Execute callbacks returned by the `onBeforeStartDevServer` hook.
   // This is the ideal place for users to add custom middlewares because:
   // 1. It runs after most of the default middlewares
   // 2. It runs before fallback middlewares

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -67,7 +67,7 @@ export type OnBeforeStartDevServerFn = (params: {
    * A read-only object that provides some context information about different environments.
    */
   environments: Record<string, EnvironmentContext>;
-}) => MaybePromise<void>;
+}) => MaybePromise<(() => void) | void>;
 
 export type OnBeforeStartProdServerFn = () => MaybePromise<void>;
 


### PR DESCRIPTION
## Summary

Allow onBeforeStartDevServer hook to return a post callback, the post callback will be called when the default middlewares are registered:

```js
const plugin: RsbuildPlugin = {
  name: 'test-plugin',
  setup(api) {
    api.onBeforeStartDevServer(async ({ server }) => {
      server.middlewares.use((req, res, next) => {
        if (req.url === '/test.html') {
          res.end('Hello, world!');
        } else {
          next();
        }
      });

      // the post callback will be called when the default middlewares are registered
      return () => {
        server.middlewares.use((req, res, next) => {
          if (req.url === '/test2.html') {
            res.end('Hello, world2!');
          } else {
            next();
          }
        });
      };
    });
  },
};
```

Documentation will be updated later.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
