### PR TITLE
fix(core): respect `server.port` when replacing `<port>`

### DIFF
--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -26,7 +26,7 @@ function getPublicPath({
   const { dev, output, server } = config;
 
   let publicPath = DEFAULT_ASSET_PREFIX;
-  const port = context.devServer?.port || DEFAULT_PORT;
+  const port = context.devServer?.port || server.port || DEFAULT_PORT;
 
   if (isProd) {
     if (typeof output.assetPrefix === 'string') {

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -178,6 +178,20 @@ describe('plugin-output', () => {
     expect(config?.output?.publicPath).toEqual('http://example-3000.com:3000/');
   });
 
+  it('should replace `<port>` placeholder with server.port', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [pluginOutput()],
+      rsbuildConfig: {
+        server: { port: 4000 },
+        dev: {
+          assetPrefix: 'http://example-<port>.com:<port>/',
+        },
+      },
+    });
+    const [config] = await rsbuild.initConfigs();
+    expect(config?.output?.publicPath).toEqual('http://example-4000.com:4000/');
+  });
+
   it('should replace `<port>` placeholder of `output.assetPrefix` with default port', async () => {
     vi.stubEnv('NODE_ENV', 'production');
     const rsbuild = await createStubRsbuild({


### PR DESCRIPTION
## Summary

When using Rsbuild without development server(e.g.: `rsbuild.initConfig()` or `rsbuild inspect`), the `publicPath` is not correct since we are using `context.devServer?.port || DEFAULT_PORT`

This patch fix this to use `server.port` when needed.

## Related Links

A fix of #3098.

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or **not required**).
