### PR TITLE
docs: correct `getTransformedHtml` link

### DIFF
--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -98,7 +98,7 @@ export default defineConfig({
 
 It should be noted that plugin registration can only be performed during the Rsbuild initialization phase. You cannot dynamically add other plugins within a plugin through the plugin API:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 // Wrong
 function myPlugin() {
   return {

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -23,7 +23,7 @@ Rsbuild supports defining different Rsbuild configs for each environment through
 
 For example, if your project wants to support the SSR function, you need to define different configs for client and SSR respectively. You can define a web and node environment respectively.
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     // Configure the web environment for browsers
@@ -97,7 +97,7 @@ config inspection completed, generated files:
 
 When environments is not specified, Rsbuild will by default create an environment with the same name based on the currently target type (the value of [output.target](/config/output/target)).
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     target: 'web',
@@ -107,7 +107,7 @@ export default {
 
 The above config is equivalent to a simplification of the following config:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     web: {
@@ -143,7 +143,7 @@ Plugins configured through the [plugins](/config/plugins) field support running 
 
 For example, enable the React plugin only in the web environment:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default {
@@ -308,7 +308,7 @@ To control the build order between different environments, you can set build dep
 
 For example, if you need to build the `web` environment first, then build the `node` environment, you can add the following configuration:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     web: {

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -268,7 +268,7 @@ const serverRender = (serverAPI) => async (_req, res) => {
 };
 
 export async function startDevServer() {
-  const { content } = await loadConfig({});
+  const { content } = await loadConfig();
 
   // Init Rsbuild
   const rsbuild = await createRsbuild({

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -37,7 +37,7 @@ In the SSR scenario, two types of outputs (web and node targets), need to be gen
 
 At this time, you can use Rsbuild's [multi-environment builds](guide/advanced/environments) capability, define the following configuration:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     // Configure the web environment for browsers
@@ -157,7 +157,7 @@ By default, scripts and links associated with the current page are automatically
 
 When you need to dynamically generate HTML on the server side, you'll need to inject the URLs of JavaScript and CSS assets into the HTML. By configuring [output.manifest](/config/output/manifest), you can easily obtain the manifest information of these assets. Here's an example:
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     manifest: true,

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -100,8 +100,7 @@ const serverRender = (serverAPI) => async (_req, res) => {
 
 // Custom server
 async function startDevServer() {
-  const { content } = await loadConfig({});
-
+  const { content } = await loadConfig();
   const rsbuild = await createRsbuild({
     rsbuildConfig: content,
   });
@@ -154,7 +153,7 @@ Now, you can run the `npm run dev` command to start the dev server with SSR rend
 
 ## Get manifest
 
-By default, scripts and links associated with the current page are automatically inserted into the HTML template. At this time, the compiled HTML template content can be obtained through [getTransformedHtml](/guide/advanced/environments#environment-api).
+By default, scripts and links associated with the current page are automatically inserted into the HTML template. At this time, the compiled HTML template content can be obtained through [getTransformedHtml](/api/javascript-api/environment-api#gettransformedhtml).
 
 When you need to dynamically generate HTML on the server side, you'll need to inject the URLs of JavaScript and CSS assets into the HTML. By configuring [output.manifest](/config/output/manifest), you can easily obtain the manifest information of these assets. Here's an example:
 

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -40,7 +40,7 @@ When entry is index, the page can be accessed through `/`; when entry is foo, th
 
 When server.base is `/base`, the index page can be accessed through `/base` and the foo page can be accessed through `/base/foo`.
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   source: {
     entry: {
@@ -58,7 +58,7 @@ By default, when the request meets the following conditions and the correspondin
 - The request is a `GET` or `HEAD` request
 - Which accepts `text/html` (the request header accept type is `text/html` or `*/*`)
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   server: {
     htmlFallback: 'index',
@@ -70,7 +70,7 @@ export default {
 
 When Rsbuild's default [server.htmlFallback](/config/server/html-fallback) configuration cannot meet your needs, for example, if you want to be able to access `main.html` when accessing `/`, you can set it up using [server.historyApiFallback](/config/server/history-api-fallback).
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   source: {
     entry: {

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -98,7 +98,7 @@ export default defineConfig({
 
 需要注意的是，插件的注册只能在 Rsbuild 初始化阶段进行，你不能在一个插件内通过插件 API 动态地添加其他插件：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 // 错误
 function myPlugin() {
   return {

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -23,7 +23,7 @@ Rsbuild 支持通过 [environments](/config/environments) 为每个环境定义�
 
 例如，假如你的项目希望支持 SSR 功能，你需要分别为 client 和 SSR 定义不同的配置，你可以分别定义一个 web 和 node 的 environment。
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     // 配置 web 环境，用于浏览器端
@@ -97,7 +97,7 @@ config inspection completed, generated files:
 
 当 environments 未指定时，Rsbuild 默认会根据当前的产物类型 ([output.target](/config/output/target) 的值) 创建一个同名的环境。
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     target: 'web',
@@ -107,7 +107,7 @@ export default {
 
 以上配置相当于下面配置的语法糖：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     web: {
@@ -143,7 +143,7 @@ rsbuild dev --environment web,node
 
 例如，仅在 web 环境下开启 React 插件：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default {
@@ -308,7 +308,7 @@ export async function startDevServer() {
 
 例如，假设你需要先完成 `web` 环境的构建，再开始构建 `node` 环境，可以添加如下配置：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     web: {

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -268,7 +268,7 @@ const serverRender = (serverAPI) => async (_req, res) => {
 };
 
 export async function startDevServer() {
-  const { content } = await loadConfig({});
+  const { content } = await loadConfig();
 
   // Init Rsbuild
   const rsbuild = await createRsbuild({

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -37,7 +37,7 @@ SSR 场景下，需要同时产出 web 和 node 两种类型的产物，分别�
 
 此时可以使用 Rsbuild 的[多环境构建](/guide/advanced/environments)能力，定义如下配置：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   environments: {
     // 配置 web 环境，用于浏览器端
@@ -157,7 +157,7 @@ startDevServer(process.cwd());
 
 在服务器端动态生成 HTML 时，你需要将 JavaScript 和 CSS 资源的 URL 注入到 HTML 中。通过配置 [output.manifest](/config/output/manifest)，你可以方便地获取这些资源的清单信息。示例如下：
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     manifest: true,

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -74,7 +74,7 @@ export default {
 
 ## 自定义 Server
 
-Rsbuild 并未内置 SSR 渲染能力，你可以通过 Rsbuild 的[自定义 Server](/guide/basic/server#自定义-server) 和 [Environment API](/guide/advanced/environments#environment-api) 实现 SSR 渲染：
+Rsbuild 并未内置 SSR 渲染能力，你可以通过 Rsbuild 的 [自定义 Server](/guide/basic/server#自定义-server) 和 [Environment API](/guide/advanced/environments#environment-api) 实现 SSR 渲染：
 
 ```ts title=server.mjs
 import express from 'express';
@@ -100,8 +100,7 @@ const serverRender = (serverAPI) => async (_req, res) => {
 
 // 自定义 Server
 async function startDevServer() {
-  const { content } = await loadConfig({});
-
+  const { content } = await loadConfig();
   const rsbuild = await createRsbuild({
     rsbuildConfig: content,
   });
@@ -154,9 +153,9 @@ startDevServer(process.cwd());
 
 ## 获取资源清单
 
-默认情况下，和当前页面关联的 scripts 和 links 会自动插入到 HTML 模版中，此时通过 [getTransformedHtml](/guide/advanced/environments#environment-api) 即可获取编译后的 HTML 模版内容。
+默认情况下，和当前页面关联的 scripts 和 links 会自动插入到 HTML 模版中，此时通过 [getTransformedHtml](/api/javascript-api/environment-api#gettransformedhtml) 即可获取编译后的 HTML 模版内容。
 
-当需要在服务器端动态生成 HTML 时，你需要将 JavaScript 和 CSS 资源的 URL 注入到 HTML 中。通过配置 [output.manifest](/config/output/manifest)，你可以方便地获取这些资源的清单信息。示例如下：
+在服务器端动态生成 HTML 时，你需要将 JavaScript 和 CSS 资源的 URL 注入到 HTML 中。通过配置 [output.manifest](/config/output/manifest)，你可以方便地获取这些资源的清单信息。示例如下：
 
 ```ts title=rsbuild.config.ts
 export default {

--- a/website/docs/zh/guide/basic/server.mdx
+++ b/website/docs/zh/guide/basic/server.mdx
@@ -58,7 +58,7 @@ export default {
 - 当前请求是 GET 或 HEAD 请求
 - 当前请求头接受 `text/html` (请求头 accept 类型为 `text/html` 或 `*/*`)
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   server: {
     htmlFallback: 'index',
@@ -70,7 +70,7 @@ export default {
 
 当 Rsbuild 默认的 [server.htmlFallback](/config/server/html-fallback) 配置无法满足你的需求，例如，希望在访问 `/` 时可以访问 `main.html`，可通过 [server.historyApiFallback](/config/server/history-api-fallback) 进行设置。
 
-```ts title=rsbuild.config.ts
+```ts title="rsbuild.config.ts"
 export default {
   source: {
     entry: {


### PR DESCRIPTION
## Summary

- Updating the format of code block titles and removing unnecessary arguments in function calls.
- Correct `getTransformedHtml` link.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
