### PR TITLE
fix(types): failed to resolve postcss types

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
     "postcss": "^8.5.3",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "prebundle": "1.3.2",
+    "prebundle": "1.3.3",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
     "rslog": "^1.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
     "postcss": "^8.5.3",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "prebundle": "1.2.7",
+    "prebundle": "1.3.0",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
     "rslog": "^1.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
     "postcss": "^8.5.3",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "prebundle": "1.3.0",
+    "prebundle": "1.3.1",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
     "rslog": "^1.2.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
     "postcss": "^8.5.3",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "prebundle": "1.3.1",
+    "prebundle": "1.3.2",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
     "rslog": "^1.2.3",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -67,14 +67,7 @@ export default {
     },
     {
       name: 'rspack-chain',
-      ignoreDts: true,
-      afterBundle(task) {
-        // copy types to dist because prebundle will break the types
-        fs.cpSync(
-          join(task.depPath, 'types/index.d.ts'),
-          join(task.distPath, 'index.d.ts'),
-        );
-      },
+      copyDts: true,
     },
     {
       name: 'http-proxy-middleware',
@@ -134,7 +127,7 @@ export default {
     },
     {
       name: 'postcss',
-      ignoreDts: true,
+      copyDts: true,
       externals: {
         picocolors: '../picocolors',
       },

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, isAbsolute, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import RspackChain from '../compiled/rspack-chain/index.js';
+import RspackChain from '../compiled/rspack-chain';
 import {
   ASSETS_DIST_DIR,
   CSS_DIST_DIR,

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -1,4 +1,4 @@
-import RspackChain from '../compiled/rspack-chain/index.js';
+import RspackChain from '../compiled/rspack-chain';
 import { castArray } from './helpers';
 import { logger } from './logger';
 import type { InternalContext, ModifyBundlerChainUtils } from './types';

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -2,7 +2,7 @@ import { posix } from 'node:path';
 import { URL } from 'node:url';
 import deepmerge from 'deepmerge';
 import color from '../../compiled/picocolors/index.js';
-import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain';
 import { DEFAULT_ASSET_PREFIX } from '../constants';
 import type {
   FilenameConfig,

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,7 +1,7 @@
 import path, { posix } from 'node:path';
 import deepmerge from 'deepmerge';
-import type { AcceptedPlugin, PluginCreator } from 'postcss';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
+import type { AcceptedPlugin, PluginCreator } from '../../compiled/postcss';
 import { CSS_REGEX, LOADER_PATH } from '../constants';
 import { castArray, getFilename } from '../helpers';
 import { getCompiledPath } from '../helpers/path';

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -18,7 +18,7 @@ import type {
   Options as HttpProxyOptions,
   Filter as ProxyFilter,
 } from '../../compiled/http-proxy-middleware/index.js';
-import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain';
 import type { FileDescriptor } from '../../compiled/rspack-manifest-plugin';
 import type { BundleAnalyzerPlugin } from '../../compiled/webpack-bundle-analyzer/index.js';
 import type {

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,5 +1,5 @@
 import type { ChainIdentifier } from '..';
-import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain';
 import type { RsbuildDevServer } from '../server/devServer';
 import type {
   EnvironmentConfig,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -3,7 +3,7 @@ import type {
   Configuration as WebpackConfig,
   WebpackPluginInstance,
 } from 'webpack';
-import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain';
 import type { ChainIdentifier } from '../configChain';
 import type {
   ModifyRspackConfigUtils,

--- a/packages/core/src/types/rspack.ts
+++ b/packages/core/src/types/rspack.ts
@@ -1,5 +1,5 @@
 import type * as Rspack from '@rspack/core';
-import type RspackChain from '../../compiled/rspack-chain/index.js';
+import type RspackChain from '../../compiled/rspack-chain';
 import type { TransformHandler } from './plugin';
 
 export type { Rspack, RspackChain };

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -2,9 +2,9 @@ import type {
   CssExtractRspackLoaderOptions,
   CssExtractRspackPluginOptions,
 } from '@rspack/core';
-import type { AcceptedPlugin, ProcessOptions } from 'postcss';
 import type { Configuration as WebpackConfig } from 'webpack';
 import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin/index.js';
+import type { AcceptedPlugin, ProcessOptions } from '../../compiled/postcss';
 import type { Rspack } from './rspack';
 
 export type { HtmlRspackPlugin };
@@ -46,7 +46,7 @@ export type PostCSSLoaderOptions = {
     | ((loaderContext: Rspack.LoaderContext) => PostCSSOptions);
 };
 
-export type { AcceptedPlugin as PostCSSPlugin } from 'postcss';
+export type PostCSSPlugin = AcceptedPlugin;
 
 export type CSSLoaderModulesMode =
   | 'local'

--- a/packages/core/tests/external.test.ts
+++ b/packages/core/tests/external.test.ts
@@ -1,4 +1,4 @@
-import RspackChain from '../compiled/rspack-chain/index.js';
+import RspackChain from '../compiled/rspack-chain';
 import { pluginExternals } from '../src/plugins/externals';
 
 describe('plugin-external', () => {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -43,7 +43,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "babel-loader": "10.0.0",
-    "prebundle": "1.3.2",
+    "prebundle": "1.3.3",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -43,7 +43,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "babel-loader": "10.0.0",
-    "prebundle": "1.3.1",
+    "prebundle": "1.3.2",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -43,7 +43,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "babel-loader": "10.0.0",
-    "prebundle": "1.3.0",
+    "prebundle": "1.3.1",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -43,7 +43,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "babel-loader": "10.0.0",
-    "prebundle": "1.2.7",
+    "prebundle": "1.3.0",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -39,7 +39,7 @@
     "@types/less": "^3.0.8",
     "less": "^4.3.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.3.2",
+    "prebundle": "1.3.3",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -39,7 +39,7 @@
     "@types/less": "^3.0.8",
     "less": "^4.3.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.2.7",
+    "prebundle": "1.3.0",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -39,7 +39,7 @@
     "@types/less": "^3.0.8",
     "less": "^4.3.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.3.0",
+    "prebundle": "1.3.1",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -39,7 +39,7 @@
     "@types/less": "^3.0.8",
     "less": "^4.3.0",
     "less-loader": "^12.2.0",
-    "prebundle": "1.3.1",
+    "prebundle": "1.3.2",
     "typescript": "^5.8.2"
   },
   "peerDependencies": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "@types/sass-loader": "^8.0.9",
-    "prebundle": "1.3.2",
+    "prebundle": "1.3.3",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.8.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "@types/sass-loader": "^8.0.9",
-    "prebundle": "1.3.1",
+    "prebundle": "1.3.2",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.8.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "@types/sass-loader": "^8.0.9",
-    "prebundle": "1.2.7",
+    "prebundle": "1.3.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.8.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "@types/sass-loader": "^8.0.9",
-    "prebundle": "1.3.0",
+    "prebundle": "1.3.1",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.8.2"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "file-loader": "6.2.0",
-    "prebundle": "1.3.0",
+    "prebundle": "1.3.1",
     "svgo": "^3.3.2",
     "typescript": "^5.8.2",
     "url-loader": "4.1.1"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "file-loader": "6.2.0",
-    "prebundle": "1.2.7",
+    "prebundle": "1.3.0",
     "svgo": "^3.3.2",
     "typescript": "^5.8.2",
     "url-loader": "4.1.1"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "file-loader": "6.2.0",
-    "prebundle": "1.3.1",
+    "prebundle": "1.3.2",
     "svgo": "^3.3.2",
     "typescript": "^5.8.2",
     "url-loader": "4.1.1"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -41,7 +41,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.14.0",
     "file-loader": "6.2.0",
-    "prebundle": "1.3.2",
+    "prebundle": "1.3.3",
     "svgo": "^3.3.2",
     "typescript": "^5.8.2",
     "url-loader": "4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,8 +697,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.3.2(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.2
-        version: 1.3.2(typescript@5.8.2)
+        specifier: 1.3.3
+        version: 1.3.3(typescript@5.8.2)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -798,8 +798,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.26.10)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.2
-        version: 1.3.2(typescript@5.8.2)
+        specifier: 1.3.3
+        version: 1.3.3(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -832,8 +832,8 @@ importers:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.3.2(@swc/helpers@0.5.15))(less@4.3.0)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.2
-        version: 1.3.2(typescript@5.8.2)
+        specifier: 1.3.3
+        version: 1.3.3(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -928,8 +928,8 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
       prebundle:
-        specifier: 1.3.2
-        version: 1.3.2(typescript@5.8.2)
+        specifier: 1.3.3
+        version: 1.3.3(typescript@5.8.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1064,8 +1064,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.2
-        version: 1.3.2(typescript@5.8.2)
+        specifier: 1.3.3
+        version: 1.3.3(typescript@5.8.2)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -5690,8 +5690,8 @@ packages:
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
-  prebundle@1.3.2:
-    resolution: {integrity: sha512-kYmQPJxsoL+/rLMazCs6m85Zdyqi6M9GGDGqV/zkZWKE1YsGoFZhLsdOVhaMv9i7iVDeKSAFn5N0eHDbWBR1RA==}
+  prebundle@1.3.3:
+    resolution: {integrity: sha512-r9XaHCFjCWoFtxzbj0g1mb7Ur8JOasgjbb7UbK+bP0k/xHDvI7Ti9AOkrsx0dw5UkmOJ1LocfNY58tSc5Iei8A==}
     hasBin: true
 
   prettier@2.8.8:
@@ -12065,7 +12065,7 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prebundle@1.3.2(typescript@5.8.2):
+  prebundle@1.3.3(typescript@5.8.2):
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,8 +697,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.3.2(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.8.2)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.8.2)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -798,8 +798,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.26.10)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.8.2)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -832,8 +832,8 @@ importers:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.3.2(@swc/helpers@0.5.15))(less@4.3.0)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.8.2)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -928,8 +928,8 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
       prebundle:
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.8.2)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.8.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1064,8 +1064,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.0
-        version: 1.3.0(typescript@5.8.2)
+        specifier: 1.3.1
+        version: 1.3.1(typescript@5.8.2)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -5690,8 +5690,8 @@ packages:
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
-  prebundle@1.3.0:
-    resolution: {integrity: sha512-eNFXDrKYJF7Lz7v8mfK+G6eBnrDpbNcHrN3BKpE3bOmy3hEWxoaqL/5HLwSwubT8d7bSuPr/S/9tw0VUSEM6rA==}
+  prebundle@1.3.1:
+    resolution: {integrity: sha512-5S1M8OsU38lCYRdAKBEnzDQ4ajrOwKLy4xMmIy5YjyW7qpxX7JBATzTExs0yiwwIMx9cQnZVCHibENqMrOq/Ew==}
     hasBin: true
 
   prettier@2.8.8:
@@ -12065,7 +12065,7 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prebundle@1.3.0(typescript@5.8.2):
+  prebundle@1.3.1(typescript@5.8.2):
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.5.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,8 +697,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.3.2(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0)
       prebundle:
-        specifier: 1.2.7
-        version: 1.2.7(typescript@5.8.2)
+        specifier: 1.3.0
+        version: 1.3.0(typescript@5.8.2)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -798,8 +798,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.26.10)(webpack@5.98.0)
       prebundle:
-        specifier: 1.2.7
-        version: 1.2.7(typescript@5.8.2)
+        specifier: 1.3.0
+        version: 1.3.0(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -832,8 +832,8 @@ importers:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.3.2(@swc/helpers@0.5.15))(less@4.3.0)(webpack@5.98.0)
       prebundle:
-        specifier: 1.2.7
-        version: 1.2.7(typescript@5.8.2)
+        specifier: 1.3.0
+        version: 1.3.0(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -928,8 +928,8 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
       prebundle:
-        specifier: 1.2.7
-        version: 1.2.7(typescript@5.8.2)
+        specifier: 1.3.0
+        version: 1.3.0(typescript@5.8.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1064,8 +1064,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.98.0)
       prebundle:
-        specifier: 1.2.7
-        version: 1.2.7(typescript@5.8.2)
+        specifier: 1.3.0
+        version: 1.3.0(typescript@5.8.2)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -2322,8 +2322,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@rollup/rollup-android-arm-eabi@4.39.0':
+    resolution: {integrity: sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==}
+    cpu: [arm]
+    os: [android]
+
   '@rollup/rollup-android-arm64@4.34.8':
     resolution: {integrity: sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.39.0':
+    resolution: {integrity: sha512-It9+M1zE31KWfqh/0cJLrrsCPiF72PoJjIChLX+rEcujVRCb4NLQ5QzFkzIZW8Kn8FTbvGQBY5TkKBau3S8cCQ==}
     cpu: [arm64]
     os: [android]
 
@@ -2332,8 +2342,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rollup/rollup-darwin-arm64@4.39.0':
+    resolution: {integrity: sha512-lXQnhpFDOKDXiGxsU9/l8UEGGM65comrQuZ+lDcGUx+9YQ9dKpF3rSEGepyeR5AHZ0b5RgiligsBhWZfSSQh8Q==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rollup/rollup-darwin-x64@4.34.8':
     resolution: {integrity: sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.39.0':
+    resolution: {integrity: sha512-mKXpNZLvtEbgu6WCkNij7CGycdw9cJi2k9v0noMb++Vab12GZjFgUXD69ilAbBh034Zwn95c2PNSz9xM7KYEAQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -2342,8 +2362,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@rollup/rollup-freebsd-arm64@4.39.0':
+    resolution: {integrity: sha512-jivRRlh2Lod/KvDZx2zUR+I4iBfHcu2V/BA2vasUtdtTN2Uk3jfcZczLa81ESHZHPHy4ih3T/W5rPFZ/hX7RtQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@rollup/rollup-freebsd-x64@4.34.8':
     resolution: {integrity: sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.39.0':
+    resolution: {integrity: sha512-8RXIWvYIRK9nO+bhVz8DwLBepcptw633gv/QT4015CpJ0Ht8punmoHU/DuEd3iw9Hr8UwUV+t+VNNuZIWYeY7Q==}
     cpu: [x64]
     os: [freebsd]
 
@@ -2352,8 +2382,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.39.0':
+    resolution: {integrity: sha512-mz5POx5Zu58f2xAG5RaRRhp3IZDK7zXGk5sdEDj4o96HeaXhlUwmLFzNlc4hCQi5sGdR12VDgEUqVSHer0lI9g==}
+    cpu: [arm]
+    os: [linux]
+
   '@rollup/rollup-linux-arm-musleabihf@4.34.8':
     resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.39.0':
+    resolution: {integrity: sha512-+YDwhM6gUAyakl0CD+bMFpdmwIoRDzZYaTWV3SDRBGkMU/VpIBYXXEvkEcTagw/7VVkL2vA29zU4UVy1mP0/Yw==}
     cpu: [arm]
     os: [linux]
 
@@ -2362,8 +2402,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@rollup/rollup-linux-arm64-gnu@4.39.0':
+    resolution: {integrity: sha512-EKf7iF7aK36eEChvlgxGnk7pdJfzfQbNvGV/+l98iiMwU23MwvmV0Ty3pJ0p5WQfm3JRHOytSIqD9LB7Bq7xdQ==}
+    cpu: [arm64]
+    os: [linux]
+
   '@rollup/rollup-linux-arm64-musl@4.34.8':
     resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.39.0':
+    resolution: {integrity: sha512-vYanR6MtqC7Z2SNr8gzVnzUul09Wi1kZqJaek3KcIlI/wq5Xtq4ZPIZ0Mr/st/sv/NnaPwy/D4yXg5x0B3aUUA==}
     cpu: [arm64]
     os: [linux]
 
@@ -2372,8 +2422,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@rollup/rollup-linux-loongarch64-gnu@4.39.0':
+    resolution: {integrity: sha512-NMRUT40+h0FBa5fb+cpxtZoGAggRem16ocVKIv5gDB5uLDgBIwrIsXlGqYbLwW8YyO3WVTk1FkFDjMETYlDqiw==}
+    cpu: [loong64]
+    os: [linux]
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
     resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.39.0':
+    resolution: {integrity: sha512-0pCNnmxgduJ3YRt+D+kJ6Ai/r+TaePu9ZLENl+ZDV/CdVczXl95CbIiwwswu4L+K7uOIGf6tMo2vm8uadRaICQ==}
     cpu: [ppc64]
     os: [linux]
 
@@ -2382,8 +2442,23 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@rollup/rollup-linux-riscv64-gnu@4.39.0':
+    resolution: {integrity: sha512-t7j5Zhr7S4bBtksT73bO6c3Qa2AV/HqiGlj9+KB3gNF5upcVkx+HLgxTm8DK4OkzsOYqbdqbLKwvGMhylJCPhQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.39.0':
+    resolution: {integrity: sha512-m6cwI86IvQ7M93MQ2RF5SP8tUjD39Y7rjb1qjHgYh28uAPVU8+k/xYWvxRO3/tBN2pZkSMa5RjnPuUIbrwVxeA==}
+    cpu: [riscv64]
+    os: [linux]
+
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
     resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.39.0':
+    resolution: {integrity: sha512-iRDJd2ebMunnk2rsSBYlsptCyuINvxUfGwOUldjv5M4tpa93K8tFMeYGpNk2+Nxl+OBJnBzy2/JCscGeO507kA==}
     cpu: [s390x]
     os: [linux]
 
@@ -2392,8 +2467,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@rollup/rollup-linux-x64-gnu@4.39.0':
+    resolution: {integrity: sha512-t9jqYw27R6Lx0XKfEFe5vUeEJ5pF3SGIM6gTfONSMb7DuG6z6wfj2yjcoZxHg129veTqU7+wOhY6GX8wmf90dA==}
+    cpu: [x64]
+    os: [linux]
+
   '@rollup/rollup-linux-x64-musl@4.34.8':
     resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.39.0':
+    resolution: {integrity: sha512-ThFdkrFDP55AIsIZDKSBWEt/JcWlCzydbZHinZ0F/r1h83qbGeenCt/G/wG2O0reuENDD2tawfAj2s8VK7Bugg==}
     cpu: [x64]
     os: [linux]
 
@@ -2402,13 +2487,28 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rollup/rollup-win32-arm64-msvc@4.39.0':
+    resolution: {integrity: sha512-jDrLm6yUtbOg2TYB3sBF3acUnAwsIksEYjLeHL+TJv9jg+TmTwdyjnDex27jqEMakNKf3RwwPahDIt7QXCSqRQ==}
+    cpu: [arm64]
+    os: [win32]
+
   '@rollup/rollup-win32-ia32-msvc@4.34.8':
     resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
     cpu: [ia32]
     os: [win32]
 
+  '@rollup/rollup-win32-ia32-msvc@4.39.0':
+    resolution: {integrity: sha512-6w9uMuza+LbLCVoNKL5FSLE7yvYkq9laSd09bwS0tMjkwXrmib/4KmoJcrKhLWHvw19mwU+33ndC69T7weNNjQ==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rollup/rollup-win32-x64-msvc@4.34.8':
     resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.39.0':
+    resolution: {integrity: sha512-yAkUOkIKZlK5dl7u6dg897doBgLXmUHhIINM2c+sND3DZwnrdQkkSiDh7N75Ll4mM4dxSkYfXqU9fW3lLkMFug==}
     cpu: [x64]
     os: [win32]
 
@@ -2989,6 +3089,9 @@ packages:
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
+
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
   '@types/express-serve-static-core@5.0.6':
     resolution: {integrity: sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==}
@@ -5587,8 +5690,8 @@ packages:
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
-  prebundle@1.2.7:
-    resolution: {integrity: sha512-2i+g+cJA7vdLiap9ztl/fdTtmfAZnz6rbgX668eCdcMzu22aVjoaIqe0Wu1MNL4eHN142OHnxwnNhIXptRo6oQ==}
+  prebundle@1.3.0:
+    resolution: {integrity: sha512-eNFXDrKYJF7Lz7v8mfK+G6eBnrDpbNcHrN3BKpE3bOmy3hEWxoaqL/5HLwSwubT8d7bSuPr/S/9tw0VUSEM6rA==}
     hasBin: true
 
   prettier@2.8.8:
@@ -5833,8 +5936,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rollup-plugin-dts@6.1.1:
-    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
+  rollup-plugin-dts@6.2.1:
+    resolution: {integrity: sha512-sR3CxYUl7i2CHa0O7bA45mCrgADyAQ0tVtGSqi3yvH28M+eg1+g5d7kQ9hLvEz5dorK3XVsH5L2jwHLQf72DzA==}
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
@@ -5842,6 +5945,11 @@ packages:
 
   rollup@4.34.8:
     resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rollup@4.39.0:
+    resolution: {integrity: sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -8137,58 +8245,118 @@ snapshots:
   '@rollup/rollup-android-arm-eabi@4.34.8':
     optional: true
 
+  '@rollup/rollup-android-arm-eabi@4.39.0':
+    optional: true
+
   '@rollup/rollup-android-arm64@4.34.8':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.39.0':
     optional: true
 
   '@rollup/rollup-darwin-arm64@4.34.8':
     optional: true
 
+  '@rollup/rollup-darwin-arm64@4.39.0':
+    optional: true
+
   '@rollup/rollup-darwin-x64@4.34.8':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.39.0':
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.34.8':
     optional: true
 
+  '@rollup/rollup-freebsd-arm64@4.39.0':
+    optional: true
+
   '@rollup/rollup-freebsd-x64@4.34.8':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.39.0':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-arm-gnueabihf@4.39.0':
+    optional: true
+
   '@rollup/rollup-linux-arm-musleabihf@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.39.0':
     optional: true
 
   '@rollup/rollup-linux-arm64-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-arm64-gnu@4.39.0':
+    optional: true
+
   '@rollup/rollup-linux-arm64-musl@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.39.0':
     optional: true
 
   '@rollup/rollup-linux-loongarch64-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-loongarch64-gnu@4.39.0':
+    optional: true
+
   '@rollup/rollup-linux-powerpc64le-gnu@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.39.0':
     optional: true
 
   '@rollup/rollup-linux-riscv64-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-riscv64-gnu@4.39.0':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.39.0':
+    optional: true
+
   '@rollup/rollup-linux-s390x-gnu@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.39.0':
     optional: true
 
   '@rollup/rollup-linux-x64-gnu@4.34.8':
     optional: true
 
+  '@rollup/rollup-linux-x64-gnu@4.39.0':
+    optional: true
+
   '@rollup/rollup-linux-x64-musl@4.34.8':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.39.0':
     optional: true
 
   '@rollup/rollup-win32-arm64-msvc@4.34.8':
     optional: true
 
+  '@rollup/rollup-win32-arm64-msvc@4.39.0':
+    optional: true
+
   '@rollup/rollup-win32-ia32-msvc@4.34.8':
     optional: true
 
+  '@rollup/rollup-win32-ia32-msvc@4.39.0':
+    optional: true
+
   '@rollup/rollup-win32-x64-msvc@4.34.8':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.39.0':
     optional: true
 
   '@rsbuild/core@1.3.0':
@@ -8926,6 +9094,8 @@ snapshots:
   '@types/estree@1.0.5': {}
 
   '@types/estree@1.0.6': {}
+
+  '@types/estree@1.0.7': {}
 
   '@types/express-serve-static-core@5.0.6':
     dependencies:
@@ -11895,12 +12065,12 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prebundle@1.2.7(typescript@5.8.2):
+  prebundle@1.3.0(typescript@5.8.2):
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.5.3
-      rollup: 4.34.8
-      rollup-plugin-dts: 6.1.1(rollup@4.34.8)(typescript@5.8.2)
+      rollup: 4.39.0
+      rollup-plugin-dts: 6.2.1(rollup@4.39.0)(typescript@5.8.2)
       terser: 5.39.0
     transitivePeerDependencies:
       - typescript
@@ -12168,10 +12338,10 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup-plugin-dts@6.1.1(rollup@4.34.8)(typescript@5.8.2):
+  rollup-plugin-dts@6.2.1(rollup@4.39.0)(typescript@5.8.2):
     dependencies:
       magic-string: 0.30.17
-      rollup: 4.34.8
+      rollup: 4.39.0
       typescript: 5.8.2
     optionalDependencies:
       '@babel/code-frame': 7.26.2
@@ -12199,6 +12369,32 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.34.8
       '@rollup/rollup-win32-ia32-msvc': 4.34.8
       '@rollup/rollup-win32-x64-msvc': 4.34.8
+      fsevents: 2.3.3
+
+  rollup@4.39.0:
+    dependencies:
+      '@types/estree': 1.0.7
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.39.0
+      '@rollup/rollup-android-arm64': 4.39.0
+      '@rollup/rollup-darwin-arm64': 4.39.0
+      '@rollup/rollup-darwin-x64': 4.39.0
+      '@rollup/rollup-freebsd-arm64': 4.39.0
+      '@rollup/rollup-freebsd-x64': 4.39.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.39.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.39.0
+      '@rollup/rollup-linux-arm64-gnu': 4.39.0
+      '@rollup/rollup-linux-arm64-musl': 4.39.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.39.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.39.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.39.0
+      '@rollup/rollup-linux-riscv64-musl': 4.39.0
+      '@rollup/rollup-linux-s390x-gnu': 4.39.0
+      '@rollup/rollup-linux-x64-gnu': 4.39.0
+      '@rollup/rollup-linux-x64-musl': 4.39.0
+      '@rollup/rollup-win32-arm64-msvc': 4.39.0
+      '@rollup/rollup-win32-ia32-msvc': 4.39.0
+      '@rollup/rollup-win32-x64-msvc': 4.39.0
       fsevents: 2.3.3
 
   rsbuild-dev-middleware@0.2.0(webpack@5.98.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -697,8 +697,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.3.2(@swc/helpers@0.5.15))(postcss@8.5.3)(typescript@5.8.2)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@5.8.2)
+        specifier: 1.3.2
+        version: 1.3.2(typescript@5.8.2)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -798,8 +798,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.26.10)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@5.8.2)
+        specifier: 1.3.2
+        version: 1.3.2(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -832,8 +832,8 @@ importers:
         specifier: ^12.2.0
         version: 12.2.0(@rspack/core@1.3.2(@swc/helpers@0.5.15))(less@4.3.0)(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@5.8.2)
+        specifier: 1.3.2
+        version: 1.3.2(typescript@5.8.2)
       typescript:
         specifier: ^5.8.2
         version: 5.8.2
@@ -928,8 +928,8 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
       prebundle:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@5.8.2)
+        specifier: 1.3.2
+        version: 1.3.2(typescript@5.8.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1064,8 +1064,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.98.0)
       prebundle:
-        specifier: 1.3.1
-        version: 1.3.1(typescript@5.8.2)
+        specifier: 1.3.2
+        version: 1.3.2(typescript@5.8.2)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -5690,8 +5690,8 @@ packages:
   preact@10.26.4:
     resolution: {integrity: sha512-KJhO7LBFTjP71d83trW+Ilnjbo+ySsaAgCfXOXUlmGzJ4ygYPWmysm77yg4emwfmoz3b22yvH5IsVFHbhUaH5w==}
 
-  prebundle@1.3.1:
-    resolution: {integrity: sha512-5S1M8OsU38lCYRdAKBEnzDQ4ajrOwKLy4xMmIy5YjyW7qpxX7JBATzTExs0yiwwIMx9cQnZVCHibENqMrOq/Ew==}
+  prebundle@1.3.2:
+    resolution: {integrity: sha512-kYmQPJxsoL+/rLMazCs6m85Zdyqi6M9GGDGqV/zkZWKE1YsGoFZhLsdOVhaMv9i7iVDeKSAFn5N0eHDbWBR1RA==}
     hasBin: true
 
   prettier@2.8.8:
@@ -12065,7 +12065,7 @@ snapshots:
 
   preact@10.26.4: {}
 
-  prebundle@1.3.1(typescript@5.8.2):
+  prebundle@1.3.2(typescript@5.8.2):
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.5.3


### PR DESCRIPTION
## Summary

Fix failed to resolve `postcss` types.

The `postcss` package has been prebundled and we can use the `copyDts` option to copy declaration types to the compiled folder.

<img width="1291" alt="Screenshot 2025-03-31 at 21 01 33" src="https://github.com/user-attachments/assets/0133fdf0-82f3-417b-af83-30ef541687c0" />

## Related Links

- https://github.com/rspack-contrib/prebundle/releases/tag/v1.3.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
