### PR TITLE
fix: simplify build error logs

### DIFF
--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -53,7 +53,7 @@ export const build = async (
       if (err) {
         reject(err);
       } else if (stats?.hasErrors()) {
-        reject(new Error('Webpack build failed!'));
+        reject(new Error('webpack build failed.'));
       }
       // If there is a compilation error, the close method should not be called.
       // Otherwise bundler may generate an invalid cache.

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,6 +1,7 @@
 import cac, { type CAC, type Command } from 'cac';
 import type { ConfigLoader } from '../config';
 import { logger } from '../logger';
+import { RSPACK_BUILD_ERROR } from '../provider/build';
 import { onBeforeRestartServer } from '../server/restart';
 import type { RsbuildMode } from '../types';
 import { init } from './init';
@@ -131,7 +132,12 @@ export function setupCommands(): void {
           }
         }
       } catch (err) {
-        logger.error('Failed to build.');
+        const isRspackError =
+          err instanceof Error && err.message === RSPACK_BUILD_ERROR;
+        if (!isRspackError) {
+          logger.error('Failed to build.');
+        }
+
         logger.error(err);
         process.exit(1);
       }

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -5,6 +5,8 @@ import type { Build, BuildOptions, Rspack } from '../types';
 import { createCompiler } from './createCompiler';
 import type { InitConfigsOptions } from './initConfigs';
 
+export const RSPACK_BUILD_ERROR = 'Rspack build failed.';
+
 export const build = async (
   initOptions: InitConfigsOptions,
   { watch, compiler: customCompiler }: BuildOptions = {},
@@ -54,7 +56,7 @@ export const build = async (
       if (err) {
         reject(err);
       } else if (stats?.hasErrors()) {
-        reject(new Error('Rspack build failed!'));
+        reject(new Error(RSPACK_BUILD_ERROR));
       }
       // If there is a compilation error, the close method should not be called.
       // Otherwise the bundler may generate an invalid cache.


### PR DESCRIPTION
## Summary

Outputting two lines of build error logs seems a bit redundant. This PR adds a check to avoid this.

<img width="859" alt="Screenshot 2025-03-13 at 13 32 08" src="https://github.com/user-attachments/assets/3e324821-11b3-4e23-976c-993ae4bb0d43" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
