### PR TITLE
fix(plugin-svgr): unpin @rsbuild/plugin-react dependency version

### DIFF
--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@rsbuild/plugin-svgr",
   "version": "1.1.0",
-  "description": "svgr plugin for Rsbuild",
+  "description": "SVGR plugin for Rsbuild",
   "repository": {
     "type": "git",
     "url": "https://github.com/web-infra-dev/rsbuild",
@@ -28,7 +28,7 @@
     "prebundle": "prebundle"
   },
   "dependencies": {
-    "@rsbuild/plugin-react": "workspace:*",
+    "@rsbuild/plugin-react": "workspace:^1.1.0",
     "@svgr/core": "8.1.0",
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1030,7 +1030,7 @@ importers:
   packages/plugin-svgr:
     dependencies:
       '@rsbuild/plugin-react':
-        specifier: workspace:*
+        specifier: workspace:^1.1.0
         version: link:../plugin-react
       '@svgr/core':
         specifier: 8.1.0


### PR DESCRIPTION
## Summary

Unpin `@rsbuild/plugin-react` dependency version in `@rsbuild/plugin-svgr` to avoid repeated installation of `@rsbuild/plugin-react`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
