### PR TITLE
docs: install latest tailwindcss

### DIFF
--- a/website/docs/zh/guide/basic/tailwindcss-v3.mdx
+++ b/website/docs/zh/guide/basic/tailwindcss-v3.mdx
@@ -10,7 +10,7 @@ Rsbuild 内置支持 PostCSS，你可以安装 `tailwindcss` 包来接入 Tailwi
 
 import { PackageManagerTabs } from '@theme';
 
-<PackageManagerTabs command="add tailwindcss@3 -D" />
+<PackageManagerTabs command="add tailwindcss@^3 -D" />
 
 ## 配置 PostCSS
 


### PR DESCRIPTION
## Summary

Updated the PackageManagerTabs command to use tailwindcss@^3 instead of tailwindcss@3

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
