### PR TITLE
fix(server)!: should respect the value of the `server.cors` option

### DIFF
--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -41,7 +41,29 @@ test('should include CORS headers for preview server if `cors` is `true`', async
   await rsbuild.close();
 });
 
-test('should allow to disable CORS', async ({ page, request }) => {
+test('should not include CORS headers for dev server if `cors` is `false`', async ({
+  page,
+  request,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      server: {
+        cors: false,
+      },
+    },
+  });
+
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+  expect(response.headers()).not.toHaveProperty('access-control-allow-origin');
+  await rsbuild.close();
+});
+
+test('should not include CORS headers for preview server if `cors` is `false`', async ({
+  page,
+  request,
+}) => {
   const rsbuild = await build({
     cwd: __dirname,
     page,
@@ -54,7 +76,6 @@ test('should allow to disable CORS', async ({ page, request }) => {
 
   const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
   expect(response.headers()).not.toHaveProperty('access-control-allow-origin');
-
   await rsbuild.close();
 });
 

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -41,6 +41,26 @@ test('should include CORS headers for preview server if `cors` is `true`', async
   await rsbuild.close();
 });
 
+test('should include CORS headers for MF', async ({ page, request }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      moduleFederation: {
+        options: {
+          name: 'foo',
+          exposes: {},
+        },
+      },
+    },
+  });
+
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+  expect(response.headers()['access-control-allow-origin']).toEqual('*');
+
+  await rsbuild.close();
+});
+
 test('should not include CORS headers for dev server if `cors` is `false`', async ({
   page,
   request,

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -60,6 +60,17 @@ test('should not include CORS headers for dev server if `cors` is `false`', asyn
   await rsbuild.close();
 });
 
+test('should set `cors` to `false` by default', async ({ page, request }) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+  expect(response.headers()).not.toHaveProperty('access-control-allow-origin');
+  await rsbuild.close();
+});
+
 test('should not include CORS headers for preview server if `cors` is `false`', async ({
   page,
   request,

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -1,4 +1,4 @@
-import { build, dev } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should include CORS headers for dev server if `cors` is `true`', async ({
@@ -41,25 +41,28 @@ test('should include CORS headers for preview server if `cors` is `true`', async
   await rsbuild.close();
 });
 
-test('should include CORS headers for MF', async ({ page, request }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      moduleFederation: {
-        options: {
-          name: 'foo',
-          exposes: {},
+rspackOnlyTest(
+  'should include CORS headers for MF',
+  async ({ page, request }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        moduleFederation: {
+          options: {
+            name: 'foo',
+            exposes: {},
+          },
         },
       },
-    },
-  });
+    });
 
-  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
-  expect(response.headers()['access-control-allow-origin']).toEqual('*');
+    const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+    expect(response.headers()['access-control-allow-origin']).toEqual('*');
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);
 
 test('should not include CORS headers for dev server if `cors` is `false`', async ({
   page,

--- a/e2e/cases/server/fallback/index.test.ts
+++ b/e2e/cases/server/fallback/index.test.ts
@@ -17,7 +17,6 @@ test('OPTIONS request should fallback success when no other middleware responses
     method: 'OPTIONS',
   });
   expect(response.status).toBe(204);
-  expect(response.headers.get('access-control-allow-origin')).toBe('*');
 
   await rsbuild.close();
 });

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -163,14 +163,6 @@ export const canParse = (url: string): boolean => {
   }
 };
 
-export const parseUrl = (url: string): URL | null => {
-  try {
-    return new URL(url);
-  } catch {
-    return null;
-  }
-};
-
 export const ensureAssetPrefix = (
   url: string,
   assetPrefix: Rspack.PublicPath = DEFAULT_ASSET_PREFIX,

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -100,6 +100,15 @@ export function pluginModuleFederation(): RsbuildPlugin {
 
       api.modifyRsbuildConfig((config) => {
         const { moduleFederation } = config;
+
+        if (api.isPluginExists('rsbuild:module-federation-enhanced')) {
+          // Allow remote modules to be loaded by setting CORS headers
+          // This is required for MF to work properly across different origins
+          // TODO: remove this after https://github.com/module-federation/core/pull/3635 is released
+          config.server ||= {};
+          config.server.cors ||= true;
+        }
+
         if (!moduleFederation?.options) {
           return;
         }
@@ -107,6 +116,11 @@ export function pluginModuleFederation(): RsbuildPlugin {
         // Change some default configs for remote modules
         if (moduleFederation.options.exposes) {
           config.dev ||= {};
+          config.server ||= {};
+
+          // Allow remote modules to be loaded by setting CORS headers
+          // This is required for MF to work properly across different origins
+          config.server.cors ||= true;
 
           // For remote modules, Rsbuild should send the ws request to the provider's dev server.
           // This allows the provider to do HMR when the provider module is loaded in the consumer's page.

--- a/packages/core/src/server/getDevMiddlewares.ts
+++ b/packages/core/src/server/getDevMiddlewares.ts
@@ -1,6 +1,5 @@
 import { isAbsolute, join } from 'node:path';
 import { normalizePublicDirs } from '../config';
-import { parseUrl } from '../helpers';
 import { logger } from '../logger';
 import type {
   DevConfig,
@@ -95,14 +94,8 @@ const applyDefaultMiddlewares = async ({
     middlewares.push(gzipMiddleware());
   }
 
-  middlewares.push((req, res, next) => {
-    // allow HMR request cross-domain, because the user may use global proxy
-    res.setHeader('Access-Control-Allow-Origin', '*');
-    const path = req.url ? parseUrl(req.url)?.pathname : '';
-    if (path?.includes('hot-update')) {
-      res.setHeader('Access-Control-Allow-Credentials', 'false');
-    }
-
+  // apply `server.headers` option
+  middlewares.push((_req, res, next) => {
     // The headers configured by the user on devServer will not take effect on html requests. Add the following code to make the configured headers take effect on all requests.
     const confHeaders = server.headers;
     if (confHeaders) {


### PR DESCRIPTION
## Summary

The Rsbuild dev server unexpectedly set `Access-Control-Allow-Origin` to `*` by default, which caused the `server.cors` option not to work as expected and introduced security risks.

This PR removes the default `Access-Control-Allow-Origin: *` and strictly enables CORS according to the value of `server.cors`.

This may break users who are using Module Federation or proxy tools, so I added compatibility code for Module Federation.

## Migration

To enable CORS, set [server.cors](https://rsbuild.dev/config/server/cors) to `true`:

```js
export default {
  server: {
    cors: true,
  },
};
```

## Related Links

-  https://github.com/module-federation/core/pull/3635
- https://github.com/vitejs/vite/security/advisories/GHSA-vg6x-rcgg-rjx6

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
