### PR TITLE
docs: add guide for customizing JSX in React

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -283,3 +283,78 @@ export default defineConfig({
 ```
 
 > You can refer to this example: [stylex](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/stylex).
+
+## Customize JSX
+
+Rsbuild uses SWC to compile JSX, you can customize the functions used by the compiled JSX code:
+
+- If the JSX runtime is `automatic`, use [jsxImportSource](/plugins/list/plugin-react#swcreactoptionsimportsource) to customize the import path of the JSX runtime, for example, import from Preact or Emotion.
+- If the JSX runtime is `classic`, use `pragma` and `pragmaFrag` to specify the JSX function and Fragment component.
+
+> `@rsbuild/plugin-react` uses `automatic` as the default JSX runtime, see [swcReactOptions.runtime](/plugins/list/plugin-react#swcreactoptionsruntime).
+
+### Via configuration
+
+Configure through the `@rsbuild/plugin-react`'s [swcReactOptions](/plugins/list/plugin-react#swcreactoptions).
+
+- If `runtime` is `automatic`:
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'automatic',
+        jsxImportSource: '@emotion/react',
+      },
+    }),
+  ],
+});
+```
+
+- If `runtime` is `classic`:
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'classic',
+        pragma: 'h',
+        pragmaFrag: 'Fragment',
+      },
+    }),
+  ],
+});
+```
+
+### Via comments
+
+You can also customize the JSX behavior by adding specific comments at the top of a single JSX or TSX file, which will take precedence over the configurations.
+
+- If the JSX runtime is `automatic`:
+
+```tsx title="App.tsx"
+/** @jsxImportSource custom-jsx-library */
+
+const App = () => {
+  return <div>Hello World</div>;
+};
+```
+
+- 当 JSX 的 runtime 为 `classic` 时：
+
+```tsx title="App.tsx"
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
+
+const App = () => {
+  return <div>Hello World</div>;
+};
+```

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -108,6 +108,8 @@ pluginReact({
 });
 ```
 
+> See [Customize JSX](/guide/framework/react#customize-jsx) for more details.
+
 ### swcReactOptions.refresh
 
 - **Type:** `boolean`

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -283,3 +283,78 @@ export default defineConfig({
 ```
 
 > 你可以参考这个示例：[stylex](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/stylex)。
+
+## 自定义 JSX
+
+Rsbuild 使用 SWC 来编译 JSX，你可以自定义编译后的 JSX 代码所使用的函数：
+
+- 当 JSX 的 runtime 为 `automatic` 时，使用 [jsxImportSource](/plugins/list/plugin-react#swcreactoptionsimportsource) 来自定义 JSX runtime 的导入路径，比如从 Preact 或 Emotion 中引入。
+- 当 JSX 的 runtime 为 `classic` 时，使用 `pragma` 和 `pragmaFrag` 来指定 JSX 函数和 Fragment 组件。
+
+> `@rsbuild/plugin-react` 默认使用的 JSX runtime 为 `automatic`，详见 [swcReactOptions.runtime](/plugins/list/plugin-react#swcreactoptionsruntime)。
+
+### 通过配置
+
+通过 `@rsbuild/plugin-react` 的 [swcReactOptions](/plugins/list/plugin-react#swcreactoptions) 来配置。
+
+- 当 `runtime` 为 `automatic` 时：
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'automatic',
+        jsxImportSource: '@emotion/react',
+      },
+    }),
+  ],
+});
+```
+
+- 当 `runtime` 为 `classic` 时：
+
+```ts title="rsbuild.config.ts"
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      swcReactOptions: {
+        runtime: 'classic',
+        pragma: 'h',
+        pragmaFrag: 'Fragment',
+      },
+    }),
+  ],
+});
+```
+
+### 通过注释
+
+你也可以通过在单个 JSX 或 TSX 文件顶部添加特定注释来自定义 JSX 行为，这些注释的优先级会高于配置项。
+
+- 当 JSX 的 runtime 为 `automatic` 时：
+
+```tsx title="App.tsx"
+/** @jsxImportSource custom-jsx-library */
+
+const App = () => {
+  return <div>Hello World</div>;
+};
+```
+
+- 当 JSX 的 runtime 为 `classic` 时：
+
+```tsx title="App.tsx"
+/** @jsx Preact.h */
+/** @jsxFrag Preact.Fragment */
+
+const App = () => {
+  return <div>Hello World</div>;
+};
+```

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -110,6 +110,8 @@ pluginReact({
 });
 ```
 
+> 参考 [自定义 JSX](/guide/framework/react#自定义-jsx) 了解更多。
+
 ### swcReactOptions.refresh
 
 - **类型：** `boolean`


### PR DESCRIPTION
## Summary

This pull request enhances the documentation for customizing JSX guides. It provides detailed instructions on configuring the JSX runtime using `@rsbuild/plugin-react` and includes examples for both automatic and classic runtimes.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/4654

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
