### PR TITLE
chore(ci): configure Node.js memory limit in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Configure Node.js memory limit to 6GB (default GitHub Actions limit is 7GB)
+  NODE_OPTIONS: --max-old-space-size=6144
+
 jobs:
   # ======== ut ========
   ut:


### PR DESCRIPTION
## Summary

Configure Node.js memory limit in GitHub Actions to try to fix timeout.

## Related Links

- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners#supported-runners-and-hardware-resources

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
