### PR TITLE
test(e2e): fix flaky lazy compilation case

### DIFF
--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -18,11 +18,10 @@ rspackOnlyTest(
     const { logs, restore } = proxyConsole();
     const rsbuild = await dev({
       cwd: __dirname,
-      page,
     });
 
     await expectPoll(() =>
-      logs.some((log) => log.includes('building src/index.js')),
+      logs.some((log) => log.includes('built in ')),
     ).toBeTruthy();
     expect(logs.some((log) => log.includes('building src/foo.js'))).toBeFalsy();
 

--- a/e2e/cases/lazy-compilation/dynamic-import/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/rsbuild.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({
   dev: {
-    lazyCompilation: true,
+    lazyCompilation: {
+      entries: false,
+      imports: true,
+    },
   },
 });


### PR DESCRIPTION
## Summary

Fix a flaky lazy compilation E2E case:

<img width="1170" alt="Screenshot 2025-03-29 at 20 52 13" src="https://github.com/user-attachments/assets/a703a529-930b-4c97-b847-bfe49efe7924" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
