### PR TITLE
feat(plugin-less): add support for raw query

### DIFF
--- a/e2e/cases/css/less-raw/index.test.ts
+++ b/e2e/cases/css/less-raw/index.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to import raw Less files in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.less'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to import raw Less files in production mode', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.less'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/css/less-raw/rsbuild.config.ts
+++ b/e2e/cases/css/less-raw/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginLess } from '@rsbuild/plugin-less';
+
+export default {
+  plugins: [pluginLess()],
+};

--- a/e2e/cases/css/less-raw/src/a.less
+++ b/e2e/cases/css/less-raw/src/a.less
@@ -1,0 +1,5 @@
+.header {
+  &-class {
+    color: red;
+  }
+}

--- a/e2e/cases/css/less-raw/src/b.module.less
+++ b/e2e/cases/css/less-raw/src/b.module.less
@@ -1,0 +1,5 @@
+.title {
+  &-class {
+    font-size: 14px;
+  }
+}

--- a/e2e/cases/css/less-raw/src/index.js
+++ b/e2e/cases/css/less-raw/src/index.js
@@ -1,0 +1,5 @@
+import aRaw from './a.less?raw';
+import bRaw from './b.module.less?raw';
+
+window.aRaw = aRaw;
+window.bRaw = bRaw;

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -53,6 +53,8 @@ export const CHAIN_ID = {
     CSS_RAW: 'css-raw',
     /** Rule for Less */
     LESS: 'less',
+    /** Rule for raw Less */
+    LESS_RAW: 'less-raw',
     /** Rule for Sass */
     SASS: 'sass',
     /** Rule for raw Sass */

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -139,12 +139,22 @@ export const pluginLess = (
       const { config } = environment;
 
       const ruleId = findRuleId(chain, CHAIN_ID.RULE.LESS);
+      const test = pluginOptions.include ?? /\.less$/;
       const rule = chain.module
         .rule(ruleId)
-        .test(pluginOptions.include ?? /\.less$/)
+        .test(test)
         .merge({ sideEffects: true })
         .resolve.preferRelative(true)
-        .end();
+        .end()
+        // exclude `import './foo.less?raw'`
+        .resourceQuery({ not: /raw/ });
+
+      // Support for importing raw Less files
+      chain.module
+        .rule(CHAIN_ID.RULE.LESS_RAW)
+        .test(test)
+        .type('asset/source')
+        .resourceQuery(/raw/);
 
       const { sourceMap } = config.output;
       const { excludes, options } = getLessLoaderOptions(

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -9,6 +9,9 @@ exports[`plugin-less > should add less-loader 1`] = `
     "resolve": {
       "preferRelative": true,
     },
+    "resourceQuery": {
+      "not": /raw/,
+    },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
@@ -55,6 +58,11 @@ exports[`plugin-less > should add less-loader 1`] = `
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -66,6 +74,9 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -113,6 +124,11 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -127,6 +143,9 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
     ],
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -174,6 +193,11 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -185,6 +209,9 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -232,6 +259,11 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -243,6 +275,9 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -296,6 +331,11 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
   },
 ]
 `;

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -109,6 +109,6 @@ describe('plugin-less', () => {
 
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(1);
-    expect(matchRules(bundlerConfigs[0], 'b.less').length).toBe(2);
+    expect(matchRules(bundlerConfigs[0], 'b.less').length).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary

Supports importing raw Less files as strings in JavaScript by using the `?raw` query parameter:

```ts title="src/index.js"
import rawLess from './style.less?raw';

console.log(rawLess); // Output the raw content of the Less file
```

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4841

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
