### PR TITLE
fix(server): support access globalThis in esm vm

### DIFF
--- a/e2e/cases/server/ssr/package.json
+++ b/e2e/cases/server/ssr/package.json
@@ -4,6 +4,6 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "npx rsbuild dev",
-    "dev:esm": "TEST_ESM_LIBRARY=true npx rsbuild dev"
+    "dev:esm": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" TEST_ESM_LIBRARY=true npx rsbuild dev"
   }
 }

--- a/e2e/cases/server/ssr/src/assert.server.ts
+++ b/e2e/cases/server/ssr/src/assert.server.ts
@@ -1,9 +1,8 @@
-function assertQueueMicroTask() {
+export function assert() {
   if (typeof queueMicrotask !== 'function') {
     throw Error('not support queueMicrotask in this environment');
   }
-}
-
-export function assert() {
-  assertQueueMicroTask();
+  if (typeof TextEncoder !== 'function') {
+    throw Error('not support TextEncoder in this environment');
+  }
 }

--- a/packages/core/src/server/runner/asModule.ts
+++ b/packages/core/src/server/runner/asModule.ts
@@ -1,7 +1,5 @@
 import vm from 'node:vm';
 
-const SYNTHETIC_MODULES_STORE = '__SYNTHETIC_MODULES_STORE';
-
 export const asModule = async (
   something: Record<string, any>,
   context: Record<string, any>,
@@ -10,20 +8,20 @@ export const asModule = async (
   if (something instanceof vm.Module) {
     return something;
   }
-  context[SYNTHETIC_MODULES_STORE] = context[SYNTHETIC_MODULES_STORE] || [];
-  const i = context[SYNTHETIC_MODULES_STORE].length;
-  context[SYNTHETIC_MODULES_STORE].push(something);
-  const code = [...new Set(['default', ...Object.keys(something)])]
-    .map(
-      (name) =>
-        `const _${name} = ${SYNTHETIC_MODULES_STORE}[${i}]${
-          name === 'default' ? '' : `[${JSON.stringify(name)}]`
-        }; export { _${name} as ${name}};`,
-    )
-    .join('\n');
-  const m = new vm.SourceTextModule(code, {
-    context,
-  });
+
+  const exports = [...new Set(['default', ...Object.keys(something)])];
+
+  const m = new vm.SyntheticModule(
+    exports,
+    () => {
+      for (const name of exports) {
+        m.setExport(name, name === 'default' ? something : something[name]);
+      }
+    },
+    {
+      context,
+    },
+  );
   if (unlinked) return m;
   await m.link((() => {}) as () => vm.Module);
   // @ts-expect-error copy from webpack

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -35,9 +35,16 @@ export class EsmRunner extends CommonJsRunner {
   }
 
   protected createEsmRequirer(): RunnerRequirer {
-    const esmContext = vm.createContext(this.baseModuleScope!, {
-      name: 'context for esm',
-    });
+    const esmContext = vm.createContext(
+      {
+        ...this.baseModuleScope!,
+        // support access globalThis in esm vm
+        global: globalThis,
+      },
+      {
+        name: 'context for esm',
+      },
+    );
     const esmCache = new Map<string, SourceTextModule>();
     const esmIdentifier = this._options.name;
     return (currentDirectory, modulePath, context = {}) => {

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -35,16 +35,6 @@ export class EsmRunner extends CommonJsRunner {
   }
 
   protected createEsmRequirer(): RunnerRequirer {
-    const esmContext = vm.createContext(
-      {
-        ...this.baseModuleScope!,
-        // support access globalThis in esm vm
-        global: globalThis,
-      },
-      {
-        name: 'context for esm',
-      },
-    );
     const esmCache = new Map<string, SourceTextModule>();
     const esmIdentifier = this._options.name;
     return (currentDirectory, modulePath, context = {}) => {
@@ -65,7 +55,7 @@ export class EsmRunner extends CommonJsRunner {
           identifier: `${esmIdentifier}-${file.path}`,
           // no attribute
           url: `${pathToFileURL(file.path).href}?${esmIdentifier}`,
-          context: esmContext,
+          // run in current execution context
           initializeImportMeta: (meta: { url: string }, _: any) => {
             meta.url = pathToFileURL(file!.path).href;
           },


### PR DESCRIPTION
## Summary

Fix ssr render error. support access globalThis attributes in esm vm, like `TextEncoder`.

We need to use `vm.SourceTextModule` to run ESM code in the **current context** like it was possible with CJS with `vm.runInThisContext`.


- Remove context specified, run esm code in current context (allow access globalThis attributes). 
- Use `vm.SyntheticModule` instead of legacy hard code which dependent `context`

https://nodejs.org/api/vm.html

<img width="1651" alt="image" src="https://github.com/user-attachments/assets/f11b8110-8e6f-4bc9-b97f-5e03fde3c169" />


<img width="1515" alt="image" src="https://github.com/user-attachments/assets/64b57fce-8848-42a1-baea-13c23a437a5d" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
