### PR TITLE
release: v1.2.9

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-webpack-swc",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "SWC plugin for Rsbuild webpack provider",
   "repository": {
     "type": "git",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "homepage": "https://rsbuild.dev",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.dev",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-assets-retry/package.json
+++ b/packages/plugin-assets-retry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Assets retry plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-babel",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Babel plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-less",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Less plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "React plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-sass",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Sass plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-solid",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Solid plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-stylus",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Stylus plugin for Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svelte",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Svelte plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-svgr",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "svgr plugin for Rsbuild",
   "repository": {
     "type": "git",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-vue",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Vue 3 plugin of Rsbuild",
   "homepage": "https://rsbuild.dev",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: expose `httpServer` in RsbuildDevServer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4570
* feat: allow `onBeforeStartDevServer` hook to return post callback by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4573
* feat: add npm link to plugin hints by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4583
### Bug Fixes 🐞
* fix: prevent some hook return values from affecting other hooks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4569
* fix: type infer for plugin hooks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4571
* fix: should handle proxy error correctly by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/4577
* fix(core): respect `server.port` when replacing `<port>` by @colinaaa in https://github.com/web-infra-dev/rsbuild/pull/4578
### Document 📖
* docs: extract dev server API to separate page by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4566
* docs: improve server middlewares documentation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4567
* docs: add example for accessing dev server in plugin hooks by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4568
* docs: update CRA migration guide by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4572
* docs: register middlewares in onBeforeStartDevServer by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4576
* docs: update README files for plugin packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4590
### Other Changes
* chore(deps): update sass to ^1.85.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4565
* chore(deps): update dependency @rsbuild/plugin-check-syntax to ^1.3.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4564
* chore(deps): update all patch dependencies by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4574
* chore(deps): update dependency preact to ^10.26.0 by @renovate in https://github.com/web-infra-dev/rsbuild/pull/4575
* test(e2e): avoid opening Rsdoctor pages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4558
* test(e2e): migrate all cases to ESM by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4579
* test(e2e): enable Rsdoctor cases on Windows by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4582
* test: correct react version for MF cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/4585


**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.2.8...v1.2.9TODO