### PR TITLE
fix(create-rsbuild): Vue TS ESLint template

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -28,7 +28,7 @@
     "start": "node ./dist/index.js"
   },
   "dependencies": {
-    "create-rstack": "1.3.1"
+    "create-rstack": "1.4.0"
   },
   "devDependencies": {
     "@rslib/core": "0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,8 +742,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.3.1
-        version: 1.3.1
+        specifier: 1.4.0
+        version: 1.4.0
     devDependencies:
       '@rslib/core':
         specifier: 0.6.1
@@ -3725,8 +3725,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.3.1:
-    resolution: {integrity: sha512-HRpZNkjYIQT4sPrxk/aBEjjOIK34gNUcM/NwTk/TRv3Amw78p2u3GcBtayDtU89TVuwy9+MYFPZMuLbPMJaXyw==}
+  create-rstack@1.4.0:
+    resolution: {integrity: sha512-XQelsLV+hJkrZB7hEUtrFKxnUqbGOyO+ws/cZ6cyuCOOvHq1bSUBlnT/nIPAMxlWWv1bejvqu8nKxqXv4EX/Yg==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9743,7 +9743,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
-  create-rstack@1.3.1: {}
+  create-rstack@1.4.0: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

Update create-rstack to v1.4.0 to fix Vue TS ESLint template.

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.4.0
- https://github.com/web-infra-dev/rsbuild/issues/4962

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
