### PR TITLE
test(e2e): ensure proper async handling

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -19,6 +19,6 @@ rspackOnlyTest(
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/module/glob-import/index.test.ts
+++ b/e2e/cases/module/glob-import/index.test.ts
@@ -12,7 +12,7 @@ rspackOnlyTest(
     await expect(page.locator('#header')).toHaveText('Header');
     await expect(page.locator('#footer')).toHaveText('Footer');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -27,6 +27,6 @@ rspackOnlyTest(
     await expect(page.locator('#header')).toHaveText('Header');
     await expect(page.locator('#footer')).toHaveText('Footer');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );

--- a/e2e/cases/preact/basic/index.test.ts
+++ b/e2e/cases/preact/basic/index.test.ts
@@ -11,7 +11,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     await rsbuild.close();
@@ -28,7 +28,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     await rsbuild.close();

--- a/e2e/cases/react/basic/index.test.ts
+++ b/e2e/cases/react/basic/index.test.ts
@@ -11,7 +11,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     await rsbuild.close();
@@ -28,7 +28,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     await rsbuild.close();

--- a/e2e/cases/react/react-compiler-babel/index.test.ts
+++ b/e2e/cases/react/react-compiler-babel/index.test.ts
@@ -11,7 +11,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     await rsbuild.close();
@@ -28,7 +28,7 @@ rspackOnlyTest(
 
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
 
     const index = await rsbuild.getIndexFile();

--- a/e2e/cases/solid/index.test.ts
+++ b/e2e/cases/solid/index.test.ts
@@ -33,9 +33,9 @@ rspackOnlyTest(
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
 
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -49,9 +49,9 @@ rspackOnlyTest(
     const button = page.locator('#button');
     await expect(button).toHaveText('count: 0');
 
-    button.click();
+    await button.click();
     await expect(button).toHaveText('count: 1');
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -70,7 +70,7 @@ for (const name of ['less', 'scss', 'stylus']) {
       // use the text color to assert the compilation result
       await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
 
-      rsbuild.close();
+      await rsbuild.close();
     },
   );
 }

--- a/e2e/cases/svelte/hmr/index.test.ts
+++ b/e2e/cases/svelte/hmr/index.test.ts
@@ -43,5 +43,5 @@ rspackOnlyTest('HMR should work properly', async ({ page }) => {
   await expect(a).toHaveText('A: 0');
 
   fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
-  rsbuild.close();
+  await rsbuild.close();
 });

--- a/e2e/cases/svelte/index.test.ts
+++ b/e2e/cases/svelte/index.test.ts
@@ -34,7 +34,7 @@ rspackOnlyTest(
 
     await expect(title).toHaveText('Hello world!');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );
 
@@ -53,7 +53,7 @@ for (const name of ['less', 'scss', 'stylus']) {
       // use the text color to assert the compilation result
       await expect(title).toHaveCSS('color', 'rgb(255, 62, 0)');
 
-      rsbuild.close();
+      await rsbuild.close();
     },
   );
 }

--- a/e2e/cases/svelte/ts/index.test.ts
+++ b/e2e/cases/svelte/ts/index.test.ts
@@ -17,6 +17,6 @@ rspackOnlyTest(
     const count = page.locator('#count');
     await expect(count).toHaveText('Count: 2');
 
-    rsbuild.close();
+    await rsbuild.close();
   },
 );


### PR DESCRIPTION
## Summary

Improve the handling of async operations in E2E tests, ensuring that the `rsbuild.close()` and `button.click()` operations are awaited properly.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
