### PR TITLE
feat(plugin-stylus): add support for raw query

### DIFF
--- a/e2e/cases/css/stylus-raw/index.test.ts
+++ b/e2e/cases/css/stylus-raw/index.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to import raw Stylus files in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.styl'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to import raw Stylus files in production mode', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bRaw')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.styl'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/css/stylus-raw/rsbuild.config.ts
+++ b/e2e/cases/css/stylus-raw/rsbuild.config.ts
@@ -1,0 +1,5 @@
+import { pluginStylus } from '@rsbuild/plugin-stylus';
+
+export default {
+  plugins: [pluginStylus()],
+};

--- a/e2e/cases/css/stylus-raw/src/a.styl
+++ b/e2e/cases/css/stylus-raw/src/a.styl
@@ -1,0 +1,3 @@
+.header
+  &-class
+    color red

--- a/e2e/cases/css/stylus-raw/src/b.module.styl
+++ b/e2e/cases/css/stylus-raw/src/b.module.styl
@@ -1,0 +1,3 @@
+.title
+  &-class
+    font-size 14px

--- a/e2e/cases/css/stylus-raw/src/index.js
+++ b/e2e/cases/css/stylus-raw/src/index.js
@@ -1,0 +1,5 @@
+import aRaw from './a.styl?raw';
+import bRaw from './b.module.styl?raw';
+
+window.aRaw = aRaw;
+window.bRaw = bRaw;

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -61,6 +61,8 @@ export const CHAIN_ID = {
     SASS_RAW: 'sass-raw',
     /** Rule for stylus */
     STYLUS: 'stylus',
+    /** Rule for raw stylus */
+    STYLUS_RAW: 'stylus-raw',
     /** Rule for svg */
     SVG: 'svg',
     /** Rule for pug */

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -49,12 +49,23 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         mergeFn: deepmerge,
       });
 
+      const test = /\.styl(us)?$/;
+
       const rule = chain.module
         .rule(CHAIN_ID.RULE.STYLUS)
-        .test(/\.styl(us)?$/)
+        .test(test)
         .merge({ sideEffects: true })
         .resolve.preferRelative(true)
-        .end();
+        .end()
+        // exclude `import './foo.styl?raw'`
+        .resourceQuery({ not: /raw/ });
+
+      // Support for importing raw Stylus files
+      chain.module
+        .rule(CHAIN_ID.RULE.STYLUS_RAW)
+        .test(test)
+        .type('asset/source')
+        .resourceQuery(/raw/);
 
       // Copy the builtin CSS rules
       const cssRule = chain.module.rules.get(CHAIN_ID.RULE.CSS);

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -9,6 +9,9 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     "resolve": {
       "preferRelative": true,
     },
+    "resourceQuery": {
+      "not": /raw/,
+    },
     "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
@@ -48,6 +51,11 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -59,6 +67,9 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     },
     "resolve": {
       "preferRelative": true,
+    },
+    "resourceQuery": {
+      "not": /raw/,
     },
     "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
@@ -101,6 +112,11 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
+    "type": "asset/source",
   },
 ]
 `;


### PR DESCRIPTION
## Summary

Supports importing raw Stylus files as strings in JavaScript by using the `?raw` query parameter:

```ts title="src/index.js"
import rawStylus from './style.styl?raw';

console.log(rawStylus); // Output the raw content of the Stylus file
```

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4841

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
