### PR TITLE
test(e2e): add case for manifest with single vendor

### DIFF
--- a/e2e/cases/output/manifest-single-vendor/index.test.ts
+++ b/e2e/cases/output/manifest-single-vendor/index.test.ts
@@ -1,0 +1,28 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+const fixtures = __dirname;
+
+test('should generate manifest with single vendor as expected', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const manifestContent =
+    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+
+  expect(manifestContent).toBeDefined();
+
+  const manifest = JSON.parse(manifestContent);
+
+  expect(Object.keys(manifest.allFiles).length).toBe(3);
+
+  expect(manifest.entries.index).toMatchObject({
+    html: ['/index.html'],
+    initial: {
+      js: ['/static/js/vendor.js', '/static/js/index.js'],
+    },
+  });
+});

--- a/e2e/cases/output/manifest-single-vendor/rsbuild.config.ts
+++ b/e2e/cases/output/manifest-single-vendor/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    manifest: true,
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'single-vendor',
+    },
+  },
+});

--- a/e2e/cases/output/manifest-single-vendor/src/foo.ts
+++ b/e2e/cases/output/manifest-single-vendor/src/foo.ts
@@ -1,0 +1,3 @@
+import ReactDOM from 'react-dom';
+
+export default ReactDOM;

--- a/e2e/cases/output/manifest-single-vendor/src/index.ts
+++ b/e2e/cases/output/manifest-single-vendor/src/index.ts
@@ -1,0 +1,4 @@
+import React from 'react';
+import ReactDOM from './foo';
+
+console.log(React, ReactDOM);


### PR DESCRIPTION
## Summary

Add case for generating manifest with a single vendor.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4696

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
