### PR TITLE
feat: add `processEnv` option to loadEnv

### DIFF
--- a/e2e/cases/javascript-api/load-env/index.test.ts
+++ b/e2e/cases/javascript-api/load-env/index.test.ts
@@ -42,3 +42,23 @@ rspackOnlyTest('should load env files correctly', () => {
   env.cleanup();
   expect(process.env.REACT_NAME).toEqual(undefined);
 });
+
+rspackOnlyTest(
+  'should not modify process.env if processEnv is provided',
+  () => {
+    delete process.env.REACT_NAME;
+
+    const targetEnv: Record<string, string> = {};
+    const env = loadEnv({
+      cwd: __dirname,
+      processEnv: targetEnv,
+    });
+
+    expect(process.env.REACT_NAME).toEqual(undefined);
+    expect(targetEnv.REACT_NAME).toEqual('react');
+
+    env.cleanup();
+    expect(process.env.REACT_NAME).toEqual(undefined);
+    expect(targetEnv.REACT_NAME).toEqual(undefined);
+  },
+);

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -21,16 +21,27 @@ export type LoadEnvOptions = {
    * @default ['PUBLIC_']
    */
   prefixes?: string[];
+  /**
+   * Specify a target object to store environment variables.
+   * If not provided, variables will be written to `process.env`.
+   * @default process.env
+   */
+  processEnv?: Record<string, string>;
 };
 
 export function loadEnv({
   cwd = process.cwd(),
   mode = getNodeEnv(),
   prefixes = ['PUBLIC_'],
+  processEnv = process.env as Record<string, string>,
 }: LoadEnvOptions = {}): {
-  /** All env variables in the .env file */
+  /**
+   * All env variables in the .env file
+   */
   parsed: Record<string, string>;
-  /** The absolute paths to all env files */
+  /**
+   * The absolute paths to all env files
+   */
   filePaths: string[];
   /**
    * Env variables that start with prefixes.
@@ -57,7 +68,9 @@ export function loadEnv({
    * ```
    **/
   publicVars: Record<string, string>;
-  /** Clear the env variables mounted on `process.env` */
+  /**
+   * Clear the env variables mounted on `process.env`
+   */
   cleanup: () => void;
 } {
   if (mode === 'local') {
@@ -88,17 +101,17 @@ export function loadEnv({
   // but we should allow overriding NODE_ENV, which is very common.
   // https://github.com/web-infra-dev/rsbuild/issues/2904
   if (parsed.NODE_ENV) {
-    process.env.NODE_ENV = parsed.NODE_ENV;
+    processEnv.NODE_ENV = parsed.NODE_ENV;
   }
 
-  expand({ parsed });
+  expand({ parsed, processEnv });
 
   const publicVars: Record<string, string> = {};
   const rawPublicVars: Record<string, string | undefined> = {};
 
-  for (const key of Object.keys(process.env)) {
+  for (const key of Object.keys(processEnv)) {
     if (prefixes.some((prefix) => key.startsWith(prefix))) {
-      const val = process.env[key];
+      const val = processEnv[key];
       publicVars[`import.meta.env.${key}`] = JSON.stringify(val);
       publicVars[`process.env.${key}`] = JSON.stringify(val);
       rawPublicVars[key] = val;
@@ -118,8 +131,8 @@ export function loadEnv({
         continue;
       }
 
-      if (process.env[key] === parsed[key]) {
-        delete process.env[key];
+      if (processEnv[key] === parsed[key]) {
+        delete processEnv[key];
       }
     }
 

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -141,6 +141,12 @@ type LoadEnvOptions = {
    * @default ['PUBLIC_']
    */
   prefixes?: string[];
+  /**
+   * Specify a target object to store environment variables.
+   * If not provided, variables will be written to `process.env`.
+   * @default process.env
+   */
+  processEnv?: Record<string, string>;
 };
 
 function loadEnv(options: LoadEnvOptions): {
@@ -200,6 +206,20 @@ This method will also load files such as `.env.local` and `.env.[mode]`, see [En
 :::tip
 Rsbuild CLI will automatically call the `loadEnv()` method. If you are using the Rsbuild CLI, you can set the `mode` parameter through the [--env-mode](/guide/advanced/env-vars#env-mode) option.
 :::
+
+### Specify the target object
+
+By default, `loadEnv` uses the `process.env` object to store environment variables. You can specify a target object to store environment variables through the `processEnv` option:
+
+```ts
+import { loadEnv } from '@rsbuild/core';
+
+// Pass an empty object to avoid modifying `process.env`
+loadEnv({ processEnv: {} });
+
+// Pass a copy of the `process.env` object to avoid modifying the original object
+loadEnv({ processEnv: { ...process.env } });
+```
 
 ## mergeRsbuildConfig
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -141,6 +141,12 @@ type LoadEnvOptions = {
    * @default ['PUBLIC_']
    */
   prefixes?: string[];
+  /**
+   * 指定一个目标对象来存储环境变量。
+   * 如果未提供，变量将写入 `process.env`。
+   * @default process.env
+   */
+  processEnv?: Record<string, string>;
 };
 
 function loadEnv(options: LoadEnvOptions): {
@@ -200,6 +206,20 @@ const mergedConfig = mergeRsbuildConfig(
 :::tip
 Rsbuild CLI 会自动调用 `loadEnv()` 方法，如果你在使用 Rsbuild CLI，可以通过 [--env-mode](/guide/advanced/env-vars#env-模式) 选项来设置 `mode` 参数。
 :::
+
+### 指定目标对象
+
+默认情况下，`loadEnv` 会使用 `process.env` 对象来存储环境变量。你可以通过 `processEnv` 选项来指定一个目标对象来存储环境变量：
+
+```ts
+import { loadEnv } from '@rsbuild/core';
+
+// 传入一个空对象，避免修改 `process.env`
+loadEnv({ processEnv: {} });
+
+// 传入 `process.env` 对象的副本，避免修改原始对象
+loadEnv({ processEnv: { ...process.env } });
+```
 
 ## mergeRsbuildConfig
 


### PR DESCRIPTION
## Summary

Add a new `processEnv` option to `loadEnv` to specify a target object to store environment variables.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4638

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
