### PR TITLE
docs: register middlewares in onBeforeStartDevServer

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -642,6 +642,8 @@ rsbuild.onBeforeStartDevServer(({ server, environments }) => {
 });
 ```
 
+> See [Plugin hooks - onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) for more details.
+
 ## rsbuild.onAfterStartDevServer
 
 import OnAfterStartDevServer from '@en/shared/onAfterStartDevServer.mdx';

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -668,6 +668,44 @@ const myPlugin = () => ({
 });
 ```
 
+#### Register middlewares
+
+A common usage scenario is to register custom middlewares in `onBeforeStartDevServer`:
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      server.middlewares.use((req, res, next) => {
+        next();
+      });
+    });
+  },
+});
+```
+
+When `onBeforeStartDevServer` is called, the default middlewares of Rsbuild are not registered yet, so the middlewares you add will run before the default middlewares.
+
+`onBeforeStartDevServer` allows you to return a callback function, which will be called when the default middlewares of Rsbuild are registered. The middlewares you register in the callback function will run after the default middlewares.
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      // the returned callback will be called when the default
+      // middlewares are registered
+      return () => {
+        server.middlewares.use((req, res, next) => {
+          next();
+        });
+      };
+    });
+  },
+});
+```
+
+#### Store server instance
+
 If you need to access `server` in other hooks, you can store the `server` instance through `api.onBeforeStartDevServer`, and then access it in the hooks executed later. Note that you cannot access `server` in hooks that are executed earlier than `onBeforeStartDevServer`.
 
 ```ts

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -665,6 +665,8 @@ rsbuild.onBeforeStartDevServer(({ server, environments }) => {
 });
 ```
 
+> 查看 [Plugin hooks - onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 了解更多用法。
+
 ## rsbuild.onAfterStartDevServer
 
 import OnAfterStartDevServer from '@zh/shared/onAfterStartDevServer.mdx';

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -664,6 +664,44 @@ const myPlugin = () => ({
 });
 ```
 
+#### 注册中间件
+
+一个常见的使用场景是在 `onBeforeStartDevServer` 中注册自定义的中间件：
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      server.middlewares.use((req, res, next) => {
+        next();
+      });
+    });
+  },
+});
+```
+
+当 `onBeforeStartDevServer` 被调用时，Rsbuild 内置的中间件还未注册，因此你添加的中间件会早于内置中间件执行。
+
+`onBeforeStartDevServer` 允许你返回一个回调函数，当 Rsbuild 内置的中间件注册完成后，会执行你返回的回调函数，在回调函数中注册的中间件会晚于内置中间件执行。
+
+```ts
+const myPlugin = () => ({
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      // the returned callback will be called when the default
+      // middlewares are registered
+      return () => {
+        server.middlewares.use((req, res, next) => {
+          next();
+        });
+      };
+    });
+  },
+});
+```
+
+#### 保存 server 实例
+
 如果你需要在其他 hooks 中访问 `server`，可以通过 `onBeforeStartDevServer` 来存储 `server` 实例，并在执行后续的 hooks 时访问它。注意你不能在执行时机早于 `onBeforeStartDevServer` 的 hooks 中访问 `server`。
 
 ```ts


### PR DESCRIPTION
## Summary

Add guide for register middlewares in the `onBeforeStartDevServer` hook.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4573

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
