### PR TITLE
fix: handle errors in transform loader with try-catch block

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
@@ -1,0 +1,18 @@
+import { dev, expectPoll, proxyConsole, rspackOnlyTest } from '@e2e/helper';
+
+rspackOnlyTest('should handle transform error in dev mode', async () => {
+  const { logs, restore } = proxyConsole();
+  const rsbuild = await dev({
+    cwd: __dirname,
+  });
+
+  await expectPoll(() =>
+    logs.some(
+      (log) =>
+        log.includes('transform error') && log.includes('Failed to compile'),
+    ),
+  ).toBeTruthy();
+
+  restore();
+  await rsbuild.close();
+});

--- a/e2e/cases/plugin-api/plugin-transform-error-handle/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/myPlugin.ts
@@ -1,0 +1,10 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.transform({ test: /\.js$/ }, () => {
+      throw new Error('transform error');
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-error-handle/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { myPlugin } from './myPlugin';
+
+export default {
+  plugins: [myPlugin],
+};

--- a/e2e/cases/plugin-api/plugin-transform-error-handle/src/index.js
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -24,28 +24,36 @@ export default async function transform(
     return bypass();
   }
 
-  const result = await transform({
-    code: source,
-    context: this.context,
-    resource: this.resource,
-    resourcePath: this.resourcePath,
-    resourceQuery: this.resourceQuery,
-    environment: getEnvironment(),
-    addDependency: this.addDependency.bind(this),
-    emitFile: this.emitFile.bind(this),
-    importModule: this.importModule.bind(this),
-    resolve: this.resolve.bind(this),
-  });
+  try {
+    const result = await transform({
+      code: source,
+      context: this.context,
+      resource: this.resource,
+      resourcePath: this.resourcePath,
+      resourceQuery: this.resourceQuery,
+      environment: getEnvironment(),
+      addDependency: this.addDependency.bind(this),
+      emitFile: this.emitFile.bind(this),
+      importModule: this.importModule.bind(this),
+      resolve: this.resolve.bind(this),
+    });
 
-  if (result === null || result === undefined) {
-    return bypass();
+    if (result === null || result === undefined) {
+      return bypass();
+    }
+
+    if (typeof result === 'string') {
+      return callback(null, result, map);
+    }
+
+    const useMap = map !== undefined && map !== null;
+    const finalMap = result.map ?? map;
+    callback(null, result.code, useMap ? finalMap : undefined);
+  } catch (error) {
+    if (error instanceof Error) {
+      callback(error);
+    } else {
+      callback(new Error(String(error)));
+    }
   }
-
-  if (typeof result === 'string') {
-    return callback(null, result, map);
-  }
-
-  const useMap = map !== undefined && map !== null;
-  const finalMap = result.map ?? map;
-  callback(null, result.code, useMap ? finalMap : undefined);
 }


### PR DESCRIPTION
## Summary

Handle errors in transform loader with try-catch block. 

When I was fixing the unplugin transform issue, I found that Rsbuild's `api.transform` also had this issue, related https://github.com/web-infra-dev/rsbuild/issues/4789.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
