### PR TITLE
fix: inject tags to HTML template without `<head>` tag

### DIFF
--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -1,0 +1,16 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+// https://github.com/web-infra-dev/rsbuild/issues/4924
+test('should inject tags to HTML template without <head> tag', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+  const files = await rsbuild.unwrapOutputJSON();
+
+  const indexHtml =
+    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  expect(indexHtml).toContain(
+    '<!doctype html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
+  );
+});

--- a/e2e/cases/html/template-no-head/rsbuild.config.ts
+++ b/e2e/cases/html/template-no-head/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    template: './static/index.html',
+  },
+});

--- a/e2e/cases/html/template-no-head/src/index.js
+++ b/e2e/cases/html/template-no-head/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/e2e/cases/html/template-no-head/static/index.html
+++ b/e2e/cases/html/template-no-head/static/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<div id="<%= mountId %>"></div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "deepmerge": "^4.3.1",
     "dotenv": "16.4.7",
     "dotenv-expand": "12.0.1",
-    "html-rspack-plugin": "6.0.2",
+    "html-rspack-plugin": "6.0.3",
     "http-proxy-middleware": "^2.0.6",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,8 +667,8 @@ importers:
         specifier: 12.0.1
         version: 12.0.1
       html-rspack-plugin:
-        specifier: 6.0.2
-        version: 6.0.2(@rspack/core@1.3.0(@swc/helpers@0.5.15))
+        specifier: 6.0.3
+        version: 6.0.3(@rspack/core@1.3.0(@swc/helpers@0.5.15))
       http-proxy-middleware:
         specifier: ^2.0.6
         version: 2.0.7
@@ -4520,8 +4520,8 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  html-rspack-plugin@6.0.2:
-    resolution: {integrity: sha512-34ICP1ULwi9uFq0QJzT3jdnIp6RmZozp9PUPaH6YLaM69cy1r7WvSh1Mjqk5XEG2XQoktjbGz2WQPdW5O6jELw==}
+  html-rspack-plugin@6.0.3:
+    resolution: {integrity: sha512-af/qbzIxEPGf0su9yQa1IRwK8zgkupM1afNp2mtw3O5EZPaYNZE5IGyHG5CGOUPdQgN9nGbj7F/evcqwhsD7fQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10648,7 +10648,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-rspack-plugin@6.0.2(@rspack/core@1.3.0(@swc/helpers@0.5.15)):
+  html-rspack-plugin@6.0.3(@rspack/core@1.3.0(@swc/helpers@0.5.15)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Allow tags to be injected into an HTML template that does not have a `<head>' tag.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/4924

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
