### PR TITLE
chore: replace merge with rspack-chain methods

### DIFF
--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -11,9 +11,7 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
     rsbuildConfig: {
       tools: {
         bundlerChain: (chain) => {
-          chain.resolve.alias.merge({
-            '@common': join(__dirname, 'src/common'),
-          });
+          chain.resolve.alias.set('@common', join(__dirname, 'src/common'));
         },
       },
     },
@@ -35,9 +33,7 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
         bundlerChain: async (chain) => {
           return new Promise((resolve) => {
             setTimeout(() => {
-              chain.resolve.alias.merge({
-                '@common': join(__dirname, 'src/common'),
-              });
+              chain.resolve.alias.set('@common', join(__dirname, 'src/common'));
               resolve();
             }, 0);
           });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
     "rslog": "^1.2.3",
-    "rspack-chain": "^1.2.2",
+    "rspack-chain": "^1.2.3",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -122,16 +122,20 @@ export const pluginAsset = (): RsbuildPlugin => ({
 
       // image
       createAssetRule(CHAIN_ID.RULE.IMAGE, IMAGE_EXTENSIONS, emitAssets);
+
       // svg
       createAssetRule(CHAIN_ID.RULE.SVG, ['svg'], emitAssets);
+
       // media
       createAssetRule(
         CHAIN_ID.RULE.MEDIA,
         [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS],
         emitAssets,
       );
+
       // font
       createAssetRule(CHAIN_ID.RULE.FONT, FONT_EXTENSIONS, emitAssets);
+
       // assets
       const assetsFilename = getMergedFilename('assets');
       chain.output.assetModuleFilename(assetsFilename);

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -54,11 +54,9 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         chain.mode(environment.config.mode);
 
-        chain.merge({
-          infrastructureLogging: {
-            // Using `error` level to avoid `cache.PackFileCacheStrategy` logs
-            level: 'error',
-          },
+        chain.infrastructureLogging({
+          // Using `error` level to avoid `cache.PackFileCacheStrategy` logs
+          level: 'error',
         });
 
         chain.watchOptions({

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -412,7 +412,7 @@ export const pluginCss = (): RsbuildPlugin => ({
           );
 
           // CSS imports should always be treated as sideEffects
-          rule.merge({ sideEffects: true });
+          rule.sideEffects(true);
 
           // Enable preferRelative by default, which is consistent with the default behavior of css-loader
           // see: https://github.com/webpack-contrib/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -117,10 +117,9 @@ export const pluginResolve = (): RsbuildPlugin => ({
         if (isTsProject) {
           // TypeScript allows importing TS files with `.js` extension
           // See: https://github.com/microsoft/TypeScript/blob/c09e2ab4/src/compiler/moduleNameResolver.ts#L2151-L2168
-          chain.resolve.extensionAlias.merge({
-            '.js': ['.js', '.ts', '.tsx'],
-            '.jsx': ['.jsx', '.tsx'],
-          });
+          chain.resolve.extensionAlias
+            .set('.js', ['.js', '.ts', '.tsx'])
+            .set('.jsx', ['.jsx', '.tsx']);
         }
 
         applyAlias({

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -15,19 +15,14 @@ export const pluginWasm = (): RsbuildPlugin => ({
       });
 
       const wasmFilename = posix.join(distPath, '[hash].module.wasm');
-
-      chain.output.merge({
-        webassemblyModuleFilename: wasmFilename,
-      });
+      chain.output.webassemblyModuleFilename(wasmFilename);
 
       // support new URL('./abc.wasm', import.meta.url)
       chain.module
         .rule(CHAIN_ID.RULE.WASM)
         .test(/\.wasm$/)
         // only include assets that came from new URL calls
-        .merge({
-          dependency: 'url',
-        })
+        .dependency('url')
         .type('asset/resource')
         .set('generator', {
           filename: wasmFilename,

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -143,7 +143,7 @@ export const pluginLess = (
       const rule = chain.module
         .rule(ruleId)
         .test(test)
-        .merge({ sideEffects: true })
+        .sideEffects(true)
         .resolve.preferRelative(true)
         .end()
         // exclude `import './foo.less?raw'`

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -122,7 +122,7 @@ export const pluginSass = (
       const rule = chain.module
         .rule(ruleId)
         .test(test)
-        .merge({ sideEffects: true })
+        .sideEffects(true)
         .resolve.preferRelative(true)
         .end()
         // exclude `import './foo.scss?raw'`

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -44,11 +44,10 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
                   require.resolve('solid-refresh/babel'),
                 ]);
 
-                chain.resolve.alias.merge({
-                  'solid-refresh': require.resolve(
-                    'solid-refresh/dist/solid-refresh.mjs',
-                  ),
-                });
+                chain.resolve.alias.set(
+                  'solid-refresh',
+                  require.resolve('solid-refresh/dist/solid-refresh.mjs'),
+                );
               }
 
               return babelOptions;

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -54,7 +54,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       const rule = chain.module
         .rule(CHAIN_ID.RULE.STYLUS)
         .test(test)
-        .merge({ sideEffects: true })
+        .sideEffects(true)
         .resolve.preferRelative(true)
         .end()
         // exclude `import './foo.styl?raw'`

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -98,13 +98,7 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
           // imports with inline loader reference like `!svelte-loader...`,
           // which would cause the bundler failed to resolve the loader.
           // See https://github.com/sveltejs/svelte-loader/blob/344f00744b06a98ff5ee7e7a04d5e04ac496988c/index.js#L128
-          chain.merge({
-            resolveLoader: {
-              alias: {
-                'svelte-loader': loaderPath,
-              },
-            },
-          });
+          chain.resolveLoader.alias.set('svelte-loader', loaderPath);
 
           const userLoaderOptions = options.svelteLoaderOptions ?? {};
           const svelteLoaderOptions = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -706,8 +706,8 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       rspack-chain:
-        specifier: ^1.2.2
-        version: 1.2.2
+        specifier: ^1.2.3
+        version: 1.2.3
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.3.0-beta.0(@swc/helpers@0.5.15))
@@ -5676,8 +5676,8 @@ packages:
     resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
     engines: {node: '>=14.17.6'}
 
-  rspack-chain@1.2.2:
-    resolution: {integrity: sha512-NdSiOvtwXJgg1A5Ss579GUh6PRbkzz5dV+3D7nzM3V0HLm2wrL4Rv359AjoNAD1iXh+kEqf2Zj95gnhhyrEzLA==}
+  rspack-chain@1.2.3:
+    resolution: {integrity: sha512-w9rOSoejQt7+oQRCboMiecm+1Nvcaf0OaXRzhkH7uZh21W2svlbxfm9r0sjLdhi3EyUA+qZa0GPQCiSPtoPJow==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -11820,7 +11820,7 @@ snapshots:
 
   rslog@1.2.3: {}
 
-  rspack-chain@1.2.2:
+  rspack-chain@1.2.3:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

- Replace `merge()` with `rspack-chain` methods for better readability and performance.
- Update `rspack-chain` to v1.2.3, https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.2.3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
