### PR TITLE
fix: handle null stats JSON in Socket server

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -240,6 +240,11 @@ export class SocketServer {
     const statsOptions = getStatsOptions(curStats.compilation.compiler);
     const statsJson = curStats.toJson({ ...defaultStats, ...statsOptions });
 
+    // statsJson is null when the previous compilation is removed on the Rust side
+    if (!statsJson) {
+      return null;
+    }
+
     return {
       statsJson,
       root: curStats.compilation.compiler.options.context,


### PR DESCRIPTION
## Summary

Handle null stats JSON in Socket server.

If the previous compilation is removed on the Rust side, `stats.toJson` gets a `null` instead of an object.

```bash
Failed to get stats due to error: Unable to access compilation with id = CompilationId(1) now. The compilation have been removed on the Rust side. The latest compilation id is CompilationId(4), are you trying to access the stats from the previous compilation?
file:///user/app/node_modules/.pnpm/@rsbuild+core@1.2.18/node_modules/@rsbuild/core/dist/index.js:5275
        if (statsJson.entrypoints) for (let entrypoint of Object.values(statsJson.entrypoints)){
                      ^

TypeError: Cannot read properties of null (reading 'entrypoints')
    at SocketServer.sendStats 
```

## Related Links

https://discord.com/channels/977448667919286283/1167025132905173063/1349740225999405218

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
