### PR TITLE
chore(deps): update Rspress to 2.0.0-alpha.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1143,12 +1143,15 @@ importers:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@rsbuild/plugin-sass':
+        specifier: workspace:*
+        version: link:../packages/plugin-sass
       '@rspress/plugin-client-redirects':
-        specifier: ^2.0.0-alpha.0
-        version: 2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)
+        specifier: ^2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@rspress/runtime@2.0.0-alpha.2)
       '@rspress/plugin-rss':
-        specifier: ^2.0.0-alpha.0
-        version: 2.0.0-alpha.0(react@19.0.0)(rspress@2.0.0-alpha.0(webpack@5.98.0))
+        specifier: ^2.0.0-alpha.2
+        version: 2.0.0-alpha.2(react@19.0.0)(rspress@2.0.0-alpha.2(webpack@5.98.0))
       '@rstack-dev/doc-ui':
         specifier: 1.7.2
         version: 1.7.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1177,8 +1180,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
       rspress:
-        specifier: ^2.0.0-alpha.0
-        version: 2.0.0-alpha.0(webpack@5.98.0)
+        specifier: ^2.0.0-alpha.2
+        version: 2.0.0-alpha.2(webpack@5.98.0)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2202,6 +2205,11 @@ packages:
     engines: {node: '>=16.7.0'}
     hasBin: true
 
+  '@rsbuild/core@1.2.16':
+    resolution: {integrity: sha512-LxiZUTKhg3ZHFIeZkDmrOG8pWn/lny4vx0AqtSxovWPDnFHgYeuL45rAGDfkrx4TuGwwDN3qJgbetPRSYA8cWw==}
+    engines: {node: '>=16.7.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.4':
     resolution: {integrity: sha512-ZYbyC3zNYluTWTJDVrAW3eRJfvSTIQlp/bs20iY/MATm8/rRq2xtlAP5keCYxpx5CJZX7IT7i6f4z24/YrJJwA==}
     peerDependencies:
@@ -2223,11 +2231,6 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  '@rsbuild/plugin-less@1.1.1':
-    resolution: {integrity: sha512-Gkp73c9p4CQs2dB4BVCmw/cJ6JpIaWbsKcmZqyr+tlsKqZvZn9aYU+Zx4qWSqPR8I5zatiV2Lh15ObL9CCnlXw==}
-    peerDependencies:
-      '@rsbuild/core': 1.x
-
   '@rsbuild/plugin-react@1.1.1':
     resolution: {integrity: sha512-gkATKrOQauXMMtrYA5jbTQkhmYTE0VXoknPLtVpiXtwDbBUwgX23LFf1XJ51YOwqYpP7g5SfPEMgD2FENtCq0A==}
     peerDependencies:
@@ -2240,11 +2243,6 @@ packages:
     peerDependenciesMeta:
       '@rsbuild/core':
         optional: true
-
-  '@rsbuild/plugin-sass@1.2.2':
-    resolution: {integrity: sha512-vznLfxxPXDyFSPYW7JWTYf/6SJMx5DEgKParNd5lXo7FRa1IKsQOrJdf6F3Rm+T7jKoAvnCVXjM2IkxBW2yJSA==}
-    peerDependencies:
-      '@rsbuild/core': 1.x
 
   '@rsbuild/plugin-type-check@1.2.1':
     resolution: {integrity: sha512-PtbjeMqDQy8IiPDTuaj8ZmvR42b0AsRq6RUF6wxa8dDsOzD0Dl1GcvemVGCto+/Dh8frLUmnlWF+T8riBw5rtA==}
@@ -2442,8 +2440,8 @@ packages:
       react-refresh:
         optional: true
 
-  '@rspress/core@2.0.0-alpha.0':
-    resolution: {integrity: sha512-x/v5laQJw3mjiyAGgJjyRfgpGab4hX1+DpGcxL5JIFwSbBt3oN/RENJJrnaZcL15lFnNFgck/8cb3hVFZ/F5Cg==}
+  '@rspress/core@2.0.0-alpha.2':
+    resolution: {integrity: sha512-qwWi4oly7y0mN95nx5AtmIxkOxC5JDUexyTEYdY6PpDnld0dvzRHhXBmx1psSF91gudRyHrYKQWr34LbGoqDqA==}
     engines: {node: '>=14.17.6'}
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
@@ -2498,46 +2496,46 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.0':
-    resolution: {integrity: sha512-PdBFXHXC//hhUHgRmo2doFK6jQT3FZGyokxvrJeTA1M2LcMroI61sG2WbN/x0WIHxYlzw9hFtE5yFTmCqFP8rw==}
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.2':
+    resolution: {integrity: sha512-XI5V3gw0q15V0MU2yAF/AnM1IXroHeSyf2866KZBiPqrRtF4D8fGiygFAWPInMFqh+n51D7t1msBzi+/lyrbbA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/plugin-client-redirects@2.0.0-alpha.0':
-    resolution: {integrity: sha512-PIb3gx39J4nr+7CCwpl85NdwiQ1prWT+7POQbfDROQ8nHLhnBpFuIdjLlpsrji3JWk76ZDp9rW0bYdf1eUy0WQ==}
-    engines: {node: '>=14.17.6'}
-    peerDependencies:
-      '@rspress/runtime': ^2.0.0-alpha.0
-
-  '@rspress/plugin-container-syntax@2.0.0-alpha.0':
-    resolution: {integrity: sha512-42cTxgwTEMbrY9XX34UhC0bxB78YxPZEBMV2A8TKIWHL/ZR/5txlWxH0RUTn+jVqFR8+eofy1CKQAtVSmjSOeQ==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-last-updated@2.0.0-alpha.0':
-    resolution: {integrity: sha512-sEuID+U7w6NxivNWX+Vw4a9foge+TAN2IwW/jI31eF921tuOFrhcISsGMTc6/exvw54v0dhc2p0mc86zqmo0rA==}
-    engines: {node: '>=14.17.6'}
-
-  '@rspress/plugin-medium-zoom@2.0.0-alpha.0':
-    resolution: {integrity: sha512-tcEz6meI3o3VXvoO6RE4KlxQ0UvK0MZsjxtYfOh2qsqSrMqB6HZopXKQk4VqPP4v8b/OLgnK2jArB+wdBeYz8Q==}
+  '@rspress/plugin-client-redirects@2.0.0-alpha.2':
+    resolution: {integrity: sha512-swOtztukz3Q0F5lN6GuZXymg4vylmgCGpKmOLsVn8ISAzrJK+XMU8vgQMJlaXyDmVZnFaLU6XuqdODlS6L+RRQ==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
-      '@rspress/runtime': ^2.0.0-alpha.0
+      '@rspress/runtime': ^2.0.0-alpha.2
 
-  '@rspress/plugin-rss@2.0.0-alpha.0':
-    resolution: {integrity: sha512-VlTGHnq4ecLVVAtc0RO2v0C0JW6btIfiP1hIjExACwSESfcTfgGcee9nVhfZy/0/1TMDfvaYF0JZWEX6ftVVOw==}
+  '@rspress/plugin-container-syntax@2.0.0-alpha.2':
+    resolution: {integrity: sha512-hbtjGIH0TjKxgJXDoH7lsn4BTspgPXlSd5z+lCOh7q00ZrOq9DaY8w8G2D/naNg4miQDKkm2gBXsVq4UhA9tUg==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-last-updated@2.0.0-alpha.2':
+    resolution: {integrity: sha512-I/mJt2cy7oUdA72dwfmsjp7C+tLndFH5kognirzpV2L9Je+aPllFMDURxvdtSd42LMNE33T3V/ytru9HC5fuuQ==}
+    engines: {node: '>=14.17.6'}
+
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.2':
+    resolution: {integrity: sha512-n+PCey+dzxT7Le6tM9IgM0gFCQvz27mYDp6+YxbVJpVaYpBd1wVrmW9f9Zg6LBU+ojaR6NSP9TL0nyK+3AWHvQ==}
+    engines: {node: '>=14.17.6'}
+    peerDependencies:
+      '@rspress/runtime': ^2.0.0-alpha.2
+
+  '@rspress/plugin-rss@2.0.0-alpha.2':
+    resolution: {integrity: sha512-0SYV+iusi+q8WllZ8MIBtXf10EWgtFLZqTd64aTf0T3Fx41app5iXu7q8tHErKc+d7yOyxpa7RvIGQ3duaRwQg==}
     engines: {node: '>=14.17.6'}
     peerDependencies:
       react: '>=17.0.0'
-      rspress: ^2.0.0-alpha.0
+      rspress: ^2.0.0-alpha.2
 
-  '@rspress/runtime@2.0.0-alpha.0':
-    resolution: {integrity: sha512-fMxDd7xIYHVBHBfAEeCcVIHLcMRduyHvvd5ivWgGLIL+WxF6TxfIsx8T0GwnI5L3JF5O15F+X7Ir7a7VKXEezg==}
+  '@rspress/runtime@2.0.0-alpha.2':
+    resolution: {integrity: sha512-QxR0IgwOUF4O2tNhT+9yir/5lUvOnGSnP63N90tKxAX8SPb8UTwK43MPtaBlGMGzTnW+SzRj4XeiX5jTTaYtfA==}
     engines: {node: '>=14.17.6'}
 
-  '@rspress/shared@2.0.0-alpha.0':
-    resolution: {integrity: sha512-+M5MqExmdsQ3T/JE254FudPioapxZf0gQKw7UJdAmw5jBno3IlxISHFmfY9oLXxJKKjHwvr2gcZcfr8JegEfCA==}
+  '@rspress/shared@2.0.0-alpha.2':
+    resolution: {integrity: sha512-mHbiWdB5zN4dyy3fmIVw19N7t93ptNk9UdhANuBphh0yvlbhyJmhawioAGWGsMFWl6EZ4QTVKt0TuJuvcWOUgQ==}
 
-  '@rspress/theme-default@2.0.0-alpha.0':
-    resolution: {integrity: sha512-0e3x4COOVKLpAYeI/Uy8/VrD2iaogf7EOndyxIjBSU6+4ZOvRnJndHMT8Yh+LMmijy5VLGSqhUopYBh4h7ewsg==}
+  '@rspress/theme-default@2.0.0-alpha.2':
+    resolution: {integrity: sha512-JR1CpJ6Qufe1JQy03Bb7rBZiu+NogkyQMRJqbyzhwc1EX9Y9GtcY5Bf/Tog5iR4A8LuVznyNQ5ZnkJZ7UZ/hdg==}
     engines: {node: '>=14.17.6'}
 
   '@rstack-dev/doc-ui@1.7.2':
@@ -5677,8 +5675,8 @@ packages:
   rspress-plugin-sitemap@1.1.1:
     resolution: {integrity: sha512-usb6zWoi5wFFmBeA9HKR6BhsnnsItudMBarc54GYpuRL55SWkLxyWyMijv14mUI04FI7J7lEmea08uZE0bVKxg==}
 
-  rspress@2.0.0-alpha.0:
-    resolution: {integrity: sha512-O3KacOnl6XO/4MXFoDJs7KBDCI90q+kiwNKzgipVY+adC6XcsQXTw+iLBhSQ4Nr7C7geRh83MrRdNU3mrlZXNQ==}
+  rspress@2.0.0-alpha.2:
+    resolution: {integrity: sha512-Ds/bQC/7YZTrSyLafnm8RIgT2EyjaDjuHOJk/wTc5TTczqnEXThu2NcDmorcLYrKEBQLTM0De1LlnXtBrBeCDA==}
     hasBin: true
 
   run-parallel@1.2.0:
@@ -7768,6 +7766,16 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
+  '@rsbuild/core@1.2.16':
+    dependencies:
+      '@rspack/core': 1.2.7(@swc/helpers@0.5.15)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.15
+      core-js: 3.41.0
+      jiti: 2.4.2
+    transitivePeerDependencies:
+      - '@rspack/tracing'
+
   '@rsbuild/plugin-babel@1.0.4(@rsbuild/core@packages+core)':
     dependencies:
       '@babel/core': 7.26.9
@@ -7802,15 +7810,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-less@1.1.1(@rsbuild/core@1.2.15)':
+  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.16)':
     dependencies:
-      '@rsbuild/core': 1.2.15
-      deepmerge: 4.3.1
-      reduce-configs: 1.1.0
-
-  '@rsbuild/plugin-react@1.1.1(@rsbuild/core@1.2.15)':
-    dependencies:
-      '@rsbuild/core': 1.2.15
+      '@rsbuild/core': 1.2.16
       '@rspack/plugin-react-refresh': 1.0.1(react-refresh@0.16.0)
       react-refresh: 0.16.0
 
@@ -7820,15 +7822,6 @@ snapshots:
       terser: 5.39.0
     optionalDependencies:
       '@rsbuild/core': link:packages/core
-
-  '@rsbuild/plugin-sass@1.2.2(@rsbuild/core@1.2.15)':
-    dependencies:
-      '@rsbuild/core': 1.2.15
-      deepmerge: 4.3.1
-      loader-utils: 2.0.4
-      postcss: 8.5.3
-      reduce-configs: 1.1.0
-      sass-embedded: 1.85.1
 
   '@rsbuild/plugin-type-check@1.2.1(@rsbuild/core@packages+core)(@rspack/core@1.2.8(@swc/helpers@0.5.15))(typescript@5.8.2)':
     dependencies:
@@ -8091,23 +8084,21 @@ snapshots:
     optionalDependencies:
       react-refresh: 0.16.0
 
-  '@rspress/core@2.0.0-alpha.0(webpack@5.98.0)':
+  '@rspress/core@2.0.0-alpha.2(webpack@5.98.0)':
     dependencies:
       '@mdx-js/loader': 2.3.0(webpack@5.98.0)
       '@mdx-js/mdx': 2.3.0
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rsbuild/core': 1.2.15
-      '@rsbuild/plugin-less': 1.1.1(@rsbuild/core@1.2.15)
-      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.15)
-      '@rsbuild/plugin-sass': 1.2.2(@rsbuild/core@1.2.15)
+      '@rsbuild/core': 1.2.16
+      '@rsbuild/plugin-react': 1.1.1(@rsbuild/core@1.2.16)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/plugin-auto-nav-sidebar': 2.0.0-alpha.0
-      '@rspress/plugin-container-syntax': 2.0.0-alpha.0
-      '@rspress/plugin-last-updated': 2.0.0-alpha.0
-      '@rspress/plugin-medium-zoom': 2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)
-      '@rspress/runtime': 2.0.0-alpha.0
-      '@rspress/shared': 2.0.0-alpha.0
-      '@rspress/theme-default': 2.0.0-alpha.0
+      '@rspress/plugin-auto-nav-sidebar': 2.0.0-alpha.2
+      '@rspress/plugin-container-syntax': 2.0.0-alpha.2
+      '@rspress/plugin-last-updated': 2.0.0-alpha.2
+      '@rspress/plugin-medium-zoom': 2.0.0-alpha.2(@rspress/runtime@2.0.0-alpha.2)
+      '@rspress/runtime': 2.0.0-alpha.2
+      '@rspress/shared': 2.0.0-alpha.2
+      '@rspress/theme-default': 2.0.0-alpha.2
       enhanced-resolve: 5.18.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8116,7 +8107,6 @@ snapshots:
       htmr: 1.0.2(react@18.3.1)
       lodash-es: 4.17.21
       mdast-util-mdxjs-esm: 1.3.1
-      memfs: 4.17.0
       picocolors: 1.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -8171,48 +8161,48 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.0':
+  '@rspress/plugin-auto-nav-sidebar@2.0.0-alpha.2':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-client-redirects@2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)':
+  '@rspress/plugin-client-redirects@2.0.0-alpha.2(@rspress/runtime@2.0.0-alpha.2)':
     dependencies:
-      '@rspress/runtime': 2.0.0-alpha.0
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/runtime': 2.0.0-alpha.2
+      '@rspress/shared': 2.0.0-alpha.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-container-syntax@2.0.0-alpha.0':
+  '@rspress/plugin-container-syntax@2.0.0-alpha.2':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-last-updated@2.0.0-alpha.0':
+  '@rspress/plugin-last-updated@2.0.0-alpha.2':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/plugin-medium-zoom@2.0.0-alpha.0(@rspress/runtime@2.0.0-alpha.0)':
+  '@rspress/plugin-medium-zoom@2.0.0-alpha.2(@rspress/runtime@2.0.0-alpha.2)':
     dependencies:
-      '@rspress/runtime': 2.0.0-alpha.0
+      '@rspress/runtime': 2.0.0-alpha.2
       medium-zoom: 1.1.0
 
-  '@rspress/plugin-rss@2.0.0-alpha.0(react@19.0.0)(rspress@2.0.0-alpha.0(webpack@5.98.0))':
+  '@rspress/plugin-rss@2.0.0-alpha.2(react@19.0.0)(rspress@2.0.0-alpha.2(webpack@5.98.0))':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.2
       feed: 4.2.2
       react: 19.0.0
-      rspress: 2.0.0-alpha.0(webpack@5.98.0)
+      rspress: 2.0.0-alpha.2(webpack@5.98.0)
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/runtime@2.0.0-alpha.0':
+  '@rspress/runtime@2.0.0-alpha.2':
     dependencies:
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/shared': 2.0.0-alpha.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8220,20 +8210,20 @@ snapshots:
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/shared@2.0.0-alpha.0':
+  '@rspress/shared@2.0.0-alpha.2':
     dependencies:
-      '@rsbuild/core': 1.2.15
+      '@rsbuild/core': 1.2.16
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 10.1.2
     transitivePeerDependencies:
       - '@rspack/tracing'
 
-  '@rspress/theme-default@2.0.0-alpha.0':
+  '@rspress/theme-default@2.0.0-alpha.2':
     dependencies:
       '@mdx-js/react': 2.3.0(react@18.3.1)
-      '@rspress/runtime': 2.0.0-alpha.0
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rspress/runtime': 2.0.0-alpha.2
+      '@rspress/shared': 2.0.0-alpha.2
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
       flexsearch: 0.7.43
@@ -11793,11 +11783,11 @@ snapshots:
 
   rspress-plugin-sitemap@1.1.1: {}
 
-  rspress@2.0.0-alpha.0(webpack@5.98.0):
+  rspress@2.0.0-alpha.2(webpack@5.98.0):
     dependencies:
-      '@rsbuild/core': 1.2.15
-      '@rspress/core': 2.0.0-alpha.0(webpack@5.98.0)
-      '@rspress/shared': 2.0.0-alpha.0
+      '@rsbuild/core': 1.2.16
+      '@rspress/core': 2.0.0-alpha.2(webpack@5.98.0)
+      '@rspress/shared': 2.0.0-alpha.2
       cac: 6.7.14
       chokidar: 3.6.0
       picocolors: 1.1.1

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,9 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rspress/plugin-client-redirects": "^2.0.0-alpha.0",
-    "@rspress/plugin-rss": "^2.0.0-alpha.0",
+    "@rsbuild/plugin-sass": "workspace:*",
+    "@rspress/plugin-client-redirects": "^2.0.0-alpha.2",
+    "@rspress/plugin-rss": "^2.0.0-alpha.2",
     "@rstack-dev/doc-ui": "1.7.2",
     "@types/node": "^22.13.10",
     "@types/react": "^19.0.10",
@@ -21,7 +22,7 @@
     "react-dom": "^19.0.0",
     "rsbuild-plugin-google-analytics": "^1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",
-    "rspress": "^2.0.0-alpha.0",
+    "rspress": "^2.0.0-alpha.2",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.1.1",
     "typescript": "^5.8.2"

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,3 +1,4 @@
+import { pluginSass } from '@rsbuild/plugin-sass';
 import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import { pluginRss } from '@rspress/plugin-rss';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
@@ -162,6 +163,7 @@ export default defineConfig({
     },
     plugins: [
       rsbuildPluginOverview,
+      pluginSass(),
       pluginGoogleAnalytics({ id: 'G-L6BZ6TKW4R' }),
       pluginOpenGraph({
         title: 'Rsbuild',


### PR DESCRIPTION
## Summary

Update Rspress to 2.0.0-alpha.2.

## Related Links

- https://github.com/web-infra-dev/rspress/releases/tag/v2.0.0-alpha.2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
