### PR TITLE
fix: should handle proxy error correctly

### DIFF
--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { dev } from '@e2e/helper';
+import { dev, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const prj1 = join(__dirname, 'project1');
@@ -39,4 +39,43 @@ test('should apply basic proxy rules correctly', async ({ page }) => {
 
   await rsbuild1.close();
   await rsbuild2.close();
+});
+
+test('should handle proxy error correctly', async ({ page }) => {
+  const { logs, restore } = proxyConsole();
+  const rsbuild1 = await dev({
+    cwd: prj1,
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(prj1, 'src/index.js'),
+        },
+      },
+      server: {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+        },
+        proxy: [
+          {
+            context: [`/api`],
+            target: `http://somepagewhichdoesnotexits.com:9000`,
+            changeOrigin: true,
+            secure: false,
+          },
+        ],
+      },
+    },
+  });
+
+  const res = await page.goto(`http://localhost:${rsbuild1.port}/api`);
+
+  expect(res?.status()).toBe(504);
+
+  expect(
+    logs.some((log) => log.includes('Error occurred while proxying request')),
+  ).toBeTruthy();
+
+  await rsbuild1.close();
+
+  restore();
 });

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -57,8 +57,8 @@ test('should handle proxy error correctly', async ({ page }) => {
         },
         proxy: [
           {
-            context: [`/api`],
-            target: `http://somepagewhichdoesnotexits.com:9000`,
+            context: ['/api'],
+            target: 'http://somepagewhichdoesnotexits.com:9000',
             changeOrigin: true,
             secure: false,
           },

--- a/packages/core/src/server/proxy.ts
+++ b/packages/core/src/server/proxy.ts
@@ -20,6 +20,7 @@ function formatProxyOptions(proxyOptions: ProxyConfig) {
         context,
         changeOrigin: true,
         logLevel: 'warn',
+        logProvider: () => logger,
       };
       if (typeof options === 'string') {
         opts.target = options;
@@ -28,12 +29,6 @@ function formatProxyOptions(proxyOptions: ProxyConfig) {
       }
       ret.push(opts);
     }
-  }
-
-  const handleError = (err: unknown) => logger.error(err);
-
-  for (const opts of ret) {
-    opts.onError ??= handleError;
   }
 
   return ret;


### PR DESCRIPTION
## Summary

use `http-proxy-middleware` default error handler.

## Related Links

fix: https://github.com/web-infra-dev/rsbuild/issues/4563
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
