### PR TITLE
fix(overlay): avoid multiple error overlay instances

### DIFF
--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -41,7 +41,7 @@ class ErrorOverlay extends HTMLElement {
     document.addEventListener('keydown', onEscKeydown);
   }
 
-  close = (immediate = false) => {
+  close = (immediate: unknown = false) => {
     const remove = () => this.parentNode?.removeChild(this);
 
     if (this.animate && immediate !== true) {

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -41,10 +41,10 @@ class ErrorOverlay extends HTMLElement {
     document.addEventListener('keydown', onEscKeydown);
   }
 
-  close = () => {
+  close = (immediate = false) => {
     const remove = () => this.parentNode?.removeChild(this);
 
-    if (this.animate) {
+    if (this.animate && immediate !== true) {
       this.animate([{ opacity: 1 }, { opacity: 0 }], {
         duration: 300,
         easing: 'ease-out',
@@ -69,7 +69,10 @@ function createOverlay(html: string) {
 function clearOverlay() {
   // use NodeList's forEach api instead of dom.iterable
   // biome-ignore lint/complexity/noForEach: <explanation>
-  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close());
+  document
+    .querySelectorAll<ErrorOverlay>(overlayId)
+    // close overlay immediately to avoid multiple overlays at the same time
+    .forEach((n) => n.close(true));
 }
 
 if (typeof document !== 'undefined') {


### PR DESCRIPTION
## Summary

Clear error overlay immediately to avoid multiple error overlay instances.

The overlay animation is only needed when the user manually clicks the close icon

Fix the flaky E2E case:

<img width="1248" alt="Screenshot 2025-03-16 at 12 59 42" src="https://github.com/user-attachments/assets/c24ec766-5efe-4ae6-945f-78587db04c29" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
