### PR TITLE
chore(server): remove useless runInNewContext option

### DIFF
--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -35,7 +35,6 @@ const getSubPath = (p: string) => {
 export interface IBasicRunnerOptions {
   name: string;
   isBundleOutput: (modulePath: string) => boolean;
-  runInNewContext?: boolean;
   readFileSync: (path: string) => string;
   dist: string;
   compilerOptions: CompilerOptions;

--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -119,8 +119,10 @@ export class CommonJsRunner extends BasicRunner {
         'specifier',
         'return import(specifier)',
       );
+      // Runs the compiled code contained by the `vm.Script` within the context of the current `global` object.
       const fn = vm.runInThisContext(code, {
         filename: file.path,
+        // Specify how the modules should be loaded during the evaluation of this script when `import()` is called.
         importModuleDynamically: async (specifier) => {
           const result = await dynamicImport(specifier);
           return result;

--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -119,21 +119,13 @@ export class CommonJsRunner extends BasicRunner {
         'specifier',
         'return import(specifier)',
       );
-      const fn = this._options.runInNewContext
-        ? vm.runInNewContext(code, this.globalContext!, {
-            filename: file.path,
-            importModuleDynamically: async (specifier) => {
-              const result = await dynamicImport(specifier);
-              return result;
-            },
-          })
-        : vm.runInThisContext(code, {
-            filename: file.path,
-            importModuleDynamically: async (specifier) => {
-              const result = await dynamicImport(specifier);
-              return result;
-            },
-          });
+      const fn = vm.runInThisContext(code, {
+        filename: file.path,
+        importModuleDynamically: async (specifier) => {
+          const result = await dynamicImport(specifier);
+          return result;
+        },
+      });
 
       fn.call(m.exports, ...argValues);
 


### PR DESCRIPTION
## Summary

remove useless `runInNewContext` option in server runner.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
