### PR TITLE
docs: update rspack-examples references to rstack-examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To get started with Rsbuild, see the [Quick start](https://rsbuild.dev/guide/sta
 - [Rslib](https://github.com/web-infra-dev/rslib): The library development tool powered by Rsbuild.
 - [Modern.js](https://github.com/web-infra-dev/modern.js): A progressive React framework based on Rsbuild.
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): A curated list of awesome things related to Rspack and Rsbuild.
-- [rspack-examples](https://github.com/rspack-contrib/rspack-examples): Examples for Rspack, Rsbuild, Rspress and Rsdoctor.
+- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Examples showcasing Rstack ecosystem tools (Rspack, Rsbuild, Rspress, Rsdoctor).
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：Use this template to create your own Rsbuild plugin.
 - [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -84,7 +84,7 @@ Para começar a usar o Rsbuild, consulte a seção [Início Rápido](https://rsb
 - [Rslib](https://github.com/web-infra-dev/rslib): A ferramenta de compilação de bibliotecas desenvolvida pelo Rsbuild.
 - [Modern.js](https://github.com/web-infra-dev/modern.js): Uma estrutura React progressiva baseada no Rsbuild.
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): Uma lista com curadoria de coisas incríveis relacionadas ao Rspack e ao Rsbuild.
-- [rspack-examples](https://github.com/rspack-contrib/rspack-examples): Exemplos para Rspack, Rsbuild, Rspress e Rsdoctor.
+- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Exemplos demonstrando ferramentas do ecossistema Rstack (Rspack, Rsbuild, Rspress, Rsdoctor).
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Construtor de livros de histórias desenvolvido pelo Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：Use esse modelo para criar seu próprio plug-in do Rsbuild.
 - [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Recursos de design para Rspack, Rsbuild, Rspress e Rsdoctor.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -84,7 +84,7 @@ Rsbuild 为上层的框架和工具提供了 JavaScript API 和 plugin API。例
 - [Rslib](https://github.com/web-infra-dev/rslib): 基于 Rsbuild 的 library 开发工具。
 - [Modern.js](https://github.com/web-infra-dev/modern.js)：基于 Rsbuild 的渐进式 React 框架。
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)：与 Rspack 和 Rsbuild 相关的精彩内容列表。
-- [rspack-examples](https://github.com/rspack-contrib/rspack-examples)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的示例项目。
+- [rstack-examples](https://github.com/rspack-contrib/rstack-examples)：Rstack 生态（Rspack、Rsbuild、Rspress、Rsdoctor）的示例。
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
 - [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,4 +8,4 @@ More use cases can be found in [e2e/cases](../e2e/cases/).
 
 ## Add examples
 
-It is recommended to add more examples to [rspack-examples](https://github.com/rspack-contrib/rspack-examples).
+It is recommended to add more examples to [rstack-examples](https://github.com/rspack-contrib/rstack-examples).

--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -167,7 +167,7 @@ async function startDevServer() {
 
 For detailed usage, please refer to:
 
-- [Example code](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/express/server.mjs).
+- [Example code](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs).
 - [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
 - [server.middlewareMode](/config/server/middleware-mode)
 

--- a/website/docs/en/community/index.mdx
+++ b/website/docs/en/community/index.mdx
@@ -37,4 +37,4 @@ Please visit [Rspack - Blog](https://www.rspack.dev/blog/index) to read our late
 
 ## Examples
 
-Please visit [rspack-contrib/rspack-examples](https://github.com/rspack-contrib/rspack-examples) to view or contribute to the example projects of Rsbuild.
+Please visit [rspack-contrib/rstack-examples](https://github.com/rspack-contrib/rstack-examples) to view or contribute to the example projects of Rsbuild.

--- a/website/docs/en/config/module-federation/options.mdx
+++ b/website/docs/en/config/module-federation/options.mdx
@@ -85,5 +85,5 @@ export default defineConfig({
 
 For more examples, please see:
 
-- [Rsbuild - module-federation example](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation)
+- [Rsbuild - module-federation example](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation)
 - [module-federation/module-federation-examples](https://github.com/module-federation/module-federation-examples)

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -298,7 +298,7 @@ export async function startDevServer() {
 }
 ```
 
-For detailed usage, please refer to: [SSR + Express Example](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/ssr-express).
+For detailed usage, please refer to: [SSR + Express Example](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/ssr-express).
 
 ## Build order
 

--- a/website/docs/en/guide/advanced/module-federation.mdx
+++ b/website/docs/en/guide/advanced/module-federation.mdx
@@ -72,5 +72,5 @@ export default defineConfig({
 
 Rsbuild has provided some example projects of Module Federation, you can refer to:
 
-- [Module Federation v2.0 Example](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation-enhanced)
-- [Module Federation v1.5 Example](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation)
+- [Module Federation v2.0 Example](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation-enhanced)
+- [Module Federation v1.5 Example](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation)

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -138,7 +138,7 @@ startDevServer(process.cwd());
 
 After using a custom Server, you need to change the startup command from `rsbuild dev` to `node ./server.mjs`.
 
-If you need to preview the online effect of SSR rendering, you also need to modify the preview command. SSR Prod Server example reference: [Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express/prod-server.mjs).
+If you need to preview the online effect of SSR rendering, you also need to modify the preview command. SSR Prod Server example reference: [Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express/prod-server.mjs).
 
 ```json title=package.json
 {
@@ -196,5 +196,5 @@ async function renderHtmlPage(): Promise<string> {
 
 ## Examples
 
-- [SSR + Express Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express)
-- [SSR + Express + Manifest Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express-with-manifest)
+- [SSR + Express Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express)
+- [SSR + Express + Manifest Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express-with-manifest)

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -110,7 +110,7 @@ export default defineConfig({
 });
 ```
 
-> You can also refer to the [example project](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/react-compiler-babel).
+> You can also refer to the [example project](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-compiler-babel).
 
 ### Configuration
 
@@ -175,7 +175,7 @@ Rsbuild supports compiling [styled-components](https://github.com/styled-compone
 
 To use styled-components, we recommend using the [@rsbuild/plugin-styled-components](https://github.com/rsbuild-contrib/rsbuild-plugin-styled-components).
 
-> You can refer to this example: [styled-components](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/styled-components).
+> You can refer to this example: [styled-components](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/styled-components).
 
 ### Using Emotion
 
@@ -208,7 +208,7 @@ export default defineConfig({
 });
 ```
 
-> You can refer to this example: [emotion](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/emotion).
+> You can refer to this example: [emotion](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/emotion).
 
 ### Use styled-jsx
 
@@ -234,7 +234,7 @@ export default defineConfig({
 
 Please note, you must select the SWC plugin that matches the current version of `@swc/core` for SWC to work, see [tools.swc](/config/tools/swc).
 
-> You can refer to this example: [styled-jsx](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/styled-jsx).
+> You can refer to this example: [styled-jsx](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/styled-jsx).
 
 ### Use vanilla-extract
 
@@ -261,7 +261,7 @@ export default defineConfig({
 });
 ```
 
-> You can refer to this example: [vanilla-extract](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/vanilla-extract).
+> You can refer to this example: [vanilla-extract](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/vanilla-extract).
 
 ### Use StyleX
 
@@ -282,7 +282,7 @@ export default defineConfig({
 });
 ```
 
-> You can refer to this example: [stylex](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/stylex).
+> You can refer to this example: [stylex](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/stylex).
 
 ## Customize JSX
 

--- a/website/docs/en/guide/migration/cra.mdx
+++ b/website/docs/en/guide/migration/cra.mdx
@@ -43,7 +43,7 @@ Next, you need to update the npm scripts in package.json to Rsbuild's CLI comman
 ```
 
 :::tip
-Rsbuild does not integrate testing frameworks, so it does not provide a command to replace `react-scripts test`. You can directly use testing frameworks such as Jest or Vitest. You can refer to the [Rsbuild react-jest](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/react-jest) example project for configuration.
+Rsbuild does not integrate testing frameworks, so it does not provide a command to replace `react-scripts test`. You can directly use testing frameworks such as Jest or Vitest. You can refer to the [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) example project for configuration.
 :::
 
 ## Creating configuration file

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -72,7 +72,7 @@ The following diagram illustrates the relationship between Rsbuild and other too
 - [Rslib](https://github.com/web-infra-dev/rslib): The library development tool powered by Rsbuild.
 - [Modern.js](https://github.com/web-infra-dev/modern.js): A progressive React framework based on Rsbuild.
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack): A curated list of awesome things related to Rspack and Rsbuild.
-- [rspack-examples](https://github.com/rspack-contrib/rspack-examples): Examples for Rspack, Rsbuild, Rspress and Rsdoctor.
+- [rstack-examples](https://github.com/rspack-contrib/rstack-examples): Examples for Rspack, Rsbuild, Rspress and Rsdoctor.
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): Storybook builder powered by Rsbuild.
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template): Use this template to create your own Rsbuild plugin.
 - [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources): Design resources for Rspack, Rsbuild, Rspress and Rsdoctor.

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -167,7 +167,7 @@ async function startDevServer() {
 
 更多用法可参考：
 
-- [示例代码](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/express/server.mjs)。
+- [示例代码](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs)。
 - [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
 - [server.middlewareMode](/config/server/middleware-mode)
 

--- a/website/docs/zh/community/index.mdx
+++ b/website/docs/zh/community/index.mdx
@@ -37,4 +37,4 @@ Rsbuild 的开发是由 ByteDance 的 Rspack 团队和社区贡献者驱动的�
 
 ## 示例
 
-请访问 [rspack-contrib/rspack-examples](https://github.com/rspack-contrib/rspack-examples) 来查看或贡献 Rsbuild 的示例项目。
+请访问 [rspack-contrib/rstack-examples](https://github.com/rspack-contrib/rstack-examples) 来查看或贡献 Rsbuild 的示例项目。

--- a/website/docs/zh/config/module-federation/options.mdx
+++ b/website/docs/zh/config/module-federation/options.mdx
@@ -85,5 +85,5 @@ export default defineConfig({
 
 更多示例请查看：
 
-- [Rsbuild - module-federation example](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation)
+- [Rsbuild - module-federation example](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation)
 - [module-federation/module-federation-examples](https://github.com/module-federation/module-federation-examples)

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -298,7 +298,7 @@ export async function startDevServer() {
 }
 ```
 
-详细使用情况可参考：[SSR + Express 示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/ssr-express)。
+详细使用情况可参考：[SSR + Express 示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/ssr-express)。
 
 ## 构建顺序
 

--- a/website/docs/zh/guide/advanced/module-federation.mdx
+++ b/website/docs/zh/guide/advanced/module-federation.mdx
@@ -72,5 +72,5 @@ export default defineConfig({
 
 Rsbuild 提供了一些 Module Federation 的示例项目，你可以参考：
 
-- [Module Federation v2.0 示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation-enhanced)
-- [Module Federation v1.5 示例](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/module-federation)
+- [Module Federation v2.0 示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation-enhanced)
+- [Module Federation v1.5 示例](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/module-federation)

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -138,7 +138,7 @@ startDevServer(process.cwd());
 
 使用自定义 Server 后，需要将启动命令由 `rsbuild dev` 改为 `node ./server.mjs`。
 
-如果需要预览 SSR 渲染的线上效果，同样需要修改预览命令。SSR Prod Server 示例参考：[Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express/prod-server.mjs)。
+如果需要预览 SSR 渲染的线上效果，同样需要修改预览命令。SSR Prod Server 示例参考：[Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express/prod-server.mjs)。
 
 ```json title=package.json
 {
@@ -196,5 +196,5 @@ async function renderHtmlPage(): Promise<string> {
 
 ## 示例项目
 
-- [SSR + Express Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express)
-- [SSR + Express + Manifest Example](https://github.com/rspack-contrib/rspack-examples/blob/main/rsbuild/ssr-express-with-manifest)
+- [SSR + Express Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express)
+- [SSR + Express + Manifest Example](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/ssr-express-with-manifest)

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -110,7 +110,7 @@ export default defineConfig({
 });
 ```
 
-> 你也可以参考 [示例项目](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/react-compiler-babel)。
+> 你也可以参考 [示例项目](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-compiler-babel)。
 
 ### 配置
 
@@ -175,7 +175,7 @@ Rsbuild 支持编译 [styled-components](https://github.com/styled-components/st
 
 如果你需要使用 styled-components, 我们推荐使用 [@rsbuild/plugin-styled-components](https://github.com/rsbuild-contrib/rsbuild-plugin-styled-components)。
 
-> 你可以参考这个示例：[styled-components](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/styled-components)。
+> 你可以参考这个示例：[styled-components](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/styled-components)。
 
 ### 使用 Emotion
 
@@ -208,7 +208,7 @@ export default defineConfig({
 });
 ```
 
-> 你可以参考这个示例：[emotion](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/emotion)。
+> 你可以参考这个示例：[emotion](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/emotion)。
 
 ### 使用 styled-jsx
 
@@ -234,7 +234,7 @@ export default defineConfig({
 
 请注意，你需要选择和当前 `@swc/core` 版本匹配的 SWC 插件，才能使 SWC 正常执行，详见 [tools.swc](/config/tools/swc)。
 
-> 你可以参考这个示例：[styled-jsx](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/styled-jsx)。
+> 你可以参考这个示例：[styled-jsx](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/styled-jsx)。
 
 ### 使用 vanilla-extract
 
@@ -261,7 +261,7 @@ export default defineConfig({
 });
 ```
 
-> 你可以参考这个示例：[vanilla-extract](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/vanilla-extract)。
+> 你可以参考这个示例：[vanilla-extract](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/vanilla-extract)。
 
 ### 使用 StyleX
 
@@ -282,7 +282,7 @@ export default defineConfig({
 });
 ```
 
-> 你可以参考这个示例：[stylex](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/stylex)。
+> 你可以参考这个示例：[stylex](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/stylex)。
 
 ## 自定义 JSX
 

--- a/website/docs/zh/guide/migration/cra.mdx
+++ b/website/docs/zh/guide/migration/cra.mdx
@@ -43,7 +43,7 @@ import { PackageManagerTabs } from '@theme';
 ```
 
 :::tip
-Rsbuild 未集成测试框架，因此没有提供用于替换 `react-scripts test` 的命令，你可以直接使用 Jest 或 Vitest 等测试框架。你可以参考 [Rsbuild react-jest](https://github.com/rspack-contrib/rspack-examples/tree/main/rsbuild/react-jest) 示例项目进行配置。
+Rsbuild 未集成测试框架，因此没有提供用于替换 `react-scripts test` 的命令，你可以直接使用 Jest 或 Vitest 等测试框架。你可以参考 [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) 示例项目进行配置。
 :::
 
 ## 创建配置文件

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -72,7 +72,7 @@ Rsbuild 为上层的框架和工具提供了 JavaScript API 和 plugin API。例
 - [Rslib](https://github.com/web-infra-dev/rslib): 基于 Rsbuild 的 library 开发工具。
 - [Modern.js](https://github.com/web-infra-dev/modern.js)：基于 Rsbuild 的渐进式 React 框架。
 - [awesome-rspack](https://github.com/web-infra-dev/awesome-rspack)：与 Rspack 和 Rsbuild 相关的精彩内容列表。
-- [rspack-examples](https://github.com/rspack-contrib/rspack-examples)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的示例项目。
+- [rstack-examples](https://github.com/rspack-contrib/rstack-examples)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的示例项目。
 - [storybook-rsbuild](https://github.com/rspack-contrib/storybook-rsbuild): 基于 Rsbuild 构建的 Storybook。
 - [rsbuild-plugin-template](https://github.com/rspack-contrib/rsbuild-plugin-template)：使用此模板创建你的 Rsbuild 插件。
 - [rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources)：Rspack、Rsbuild、Rspress 和 Rsdoctor 的设计资源。


### PR DESCRIPTION
## Summary

Update rspack-examples references  to rstack-examples.

## Related Links

- https://github.com/rspack-contrib/rstack-examples

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
