### PR TITLE
feat: integrate env variable loading into createRsbuild options

### DIFF
--- a/e2e/cases/javascript-api/build-and-load-env/.env
+++ b/e2e/cases/javascript-api/build-and-load-env/.env
@@ -1,0 +1,1 @@
+PUBLIC_FOO=foo

--- a/e2e/cases/javascript-api/build-and-load-env/.env.prod
+++ b/e2e/cases/javascript-api/build-and-load-env/.env.prod
@@ -1,1 +1,1 @@
-PUBLIC_FOO=bar
+PUBLIC_BAR=bar

--- a/e2e/cases/javascript-api/build-and-load-env/.env.prod
+++ b/e2e/cases/javascript-api/build-and-load-env/.env.prod
@@ -1,0 +1,1 @@
+PUBLIC_FOO=bar

--- a/e2e/cases/javascript-api/build-and-load-env/index.test.ts
+++ b/e2e/cases/javascript-api/build-and-load-env/index.test.ts
@@ -1,0 +1,20 @@
+import { expect } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+import { rspackOnlyTest } from 'scripts';
+
+rspackOnlyTest(
+  'should allow to call `build` with `loadEnv` option',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      loadEnv: {
+        mode: 'prod',
+      },
+    });
+
+    expect(process.env.PUBLIC_FOO).toBe('bar');
+    const { close } = await rsbuild.build();
+    await close();
+    expect(process.env.PUBLIC_FOO).toBe(undefined);
+  },
+);

--- a/e2e/cases/javascript-api/build-and-load-env/index.test.ts
+++ b/e2e/cases/javascript-api/build-and-load-env/index.test.ts
@@ -2,19 +2,45 @@ import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
 import { rspackOnlyTest } from 'scripts';
 
+rspackOnlyTest('should not load env by default', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+    loadEnv: false,
+    rsbuildConfig: {
+      performance: {
+        printFileSize: false,
+      },
+    },
+  });
+
+  expect(process.env.PUBLIC_FOO).toBe(undefined);
+  expect(process.env.PUBLIC_BAR).toBe(undefined);
+  const { close } = await rsbuild.build();
+  await close();
+});
+
 rspackOnlyTest(
-  'should allow to call `build` with `loadEnv` option',
+  'should allow to call `build` with `loadEnv` options',
   async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
       loadEnv: {
         mode: 'prod',
       },
+      rsbuildConfig: {
+        performance: {
+          printFileSize: false,
+        },
+      },
     });
 
-    expect(process.env.PUBLIC_FOO).toBe('bar');
+    expect(process.env.PUBLIC_FOO).toBe('foo');
+    expect(process.env.PUBLIC_BAR).toBe('bar');
+
     const { close } = await rsbuild.build();
     await close();
+
     expect(process.env.PUBLIC_FOO).toBe(undefined);
+    expect(process.env.PUBLIC_BAR).toBe(undefined);
   },
 );

--- a/e2e/cases/javascript-api/build-and-load-env/src/index.js
+++ b/e2e/cases/javascript-api/build-and-load-env/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -133,9 +133,8 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
     return;
   }
 
-  config.dev ||= {};
-
   // watch the env files
+  config.dev ||= {};
   config.dev.watchFiles = [
     ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
     {

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -165,7 +165,10 @@ export async function createRsbuild(
   options: CreateRsbuildOptions = {},
 ): Promise<RsbuildInstance> {
   const envs = options.loadEnv
-    ? loadEnv(typeof options.loadEnv === 'boolean' ? {} : options.loadEnv)
+    ? loadEnv({
+        cwd: options.cwd,
+        ...(typeof options.loadEnv === 'boolean' ? {} : options.loadEnv),
+      })
     : null;
 
   const config = isFunction(options.rsbuildConfig)

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { isPromise } from 'node:util/types';
 import { createContext } from './createContext';
 import {
+  castArray,
   color,
   getNodeEnv,
   isEmptyDir,
@@ -10,6 +11,7 @@ import {
   setNodeEnv,
 } from './helpers';
 import { initPluginAPI } from './initPlugins';
+import { type LoadEnvResult, loadEnv } from './loadEnv';
 import { logger } from './logger';
 import { createPluginManager } from './pluginManager';
 import { pluginAppIcon } from './plugins/appIcon';
@@ -59,6 +61,7 @@ import type {
   PluginManager,
   PreviewOptions,
   ResolvedCreateRsbuildOptions,
+  RsbuildConfig,
   RsbuildInstance,
   RsbuildPlugin,
   RsbuildPlugins,
@@ -114,25 +117,69 @@ async function applyDefaultPlugins(
   ]);
 }
 
+function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
+  if (envs === null) {
+    return;
+  }
+
+  config.dev ||= {};
+  config.source ||= {};
+
+  // define the public env variables
+  config.source.define = {
+    ...envs.publicVars,
+    ...config.source.define,
+  };
+
+  // watch the env files
+  config.dev.watchFiles = [
+    ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
+    {
+      paths: envs.filePaths,
+      type: 'reload-server',
+    },
+  ];
+
+  // add env files to build dependencies, so that the build cache
+  // can be invalidated when the env files are changed.
+  if (config.performance?.buildCache && envs.filePaths.length > 0) {
+    const { buildCache } = config.performance;
+    if (buildCache === true) {
+      config.performance.buildCache = {
+        buildDependencies: envs.filePaths,
+      };
+    } else {
+      buildCache.buildDependencies ||= [];
+      buildCache.buildDependencies.push(...envs.filePaths);
+    }
+  }
+}
+
 /**
  * Create an Rsbuild instance.
  */
 export async function createRsbuild(
   options: CreateRsbuildOptions = {},
 ): Promise<RsbuildInstance> {
-  const rsbuildConfig = isFunction(options.rsbuildConfig)
+  const envs = options.loadEnv
+    ? loadEnv(typeof options.loadEnv === 'boolean' ? {} : options.loadEnv)
+    : null;
+
+  const config = isFunction(options.rsbuildConfig)
     ? await options.rsbuildConfig()
     : options.rsbuildConfig || {};
+
+  applyEnvsToConfig(config, envs);
 
   const resolvedOptions: ResolvedCreateRsbuildOptions = {
     cwd: process.cwd(),
     ...options,
-    rsbuildConfig,
+    rsbuildConfig: config,
   };
 
   const pluginManager = createPluginManager();
 
-  const context = await createContext(resolvedOptions, rsbuildConfig);
+  const context = await createContext(resolvedOptions, config);
 
   const getPluginAPI = initPluginAPI({ context, pluginManager });
   context.getPluginAPI = getPluginAPI;
@@ -142,8 +189,7 @@ export async function createRsbuild(
   await applyDefaultPlugins(pluginManager, context);
   logger.debug('add default plugins done');
 
-  const provider =
-    (rsbuildConfig.provider as RsbuildProvider) || rspackProvider;
+  const provider = (config.provider as RsbuildProvider) || rspackProvider;
 
   const providerInstance = await provider({
     context,
@@ -260,6 +306,11 @@ export async function createRsbuild(
     ...pick(providerInstance, ['initConfigs', 'inspectConfig']),
   };
 
+  if (envs) {
+    rsbuild.onCloseBuild(envs.cleanup);
+    rsbuild.onCloseDevServer(envs.cleanup);
+  }
+
   const getFlattenedPlugins = async (pluginOptions: RsbuildPlugins) => {
     let plugins = pluginOptions;
     do {
@@ -271,32 +322,34 @@ export async function createRsbuild(
     return plugins as Array<RsbuildPlugin | Falsy>;
   };
 
-  if (rsbuildConfig.plugins) {
-    const plugins = await getFlattenedPlugins(rsbuildConfig.plugins);
+  if (config.plugins) {
+    const plugins = await getFlattenedPlugins(config.plugins);
     rsbuild.addPlugins(plugins);
   }
 
   // Register environment plugin
-  if (rsbuildConfig.environments) {
+  if (config.environments) {
     await Promise.all(
-      Object.entries(rsbuildConfig.environments).map(async ([name, config]) => {
-        if (!config.plugins) {
-          return;
-        }
+      Object.entries(config.environments).map(
+        async ([name, environmentConfig]) => {
+          if (!environmentConfig.plugins) {
+            return;
+          }
 
-        // If the current environment is not specified, skip it
-        if (
-          context.specifiedEnvironments &&
-          !context.specifiedEnvironments.includes(name)
-        ) {
-          return;
-        }
+          // If the current environment is not specified, skip it
+          if (
+            context.specifiedEnvironments &&
+            !context.specifiedEnvironments.includes(name)
+          ) {
+            return;
+          }
 
-        const plugins = await getFlattenedPlugins(config.plugins);
-        rsbuild.addPlugins(plugins, {
-          environment: name,
-        });
-      }),
+          const plugins = await getFlattenedPlugins(environmentConfig.plugins);
+          rsbuild.addPlugins(plugins, {
+            environment: name,
+          });
+        },
+      ),
     );
   }
 

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -122,14 +122,18 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
     return;
   }
 
-  config.dev ||= {};
-  config.source ||= {};
-
   // define the public env variables
+  config.source ||= {};
   config.source.define = {
     ...envs.publicVars,
     ...config.source.define,
   };
+
+  if (envs.filePaths.length === 0) {
+    return;
+  }
+
+  config.dev ||= {};
 
   // watch the env files
   config.dev.watchFiles = [
@@ -142,7 +146,7 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
 
   // add env files to build dependencies, so that the build cache
   // can be invalidated when the env files are changed.
-  if (config.performance?.buildCache && envs.filePaths.length > 0) {
+  if (config.performance?.buildCache) {
     const { buildCache } = config.performance;
     if (buildCache === true) {
       config.performance.buildCache = {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -1,4 +1,5 @@
 import type { Compiler, MultiCompiler } from '@rspack/core';
+import type { LoadEnvOptions } from '../loadEnv';
 import type * as providerHelpers from '../provider/helpers';
 import type { RsbuildDevServer } from '../server/devServer';
 import type { StartServerResult } from '../server/helper';
@@ -126,14 +127,20 @@ export type CreateRsbuildOptions = {
    * Passing a function to load the config asynchronously with custom logic.
    */
   rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  /**
+   * Whether to call `loadEnv` to load environment variables and define them
+   * as global variables.
+   * @default false
+   */
+  loadEnv?: boolean | LoadEnvOptions;
 };
 
 export type ResolvedCreateRsbuildOptions = Required<
-  Omit<CreateRsbuildOptions, 'environment' | 'rsbuildConfig'>
-> & {
-  rsbuildConfig: RsbuildConfig;
-  environment?: CreateRsbuildOptions['environment'];
-};
+  Pick<CreateRsbuildOptions, 'cwd'>
+> &
+  Pick<CreateRsbuildOptions, 'loadEnv' | 'environment'> & {
+    rsbuildConfig: RsbuildConfig;
+  };
 
 export type CreateDevServer = (
   options?: CreateDevServerOptions,


### PR DESCRIPTION
## Summary

Although Rsbuild's JavaScript API already provides the `loadEnv` method, combining `loadEnv` with `createRsbuild` is still somewhat cumbersome.

This PR introduces a new `loadEnv` option for `createRsbuild` to simplify the logic of env loading.

```js
const rsbuild = createRsbuild({ loadEnv: true });
```

This is equivalent to:

```js
const envs = loadEnv();

const config = {
  // some options
};

config.source.define = {
  ...envs.publicVars,
  ...config.source.define,
};

// watch the env files
config.dev.watchFiles = [
  ...(config.dev.watchFiles ? castArray(config.dev.watchFiles) : []),
  {
    paths: envs.filePaths,
    type: 'reload-server',
  },
];

// add env files to build dependencies, so that the build cache
// can be invalidated when the env files are changed.
if (config.performance?.buildCache && envs.filePaths.length > 0) {
  const { buildCache } = config.performance;
  if (buildCache === true) {
    config.performance.buildCache = {
      buildDependencies: envs.filePaths,
    };
  } else {
    buildCache.buildDependencies ||= [];
    buildCache.buildDependencies.push(...envs.filePaths);
  }
}

const rsbuild = createRsbuild({
  rsbuildConfig: config,
});

rsbuild.onCloseBuild(envs.cleanup);
rsbuild.onCloseDevServer(envs.cleanup);
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
