### PR TITLE
chore(workflow): let prettier ignore pnpm lock file

### DIFF
--- a/.github/actions/eco-ci-result/action.yml
+++ b/.github/actions/eco-ci-result/action.yml
@@ -12,7 +12,7 @@ outputs:
     value: ${{ steps.get-result.outputs.result }}
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - id: get-result
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -56,11 +56,11 @@ jobs:
         continue-on-error: true
         uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be # v1.6.5
         with:
-          owner: "rspack-contrib"
-          repo: "rsbuild-ecosystem-ci"
-          workflow_file_name: "ecosystem-ci-from-commit.yml"
+          owner: 'rspack-contrib'
+          repo: 'rsbuild-ecosystem-ci'
+          workflow_file_name: 'ecosystem-ci-from-commit.yml'
           github_token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN }}
-          ref: "main"
+          ref: 'main'
           client_payload: '{"commitSHA":"${{ github.sha }}","updateComment":true,"repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
 
       - name: Checkout
@@ -165,11 +165,11 @@ jobs:
         uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be # v1.6.5
         continue-on-error: true
         with:
-          owner: "rspack-contrib"
-          repo: "rsbuild-ecosystem-ci"
-          workflow_file_name: "ecosystem-ci-selected.yml"
+          owner: 'rspack-contrib'
+          repo: 'rsbuild-ecosystem-ci'
+          workflow_file_name: 'ecosystem-ci-selected.yml'
           github_token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN }}
-          ref: "main"
+          ref: 'main'
           client_payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
 
       - name: Checkout
@@ -195,4 +195,3 @@ jobs:
               comment_id: ${{ steps.create-comment.outputs.result }},
               body: ${{ steps.eco-ci-result.outputs.result }}
             })
-

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
           configuration-path: .github/pr-labeler.yml
           enable-versioned-regex: 0
           include-title: 1

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 dist
 compiled
 doc_build
+pnpm-lock.yaml
 
 # Avoid CSS syntax error
-**/less-inline-js/**/*.less
+**/less/inline-js/**/*.less


### PR DESCRIPTION
## Summary

- Let prettier ignore pnpm lock file to avoid breaking the lock file content.
- Run `pnpm run format` to format all files.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
