### PR TITLE
test(e2e): replace fs.rmSync with async remove from fs-extra

### DIFF
--- a/e2e/cases/cache/build-dependencies/index.test.ts
+++ b/e2e/cases/cache/build-dependencies/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { build, webpackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import type { RsbuildConfig } from '@rsbuild/core';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 test('`buildCache.buildDependencies` should work as expected', async () => {
   const cacheDirectory = path.resolve(
@@ -13,7 +13,7 @@ test('`buildCache.buildDependencies` should work as expected', async () => {
 
   const testDepsPath = path.resolve(__dirname, './test-temp-deps.js');
 
-  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+  await remove(cacheDirectory);
 
   const getBuildConfig = (input: string) => {
     fs.writeFileSync(testDepsPath, input);
@@ -82,7 +82,7 @@ webpackOnlyTest(
 
     const configFile = path.resolve(cacheDirectory, 'buildDependencies.json');
 
-    fs.rmSync(cacheDirectory, { recursive: true, force: true });
+    await remove(cacheDirectory);
 
     // first build without cache
     let rsbuild = await build(buildConfig);

--- a/e2e/cases/cache/cache-digest/index.test.ts
+++ b/e2e/cases/cache/cache-digest/index.test.ts
@@ -1,8 +1,8 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import type { RsbuildConfig } from '@rsbuild/core';
+import { remove } from 'fs-extra';
 
 test('`buildCache.cacheDigest` should work as expected', async () => {
   const cacheDirectory = path.resolve(
@@ -10,7 +10,7 @@ test('`buildCache.cacheDigest` should work as expected', async () => {
     './node_modules/.cache/test-cache-digest',
   );
 
-  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+  await remove(cacheDirectory);
 
   const getBuildConfig = (input: string) => ({
     cwd: __dirname,

--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -2,14 +2,15 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 test('`buildCache.cacheDirectory` should work as expected in development mode', async ({
   page,
 }) => {
   const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
   const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
-  fs.rmSync(defaultDirectory, { recursive: true, force: true });
-  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+  await remove(defaultDirectory);
+  await remove(cacheDirectory);
 
   const rsbuild = await dev({
     page,
@@ -31,8 +32,8 @@ test('`buildCache.cacheDirectory` should work as expected in development mode', 
 test('`buildCache.cacheDirectory` should work as expected in production mode', async () => {
   const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
   const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
-  fs.rmSync(defaultDirectory, { recursive: true, force: true });
-  fs.rmSync(cacheDirectory, { recursive: true, force: true });
+  await remove(defaultDirectory);
+  await remove(cacheDirectory);
 
   await build({
     cwd: __dirname,

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -3,13 +3,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, rspackOnlyTest, webpackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 rspackOnlyTest('should support restart build when config changed', async () => {
   const indexFile = path.join(__dirname, 'src/index.js');
   const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  fs.rmSync(indexFile, { force: true });
-  fs.rmSync(distIndexFile, { force: true });
+  await remove(indexFile);
+  await remove(distIndexFile);
   const tempConfigFile = path.join(__dirname, 'test-temp-rsbuild.config.mjs');
 
   fse.outputFileSync(
@@ -30,7 +30,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-  fs.rmSync(distIndexFile, { force: true });
+  await remove(distIndexFile);
 
   fse.outputFileSync(
     tempConfigFile,
@@ -45,7 +45,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-  fs.rmSync(distIndexFile, { force: true });
+  await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await expectFile(distIndexFile);
@@ -59,8 +59,8 @@ webpackOnlyTest(
   async () => {
     const indexFile = path.join(__dirname, 'src/index.js');
     const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-    fs.rmSync(indexFile, { force: true });
-    fs.rmSync(distIndexFile, { force: true });
+    await remove(indexFile);
+    await remove(distIndexFile);
     const tempConfigFile = path.join(__dirname, 'test-temp-rsbuild.config.mjs');
 
     fse.outputFileSync(
@@ -87,7 +87,7 @@ export default defineConfig({
 
     await expectFile(distIndexFile);
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-    fs.rmSync(distIndexFile, { force: true });
+    await remove(distIndexFile);
 
     fse.outputFileSync(
       tempConfigFile,
@@ -108,7 +108,7 @@ export default defineConfig({
 
     await expectFile(distIndexFile);
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-    fs.rmSync(distIndexFile, { force: true });
+    await remove(distIndexFile);
 
     fse.outputFileSync(indexFile, `console.log('hello2!');`);
     await expectFile(distIndexFile);

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -3,13 +3,13 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 rspackOnlyTest('should support watch mode for build command', async () => {
   const indexFile = path.join(__dirname, 'src/index.js');
   const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  fs.rmSync(indexFile, { force: true });
-  fs.rmSync(distIndexFile, { force: true });
+  await remove(indexFile);
+  await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
@@ -19,7 +19,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
-  fs.rmSync(distIndexFile, { force: true });
+  await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await expectFile(distIndexFile);

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,13 +1,13 @@
 import { execSync } from 'node:child_process';
-import fs from 'node:fs';
 import path from 'node:path';
 import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 rspackOnlyTest('should allow to export function in config file', async () => {
   const targetDir = path.join(__dirname, 'dist-production-build');
 
-  fs.rmSync(targetDir, { recursive: true, force: true });
+  await remove(targetDir);
 
   delete process.env.NODE_ENV;
   execSync('npx rsbuild build', {

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 const localFile = path.join(__dirname, '.env.local');
 const prodLocalFile = path.join(__dirname, '.env.production.local');
 
-test.beforeEach(() => {
-  fs.rmSync(localFile, { force: true });
-  fs.rmSync(prodLocalFile, { force: true });
+test.beforeEach(async () => {
+  await remove(localFile);
+  await remove(prodLocalFile);
 });
 
 rspackOnlyTest(

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -3,14 +3,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 const localFile = path.join(__dirname, '.env.local');
 const prodLocalFile = path.join(__dirname, '.env.production.local');
 
-test.beforeEach(() => {
-  fs.rmSync(localFile, { force: true });
-  fs.rmSync(prodLocalFile, { force: true });
+test.beforeEach(async () => {
+  await remove(localFile);
+  await remove(prodLocalFile);
 });
 
 rspackOnlyTest(

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -2,6 +2,7 @@ import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { remove } from 'fs-extra';
 
 rspackOnlyTest(
   'should restart dev server and reload config when config file changed',
@@ -10,9 +11,9 @@ rspackOnlyTest(
     const dist2 = path.join(__dirname, 'dist-2');
     const configFile = path.join(__dirname, 'rsbuild.config.mjs');
 
-    fs.rmSync(dist1, { force: true, recursive: true });
-    fs.rmSync(dist2, { force: true, recursive: true });
-    fs.rmSync(configFile, { force: true });
+    await remove(dist1);
+    await remove(dist2);
+    await remove(configFile);
 
     fs.writeFileSync(
       configFile,

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, getRandomPort } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 // Skipped as it occasionally failed in CI
 test.skip('should restart dev server when .env file is changed', async () => {
@@ -11,9 +12,9 @@ test.skip('should restart dev server when .env file is changed', async () => {
   const envLocalFile = path.join(__dirname, '.env.local');
   const distIndex = path.join(dist, 'static/js/index.js');
 
-  fs.rmSync(dist, { recursive: true, force: true });
-  fs.rmSync(configFile, { force: true });
-  fs.rmSync(envLocalFile, { force: true });
+  await remove(dist);
+  await remove(configFile);
+  await remove(envLocalFile);
 
   fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
   fs.writeFileSync(
@@ -37,7 +38,7 @@ test.skip('should restart dev server when .env file is changed', async () => {
   await expectFile(distIndex);
   expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
 
-  fs.rmSync(distIndex, { force: true });
+  await remove(distIndex);
 
   fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
   await expectFile(distIndex);

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 const tempConfigPath = './test-temp-config.ts';
 
@@ -12,8 +13,8 @@ rspackOnlyTest(
     const dist = path.join(__dirname, 'dist');
     const extraConfigFile = path.join(__dirname, tempConfigPath);
 
-    fs.rmSync(extraConfigFile, { force: true });
-    fs.rmSync(dist, { recursive: true, force: true });
+    await remove(extraConfigFile);
+    await remove(dist);
     fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
 
     const childProcess = exec('npx rsbuild dev', {
@@ -26,7 +27,7 @@ rspackOnlyTest(
 
     await expectFile(dist);
 
-    fs.rmSync(dist, { recursive: true });
+    await remove(dist);
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default { foo: 2 };');
 

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 const dist = path.join(__dirname, 'dist');
 const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
@@ -10,10 +11,10 @@ const tempConfigPath = './test-temp-config.ts';
 const tempOutputFile = path.join(__dirname, 'test-temp-file.txt');
 const extraConfigFile = path.join(__dirname, tempConfigPath);
 
-test.beforeEach(() => {
-  fs.rmSync(dist, { recursive: true, force: true });
-  fs.rmSync(tempOutputFile, { force: true });
-  fs.rmSync(extraConfigFile, { force: true });
+test.beforeEach(async () => {
+  await remove(dist);
+  await remove(tempOutputFile);
+  await remove(extraConfigFile);
   fs.writeFileSync(extraConfigFile, 'export default 1;');
 });
 
@@ -32,7 +33,7 @@ rspackOnlyTest(
     // the first build
     await expectFile(distIndexFile);
 
-    fs.rmSync(tempOutputFile, { force: true });
+    await remove(tempOutputFile);
     // temp config changed and trigger rebuild
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
@@ -58,7 +59,7 @@ rspackOnlyTest(
 
     await expectFile(distIndexFile);
 
-    fs.rmSync(distIndexFile);
+    await remove(distIndexFile);
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
@@ -84,7 +85,7 @@ rspackOnlyTest(
     // Sometimes the dist directory exists, but the files in the dist directory have not been completely written.
     await expectFile(distIndexFile);
 
-    fs.rmSync(distIndexFile);
+    await remove(distIndexFile);
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { createRsbuild, proxyConsole, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 const rsbuildConfig = path.resolve(
   __dirname,
@@ -40,8 +41,8 @@ rspackOnlyTest(
       logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
-    fs.rmSync(rsbuildConfig, { force: true });
-    fs.rmSync(bundlerConfig, { force: true });
+    await remove(rsbuildConfig);
+    await remove(bundlerConfig);
 
     restore();
   },
@@ -77,8 +78,8 @@ rspackOnlyTest(
       logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
-    fs.rmSync(rsbuildConfig, { force: true });
-    fs.rmSync(bundlerConfig, { force: true });
+    await remove(rsbuildConfig);
+    await remove(bundlerConfig);
 
     restore();
   },
@@ -118,10 +119,10 @@ rspackOnlyTest(
       logs.some((log) => log.includes('config inspection completed')),
     ).toBeTruthy();
 
-    fs.rmSync(rsbuildConfig, { force: true });
-    fs.rmSync(rsbuildNodeConfig, { force: true });
-    fs.rmSync(bundlerConfig, { force: true });
-    fs.rmSync(bundlerNodeConfig, { force: true });
+    await remove(rsbuildConfig);
+    await remove(rsbuildNodeConfig);
+    await remove(bundlerConfig);
+    await remove(bundlerNodeConfig);
 
     restore();
   },
@@ -163,7 +164,7 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
     fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
   ).toBeTruthy();
 
-  fs.rmSync(rsbuildConfig, { force: true });
+  await remove(rsbuildConfig);
 
   restore();
 });

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 test('should compile Node addons correctly', async () => {
   const rsbuild = await build({
@@ -29,7 +29,7 @@ test('should compile Node addons correctly', async () => {
 test('should compile Node addons in the node_modules correctly', async () => {
   const pkgDir = join(__dirname, 'node_modules', 'node-addon-pkg');
 
-  fs.rmSync(pkgDir, { recursive: true, force: true });
+  await remove(pkgDir);
 
   fse.outputJSONSync(join(pkgDir, 'package.json'), {
     name: 'node-addon-pkg',

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { build, dev, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 const cwd = __dirname;
 const testDistFile = join(cwd, 'dist/test.json');
@@ -31,7 +31,7 @@ test('should not clean dist path in dev mode when writeToDisk is false', async (
   });
 
   expect(fs.existsSync(testDistFile)).toBeTruthy();
-  fs.rmSync(testDistFile, { force: true });
+  await remove(testDistFile);
 });
 
 test('should clean dist path in dev mode when writeToDisk is true', async () => {
@@ -71,7 +71,7 @@ test('should not clean dist path if it is outside root', async () => {
 
   expect(fs.existsSync(testOutsideFile)).toBeTruthy();
 
-  fs.rmSync(testOutsideFile, { force: true });
+  await remove(testOutsideFile);
   restore();
 });
 
@@ -89,7 +89,7 @@ test('should allow to disable cleanDistPath', async () => {
 
   expect(fs.existsSync(testDistFile)).toBeTruthy();
 
-  fs.rmSync(testDistFile, { force: true });
+  await remove(testDistFile);
 });
 
 test('should allow to use `cleanDistPath.keep` to keep some files', async () => {

--- a/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 const distFile = path.join(__dirname, 'node_modules/hooksTempFile');
 
@@ -34,7 +34,7 @@ const plugin: RsbuildPlugin = {
 rspackOnlyTest(
   'should run onAfterBuild hooks correctly when have multiple targets',
   async () => {
-    fs.rmSync(distFile, { force: true });
+    await remove(distFile);
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expectFile, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rm, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
 import fse from 'fs-extra';
@@ -72,7 +72,7 @@ rspackOnlyTest(
     const filePath = join(cwd, 'test-temp-src', 'index.js');
     const distPath = join(cwd, 'dist/index.html');
 
-    await fs.promises.rm(distPath, { recursive: true, force: true });
+    await rm(distPath);
     await fs.promises.writeFile(filePath, "console.log('1');");
 
     const { plugin, names } = createPlugin();
@@ -97,7 +97,7 @@ rspackOnlyTest(
     const result = await rsbuild.build({ watch: true });
     await expectFile(distPath);
 
-    await fs.promises.rm(distPath, { recursive: true, force: true });
+    await rm(distPath);
     await fs.promises.writeFile(filePath, "console.log('2');");
     await expectFile(distPath);
 

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expectFile, rm, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { type RsbuildPlugin, createRsbuild } from '@rsbuild/core';
-import fse from 'fs-extra';
+import fse, { remove } from 'fs-extra';
 
 const createPlugin = () => {
   const names: string[] = [];
@@ -72,7 +72,7 @@ rspackOnlyTest(
     const filePath = join(cwd, 'test-temp-src', 'index.js');
     const distPath = join(cwd, 'dist/index.html');
 
-    await rm(distPath);
+    await remove(distPath);
     await fs.promises.writeFile(filePath, "console.log('1');");
 
     const { plugin, names } = createPlugin();
@@ -97,7 +97,7 @@ rspackOnlyTest(
     const result = await rsbuild.build({ watch: true });
     await expectFile(distPath);
 
-    await rm(distPath);
+    await remove(distPath);
     await fs.promises.writeFile(filePath, "console.log('2');");
     await expectFile(distPath);
 

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -3,11 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 const distFile = path.join(__dirname, 'node_modules/hooksTempFile');
 
 rspackOnlyTest('should run onExit hook before process exit', async () => {
-  fs.rmSync(distFile, { force: true });
+  await remove(distFile);
 
   await new Promise<void>((resolve, reject) => {
     const timeoutId = setTimeout(() => {

--- a/e2e/cases/resolve/extension-alias-js/index.test.ts
+++ b/e2e/cases/resolve/extension-alias-js/index.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { build } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { remove } from 'fs-extra';
 
 test('should allow to import TS files with .js extension', async ({ page }) => {
   await build({
@@ -41,5 +42,5 @@ test('should resolve the .js file first if both .js and .ts exist', async ({
 
   expect(await page.evaluate(() => window.test)).toBe('js');
 
-  fs.rmSync(join(__dirname, 'test-temp-src'), { recursive: true });
+  await remove(join(__dirname, 'test-temp-src'));
 });


### PR DESCRIPTION
## Summary

`fse.remove` is less verbose and can avoid exceptions caused by forgetting to add `force: true`.

Fix flaky cases like:

<img width="1243" alt="Screenshot 2025-03-16 at 13 09 12" src="https://github.com/user-attachments/assets/bc7daffb-f5b3-4ef3-be6e-ea1c4d243efa" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
