### PR TITLE
docs: import static assets as string

### DIFF
--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -153,6 +153,20 @@ console.log(image); // "data:image/png;base64,iVBORw0KGgo..."
 
 For a more detailed introduction to asset inlining, please refer to the [Static Asset Inlining](/guide/optimization/inline-assets) chapter.
 
+## Import as string
+
+Rsbuild supports using the `?raw` query parameter to import the raw content of static assets as a string in JavaScript.
+
+```ts
+import rawSvg from './static/logo.svg?raw';
+
+console.log(rawSvg); // The raw content of the SVG file
+```
+
+:::tip
+Rsbuild >= 1.3.0 supports the `?raw` query parameter.
+:::
+
 ## Output files
 
 When static assets are imported, they will be output to the dist directory. You can:

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -153,6 +153,20 @@ console.log(image); // "data:image/png;base64,iVBORw0KGgo..."
 
 关于资源内联的更详细介绍，请参考 [静态资源内联](/guide/optimization/inline-assets) 章节。
 
+## 导入为字符串
+
+Rsbuild 支持通过 `?raw` 查询参数引用静态资源的原始内容，并将其作为字符串导入到 JavaScript 中。
+
+```ts
+import rawSvg from './static/logo.svg?raw';
+
+console.log(rawSvg); // 输出 SVG 文件的原始内容
+```
+
+:::tip
+Rsbuild >= 1.3.0 支持 `?raw` 查询参数。
+:::
+
 ## 构建产物
 
 当静态资源被引用后，会自动被输出到构建产物的目录下，你可以：


### PR DESCRIPTION
## Summary

Add guide for importing static assets as string via the `?raw` query parameter.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4869

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
