### PR TITLE
docs: update examples for server close method

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -32,9 +32,19 @@ export type UpgradeEvent = (
 ) => void;
 
 export type StartServerResult = {
+  /**
+   * The URLs that server is listening on.
+   */
   urls: string[];
+  /**
+   * The actual port used by the server.
+   */
   port: number;
   server: {
+    /**
+     * Close the server.
+     * In development mode, this will call the `onCloseDevServer` hook.
+     */
     close: () => Promise<void>;
   };
 };

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -225,9 +225,21 @@ type StartDevServerOptions = {
 };
 
 type StartServerResult = {
+  /**
+   * The URLs that server is listening on.
+   */
   urls: string[];
+  /**
+   * The actual port used by the server.
+   */
   port: number;
-  server: Server;
+  server: {
+    /**
+     * Close the server.
+     * In development mode, this will call the `onCloseDevServer` hook.
+     */
+    close: () => Promise<void>;
+  };
 };
 
 function StartDevServer(
@@ -269,12 +281,28 @@ After successfully starting dev server, you can see the following logs:
 - `server`: Server instance object.
 
 ```ts
-const { urls, port, server } = await rsbuild.startDevServer();
+const { urls, port } = await rsbuild.startDevServer();
 console.log(urls); // ['http://localhost:3000', 'http://192.168.0.1:3000']
 console.log(port); // 3000
+```
 
-// Close the dev server
+### Close server
+
+Calling the `close()` method will close the dev server and trigger the [onCloseDevServer](/plugins/dev/hooks#onclosedevserver) hook to perform cleanup operations.
+
+```ts
+const { server } = await rsbuild.startDevServer();
 await server.close();
+```
+
+### Get port silently
+
+In some cases, the default startup port number is already occupied. In this situation, Rsbuild will automatically increment the port number until it finds an available one. This process will output a prompt log. If you do not want this log, you can set `getPortSilently` to `true`.
+
+```ts
+await rsbuild.startDevServer({
+  getPortSilently: true,
+});
 ```
 
 ### Custom compiler
@@ -289,16 +317,6 @@ const compiler = rspack({
 });
 await rsbuild.startDevServer({
   compiler,
-});
-```
-
-### Get port silently
-
-In some cases, the default startup port number is already occupied. In this situation, Rsbuild will automatically increment the port number until it finds an available one. This process will output a prompt log. If you do not want this log, you can set `getPortSilently` to `true`.
-
-```ts
-await rsbuild.startDevServer({
-  getPortSilently: true,
 });
 ```
 
@@ -335,9 +353,18 @@ type PreviewOptions = {
 };
 
 type StartServerResult = {
+  /**
+   * The URLs that server is listening on.
+   */
   urls: string[];
+  /**
+   * The actual port used by the server.
+   */
   port: number;
   server: {
+    /**
+     * Close the server.
+     */
     close: () => Promise<void>;
   };
 };
@@ -372,11 +399,17 @@ try {
 - `server`: Server instance object.
 
 ```ts
-const { urls, port, server } = await rsbuild.preview();
+const { urls, port } = await rsbuild.preview();
 console.log(urls); // ['http://localhost:3000', 'http://192.168.0.1:3000']
 console.log(port); // 3000
+```
 
-// Close the server
+### Close server
+
+Calling the `close()` method will close the preview server.
+
+```ts
+const { server } = await rsbuild.preview();
 await server.close();
 ```
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@ Called only when running the `rsbuild dev` command or the `rsbuild.startDevServe
 - [onAfterStartDevServer](#onafterstartdevserver): Called after starting the dev server.
 - [onDevCompileDone](#ondevcompiledone): Called after each build in development mode.
 
-Called only when Rsbuild is restarted or when the `close()` method of `rsbuild.startDevServer()` is executed.
+Called only when Rsbuild is restarted or when the [close()](/api/javascript-api/instance#close-server) method of `rsbuild.startDevServer()` is executed.
 
 - [onCloseDevServer](#onclosedevserver): Called when the dev server is closed.
 

--- a/website/docs/en/shared/onCloseDevServer.mdx
+++ b/website/docs/en/shared/onCloseDevServer.mdx
@@ -1,5 +1,7 @@
 Called when closing the dev server. Can be used to perform cleanup operations when the dev server is closed.
 
+Rsbuild CLI will automatically call this hook at the appropriate time, while users of the JavaScript API need to manually call the [server.close()](/api/javascript-api/instance#close-server) method to trigger this hook.
+
 - **Type:**
 
 ```ts

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -248,9 +248,21 @@ type StartDevServerOptions = {
 };
 
 type StartServerResult = {
+  /**
+   * 服务器监听的 URLs
+   */
   urls: string[];
+  /**
+   * 服务器实际使用的端口号
+   */
   port: number;
-  server: Server;
+  server: {
+    /**
+     * 关闭服务器
+     * 在开发模式下，此方法会调用 `onCloseDevServer` 钩子
+     */
+    close: () => Promise<void>;
+  };
 };
 
 function StartDevServer(
@@ -292,12 +304,28 @@ try {
 - `server`：Server 实例对象
 
 ```ts
-const { urls, port, server } = await rsbuild.startDevServer();
+const { urls, port } = await rsbuild.startDevServer();
 console.log(urls); // ['http://localhost:3000', 'http://192.168.0.1:3000']
 console.log(port); // 3000
+```
 
-// 关闭 dev server
+### 关闭 server
+
+调用 `close()` 方法会关闭开发服务器，并触发 [onCloseDevServer](/plugins/dev/hooks#onclosedevserver) 钩子，执行清理操作。
+
+```ts
+const { server } = await rsbuild.startDevServer();
 await server.close();
+```
+
+### 静默获取端口号
+
+某些情况下，默认启动的端口号已经被占用，此时 Rsbuild 会自动递增端口号，直至找到一个可用端口。这个过程会输出提示日志，如果你不希望这段日志，可以将 `getPortSilently` 设置为 `true`。
+
+```ts
+await rsbuild.startDevServer({
+  getPortSilently: true,
+});
 ```
 
 ### 自定义 Compiler
@@ -312,16 +340,6 @@ const compiler = rspack({
 });
 await rsbuild.startDevServer({
   compiler,
-});
-```
-
-### 静默获取端口号
-
-某些情况下，默认启动的端口号已经被占用，此时 Rsbuild 会自动递增端口号，直至找到一个可用端口。这个过程会输出提示日志，如果你不希望这段日志，可以将 `getPortSilently` 设置为 `true`。
-
-```ts
-await rsbuild.startDevServer({
-  getPortSilently: true,
 });
 ```
 
@@ -358,9 +376,18 @@ type PreviewOptions = {
 };
 
 type StartServerResult = {
+  /**
+   * 服务器监听的 URLs
+   */
   urls: string[];
+  /**
+   * 服务器实际使用的端口号
+   */
   port: number;
   server: {
+    /**
+     * 关闭服务器
+     */
     close: () => Promise<void>;
   };
 };
@@ -395,11 +422,17 @@ try {
 - `server`：Server 实例对象
 
 ```ts
-const { urls, port, server } = await rsbuild.preview();
+const { urls, port } = await rsbuild.preview();
 console.log(urls); // ['http://localhost:3000', 'http://192.168.0.1:3000']
 console.log(port); // 3000
+```
 
-// 关闭 Server
+### 关闭 server
+
+调用 `close()` 方法会关闭预览服务器。
+
+```ts
+const { server } = await rsbuild.preview();
 await server.close();
 ```
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@
 - [onAfterStartDevServer](#onafterstartdevserver)：在启动开发服务器后调用。
 - [onDevCompileDone](#ondevcompiledone)：在每次开发模式构建结束后调用。
 
-仅在 Rsbuild restart 时，或是执行 `rsbuild.startDevServer()` 的 `close()` 方法时调用。
+仅在 Rsbuild restart 时，或是执行 `rsbuild.startDevServer()` 的 [close()](/api/javascript-api/instance#关闭-server) 方法时调用。
 
 - [onCloseDevServer](#onclosedevserver)：在关闭开发服务器时调用。
 

--- a/website/docs/zh/shared/onCloseDevServer.mdx
+++ b/website/docs/zh/shared/onCloseDevServer.mdx
@@ -1,5 +1,7 @@
 关闭开发服务器时调用，可用于在开发服务器关闭时执行清理操作。
 
+Rsbuild CLI 会自动在合适的时机调用此钩子，使用 JavaScript API 的用户需要手动调用 [server.close()](/api/javascript-api/instance#关闭-server) 方法来触发此钩子。
+
 - **类型：**
 
 ```ts


### PR DESCRIPTION
## Summary

Update the `StartServerResult` type and related documentation to provide more detailed information for server close method.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
