### PR TITLE
fix(mf): add more MF packages to `source.include`

### DIFF
--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -150,8 +150,7 @@ export function pluginModuleFederation(): RsbuildPlugin {
         // adding to include and let SWC transform it
         config.source.include = [
           ...(config.source.include || []),
-          /@module-federation[\\/]sdk/,
-          /@module-federation[\\/]runtime/,
+          /@module-federation[\\/]/,
         ];
       });
 


### PR DESCRIPTION
## Summary

Add all `@module-federation/*` packages to `source.include` to avoid browser compatibility issues.

This change is to fix a syntax issue introduced in `@module-federation/webpack-bundler-runtime` in 0.9.1.

<img width="1294" alt="Screenshot 2025-03-03 at 10 28 30" src="https://github.com/user-attachments/assets/87aef811-f594-4605-8c3a-ae59816252fc" />

## Related Links

- https://github.com/module-federation/core/pull/3565
- https://github.com/web-infra-dev/rsbuild/actions/runs/13622050663/job/38073072909?pr=4690#step:7:920

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
