### PR TITLE
fix: MaxListenersExceeded warning after restarting server

### DIFF
--- a/packages/core/src/server/gracefulShutdown.ts
+++ b/packages/core/src/server/gracefulShutdown.ts
@@ -44,7 +44,8 @@ export const setupGracefulShutdown = (): (() => void) => {
   process.once('SIGTERM', handleTermination);
 
   // Listen for CTRL+D (stdin end) in non-CI environments
-  if (process.env.CI !== 'true') {
+  const isCI = process.env.CI === 'true';
+  if (!isCI) {
     process.stdin.on('end', handleTermination);
   }
 
@@ -56,7 +57,7 @@ export const setupGracefulShutdown = (): (() => void) => {
     }
 
     process.removeListener('SIGTERM', handleTermination);
-    if (process.stdin.listenerCount('end') === 0) {
+    if (!isCI) {
       process.stdin.removeListener('end', handleTermination);
     }
   };


### PR DESCRIPTION
## Summary

Fix the MaxListenersExceeded warning after restarting server multiple times:

<img width="1272" alt="Screenshot 2025-03-20 at 14 29 35" src="https://github.com/user-attachments/assets/62846350-3dbd-492d-b505-de7cd50bed46" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
