### PR TITLE
fix(fileSize): incorrect alignment if environment name is long

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -40,12 +40,12 @@ const getAssetColor = (size: number) => {
 };
 
 function getHeader(
-  longestFileLength: number,
-  longestSizeLength: number,
+  maxFileLength: number,
+  maxSizeLength: number,
   fileHeader: string,
   showGzipHeader: boolean,
 ) {
-  const lengths = [longestFileLength, longestSizeLength];
+  const lengths = [maxFileLength, maxSizeLength];
   const rowTypes = [fileHeader, 'Size'];
 
   if (showGzipHeader) {
@@ -174,23 +174,18 @@ async function printFileSizes(
   assets.sort((a, b) => a.size - b.size);
 
   const fileHeader = `File (${environmentName})`;
-  const longestFileLength = Math.max(
+  const maxFileLength = Math.max(
     ...assets.map((a) => (a.folder + path.sep + a.name).length),
     fileHeader.length,
   );
-  const longestSizeLength = Math.max(...assets.map((a) => a.sizeLabel.length));
+  const maxSizeLength = Math.max(...assets.map((a) => a.sizeLabel.length));
 
   if (options.detail !== false) {
     const showGzipHeader = Boolean(
       options.compressed && assets.some((item) => item.gzippedSize !== null),
     );
     logs.push(
-      getHeader(
-        longestFileLength,
-        longestSizeLength,
-        fileHeader,
-        showGzipHeader,
-      ),
+      getHeader(maxFileLength, maxSizeLength, fileHeader, showGzipHeader),
     );
   }
 
@@ -210,16 +205,16 @@ async function printFileSizes(
     }
 
     if (options.detail !== false) {
-      if (sizeLength < longestSizeLength) {
-        const rightPadding = ' '.repeat(longestSizeLength - sizeLength);
+      if (sizeLength < maxSizeLength) {
+        const rightPadding = ' '.repeat(maxSizeLength - sizeLength);
         sizeLabel += rightPadding;
       }
 
       let fileNameLabel =
         color.dim(asset.folder + path.sep) + coloringAssetName(asset.name);
 
-      if (fileNameLength < longestFileLength) {
-        const rightPadding = ' '.repeat(longestFileLength - fileNameLength);
+      if (fileNameLength < maxFileLength) {
+        const rightPadding = ' '.repeat(maxFileLength - fileNameLength);
         fileNameLabel += rightPadding;
       }
 

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -41,19 +41,19 @@ const getAssetColor = (size: number) => {
 
 function getHeader(
   longestFileLength: number,
-  longestLabelLength: number,
-  environmentName: string,
+  longestSizeLength: number,
+  fileHeader: string,
   showGzipHeader: boolean,
 ) {
-  const longestLengths = [longestFileLength, longestLabelLength];
-  const rowTypes = [`File (${environmentName})`, 'Size'];
+  const lengths = [longestFileLength, longestSizeLength];
+  const rowTypes = [fileHeader, 'Size'];
 
   if (showGzipHeader) {
     rowTypes.push('Gzip');
   }
 
   const headerRow = rowTypes.reduce((prev, cur, index) => {
-    const length = longestLengths[index];
+    const length = lengths[index];
     let curLabel = cur;
     if (length) {
       curLabel =
@@ -173,10 +173,12 @@ async function printFileSizes(
 
   assets.sort((a, b) => a.size - b.size);
 
-  const longestLabelLength = Math.max(...assets.map((a) => a.sizeLabel.length));
+  const fileHeader = `File (${environmentName})`;
   const longestFileLength = Math.max(
     ...assets.map((a) => (a.folder + path.sep + a.name).length),
+    fileHeader.length,
   );
+  const longestSizeLength = Math.max(...assets.map((a) => a.sizeLabel.length));
 
   if (options.detail !== false) {
     const showGzipHeader = Boolean(
@@ -185,8 +187,8 @@ async function printFileSizes(
     logs.push(
       getHeader(
         longestFileLength,
-        longestLabelLength,
-        environmentName,
+        longestSizeLength,
+        fileHeader,
         showGzipHeader,
       ),
     );
@@ -208,8 +210,8 @@ async function printFileSizes(
     }
 
     if (options.detail !== false) {
-      if (sizeLength < longestLabelLength) {
-        const rightPadding = ' '.repeat(longestLabelLength - sizeLength);
+      if (sizeLength < longestSizeLength) {
+        const rightPadding = ' '.repeat(longestSizeLength - sizeLength);
         sizeLabel += rightPadding;
       }
 


### PR DESCRIPTION
## Summary

Fix incorrect alignment of the file size logs if environment name is longer than filenames.

- before:

<img width="743" alt="Screenshot 2025-04-08 at 17 42 39" src="https://github.com/user-attachments/assets/6721fcea-eace-4cfe-85b6-9e586952c507" />

- after:

<img width="734" alt="Screenshot 2025-04-08 at 17 45 04" src="https://github.com/user-attachments/assets/07d2711e-f9e4-45e2-b9c2-8d8f7dd56cb3" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
