### PR TITLE
test(e2e): fix flaky watch files cases

### DIFF
--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -5,11 +5,12 @@ import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should inject public env vars to client', async () => {
-  const { NODE_ENV } = process.env;
-  process.env.NODE_ENV = 'production';
-
   execSync('npx rsbuild build', {
     cwd: __dirname,
+    env: {
+      ...process.env,
+      NODE_ENV: 'production',
+    },
   });
 
   const content = fs.readFileSync(
@@ -19,6 +20,4 @@ rspackOnlyTest('should inject public env vars to client', async () => {
   expect(content).not.toContain('jack');
   expect(content).toContain('"process.env","rose"');
   expect(content).toContain('"import.meta.env","rose"');
-
-  process.env.NODE_ENV = NODE_ENV;
 });

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -26,6 +26,7 @@ rspackOnlyTest(
       env: {
         ...process.env,
         PORT: String(await getRandomPort()),
+        NODE_ENV: 'development',
         WATCH_FILES_TYPE: 'reload-server',
       },
     });
@@ -53,6 +54,7 @@ rspackOnlyTest(
       env: {
         ...process.env,
         PORT: String(await getRandomPort()),
+        NODE_ENV: 'development',
         WATCH_FILES_TYPE: 'reload-page',
       },
     });
@@ -78,6 +80,7 @@ rspackOnlyTest(
       env: {
         ...process.env,
         PORT: String(await getRandomPort()),
+        NODE_ENV: 'development',
       },
     });
 

--- a/e2e/cases/cli/watch-files/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files/rsbuild.config.ts
@@ -16,6 +16,7 @@ const testPlugin: RsbuildPlugin = {
 };
 
 export default defineConfig({
+  plugins: [testPlugin],
   dev: {
     writeToDisk: true,
     watchFiles: {
@@ -23,7 +24,6 @@ export default defineConfig({
       paths: ['./test-temp-config.ts'],
     },
   },
-  plugins: [testPlugin],
   server: {
     port: Number(process.env.PORT),
   },


### PR DESCRIPTION
## Summary

The `process.env.NODE_ENV` of the watch files case is affected by other test cases. We need to find a way to isolate the process.env.NODE_ENV of different test cases.

Fix:

<img width="1205" alt="Screenshot 2025-03-29 at 21 08 46" src="https://github.com/user-attachments/assets/b7239f46-ef91-4d63-b19f-3913403f25a3" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
