### PR TITLE
fix: invalid type in http-proxy-middleware

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -93,17 +93,20 @@ export default {
         );
       },
       afterBundle(task) {
-        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) =>
-          // TODO: Due to the breaking change of http-proxy-middleware, it needs to be upgraded in rsbuild 2.0
-          // https://github.com/chimurai/http-proxy-middleware/pull/730
-          `${content
-            .replace('express.Request', 'http.IncomingMessage')
-            .replace('express.Response', 'http.ServerResponse')
-            .replace(
-              'extends express.RequestHandler {',
-              `{
+        replaceFileContent(
+          join(task.distPath, 'index.d.ts'),
+          (content) =>
+            // TODO: Due to the breaking change of http-proxy-middleware, it needs to be upgraded in rsbuild 2.0
+            // https://github.com/chimurai/http-proxy-middleware/pull/730
+            `${content
+              .replace('express.Request', 'http.IncomingMessage')
+              .replace('express.Response', 'http.ServerResponse')
+              .replace("import * as express from 'express';", '')
+              .replace(
+                'extends express.RequestHandler {',
+                `{
   (req: Request, res: Response, next?: (err?: any) => void): void | Promise<void>;`,
-            )}`.replace("import * as express from 'express';", ''),
+              )}`,
         );
       },
     },

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -93,19 +93,17 @@ export default {
         );
       },
       afterBundle(task) {
-        replaceFileContent(
-          join(task.distPath, 'index.d.ts'),
-          (content) =>
-            // TODO: Due to the breaking change of http-proxy-middleware, it needs to be upgraded in rsbuild 2.0
-            // https://github.com/chimurai/http-proxy-middleware/pull/730
-            `${content
-              .replace('express.Request', 'http.IncomingMessage')
-              .replace('express.Response', 'http.ServerResponse')
-              .replace(
-                'extends express.RequestHandler {',
-                `{
+        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) =>
+          // TODO: Due to the breaking change of http-proxy-middleware, it needs to be upgraded in rsbuild 2.0
+          // https://github.com/chimurai/http-proxy-middleware/pull/730
+          `${content
+            .replace('express.Request', 'http.IncomingMessage')
+            .replace('express.Response', 'http.ServerResponse')
+            .replace(
+              'extends express.RequestHandler {',
+              `{
   (req: Request, res: Response, next?: (err?: any) => void): void | Promise<void>;`,
-              )}`,
+            )}`.replace("import * as express from 'express';", ''),
         );
       },
     },


### PR DESCRIPTION
## Summary

Fix invalid type in http-proxy-middleware:

<img width="1294" alt="Screenshot 2025-04-06 at 15 41 30" src="https://github.com/user-attachments/assets/d34e27cd-422b-4dc2-aacb-a2b4f66b027e" />

This workaround can be removed after upgrading to http-proxy-middleware v3, which should be done before the release of Rsbuild 2.0.

Related: https://github.com/web-infra-dev/rsbuild/pull/3936

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
