### PR TITLE
test(e2e): improve plugin watch hook test reliability

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
 import fse from 'fs-extra';
@@ -70,7 +70,9 @@ rspackOnlyTest(
     fse.ensureDirSync(join(cwd, 'test-temp-src'));
 
     const filePath = join(cwd, 'test-temp-src', 'index.js');
+    const distPath = join(cwd, 'dist/index.html');
 
+    await fs.promises.rm(distPath, { recursive: true, force: true });
     await fs.promises.writeFile(filePath, "console.log('1');");
 
     const { plugin, names } = createPlugin();
@@ -93,10 +95,11 @@ rspackOnlyTest(
     });
 
     const result = await rsbuild.build({ watch: true });
+    await expectFile(distPath);
 
+    await fs.promises.rm(distPath, { recursive: true, force: true });
     await fs.promises.writeFile(filePath, "console.log('2');");
-
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await expectFile(distPath);
 
     expect(names).toEqual([
       'ModifyRsbuildConfig',


### PR DESCRIPTION
## Summary

Improve plugin watch hook test reliability, replace `setTimeout` with `expectFile`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
