### PR TITLE
fix: await watcher close before restart

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -390,7 +390,7 @@ export async function watchFilesForRestart(
 
   const callback = debounce(
     async (filePath) => {
-      watcher.close();
+      await watcher.close();
       if (isBuildWatch) {
         await restartBuild({ filePath });
       } else {


### PR DESCRIPTION
## Summary

The `watcher.close` method returns a Promise and should be awaited.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
