### PR TITLE
feat: make it easier to set browser name

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -101,10 +101,12 @@ async function openBrowser(url: string): Promise<boolean> {
   // It will always open new tab
   try {
     const { default: open } = await import('../../compiled/open/index.js');
+    const { apps } = open;
+
     const options = browser
       ? {
           app: {
-            name: browser,
+            name: apps[browser as keyof typeof apps] ?? browser,
             arguments: browserArgs?.split(' '),
           },
         }

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -96,9 +96,27 @@ Rsbuild opens pages in the system default browser by default, and also supports 
 
 ### Browser name
 
-Rsbuild uses the [open](https://github.com/sindresorhus/open) library to open the browser, you can refer to its [app options](https://github.com/sindresorhus/open?tab=readme-ov-file#app) to configure the value of `BROWSER`.
+Rsbuild uses the [open](https://github.com/sindresorhus/open) library to open browsers, and supports opening Chrome, Edge, and Firefox:
 
-On different operating systems, you need to set the app name differently, take opening Chrome as an example:
+```bash
+# Chrome
+BROWSER=chrome npx rsbuild dev
+
+# Edge
+BROWSER=edge npx rsbuild dev
+
+# Firefox
+BROWSER=firefox npx rsbuild dev
+```
+
+On Windows, use [cross-env](https://www.npmjs.com/package/cross-env) to set environment variables:
+
+```bash
+npm i cross-env -D
+cross-env BROWSER=chrome npx rsbuild dev
+```
+
+You can also refer to the [app option](https://github.com/sindresorhus/open?tab=readme-ov-file#app) of `open` to configure more special `BROWSER` values, such as some OS-specific browser names:
 
 ```bash
 # macOS
@@ -106,12 +124,9 @@ BROWSER="google chrome" npx rsbuild dev
 
 # Linux
 BROWSER="google-chrome" npx rsbuild dev
-
-# Windows
-# You need to use cross-env to set the environment variable
-npm i cross-env -D
-cross-env BROWSER=chrome npx rsbuild dev
 ```
+
+### Browser arguments
 
 Pass browser arguments through `BROWSER_ARGS`, with multiple arguments separated by spaces:
 

--- a/website/docs/zh/config/server/open.mdx
+++ b/website/docs/zh/config/server/open.mdx
@@ -96,9 +96,27 @@ Rsbuild 默认在系统默认浏览器中打开页面，同时也支持通过环
 
 ### 浏览器名称
 
-Rsbuild 基于 [open](https://github.com/sindresorhus/open) 库来打开浏览器，你需要参考它的 [app 选项](https://github.com/sindresorhus/open?tab=readme-ov-file#app) 来配置 `BROWSER` 的值。
+Rsbuild 基于 [open](https://github.com/sindresorhus/open) 库来打开浏览器，支持打开 Chrome、Edge 和 Firefox：
 
-在不同的操作系统上，你需要设置的 app name 是不同的，以打开 Chrome 为例：
+```bash
+# Chrome
+BROWSER=chrome npx rsbuild dev
+
+# Edge
+BROWSER=edge npx rsbuild dev
+
+# Edge
+BROWSER=firefox npx rsbuild dev
+```
+
+在 Windows 上，使用 [cross-env](https://www.npmjs.com/package/cross-env) 来设置环境变量：
+
+```bash
+npm i cross-env -D
+cross-env BROWSER=chrome npx rsbuild dev
+```
+
+你也可以参考 `open` 的 [app 选项](https://github.com/sindresorhus/open?tab=readme-ov-file#app) 来配置更多特殊的 `BROWSER` 值，例如一些操作系统特有的浏览器名称：
 
 ```bash
 # macOS
@@ -106,12 +124,9 @@ BROWSER="google chrome" npx rsbuild dev
 
 # Linux
 BROWSER="google-chrome" npx rsbuild dev
-
-# Windows
-# 需要使用 cross-env 来设置环境变量
-npm i cross-env -D
-cross-env BROWSER=chrome npx rsbuild dev
 ```
+
+### 浏览器参数
 
 通过 `BROWSER_ARGS` 来传递浏览器参数，多个参数之间用空格分隔：
 


### PR DESCRIPTION
## Summary

Using the `open` library's `apps` object to make it easier to set browser names across different operating systems.

## Related Links

- https://github.com/sindresorhus/open?tab=readme-ov-file#apps

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
