### PR TITLE
build: remove CJS export annotation

### DIFF
--- a/packages/compat/webpack/rslib.config.ts
+++ b/packages/compat/webpack/rslib.config.ts
@@ -3,19 +3,9 @@ import {
   dualPackage,
   esmConfig,
 } from '@rsbuild/config/rslib.config.ts';
-import { mergeRsbuildConfig } from '@rsbuild/core';
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
   ...dualPackage,
-  lib: [
-    esmConfig,
-    mergeRsbuildConfig(cjsConfig, {
-      footer: {
-        // TODO https://github.com/web-infra-dev/rslib/issues/351
-        js: `// Annotate the CommonJS export names for ESM import in node:
-0 && (module.exports = { webpackProvider: exports.webpackProvider });`,
-      },
-    }),
-  ],
+  lib: [esmConfig, cjsConfig],
 });

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -116,23 +116,6 @@ export default defineConfig({
       output: {
         minify: nodeMinifyConfig,
       },
-      footer: {
-        // TODO https://github.com/web-infra-dev/rslib/issues/351
-        js: `// Annotate the CommonJS export names for ESM import in node:
-0 && (module.exports = {
-  PLUGIN_CSS_NAME,
-  PLUGIN_SWC_NAME,
-  createRsbuild,
-  defineConfig,
-  ensureAssetPrefix,
-  loadConfig,
-  loadEnv,
-  logger,
-  mergeRsbuildConfig,
-  rspack,
-  version
-});`,
-      },
     },
     {
       id: 'esm:client',


### PR DESCRIPTION
## Summary

Since Rslib 0.6.0. No need to manually add CJS export annotation anymore.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
