### PR TITLE
fix: let jiti load `@rspack/core` with native require

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -469,6 +469,9 @@ export async function loadConfig({
         // disable require cache to support restart CLI and read the new config
         moduleCache: false,
         interopDefault: true,
+        // Always use native `require()` for these packages,
+        // This avoids `@rspack/core` being loaded twice.
+        nativeModules: ['@rspack/core', 'typescript'],
       });
 
       configExport = await jiti.import<RsbuildConfigExport>(configFilePath, {


### PR DESCRIPTION
## Summary

Add `@rspack/core` to jiti's `nativeModules` options. This allows jiti load `@rspack/core` with native `require()` and avoids `@rspack/core` being loaded twice.

This PR should fixes the "The 'compilation' argument must be an instance of Compilation error" error after upgrade to v1.3.0.

## Related Links

- https://github.com/unjs/jiti?tab=readme-ov-file#nativemodules
- https://github.com/web-infra-dev/rspack/issues/9841

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
