### PR TITLE
docs: add Tailwind CSS v4 compatibility tip for preprocessors

### DIFF
--- a/website/docs/en/guide/basic/tailwindcss.mdx
+++ b/website/docs/en/guide/basic/tailwindcss.mdx
@@ -40,6 +40,10 @@ Add an `@import` to your CSS entry file that imports Tailwind CSS.
 @import 'tailwindcss';
 ```
 
+:::tip
+Tailwind CSS v4 cannot be used with CSS preprocessors like Sass, Less, or Stylus. You need to place the `@tailwind` directive at the beginning of your `.css` file, see [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility#sass-less-and-stylus) for more details.
+:::
+
 ## Done
 
 You have now completed all the steps to integrate Tailwind CSS in Rsbuild!

--- a/website/docs/zh/guide/basic/tailwindcss.mdx
+++ b/website/docs/zh/guide/basic/tailwindcss.mdx
@@ -40,6 +40,10 @@ export default {
 @import 'tailwindcss';
 ```
 
+:::tip
+Tailwind CSS v4 不能与 Sass、Less 或 Stylus 等 CSS 预处理器一起使用，你需要将 `@tailwind` 指令放在 `.css` 文件的开头，详见 [Tailwind CSS - Compatibility](https://tailwindcss.com/docs/compatibility#sass-less-and-stylus)。
+:::
+
 ## 完成
 
 你已经完成了在 Rsbuild 中接入 Tailwind CSS 的全部步骤！


### PR DESCRIPTION
## Summary

Add Tailwind CSS v4 compatibility tip for other CSS preprocessors.

## Related Links

https://tailwindcss.com/docs/compatibility#sass-less-and-stylus

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
