### PR TITLE
docs: `pluginReact` is also needed when using `pluginSvgr`

### DIFF
--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -23,10 +23,11 @@ import { PackageManagerTabs } from '@theme';
 You can register the plugin in the `rsbuild.config.ts` file:
 
 ```ts title="rsbuild.config.ts"
+import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
 export default {
-  plugins: [pluginSvgr()],
+  plugins: [pluginReact(), pluginSvgr()],
 };
 ```
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -23,10 +23,11 @@ import { PackageManagerTabs } from '@theme';
 你可以在 `rsbuild.config.ts` 文件中注册插件：
 
 ```ts title="rsbuild.config.ts"
+import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
 export default {
-  plugins: [pluginSvgr()],
+  plugins: [pluginReact(), pluginSvgr()],
 };
 ```
 


### PR DESCRIPTION
## Summary

update `pluginSvgr` usage example, `pluginReact` is also needed when using `pluginSvgr`.

```ts title="rsbuild.config.ts"
import { pluginReact } from '@rsbuild/plugin-react';
import { pluginSvgr } from '@rsbuild/plugin-svgr';

export default {
  plugins: [pluginReact(), pluginSvgr()],
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
