### PR TITLE
test(ut): add test cases for overlay links

### DIFF
--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -127,4 +127,20 @@ describe('convertLinksInHtml', () => {
       '[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="/path/to/src/index.js:4:1">/path/to/src/index.js:4:1</a></span>]\n';
     expect(convertLinksInHtml(ansiHTML(input2))).toEqual(expected2);
   });
+
+  it('should convert relative path to absolute path', () => {
+    const root = '/path/to';
+    const input = '[\u001b[36;1;4m./src/index.js\u001b[0m:4:1]\n';
+    const expected = `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="${root}/src/index.js:4:1">./src/index.js:4:1</a></span>]\n`;
+    expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
+  });
+
+  it('should convert Windows absolute path to absolute path', () => {
+    const root = 'C:\\Users\\username\\project';
+    const input =
+      '[\u001b[36;1;4mC:\\Users\\username\\project\\src\\index.js\u001b[0m:4:1]\n';
+    const expected =
+      '[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="C:\\Users\\username\\project\\src\\index.js:4:1">C:\\Users\\username\\project\\src\\index.js:4:1</a></span>]\n';
+    expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
+  });
 });

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -131,7 +131,10 @@ describe('convertLinksInHtml', () => {
   it('should convert relative path to absolute path', () => {
     const root = '/path/to';
     const input = '[\u001b[36;1;4m./src/index.js\u001b[0m:4:1]\n';
-    const expected = `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="${root}/src/index.js:4:1">./src/index.js:4:1</a></span>]\n`;
+    const expected =
+      process.platform === 'win32'
+        ? `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="\\path\\to\\src\\index.js:4:1">./src/index.js:4:1</a></span>]\n`
+        : `[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="${root}/src/index.js:4:1">./src/index.js:4:1</a></span>]\n`;
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 


### PR DESCRIPTION
## Summary

Add some test cases for the `convertLinksInHtml` method.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4739

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
