### PR TITLE
docs: `getPlugins` can accept `environment` option

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -467,13 +467,23 @@ Get all the Rsbuild plugins registered in the current Rsbuild instance.
 - **Type:**
 
 ```ts
-function GetPlugins(): RsbuildPlugin[];
+function GetPlugins(options?: {
+  /**
+   * Get the plugins in the specified environment.
+   * If environment is not specified, get the global plugins.
+   */
+  environment: string;
+}): RsbuildPlugin[];
 ```
 
 - **Example:**
 
 ```ts
+// get all plugins
 console.log(rsbuild.getPlugins());
+
+// get plugins in `web` environment
+console.log(rsbuild.getPlugins({ environment: 'web' }));
 ```
 
 ## rsbuild.removePlugins

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -490,13 +490,23 @@ rsbuild.addPlugins([pluginFoo()], { environment: 'node' });
 - **类型：**
 
 ```ts
-function GetPlugins(): RsbuildPlugin[];
+function GetPlugins(options?: {
+  /**
+   * Get the plugins in the specified environment.
+   * If environment is not specified, get the global plugins.
+   */
+  environment: string;
+}): RsbuildPlugin[];
 ```
 
 - **示例：**
 
 ```ts
+// get all plugins
 console.log(rsbuild.getPlugins());
+
+// get plugins in `web` environment
+console.log(rsbuild.getPlugins({ environment: 'web' }));
 ```
 
 ## rsbuild.removePlugins


### PR DESCRIPTION
## Summary

Update documentation to add the `environment` option to `rsbuild.getPlugins` to specify an environment from which to retrieve plugins.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
