### PR TITLE
perf: remove unless `path.resolve` call

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -11,7 +11,7 @@ let commonOpts: CommonOptions = {};
 
 const getEnvDir = (cwd: string, envDir?: string) => {
   if (envDir) {
-    return path.isAbsolute(envDir) ? envDir : path.resolve(cwd, envDir);
+    return path.isAbsolute(envDir) ? envDir : path.join(cwd, envDir);
   }
   return cwd;
 };

--- a/packages/core/src/helpers/fs.ts
+++ b/packages/core/src/helpers/fs.ts
@@ -80,7 +80,7 @@ export async function emptyDir(
 
     await Promise.all(
       entries.map(async (entry) => {
-        const fullPath = path.resolve(dir, entry.name);
+        const fullPath = path.join(dir, entry.name);
         if (keep.some((reg) => reg.test(toPosixPath(fullPath)))) {
           return;
         }

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { toPosixPath } from '../helpers/path';
 import type {
   NormalizedEnvironmentConfig,

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -92,7 +92,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           // this helps VS Code break points working correctly in monorepo
           chain.output.devtoolModuleFilenameTemplate(
             (info: { absoluteResourcePath: string }) =>
-              toPosixPath(path.resolve(info.absoluteResourcePath)),
+              toPosixPath(info.absoluteResourcePath),
           );
         }
 

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -69,7 +69,7 @@ export async function getTemplate(
 
   const absolutePath = isAbsolute(templatePath)
     ? templatePath
-    : path.resolve(rootPath, templatePath);
+    : path.join(rootPath, templatePath);
 
   if (!existTemplatePath.has(absolutePath)) {
     // Check if custom template exists

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -261,7 +261,7 @@ export class RsbuildHtmlPlugin {
         );
       }
 
-      const filename = path.resolve(compilation.compiler.context, favicon);
+      const filename = path.join(compilation.compiler.context, favicon);
       const buf = await promisify(compilation.inputFileSystem.readFile)(
         filename,
       );


### PR DESCRIPTION
## Summary

- remove unless `path.resolve` call from `devtoolModuleFilenameTemplate` callback.
- use `path.join` instead of `path.resolve` for path concatenation (it's faster).

## Related Links

- https://www.reddit.com/r/node/comments/1adklxy/any_reason_to_use_pathjoin_over_pathresolve/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
