### PR TITLE
feat: improve socket server connection handling and cleanup

### DIFF
--- a/packages/core/src/server/compilerDevMiddleware.ts
+++ b/packages/core/src/server/compilerDevMiddleware.ts
@@ -124,7 +124,7 @@ export class CompilerDevMiddleware {
 
   public async close(): Promise<void> {
     // socketServer close should before app close
-    this.socketServer.close();
+    await this.socketServer.close();
 
     if (this.middleware) {
       await new Promise<void>((resolve) => {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -164,7 +164,6 @@ export class SocketServer {
 
     return new Promise<void>((resolve, reject) => {
       this.wsServer.close((err) => {
-        console.log('==close', err);
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
## Summary

Improve socket server connection handling and cleanup to avoid potential memory leaks:

- Call `this.wsServer.close` when closing the ws server.
- Reset all properties when closing the ws server.
- Use `setTimeout` instead of `setInternal` for heartbeats checking.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
