### PR TITLE
perf: bundle webpack-merge for faster startup

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -25,7 +25,6 @@ export default {
     'on-finished',
     'connect',
     'rspack-manifest-plugin',
-    'webpack-merge',
     'html-rspack-plugin',
     'mrmime',
     'tinyglobby',

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -1,5 +1,6 @@
 import { rspack } from '@rspack/core';
 import { reduceConfigsAsyncWithContext } from 'reduce-configs';
+import { merge } from 'webpack-merge';
 import { CHAIN_ID, modifyBundlerChain } from '../configChain';
 import { castArray, color, getNodeEnv } from '../helpers';
 import { logger } from '../logger';
@@ -41,8 +42,6 @@ export async function getConfigUtils(
   config: Rspack.Configuration,
   chainUtils: ModifyChainUtils,
 ): Promise<ModifyRspackConfigUtils> {
-  const { merge } = await import('../../compiled/webpack-merge/index.js');
-
   return {
     ...chainUtils,
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -76,6 +76,12 @@ export type ToolsHtmlPluginConfig = ConfigChainWithContext<
   }
 >;
 
+// equivalent to import('webpack-merge').merge
+export type WebpackMerge = <Configuration extends object>(
+  firstConfiguration: Configuration | Configuration[],
+  ...configurations: Configuration[]
+) => Configuration;
+
 export type ModifyRspackConfigUtils = ModifyChainUtils & {
   addRules: (rules: RspackRule | RspackRule[]) => void;
   appendRules: (rules: RspackRule | RspackRule[]) => void;
@@ -86,7 +92,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
     plugins: BundlerPluginInstance | BundlerPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
-  mergeConfig: typeof import('webpack-merge').merge;
+  mergeConfig: WebpackMerge;
   rspack: typeof rspack;
 };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -86,7 +86,7 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
     plugins: BundlerPluginInstance | BundlerPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
-  mergeConfig: typeof import('../../compiled/webpack-merge/index.js').merge;
+  mergeConfig: typeof import('webpack-merge').merge;
   rspack: typeof rspack;
 };
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -10,6 +10,7 @@ import type {
   NormalizedConfig,
   NormalizedEnvironmentConfig,
   RsbuildConfig,
+  WebpackMerge,
 } from './config';
 import type { RsbuildContext } from './context';
 import type {
@@ -159,7 +160,7 @@ export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
-  mergeConfig: typeof import('webpack-merge').merge;
+  mergeConfig: WebpackMerge;
 };
 
 export type ModifyWebpackChainFn = (

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -159,7 +159,7 @@ export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
-  mergeConfig: typeof import('../../compiled/webpack-merge/index.js').merge;
+  mergeConfig: typeof import('webpack-merge').merge;
 };
 
 export type ModifyWebpackChainFn = (


### PR DESCRIPTION
## Summary

Bundle `webpack-merge` to reduce `require` calls. This should improve startup performance slightly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
