### PR TITLE
docs: add dynamic asset prefix guide

### DIFF
--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -122,3 +122,9 @@ The differences from the native configuration are as follows:
 - `dev.assetPrefix` default value is the same as [server.base](/config/server/base).
 - `dev.assetPrefix` automatically appends a trailing `/` by default.
 - The value of `dev.assetPrefix` is written to the [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) environment variable (can only be accessed in client code).
+
+## Dynamic asset prefix
+
+Use the `__webpack_public_path__` variable provided by Rspack to dynamically set the URL prefix of static assets in JavaScript code.
+
+See [Rspack - Dynamically set publicPath](https://rspack.dev/config/output#dynamically-set-publicpath).

--- a/website/docs/en/config/output/asset-prefix.mdx
+++ b/website/docs/en/config/output/asset-prefix.mdx
@@ -89,3 +89,9 @@ The differences from the native configuration are as follows:
 - `output.assetPrefix` default value is the same as [server.base](/config/server/base).
 - `output.assetPrefix` automatically appends a trailing `/` by default.
 - The value of `output.assetPrefix` is written to the [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) environment variable (can only be accessed in client code).
+
+## Dynamic asset prefix
+
+Use the `__webpack_public_path__` variable provided by Rspack to dynamically set the URL prefix of static assets in JavaScript code.
+
+See [Rspack - Dynamically set publicPath](https://rspack.dev/config/output#dynamically-set-publicpath).

--- a/website/docs/zh/config/dev/asset-prefix.mdx
+++ b/website/docs/zh/config/dev/asset-prefix.mdx
@@ -122,3 +122,9 @@ assetPrefix 可以设置为以下类型的路径：
 - `dev.assetPrefix` 默认值与 [server.base](/config/server/base) 相同。
 - `dev.assetPrefix` 默认会自动补全尾部的 `/`。
 - `dev.assetPrefix` 的值会写入 [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) 环境变量（只能在 client 代码中访问）。
+
+## 动态 asset prefix
+
+使用 Rspack 提供的 `__webpack_public_path__` 变量，可以在 JavaScript 代码中动态设置静态资源 URL 的前缀。
+
+详见 [Rspack - 动态设置 publicPath](https://rspack.dev/zh/config/output#%E5%8A%A8%E6%80%81%E8%AE%BE%E7%BD%AE-publicpath)。

--- a/website/docs/zh/config/output/asset-prefix.mdx
+++ b/website/docs/zh/config/output/asset-prefix.mdx
@@ -89,3 +89,9 @@ assetPrefix 可以设置为以下类型的路径：
 - `output.assetPrefix` 默认值与 [server.base](/config/server/base) 相同。
 - `output.assetPrefix` 默认会自动补全尾部的 `/`。
 - `output.assetPrefix` 的值会写入 [process.env.ASSET_PREFIX](/guide/advanced/env-vars#processenvasset_prefix) 环境变量（只能在 client 代码中访问）。
+
+## 动态 asset prefix
+
+使用 Rspack 提供的 `__webpack_public_path__` 变量，可以在 JavaScript 代码中动态设置静态资源 URL 的前缀。
+
+详见 [Rspack - 动态设置 publicPath](https://rspack.dev/zh/config/output#%E5%8A%A8%E6%80%81%E8%AE%BE%E7%BD%AE-publicpath)。


### PR DESCRIPTION
## Summary

Add dynamic asset prefix guide to documentation.

## Related Links

https://github.com/web-infra-dev/rspack/pull/9629

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
