### PR TITLE
feat: expose `context.action` property

### DIFF
--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -46,7 +46,7 @@ export async function createCompiler(options: InitConfigsOptions) {
     done(stats as Rspack.Stats);
   });
 
-  if (context.command === 'dev') {
+  if (context.action === 'dev') {
     helpers.registerDevHook({
       compiler,
       context,

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -99,37 +99,39 @@ export async function init({
     });
 
     rsbuild.onBeforeCreateCompiler(() => {
-      const command = process.argv[2];
-      if (command === 'dev' || isBuildWatch) {
-        const files: string[] = [];
-        const config = rsbuild.getNormalizedConfig();
+      // Skip watching files when not in dev mode or not in build watch mode
+      if (rsbuild.context.action !== 'dev' && !isBuildWatch) {
+        return;
+      }
 
-        if (config.dev?.watchFiles) {
-          for (const watchFilesConfig of castArray(config.dev.watchFiles)) {
-            if (watchFilesConfig.type !== 'reload-server') {
-              continue;
-            }
+      const files: string[] = [];
+      const config = rsbuild.getNormalizedConfig();
 
-            const paths = castArray(watchFilesConfig.paths);
-            if (watchFilesConfig.options) {
-              watchFilesForRestart({
-                files: paths,
-                rsbuild,
-                isBuildWatch,
-                watchOptions: watchFilesConfig.options,
-              });
-            } else {
-              files.push(...paths);
-            }
+      if (config.dev?.watchFiles) {
+        for (const watchFilesConfig of castArray(config.dev.watchFiles)) {
+          if (watchFilesConfig.type !== 'reload-server') {
+            continue;
+          }
+
+          const paths = castArray(watchFilesConfig.paths);
+          if (watchFilesConfig.options) {
+            watchFilesForRestart({
+              files: paths,
+              rsbuild,
+              isBuildWatch,
+              watchOptions: watchFilesConfig.options,
+            });
+          } else {
+            files.push(...paths);
           }
         }
-
-        watchFilesForRestart({
-          files,
-          rsbuild,
-          isBuildWatch,
-        });
       }
+
+      watchFilesForRestart({
+        files,
+        rsbuild,
+        isBuildWatch,
+      });
     });
 
     return rsbuild;

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -150,6 +150,7 @@ export function createPublicContext(
   context: RsbuildContext,
 ): Readonly<RsbuildContext> {
   const exposedKeys: Array<keyof RsbuildContext> = [
+    'action',
     'version',
     'rootPath',
     'distPath',

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -205,7 +205,7 @@ export async function createRsbuild(
   });
 
   const preview = async (options: PreviewOptions = {}) => {
-    context.command = 'preview';
+    context.action = 'preview';
 
     if (!getNodeEnv()) {
       setNodeEnv('production');
@@ -237,7 +237,7 @@ export async function createRsbuild(
   };
 
   const build: Build = async (...args) => {
-    context.command = 'build';
+    context.action = 'build';
 
     if (!getNodeEnv()) {
       setNodeEnv('production');
@@ -254,7 +254,7 @@ export async function createRsbuild(
   };
 
   const startDevServer: StartDevServer = (...args) => {
-    context.command = 'dev';
+    context.action = 'dev';
 
     if (!getNodeEnv()) {
       setNodeEnv('development');
@@ -264,7 +264,7 @@ export async function createRsbuild(
   };
 
   const createDevServer: CreateDevServer = (...args) => {
-    context.command = 'dev';
+    context.action = 'dev';
 
     if (!getNodeEnv()) {
       setNodeEnv('development');
@@ -274,8 +274,8 @@ export async function createRsbuild(
   };
 
   const createCompiler: CreateCompiler = (...args) => {
-    if (!context.command) {
-      context.command = getNodeEnv() === 'development' ? 'dev' : 'build';
+    if (!context.action) {
+      context.action = getNodeEnv() === 'development' ? 'dev' : 'build';
     }
     return providerInstance.createCompiler(...args);
   };

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -123,7 +123,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     isCompiling = true;
   });
 
-  if (context.command === 'build') {
+  if (context.action === 'build') {
     compiler.hooks.run.tap('rsbuild:run', logRspackVersion);
   }
 
@@ -181,7 +181,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     },
   );
 
-  if (context.command === 'dev') {
+  if (context.action === 'dev') {
     registerDevHook({
       context,
       compiler,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -21,6 +21,16 @@ export type RsbuildContext = {
     port: number;
     https: boolean;
   };
+  /**
+   * The current action type.
+   * - dev: will be set when running `rsbuild dev` or `rsbuild.startDevServer()`
+   * - build: will be set when running `rsbuild build` or `rsbuild.build()`
+   * - preview: will be set when running `rsbuild preview` or `rsbuild.preview()`
+   */
+  action?: 'dev' | 'build' | 'preview';
+  /**
+   * The bundler type, can be `rspack` or `webpack`.
+   */
   bundlerType: BundlerType;
 };
 
@@ -44,12 +54,4 @@ export type InternalContext = RsbuildContext & {
   environments: Record<string, EnvironmentContext>;
   /** Only build specified environment. */
   specifiedEnvironments?: string[];
-  /**
-   * The command type.
-   *
-   * - dev: `rsbuild dev` or `rsbuild.startDevServer()`
-   * - build: `rsbuild build` or `rsbuild.build()`
-   * - preview: `rsbuild preview` or `rsbuild.preview()`
-   */
-  command?: 'dev' | 'build' | 'preview';
 };

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -63,6 +63,30 @@ type DevServer = {
 };
 ```
 
+### context.action
+
+The current action type.
+
+- **Type:**
+
+```ts
+type Action = 'dev' | 'build' | 'preview' | undefined;
+```
+
+`context.action` is set when running CLI commands or calling Rsbuild instance methods:
+
+- `dev`: will be set when running [rsbuild dev](/guide/basic/cli#rsbuild-dev) or [rsbuild.startDevServer()](/api/javascript-api/instance#rsbuildstartdevserver)
+- `build`: will be set when running [rsbuild build](/guide/basic/cli#rsbuild-build) or [rsbuild.build()](/api/javascript-api/instance#rsbuildbuild)
+- `preview`: will be set when running [rsbuild preview](/guide/basic/cli#rsbuild-preview) or [rsbuild.preview()](/api/javascript-api/instance#rsbuildpreview)
+
+For example:
+
+```ts
+if (rsbuild.context.action === 'dev') {
+  // do something
+}
+```
+
 ### context.bundlerType
 
 The bundler type of current build.

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -63,6 +63,30 @@ type DevServer = {
 };
 ```
 
+### context.action
+
+当前的动作类型。
+
+- **类型：**
+
+```ts
+type Action = 'dev' | 'build' | 'preview' | undefined;
+```
+
+`context.action` 在运行 CLI 命令或调用 Rsbuild 实例方法时设置：
+
+- `dev`: 当运行 [rsbuild dev](/guide/basic/cli#rsbuild-dev) 或 [rsbuild.startDevServer()](/api/javascript-api/instance#rsbuildstartdevserver) 时设置。
+- `build`: 当运行 [rsbuild build](/guide/basic/cli#rsbuild-build) 或 [rsbuild.build()](/api/javascript-api/instance#rsbuildbuild) 时设置。
+- `preview`: 当运行 [rsbuild preview](/guide/basic/cli#rsbuild-preview) 或 [rsbuild.preview()](/api/javascript-api/instance#rsbuildpreview) 时设置。
+
+示例：
+
+```ts
+if (rsbuild.context.action === 'dev') {
+  // do something
+}
+```
+
 ### context.bundlerType
 
 当前执行构建的构建工具类型。


### PR DESCRIPTION
## Summary

Expose a new `context.action` property.

`context.action` is set when running CLI commands or calling Rsbuild instance methods:

- `dev`: will be set when running [rsbuild dev](https://rsbuild.dev/guide/basic/cli#rsbuild-dev) or [rsbuild.startDevServer()](https://rsbuild.dev/api/javascript-api/instance#rsbuildstartdevserver)
- `build`: will be set when running [rsbuild build](https://rsbuild.dev/guide/basic/cli#rsbuild-build) or [rsbuild.build()](https://rsbuild.dev/api/javascript-api/instance#rsbuildbuild)
- `preview`: will be set when running [rsbuild preview](https://rsbuild.dev/guide/basic/cli#rsbuild-preview) or [rsbuild.preview()](https://rsbuild.dev/api/javascript-api/instance#rsbuildpreview)

For example:

```ts
if (rsbuild.context.action === 'dev') {
  // do something
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
