### PR TITLE
fix: use Buffer.byteLength for accurate file size calculation

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -20,7 +20,7 @@ const gzip = promisify(zlib.gzip);
 
 async function gzipSize(input: Buffer) {
   const data = await gzip(input);
-  return data.length;
+  return Buffer.byteLength(data);
 }
 
 const EXCLUDE_ASSET_REGEX = /\.(?:map|LICENSE\.txt|d\.ts)$/;
@@ -107,7 +107,7 @@ async function printFileSizes(
   ) => {
     const fileName = asset.name.split('?')[0];
     const contents = await fs.promises.readFile(path.join(distPath, fileName));
-    const size = contents.length;
+    const size = Buffer.byteLength(contents);
     const compressible = options.compressed && isCompressible(fileName);
     const gzippedSize = compressible ? await gzipSize(contents) : null;
     const gzipSizeLabel = gzippedSize


### PR DESCRIPTION
## Summary

Replaces `contents.length` with `Buffer.byteLength(contents)` to ensure accurate file size measurements, especially when handling files containing non-ASCII characters.

While `contents` is already a Buffer object in the current implementation, using `Buffer.byteLength()` makes the intention clearer and future-proofs the code against potential refactors that might change the type of `contents`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
