### PR TITLE
fix(plugin-stylus): `define` option type

### DIFF
--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -9,7 +9,17 @@ export const PLUGIN_STYLUS_NAME = 'rsbuild:stylus';
 
 type StylusOptions = {
   use?: string[];
-  define?: [string, any, boolean?];
+  /**
+   * Define Stylus variables or functions.
+   *
+   * @default {}
+   * @example
+   * define: [
+   *   ["$development", process.env.NODE_ENV === "development"],
+   *   ["rawVar", 42, true],
+   * ]
+   */
+  define?: [string, any, boolean?][];
   include?: string[];
   /**
    * Import the specified Stylus files/paths, can not be relative path.

--- a/website/docs/en/plugins/list/plugin-stylus.mdx
+++ b/website/docs/en/plugins/list/plugin-stylus.mdx
@@ -67,7 +67,7 @@ To customize the compilation behavior of Stylus, use the following options.
 ```ts
 type StylusOptions = {
   use?: string[];
-  define?: [string, any, boolean?];
+  define?: [string, any, boolean?][];
   include?: string[];
   import?: string[];
   resolveURL?: boolean;

--- a/website/docs/zh/plugins/list/plugin-stylus.mdx
+++ b/website/docs/zh/plugins/list/plugin-stylus.mdx
@@ -67,7 +67,7 @@ console.log(style.title);
 ```ts
 type StylusOptions = {
   use?: string[];
-  define?: [string, any, boolean?];
+  define?: [string, any, boolean?][];
   include?: string[];
   import?: string[];
   resolveURL?: boolean;


### PR DESCRIPTION
## Summary

Fix the documentation and type definitions for the `define` option in `StylusOptions`. 

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/4840

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
