### PR TITLE
docs: add guide for access Rspack API

### DIFF
--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -449,21 +449,26 @@ logger.info('hello'); // [info] hello
 
 ## rspack
 
-The `rspack` object exported from `@rspack/core`.
-
-You can import to the `rspack` object from `@rsbuild/core` without the need to install the `@rspack/core` dependency.
+If you need to access the API or plugins exported by [@rspack/core](https://www.npmjs.com/package/@rspack/core), you can directly import the `rspack` object from `@rsbuild/core` without installing the `@rspack/core` package separately.
 
 - **Type:** `Rspack`
 - **Example:**
 
 ```ts
+// the same as `import { rspack } from '@rspack/core'`
 import { rspack } from '@rsbuild/core';
 
-console.log(rspack.rspackVersion); // 1.0.0
+console.log(rspack.rspackVersion); // a.b.c
 console.log(rspack.util.createHash);
+console.log(rspack.BannerPlugin);
 ```
 
-> Please refer to [Rspack - JavaScript API](https://rspack.dev/api/javascript-api/) for more information.
+:::tip
+
+- Refer to [Rspack plugins](https://rspack.dev/plugins/) and [Rspack JavaScript API](https://rspack.dev/api/javascript-api/) to learn more about the available Rspack APIs.
+- It's not recommended to manually install the `@rspack/core` package, as it may conflict with the version that Rsbuild depends on.
+
+:::
 
 ## version
 

--- a/website/docs/en/config/server/base.mdx
+++ b/website/docs/en/config/server/base.mdx
@@ -8,7 +8,7 @@
 
 ## Example
 
-By default, the base path of the server is `/`, and users can access `index.html` through http://localhost:3000.
+By default, the Rsbuild server's base path is `/`. You can access output files like `index.html` and assets in the [public folder](/guide/basic/static-assets#public-folder) through `http://localhost:3000/`.
 
 If you want to access `index.html` through `http://localhost:3000/foo/`, you can change `server.base` to `/foo`.
 

--- a/website/docs/en/guide/basic/configure-rspack.mdx
+++ b/website/docs/en/guide/basic/configure-rspack.mdx
@@ -45,6 +45,33 @@ export default {
 
 > Please refer to the [tools.rspack documentation](/config/tools/rspack) for detailed usage.
 
+## Access Rspack API
+
+If you need to access the API or plugins exported by [@rspack/core](https://www.npmjs.com/package/@rspack/core), you can directly import the [rspack](/api/javascript-api/core#rspack) object from `@rsbuild/core` without installing the `@rspack/core` package separately.
+
+```ts title="rsbuild.config.ts"
+import { rspack } from '@rsbuild/core';
+
+export default {
+  tools: {
+    rspack: {
+      plugins: [
+        new rspack.BannerPlugin({
+          // ...
+        }),
+      ],
+    },
+  },
+};
+```
+
+:::tip
+
+- Refer to [Rspack plugins](https://rspack.dev/plugins/) and [Rspack JavaScript API](https://rspack.dev/api/javascript-api/) to learn more about the available Rspack APIs.
+- It's not recommended to manually install the `@rspack/core` package, as it may conflict with the version that Rsbuild depends on.
+
+:::
+
 ## Use bundler chain
 
 import RspackChain from '@en/shared/rspackChain.mdx';

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -4,7 +4,7 @@ Rsbuild comes with a built-in dev server designed to improve the development exp
 
 ## Base path
 
-By default, the base path of the server is `/`, and users can access output files such as `index.html` and public folder assets through http://localhost:3000/.
+By default, the Rsbuild server's base path is `/`. You can access output files like `index.html` and assets in the [public folder](/guide/basic/static-assets#public-folder) through `http://localhost:3000/`.
 
 Rsbuild supports modifying the base path of the server through [server.base](/config/server/base). If you to access these files through `http://localhost:3000/foo/`, you can configure the following:
 

--- a/website/docs/en/guide/framework/preact.mdx
+++ b/website/docs/en/guide/framework/preact.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 
 Preact plugin uses [@preact/prefresh](https://github.com/preactjs/prefresh) and [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) to hot reload Preact components.
 
-### Recognition
+### Component Recognition
 
 Prefresh need to be able to recognize your components, this means that components should
 start with a capital letter and hook should start with `use` followed by a capital letter.

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -449,21 +449,26 @@ logger.info('hello'); // [info] hello
 
 ## rspack
 
-由 `@rspack/core` 导出的 `rspack` 对象。
-
-你可以直接从 `@rsbuild/core` 中引用 `rspack` 对象，而无须额外安装 `@rspack/core` 依赖。
+如果你需要访问 [@rspack/core](https://www.npmjs.com/package/@rspack/core) 导出的 API 或插件，可以直接从 `@rsbuild/core` 中引用 `rspack` 对象，无须额外安装 `@rspack/core` 包。
 
 - **类型：** `Rspack`
 - **示例：**
 
 ```ts
+// the same as `import { rspack } from '@rspack/core'`
 import { rspack } from '@rsbuild/core';
 
-console.log(rspack.rspackVersion); // 1.0.0
+console.log(rspack.rspackVersion); // a.b.c
 console.log(rspack.util.createHash);
+console.log(rspack.BannerPlugin);
 ```
 
-> 请参考 [Rspack - JavaScript API](https://rspack.dev/zh/api/javascript-api/) 了解更多。
+:::tip
+
+- 参考 [Rspack 插件](https://rspack.dev/zh/plugins/) 和 [Rspack JavaScript API](https://rspack.dev/zh/api/javascript-api/) 了解可用的 Rspack API。
+- 不推荐手动安装 `@rspack/core` 包，因为这可能与 Rsbuild 依赖的版本不一致。
+
+:::
 
 ## version
 

--- a/website/docs/zh/config/server/base.mdx
+++ b/website/docs/zh/config/server/base.mdx
@@ -4,11 +4,11 @@
 - **默认值：** `/`
 - **版本：** `>= 1.0.10`
 
-`server.base` 用于配置服务端的[基础路径](/guide/basic/server#服务端基础路径)。
+`server.base` 用于配置服务器的 [基础路径](/guide/basic/server#服务端基础路径)。
 
 ## 示例
 
-默认情况下，服务端的基础路径为 `/`，用户可通过 http://localhost:3000 访问到 `index.html`。
+默认情况下，Rsbuild 服务器的基础路径是 `/`，你可以通过 http://localhost:3000/ 访问 `index.html` 等输出文件，以及 [public 目录](/guide/basic/static-assets#public-目录) 下的资源。
 
 当你希望通过 `http://localhost:3000/foo/` 访问到 `index.html` 时，可以将 `server.base` 修改为 `/foo`。
 

--- a/website/docs/zh/guide/basic/configure-rspack.mdx
+++ b/website/docs/zh/guide/basic/configure-rspack.mdx
@@ -45,6 +45,33 @@ export default {
 
 > 请查看 [tools.rspack 文档](/config/tools/rspack) 来了解完整用法。
 
+## 访问 Rspack API
+
+如果你需要访问 [@rspack/core](https://www.npmjs.com/package/@rspack/core) 导出的 API 或插件，可以直接从 `@rsbuild/core` 中引用 [rspack](/api/javascript-api/core#rspack) 对象，无须额外安装 `@rspack/core` 包。
+
+```ts title="rsbuild.config.ts"
+import { rspack } from '@rsbuild/core';
+
+export default {
+  tools: {
+    rspack: {
+      plugins: [
+        new rspack.BannerPlugin({
+          // ...
+        }),
+      ],
+    },
+  },
+};
+```
+
+:::tip
+
+- 参考 [Rspack 插件](https://rspack.dev/zh/plugins/) 和 [Rspack JavaScript API](https://rspack.dev/zh/api/javascript-api/) 了解可用的 Rspack API。
+- 不推荐手动安装 `@rspack/core` 包，因为这可能与 Rsbuild 依赖的版本不一致。
+
+:::
+
 ## 使用 Rspack chain
 
 import RspackChain from '@zh/shared/rspackChain.mdx';

--- a/website/docs/zh/guide/basic/server.mdx
+++ b/website/docs/zh/guide/basic/server.mdx
@@ -2,9 +2,9 @@
 
 Rsbuild 配备了一个内置的开发服务器，旨在提升开发体验。当你执行 `rsbuild dev` 或 `rsbuild preview` 命令时，该服务器将启动，并提供页面预览、路由、模块热更新等功能。
 
-## 服务端基础路径
+## 基础路径
 
-默认情况下，服务端的基础路径为 `/`，用户可通过 http://localhost:3000/ 访问到 `index.html` 等产物资源、以及 public 目录下的资源。
+默认情况下，Rsbuild 服务器的基础路径是 `/`，你可以通过 http://localhost:3000/ 访问 `index.html` 等输出文件，以及 [public 目录](/guide/basic/static-assets#public-目录) 下的资源。
 
 Rsbuild 支持通过 [server.base](/config/server/base) 修改服务端的基础路径。当我们希望通过 http://localhost:3000/foo/ 访问到这些资源时，可以添加如下配置：
 

--- a/website/docs/zh/guide/framework/preact.mdx
+++ b/website/docs/zh/guide/framework/preact.mdx
@@ -38,7 +38,7 @@ export default defineConfig({
 
 Preact 插件使用 [@preact/prefresh](https://github.com/preactjs/prefresh) 和 [@rspack/plugin-preact-refresh](https://github.com/rspack-contrib/rspack-plugin-preact-refresh) 来热替换 Preact 组件。
 
-### 识别
+### 识别组件
 
 Prefresh 需要能够识别你的组件，这意味着组件名称应该以大写字母开头，hook 名称应该以 `use` 开头，后跟一个大写字母。这使得插件能够有效地识别这些内容。
 


### PR DESCRIPTION
## Summary

Improving clarity and providing additional guidance for accessing Rspack APIs and configuring the server base path.

## Related Links

https://github.com/web-infra-dev/rspack/issues/9841#issuecomment-2765163053

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
