### PR TITLE
feat: add npm link to plugin hints

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -42,38 +42,46 @@ function hintUnknownFiles(message: string): string {
     return message;
   }
 
+  const createPluginHint = (packageName: string, keyword: string) => {
+    return `To enable support for ${keyword}, use "${color.yellow(
+      `@rsbuild/plugin-${packageName}`,
+    )}" ${color.dim(
+      `(https://www.npmjs.com/package/@rsbuild/plugin-${packageName})`,
+    )}.`;
+  };
+
   const recommendPlugins = [
     {
       test: /File: .+\.s(c|a)ss/,
-      hint: `To enable support for Sass, use "${color.yellow('@rsbuild/plugin-sass')}".`,
+      hint: createPluginHint('sass', 'Sass'),
     },
     {
       test: /File: .+\.less/,
-      hint: `To enable support for Less, use "${color.yellow('@rsbuild/plugin-less')}".`,
+      hint: createPluginHint('less', 'Less'),
     },
     {
       test: /File: .+\.styl(us)?/,
-      hint: `To enable support for Stylus, use "${color.yellow('@rsbuild/plugin-stylus')}".`,
+      hint: createPluginHint('stylus', 'Stylus'),
     },
     {
       test: /File: .+\.vue?/,
-      hint: `To enable support for Vue, use "${color.yellow('@rsbuild/plugin-vue')}".`,
+      hint: createPluginHint('vue', 'Vue'),
     },
     {
       test: /File: .+\.svelte?/,
-      hint: `To enable support for Svelte, use "${color.yellow('@rsbuild/plugin-svelte')}".`,
+      hint: createPluginHint('svelte', 'Svelte'),
     },
     {
       test: /File: .+\.mdx/,
-      hint: `To enable support for MDX, use "${color.yellow('@rsbuild/plugin-mdx')}".`,
+      hint: createPluginHint('mdx', 'MDX'),
     },
     {
       test: /File: .+\.toml/,
-      hint: `To enable support for TOML, use "${color.yellow('@rsbuild/plugin-toml')}".`,
+      hint: createPluginHint('toml', 'TOML'),
     },
     {
       test: /File: .+\.yaml/,
-      hint: `To enable support for YAML, use "${color.yellow('@rsbuild/plugin-yaml')}".`,
+      hint: createPluginHint('yaml', 'YAML'),
     },
   ];
 


### PR DESCRIPTION
## Summary

Add the npm link to plugin hints to help users access the plugin:

<img width="1233" alt="Screenshot 2025-02-18 at 19 02 07" src="https://github.com/user-attachments/assets/8905314d-3398-4cdd-a6ec-8d27376958ac" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
