### PR TITLE
test: conditionally skip config loader test on older Node.js versions

### DIFF
--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -3,7 +3,14 @@ import path from 'node:path';
 import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should use Node.js native loader to load config', async () => {
+const nodeVersion = process.version.slice(1).split('.')[0];
+const isNodeVersionCompatible = Number(nodeVersion) >= 22;
+
+const conditionalTest = isNodeVersionCompatible
+  ? rspackOnlyTest
+  : rspackOnlyTest.skip;
+
+conditionalTest('should use Node.js native loader to load config', async () => {
   execSync('npx rsbuild build --config-loader native', {
     cwd: __dirname,
     env: {


### PR DESCRIPTION
## Summary

Conditionally skip config loader test on older Node.js versions to fix Rspack ecosystem CI.

## Related Links

https://github.com/rspack-contrib/rspack-ecosystem-ci/actions/runs/13515028079/job/37762789136

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
