### PR TITLE
fix(socket): prevent heartbeat timers from keeping process alive

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -79,7 +79,7 @@ export class SocketServer {
       this.heartbeatTimer = setTimeout(
         this.checkSockets,
         CHECK_SOCKETS_INTERVAL,
-      );
+      ).unref();
     }
   };
 
@@ -105,7 +105,10 @@ export class SocketServer {
       logger.error(err);
     });
 
-    this.heartbeatTimer = setTimeout(this.checkSockets, CHECK_SOCKETS_INTERVAL);
+    this.heartbeatTimer = setTimeout(
+      this.checkSockets,
+      CHECK_SOCKETS_INTERVAL,
+    ).unref();
 
     this.wsServer.on('connection', (socket, req) => {
       // /rsbuild-hmr?compilationId=web


### PR DESCRIPTION
## Summary

Call `unref()` to prevent heartbeat timers from keeping process alive.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
