### PR TITLE
feat: add types for raw imports of CSS preprocessors

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -184,7 +184,30 @@ declare module '*?inline' {
   export default content;
 }
 
+/**
+ * Raw css
+ */
 declare module '*.css?raw' {
+  const content: string;
+  export default content;
+}
+declare module '*.scss?raw' {
+  const content: string;
+  export default content;
+}
+declare module '*.sass?raw' {
+  const content: string;
+  export default content;
+}
+declare module '*.less?raw' {
+  const content: string;
+  export default content;
+}
+declare module '*.styl?raw' {
+  const content: string;
+  export default content;
+}
+declare module '*.stylus?raw' {
   const content: string;
   export default content;
 }

--- a/website/docs/en/guide/basic/css-usage.mdx
+++ b/website/docs/en/guide/basic/css-usage.mdx
@@ -172,3 +172,7 @@ Using `import "*.css?raw"` has the following behaviors:
 - Get the raw text content of the CSS file, without any preprocessing or compilation
 - The content of the CSS file will be inlined into the final JavaScript bundle
 - No separate CSS file will be generated
+
+:::tip
+Rsbuild's Sass, Less, and Stylus plugins also support the `?raw` query parameter.
+:::

--- a/website/docs/zh/guide/basic/css-usage.mdx
+++ b/website/docs/zh/guide/basic/css-usage.mdx
@@ -172,3 +172,7 @@ console.log(rawCss); // 输出 CSS 文件的原始内容
 - 获取 CSS 文件的原始文本内容，不经过任何预处理或编译
 - 内容会作为字符串内联到最终的 JavaScript 包中
 - 不会生成单独的 CSS 文件
+
+:::tip
+Rsbuild 的 Sass、Less 和 Stylus 插件也支持 `?raw` 查询参数。
+:::


### PR DESCRIPTION
## Summary

- Add types for raw imports of CSS preprocessors
- Updates the documentation to include information about the support for the `?raw` query parameter in Rsbuild's Sass, Less, and Stylus plugins.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/4843
- https://github.com/web-infra-dev/rsbuild/pull/4844
- https://github.com/web-infra-dev/rsbuild/pull/4845

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
