### PR TITLE
docs: improve stats usage example in JavaScript API documentation

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -123,11 +123,15 @@ try {
   process.exit(1);
 }
 
-// Example 3: build and get all stats
+// Example 3: build and get all assets
 const { stats } = await rsbuild.build();
 
 if (stats) {
-  const { assets } = stats.toJson({ assets: true });
+  const { assets } = stats.toJson({
+    // exclude unused fields to improve performance
+    all: false,
+    assets: true,
+  });
   console.log(assets);
 }
 ```
@@ -154,12 +158,22 @@ await result.close();
 
 ### Stats object
 
-In non-watch mode, the `rsbuild.build() returns an Rspack [stats](https://rspack.dev/api/javascript-api/stats) object:
+In non-watch mode, the `rsbuild.build()` returns an Rspack [stats](https://rspack.dev/api/javascript-api/stats) object.
+
+For example, use the `stats.toJson()` method to get all assets information:
 
 ```ts
 const result = await rsbuild.build();
+const { stats } = result;
 
-console.log(result.stats);
+if (stats) {
+  const { assets } = stats.toJson({
+    // exclude unused fields to improve performance
+    all: false,
+    assets: true,
+  });
+  console.log(assets);
+}
 ```
 
 ### Custom compiler

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -146,11 +146,15 @@ try {
   process.exit(1);
 }
 
-// Example 3: build and get all stats
+// Example 3: build and get all assets
 const { stats } = await rsbuild.build();
 
 if (stats) {
-  const { assets } = stats.toJson({ assets: true });
+  const { assets } = stats.toJson({
+    // 排除不需要的字段以提高性能
+    all: false,
+    assets: true,
+  });
   console.log(assets);
 }
 ```
@@ -177,12 +181,22 @@ await result.close();
 
 ### Stats 对象
 
-在非 watch 模式下，`rsbuild.build()` 会返回一个 Rspack 的 [stats](https://rspack.dev/api/javascript-api/stats) 对象：
+在非 watch 模式下，`rsbuild.build()` 会返回一个 Rspack 的 [stats](https://rspack.dev/api/javascript-api/stats) 对象。
+
+例如，使用 `stats.toJson()` 方法获取所有 assets 信息：
 
 ```ts
 const result = await rsbuild.build();
+const { stats } = result;
 
-console.log(result.stats);
+if (stats) {
+  const { assets } = stats.toJson({
+    // 排除不需要的字段以提高性能
+    all: false,
+    assets: true,
+  });
+  console.log(assets);
+}
 ```
 
 ### 自定义 Compiler


### PR DESCRIPTION
## Summary

Improve stats usage example in JavaScript API documentation, should add `all: false` to improve performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
