### PR TITLE
fix: should merge copy config correctly when copy config type is different

### DIFF
--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -51,7 +51,7 @@ test('should copy asset to dist sub-folder correctly', async () => {
   expect(fs.existsSync(join(__dirname, 'dist-1/foo/icon.png'))).toBeTruthy();
 });
 
-test.only('should merge copy config correctly', async () => {
+test('should merge copy config correctly', async () => {
   const rsbuildPlugin = (): RsbuildPlugin => ({
     name: 'example',
     setup(api) {

--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should copy asset to dist folder correctly', async () => {
   await build({
@@ -48,4 +49,57 @@ test('should copy asset to dist sub-folder correctly', async () => {
   });
 
   expect(fs.existsSync(join(__dirname, 'dist-1/foo/icon.png'))).toBeTruthy();
+});
+
+test.only('should merge copy config correctly', async () => {
+  const rsbuildPlugin = (): RsbuildPlugin => ({
+    name: 'example',
+    setup(api) {
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        return mergeRsbuildConfig(config, {
+          output: {
+            copy: {
+              patterns: [
+                {
+                  from: '../../../assets/icon.png',
+                },
+              ],
+            },
+          },
+        });
+      });
+    },
+  });
+
+  const rsbuildPlugin2 = (): RsbuildPlugin => ({
+    name: 'example1',
+    setup(api) {
+      api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+        return mergeRsbuildConfig(config, {
+          output: {
+            copy: [
+              {
+                from: '../../../assets/image.png',
+              },
+            ],
+          },
+        });
+      });
+    },
+  });
+
+  await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      output: {
+        distPath: {
+          root: 'dist-4',
+        },
+      },
+      plugins: [rsbuildPlugin(), rsbuildPlugin2()],
+    },
+  });
+
+  expect(fs.existsSync(join(__dirname, 'dist-4/icon.png'))).toBeTruthy();
+  expect(fs.existsSync(join(__dirname, 'dist-4/image.png'))).toBeTruthy();
 });

--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -72,7 +72,7 @@ test('should merge copy config correctly', async () => {
   });
 
   const rsbuildPlugin2 = (): RsbuildPlugin => ({
-    name: 'example1',
+    name: 'example2',
     setup(api) {
       api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
         return mergeRsbuildConfig(config, {

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -48,6 +48,12 @@ const merge = (x: unknown, y: unknown, path = '') => {
 
   // combine array
   if (pair.some(Array.isArray)) {
+    if (path === 'output.copy' && !pair.every(Array.isArray)) {
+      // x: { patterns: [A] }、y: [B, C] => { patterns: [A,B,C] }
+      return Array.isArray(x)
+        ? merge({ patterns: x }, y, path)
+        : merge(x, { patterns: y }, path);
+    }
     return [...castArray(x), ...castArray(y)];
   }
 

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -25,7 +25,7 @@ const isOverridePath = (key: string) => {
   return OVERRIDE_PATHS.includes(key);
 };
 
-const merge = (x: unknown, y: unknown, path = '') => {
+const merge = (x: unknown, y: unknown, path = ''): unknown => {
   // force some keys to override
   if (isOverridePath(path)) {
     return y ?? x;


### PR DESCRIPTION
## Summary

 should merge copy config correctly when copy config type difference.

```ts
// config1 
output: {
  copy: {
    patterns: [
      {
        from: '../../../assets/icon.png',
      },
    ],
   },
},

// config2
output: {
  copy: [
    {
      from: '../../../assets/image.png',
    },
  ],
},
```

expect:
```ts
output: {
  copy: {
    patterns: [
      {
        from: '../../../assets/icon.png',
      },
      {
        from: '../../../assets/image.png',
      },
    ],
  },
},
```

actual:
```ts
output: {
  copy: [
    {
      patterns: [
        {
          from: '../../../assets/icon.png',
        },
      ],
    },
    {
      from: '../../../assets/image.png',
    },
  ],
 }
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
