### PR TITLE
feat(security): add warnings for defining `process.env`

### DIFF
--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -12,7 +12,7 @@ function checkProcessEnvSecurity(define: Define) {
   const check = (value: Record<string, unknown>) => {
     const pathKey = Object.keys(value).find(
       // Windows uses `Path`, other platforms use `PATH`
-      (key) => key.toLowerCase() === 'path' && Boolean(value[key]),
+      (key) => key.toLowerCase() === 'path' && value[key] === process.env[key],
     );
 
     if (!pathKey) {


### PR DESCRIPTION
## Summary

Warn users about potential security risks when defining `process.env` in the `source.define` configuration. It also includes updates to the test cases to ensure these warnings are properly handled.

<img width="1222" alt="Screenshot 2025-03-21 at 12 00 32" src="https://github.com/user-attachments/assets/0975706f-1473-4268-80b6-887f9ba031b5" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
