### PR TITLE
fix(server): allow `server.headers` to override `server.cors`

### DIFF
--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -133,3 +133,53 @@ test('should allow to configure CORS', async ({ page, request }) => {
 
   await rsbuild.close();
 });
+
+test('`server.headers` should override `server.cors` for dev server', async ({
+  page,
+  request,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      server: {
+        cors: true,
+        headers: {
+          'Access-Control-Allow-Origin': 'https://example.com',
+        },
+      },
+    },
+  });
+
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+  expect(response.headers()['access-control-allow-origin']).toEqual(
+    'https://example.com',
+  );
+
+  await rsbuild.close();
+});
+
+test('`server.headers` should override `server.cors` for preview server', async ({
+  page,
+  request,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      server: {
+        cors: true,
+        headers: {
+          'Access-Control-Allow-Origin': 'https://example.com',
+        },
+      },
+    },
+  });
+
+  const response = await request.get(`http://127.0.0.1:${rsbuild.port}`);
+  expect(response.headers()['access-control-allow-origin']).toEqual(
+    'https://example.com',
+  );
+
+  await rsbuild.close();
+});

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -52,9 +52,7 @@ test('should handle proxy error correctly', async ({ page }) => {
         },
       },
       server: {
-        headers: {
-          'Access-Control-Allow-Origin': '*',
-        },
+        cors: true,
         proxy: [
           {
             context: ['/api'],

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -101,7 +101,7 @@ const applyDefaultMiddlewares = async ({
   }
 
   // apply `server.headers` option
-  // server.headers` can override `server.cors`
+  // `server.headers` can override `server.cors`
   const { headers } = server;
   if (headers) {
     middlewares.push((_req, res, next) => {

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -101,9 +101,9 @@ const applyDefaultMiddlewares = async ({
   }
 
   // apply `server.headers` option
+  // server.headers` can override `server.cors`
   const { headers } = server;
   if (headers) {
-    // Note that `server.headers` can override `server.cors`
     middlewares.push((_req, res, next) => {
       for (const [key, value] of Object.entries(headers)) {
         console.log('set header', key, value);

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -91,18 +91,6 @@ const applyDefaultMiddlewares = async ({
     middlewares.push(gzipMiddleware());
   }
 
-  // apply `server.headers` option
-  middlewares.push((_req, res, next) => {
-    // The headers configured by the user on devServer will not take effect on html requests. Add the following code to make the configured headers take effect on all requests.
-    const confHeaders = server.headers;
-    if (confHeaders) {
-      for (const [key, value] of Object.entries(confHeaders)) {
-        res.setHeader(key, value);
-      }
-    }
-    next();
-  });
-
   if (server.cors) {
     const { default: corsMiddleware } = await import(
       '../../compiled/cors/index.js'
@@ -110,6 +98,19 @@ const applyDefaultMiddlewares = async ({
     middlewares.push(
       corsMiddleware(typeof server.cors === 'boolean' ? {} : server.cors),
     );
+  }
+
+  // apply `server.headers` option
+  const { headers } = server;
+  if (headers) {
+    // Note that `server.headers` can override `server.cors`
+    middlewares.push((_req, res, next) => {
+      for (const [key, value] of Object.entries(headers)) {
+        console.log('set header', key, value);
+        res.setHeader(key, value);
+      }
+      next();
+    });
   }
 
   if (

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -106,7 +106,6 @@ const applyDefaultMiddlewares = async ({
   if (headers) {
     middlewares.push((_req, res, next) => {
       for (const [key, value] of Object.entries(headers)) {
-        console.log('set header', key, value);
         res.setHeader(key, value);
       }
       next();

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -90,7 +90,7 @@ export class RsbuildProdServer {
     }
 
     // apply `server.headers` option
-    // Note that `server.headers` can override `server.cors`
+    // `server.headers` can override `server.cors`
     if (headers) {
       this.middlewares.use((_req, res, next) => {
         for (const [key, value] of Object.entries(headers)) {

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -80,15 +80,6 @@ export class RsbuildProdServer {
       );
     }
 
-    if (headers) {
-      this.middlewares.use((_req, res, next) => {
-        for (const [key, value] of Object.entries(headers)) {
-          res.setHeader(key, value);
-        }
-        next();
-      });
-    }
-
     if (cors) {
       const { default: corsMiddleware } = await import(
         '../../compiled/cors/index.js'
@@ -96,6 +87,17 @@ export class RsbuildProdServer {
       this.middlewares.use(
         corsMiddleware(typeof cors === 'boolean' ? {} : cors),
       );
+    }
+
+    // apply `server.headers` option
+    // Note that `server.headers` can override `server.cors`
+    if (headers) {
+      this.middlewares.use((_req, res, next) => {
+        for (const [key, value] of Object.entries(headers)) {
+          res.setHeader(key, value);
+        }
+        next();
+      });
     }
 
     if (proxy) {

--- a/website/docs/en/config/server/headers.mdx
+++ b/website/docs/en/config/server/headers.mdx
@@ -8,7 +8,11 @@ Adds headers to all responses sent from Rsbuild server. This configuration direc
 If the header already exists in the to-be-sent headers, its value will be overwritten.
 
 :::tip
+
 To set CORS headers like `Access-Control-Allow-Origin`, use [server.cors](/config/server/cors) option.
+
+If both `server.headers` and `server.cors` are used, `server.headers` will override `server.cors`.
+
 :::
 
 ## Usage

--- a/website/docs/zh/config/server/headers.mdx
+++ b/website/docs/zh/config/server/headers.mdx
@@ -8,7 +8,11 @@
 如果待发送的 headers 中已存在该 header，它的值将被覆盖。
 
 :::tip
+
 如果要设置 CORS headers，如 `Access-Control-Allow-Origin`，可以使用 [server.cors](/config/server/cors) 选项。
+
+如果同时使用 `server.headers` 和 `server.cors`，`server.headers` 会覆盖 `server.cors`。
+
 :::
 
 ## 用法


### PR DESCRIPTION
## Summary

Allow `server.headers` to override `server.cors`. This ensures that fields explicitly defined in `server.headers` always work as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
