### PR TITLE
fix(plugin-vue): order problem with pluginReact

### DIFF
--- a/e2e/cases/vue/with-react/index.test.ts
+++ b/e2e/cases/vue/with-react/index.test.ts
@@ -1,0 +1,22 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to build Vue SFC when pluginReact is also used',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+
+    const button1 = page.locator('#button1');
+    const button2 = page.locator('#button2');
+    const list1 = page.locator('.list1');
+
+    await expect(button1).toHaveText('A: 0');
+    await expect(button2).toHaveText('B: 0');
+    await expect(list1).toHaveCount(3);
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/vue/with-react/rsbuild.config.ts
+++ b/e2e/cases/vue/with-react/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  // pluginReact should be used before pluginVue to test the issue
+  // see https://github.com/web-infra-dev/rsbuild/discussions/4712
+  plugins: [pluginReact(), pluginVue()],
+});

--- a/e2e/cases/vue/with-react/src/A.vue
+++ b/e2e/cases/vue/with-react/src/A.vue
@@ -1,0 +1,27 @@
+<template>
+  <button id="button1" type="button" @click="count++">A: {{ count }}</button>
+  <div class="list1" v-for="item in list.filter(Boolean)" :key="item">
+    {{ item }}
+  </div>
+  <B />
+</template>
+
+<script>
+import { ref } from 'vue';
+import B from './B.vue';
+
+export default {
+  components: {
+    B,
+  },
+
+  setup() {
+    const count = ref(0);
+
+    return {
+      count,
+      list: [1, 2, null, 3],
+    };
+  },
+};
+</script>

--- a/e2e/cases/vue/with-react/src/B.vue
+++ b/e2e/cases/vue/with-react/src/B.vue
@@ -1,0 +1,9 @@
+<template>
+  <button id="button2" @click="count++">B: {{ count }}</button>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+
+const count = ref(0);
+</script>

--- a/e2e/cases/vue/with-react/src/index.js
+++ b/e2e/cases/vue/with-react/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import A from './A.vue';
+
+createApp(A).mount('#root');

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -95,7 +95,12 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
         // Support for lang="postcss" and lang="pcss" in SFC
         chain.module.rule(CHAIN_ID.RULE.CSS).test(/\.(?:css|postcss|pcss)$/);
 
-        chain.plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN).use(VueLoaderPlugin);
+        chain
+          .plugin(CHAIN_ID.PLUGIN.VUE_LOADER_PLUGIN)
+          // Ensure that the VueLoaderPlugin is applied before the ReactFastRefreshPlugin
+          // otherwise the VueLoaderPlugin will throw an error for `builtin:react-refresh-loader`
+          .before(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)
+          .use(VueLoaderPlugin);
       });
 
       applySplitChunksRule(api, options.splitChunks);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,9 +476,6 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../packages/core
-      '@rsbuild/plugin-react':
-        specifier: workspace:*
-        version: link:../../packages/plugin-react
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../../packages/plugin-vue

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@rsbuild/plugin-react':
+        specifier: workspace:*
+        version: link:../../packages/plugin-react
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../../packages/plugin-vue


### PR DESCRIPTION
## Summary

Ensure that the `VueLoaderPlugin` is applied before the `ReactFastRefreshPlugin`, otherwise the `VueLoaderPlugin` will throw an error for `builtin:react-refresh-loader`.

The root cause is that `VueLoaderPlugin` ignored the `include` option of rules. See https://github.com/vuejs/vue-loader/blob/main/src/pluginWebpack5.ts#L319-L321

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/4712

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
