### PR TITLE
fix: absolute path for favicon configuration

### DIFF
--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -23,6 +23,27 @@ test('should emit local favicon to dist path', async () => {
   expect(html).toContain('<link rel="icon" href="/icon.png">');
 });
 
+test('should allow `html.favicon` to be an absolute path', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        favicon: path.resolve(__dirname, '../../../assets/icon.png'),
+      },
+    },
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  expect(
+    Object.keys(files).some((file) => file.endsWith('/icon.png')),
+  ).toBeTruthy();
+
+  const html =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+
+  expect(html).toContain('<link rel="icon" href="/icon.png">');
+});
+
 test('should add type attribute for SVG favicon', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -261,7 +261,10 @@ export class RsbuildHtmlPlugin {
         );
       }
 
-      const filename = path.join(compilation.compiler.context, favicon);
+      const filename = path.isAbsolute(favicon)
+        ? favicon
+        : path.join(compilation.compiler.context, favicon);
+
       const buf = await promisify(compilation.inputFileSystem.readFile)(
         filename,
       );


### PR DESCRIPTION
## Summary

Fix a bug introduced by https://github.com/web-infra-dev/rsbuild/pull/4669

## Related Links

https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/13562976143/job/37909714106

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
