### PR TITLE
test(e2e): fix warnings for plugin hook cases

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
@@ -83,6 +83,9 @@ rspackOnlyTest(
           web: {},
           node: {},
         },
+        performance: {
+          printFileSize: false,
+        },
       },
     });
 
@@ -144,6 +147,9 @@ rspackOnlyTest(
         environments: {
           web: {},
           node: {},
+        },
+        performance: {
+          printFileSize: false,
         },
       },
     });

--- a/e2e/cases/plugin-api/plugin-hooks-environment/src/index.js
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/src/index.js
@@ -1,0 +1,1 @@
+console.log('1');

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -80,6 +80,9 @@ rspackOnlyTest(
       cwd: __dirname,
       rsbuildConfig: {
         plugins: [plugin],
+        performance: {
+          printFileSize: false,
+        },
       },
     });
 
@@ -113,6 +116,9 @@ rspackOnlyTest(
       rsbuildConfig: {
         mode: 'development',
         plugins: [plugin],
+        performance: {
+          printFileSize: false,
+        },
       },
     });
 


### PR DESCRIPTION
## Summary

Fix the print file size warnings for plugin hook E2E cases:

<img width="1256" alt="Screenshot 2025-02-21 at 10 55 56" src="https://github.com/user-attachments/assets/44057b5b-1525-44df-9c14-feb579b088d2" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
