### PR TITLE
test(e2e): fix flaky watch-files cases

### DIFF
--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -62,7 +62,7 @@ rspackOnlyTest(
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await expectFile(tempOutputFile);
     expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
 
     childProcess.kill();
@@ -88,7 +88,7 @@ rspackOnlyTest(
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    await expectFile(tempOutputFile);
     expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
 
     childProcess.kill();


### PR DESCRIPTION
## Summary

The `watch-files/index.test.ts` contains three flaky cases. This PR makes the next two cases stable, but the first case is still unstable and needs further investigation.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
