### PR TITLE
docs: improve formatting for plugin-assets-retry and app-icon

### DIFF
--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -90,7 +90,7 @@ For Chromium, you must provide at least a 192x192 pixel icon and a 512x512 pixel
 ## name
 
 - **Type:** `string`
-- **Default value:** `undefined`
+- **Default:** `undefined`
 
 The name of the application that will be displayed when it is added to the home screen of the mobile device. If not set, the `manifest.webmanifest` file will not be generated.
 
@@ -99,7 +99,7 @@ The name of the application that will be displayed when it is added to the home 
 ## icons
 
 - **Type:** `AppIconItem[]`
-- **Default value:** `undefined`
+- **Default:** `undefined`
 
 The list of icons:
 
@@ -159,7 +159,7 @@ export default {
 ### filename
 
 - **Type:** `string`
-- **Default value:** `'manifest.webmanifest'`
+- **Default:** `'manifest.webmanifest'`
 
 The filename of the manifest file.
 

--- a/website/docs/en/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/en/plugins/list/plugin-assets-retry.mdx
@@ -276,8 +276,8 @@ pluginAssetsRetry({
 
 ### delay
 
-- **Type：** `number | ((context: AssetsRetryHookContext) => number);`
-- **Default value：** `0`
+- **Type:** `number | ((context: AssetsRetryHookContext) => number)`
+- **Default:** `0`
 
 The delay time (in milliseconds) before retrying a failed asset.
 
@@ -290,7 +290,7 @@ pluginAssetsRetry({
 });
 ```
 
-Or pass a function that receives AssetsRetryHookContext and returns the delay time:
+Or pass a function that receives `AssetsRetryHookContext` and returns the delay time:
 
 ```js
 // Calculate delay based on retry attempts

--- a/website/docs/zh/plugins/list/plugin-assets-retry.mdx
+++ b/website/docs/zh/plugins/list/plugin-assets-retry.mdx
@@ -276,7 +276,7 @@ pluginAssetsRetry({
 
 ### delay
 
-- **类型：** `number | ((context: AssetsRetryHookContext) => number);`
+- **类型：** `number | ((context: AssetsRetryHookContext) => number)`
 - **默认值：** `0`
 
 在资源重试前的延迟时间，单位为毫秒。
@@ -284,7 +284,7 @@ pluginAssetsRetry({
 你可以传入一个数字：
 
 ```js
-// 延时1s重试
+// 延时 1s 重试
 pluginAssetsRetry({
   delay: 1000,
 });


### PR DESCRIPTION
## Summary

Improve formatting for plugin-assets-retry and app-icon.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4643

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
