### PR TITLE
Fix typo in English HMR guide

### DIFF
--- a/website/docs/en/guide/advanced/hmr.mdx
+++ b/website/docs/en/guide/advanced/hmr.mdx
@@ -50,7 +50,7 @@ export default {
 
 ## File watching
 
-By default, Rsbuild does not watching files in the `.git/` and `node_modules/` directories. When files in these directories changed, Rsbuild will not trigger a rebuild. This helps to reduce memory usage and improve build performance.
+By default, Rsbuild does not watch files in the `.git/` and `node_modules/` directories. When files in these directories changed, Rsbuild will not trigger a rebuild. This helps to reduce memory usage and improve build performance.
 
 If you want to watch these directories, you can manually configure Rspack's [watchOptions.ignored](https://rspack.dev/config/watch#watchoptionsignored) to override the default behavior.
 


### PR DESCRIPTION
## Summary
Fixed a minor typo in the English translation of the hot-module-reload guide page

## Checklist

- [x] Tests not required.
- [x] Documentation updated.
