### PR TITLE
fix: print environment name only when using multi compiler

### DIFF
--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -100,10 +100,10 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     );
   }
 
-  const compiler =
-    rspackConfigs.length === 1
-      ? rspack(rspackConfigs[0])
-      : rspack(rspackConfigs);
+  const isMultiCompiler = rspackConfigs.length > 1;
+  const compiler = isMultiCompiler
+    ? rspack(rspackConfigs)
+    : rspack(rspackConfigs[0]);
 
   let isVersionLogged = false;
   let isCompiling = false;
@@ -142,7 +142,9 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
       if (c.time) {
         const time = prettyTime(c.time / 1000);
         const { name } = rspackConfigs[index];
-        const suffix = name ? color.gray(` (${name})`) : '';
+
+        // When using multi compiler, print name to distinguish different compilers
+        const suffix = name && isMultiCompiler ? color.gray(` (${name})`) : '';
         logger.ready(`built in ${time}${suffix}`);
       }
     };
@@ -151,7 +153,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
     if (!hasErrors) {
       // only print children compiler time when multi compiler
-      if (rspackConfigs.length > 1 && statsJson.children?.length) {
+      if (isMultiCompiler && statsJson.children?.length) {
         statsJson.children.forEach((c, index) => {
           printTime(c, index);
         });


### PR DESCRIPTION
## Summary

Print environment name only when using multi compiler. This can keep the logs clean if there is only one environment.

<img width="496" alt="Screenshot 2025-03-11 at 11 59 05" src="https://github.com/user-attachments/assets/11588bd7-ae81-4c4c-947c-7e6595e8b4e1" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
