### PR TITLE
docs: add MultiCompiler references

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -439,7 +439,7 @@ await server.close();
 
 ## rsbuild.createCompiler
 
-Create an Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) instance. If there are multiple [environments](/config/environments) for this build, the return value is `MultiCompiler`.
+Create an Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) instance. If there are multiple [environments](/config/environments) for this build, the return value is [MultiCompiler](https://rspack.dev/api/javascript-api/compiler#multicompiler).
 
 - **Type:**
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -13,7 +13,7 @@ You can also define different environments for the same build target, for exampl
 - Define `rsc` and `ssr` environments, both targeting `node`, used separately for React Server Components and SSR.
 - Define `desktop` and `mobile` environments, both targeting `web`, used separately for desktop and mobile browsers.
 
-Without the `environments` configuration, you would need to define multiple configurations for these scenarios and run multiple independent Rsbuild builds. Now, with the `environments` configuration, you can complete the build for multiple outputs in a single Rsbuild run (Rsbuild achieves this using Rspack's `MultiCompiler`).
+Without the `environments` configuration, you would need to define multiple configurations for these scenarios and run multiple independent Rsbuild builds. Now, with the `environments` configuration, you can complete the build for multiple outputs in a single Rsbuild run (Rsbuild achieves this using Rspack's [MultiCompiler](https://rspack.dev/api/javascript-api/compiler#multicompiler)).
 
 In Rsbuild, each `environment` is associated with an Rsbuild configuration, an Rspack configuration, and a set of build outputs. Rsbuild plugin developers can customize the build process for a specified environment based on the `environment` name, such as modifying Rsbuild or Rspack configurations, registering or removing plugins, adjusting Rspack rules, and viewing assets information.
 
@@ -79,8 +79,8 @@ Then, Rsbuild will use these environments configs to internally generate two Rsp
 
 When you execute the command `npx rsbuild inspect` in the project root directory, you will find the following output:
 
-- rsbuild.config.[name].mjs: Indicates the Rsbuild config used for a certain environment during build.
-- rspack.config.[name].mjs: Indicates the Rspack config corresponding to a certain environment when building.
+- `rsbuild.config.[name].mjs`: The Rsbuild config used for a certain environment during build.
+- `rspack.config.[name].mjs`: The Rspack config corresponding to a certain environment when building.
 
 ```bash
 ➜ npx rsbuild inspect

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -462,7 +462,7 @@ await server.close();
 
 ## rsbuild.createCompiler
 
-创建一个 Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) 实例；如果本次构建存在多个 [environments](/config/environments)，则返回值为 `MultiCompiler`。
+创建一个 Rspack [Compiler](https://rspack.dev/api/javascript-api/compiler) 实例；如果本次构建存在多个 [environments](/config/environments)，则返回值为 [MultiCompiler](https://rspack.dev/zh/api/javascript-api/compiler#multicompiler)。
 
 - **类型：**
 

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -13,7 +13,7 @@ Rsbuild 支持同时为多个环境构建产物。你可以使用 [environments]
 - 定义 `rsc` 和 `ssr` 两个环境，它们的构建目标都是 `node`，分别用于 React Server Components 和 SSR。
 - 定义 `desktop` 和 `mobile` 两个环境，它们的构建目标都是 ` web`，分别用于桌面端浏览器和移动端浏览器。
 
-如果没有 `environments` 配置，你需要为这些场景定义多份配置，并执行多次独立的 Rsbuild 构建。现在通过 `environments` 配置，你可以在一次 Rsbuild 构建中完成多种产物的构建（Rsbuild 基于 Rspack 的 `MultiCompiler` 来实现这一点）。
+如果没有 `environments` 配置，你需要为这些场景定义多份配置，并执行多次独立的 Rsbuild 构建。现在通过 `environments` 配置，你可以在一次 Rsbuild 构建中完成多种产物的构建（Rsbuild 基于 Rspack 的 [MultiCompiler](https://rspack.dev/zh/api/javascript-api/compiler#multicompiler) 来实现这一点）。
 
 Rsbuild 中的每个 `environment` 关联一份 Rsbuild 配置、一份 Rspack 配置和一份构建产物。Rsbuild 插件的开发者可以基于 `environment` 名称，对指定环境的构建流程进行定制，如修改 Rsbuild 或 Rspack 配置、注册或移除插件、调整 Rspack 规则和查看静态资源信息等。
 
@@ -79,8 +79,8 @@ export default {
 
 当你在项目根目录下执行命令 `npx rsbuild inspect` 后，会发现有如下输出：
 
-- rsbuild.config.[name].mjs: 表示在构建时某个 environment 对应使用的 Rsbuild 配置。
-- rspack.config.[name].mjs: 表示在构建时某个 environment 对应使用的 Rspack 配置。
+- `rsbuild.config.[name].mjs`: 表示在构建时某个 environment 对应使用的 Rsbuild 配置。
+- `rspack.config.[name].mjs`: 表示在构建时某个 environment 对应使用的 Rspack 配置。
 
 ```bash
 ➜ npx rsbuild inspect
@@ -244,7 +244,7 @@ const myPlugin = () => ({
 
 Rsbuild server 提供了一系列和构建环境相关的 API，用户可通过 Rsbuild [environment API](/api/javascript-api/environment-api#environment-api) 在服务器端操作特定环境下的构建产物。
 
-你可以在 [Rsbuild DevMiddleware](/config/dev/setup-middlewares) 或[自定义 Server](/api/javascript-api/instance#rsbuildcreatedevserver) 中使用 environment API。
+你可以在 [Rsbuild DevMiddleware](/config/dev/setup-middlewares) 或 [自定义 Server](/api/javascript-api/instance#rsbuildcreatedevserver) 中使用 environment API。
 
 例如，你可以通过 Rsbuild environment API 在开发模式下快速实现一个 SSR 功能：
 


### PR DESCRIPTION
## Summary

Improve clarity by adding additional links to the Rspack `MultiCompiler` documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
