### PR TITLE
fix: improve app icon handling with better error logging

### DIFF
--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -2,6 +2,8 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import { lookup } from '../../compiled/mrmime/index.js';
 import {
+  addCompilationError,
+  color,
   ensureAssetPrefix,
   fileExistsByCompilation,
   getPublicPathFromCompiler,
@@ -96,24 +98,30 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
 
         for (const icon of icons) {
           if (icon.target === 'web-app-manifest' && !appIcon.name) {
-            throw new Error(
-              "[rsbuild:app-icon] `appIcon.name` is required when `target` is 'web-app-manifest'.",
+            addCompilationError(
+              compilation,
+              `[rsbuild:app-icon] "appIcon.name" is required when "target" is "web-app-manifest".`,
             );
+            continue;
           }
 
           if (!icon.isURL) {
             if (!compilation.inputFileSystem) {
-              throw new Error(
-                `[rsbuild:app-icon] 'compilation.inputFileSystem' is not available.`,
+              addCompilationError(
+                compilation,
+                `[rsbuild:app-icon] Failed to read the icon file as "compilation.inputFileSystem" is not available.`,
               );
+              continue;
             }
 
             if (
               !(await fileExistsByCompilation(compilation, icon.absolutePath))
             ) {
-              throw new Error(
-                `[rsbuild:app-icon] Can not find the app icon, please check if the '${icon.relativePath}' file exists'.`,
+              addCompilationError(
+                compilation,
+                `[rsbuild:app-icon] Failed to find the icon file at "${color.cyan(icon.absolutePath)}".`,
               );
+              continue;
             }
 
             const source = await promisify(
@@ -121,9 +129,11 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             )(icon.absolutePath);
 
             if (!source) {
-              throw new Error(
-                `[rsbuild:app-icon] Failed to read the app icon file, please check if the '${icon.relativePath}' file exists'.`,
+              addCompilationError(
+                compilation,
+                `[rsbuild:app-icon] Failed to find the icon file at "${color.cyan(icon.absolutePath)}".`,
               );
+              continue;
             }
 
             compilation.emitAsset(

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -266,7 +266,7 @@ export class RsbuildHtmlPlugin {
       if (!compilation.inputFileSystem) {
         addCompilationError(
           compilation,
-          `[rsbuild:html] Failed to read the favicon as "compilation.inputFileSystem" is not available.`,
+          `[rsbuild:html] Failed to read the favicon file as "compilation.inputFileSystem" is not available.`,
         );
         return null;
       }
@@ -289,7 +289,7 @@ export class RsbuildHtmlPlugin {
 
         addCompilationError(
           compilation,
-          `[rsbuild:html] Failed to read the favicon, please check if the file "${color.cyan(filename)}" exists.`,
+          `[rsbuild:html] Failed to find the favicon file at "${color.cyan(filename)}".`,
         );
         return null;
       }


### PR DESCRIPTION
## Summary

Improve app icons handling with better error logging, now the errors can be displayed on the error overlay.

<img width="1287" alt="Screenshot 2025-02-27 at 22 26 58" src="https://github.com/user-attachments/assets/ae0a8959-e24a-4b36-a46e-370a4c6ab388" />

## Related Links

the same as https://github.com/web-infra-dev/rsbuild/pull/4674

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
