### PR TITLE
feat(CLI): allow to disable loading .env files

### DIFF
--- a/e2e/cases/cli/no-env/.env
+++ b/e2e/cases/cli/no-env/.env
@@ -1,0 +1,1 @@
+PUBLIC_NAME=jack

--- a/e2e/cases/cli/no-env/index.test.ts
+++ b/e2e/cases/cli/no-env/index.test.ts
@@ -1,0 +1,17 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should allow to disable loading env files', async () => {
+  execSync('npx rsbuild build --no-env', {
+    cwd: __dirname,
+  });
+  const content = fs.readFileSync(
+    path.join(__dirname, 'dist/static/js/index.js'),
+    'utf-8',
+  );
+  expect(content).toContain('process.env.PUBLIC_NAME');
+  expect(content).not.toContain('jack');
+});

--- a/e2e/cases/cli/no-env/rsbuild.config.ts
+++ b/e2e/cases/cli/no-env/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig, loadEnv } from '@rsbuild/core';
+
+const { publicVars } = loadEnv({ prefixes: ['REACT_APP_'] });
+
+export default defineConfig({
+  source: {
+    define: publicVars,
+  },
+  output: {
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/cli/no-env/src/index.js
+++ b/e2e/cases/cli/no-env/src/index.js
@@ -1,0 +1,1 @@
+console.log(process.env.PUBLIC_NAME);

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -12,6 +12,7 @@ export type CommonOptions = {
   mode?: RsbuildMode;
   config?: string;
   configLoader?: ConfigLoader;
+  env?: boolean;
   envDir?: string;
   envMode?: string;
   open?: boolean | string;
@@ -68,7 +69,8 @@ const applyCommonOptions = (cli: CAC) => {
         default: [],
       },
     )
-    .option('--env-dir <dir>', 'specify the directory to load `.env` files');
+    .option('--env-dir <dir>', 'specify the directory to load `.env` files')
+    .option('--no-env', 'Disable loading `.env` files');
 };
 
 const applyServerOptions = (command: Command) => {

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -92,10 +92,13 @@ export async function init({
       cwd: root,
       rsbuildConfig: () => loadConfig(root),
       environment: commonOpts.environment,
-      loadEnv: {
-        cwd: getEnvDir(root, commonOpts.envDir),
-        mode: commonOpts.envMode,
-      },
+      loadEnv:
+        commonOpts.env === false
+          ? false
+          : {
+              cwd: getEnvDir(root, commonOpts.envDir),
+              mode: commonOpts.envMode,
+            },
     });
 
     rsbuild.onBeforeCreateCompiler(() => {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -27,6 +27,7 @@ darkgrey
 datauri
 deepmerge
 docgen
+dotenvx
 dppx
 envinfo
 estree

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -293,6 +293,16 @@ const mergedConfig = mergeRsbuildConfig(
 );
 ```
 
+### Disable loading
+
+You can disable loading `.env` files by using the `--no-env` flag in the CLI.
+
+```bash
+npx rsbuild dev --no-env
+```
+
+When using the `--no-env` flag, Rsbuild CLI will not read any `.env` files, and you can manage environment variables using other tools like [dotenvx](https://dotenvx.com/).
+
 ## Public variables
 
 All env variables starting with `PUBLIC_` can be accessed in client code. For example, if the following variables are defined:

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -37,6 +37,7 @@ Rsbuild CLI provides several common flags that can be used with all commands:
 | `--environment <name>`     | Specify the name of environment to build, see [Build specified environment](/guide/advanced/environments#build-specified-environment)             |
 | `-h, --help`               | Display help for command                                                                                                                          |
 | `-m, --mode <mode>`        | Specify the build mode (`development`, `production` or `none`), see [mode](/config/mode)                                                          |
+| `--no-env`                 | Disable loading `.env` files                                                                                                                      |
 | `-r, --root <root>`        | Specify the project root directory                                                                                                                |
 
 ## rsbuild dev

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -293,6 +293,16 @@ const mergedConfig = mergeRsbuildConfig(
 );
 ```
 
+### 禁用加载
+
+你可以通过 CLI 的 `--no-env` 选项来禁用加载 `.env` 文件。
+
+```bash
+npx rsbuild dev --no-env
+```
+
+在使用 `--no-env` 选项时，Rsbuild CLI 不会读取任何 `.env` 文件，你可以自行使用其他工具来管理环境变量，例如 [dotenvx](https://dotenvx.com/)。
+
 ## public 变量
 
 所有以 `PUBLIC_` 开头的环境变量可以在 client 代码中访问，比如定义了以下变量：

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -37,6 +37,7 @@ Rsbuild CLI 提供了一些公共选项，可以用于所有命令：
 | `--environment <name>`     | 指定需要构建的 environment 名称，详见 [构建指定环境](/guide/advanced/environments#构建指定环境)                   |
 | `-h, --help`               | 显示命令帮助                                                                                                      |
 | `-m, --mode <mode>`        | 指定构建模式，可以是 `development`，`production` 或 `none`，详见 [mode](/config/mode)                             |
+| `--no-env`                 | 禁用 `.env` 文件的加载                                                                                            |
 | `-r, --root <root>`        | 指定项目根目录，可以是绝对路径或者相对于 cwd 的路径                                                               |
 
 ## rsbuild dev


### PR DESCRIPTION
## Summary

Add a `--no-env` flag to the Rsbuild CLI to disable loading of .env files. This allows users to use other tools like
[dotenvx](https://github.com/dotenvx/dotenvx).

```bash
rsbuild build --no-env
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
