### PR TITLE
feat(css): support `cssLoader.exportType` as `string`

### DIFF
--- a/e2e/cases/css/export-type-string/index.test.ts
+++ b/e2e/cases/css/export-type-string/index.test.ts
@@ -1,0 +1,54 @@
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to configure `cssLoader.exportType` as `string` in development',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
+
+    expect(await page.evaluate('window.a')).toBe(`.the-a-class {
+  color: red;
+}
+
+.the-a-class .child-class {
+  color: #00f;
+}
+`);
+
+    expect(
+      (await page.evaluate<string>('window.b')).includes(
+        '.src-b-module__the-b-class',
+      ),
+    ).toBeTruthy();
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should allow to configure `cssLoader.exportType` as `string` in production',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+
+    expect(await page.evaluate('window.a')).toBe(`.the-a-class {
+  color: red;
+}
+
+.the-a-class .child-class {
+  color: #00f;
+}
+`);
+
+    expect(
+      (await page.evaluate<string>('window.b')).includes('.the-b-class-'),
+    ).toBeTruthy();
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/css/export-type-string/rsbuild.config.ts
+++ b/e2e/cases/css/export-type-string/rsbuild.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginSass } from '@rsbuild/plugin-sass';
+
+export default defineConfig({
+  plugins: [pluginSass()],
+  tools: {
+    cssLoader: {
+      exportType: 'string',
+      modules: {
+        namedExport: true,
+      },
+    },
+  },
+});

--- a/e2e/cases/css/export-type-string/src/a.scss
+++ b/e2e/cases/css/export-type-string/src/a.scss
@@ -1,0 +1,7 @@
+.the-a-class {
+  color: red;
+
+  .child-class {
+    color: blue;
+  }
+}

--- a/e2e/cases/css/export-type-string/src/b.module.scss
+++ b/e2e/cases/css/export-type-string/src/b.module.scss
@@ -1,0 +1,3 @@
+.the-b-class {
+  color: blue;
+}

--- a/e2e/cases/css/export-type-string/src/index.js
+++ b/e2e/cases/css/export-type-string/src/index.js
@@ -1,0 +1,5 @@
+import a from './a.scss';
+import b from './b.module.scss';
+
+window.a = a;
+window.b = b;

--- a/e2e/cases/output/manifest-single-vendor/index.test.ts
+++ b/e2e/cases/output/manifest-single-vendor/index.test.ts
@@ -22,7 +22,10 @@ test('should generate manifest with single vendor as expected', async () => {
   expect(manifest.entries.index).toMatchObject({
     html: ['/index.html'],
     initial: {
-      js: ['/static/js/vendor.js', '/static/js/index.js'],
+      js: expect.arrayContaining([
+        '/static/js/vendor.js',
+        '/static/js/index.js',
+      ]),
     },
   });
 });

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -247,12 +247,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
-    },
-    HotModuleReplacementPlugin {
-      "options": {},
-    },
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
@@ -267,6 +261,12 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "insert": undefined,
         "linkType": "text/css",
       },
+    },
+    {
+      "name": "RsbuildCorePlugin",
+    },
+    HotModuleReplacementPlugin {
+      "options": {},
     },
     HtmlWebpackPlugin {
       "options": {
@@ -659,9 +659,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "hints": false,
   },
   "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
-    },
     MiniCssExtractPlugin {
       "_sortedModulesCache": WeakMap {},
       "options": {
@@ -676,6 +673,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "insert": undefined,
         "linkType": "text/css",
       },
+    },
+    {
+      "name": "RsbuildCorePlugin",
     },
     HtmlWebpackPlugin {
       "options": {

--- a/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/webpackConfig.test.ts.snap
@@ -7,9 +7,6 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "foo": "2",
     },
   },
-  {
-    "name": "RsbuildCorePlugin",
-  },
   MiniCssExtractPlugin {
     "_sortedModulesCache": WeakMap {},
     "options": {
@@ -24,6 +21,9 @@ exports[`webpackConfig > should allow to append and prepend plugins 1`] = `
       "insert": undefined,
       "linkType": "text/css",
     },
+  },
+  {
+    "name": "RsbuildCorePlugin",
   },
   HtmlWebpackPlugin {
     "options": {

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -6,7 +6,6 @@ import {
   DEFAULT_PORT,
 } from '../constants';
 import { formatPublicPath, getFilename, urlJoin } from '../helpers';
-import { getCssExtractPlugin } from '../pluginHelper';
 import { replacePortPlaceholder } from '../server/open';
 import type {
   NormalizedEnvironmentConfig,
@@ -77,7 +76,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      async (chain, { CHAIN_ID, target, isProd, isServer, environment }) => {
+      async (chain, { CHAIN_ID, isProd, isServer, environment }) => {
         const { distPath, config } = environment;
 
         const publicPath = getPublicPath({
@@ -137,40 +136,6 @@ export const pluginOutput = (): RsbuildPlugin => ({
           chain
             .plugin(CHAIN_ID.PLUGIN.COPY)
             .use(rspack.CopyRspackPlugin, [options]);
-        }
-
-        // CSS output
-        const emitCss = config.output.emitCss ?? target === 'web';
-        if (!config.output.injectStyles && emitCss) {
-          const extractPluginOptions = config.tools.cssExtract.pluginOptions;
-
-          const cssPath = config.output.distPath.css;
-          const cssFilename = getFilename(config, 'css', isProd);
-          const isCssFilenameFn = typeof cssFilename === 'function';
-
-          const cssAsyncPath =
-            config.output.distPath.cssAsync ??
-            (cssPath ? `${cssPath}/async` : 'async');
-
-          chain
-            .plugin(CHAIN_ID.PLUGIN.MINI_CSS_EXTRACT)
-            .use(getCssExtractPlugin(), [
-              {
-                filename: isCssFilenameFn
-                  ? (...args) => {
-                      const name = cssFilename(...args);
-                      return posix.join(cssPath, name);
-                    }
-                  : posix.join(cssPath, cssFilename),
-                chunkFilename: isCssFilenameFn
-                  ? (...args) => {
-                      const name = cssFilename(...args);
-                      return posix.join(cssAsyncPath, name);
-                    }
-                  : posix.join(cssAsyncPath, cssFilename),
-                ...extractPluginOptions,
-              },
-            ]);
         }
       },
     );

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -313,18 +313,18 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "hints": false,
   },
   "plugins": [
-    RsbuildCorePlugin {
-      "name": "RsbuildCorePlugin",
-    },
-    HotModuleReplacementPlugin {
-      "name": "HotModuleReplacementPlugin",
-    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",
         "filename": "static/css/[name].css",
         "ignoreOrder": true,
       },
+    },
+    RsbuildCorePlugin {
+      "name": "RsbuildCorePlugin",
+    },
+    HotModuleReplacementPlugin {
+      "name": "HotModuleReplacementPlugin",
     },
     HtmlRspackPlugin {
       "options": {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -48,6 +48,13 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
     ],
   },
   "plugins": [
+    CssExtractRspackPlugin {
+      "options": {
+        "chunkFilename": "static/css/async/[name].css",
+        "filename": "static/css/[name].css",
+        "ignoreOrder": true,
+      },
+    },
     {
       "name": "RsbuildCorePlugin",
     },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -313,18 +313,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "hints": false,
   },
   "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
-    },
-    HotModuleReplacementPlugin {
-      "name": "HotModuleReplacementPlugin",
-    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",
         "filename": "static/css/[name].css",
         "ignoreOrder": true,
       },
+    },
+    {
+      "name": "RsbuildCorePlugin",
+    },
+    HotModuleReplacementPlugin {
+      "name": "HotModuleReplacementPlugin",
     },
     HtmlRspackPlugin {
       "options": {
@@ -766,15 +766,15 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "hints": false,
   },
   "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
-    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].[contenthash:8].css",
         "filename": "static/css/[name].[contenthash:8].css",
         "ignoreOrder": true,
       },
+    },
+    {
+      "name": "RsbuildCorePlugin",
     },
     HtmlRspackPlugin {
       "options": {
@@ -1564,18 +1564,18 @@ exports[`tools.rspack > should match snapshot 1`] = `
     TestPlugin {
       "name": "TestPlugin",
     },
-    {
-      "name": "RsbuildCorePlugin",
-    },
-    HotModuleReplacementPlugin {
-      "name": "HotModuleReplacementPlugin",
-    },
     CssExtractRspackPlugin {
       "options": {
         "chunkFilename": "static/css/async/[name].css",
         "filename": "static/css/[name].css",
         "ignoreOrder": true,
       },
+    },
+    {
+      "name": "RsbuildCorePlugin",
+    },
+    HotModuleReplacementPlugin {
+      "name": "HotModuleReplacementPlugin",
     },
     HtmlRspackPlugin {
       "options": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1590,18 +1590,18 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "hints": false,
     },
     "plugins": [
-      RsbuildCorePlugin {
-        "name": "RsbuildCorePlugin",
-      },
-      HotModuleReplacementPlugin {
-        "name": "HotModuleReplacementPlugin",
-      },
       CssExtractRspackPlugin {
         "options": {
           "chunkFilename": "static/css/async/[name].css",
           "filename": "static/css/[name].css",
           "ignoreOrder": true,
         },
+      },
+      RsbuildCorePlugin {
+        "name": "RsbuildCorePlugin",
+      },
+      HotModuleReplacementPlugin {
+        "name": "HotModuleReplacementPlugin",
       },
       DefinePlugin {
         "_args": [

--- a/packages/core/tests/__snapshots__/output.test.ts.snap
+++ b/packages/core/tests/__snapshots__/output.test.ts.snap
@@ -56,13 +56,6 @@ exports[`plugin-output > should allow to set distPath.js and distPath.css to emp
     {
       "name": "RsbuildCorePlugin",
     },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "async/[name].css",
-        "filename": "[name].css",
-        "ignoreOrder": true,
-      },
-    },
   ],
 }
 `;
@@ -93,13 +86,6 @@ exports[`plugin-output > should allow to use copy plugin 1`] = `
       ],
       "affectedHooks": undefined,
       "name": "CopyRspackPlugin",
-    },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "static/css/async/[name].css",
-        "filename": "static/css/[name].css",
-        "ignoreOrder": true,
-      },
     },
   ],
 }
@@ -134,13 +120,6 @@ exports[`plugin-output > should allow to use copy plugin with multiple config 1`
       "affectedHooks": undefined,
       "name": "CopyRspackPlugin",
     },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "static/css/async/[name].css",
-        "filename": "static/css/[name].css",
-        "ignoreOrder": true,
-      },
-    },
   ],
 }
 `;
@@ -159,13 +138,6 @@ exports[`plugin-output > should allow to use filename.js to modify filename 1`] 
     {
       "name": "RsbuildCorePlugin",
     },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "static/css/async/[name].css",
-        "filename": "static/css/[name].css",
-        "ignoreOrder": true,
-      },
-    },
   ],
 }
 `;
@@ -183,13 +155,6 @@ exports[`plugin-output > should set output correctly 1`] = `
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    CssExtractRspackPlugin {
-      "options": {
-        "chunkFilename": "static/css/async/[name].css",
-        "filename": "static/css/[name].css",
-        "ignoreOrder": true,
-      },
     },
   ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
+      '@rsbuild/plugin-sass':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sass
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,9 +419,6 @@ importers:
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
-      '@rsbuild/plugin-sass':
-        specifier: workspace:*
-        version: link:../../packages/plugin-sass
       '@types/react':
         specifier: ^19.0.10
         version: 19.0.10


### PR DESCRIPTION
## Summary

When `cssLoader.exportType` is configured to `string`, the CSSExtractRspack should not be used, see https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#string-3.

```ts
export default defineConfig({
  tools: {
    cssLoader: {
      exportType: 'string',
      modules: {
        namedExport: true,
      },
    },
  },
});
```

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4689

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
