### PR TITLE
feat(asset): add support for raw query

### DIFF
--- a/e2e/cases/assets/raw/index.test.ts
+++ b/e2e/cases/assets/raw/index.test.ts
@@ -1,0 +1,40 @@
+import { promises } from 'node:fs';
+import { join } from 'node:path';
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to get raw asset content with `?raw` in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.rawImg')).toEqual(
+    await promises.readFile(
+      join(__dirname, '../../../assets/circle.svg'),
+      'utf-8',
+    ),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to get raw asset content with `?raw` in production mode', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.rawImg')).toEqual(
+    await promises.readFile(
+      join(__dirname, '../../../assets/circle.svg'),
+      'utf-8',
+    ),
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/assets/raw/src/index.js
+++ b/e2e/cases/assets/raw/src/index.js
@@ -1,0 +1,3 @@
+import img from '@assets/circle.svg?raw';
+
+window.rawImg = img;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -141,6 +141,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -166,6 +170,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -195,6 +203,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -220,6 +232,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -582,6 +598,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -607,6 +627,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -636,6 +660,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -661,6 +689,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1020,6 +1052,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -1045,6 +1081,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1074,6 +1114,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -1099,6 +1143,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1384,6 +1432,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -1409,6 +1461,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1438,6 +1494,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -1463,6 +1523,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -36,20 +36,26 @@ const chainStaticAssetRule = ({
     generatorOptions.emit = false;
   }
 
-  // force to url: "foo.png?url" or "foo.png?__inline=false"
+  // get asset URL: "foo.png?url" or "foo.png?__inline=false"
   rule
     .oneOf(`${assetType}-asset-url`)
     .type('asset/resource')
     .resourceQuery(/(__inline=false|url)/)
     .set('generator', generatorOptions);
 
-  // force to inline: "foo.png?inline"
+  // get inlined base64 content: "foo.png?inline"
   rule
     .oneOf(`${assetType}-asset-inline`)
     .type('asset/inline')
     .resourceQuery(/inline/);
 
-  // default: when size < dataUrlCondition.maxSize will inline
+  // get raw content: "foo.png?raw"
+  rule
+    .oneOf(`${assetType}-asset-raw`)
+    .type('asset/source')
+    .resourceQuery(/raw/);
+
+  // the asset will be inlined if fileSize < dataUrlCondition.maxSize
   rule
     .oneOf(`${assetType}-asset`)
     .type('asset')

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -18,6 +18,10 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -43,6 +47,10 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -72,6 +80,10 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -97,6 +109,10 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -143,6 +159,10 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "[name].[contenthash:8][ext]",
             },
@@ -168,6 +188,10 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -197,6 +221,10 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -222,6 +250,10 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -268,6 +300,10 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "foo/[name].[contenthash:8][ext]",
             },
@@ -293,6 +329,10 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -322,6 +362,10 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -347,6 +391,10 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -393,6 +441,10 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/foo[ext]",
             },
@@ -418,6 +470,10 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -447,6 +503,10 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -472,6 +532,10 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -219,6 +219,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -244,6 +248,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -273,6 +281,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -298,6 +310,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -219,6 +219,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -244,6 +248,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -273,6 +281,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -298,6 +310,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -681,6 +697,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -706,6 +726,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -735,6 +759,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -760,6 +788,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1150,6 +1182,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -1175,6 +1211,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1204,6 +1244,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -1229,6 +1273,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1570,6 +1618,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
@@ -1595,6 +1647,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {
@@ -1624,6 +1680,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/inline",
           },
           {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
+          },
+          {
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
@@ -1649,6 +1709,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "resourceQuery": /inline/,
             "type": "asset/inline",
+          },
+          {
+            "resourceQuery": /raw/,
+            "type": "asset/source",
           },
           {
             "generator": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1496,6 +1496,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "type": "asset/inline",
             },
             {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
+            },
+            {
               "generator": {
                 "filename": "static/image/[name].[contenthash:8][ext]",
               },
@@ -1521,6 +1525,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "resourceQuery": /inline/,
               "type": "asset/inline",
+            },
+            {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -1550,6 +1558,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "type": "asset/inline",
             },
             {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
+            },
+            {
               "generator": {
                 "filename": "static/media/[name].[contenthash:8][ext]",
               },
@@ -1575,6 +1587,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "resourceQuery": /inline/,
               "type": "asset/inline",
+            },
+            {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -1863,6 +1879,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "type": "asset/inline",
             },
             {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
+            },
+            {
               "generator": {
                 "filename": "static/image/[name].[contenthash:8][ext]",
               },
@@ -1888,6 +1908,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "resourceQuery": /inline/,
               "type": "asset/inline",
+            },
+            {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
             },
             {
               "generator": {
@@ -1917,6 +1941,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "type": "asset/inline",
             },
             {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
+            },
+            {
               "generator": {
                 "filename": "static/media/[name].[contenthash:8][ext]",
               },
@@ -1942,6 +1970,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "resourceQuery": /inline/,
               "type": "asset/inline",
+            },
+            {
+              "resourceQuery": /raw/,
+              "type": "asset/source",
             },
             {
               "generator": {


### PR DESCRIPTION
## Summary

Allow to use the `?raw` query to get the raw content of static assets:

```js
import rawSvg from './icon.svg?raw';

console.log(rawSvg);
```

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/3778

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
