### PR TITLE
fix(server): options fallback should only works in rsbuild server mode

### DIFF
--- a/e2e/cases/server/fallback/index.test.ts
+++ b/e2e/cases/server/fallback/index.test.ts
@@ -1,0 +1,65 @@
+import { dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('OPTIONS request should fallback success when no other middleware responses', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: import.meta.dirname,
+    page,
+    rsbuildConfig: {},
+  });
+
+  const response = await fetch(`http://127.0.0.1:${rsbuild.port}`, {
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'OPTIONS',
+  });
+  expect(response.status).toBe(204);
+  expect(response.headers.get('access-control-allow-origin')).toBe('*');
+
+  await rsbuild.close();
+});
+
+test('OPTIONS request should response correctly with middleware responses', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: import.meta.dirname,
+    page,
+    rsbuildConfig: {
+      dev: {
+        setupMiddlewares: [
+          (middlewares) => {
+            middlewares.push((req, res, next) => {
+              if (req.method === 'OPTIONS') {
+                res.statusCode = 200;
+                res.setHeader(
+                  'access-control-allow-origin',
+                  'https://example.com',
+                );
+                res.end();
+                return;
+              }
+              next();
+            });
+          },
+        ],
+      },
+    },
+  });
+
+  const response = await fetch(`http://127.0.0.1:${rsbuild.port}`, {
+    headers: {
+      'content-type': 'application/json',
+    },
+    method: 'OPTIONS',
+  });
+  expect(response.status).toBe(200);
+  expect(response.headers.get('access-control-allow-origin')).toBe(
+    'https://example.com',
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/server/fallback/src/index.js
+++ b/e2e/cases/server/fallback/src/index.js
@@ -1,0 +1,1 @@
+console.log('Hello Rsbuild!');

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -35,7 +35,7 @@ import {
   printServerURLs,
 } from './helper';
 import { createHttpServer } from './httpServer';
-import { notFoundMiddleware } from './middlewares';
+import { notFoundMiddleware, optionsFallbackMiddleware } from './middlewares';
 import { open } from './open';
 import { onBeforeRestartServer, restartDevServer } from './restart';
 import { type WatchFilesResult, setupWatchFiles } from './watchFiles';
@@ -334,6 +334,11 @@ export async function createDevServer<
             if (err) {
               throw err;
             }
+
+            // OPTIONS request fallback middleware
+            // Should register this middleware as the last
+            // see: https://github.com/web-infra-dev/rsbuild/pull/2867
+            middlewares.use(optionsFallbackMiddleware);
 
             middlewares.use(notFoundMiddleware);
             if (devMiddlewares) {

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -228,20 +228,6 @@ const applyDefaultMiddlewares = async ({
 
   middlewares.push(faviconFallbackMiddleware);
 
-  // OPTIONS request fallback middleware
-  // Should register this middleware as the last
-  // see: https://github.com/web-infra-dev/rsbuild/pull/2867
-  middlewares.push((req, res, next) => {
-    if (req.method === 'OPTIONS') {
-      // Use 204 as no content to send in the response body
-      res.statusCode = 204;
-      res.setHeader('Content-Length', '0');
-      res.end();
-      return;
-    }
-    next();
-  });
-
   return {
     onUpgrade: (...args) => {
       for (const cb of upgradeEvents) {

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -77,6 +77,17 @@ export const notFoundMiddleware: Middleware = (_req, res, _next) => {
   res.end();
 };
 
+export const optionsFallbackMiddleware: Middleware = (req, res, next) => {
+  if (req.method === 'OPTIONS') {
+    // Use 204 as no content to send in the response body
+    res.statusCode = 204;
+    res.setHeader('Content-Length', '0');
+    res.end();
+    return;
+  }
+  next();
+};
+
 const isFileExists = async (
   filePath: string,
   outputFileSystem: Rspack.OutputFileSystem,

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -25,6 +25,8 @@ import {
   faviconFallbackMiddleware,
   getBaseMiddleware,
   getRequestLoggerMiddleware,
+  notFoundMiddleware,
+  optionsFallbackMiddleware,
 } from './middlewares';
 import { open } from './open';
 import { createProxyMiddleware } from './proxy';
@@ -122,6 +124,8 @@ export class RsbuildProdServer {
     }
 
     this.middlewares.use(faviconFallbackMiddleware);
+    this.middlewares.use(optionsFallbackMiddleware);
+    this.middlewares.use(notFoundMiddleware);
   }
 
   private async applyStaticAssetMiddleware() {


### PR DESCRIPTION
## Summary

Updating the `optionsFallbackMiddleware` middleware registration order,  options fallback should only works in rsbuild server mode


## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
