### PR TITLE
test(e2e): replace custom helper with `expect.poll`

### DIFF
--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, rspackOnlyTest, webpackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest, webpackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse from 'fs-extra';
 
@@ -28,7 +28,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
     cwd: __dirname,
   });
 
-  await awaitFileExists(distIndexFile);
+  await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
   fs.rmSync(distIndexFile, { force: true });
 
@@ -43,12 +43,12 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 `,
   );
 
-  await awaitFileExists(distIndexFile);
+  await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
   fs.rmSync(distIndexFile, { force: true });
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await awaitFileExists(distIndexFile);
+  await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
   process.kill();
@@ -85,7 +85,7 @@ export default defineConfig({
       cwd: __dirname,
     });
 
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
     fs.rmSync(distIndexFile, { force: true });
 
@@ -106,12 +106,12 @@ export default defineConfig({
 `,
     );
 
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
     fs.rmSync(distIndexFile, { force: true });
 
     fse.outputFileSync(indexFile, `console.log('hello2!');`);
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
     process.kill();

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse from 'fs-extra';
 
@@ -17,12 +17,12 @@ rspackOnlyTest('should support watch mode for build command', async () => {
     cwd: __dirname,
   });
 
-  await awaitFileExists(distIndexFile);
+  await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
   fs.rmSync(distIndexFile, { force: true });
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await awaitFileExists(distIndexFile);
+  await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
   process.kill();

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should restart dev server and reload config when config file changed',
@@ -33,7 +33,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    await awaitFileExists(dist1);
+    await expectFile(dist1);
 
     fs.writeFileSync(
       configFile,
@@ -50,7 +50,7 @@ rspackOnlyTest(
     };`,
     );
 
-    await awaitFileExists(dist2);
+    await expectFile(dist2);
 
     process.kill();
   },

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, getRandomPort } from '@e2e/helper';
+import { expectFile, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 // Skipped as it occasionally failed in CI
@@ -34,13 +34,13 @@ test.skip('should restart dev server when .env file is changed', async () => {
     cwd: __dirname,
   });
 
-  await awaitFileExists(distIndex);
+  await expectFile(distIndex);
   expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
 
   fs.rmSync(distIndex, { force: true });
 
   fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
-  await awaitFileExists(distIndex);
+  await expectFile(distIndex);
   expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');
 
   devProcess.kill();

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -1,7 +1,6 @@
 import { exec } from 'node:child_process';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { rspackOnlyTest, waitFor } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expectPoll, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should display shortcuts as expected in dev', async () => {
   const devProcess = exec('node ./dev.mjs', {
@@ -16,37 +15,29 @@ rspackOnlyTest('should display shortcuts as expected in dev', async () => {
   });
 
   // help
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('press h + enter to show shortcuts')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('press h + enter to show shortcuts')),
   ).toBeTruthy();
   devProcess.stdin?.write('h\n');
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('u + enter  show urls')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('u + enter  show urls')),
   ).toBeTruthy();
 
   // print urls
   logs = [];
   devProcess.stdin?.write('u\n');
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('➜ Local:    http://localhost:')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
   ).toBeTruthy();
 
   // restart server
   logs = [];
   devProcess.stdin?.write('r\n');
-  expect(
-    await waitFor(() => logs.some((log) => log.includes('restarting server'))),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('restarting server')),
   ).toBeTruthy();
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('➜ Local:    http://localhost:')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
   ).toBeTruthy();
 
   devProcess.kill();
@@ -65,25 +56,19 @@ rspackOnlyTest('should display shortcuts as expected in preview', async () => {
   });
 
   // help
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('press h + enter to show shortcuts')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('press h + enter to show shortcuts')),
   ).toBeTruthy();
   devProcess.stdin?.write('h\n');
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('u + enter  show urls')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('u + enter  show urls')),
   ).toBeTruthy();
 
   // print urls
   logs = [];
   devProcess.stdin?.write('u\n');
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('➜ Local:    http://localhost:')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
   ).toBeTruthy();
 
   devProcess.kill();
@@ -101,16 +86,14 @@ rspackOnlyTest('should allow to custom shortcuts in dev', async () => {
     logs.push(stripAnsi(output));
   });
 
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('press h + enter to show shortcuts')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('press h + enter to show shortcuts')),
   ).toBeTruthy();
 
   logs = [];
   devProcess.stdin?.write('s\n');
-  expect(
-    await waitFor(() => logs.some((log) => log.includes('hello world!'))),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('hello world!')),
   ).toBeTruthy();
 
   devProcess.kill();
@@ -129,16 +112,14 @@ rspackOnlyTest('should allow to custom shortcuts in preview', async () => {
   });
 
   // help
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('press h + enter to show shortcuts')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('press h + enter to show shortcuts')),
   ).toBeTruthy();
 
   logs = [];
   devProcess.stdin?.write('s\n');
-  expect(
-    await waitFor(() => logs.some((log) => log.includes('hello world!'))),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('hello world!')),
   ).toBeTruthy();
 
   devProcess.kill();

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 const tempConfigPath = './test-temp-config.ts';
@@ -24,14 +24,14 @@ rspackOnlyTest(
       },
     });
 
-    await awaitFileExists(dist);
+    await expectFile(dist);
 
     fs.rmSync(dist, { recursive: true });
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default { foo: 2 };');
 
     // rebuild and generate dist files
-    await awaitFileExists(dist);
+    await expectFile(dist);
     expect(fs.existsSync(path.join(dist, 'temp.txt')));
 
     childProcess.kill();

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { awaitFileExists, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const dist = path.join(__dirname, 'dist');
@@ -30,14 +30,14 @@ rspackOnlyTest(
     });
 
     // the first build
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
 
     fs.rmSync(tempOutputFile, { force: true });
     // temp config changed and trigger rebuild
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
     // rebuild and generate dist files
-    await awaitFileExists(tempOutputFile);
+    await expectFile(tempOutputFile);
     expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('2');
 
     childProcess.kill();
@@ -56,7 +56,7 @@ rspackOnlyTest(
       },
     });
 
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
 
     fs.rmSync(distIndexFile);
     // temp config changed
@@ -82,7 +82,7 @@ rspackOnlyTest(
 
     // Fix occasional 'directory not empty' error when wait and rm dist.
     // Sometimes the dist directory exists, but the files in the dist directory have not been completely written.
-    await awaitFileExists(distIndexFile);
+    await expectFile(distIndexFile);
 
     fs.rmSync(distIndexFile);
     // temp config changed

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -2,7 +2,7 @@ import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { rspackOnlyTest, waitFor } from '@e2e/helper';
+import { expectPoll, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -23,16 +23,14 @@ rspackOnlyTest(
       logs.push(stripAnsi(output));
     });
 
-    expect(
-      await waitFor(() => logs.some((log) => log.includes('built in'))),
+    await expectPoll(() =>
+      logs.some((log) => log.includes('built in')),
     ).toBeTruthy();
 
     // quit process
     devProcess.stdin?.write('q\n');
-    expect(
-      await waitFor(() =>
-        logs.some((log) => log.includes('saved Rspack profile file to')),
-      ),
+    await expectPoll(() =>
+      logs.some((log) => log.includes('saved Rspack profile file to')),
     ).toBeTruthy();
 
     const profileDir = logs
@@ -67,14 +65,12 @@ rspackOnlyTest(
       logs.push(stripAnsi(output));
     });
 
-    expect(
-      await waitFor(() => logs.some((log) => log.includes('built in'))),
+    await expectPoll(() =>
+      logs.some((log) => log.includes('built in')),
     ).toBeTruthy();
 
-    expect(
-      await waitFor(() =>
-        logs.some((log) => log.includes('saved Rspack profile file to')),
-      ),
+    await expectPoll(() =>
+      logs.some((log) => log.includes('saved Rspack profile file to')),
     ).toBeTruthy();
 
     const profileDir = logs

--- a/e2e/cases/server/hmr-with-error/index.test.ts
+++ b/e2e/cases/server/hmr-with-error/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, proxyConsole, rspackOnlyTest, waitFor } from '@e2e/helper';
+import { dev, expectPoll, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -45,10 +45,8 @@ rspackOnlyTest(
         ),
     );
 
-    expect(
-      await waitFor(() =>
-        logs.some((log) => log.includes('Module build failed')),
-      ),
+    await expectPoll(() =>
+      logs.some((log) => log.includes('Module build failed')),
     ).toBeTruthy();
 
     await fs.promises.writeFile(

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, proxyConsole, waitFor } from '@e2e/helper';
+import { dev, expectPoll, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -16,8 +16,8 @@ test('should display type errors on overlay correctly', async ({ page }) => {
     page,
   });
 
-  expect(
-    await waitFor(() => logs.some((log) => log.includes('TS2322:'))),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('TS2322:')),
   ).toBeTruthy();
 
   const errorOverlay = page.locator('rsbuild-error-overlay');

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, proxyConsole, waitFor } from '@e2e/helper';
+import { dev, expectPoll, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -34,8 +34,8 @@ test('should show overlay correctly', async ({ page }) => {
     },
   });
 
-  expect(
-    await waitFor(() => logs.some((log) => log.includes('[HMR] connected.'))),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('[HMR] connected.')),
   ).toBeTruthy();
 
   const errorOverlay = page.locator('rsbuild-error-overlay');
@@ -49,10 +49,8 @@ test('should show overlay correctly', async ({ page }) => {
     fs.readFileSync(appPath, 'utf-8').replace('</div>', '</aaaaa>'),
   );
 
-  expect(
-    await waitFor(() =>
-      logs.some((log) => log.includes('Module build failed')),
-    ),
+  await expectPoll(() =>
+    logs.some((log) => log.includes('Module build failed')),
   ).toBeTruthy();
 
   await expect(errorOverlay.locator('.title')).toHaveText('Build failed');

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -64,8 +64,8 @@ export const globContentJSON = async (path: string, options?: GlobOptions) => {
   return ret;
 };
 
-export const expectFile = async (dir: string) =>
-  await expectPoll(() => fs.existsSync(dir)).toBeTruthy();
+export const expectFile = (dir: string) =>
+  expectPoll(() => fs.existsSync(dir)).toBeTruthy();
 
 export const proxyConsole = (
   types: ConsoleType | ConsoleType[] = ['log', 'warn', 'info', 'error'],

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import type { ConsoleType } from '@rsbuild/core';
 import glob, {
   convertPathToPattern,
@@ -64,35 +64,8 @@ export const globContentJSON = async (path: string, options?: GlobOptions) => {
   return ret;
 };
 
-export const waitFor = async (
-  fn: () => boolean,
-  {
-    maxChecks = 300,
-    interval = 20,
-  }: {
-    maxChecks?: number;
-    interval?: number;
-  } = {},
-) => {
-  let checks = 0;
-
-  while (checks < maxChecks) {
-    if (fn()) {
-      return true;
-    }
-    checks++;
-    await new Promise((resolve) => setTimeout(resolve, interval));
-  }
-
-  return false;
-};
-
-export const awaitFileExists = async (dir: string) => {
-  const result = await waitFor(() => fs.existsSync(dir), { interval: 50 });
-  if (!result) {
-    throw new Error(`awaitFileExists failed: ${dir}`);
-  }
-};
+export const expectFile = async (dir: string) =>
+  await expectPoll(() => fs.existsSync(dir)).toBeTruthy();
 
 export const proxyConsole = (
   types: ConsoleType | ConsoleType[] = ['log', 'warn', 'info', 'error'],
@@ -125,3 +98,12 @@ export const proxyConsole = (
 
 // Windows and macOS use different new lines
 export const normalizeNewlines = (str: string) => str.replace(/\r\n/g, '\n');
+
+/**
+ * A faster `expect.poll`
+ */
+export const expectPoll = (fn: () => boolean) => {
+  return expect.poll(fn, {
+    intervals: [20, 30, 40, 50, 60, 70, 80, 90, 100],
+  });
+};


### PR DESCRIPTION
## Summary

This pull request focuses on improving the reliability and readability of the E2E tests by replacing the `awaitFileExists` helper with the `expectFile` function and replacing `waitFor` with `expectPoll` in various test cases.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
