### PR TITLE
chore(build): specify Rslib build id

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -74,8 +74,8 @@ export default defineConfig({
     externals,
   },
   lib: [
-    // Node / ESM / index
     {
+      id: 'esm:index',
       format: 'esm',
       syntax: 'es2021',
       plugins: [pluginFixDtsTypes, pluginCleanTscCache],
@@ -86,8 +86,8 @@ export default defineConfig({
         minify: nodeMinifyConfig,
       },
     },
-    // Node / ESM / loaders
     {
+      id: 'esm:loaders',
       format: 'esm',
       syntax: 'es2021',
       source: {
@@ -104,8 +104,8 @@ export default defineConfig({
         minify: nodeMinifyConfig,
       },
     },
-    // Node / CJS
     {
+      id: 'cjs:index',
       format: 'cjs',
       syntax: 'es2021',
       source: {
@@ -134,8 +134,8 @@ export default defineConfig({
 });`,
       },
     },
-    // Client / ESM
     {
+      id: 'esm:client',
       format: 'esm',
       syntax: 'es2017',
       source: {


### PR DESCRIPTION
## Summary

Specify Rslib build id to make the build logs clearer:

<img width="520" alt="Screenshot 2025-02-21 at 21 12 53" src="https://github.com/user-attachments/assets/5fb1e634-e0d3-4b51-a7a5-2a24ce45f557" />

Ref: https://lib.rsbuild.dev/config/lib/id

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
