### PR TITLE
feat(css): add support for raw CSS imports

### DIFF
--- a/e2e/cases/css/css-raw/index.test.ts
+++ b/e2e/cases/css/css-raw/index.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to import raw CSS files in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to import raw CSS files in production mode', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/css/css-raw/src/a.css
+++ b/e2e/cases/css/css-raw/src/a.css
@@ -1,0 +1,3 @@
+.header-class {
+  color: red;
+}

--- a/e2e/cases/css/css-raw/src/b.module.css
+++ b/e2e/cases/css/css-raw/src/b.module.css
@@ -1,0 +1,3 @@
+.title-class {
+  font-size: 14px;
+}

--- a/e2e/cases/css/css-raw/src/index.js
+++ b/e2e/cases/css/css-raw/src/index.js
@@ -1,0 +1,5 @@
+import aRaw from './a.css?raw';
+import bRaw from './b.module.css?raw';
+
+window.aRaw = aRaw;
+window.bRaw = bRaw;

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,4 +1,4 @@
-import './App.css';
+import rawCss from './App.css?raw';
 
 const App = () => {
   return (

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -49,6 +49,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -71,6 +74,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -463,6 +471,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -485,6 +496,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -872,6 +888,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -895,6 +914,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -1208,6 +1232,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1231,6 +1258,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -49,6 +49,8 @@ export const CHAIN_ID = {
     TS: 'ts',
     /** Rule for CSS */
     CSS: 'css',
+    /** Rule for raw CSS */
+    CSS_RAW: 'css-raw',
     /** Rule for less */
     LESS: 'less',
     /** Rule for sass */

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -265,6 +265,7 @@ export const pluginCss = (): RsbuildPlugin => ({
       order: 'pre',
       handler: async (chain, { target, isProd, CHAIN_ID, environment }) => {
         const rule = chain.module.rule(CHAIN_ID.RULE.CSS);
+        const rawRule = chain.module.rule(CHAIN_ID.RULE.CSS_RAW);
         const { config } = environment;
 
         rule
@@ -273,7 +274,12 @@ export const pluginCss = (): RsbuildPlugin => ({
           .type('javascript/auto')
           // When using `new URL('./path/to/foo.css', import.meta.url)`,
           // the module should be treated as an asset module rather than a JS module.
-          .dependency({ not: 'url' });
+          .dependency({ not: 'url' })
+          // exclude `import './foo.css?raw'`
+          .resourceQuery({ not: /raw/ });
+
+        // Support for importing raw CSS files
+        rawRule.test(CSS_REGEX).type('asset/source').resourceQuery(/raw/);
 
         const emitCss = config.output.emitCss ?? target === 'web';
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -36,6 +36,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -69,6 +72,11 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -11,6 +11,9 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -45,6 +48,11 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           },
         ],
       },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
+      },
     ],
   },
   "plugins": [
@@ -73,6 +81,9 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -97,6 +108,11 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
           },
         ],
       },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
+      },
     ],
   },
   "plugins": [
@@ -117,6 +133,9 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
         },
         "resolve": {
           "preferRelative": true,
+        },
+        "resourceQuery": {
+          "not": /raw/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -152,6 +171,11 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           },
         ],
       },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
+      },
     ],
   },
   "plugins": [
@@ -170,6 +194,9 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -220,6 +247,11 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.css\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -231,6 +263,9 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -280,6 +315,11 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.css\\$/,
+    "type": "asset/source",
   },
 ]
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -36,6 +36,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -69,6 +72,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -459,6 +467,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -492,6 +503,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -918,6 +934,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -941,6 +960,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {
@@ -1280,6 +1304,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "resolve": {
           "preferRelative": true,
         },
+        "resourceQuery": {
+          "not": /raw/,
+        },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1313,6 +1340,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.css\\$/,
+        "type": "asset/source",
       },
       {
         "dependency": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1313,6 +1313,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "resolve": {
             "preferRelative": true,
           },
+          "resourceQuery": {
+            "not": /raw/,
+          },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
           "type": "javascript/auto",
@@ -1346,6 +1349,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.css\\$/,
+          "type": "asset/source",
         },
         {
           "dependency": {
@@ -1671,6 +1679,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "resolve": {
             "preferRelative": true,
           },
+          "resourceQuery": {
+            "not": /raw/,
+          },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
           "type": "javascript/auto",
@@ -1694,6 +1705,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.css\\$/,
+          "type": "asset/source",
         },
         {
           "dependency": {

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -184,6 +184,11 @@ declare module '*?inline' {
   export default content;
 }
 
+declare module '*.css?raw' {
+  const content: string;
+  export default content;
+}
+
 /**
  * CSS Modules
  */


### PR DESCRIPTION
## Summary

Supports importing raw CSS files as strings in JavaScript by using the `?raw` query parameter:

```ts title="src/index.js"
import rawCss from './style.css?raw';

console.log(rawCss); // Output the raw content of the CSS file
```

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/4562
- https://github.com/web-infra-dev/rsbuild/issues/3778

## Alternatives

While it is possible to support `?raw` query for all resources using the `NormalModuleReplacementPlugin`, this would result in a significant degradation in build performance, so this PR does not use it.

```js
export default defineConfig({
  tools: {
    rspack: (config, { rspack }) => {
      config.module?.rules?.push({
        resourceQuery: /raw/,
        type: 'asset/source',
      });
      config.plugins?.push(
        new rspack.NormalModuleReplacementPlugin(/\?raw$/, (resource) => {
          resource.request = '!' + resource.request;
        }),
      );
    },
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
