### PR TITLE
fix(security): update http-proxy-middleware to 2.0.7

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "dotenv": "16.4.7",
     "dotenv-expand": "12.0.1",
     "html-rspack-plugin": "6.0.4",
-    "http-proxy-middleware": "^2.0.6",
+    "http-proxy-middleware": "^2.0.7",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",
     "on-finished": "2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,7 +670,7 @@ importers:
         specifier: 6.0.4
         version: 6.0.4(@rspack/core@1.3.2(@swc/helpers@0.5.15))
       http-proxy-middleware:
-        specifier: ^2.0.6
+        specifier: ^2.0.7
         version: 2.0.7
       launch-editor-middleware:
         specifier: ^2.10.0


### PR DESCRIPTION
## Summary

> Versions of the package http-proxy-middleware before 2.0.7, from 3.0.0 and before 3.0.3 are vulnerable to Denial of Service (DoS) due to an UnhandledPromiseRejection error thrown by micromatch. An attacker could kill the Node.js process and crash the server by making requests to certain paths.

See https://nvd.nist.gov/vuln/detail/CVE-2024-21536 for more details.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
