### PR TITLE
docs: add cacheDir option to migration guide

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -111,7 +111,8 @@ Here is the corresponding Rsbuild configuration for Vite configuration:
 | define                                | [source.define](/config/source/define)                           |
 | plugins                               | [plugins](/config/plugins)                                       |
 | appType                               | [server.historyApiFallback](/config/server/history-api-fallback) |
-| envDir                                | [Env Directory](/guide/advanced/env-vars#env-directory)          |
+| envDir                                | [Env directory](/guide/advanced/env-vars#env-directory)          |
+| cacheDir                              | [buildCache](/config/performance/build-cache)                    |
 | publicDir                             | [server.publicDir](/config/server/public-dir)                    |
 | assetsInclude                         | [source.assetsInclude](/config/source/assets-include)            |
 | resolve.alias                         | [resolve.alias](/config/resolve/alias)                           |

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -112,6 +112,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | appType                               | [server.historyApiFallback](/config/server/history-api-fallback) |
 | plugins                               | [plugins](/config/plugins)                                       |
 | envDir                                | [Env Directory](/guide/advanced/env-vars#env-目录)               |
+| cacheDir                              | [buildCache](/config/performance/build-cache)                    |
 | publicDir                             | [server.publicDir](/config/server/public-dir)                    |
 | assetsInclude                         | [source.assetsInclude](/config/source/assets-include)            |
 | resolve.alias                         | [resolve.alias](/config/resolve/alias)                           |


### PR DESCRIPTION
## Summary

Adding the `cacheDir` option to migration guide.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
