### PR TITLE
docs: correct `server.headers` type

### DIFF
--- a/website/docs/en/config/server/headers.mdx
+++ b/website/docs/en/config/server/headers.mdx
@@ -1,15 +1,43 @@
 # server.headers
 
-- **Type:** `Record<string, string>`
+- **Type:** `Record<string, string | string[]>`
 - **Default:** `undefined`
 
-Adds headers to all responses.
+Adds headers to all responses sent from Rsbuild server. This configuration directly leverages Node.js [response.setHeader()](https://nodejs.org/api/http.html#responsesetheadername-value) method under the hood.
 
-```js
+If the header already exists in the to-be-sent headers, its value will be overwritten.
+
+:::tip
+To set CORS headers like `Access-Control-Allow-Origin`, use [server.cors](/config/server/cors) option.
+:::
+
+## Usage
+
+The `server.headers` option accepts an object where:
+
+- Keys are header names (case-insensitive)
+- Values are either a string or an array of strings
+
+```ts title="rsbuild.config.ts"
 export default {
   server: {
     headers: {
       'X-Custom-Foo': 'bar',
+    },
+  },
+};
+```
+
+## Multiple values
+
+Use an array of strings to send multiple headers with the same name.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    headers: {
+      // Multiple Set-Cookie headers
+      'Set-Cookie': ['type=ninja', 'language=javascript'],
     },
   },
 };

--- a/website/docs/zh/config/server/headers.mdx
+++ b/website/docs/zh/config/server/headers.mdx
@@ -1,15 +1,43 @@
 # server.headers
 
-- **类型：** `Record<string, string>`
+- **类型：** `Record<string, string | string[]>`
 - **默认值：** `undefined`
 
-设置自定义响应头。
+向所有 Rsbuild 服务器发送的响应添加 headers。此配置基于 Node.js 的 [response.setHeader()](https://nodejs.org/api/http.html#responsesetheadername-value) 方法实现。
 
-```js
+如果待发送的 headers 中已存在该 header，它的值将被覆盖。
+
+:::tip
+如果要设置 CORS headers，如 `Access-Control-Allow-Origin`，可以使用 [server.cors](/config/server/cors) 选项。
+:::
+
+## 用法
+
+`server.headers` 选项接受一个对象，其中：
+
+- 键是 header 名称（不区分大小写）
+- 值可以是字符串或字符串数组
+
+```ts title="rsbuild.config.ts"
 export default {
   server: {
     headers: {
       'X-Custom-Foo': 'bar',
+    },
+  },
+};
+```
+
+## 多个值
+
+使用字符串数组可以发送具有相同名称的多个 header。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    headers: {
+      // 多个 Set-Cookie headers
+      'Set-Cookie': ['type=ninja', 'language=javascript'],
     },
   },
 };


### PR DESCRIPTION
## Summary

- Correct `server.headers` type.
- Add examples and description for `server.headers`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
