### PR TITLE
feat: display relative paths on error overlay

### DIFF
--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -1,8 +1,20 @@
-import { isAbsolute, join, resolve, sep } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { COMPILED_PATH } from '../constants';
 
 export function getAbsolutePath(base: string, filepath: string): string {
   return isAbsolute(filepath) ? filepath : join(base, filepath);
+}
+
+export function getRelativePath(base: string, filepath: string): string {
+  const relativePath = relative(base, filepath);
+
+  if (relativePath === '') {
+    return `.${sep}`;
+  }
+  if (!relativePath.startsWith('.')) {
+    return `.${sep}${relativePath}`;
+  }
+  return relativePath;
 }
 
 export function getCommonParentPath(paths: string[]): string {

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path';
+import { getAbsolutePath, getRelativePath } from '../helpers';
 import ansiHTML from './ansiHTML';
 import { escapeHtml } from './helper';
 
@@ -20,10 +20,10 @@ export function convertLinksInHtml(text: string, root?: string): string {
     const hasClosingSpan = file.includes('</span>') && !file.includes('<span');
     const filePath = hasClosingSpan ? file.replace('</span>', '') : file;
     const suffix = hasClosingSpan ? '</span>' : '';
-    const absolutePath =
-      root && filePath.startsWith('.') ? join(root, filePath) : filePath;
+    const absolutePath = root ? getAbsolutePath(root, filePath) : filePath;
+    const relativePath = root ? getRelativePath(root, filePath) : filePath;
 
-    return `<a class="file-link" data-file="${absolutePath}">${filePath}</a>${suffix}`;
+    return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
   });
 }
 

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -1,4 +1,5 @@
-import { getAbsolutePath, getRelativePath } from '../helpers';
+import path from 'node:path';
+import { getRelativePath } from '../helpers';
 import ansiHTML from './ansiHTML';
 import { escapeHtml } from './helper';
 
@@ -20,8 +21,11 @@ export function convertLinksInHtml(text: string, root?: string): string {
     const hasClosingSpan = file.includes('</span>') && !file.includes('<span');
     const filePath = hasClosingSpan ? file.replace('</span>', '') : file;
     const suffix = hasClosingSpan ? '</span>' : '';
-    const absolutePath = root ? getAbsolutePath(root, filePath) : filePath;
-    const relativePath = root ? getRelativePath(root, filePath) : filePath;
+    const isAbsolute = path.isAbsolute(filePath);
+    const absolutePath =
+      root && !isAbsolute ? path.join(root, filePath) : filePath;
+    const relativePath =
+      root && isAbsolute ? getRelativePath(root, filePath) : filePath;
 
     return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
   });

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -128,7 +128,7 @@ describe('convertLinksInHtml', () => {
     expect(convertLinksInHtml(ansiHTML(input2))).toEqual(expected2);
   });
 
-  it('should convert relative path to absolute path', () => {
+  it('should convert relative path as expected', () => {
     const root = '/path/to';
     const input = '[\u001b[36;1;4m./src/index.js\u001b[0m:4:1]\n';
     const expected =
@@ -138,7 +138,7 @@ describe('convertLinksInHtml', () => {
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 
-  it('should convert Windows absolute path to absolute path', () => {
+  it('should convert Windows absolute path as expected', () => {
     // only run on Windows
     if (process.platform !== 'win32') {
       return;

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -139,6 +139,11 @@ describe('convertLinksInHtml', () => {
   });
 
   it('should convert Windows absolute path to absolute path', () => {
+    // only run on Windows
+    if (process.platform !== 'win32') {
+      return;
+    }
+
     const root = 'C:\\Users\\username\\project';
     const input =
       '[\u001b[36;1;4mC:\\Users\\username\\project\\src\\index.js\u001b[0m:4:1]\n';

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -148,7 +148,7 @@ describe('convertLinksInHtml', () => {
     const input =
       '[\u001b[36;1;4mC:\\Users\\username\\project\\src\\index.js\u001b[0m:4:1]\n';
     const expected =
-      '[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="C:\\Users\\username\\project\\src\\index.js:4:1">C:\\Users\\username\\project\\src\\index.js:4:1</a></span>]\n';
+      '[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="C:\\Users\\username\\project\\src\\index.js:4:1">.\\src\\index.js:4:1</a></span>]\n';
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 });


### PR DESCRIPTION
## Summary

Display relative paths on error overlay to improve readability.

- before:

<img width="1009" alt="Screenshot 2025-03-10 at 13 13 24" src="https://github.com/user-attachments/assets/bc7141e7-6161-48d9-a387-f6925fde5c1e" />

- after:

<img width="1002" alt="Screenshot 2025-03-10 at 13 17 42" src="https://github.com/user-attachments/assets/427f6f89-e549-4578-9217-7de558ccef91" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
