### PR TITLE
docs: add React Router to React guide

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -295,13 +295,11 @@ await rsbuild.startDevServer({
 
 Rsbuild includes a built-in dev server designed to improve the development experience. When you run the `rsbuild dev` command, the server starts automatically and provides features such as page preview, routing, and hot module reloading.
 
-If you want to integrate the Rsbuild dev server into a custom server, you can use the `createDevServer` method to create a dev server instance. Please refer to [Dev server API](/api/javascript-api/dev-server-api) for all available APIs.
-
-If you want to use Rsbuild dev server to start the project directly, you can use the [Rsbuild - startDevServer](#rsbuildstartdevserver) method directly. `startDevServer` is actually syntactic sugar for the following code:
+- To integrate the Rsbuild dev server into a custom server, you can use the `createDevServer` method to create a dev server instance. Please refer to [Dev server API](/api/javascript-api/dev-server-api) for all available APIs.
+- To use Rsbuild dev server to start the project directly, you can use the [rsbuild.startDevServer](#rsbuildstartdevserver) method directly. `rsbuild.startDevServer` is actually syntactic sugar for the following code:
 
 ```ts
 const server = await rsbuild.createDevServer();
-
 await server.listen();
 ```
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -160,6 +160,13 @@ TanStack Router provides `@tanstack/router-plugin` to integrate with Rsbuild, wh
 - [File-Based Routing documentation](https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing)
 - [TanStack Router + Rsbuild Example](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
 
+### React Router
+
+[React Router](https://reactrouter.com/) is a user‑obsessed, standards‑focused, multi‑strategy router for React.
+
+- To use React Router as a library, you can just follow the official documentation and no configuration is required.
+- To use React Router as a framework, the community is working on an experimental Rsbuild plugin, see [rsbuild-plugin-react-router](https://github.com/rspack-contrib/rsbuild-plugin-react-router).
+
 ## CSS-in-JS
 
 ### Use styled-components

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -318,13 +318,11 @@ await rsbuild.startDevServer({
 
 Rsbuild 配备了一个内置的开发服务器，当你执行 `rsbuild dev` 时，将启动 Rsbuild dev server，并提供页面预览、路由、模块热更新等功能。
 
-如果你希望将 Rsbuild dev server 集成到自定义的 server 中，可以通过 `createDevServer` 方法创建一个 dev server 实例，请参考 [Dev server API](/api/javascript-api/dev-server-api) 了解所有可用的 API。
-
-如果你希望直接使用 Rsbuild dev server 启动项目，可以直接使用 [Rsbuild - startDevServer](#rsbuildstartdevserver) 方法。 `startDevServer` 实际上是以下代码的语法糖：
+- 如果你需要将 Rsbuild dev server 集成到自定义的 server 中，可以通过 `createDevServer` 方法创建一个 dev server 实例，请参考 [Dev server API](/api/javascript-api/dev-server-api) 了解所有可用的 API。
+- 如果你需要直接使用 Rsbuild dev server 启动项目，可以直接使用 [rsbuild.startDevServer](#rsbuildstartdevserver) 方法。 `rsbuild.startDevServer` 实际上是以下代码的语法糖：
 
 ```ts
 const server = await rsbuild.createDevServer();
-
 await server.listen();
 ```
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -149,7 +149,7 @@ const ReactCompilerConfig = {
 };
 ```
 
-## Router
+## 路由
 
 ### TanStack Router
 
@@ -159,6 +159,13 @@ TanStack Router 提供了 `@tanstack/router-plugin` 来与 Rsbuild 集成，该�
 
 - [File-Based Routing 文档](https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing)
 - [TanStack Router + Rsbuild 示例](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
+
+### React Router
+
+[React Router](https://reactrouter.com/) 是一个以用户为中心、注重标准的 React 多策略路由库。
+
+- 如果你想将 React Router 作为库来使用，只需按照官方文档操作即可，无需额外配置。
+- 如果你想将 React Router 作为框架来使用，社区正在开发一个实验性的 Rsbuild 插件，参考 [rsbuild-plugin-react-router](https://github.com/rspack-contrib/rsbuild-plugin-react-router)。
 
 ## CSS-in-JS
 


### PR DESCRIPTION
## Summary

Add React Router to React guide, and link to [rsbuild-plugin-react-router](https://github.com/rspack-contrib/rsbuild-plugin-react-router).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
