### PR TITLE
fix: make CSS preprocessor plugins compat with Rsbuild 1.2

### DIFF
--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -149,11 +149,6 @@ export const pluginLess = (
         .resolve.preferRelative(true)
         .end();
 
-      const inlineRule = chain.module
-        .rule(findRuleId(chain, CHAIN_ID.RULE.LESS_INLINE))
-        .test(include)
-        .resourceQuery(/inline/);
-
       // Support for importing raw Less files
       chain.module
         .rule(CHAIN_ID.RULE.LESS_RAW)
@@ -173,7 +168,15 @@ export const pluginLess = (
         callback: (rule: RspackChain.Rule, type: 'normal' | 'inline') => void,
       ) => {
         callback(rule, 'normal');
-        callback(inlineRule, 'inline');
+
+        // Rsbuild < 1.3.0 does not have RULE.CSS_INLINE.
+        if (chain.module.rules.has(CHAIN_ID.RULE.CSS_INLINE)) {
+          const inlineRule = chain.module
+            .rule(findRuleId(chain, CHAIN_ID.RULE.LESS_INLINE))
+            .test(include)
+            .resourceQuery(/inline/);
+          callback(inlineRule, 'inline');
+        }
       };
 
       const lessLoaderPath = path.join(

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -59,6 +59,11 @@ exports[`plugin-less > should add less-loader 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.less\\$/,
     "use": [
@@ -96,11 +101,6 @@ exports[`plugin-less > should add less-loader 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.less\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -164,6 +164,11 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.less\\$/,
     "use": [
@@ -201,11 +206,6 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.less\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -272,6 +272,11 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
+  {
     "exclude": [
       /node_modules/,
     ],
@@ -312,11 +317,6 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.less\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -380,6 +380,11 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.less\\$/,
     "use": [
@@ -417,11 +422,6 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.less\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -492,6 +492,11 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.less\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.less\\$/,
     "use": [
@@ -536,11 +541,6 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.less\\$/,
-    "type": "asset/source",
   },
 ]
 `;

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild } from '@rsbuild/core';
+import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginLess } from '../src';
 
@@ -110,5 +110,31 @@ describe('plugin-less', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(2);
     expect(matchRules(bundlerConfigs[0], 'b.less').length).toBe(5);
+  });
+
+  it('should be compatible with Rsbuild < 1.3.0', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          {
+            name: 'rsbuild-plugin-test',
+            post: ['rsbuild:css'],
+            setup(api: RsbuildPluginAPI) {
+              // Mock the behavior of Rsbuild < 1.3.0
+              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+              });
+            },
+          },
+          pluginLess(),
+        ],
+      },
+    });
+
+    await rsbuild.initConfigs();
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.less').length).toBe(2);
+    expect(matchRules(bundlerConfigs[0], 'a.less?inline').length).toBe(0);
   });
 });

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
+import { type RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginLess } from '../src';
 

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -67,6 +67,11 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
@@ -112,11 +117,6 @@ exports[`plugin-sass > should add sass-loader 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -188,6 +188,11 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
@@ -233,11 +238,6 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -312,6 +312,11 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    "type": "asset/source",
+  },
+  {
     "exclude": [
       /node_modules/,
     ],
@@ -360,11 +365,6 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -437,6 +437,11 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
@@ -483,11 +488,6 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
-    "type": "asset/source",
   },
 ]
 `;

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
+import { type RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSass } from '../src';
 

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild } from '@rsbuild/core';
+import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginSass } from '../src';
 
@@ -79,5 +79,31 @@ describe('plugin-sass', () => {
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.scss').length).toBe(2);
     expect(matchRules(bundlerConfigs[0], 'b.scss').length).toBe(5);
+  });
+
+  it('should be compatible with Rsbuild < 1.3.0', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          {
+            name: 'rsbuild-plugin-test',
+            post: ['rsbuild:css'],
+            setup(api: RsbuildPluginAPI) {
+              // Mock the behavior of Rsbuild < 1.3.0
+              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+              });
+            },
+          },
+          pluginSass(),
+        ],
+      },
+    });
+
+    await rsbuild.initConfigs();
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.scss').length).toBe(2);
+    expect(matchRules(bundlerConfigs[0], 'a.scss?inline').length).toBe(0);
   });
 });

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -95,11 +95,6 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         .resolve.preferRelative(true)
         .end();
 
-      const inlineRule = chain.module
-        .rule(CHAIN_ID.RULE.STYLUS_INLINE)
-        .test(test)
-        .resourceQuery(/inline/);
-
       // Support for importing raw Stylus files
       chain.module
         .rule(CHAIN_ID.RULE.STYLUS_RAW)
@@ -112,7 +107,16 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         callback: (rule: RspackChain.Rule, type: 'normal' | 'inline') => void,
       ) => {
         callback(rule, 'normal');
-        callback(inlineRule, 'inline');
+
+        // Rsbuild < 1.3.0 does not have RULE.CSS_INLINE.
+        if (chain.module.rules.has(CHAIN_ID.RULE.CSS_INLINE)) {
+          const inlineRule = chain.module
+            .rule(CHAIN_ID.RULE.STYLUS_INLINE)
+            .test(test)
+            .resourceQuery(/inline/);
+
+          callback(inlineRule, 'inline');
+        }
       };
 
       updateRules((rule, type) => {

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -52,6 +52,11 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
@@ -82,11 +87,6 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
-    "type": "asset/source",
   },
 ]
 `;
@@ -146,6 +146,11 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     ],
   },
   {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
+    "type": "asset/source",
+  },
+  {
     "resourceQuery": /inline/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
@@ -179,11 +184,6 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
         },
       },
     ],
-  },
-  {
-    "resourceQuery": /raw/,
-    "test": /\\\\\\.styl\\(us\\)\\?\\$/,
-    "type": "asset/source",
   },
 ]
 `;

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { createRsbuild } from '@rsbuild/core';
+import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginStylus } from '../src';
 
@@ -28,5 +28,30 @@ describe('plugin-stylus', () => {
     });
     const bundlerConfigs = await rsbuild.initConfigs();
     expect(matchRules(bundlerConfigs[0], 'a.styl')).toMatchSnapshot();
+  });
+
+  it('should be compatible with Rsbuild < 1.3.0', async () => {
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          {
+            name: 'rsbuild-plugin-test',
+            post: ['rsbuild:css'],
+            setup(api: RsbuildPluginAPI) {
+              api.modifyBundlerChain((chain, { CHAIN_ID }) => {
+                chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+              });
+            },
+          },
+          pluginStylus(),
+        ],
+      },
+    });
+
+    await rsbuild.initConfigs();
+
+    const bundlerConfigs = await rsbuild.initConfigs();
+    expect(matchRules(bundlerConfigs[0], 'a.styl').length).toBe(2);
+    expect(matchRules(bundlerConfigs[0], 'a.styl?inline').length).toBe(0);
   });
 });

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
+import { type RsbuildPluginAPI, createRsbuild } from '@rsbuild/core';
 import { matchRules } from '@scripts/test-helper';
 import { pluginStylus } from '../src';
 


### PR DESCRIPTION
## Summary

Ensure compatibility of plugin-less, plugin-sass, and plugin-stylus with Rsbuild 1.2.x.

> I believe it might also crash when using Rsbuild v1.2.x with plugin-sass v1.3.0, though I haven’t tested it myself. 😉

## Related Links

<!--- Provide links of related issues or pages -->

See https://github.com/lynx-family/lynx-stack/pull/386.

## Checklist

<!--- Check and mark with an "x" -->

- [x] **Tests updated** (or not required).
- [ ] Documentation updated (or **not required**).
