### PR TITLE
fix(create-rsbuild): missing eslint-plugin-vue

### DIFF
--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -35,7 +35,7 @@ rspackOnlyTest('should create project with prettier as expected', async () => {
 });
 
 rspackOnlyTest(
-  'should create project with eslint and prettier as expected',
+  'should create project with ESLint and prettier as expected',
   async () => {
     const { dir, pkgJson, clean } = await createAndValidate(
       __dirname,
@@ -49,6 +49,44 @@ rspackOnlyTest(
     expect(pkgJson.devDependencies.eslint).toBeTruthy();
     expect(pkgJson.devDependencies.prettier).toBeTruthy();
     expect(existsSync(join(dir, '.prettierrc'))).toBeTruthy();
+    expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
+    await clean();
+  },
+);
+
+rspackOnlyTest(
+  'should create React project with ESLint as expected',
+  async () => {
+    const { dir, pkgJson, clean } = await createAndValidate(
+      __dirname,
+      'react-ts',
+      {
+        name: 'test-temp-react-eslint',
+        tools: ['eslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies.eslint).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-react']).toBeTruthy();
+    expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
+    await clean();
+  },
+);
+
+rspackOnlyTest(
+  'should create Vue project with ESLint as expected',
+  async () => {
+    const { dir, pkgJson, clean } = await createAndValidate(
+      __dirname,
+      'vue3-ts',
+      {
+        name: 'test-temp-vue-eslint',
+        tools: ['eslint'],
+        clean: false,
+      },
+    );
+    expect(pkgJson.devDependencies.eslint).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-vue']).toBeTruthy();
     expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
     await clean();
   },

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -58,11 +58,15 @@ function mapESLintTemplate(templateName: string): ESLintTemplateName {
   switch (templateName) {
     case 'react-js':
     case 'react-ts':
-    case 'vue-js':
-    case 'vue-ts':
     case 'svelte-js':
     case 'svelte-ts':
       return templateName;
+    case 'vue2-js':
+    case 'vue3-js':
+      return 'vue-js';
+    case 'vue2-ts':
+    case 'vue3-ts':
+      return 'vue-ts';
     case 'react18-js':
       return 'react-js';
     case 'react18-ts':


### PR DESCRIPTION
## Summary

Fix the ESLint template name mapping to add back the `eslint-plugin-vue` to Vue templates.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
