### PR TITLE
feat: allow opening relative paths on error overlay

### DIFF
--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -29,11 +29,12 @@ test('should display type errors on overlay correctly', async ({ page }) => {
   expect(await firstSpan.textContent()).toEqual('TS2322: ');
   expect(await firstSpan.getAttribute('style')).toEqual('color:#888;');
 
-  // The first link is "<a class="file-link">/src/index.ts:3:1</a>"
+  // The first link is "<a class="file-link">./path/to/src/index.ts:3:1</a>"
   const firstLink = errorOverlay.locator('.file-link').first();
   expect(await firstLink.getAttribute('class')).toEqual('file-link');
+  const linkText = await firstLink.textContent();
   expect(
-    (await firstLink.textContent())?.endsWith('/src/index.ts:3:1'),
+    linkText?.endsWith('/src/index.ts:3:1') && linkText.startsWith('.'),
   ).toBeTruthy();
 
   await rsbuild.close();

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -1,25 +1,36 @@
+import { join } from 'node:path';
 import ansiHTML from './ansiHTML';
 import { escapeHtml } from './helper';
 
-export function convertLinksInHtml(text: string): string {
-  const fileRegex = /(?:[a-zA-Z]:\\|\/).*?:\d+:\d+/g;
+export function convertLinksInHtml(text: string, root?: string): string {
+  /**
+   * Match absolute or relative paths with line and column
+   * @example
+   * 1. `./src/index.js:1:1`
+   * 2. `.\src\index.js:1:1`
+   * 3. `../Button.js:1:1`
+   * 4. `C:\Users\username\project\src\index.js:1:1`
+   * 5. `/home/user/project/src/index.js:1:1`
+   */
+  const pathRegex = /(?:\.\.?[\/\\]|[a-zA-Z]:\\|\/)[^:]*:\d+:\d+/g;
 
-  return text.replace(fileRegex, (file) => {
+  return text.replace(pathRegex, (file) => {
     // If the file contains `</span>`, it means the file path contains ANSI codes.
     // We need to move the `</span>` to the end of the file path.
     const hasClosingSpan = file.includes('</span>') && !file.includes('<span');
     const filePath = hasClosingSpan ? file.replace('</span>', '') : file;
+    const suffix = hasClosingSpan ? '</span>' : '';
+    const absolutePath =
+      root && filePath.startsWith('.') ? join(root, filePath) : filePath;
 
-    return `<a class="file-link" data-file="${filePath}">${filePath}</a>${
-      hasClosingSpan ? '</span>' : ''
-    }`;
+    return `<a class="file-link" data-file="${absolutePath}">${filePath}</a>${suffix}`;
   });
 }
 
 // HTML template for error overlay
-export function genOverlayHTML(errors: string[]) {
+export function genOverlayHTML(errors: string[], root?: string) {
   const htmlItems = errors.map((item) =>
-    convertLinksInHtml(ansiHTML(escapeHtml(item))),
+    convertLinksInHtml(ansiHTML(escapeHtml(item)), root),
   );
   return `
 <style>


### PR DESCRIPTION
## Summary

This PR adds support for opening relative paths on error overlay.

<img width="997" alt="Screenshot 2025-03-09 at 19 57 05" src="https://github.com/user-attachments/assets/21ebaeef-4ce9-4963-b5dd-44a5d0c307dc" />

## Related Links

https://github.com/rspack-contrib/rsbuild-plugin-type-check/issues/19

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
