### PR TITLE
test: fix flaky hooks order case

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks/environments.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/environments.test.ts
@@ -158,7 +158,18 @@ rspackOnlyTest(
       names.filter((name) => name.includes(' node')).length,
     );
 
-    expect(names.filter((name) => !name.includes(' node'))).toEqual([
+    expect(names.filter((name) => name.includes('DevServer'))).toEqual([
+      'BeforeStartDevServer',
+      'AfterStartDevServer',
+      'OnCloseDevServer',
+    ]);
+
+    // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
+    expect(
+      names.filter(
+        (name) => !name.includes(' node') && name !== 'AfterStartDevServer',
+      ),
+    ).toEqual([
       'ModifyRsbuildConfig',
       'ModifyEnvironmentConfig web',
       'BeforeStartDevServer',
@@ -167,14 +178,17 @@ rspackOnlyTest(
       'BeforeCreateCompiler',
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile web',
-      'AfterStartDevServer',
       'ModifyHTMLTags web',
       'AfterEnvironmentCompile web',
       'OnDevCompileDone',
       'OnCloseDevServer',
     ]);
 
-    expect(names.filter((name) => !name.includes(' web'))).toEqual([
+    expect(
+      names.filter(
+        (name) => !name.includes(' web') && name !== 'AfterStartDevServer',
+      ),
+    ).toEqual([
       'ModifyRsbuildConfig',
       'ModifyEnvironmentConfig node',
       'BeforeStartDevServer',
@@ -183,7 +197,6 @@ rspackOnlyTest(
       'BeforeCreateCompiler',
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile node',
-      'AfterStartDevServer',
       'ModifyHTMLTags node',
       'AfterEnvironmentCompile node',
       'OnDevCompileDone',

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -160,7 +160,14 @@ rspackOnlyTest(
 
     await result.server.close();
 
-    expect(names).toEqual([
+    expect(names.filter((name) => name.includes('DevServer'))).toEqual([
+      'BeforeStartDevServer',
+      'AfterStartDevServer',
+      'OnCloseDevServer',
+    ]);
+
+    // compile is async, so the execution order of AfterStartDevServer and the compile hooks is uncertain
+    expect(names.filter((name) => name !== 'AfterStartDevServer')).toEqual([
       'ModifyRsbuildConfig',
       'ModifyEnvironmentConfig',
       'BeforeStartDevServer',
@@ -169,7 +176,6 @@ rspackOnlyTest(
       'BeforeCreateCompiler',
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile',
-      'AfterStartDevServer',
       'ModifyHTMLTags',
       'AfterEnvironmentCompile',
       'OnDevCompileDone',


### PR DESCRIPTION
## Summary

Compile is async in dev, so the execution order of AfterStartDevServer and the compile hooks is uncertain.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
