### PR TITLE
fix(create-rsbuild): update tsconfig `moduleResolution` to lowercase

### DIFF
--- a/e2e/cases/server/overlay-type-errors/tsconfig.json
+++ b/e2e/cases/server/overlay-type-errors/tsconfig.json
@@ -6,7 +6,7 @@
     "strict": true,
     "skipLibCheck": true,
     "isolatedModules": true,
-    "moduleResolution": "Bundler"
+    "moduleResolution": "bundler"
   },
   "include": ["src"]
 }

--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -7,7 +7,7 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "useDefineForClassFields": true
   },
   "include": ["src"]

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "useDefineForClassFields": true
   },
   "include": ["src"]

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "useDefineForClassFields": true
   },
   "include": ["src"]

--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-preact-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-preact-ts/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "paths": {
       "react": ["./node_modules/preact/compat/"],

--- a/packages/create-rsbuild/template-react-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react-ts/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-react18-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react18-ts/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -13,7 +13,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -8,7 +8,7 @@
 
     /* modules */
     "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "isolatedModules": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-vue2-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue2-ts/tsconfig.json
@@ -11,7 +11,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/packages/create-rsbuild/template-vue3-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue3-ts/tsconfig.json
@@ -12,7 +12,7 @@
     "module": "ESNext",
     "isolatedModules": true,
     "resolveJsonModule": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
 
     /* type checking */

--- a/scripts/config/tsconfig-node16.json
+++ b/scripts/config/tsconfig-node16.json
@@ -2,6 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "module": "Node16",
-    "moduleResolution": "Node16"
+    "moduleResolution": "node16"
   }
 }

--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -10,7 +10,7 @@
     "module": "ES2020",
     "esModuleInterop": true,
     "isolatedModules": true,
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
 
     /* type checking */


### PR DESCRIPTION
## Summary

SchemaStore have updated `moduleResolution` value casing. let we align it.

## Related Links
https://github.com/SchemaStore/schemastore/pull/4210
https://github.com/vitejs/vite/pull/18774
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
