### PR TITLE
fix(types): missing `server.cors` object type

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,7 @@
   "devDependencies": {
     "@rslib/core": "0.5.5",
     "@types/connect": "3.4.38",
+    "@types/cors": "^2.8.17",
     "@types/node": "^22.13.11",
     "@types/on-finished": "2.3.4",
     "@types/webpack-bundle-analyzer": "4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,6 +621,9 @@ importers:
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
+      '@types/cors':
+        specifier: ^2.8.17
+        version: 2.8.17
       '@types/node':
         specifier: ^22.13.11
         version: 22.13.11


### PR DESCRIPTION
## Summary

The `cors` package does not contain any type declaration files, we should install `@types/cors` to ensure that the `server.cors` option is correctly typed.

## Related Links

- https://www.npmjs.com/package/@types/cors

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
