### PR TITLE
 docs: fix broken TanStack Router link

### DIFF
--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -157,7 +157,7 @@ const ReactCompilerConfig = {
 
 TanStack Router provides `@tanstack/router-plugin` to integrate with Rsbuild, which provides support for file-based routing. See:
 
-- [File-Based Routing documentation](https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing)
+- [Installation with Rsbuild](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
 - [TanStack Router + Rsbuild Example](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
 
 ### React Router

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -157,8 +157,8 @@ const ReactCompilerConfig = {
 
 TanStack Router provides `@tanstack/router-plugin` to integrate with Rsbuild, which provides support for file-based routing. See:
 
-- [Installation with Rsbuild](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
-- [TanStack Router + Rsbuild Example](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
+- [Installation guide](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
+- [Example project](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
 
 ### React Router
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -157,8 +157,8 @@ const ReactCompilerConfig = {
 
 TanStack Router 提供了 `@tanstack/router-plugin` 来与 Rsbuild 集成，该插件支持基于文件的路由，详见：
 
-- [Installation with Rsbuild](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
-- [TanStack Router + Rsbuild 示例](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
+- [安装指南](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
+- [示例项目](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
 
 ### React Router
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -157,7 +157,7 @@ const ReactCompilerConfig = {
 
 TanStack Router 提供了 `@tanstack/router-plugin` 来与 Rsbuild 集成，该插件支持基于文件的路由，详见：
 
-- [File-Based Routing 文档](https://tanstack.com/router/latest/docs/framework/react/guide/file-based-routing)
+- [Installation with Rsbuild](https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack)
 - [TanStack Router + Rsbuild 示例](https://github.com/TanStack/router/tree/main/examples/react/quickstart-rspack-file-based)
 
 ### React Router


### PR DESCRIPTION
## Summary

Fix the broken TanStack Router link in `react.mdx`.

## Related Links

https://tanstack.com/router/latest/docs/framework/react/routing/installation-with-rspack

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
