### PR TITLE
refactor(appIcon): improve types and streamline icon path handling

### DIFF
--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -29,7 +29,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
 
   setup(api) {
     const htmlTagsMap = new Map<string, HtmlBasicTag[]>();
-    const iconFormatMap = new Map<string, IconExtra>();
+    const iconFormatMap = new Map<string, AppIconItem & IconExtra>();
 
     const formatIcon = (
       icon: AppIconItem,
@@ -40,22 +40,22 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
       const cached = iconFormatMap.get(src);
 
       if (cached) {
-        return { ...cached, ...icon };
+        return cached;
       }
 
       const sizes = `${size}x${size}`;
 
       if (isURL(src)) {
-        const paths = {
+        const formatted = {
+          ...icon,
           src,
           sizes,
           isURL: true as const,
           mimeType: lookup(src),
         };
 
-        iconFormatMap.set(src, paths);
-
-        return { ...paths, ...icon };
+        iconFormatMap.set(src, formatted);
+        return formatted;
       }
 
       const absolutePath = path.isAbsolute(src)
@@ -66,7 +66,8 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         path.basename(absolutePath),
       );
 
-      const paths = {
+      const formatted = {
+        ...icon,
         sizes,
         src: ensureAssetPrefix(relativePath, publicPath),
         isURL: false as const,
@@ -75,9 +76,8 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         mimeType: lookup(absolutePath),
       };
 
-      iconFormatMap.set(src, paths);
-
-      return { ...paths, ...icon };
+      iconFormatMap.set(src, formatted);
+      return formatted;
     };
 
     api.processAssets(

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -12,13 +12,17 @@ import {
 import type { AppIconItem, HtmlBasicTag, RsbuildPlugin } from '../types';
 
 type IconExtra = {
+  src: string;
   sizes: string;
-  isURL?: boolean;
-  absolutePath: string;
-  relativePath: string;
-  requestPath: string;
   mimeType?: string;
-};
+} & (
+  | { isURL: true }
+  | {
+      isURL: false;
+      absolutePath: string;
+      relativePath: string;
+    }
+);
 
 export const pluginAppIcon = (): RsbuildPlugin => ({
   name: 'rsbuild:app-icon',
@@ -43,11 +47,9 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
 
       if (isURL(src)) {
         const paths = {
+          src,
           sizes,
-          isURL: true,
-          requestPath: src,
-          absolutePath: src,
-          relativePath: src,
+          isURL: true as const,
           mimeType: lookup(src),
         };
 
@@ -63,11 +65,11 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         distDir,
         path.basename(absolutePath),
       );
-      const requestPath = ensureAssetPrefix(relativePath, publicPath);
 
       const paths = {
         sizes,
-        requestPath,
+        src: ensureAssetPrefix(relativePath, publicPath),
+        isURL: false as const,
         absolutePath,
         relativePath,
         mimeType: lookup(absolutePath),
@@ -151,7 +153,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
               attrs: {
                 rel: 'apple-touch-icon',
                 sizes: icon.sizes,
-                href: icon.requestPath,
+                href: icon.src,
               },
             });
           }
@@ -164,7 +166,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             )
             .map((icon) => {
               const result = {
-                src: icon.requestPath,
+                src: icon.src,
                 sizes: icon.sizes,
               };
               if (icon.mimeType) {
@@ -206,9 +208,12 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
       return { headTags, bodyTags };
     });
 
-    api.onCloseDevServer(() => {
+    const clean = () => {
       htmlTagsMap.clear();
       iconFormatMap.clear();
-    });
+    };
+
+    api.onCloseDevServer(clean);
+    api.onCloseBuild(clean);
   },
 });


### PR DESCRIPTION
## Summary

- Improve the appIcon plugin types and streamline icon path handling.
- Added a `clean` function to clear on closing the dev server and after the build. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
