### PR TITLE
fix: `forceSplitting` not work with `single-vendor`

### DIFF
--- a/e2e/cases/performance/single-vendor-splitting/index.test.ts
+++ b/e2e/cases/performance/single-vendor-splitting/index.test.ts
@@ -1,0 +1,20 @@
+import { basename } from 'node:path';
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to use `forceSplitting` when chunkSplit is "single-vendor"', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const jsFiles = Object.keys(files)
+    .filter((name) => name.endsWith('.js'))
+    .map((name) => basename(name));
+
+  expect(jsFiles.length).toEqual(3);
+  expect(jsFiles).toContain('index.js');
+  expect(jsFiles).toContain('vendor.js');
+  expect(jsFiles).toContain('my-react.js');
+});

--- a/e2e/cases/performance/single-vendor-splitting/rsbuild.config.ts
+++ b/e2e/cases/performance/single-vendor-splitting/rsbuild.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [
+    pluginReact({
+      splitChunks: {
+        react: false,
+      },
+    }),
+  ],
+  output: {
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'single-vendor',
+      forceSplitting: {
+        'my-react': /node_modules[\\/]react[\\/]/,
+      },
+    },
+  },
+});

--- a/e2e/cases/performance/single-vendor-splitting/src/App.jsx
+++ b/e2e/cases/performance/single-vendor-splitting/src/App.jsx
@@ -1,0 +1,3 @@
+const App = () => <div id="test">Hello Rsbuild!</div>;
+
+export default App;

--- a/e2e/cases/performance/single-vendor-splitting/src/index.js
+++ b/e2e/cases/performance/single-vendor-splitting/src/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -608,7 +608,7 @@ export interface PerformanceConfig {
   /**
    * Configure the chunk splitting strategy.
    */
-  chunkSplit?: RsbuildChunkSplit;
+  chunkSplit?: ChunkSplit;
 
   /**
    * Analyze the size of output files.
@@ -655,7 +655,7 @@ export interface PerformanceConfig {
 
 export interface NormalizedPerformanceConfig extends PerformanceConfig {
   printFileSize: PrintFileSizeOptions | boolean;
-  chunkSplit: RsbuildChunkSplit;
+  chunkSplit: ChunkSplit;
 }
 
 export type SplitChunks = Configuration extends {
@@ -693,7 +693,7 @@ export interface SplitCustom extends BaseSplitRules {
   splitChunks?: SplitChunks;
 }
 
-export type RsbuildChunkSplit = BaseChunkSplit | SplitBySize | SplitCustom;
+export type ChunkSplit = BaseChunkSplit | SplitBySize | SplitCustom;
 
 export type DistPathConfig = {
   /**


### PR DESCRIPTION
## Summary

Fix the `chunkSplit.forceSplitting` option not work when `chunkSplit.stategy` is `single-vendor`.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4697

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
