### PR TITLE
docs: add information on obtaining additional templates

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -70,6 +70,11 @@ When creating a project, you can choose from the following templates provided by
 | svelte   | [Svelte 5](https://svelte.dev/) | TypeScript        |
 | solid    | [Solid](https://solidjs.com/)   | TypeScript        |
 
+`create-rsbuild` provides out-of-the-box basic templates. You can also get more templates through the following ways:
+
+- Visit [Rspack - Ecosystem](https://rspack.dev/guide/start/quick-start#ecosystem) to learn about various higher-level tools based on Rsbuild.
+- Visit [awesome-rspack - Starter](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#starter) to get more community-maintained templates.
+
 ### Optional tools
 
 `create-rsbuild` can help you set up some commonly used tools, including [Biome](https://github.com/biomejs/biome), [ESLint](https://github.com/eslint/eslint), and [prettier](https://github.com/prettier/prettier). You can use the arrow keys and the space bar to make your selections. If you don't need these tools, you can simply press Enter to skip.

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -70,6 +70,11 @@ import { PackageManagerTabs } from '@theme';
 | svelte  | [Svelte 5](https://svelte.dev/) | TypeScript |
 | solid   | [Solid](https://solidjs.com/)   | TypeScript |
 
+`create-rsbuild` 提供了开箱即用的基础模板，你还可以通过以下方式获取更丰富的模板：
+
+- 前往 [Rspack - 生态](https://rspack.dev/zh/guide/start/quick-start#%E7%94%9F%E6%80%81) 了解基于 Rsbuild 的各种上层工具。
+- 前往 [awesome-rspack - Starter](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#starter) 获取更多社区维护的模板。
+
 ### 可选工具
 
 `create-rsbuild` 能够帮助你设置一些常用的工具，包括 [Biome](https://github.com/biomejs/biome)、[ESLint](https://github.com/eslint/eslint) 和 [prettier](https://github.com/prettier/prettier)，你可以使用上下箭头和空格进行选择。如果你不需要这些工具，可以直接按回车跳过。


### PR DESCRIPTION
## Summary

This pull request includes updates to the quick start guides to provide additional information on obtaining more templates when creating a project with `create-rsbuild`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
