### PR TITLE
feat(CLI): allow to run without sub-command to trigger dev

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -87,7 +87,8 @@ export function setupCommands(): void {
   // Apply common options to all commands
   applyCommonOptions(cli);
 
-  const devCommand = cli.command('dev', 'starting the dev server');
+  // Allow to run `rsbuild` without any sub-command to trigger dev
+  const devCommand = cli.command('', 'starting the dev server').alias('dev');
   const buildCommand = cli.command('build', 'build the app for production');
   const previewCommand = cli.command(
     'preview',

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -52,6 +52,12 @@ Options:
   --host <host>         specify the host that the Rsbuild server listens to
 ```
 
+You can also start the dev server by running `rsbuild` directly, which is equivalent to running `rsbuild dev`.
+
+```bash
+npx rsbuild
+```
+
 ### Opening page
 
 The `--open` option allows you to automatically open a page when starting the dev server, which is equivalent to setting [server.open](/config/server/open) to `true`.

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -52,6 +52,12 @@ Options:
   --host <host>         指定 Rsbuild server 启动时监听的 host
 ```
 
+你也可以直接运行 `rsbuild` 来启动 dev server，等同于运行 `rsbuild dev`。
+
+```bash
+npx rsbuild
+```
+
 ### 打开页面
 
 通过 `--open` 选项可以在启动 dev server 时自动打开页面，等同于将 [server.open](/config/server/open) 设置为 `true`。


### PR DESCRIPTION
## Summary

Allow to run `rsbuild` without sub-command to trigger dev, this will make it easier to start a development server locally.

```bash
# equivalent to running `rsbuild dev`
npx rsbuild 
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
