### PR TITLE
perf(server): sendStats should not be called when no socket connection

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -123,6 +123,10 @@ export class SocketServer {
 
     this.stats[compilationId] = stats;
 
+    if (!this.sockets.length) {
+      return;
+    }
+
     this.sendStats({
       compilationId,
     });


### PR DESCRIPTION
## Summary

`sendStats` (stats.toJson) should not be called when no socket connection

<img width="825" alt="image" src="https://github.com/user-attachments/assets/271bd15a-37f2-4415-967d-602c33def6fb" />

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4589

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
