### PR TITLE
feat(css): add support for inline CSS imports

### DIFF
--- a/e2e/cases/css/css-inline/index.test.ts
+++ b/e2e/cases/css/css-inline/index.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to import inline CSS files in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aInline')).toBe(
+    readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
+  );
+  expect(await page.evaluate('window.bInline')).toBe(
+    readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to import inline CSS files in production mode', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.aInline')).toBe(
+    '.header-class{color:red}',
+  );
+  expect(await page.evaluate('window.bInline')).toBe(
+    '.title-class{font-size:14px}',
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/css/css-inline/index.test.ts
+++ b/e2e/cases/css/css-inline/index.test.ts
@@ -1,40 +1,42 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { build, dev } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should allow to import inline CSS files in development mode', async ({
-  page,
-}) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'should allow to import inline CSS files in development mode',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
 
-  expect(await page.evaluate('window.aInline')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bInline')).toBe(
-    readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
-  );
+    expect(await page.evaluate('window.aInline')).toBe(
+      readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
+    );
+    expect(await page.evaluate('window.bInline')).toBe(
+      readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
+    );
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);
 
-test('should allow to import inline CSS files in production mode', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'should allow to import inline CSS files in production mode',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-  expect(await page.evaluate('window.aInline')).toBe(
-    '.header-class{color:red}',
-  );
-  expect(await page.evaluate('window.bInline')).toBe(
-    '.title-class{font-size:14px}',
-  );
+    expect(await page.evaluate('window.aInline')).toBe(
+      '.header-class{color:red}',
+    );
+    expect(await page.evaluate('window.bInline')).toBe(
+      '.title-class{font-size:14px}',
+    );
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/css/css-inline/index.test.ts
+++ b/e2e/cases/css/css-inline/index.test.ts
@@ -11,12 +11,15 @@ rspackOnlyTest(
       page,
     });
 
-    expect(await page.evaluate('window.aInline')).toBe(
-      readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
-    );
-    expect(await page.evaluate('window.bInline')).toBe(
-      readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
-    );
+    const aInline: string = await page.evaluate('window.aInline');
+    const bInline: string = await page.evaluate('window.bInline');
+
+    expect(
+      aInline.includes('.header-class') && aInline.includes('color: red'),
+    ).toBe(true);
+    expect(
+      bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
+    ).toBe(true);
 
     await rsbuild.close();
   },

--- a/e2e/cases/css/css-inline/src/a.css
+++ b/e2e/cases/css/css-inline/src/a.css
@@ -1,0 +1,3 @@
+.header-class {
+  color: red;
+}

--- a/e2e/cases/css/css-inline/src/b.module.css
+++ b/e2e/cases/css/css-inline/src/b.module.css
@@ -1,0 +1,3 @@
+.title-class {
+  font-size: 14px;
+}

--- a/e2e/cases/css/css-inline/src/index.js
+++ b/e2e/cases/css/css-inline/src/index.js
@@ -1,0 +1,5 @@
+import aInline from './a.css?inline';
+import bInline from './b.module.css?inline';
+
+window.aInline = aInline;
+window.bInline = bInline;

--- a/examples/react/src/App.tsx
+++ b/examples/react/src/App.tsx
@@ -1,4 +1,4 @@
-import rawCss from './App.css?raw';
+import './App.css';
 
 const App = () => {
   return (

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -89,13 +89,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -537,13 +531,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -981,14 +969,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": true,
-                "localIdentName": "[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -1352,14 +1333,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": true,
-                "localIdentName": "[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -50,7 +50,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -62,6 +62,32 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,
@@ -472,7 +498,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -484,6 +510,32 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,
@@ -889,7 +941,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -901,6 +953,33 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,
@@ -1233,7 +1312,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -1245,6 +1324,33 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -51,6 +51,8 @@ export const CHAIN_ID = {
     CSS: 'css',
     /** Rule for raw CSS */
     CSS_RAW: 'css-raw',
+    /** Rule for inline CSS */
+    CSS_INLINE: 'css-inline',
     /** Rule for Less */
     LESS: 'less',
     /** Rule for raw Less */

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -37,7 +37,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -49,6 +49,43 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": true,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -87,13 +87,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -62,13 +62,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": [Function],
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -159,14 +153,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": true,
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -249,13 +236,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -362,13 +343,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         "options": {
           "exportType": "string",
           "importLoaders": 2,
-          "modules": {
-            "auto": true,
-            "exportGlobals": false,
-            "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-            "namedExport": false,
-          },
+          "modules": false,
           "sourceMap": false,
         },
       },
@@ -483,13 +458,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
         "options": {
           "exportType": "string",
           "importLoaders": 2,
-          "modules": {
-            "auto": true,
-            "exportGlobals": false,
-            "exportLocalsConvention": "camelCase",
-            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-            "namedExport": false,
-          },
+          "modules": false,
           "sourceMap": false,
         },
       },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -12,7 +12,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -24,6 +24,43 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": [Function],
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": [Function],
@@ -82,7 +119,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -94,6 +131,33 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,
@@ -135,7 +199,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -147,6 +211,43 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": true,
@@ -196,7 +297,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw/,
+      "not": /raw\\|inline/,
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -208,6 +309,58 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
         "options": {
+          "importLoaders": 2,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
+        "options": {
+          "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
+          "postcssOptions": {
+            "config": false,
+            "plugins": [
+              {
+                "postcssPlugin": "foo",
+              },
+            ],
+          },
+          "sourceMap": false,
+        },
+      },
+    ],
+  },
+  {
+    "resolve": {
+      "preferRelative": true,
+    },
+    "resourceQuery": /inline/,
+    "sideEffects": true,
+    "test": /\\\\\\.css\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+        "options": {
+          "exportType": "string",
           "importLoaders": 2,
           "modules": {
             "auto": true,
@@ -265,7 +418,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw/,
+      "not": /raw\\|inline/,
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -277,6 +430,58 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
         "options": {
+          "importLoaders": 2,
+          "modules": {
+            "auto": true,
+            "exportGlobals": false,
+            "exportLocalsConvention": "camelCase",
+            "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+            "namedExport": false,
+          },
+          "sourceMap": false,
+        },
+      },
+      {
+        "loader": "builtin:lightningcss-loader",
+        "options": {
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+      },
+      {
+        "loader": "<ROOT>/packages/core/compiled/postcss-loader/index.js",
+        "options": {
+          "implementation": "<ROOT>/packages/core/compiled/postcss/index.js",
+          "postcssOptions": {
+            "config": false,
+            "plugins": [
+              {
+                "postcssPlugin": "bar",
+              },
+            ],
+          },
+          "sourceMap": false,
+        },
+      },
+    ],
+  },
+  {
+    "resolve": {
+      "preferRelative": true,
+    },
+    "resourceQuery": /inline/,
+    "sideEffects": true,
+    "test": /\\\\\\.css\\$/,
+    "type": "javascript/auto",
+    "use": [
+      {
+        "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+        "options": {
+          "exportType": "string",
           "importLoaders": 2,
           "modules": {
             "auto": true,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -37,7 +37,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -49,6 +49,43 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": true,
@@ -468,7 +505,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -480,6 +517,43 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": true,
@@ -935,7 +1009,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -947,6 +1021,33 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 0,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "exportOnlyLocals": true,
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 0,
               "modules": {
                 "auto": true,
@@ -1305,7 +1406,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw/,
+          "not": /raw\\|inline/,
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -1317,6 +1418,43 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
+              "importLoaders": 1,
+              "modules": {
+                "auto": true,
+                "exportGlobals": false,
+                "exportLocalsConvention": "camelCase",
+                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                "namedExport": false,
+              },
+              "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "targets": [
+                "chrome >= 87",
+                "edge >= 88",
+                "firefox >= 78",
+                "safari >= 14",
+              ],
+            },
+          },
+        ],
+      },
+      {
+        "resolve": {
+          "preferRelative": true,
+        },
+        "resourceQuery": /inline/,
+        "sideEffects": true,
+        "test": /\\\\\\.css\\$/,
+        "type": "javascript/auto",
+        "use": [
+          {
+            "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+            "options": {
+              "exportType": "string",
               "importLoaders": 1,
               "modules": {
                 "auto": true,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -87,13 +87,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -555,19 +549,14 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "minify": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -1049,14 +1038,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "options": {
               "exportType": "string",
               "importLoaders": 0,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "exportOnlyLocals": true,
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },
@@ -1456,13 +1438,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "options": {
               "exportType": "string",
               "importLoaders": 1,
-              "modules": {
-                "auto": true,
-                "exportGlobals": false,
-                "exportLocalsConvention": "camelCase",
-                "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                "namedExport": false,
-              },
+              "modules": false,
               "sourceMap": false,
             },
           },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1364,13 +1364,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "options": {
                 "exportType": "string",
                 "importLoaders": 1,
-                "modules": {
-                  "auto": true,
-                  "exportGlobals": false,
-                  "exportLocalsConvention": "camelCase",
-                  "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                  "namedExport": false,
-                },
+                "modules": false,
                 "sourceMap": false,
               },
             },
@@ -1757,14 +1751,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "options": {
                 "exportType": "string",
                 "importLoaders": 0,
-                "modules": {
-                  "auto": true,
-                  "exportGlobals": false,
-                  "exportLocalsConvention": "camelCase",
-                  "exportOnlyLocals": true,
-                  "localIdentName": "[path][name]__[local]-[hash:base64:6]",
-                  "namedExport": false,
-                },
+                "modules": false,
                 "sourceMap": false,
               },
             },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1314,7 +1314,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "preferRelative": true,
           },
           "resourceQuery": {
-            "not": /raw/,
+            "not": /raw\\|inline/,
           },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
@@ -1326,6 +1326,43 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
               "options": {
+                "importLoaders": 1,
+                "modules": {
+                  "auto": true,
+                  "exportGlobals": false,
+                  "exportLocalsConvention": "camelCase",
+                  "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                  "namedExport": false,
+                },
+                "sourceMap": false,
+              },
+            },
+            {
+              "loader": "builtin:lightningcss-loader",
+              "options": {
+                "targets": [
+                  "chrome >= 87",
+                  "edge >= 88",
+                  "firefox >= 78",
+                  "safari >= 14",
+                ],
+              },
+            },
+          ],
+        },
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "resourceQuery": /inline/,
+          "sideEffects": true,
+          "test": /\\\\\\.css\\$/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+              "options": {
+                "exportType": "string",
                 "importLoaders": 1,
                 "modules": {
                   "auto": true,
@@ -1680,7 +1717,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "preferRelative": true,
           },
           "resourceQuery": {
-            "not": /raw/,
+            "not": /raw\\|inline/,
           },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
@@ -1692,6 +1729,33 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
               "options": {
+                "importLoaders": 0,
+                "modules": {
+                  "auto": true,
+                  "exportGlobals": false,
+                  "exportLocalsConvention": "camelCase",
+                  "exportOnlyLocals": true,
+                  "localIdentName": "[path][name]__[local]-[hash:base64:6]",
+                  "namedExport": false,
+                },
+                "sourceMap": false,
+              },
+            },
+          ],
+        },
+        {
+          "resolve": {
+            "preferRelative": true,
+          },
+          "resourceQuery": /inline/,
+          "sideEffects": true,
+          "test": /\\\\\\.css\\$/,
+          "type": "javascript/auto",
+          "use": [
+            {
+              "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
+              "options": {
+                "exportType": "string",
                 "importLoaders": 0,
                 "modules": {
                   "auto": true,

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -185,7 +185,15 @@ declare module '*?inline' {
 }
 
 /**
- * Raw css
+ * Inline CSS
+ */
+declare module '*.css?inline' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Raw CSS
  */
 declare module '*.css?raw' {
   const content: string;


### PR DESCRIPTION
## Summary

Supports importing transformed CSS files as strings in JavaScript by using the `?inline` query parameter:

```ts title="src/index.js"
import inlineCss from './style.css?inline';

console.log(inlineCss); // Output the inline content of the CSS file
```

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/4562
- https://github.com/web-infra-dev/rsbuild/issues/3778

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
