### PR TITLE
chore(deps): update Rspress to v2.0.0-alpha.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1144,11 +1144,11 @@ importers:
         specifier: workspace:*
         version: link:../packages/core
       '@rspress/plugin-client-redirects':
-        specifier: ^1.43.0
-        version: 1.43.0(@rspress/runtime@1.43.0)
+        specifier: ^2.0.0-alpha.0
+        version: 2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)
       '@rspress/plugin-rss':
-        specifier: ^1.43.0
-        version: 1.43.0(react@19.0.0)(rspress@1.43.0(webpack@5.98.0))
+        specifier: ^2.0.0-alpha.0
+        version: 2.0.0-alpha.0(react@19.0.0)(rspress@2.0.0-alpha.0(webpack@5.98.0))
       '@rstack-dev/doc-ui':
         specifier: 1.7.2
         version: 1.7.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1177,8 +1177,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
       rspress:
-        specifier: ^1.43.0
-        version: 1.43.0(webpack@5.98.0)
+        specifier: ^2.0.0-alpha.0
+        version: 2.0.0-alpha.0(webpack@5.98.0)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2202,8 +2202,8 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
-  '@rsbuild/core@1.2.3':
-    resolution: {integrity: sha512-lUCt8gQe9E2PI3srcEJ1Na3GQYmsYuvAqK0f/k00HM0pEjrbOFC9Xq2kR85UoXHFqlTCIw/fLLDe91PKRCbKAw==}
+  '@rsbuild/core@1.2.15':
+    resolution: {integrity: sha512-f17C4q3MoQ1G9CXzGkiZKZj3MHnV9oSovBjjQQ5bXVBICfGVyRHlHHCa5b9b40F67lbez2K6eLkLP9wU1j1Udw==}
     engines: {node: '>=16.7.0'}
     hasBin: true
 
@@ -2309,11 +2309,6 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-h23F8zEkXWhwMeScm0ZnN78Zh7hCDalxIWsm7bBS0eKadnlegUDwwCF8WE+8NjWr7bRzv0p3QBWlS5ufkcL4eA==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.2.3':
     resolution: {integrity: sha512-xuwYzhPgNCr4BtKXCU3xe4249TFsXAZglIlbxv8Qs3PeIarrZMRddcqH2zUXi+nJavNw3yN12sCYEzk1f+O4FQ==}
     cpu: [arm64]
@@ -2322,11 +2317,6 @@ packages:
   '@rspack/binding-darwin-arm64@1.2.7':
     resolution: {integrity: sha512-dT5eSMTknZaI8Djmz8KnaWM68rjZuBZwsKyF144o+ZSJM55vgiNXyL0lQYB8mX9nR3Gck+jKuGUAT2W/EF/t5Q==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-vG5s7FkEvwrGLfksyDRHwKAHUkhZt1zHZZXJQn4gZKjTBonje8ezdc7IFlDiWpC4S+oBYp73nDWkUzkGRbSdcQ==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.2.3':
@@ -2339,11 +2329,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-VykY/kiYOzO8E1nYzfJ9+gQEHxb5B6lt5wa8M6xFi5B6jEGU+OsaGskmAZB9/GFImeFDHxDPvhUalI4R9p8O2Q==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.2.3':
     resolution: {integrity: sha512-K2u/fPUmKujlKSWL3q2zaUu8/6ZK/bOGKcqJSib8jdanQQ/GFKwKtPAFOOa/vvqbzhDocqKOobFR10FhgJqCHg==}
     cpu: [arm64]
@@ -2351,11 +2336,6 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@1.2.7':
     resolution: {integrity: sha512-DTtFBJmgQQrVWjbklpgJDr3kE9Uf1fHsPh+1GVslsBuyn+o4O7JslrnjuVsQCYKoiEg0Lg4ZPQmwnhJLHssZ5A==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.2.2':
-    resolution: {integrity: sha512-Z5vAC4wGfXi8XXZ6hs8Q06TYjr3zHf819HB4DI5i4C1eQTeKdZSyoFD0NHFG23bP4NWJffp8KhmoObcy9jBT5Q==}
     cpu: [arm64]
     os: [linux]
 
@@ -2369,11 +2349,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-o3pDaL+cH5EeRbDE9gZcdZpBgp5iXvYZBBhe8vZQllYgI4zN5MJEuleV7WplG3UwTXlgZg3Kht4RORSOPn96vg==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.2.3':
     resolution: {integrity: sha512-542lwJzB1RMGuVdBdA3cOWTlmL9okpOppHUBWcNCjmJM+9zTI+0jwjVe8HaqOqtuR8XzNsoCwT9QonU/GLcuhg==}
     cpu: [x64]
@@ -2381,11 +2356,6 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@1.2.7':
     resolution: {integrity: sha512-lUOAUq0YSsofCXsP6XnlgfH0ZRDZ2X2XqXLXYjqf4xkSxCl5eBmE0EQYjAHF4zjUvU5rVx4a4bDLWv7+t3bOHg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-RE3e0xe4DdchHssttKzryDwjLkbrNk/4H59TkkWeGYJcLw41tmcOZVFQUOwKLUvXWVyif/vjvV/w1SMlqB4wQg==}
     cpu: [x64]
     os: [linux]
 
@@ -2399,11 +2369,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-win32-arm64-msvc@1.2.2':
-    resolution: {integrity: sha512-R+PKBYn6uzTaDdVqTHvjqiJPBr5ZHg1wg5UmFDLNH9OklzVFyQh1JInSdJRb7lzfzTRz6bEkkwUFBPQK/CGScw==}
-    cpu: [arm64]
-    os: [win32]
-
   '@rspack/binding-win32-arm64-msvc@1.2.3':
     resolution: {integrity: sha512-S8ZKddMMQDGy8jx/R0i2m1XrmfY2CpI+t6lIEpsuZuKUR4MbOGKN2DuL4MDnT3m8JaYvC8ihsvQjBXQCy3SNxQ==}
     cpu: [arm64]
@@ -2412,11 +2377,6 @@ packages:
   '@rspack/binding-win32-arm64-msvc@1.2.7':
     resolution: {integrity: sha512-1OzzM+OUSWX39XYcDfxJ8bGX5vNNrRejCMGotBEdP+uQ3KMWCPz0G4KRc3QIjghaLIYk3ofd83hcfUxyk/2Xog==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.2.2':
-    resolution: {integrity: sha512-dBqz3sRAGZ2f31FgzKLDvIRfq2haRP3X3XVCT0PsiMcvt7QJng+26aYYMy2THatd/nM8IwExYeitHWeiMBoruw==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.2.3':
@@ -2429,11 +2389,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-eeAvaN831KG553cMSHkVldyk6YQn4ujgRHov6r1wtREq7CD3/ka9LMkJUepCN85K7XtwYT0N4KpFIQyf5GTGoA==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.2.3':
     resolution: {integrity: sha512-fcU532PgFdd5Bil8jwQW0Dcb/80oM6V0qSstGIxZ4M77t4t8e/PcukXfORTL71FfNQ64Rd4Dp6XRl1NHNJVxeg==}
     cpu: [x64]
@@ -2444,26 +2399,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.2.2':
-    resolution: {integrity: sha512-GCZwpGFYlLTdJ2soPLwjw9z4LSZ+GdpbHNfBt3Cm/f/bAF8n6mZc7dHUqN893RFh7MPU17HNEL3fMw7XR+6pHg==}
-
   '@rspack/binding@1.2.3':
     resolution: {integrity: sha512-enpOXZPQOJO800wdWcR7H5Dx5UZfwkaT0D0xsHD53WbpI09Z2KJbLX7I/i1FLLy3K1KQTB+2FIHLVdRikasXZA==}
 
   '@rspack/binding@1.2.7':
     resolution: {integrity: sha512-QH+kxkG0I9C6lmlwgBUDFsy24ihXMGG5lfiNtQilk4CyBN+AgSWFENcYrnkUaBioZAvMBznQLiccV3X0JeH9iQ==}
-
-  '@rspack/core@1.2.2':
-    resolution: {integrity: sha512-EeHAmY65Uj62hSbUKesbrcWGE7jfUI887RD03G++Gj8jS4WPHEu1TFODXNOXg6pa7zyIvs2BK0Bm16Kwz8AEaQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@rspack/tracing': ^1.x
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@rspack/tracing':
-        optional: true
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@1.2.3':
     resolution: {integrity: sha512-BFgdUYf05/hjjY9Nlwq8DpWaRJN5w2kTl8ZJi20SRL60oAx+ZD2ABT+fsPhBiFSmfTZDdvGGIq5e3vfRzoIuqg==}
@@ -2507,8 +2447,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@1.43.0':
-    resolution: {integrity: sha512-vH7LMaRMF1S2Lr+wcWgze/1nBGn2mxct6ktYVXDzRFACus8PJ+9FodK9EF48lmvz/yoHQ581J8GFClViXbQ5jQ==}
+  '@rspress/core@2.0.0-alpha.0':
+    resolution: {integrity: sha512-x/v5laQJw3mjiyAGgJjyRfgpGab4hX1+DpGcxL5JIFwSbBt3oN/RENJJrnaZcL15lFnNFgck/8cb3hVFZ/F5Cg==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -2563,46 +2503,46 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@1.43.0':
-    resolution: {integrity: sha512-G6kcHxFYV3nMNOQJCLFAMob51Wt4CqYXCC6ZNmo8bVVOGjJumXvwJXXM0VBPllW/gJivrj4bsJJkt0fs5/ZvXw==}
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.0':
+    resolution: {integrity: sha512-PdBFXHXC//hhUHgRmo2doFK6jQT3FZGyokxvrJeTA1M2LcMroI61sG2WbN/x0WIHxYlzw9hFtE5yFTmCqFP8rw==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-client-redirects@1.43.0':
-    resolution: {integrity: sha512-3w8pFBqWnO4+BmsfaEBsExEBWJPUSDuKy7d9LCs2fBicyEiplaHxPW6yTXGtc6DGyCySZ1EDKqXyV9QCsFpToA==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      '@rspress/runtime': ^1.43.0
-
-  '@rspress/plugin-container-syntax@1.43.0':
-    resolution: {integrity: sha512-IupXloWXYJB+NRZyfReO1SYpNmyRg8gaL+H/BrgAdk8QOQXa7dQwbwfjFbzzcp8b/eUNnEI8Tw6gHJeZ2B9J5w==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-last-updated@1.43.0':
-    resolution: {integrity: sha512-V2jQqewWHjUvdAUv21VqR/rl/bvE0hzF8ahRU/2mVj62Y4KqphEChWTq0pTT6+/jW9ZEpALyukPLFE/66bWdlg==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-medium-zoom@1.43.0':
-    resolution: {integrity: sha512-oOiw0MYPwVetoV0cUy/42rjtT0nFbL9IbRRD7i40re7nLUhP+bors9DObHfGfz7oTO3DksL2AY6y9hez+WYakg==}
+  '@rspress/plugin-client-redirects@2.0.0-alpha.0':
+    resolution: {integrity: sha512-PIb3gx39J4nr+7CCwpl85NdwiQ1prWT+7POQbfDROQ8nHLhnBpFuIdjLlpsrji3JWk76ZDp9rW0bYdf1eUy0WQ==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^1.43.0
+      '@rspress/runtime': ^2.0.0-alpha.0
 
-  '@rspress/plugin-rss@1.43.0':
-    resolution: {integrity: sha512-quhnABovGsrPR9hrnKq0zaj2lu/nm1MH7Tu5FIGdNp0UhZasRJNzbt7Mf+o+JnjFkUqbP3ED+Dno6WdeFk0OBQ==}
+  '@rspress/plugin-container-syntax@2.0.0-alpha.0':
+    resolution: {integrity: sha512-42cTxgwTEMbrY9XX34UhC0bxB78YxPZEBMV2A8TKIWHL/ZR/5txlWxH0RUTn+jVqFR8+eofy1CKQAtVSmjSOeQ==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-last-updated@2.0.0-alpha.0':
+    resolution: {integrity: sha512-sEuID+U7w6NxivNWX+Vw4a9foge+TAN2IwW/jI31eF921tuOFrhcISsGMTc6/exvw54v0dhc2p0mc86zqmo0rA==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.0':
+    resolution: {integrity: sha512-tcEz6meI3o3VXvoO6RE4KlxQ0UvK0MZsjxtYfOh2qsqSrMqB6HZopXKQk4VqPP4v8b/OLgnK2jArB+wdBeYz8Q==}
+    engines: {node: '>=14.17.6'}
+    peerDependencies:
+      '@rspress/runtime': ^2.0.0-alpha.0
+
+  '@rspress/plugin-rss@2.0.0-alpha.0':
+    resolution: {integrity: sha512-VlTGHnq4ecLVVAtc0RO2v0C0JW6btIfiP1hIjExACwSESfcTfgGcee9nVhfZy/0/1TMDfvaYF0JZWEX6ftVVOw==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: ^1.43.0
+      rspress: ^2.0.0-alpha.0
 
-  '@rspress/runtime@1.43.0':
-    resolution: {integrity: sha512-GBNjSuI+A41bV0q/zuoCZB7qXJzaG6ooPOJUWlkTx9ozpYoVwsc14E7anCl0VowJbO1yQhbDqiEfK4Q44b0D1A==}
+  '@rspress/runtime@2.0.0-alpha.0':
+    resolution: {integrity: sha512-fMxDd7xIYHVBHBfAEeCcVIHLcMRduyHvvd5ivWgGLIL+WxF6TxfIsx8T0GwnI5L3JF5O15F+X7Ir7a7VKXEezg==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@1.43.0':
-    resolution: {integrity: sha512-MqnppP7C+eC195AAbVLDnvYsSYdLeNZuDDpFVIN+1dw6UywR6EkQD27nzEfeiUwl1EZ3MKXJxbRCuRnzpBvduw==}
+  '@rspress/shared@2.0.0-alpha.0':
+    resolution: {integrity: sha512-+M5MqExmdsQ3T/JE254FudPioapxZf0gQKw7UJdAmw5jBno3IlxISHFmfY9oLXxJKKjHwvr2gcZcfr8JegEfCA==}
 
-  '@rspress/theme-default@1.43.0':
-    resolution: {integrity: sha512-nmaDDKGyDBDzhtbQlu17du15tBawQxgo/oSMlyvFgYAbmK4PqYf2sYN1DJWyIvsA5+UhrR3YjK8XzbMqoDJbzQ==}
+  '@rspress/theme-default@2.0.0-alpha.0':
+    resolution: {integrity: sha512-0e3x4COOVKLpAYeI/Uy8/VrD2iaogf7EOndyxIjBSU6+4ZOvRnJndHMT8Yh+LMmijy5VLGSqhUopYBh4h7ewsg==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.7.2':
@@ -3817,10 +3757,6 @@ packages:
 
   enhanced-resolve@5.12.0:
     resolution: {integrity: sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==}
-    engines: {node: '>=10.13.0'}
-
-  enhanced-resolve@5.18.0:
-    resolution: {integrity: sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==}
     engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.18.1:
@@ -5746,8 +5682,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@1.43.0:
-    resolution: {integrity: sha512-hIs1ni12bYur7PWil3+yPoESl10X/wfWHFj2gUISBpXlVOK0YzJR1T26rhJQTFIvRKEdRXSnAh2bY9Ijf/s36A==}
+  rspress@2.0.0-alpha.0:
+    resolution: {integrity: sha512-O3KacOnl6XO/4MXFoDJs7KBDCI90q+kiwNKzgipVY+adC6XcsQXTw+iLBhSQ4Nr7C7geRh83MrRdNU3mrlZXNQ==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -7836,12 +7772,13 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rsbuild/core@1.2.3':
+  '@rsbuild/core@1.2.15':
     dependencies:
-      '@rspack/core': 1.2.2(@swc/helpers@0.5.15)
+      '@rspack/core': 1.2.7(@swc/helpers@0.5.15)
       '@rspack/lite-tapable': 1.0.1
       '@swc/helpers': 0.5.15
-      core-js: 3.40.0
+      core-js: 3.41.0
+      jiti: 2.4.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
@@ -7879,15 +7816,15 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.3)':
+  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.15)':
     dependencies:
-      '@rsbuild/core': 1.2.3
+      '@rsbuild/core': 1.2.15
       deepmerge: 4.3.1
       reduce-configs: 1.1.0
 
-  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.3)':
+  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.15)':
     dependencies:
-      '@rsbuild/core': 1.2.3
+      '@rsbuild/core': 1.2.15
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
@@ -7898,9 +7835,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.3)':
+  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.15)':
     dependencies:
-      '@rsbuild/core': 1.2.3
+      '@rsbuild/core': 1.2.15
       deepmerge: 4.3.1
       loader-utils: 2.0.4
       postcss: 8.5.3
@@ -8058,16 +7995,10 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspack/binding-darwin-arm64@1.2.2':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.2.3':
     optional: true
 
   '@rspack/binding-darwin-arm64@1.2.7':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.2.2':
     optional: true
 
   '@rspack/binding-darwin-x64@1.2.3':
@@ -8076,16 +8007,10 @@ snapshots:
   '@rspack/binding-darwin-x64@1.2.7':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.2.2':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.2.3':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.2.7':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.2.2':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.2.3':
@@ -8094,16 +8019,10 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.2.7':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.2.2':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.2.3':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.2.7':
-    optional: true
-
-  '@rspack/binding-linux-x64-musl@1.2.2':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.2.3':
@@ -8112,16 +8031,10 @@ snapshots:
   '@rspack/binding-linux-x64-musl@1.2.7':
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.2.2':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.2.3':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.2.7':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.2.2':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.2.3':
@@ -8130,26 +8043,11 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.2.7':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.2.2':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@1.2.3':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.2.7':
     optional: true
-
-  '@rspack/binding@1.2.2':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.2.2
-      '@rspack/binding-darwin-x64': 1.2.2
-      '@rspack/binding-linux-arm64-gnu': 1.2.2
-      '@rspack/binding-linux-arm64-musl': 1.2.2
-      '@rspack/binding-linux-x64-gnu': 1.2.2
-      '@rspack/binding-linux-x64-musl': 1.2.2
-      '@rspack/binding-win32-arm64-msvc': 1.2.2
-      '@rspack/binding-win32-ia32-msvc': 1.2.2
-      '@rspack/binding-win32-x64-msvc': 1.2.2
 
   '@rspack/binding@1.2.3':
     optionalDependencies:
@@ -8174,15 +8072,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.2.7
       '@rspack/binding-win32-ia32-msvc': 1.2.7
       '@rspack/binding-win32-x64-msvc': 1.2.7
-
-  '@rspack/core@1.2.2(@swc/helpers@0.5.15)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.8.4
-      '@rspack/binding': 1.2.2
-      '@rspack/lite-tapable': 1.0.1
-      caniuse-lite: 1.0.30001700
-    optionalDependencies:
-      '@swc/helpers': 0.5.15
 
   '@rspack/core@1.2.3(@swc/helpers@0.5.15)':
     dependencies:
@@ -8216,24 +8105,24 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.16.0
 
-  '@rspress/core@1.43.0(webpack@5.98.0)':
+  '@rspress/core@2.0.0-alpha.0(webpack@5.98.0)':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.98.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.2.3
-      '@rsbuild/plugin-less': 1.1.1(@rsbuild/core@1.2.3)
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.3)
-      '@rsbuild/plugin-sass': 1.2.2(@rsbuild/core@1.2.3)
+      '@rsbuild/core': 1.2.15
+      '@rsbuild/plugin-less': 1.1.1(@rsbuild/core@1.2.15)
+      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.15)
+      '@rsbuild/plugin-sass': 1.2.2(@rsbuild/core@1.2.15)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 1.43.0
-      '@rspress/plugin-container-syntax': 1.43.0
-      '@rspress/plugin-last-updated': 1.43.0
-      '@rspress/plugin-medium-zoom': 1.43.0(@rspress/runtime@1.43.0)
-      '@rspress/runtime': 1.43.0
-      '@rspress/shared': 1.43.0
-      '@rspress/theme-default': 1.43.0
-      enhanced-resolve: 5.18.0
+      '@rspress/plugin-auto-nav-sidebar': 2.0.0-alpha.0
+      '@rspress/plugin-container-syntax': 2.0.0-alpha.0
+      '@rspress/plugin-last-updated': 2.0.0-alpha.0
+      '@rspress/plugin-medium-zoom': 2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)
+      '@rspress/runtime': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/theme-default': 2.0.0-alpha.0
+      enhanced-resolve: 5.18.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-heading-rank: 2.1.1
@@ -8296,48 +8185,48 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-auto-nav-sidebar@1.43.0':
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.0':
     dependencies:
-      '@rspress/shared': 1.43.0
+      '@rspress/shared': 2.0.0-alpha.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-client-redirects@1.43.0(@rspress/runtime@1.43.0)':
+  '@rspress/plugin-client-redirects@2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)':
     dependencies:
-      '@rspress/runtime': 1.43.0
-      '@rspress/shared': 1.43.0
+      '@rspress/runtime': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-container-syntax@1.43.0':
+  '@rspress/plugin-container-syntax@2.0.0-alpha.0':
     dependencies:
-      '@rspress/shared': 1.43.0
+      '@rspress/shared': 2.0.0-alpha.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-last-updated@1.43.0':
+  '@rspress/plugin-last-updated@2.0.0-alpha.0':
     dependencies:
-      '@rspress/shared': 1.43.0
+      '@rspress/shared': 2.0.0-alpha.0
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-medium-zoom@1.43.0(@rspress/runtime@1.43.0)':
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)':
     dependencies:
-      '@rspress/runtime': 1.43.0
+      '@rspress/runtime': 2.0.0-alpha.0
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@1.43.0(react@19.0.0)(rspress@1.43.0(webpack@5.98.0))':
+  '@rspress/plugin-rss@2.0.0-alpha.0(react@19.0.0)(rspress@2.0.0-alpha.0(webpack@5.98.0))':
     dependencies:
-      '@rspress/shared': 1.43.0
+      '@rspress/shared': 2.0.0-alpha.0
       feed: 4.2.2
       react: 19.0.0
-      rspress: 1.43.0(webpack@5.98.0)
+      rspress: 2.0.0-alpha.0(webpack@5.98.0)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/runtime@1.43.0':
+  '@rspress/runtime@2.0.0-alpha.0':
     dependencies:
-      '@rspress/shared': 1.43.0
+      '@rspress/shared': 2.0.0-alpha.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8345,20 +8234,20 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/shared@1.43.0':
+  '@rspress/shared@2.0.0-alpha.0':
     dependencies:
-      '@rsbuild/core': 1.2.3
+      '@rsbuild/core': 1.2.15
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 10.1.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/theme-default@1.43.0':
+  '@rspress/theme-default@2.0.0-alpha.0':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 1.43.0
-      '@rspress/shared': 1.43.0
+      '@rspress/runtime': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.0
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -9661,11 +9550,6 @@ snapshots:
       - utf-8-validate
 
   enhanced-resolve@5.12.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.2.1
-
-  enhanced-resolve@5.18.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
@@ -11923,11 +11807,11 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@1.43.0(webpack@5.98.0):
+  rspress@2.0.0-alpha.0(webpack@5.98.0):
     dependencies:
-      '@rsbuild/core': 1.2.3
-      '@rspress/core': 1.43.0(webpack@5.98.0)
-      '@rspress/shared': 1.43.0
+      '@rsbuild/core': 1.2.15
+      '@rspress/core': 2.0.0-alpha.0(webpack@5.98.0)
+      '@rspress/shared': 2.0.0-alpha.0
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,8 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rspress/plugin-client-redirects": "^1.43.0",
-    "@rspress/plugin-rss": "^1.43.0",
+    "@rspress/plugin-client-redirects": "^2.0.0-alpha.0",
+    "@rspress/plugin-rss": "^2.0.0-alpha.0",
     "@rstack-dev/doc-ui": "1.7.2",
     "@types/node": "^22.13.8",
     "@types/react": "^19.0.10",
@@ -21,7 +21,7 @@
     "react-dom": "^19.0.0",
     "rsbuild-plugin-google-analytics": "^1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",
-    "rspress": "^1.43.0",
+    "rspress": "^2.0.0-alpha.0",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
     "typescript": "^5.8.2"

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,6 +1,6 @@
 import { Announcement } from '@rstack-dev/doc-ui/announcement';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
-import Theme from 'rspress/theme';
+import { Layout as BaseLayout } from 'rspress/theme';
 import { HomeLayout } from './pages';
 import './index.scss';
 import { NoSSR, useLang, usePageData } from 'rspress/runtime';
@@ -13,7 +13,7 @@ const Layout = () => {
   const lang = useLang();
 
   return (
-    <Theme.Layout
+    <BaseLayout
       beforeNavTitle={<NavIcon />}
       beforeNav={
         ANNOUNCEMENT_URL ? (
@@ -37,10 +37,6 @@ const Layout = () => {
   );
 };
 
-export default {
-  ...Theme,
-  Layout,
-  HomeLayout,
-};
+export { Layout, HomeLayout };
 
 export * from 'rspress/theme';


### PR DESCRIPTION
## Summary

Update Rspress to v2.0.0-alpha.0

## Related Links

https://github.com/web-infra-dev/rspress/releases/tag/v2.0.0-alpha.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
