### PR TITLE
feat: support async function for rsbuildConfig in createRsbuild options

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -7,7 +7,6 @@ import { initHooks } from './hooks';
 import { getHTMLPathByEntry } from './initPlugins';
 import { logger } from './logger';
 import type {
-  BundlerType,
   EnvironmentContext,
   InternalContext,
   NormalizedConfig,
@@ -183,7 +182,6 @@ export function createPublicContext(
 export async function createContext(
   options: ResolvedCreateRsbuildOptions,
   userConfig: RsbuildConfig,
-  bundlerType: BundlerType,
 ): Promise<InternalContext> {
   const { cwd } = options;
   const rootPath = userConfig.root
@@ -196,6 +194,8 @@ export async function createContext(
     options.environment && options.environment.length > 0
       ? options.environment
       : undefined;
+
+  const bundlerType = userConfig.provider ? 'webpack' : 'rspack';
 
   return {
     version: RSBUILD_VERSION,

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -1,7 +1,14 @@
 import { existsSync } from 'node:fs';
 import { isPromise } from 'node:util/types';
 import { createContext } from './createContext';
-import { color, getNodeEnv, isEmptyDir, pick, setNodeEnv } from './helpers';
+import {
+  color,
+  getNodeEnv,
+  isEmptyDir,
+  isFunction,
+  pick,
+  setNodeEnv,
+} from './helpers';
 import { initPluginAPI } from './initPlugins';
 import { logger } from './logger';
 import { createPluginManager } from './pluginManager';
@@ -113,7 +120,9 @@ async function applyDefaultPlugins(
 export async function createRsbuild(
   options: CreateRsbuildOptions = {},
 ): Promise<RsbuildInstance> {
-  const { rsbuildConfig = {} } = options;
+  const rsbuildConfig = isFunction(options.rsbuildConfig)
+    ? await options.rsbuildConfig()
+    : options.rsbuildConfig || {};
 
   const rsbuildOptions: ResolvedCreateRsbuildOptions = {
     cwd: process.cwd(),
@@ -125,7 +134,7 @@ export async function createRsbuild(
 
   const context = await createContext(
     rsbuildOptions,
-    rsbuildOptions.rsbuildConfig,
+    rsbuildConfig,
     rsbuildConfig.provider ? 'webpack' : 'rspack',
   );
 

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -132,11 +132,7 @@ export async function createRsbuild(
 
   const pluginManager = createPluginManager();
 
-  const context = await createContext(
-    rsbuildOptions,
-    rsbuildConfig,
-    rsbuildConfig.provider ? 'webpack' : 'rspack',
-  );
+  const context = await createContext(rsbuildOptions, rsbuildConfig);
 
   const getPluginAPI = initPluginAPI({ context, pluginManager });
   context.getPluginAPI = getPluginAPI;

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -123,8 +123,9 @@ export type CreateRsbuildOptions = {
   environment?: string[];
   /**
    * Rsbuild configurations.
+   * Passing a function to load the config asynchronously with custom logic.
    */
-  rsbuildConfig?: RsbuildConfig;
+  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
 };
 
 export type ResolvedCreateRsbuildOptions = CreateRsbuildOptions &

--- a/scripts/test-helper/src/index.ts
+++ b/scripts/test-helper/src/index.ts
@@ -41,7 +41,6 @@ export const matchPlugin = (
  * different with rsbuild createRsbuild. support add custom plugins instead of applyDefaultPlugins.
  */
 export async function createStubRsbuild({
-  rsbuildConfig = {},
   plugins,
   ...options
 }: CreateRsbuildOptions & {
@@ -53,10 +52,16 @@ export async function createStubRsbuild({
   }
 > {
   const { createRsbuild } = await import('@rsbuild/core');
+
+  const rsbuildConfig =
+    typeof options.rsbuildConfig === 'function'
+      ? await options.rsbuildConfig()
+      : options.rsbuildConfig || {};
+
   const rsbuildOptions = {
     cwd: process.env.REBUILD_TEST_SUITE_CWD || process.cwd(),
-    rsbuildConfig,
     ...options,
+    rsbuildConfig,
   };
 
   // mock default entry

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -34,13 +34,29 @@ The first parameter of `createRsbuild` is an `options` object, you can pass in t
 type CreateRsbuildOptions = {
   cwd?: string;
   environment?: string[];
-  rsbuildConfig?: RsbuildConfig;
+  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
 };
 ```
 
 - `cwd`: The root path of the current build, defaults to `process.cwd()`.
 - `environment`: Only build specified [environments](/guide/advanced/environments). If not specified or passing an empty array, all environments will be built.
 - `rsbuildConfig`: Rsbuild configuration object. Refer to [Configuration Overview](/config/) for all available configuration options.
+
+### Load configuration async
+
+`rsbuildConfig` can also be an async function, which allows you to dynamically load Rsbuild configuration and perform some custom operations.
+
+```ts
+import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+const rsbuild = await createRsbuild({
+  rsbuildConfig: async () => {
+    const { content } = await loadConfig();
+    someFunctionToUpdateConfig(content);
+    return content;
+  },
+});
+```
 
 ## loadConfig
 

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -34,13 +34,29 @@ const rsbuild = await createRsbuild({
 type CreateRsbuildOptions = {
   cwd?: string;
   environment?: string[];
-  rsbuildConfig?: RsbuildConfig;
+  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
 };
 ```
 
 - `cwd`：当前执行构建的根路径，默认值为 `process.cwd()`
 - `environment`：只构建指定的 [environments](/guide/advanced/environments)，如果未指定或传入空数组，则构建所有环境。
 - `rsbuildConfig`：Rsbuild 配置对象。参考 [配置总览](/config/) 查看所有可用的配置项。
+
+### 异步加载配置
+
+`rsbuildConfig` 也可以是一个异步函数，你可以通过该函数来动态加载 Rsbuild 配置，并进行一些自定义操作。
+
+```ts
+import { createRsbuild, loadConfig } from '@rsbuild/core';
+
+const rsbuild = await createRsbuild({
+  rsbuildConfig: async () => {
+    const { content } = await loadConfig();
+    someFunctionToUpdateConfig(content);
+    return content;
+  },
+});
+```
 
 ## loadConfig
 


### PR DESCRIPTION
## Summary

This is one of the prerequisites for implementing the `server.restart` method.

To allow the `loadConfig` method to be called again when restarting the server, we need to allow `createRsbuild` to call `loadConfig`. Therefore, this PR supports `creatingRsbuild`'s `rsbuildOptions` to pass in an async function to dynamically load the configuration.


```ts
import { createRsbuild, loadConfig } from '@rsbuild/core';

const rsbuild = await createRsbuild({
  rsbuildConfig: async () => {
    const { content } = await loadConfig();
    someFunctionToUpdateConfig(content);
    return content;
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
