### PR TITLE
chore(style): standardize logging messages

### DIFF
--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -41,7 +41,7 @@ rspackOnlyTest('should display shortcuts as expected in dev', async () => {
   logs = [];
   devProcess.stdin?.write('r\n');
   expect(
-    await waitFor(() => logs.some((log) => log.includes('Restarting server'))),
+    await waitFor(() => logs.some((log) => log.includes('restarting server'))),
   ).toBeTruthy();
   expect(
     await waitFor(() =>

--- a/e2e/cases/config/inspect-config/debug.test.ts
+++ b/e2e/cases/config/inspect-config/debug.test.ts
@@ -36,7 +36,7 @@ test('should generate config files when build (with DEBUG)', async () => {
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
+    logs.some((log) => log.includes('config inspection completed')),
   ).toBeTruthy();
 
   expect(logs.some((log) => log.includes('create compiler'))).toBeTruthy();
@@ -74,7 +74,7 @@ test('should generate config files when dev (with DEBUG)', async ({ page }) => {
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
+    logs.some((log) => log.includes('config inspection completed')),
   ).toBeTruthy();
 
   expect(logs.some((log) => log.includes('create compiler'))).toBeTruthy();

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -37,7 +37,7 @@ rspackOnlyTest(
     expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
     expect(
-      logs.some((log) => log.includes('Inspect config succeed')),
+      logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
     fs.rmSync(rsbuildConfig, { force: true });
@@ -74,7 +74,7 @@ rspackOnlyTest(
     expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
 
     expect(
-      logs.some((log) => log.includes('Inspect config succeed')),
+      logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
     fs.rmSync(rsbuildConfig, { force: true });
@@ -115,7 +115,7 @@ rspackOnlyTest(
     expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
 
     expect(
-      logs.some((log) => log.includes('Inspect config succeed')),
+      logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
     fs.rmSync(rsbuildConfig, { force: true });
@@ -156,7 +156,7 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
   });
 
   expect(
-    logs.some((log) => log.includes('Inspect config succeed')),
+    logs.some((log) => log.includes('config inspection completed')),
   ).toBeTruthy();
 
   expect(

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -31,13 +31,13 @@ rspackOnlyTest(
     devProcess.stdin?.write('q\n');
     expect(
       await waitFor(() =>
-        logs.some((log) => log.includes('Saved Rspack profile file to')),
+        logs.some((log) => log.includes('saved Rspack profile file to')),
       ),
     ).toBeTruthy();
 
     const profileDir = logs
-      .find((log) => log.includes('Saved Rspack profile file to'))
-      ?.split('Saved Rspack profile file to')[1]
+      .find((log) => log.includes('saved Rspack profile file to'))
+      ?.split('saved Rspack profile file to')[1]
       ?.trim();
 
     expect(fs.existsSync(path.join(profileDir!, 'trace.json'))).toBeTruthy();
@@ -73,13 +73,13 @@ rspackOnlyTest(
 
     expect(
       await waitFor(() =>
-        logs.some((log) => log.includes('Saved Rspack profile file to')),
+        logs.some((log) => log.includes('saved Rspack profile file to')),
       ),
     ).toBeTruthy();
 
     const profileDir = logs
-      .find((log) => log.includes('Saved Rspack profile file to'))
-      ?.split('Saved Rspack profile file to')[1]
+      .find((log) => log.includes('saved Rspack profile file to'))
+      ?.split('saved Rspack profile file to')[1]
       ?.trim();
 
     expect(fs.existsSync(path.join(profileDir!, 'trace.json'))).toBeTruthy();

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -199,7 +199,7 @@ function onClose() {
   if (reconnectCount >= config.reconnect) {
     if (config.reconnect > 0) {
       console.info(
-        '[HMR] Connection failure after maximum reconnect limit exceeded.',
+        '[HMR] connection failure after maximum reconnect limit exceeded.',
       );
     }
     return;

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -641,7 +641,7 @@ export async function outputInspectConfigFiles({
 
         return {
           path: outputFilePath,
-          label: 'Rsbuild Config',
+          label: 'Rsbuild config',
           content,
         };
       }
@@ -650,7 +650,7 @@ export async function outputInspectConfigFiles({
 
       return {
         path: outputFilePath,
-        label: `Rsbuild Config (${name})`,
+        label: `Rsbuild config (${name})`,
         content,
       };
     }),

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -689,7 +689,7 @@ export async function outputInspectConfigFiles({
     .join('\n');
 
   logger.success(
-    `inspect config succeed, open following files to view the content: \n\n${fileInfos}\n`,
+    `config inspection completed, generated files: \n\n${fileInfos}\n`,
   );
 }
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -689,7 +689,7 @@ export async function outputInspectConfigFiles({
     .join('\n');
 
   logger.success(
-    `Inspect config succeed, open following files to view the content: \n\n${fileInfos}\n`,
+    `inspect config succeed, open following files to view the content: \n\n${fileInfos}\n`,
   );
 }
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -1,3 +1,17 @@
+/**
+ * Logging message case convention:
+ *
+ * Info, ready, success and debug messages:
+ * - Start with lowercase
+ * - Example: "info  build started..."
+ *
+ * Errors and warnings:
+ * - Start with uppercase
+ * - Example: "error  Failed to build"
+ *
+ * This convention helps distinguish between normal operations
+ * and important alerts that require attention.
+ */
 import { type Logger, logger } from '../compiled/rslog/index.js';
 import { color } from './helpers';
 

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -113,7 +113,7 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
 
       stopProfiler(cpuProfilePath, profileSession);
 
-      logger.info(`Saved Rspack profile file to ${profileDir}`);
+      logger.info(`saved Rspack profile file to ${profileDir}`);
     });
   },
 });

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -310,7 +310,7 @@ export const getServerConfig = async ({
   const https = Boolean(config.server.https) || false;
   const portTip =
     port !== originalPort
-      ? `Port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
+      ? `port ${originalPort} is in use, ${color.yellow(`using port ${port}.`)}`
       : undefined;
 
   return {

--- a/packages/core/src/server/restart.ts
+++ b/packages/core/src/server/restart.ts
@@ -36,10 +36,10 @@ const beforeRestart = async ({
   if (filePath) {
     const filename = path.basename(filePath);
     logger.info(
-      `Restart ${id} because ${color.yellow(filename)} is changed.\n`,
+      `restarting ${id} because ${color.yellow(filename)} has changed\n`,
     );
   } else {
-    logger.info(`Restarting ${id}...\n`);
+    logger.info(`restarting ${id}...\n`);
   }
 
   for (const cleaner of cleaners) {

--- a/packages/plugin-assets-retry/rslib.config.ts
+++ b/packages/plugin-assets-retry/rslib.config.ts
@@ -74,7 +74,7 @@ const pluginCompileRuntime: RsbuildPlugin = {
       ]);
 
       logger.success(
-        `Compiled assets retry runtime code in ${(
+        `compiled assets retry runtime code in ${(
           performance.now() - startTime
         ).toFixed(1)} ms`,
       );

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -87,10 +87,10 @@ When you execute the command `npx rsbuild inspect` in the project root directory
 
 config inspection completed, generated files:
 
-  - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
-  - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
-  - Rspack Config (node): /project/dist/.rsbuild/rspack.config.node.mjs
+  - Rsbuild config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
+  - Rsbuild config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rspack config (node): /project/dist/.rsbuild/rspack.config.node.mjs
 ```
 
 ## Default environment

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -85,7 +85,7 @@ When you execute the command `npx rsbuild inspect` in the project root directory
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
   - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -124,7 +124,7 @@ When you run the command `npx rsbuild inspect` in the project root directory, th
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
@@ -153,7 +153,7 @@ If the current project has multiple build targets, such as building browser arti
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
   - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -126,8 +126,8 @@ When you run the command `npx rsbuild inspect` in the project root directory, th
 
 config inspection completed, generated files:
 
-  - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /project/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ### Specifying mode
@@ -155,8 +155,8 @@ If the current project has multiple build targets, such as building browser arti
 
 config inspection completed, generated files:
 
-  - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
-  - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
-  - Rspack Config (node): /project/dist/.rsbuild/rspack.config.node.mjs
+  - Rsbuild config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
+  - Rsbuild config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rspack config (node): /project/dist/.rsbuild/rspack.config.node.mjs
 ```

--- a/website/docs/en/guide/basic/configure-rsbuild.mdx
+++ b/website/docs/en/guide/basic/configure-rsbuild.mdx
@@ -246,7 +246,7 @@ DEBUG=rsbuild pnpm dev
 In debug mode, Rsbuild will write the Rsbuild config to the dist directory, which is convenient for developers to view and debug.
 
 ```
-Inspect config succeed, open the following files to view the content:
+config inspection completed, open the following files to view the content:
 
    - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
    - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/en/guide/basic/configure-rsbuild.mdx
+++ b/website/docs/en/guide/basic/configure-rsbuild.mdx
@@ -248,8 +248,8 @@ In debug mode, Rsbuild will write the Rsbuild config to the dist directory, whic
 ```
 config inspection completed, open the following files to view the content:
 
-   - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
-   - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
+   - Rsbuild config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
+   - Rspack config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 Open the generated `/dist/.rsbuild/rsbuild.config.mjs` file to see the complete content of the Rsbuild config.

--- a/website/docs/en/guide/debug/debug-mode.mdx
+++ b/website/docs/en/guide/debug/debug-mode.mdx
@@ -29,7 +29,7 @@ $ DEBUG=rsbuild pnpm dev
 In addition, the following logs will be output in the terminal, indicating that the Rsbuild has written the internally generated build configs to disk, and you can open these config files to view the corresponding content.
 
 ```bash
-Inspect config succeeds, open following files to view the content:
+config inspection completed, generated files:
 
    - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
    - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/en/guide/debug/debug-mode.mdx
+++ b/website/docs/en/guide/debug/debug-mode.mdx
@@ -31,8 +31,8 @@ In addition, the following logs will be output in the terminal, indicating that 
 ```bash
 config inspection completed, generated files:
 
-   - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
-   - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
+   - Rsbuild config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
+   - Rspack config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ## Rsbuild config file

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -63,7 +63,7 @@ You can enable the debug mode of Rsbuild by adding the `DEBUG=rsbuild` environme
   rsbuild use Rspack v1.0.0
   ...
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -65,8 +65,8 @@ You can enable the debug mode of Rsbuild by adding the `DEBUG=rsbuild` environme
 
 config inspection completed, generated files:
 
-  - Rsbuild Config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ---

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -87,10 +87,10 @@ export default {
 
 config inspection completed, generated files:
 
-  - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
-  - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
-  - Rspack Config (node): /project/dist/.rsbuild/rspack.config.node.mjs
+  - Rsbuild config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
+  - Rsbuild config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rspack config (node): /project/dist/.rsbuild/rspack.config.node.mjs
 ```
 
 ## 默认 environment

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -85,7 +85,7 @@ export default {
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
   - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -126,8 +126,8 @@ Options:
 
 config inspection completed, generated files:
 
-  - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /project/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ### 指定模式
@@ -155,8 +155,8 @@ rsbuild inspect --verbose
 
 config inspection completed, generated files:
 
-  - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
-  - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
-  - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
-  - Rspack Config (node): /project/dist/.rsbuild/rspack.config.node.mjs
+  - Rsbuild config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
+  - Rsbuild config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs
+  - Rspack config (web): /project/dist/.rsbuild/rspack.config.web.mjs
+  - Rspack config (node): /project/dist/.rsbuild/rspack.config.node.mjs
 ```

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -124,7 +124,7 @@ Options:
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /project/dist/.rsbuild/rspack.config.web.mjs
@@ -153,7 +153,7 @@ rsbuild inspect --verbose
 ```bash
 ➜ npx rsbuild inspect
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config (web): /project/dist/.rsbuild/rsbuild.config.web.mjs
   - Rsbuild Config (node): /project/dist/.rsbuild/rsbuild.config.node.mjs

--- a/website/docs/zh/guide/basic/configure-rsbuild.mdx
+++ b/website/docs/zh/guide/basic/configure-rsbuild.mdx
@@ -246,7 +246,7 @@ DEBUG=rsbuild pnpm dev
 在调试模式下，Rsbuild 会将内部最终生成的 Rsbuild 配置写入到产物目录下，便于开发者查看和调试。
 
 ```
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/zh/guide/basic/configure-rsbuild.mdx
+++ b/website/docs/zh/guide/basic/configure-rsbuild.mdx
@@ -248,8 +248,8 @@ DEBUG=rsbuild pnpm dev
 ```
 config inspection completed, generated files:
 
-  - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 打开生成的 `/dist/.rsbuild/rsbuild.config.mjs` 文件，即可查看 Rsbuild 配置的完整内容。

--- a/website/docs/zh/guide/debug/debug-mode.mdx
+++ b/website/docs/zh/guide/debug/debug-mode.mdx
@@ -29,7 +29,7 @@ $ DEBUG=rsbuild pnpm dev
 此外，terminal 中还会输出以下日志，表示 Rsbuild 将内部生成的构建配置写入到磁盘中，此时你可以打开这些配置文件来查看相应的内容。
 
 ```bash
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/zh/guide/debug/debug-mode.mdx
+++ b/website/docs/zh/guide/debug/debug-mode.mdx
@@ -31,8 +31,8 @@ $ DEBUG=rsbuild pnpm dev
 ```bash
 config inspection completed, generated files:
 
-  - Rsbuild Config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /Project/demo/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /Project/demo/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ## Rsbuild 配置文件

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -63,7 +63,7 @@ Rsbuild 默认提供了移除 console 的配置项，请查看 [performance.remo
   rsbuild use Rspack v1.0.0
   ...
 
-Inspect config succeed, open following files to view the content:
+config inspection completed, generated files:
 
   - Rsbuild Config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
   - Rspack Config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -65,8 +65,8 @@ Rsbuild 默认提供了移除 console 的配置项，请查看 [performance.remo
 
 config inspection completed, generated files:
 
-  - Rsbuild Config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
-  - Rspack Config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs
+  - Rsbuild config: /root/my-project/dist/.rsbuild/rsbuild.config.mjs
+  - Rspack config (web): /root/my-project/dist/.rsbuild/rspack.config.web.mjs
 ```
 
 ---


### PR DESCRIPTION
## Summary

This pull request includes several changes to enforce a consistent logging message case convention across the codebase. 

```js
/**
 * Logging message case convention:
 *
 * Info, ready, success and debug messages:
 * - Start with lowercase
 * - Example: "info  build started..."
 *
 * Errors and warnings:
 * - Start with uppercase
 * - Example: "error  Failed to build"
 *
 * This convention helps distinguish between normal operations
 * and important alerts that require attention.
 */
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
