### PR TITLE
test(e2e): add cases for `buildCache.cacheDirectory`

### DIFF
--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('`buildCache.cacheDirectory` should work as expected in development mode', async ({
+  page,
+}) => {
+  const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
+  const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
+  fs.rmSync(defaultDirectory, { recursive: true, force: true });
+  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+  const rsbuild = await dev({
+    page,
+    cwd: __dirname,
+    rsbuildConfig: {
+      performance: {
+        buildCache: {
+          cacheDirectory,
+        },
+      },
+    },
+  });
+
+  expect(fs.existsSync(cacheDirectory)).toBeTruthy();
+  expect(fs.existsSync(defaultDirectory)).toBeFalsy();
+  await rsbuild.close();
+});
+
+test('`buildCache.cacheDirectory` should work as expected in production mode', async () => {
+  const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
+  const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
+  fs.rmSync(defaultDirectory, { recursive: true, force: true });
+  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      performance: {
+        buildCache: {
+          cacheDirectory,
+        },
+      },
+    },
+  });
+
+  expect(fs.existsSync(cacheDirectory)).toBeTruthy();
+  expect(fs.existsSync(defaultDirectory)).toBeFalsy();
+});

--- a/e2e/cases/cache/cache-directory/src/index.js
+++ b/e2e/cases/cache/cache-directory/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello world');


### PR DESCRIPTION
## Summary

Add E2E cases for `buildCache.cacheDirectory` config.

## Related Links

related: https://github.com/web-infra-dev/rsbuild/pull/4790

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
