### PR TITLE
fix: incorrect link conversion in error overlay

### DIFF
--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -15,20 +15,26 @@ export function convertLinksInHtml(text: string, root?: string): string {
    */
   const pathRegex = /(?:\.\.?[\/\\]|[a-zA-Z]:\\|\/)[^:]*:\d+:\d+/g;
 
-  return text.replace(pathRegex, (file) => {
-    // If the file contains `</span>`, it means the file path contains ANSI codes.
-    // We need to move the `</span>` to the end of the file path.
-    const hasClosingSpan = file.includes('</span>') && !file.includes('<span');
-    const filePath = hasClosingSpan ? file.replace('</span>', '') : file;
-    const suffix = hasClosingSpan ? '</span>' : '';
-    const isAbsolute = path.isAbsolute(filePath);
-    const absolutePath =
-      root && !isAbsolute ? path.join(root, filePath) : filePath;
-    const relativePath =
-      root && isAbsolute ? getRelativePath(root, filePath) : filePath;
+  const lines = text.split('\n');
+  const replacedLines = lines.map((line) => {
+    return line.replace(pathRegex, (file) => {
+      // If the file contains `</span>`, it means the file path contains ANSI codes.
+      // We need to move the `</span>` to the end of the file path.
+      const hasClosingSpan =
+        file.includes('</span>') && !file.includes('<span');
+      const filePath = hasClosingSpan ? file.replace('</span>', '') : file;
+      const suffix = hasClosingSpan ? '</span>' : '';
+      const isAbsolute = path.isAbsolute(filePath);
+      const absolutePath =
+        root && !isAbsolute ? path.join(root, filePath) : filePath;
+      const relativePath =
+        root && isAbsolute ? getRelativePath(root, filePath) : filePath;
 
-    return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
+      return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
+    });
   });
+
+  return replacedLines.join('\n');
 }
 
 // HTML template for error overlay

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -151,4 +151,14 @@ describe('convertLinksInHtml', () => {
       '[<span style="color:#6eecf7;font-weight:bold;text-decoration:underline;text-underline-offset:3px;"><a class="file-link" data-file="C:\\Users\\username\\project\\src\\index.js:4:1">.\\src\\index.js:4:1</a></span>]\n';
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
+
+  it('should convert multiple lines as expected', () => {
+    const input = `
+    See https://example.com
+    at error (/path/to/src/index.js:4:1)`;
+
+    expect(convertLinksInHtml(ansiHTML(input))).toEqual(`
+    See https://example.com
+    at error (<a class="file-link" data-file="/path/to/src/index.js:4:1">/path/to/src/index.js:4:1</a>)`);
+  });
 });


### PR DESCRIPTION
## Summary

Fix incorrect link conversion in error overlay, we should avoid replaces that span multiple lines.

Fix:

<img width="1028" alt="Screenshot 2025-04-07 at 21 39 41" src="https://github.com/user-attachments/assets/85d9747a-0b41-48f7-9571-ac77dccd29d6" />

## Related Links

Found on https://github.com/web-infra-dev/rsbuild/issues/4976.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
