### PR TITLE
fix: improve favicon handling with better error logging

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -379,3 +379,12 @@ export const isTTY = (type: 'stdin' | 'stdout' = 'stdout'): boolean => {
     !process.env.CI
   );
 };
+
+export const addCompilationError = (
+  compilation: Rspack.Compilation,
+  message: string,
+): void => {
+  compilation.errors.push(
+    new compilation.compiler.webpack.WebpackError(message),
+  );
+};

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import type { Compilation, Compiler } from '@rspack/core';
 import {
+  addCompilationError,
   color,
   ensureAssetPrefix,
   isFunction,
@@ -263,10 +264,9 @@ export class RsbuildHtmlPlugin {
       }
 
       if (!compilation.inputFileSystem) {
-        compilation.errors.push(
-          new compiler.webpack.WebpackError(
-            `[rsbuild:html] Failed to read the favicon as "compilation.inputFileSystem" is not available.`,
-          ),
+        addCompilationError(
+          compilation,
+          `[rsbuild:html] Failed to read the favicon as "compilation.inputFileSystem" is not available.`,
         );
         return null;
       }
@@ -287,10 +287,9 @@ export class RsbuildHtmlPlugin {
       } catch (error) {
         logger.debug(`read favicon error: ${error}`);
 
-        compilation.errors.push(
-          new compiler.webpack.WebpackError(
-            `[rsbuild:html] Failed to read the favicon, please check if the file "${color.cyan(filename)}" exists.`,
-          ),
+        addCompilationError(
+          compilation,
+          `[rsbuild:html] Failed to read the favicon, please check if the file "${color.cyan(filename)}" exists.`,
         );
         return null;
       }

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -290,7 +290,7 @@ export class RsbuildHtmlPlugin {
           ),
         );
 
-        return;
+        return null;
       }
 
       const source = new compiler.webpack.sources.RawSource(buffer, false);
@@ -310,7 +310,7 @@ export class RsbuildHtmlPlugin {
       if (!isURL(favicon)) {
         const name = await emitFavicon(compilation, favicon);
 
-        if (name === undefined) {
+        if (name === null) {
           return;
         }
 

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -263,9 +263,12 @@ export class RsbuildHtmlPlugin {
       }
 
       if (!compilation.inputFileSystem) {
-        throw new Error(
-          `[rsbuild:html] 'compilation.inputFileSystem' is not available.`,
+        compilation.errors.push(
+          new compiler.webpack.WebpackError(
+            `[rsbuild:html] Failed to read the favicon as "compilation.inputFileSystem" is not available.`,
+          ),
         );
+        return null;
       }
 
       const filename = path.isAbsolute(favicon)
@@ -289,7 +292,6 @@ export class RsbuildHtmlPlugin {
             `[rsbuild:html] Failed to read the favicon, please check if the file "${color.cyan(filename)}" exists.`,
           ),
         );
-
         return null;
       }
 


### PR DESCRIPTION
## Summary

Improve favicon handling with better error logging, now favicon errors can be displayed on the error overlay.

<img width="1248" alt="Screenshot 2025-02-27 at 21 02 21" src="https://github.com/user-attachments/assets/cc7b2b88-8674-498c-9841-c480874f6916" />

![image](https://github.com/user-attachments/assets/89ba6cdf-814a-4d63-97fc-21bb24b67b8e)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
