### PR TITLE
refactor: move file watching and restart logic to separate module

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -2,7 +2,7 @@ import cac, { type CAC, type Command } from 'cac';
 import type { ConfigLoader } from '../config';
 import { logger } from '../logger';
 import { RSPACK_BUILD_ERROR } from '../provider/build';
-import { onBeforeRestartServer } from '../server/restart';
+import { onBeforeRestartServer } from '../restart';
 import type { RsbuildMode } from '../types';
 import { init } from './init';
 

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,8 +1,9 @@
 import path from 'node:path';
-import { loadConfig as baseLoadConfig, watchFilesForRestart } from '../config';
+import { loadConfig as baseLoadConfig } from '../config';
 import { createRsbuild } from '../createRsbuild';
 import { castArray, getAbsolutePath } from '../helpers';
 import { logger } from '../logger';
+import { watchFilesForRestart } from '../restart';
 import type { RsbuildInstance } from '../types';
 import type { CommonOptions } from './commands';
 
@@ -111,19 +112,23 @@ export async function init({
 
             const paths = castArray(watchFilesConfig.paths);
             if (watchFilesConfig.options) {
-              watchFilesForRestart(
-                paths,
-                root,
+              watchFilesForRestart({
+                files: paths,
+                rsbuild,
                 isBuildWatch,
-                watchFilesConfig.options,
-              );
+                watchOptions: watchFilesConfig.options,
+              });
             } else {
               files.push(...paths);
             }
           }
         }
 
-        watchFilesForRestart(files, root, isBuildWatch);
+        watchFilesForRestart({
+          files,
+          rsbuild,
+          isBuildWatch,
+        });
       }
     });
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -5,6 +5,7 @@ import type Connect from '../../compiled/connect/index.js';
 import { ROOT_DIST_DIR } from '../constants';
 import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers';
 import { logger } from '../logger';
+import { onBeforeRestartServer, restartDevServer } from '../restart.js';
 import type {
   CreateCompiler,
   CreateDevServerOptions,
@@ -42,7 +43,6 @@ import {
 import { createHttpServer } from './httpServer';
 import { notFoundMiddleware, optionsFallbackMiddleware } from './middlewares';
 import { open } from './open';
-import { onBeforeRestartServer, restartDevServer } from './restart';
 import { type WatchFilesResult, setupWatchFiles } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;


### PR DESCRIPTION
## Summary

Moving the `watchFilesForRestart` function and other related imports to a  `restart.ts`, file and updating the relevant imports across multiple files.

These changes help in better organizing the code by separating the restart-related functionalities into their own module.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
