### PR TITLE
fix: improve file size gzip header rendering

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -42,13 +42,13 @@ const getAssetColor = (size: number) => {
 function getHeader(
   longestFileLength: number,
   longestLabelLength: number,
-  options: PrintFileSizeOptions,
   environmentName: string,
+  showGzipHeader: boolean,
 ) {
   const longestLengths = [longestFileLength, longestLabelLength];
   const rowTypes = [`File (${environmentName})`, 'Size'];
 
-  if (options.compressed) {
+  if (showGzipHeader) {
     rowTypes.push('Gzip');
   }
 
@@ -179,12 +179,15 @@ async function printFileSizes(
   );
 
   if (options.detail !== false) {
+    const showGzipHeader = Boolean(
+      options.compressed && assets.some((item) => item.gzippedSize !== null),
+    );
     logs.push(
       getHeader(
         longestFileLength,
         longestLabelLength,
-        options,
         environmentName,
+        showGzipHeader,
       ),
     );
   }


### PR DESCRIPTION
## Summary

Should not display the `Gzip` header if all assets are not compressible.

<img width="459" alt="Screenshot 2025-03-06 at 18 26 03" src="https://github.com/user-attachments/assets/60cc4e65-dfe7-4769-9c1d-a077b94f275b" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
