### PR TITLE
fix: processAssets hook filter error

### DIFF
--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import type { RsbuildPluginAPI } from '@rsbuild/core';
 
 rspackOnlyTest(
   'should allow plugin to process assets by environments',
@@ -14,3 +15,29 @@ rspackOnlyTest(
     expect(existsSync(join(rsbuild.distPath, 'server/index.js'))).toBeTruthy();
   },
 );
+
+rspackOnlyTest('should filter environments correctly', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    plugins: [
+      {
+        name: 'my-plugin-node',
+        setup(api: RsbuildPluginAPI) {
+          api.processAssets(
+            { stage: 'summarize', environments: ['node'] },
+            ({ assets, compilation }) => {
+              for (const key of Object.keys(assets)) {
+                if (key.endsWith('.js')) {
+                  compilation.deleteAsset(key);
+                }
+              }
+            },
+          );
+        },
+      },
+    ],
+  });
+
+  expect(existsSync(join(rsbuild.distPath, 'static/index.js'))).toBeFalsy();
+  expect(existsSync(join(rsbuild.distPath, 'server/index.js'))).toBeFalsy();
+});

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -179,7 +179,7 @@ export function initPluginAPI({
             pluginEnvironment &&
             !isPluginMatchEnvironment(pluginEnvironment, environment.name)
           ) {
-            return;
+            continue;
           }
 
           compiler.hooks.compilation.tap(
@@ -213,7 +213,7 @@ export function initPluginAPI({
           } of processAssetsFns) {
             // filter by targets
             if (descriptor.targets && !descriptor.targets.includes(target)) {
-              return;
+              continue;
             }
 
             // filter by environments
@@ -224,7 +224,7 @@ export function initPluginAPI({
               (pluginEnvironment &&
                 !isPluginMatchEnvironment(pluginEnvironment, environment.name))
             ) {
-              return;
+              continue;
             }
 
             compilation.hooks.processAssets.tapPromise(


### PR DESCRIPTION
## Summary

Use `continue` instead of  `return` when filter processAssets hook handler.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
