### PR TITLE
feat(overlay): support for clicking links in error logs

### DIFF
--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -15,9 +15,12 @@ export function convertLinksInHtml(text: string, root?: string): string {
    */
   const pathRegex = /(?:\.\.?[\/\\]|[a-zA-Z]:\\|\/)[^:]*:\d+:\d+/g;
 
+  const urlRegex =
+    /(https?:\/\/(?:[\w-]+\.)+[a-z0-9](?:[\w-.~:/?#[\]@!$&'*+,;=])*)/gi;
+
   const lines = text.split('\n');
   const replacedLines = lines.map((line) => {
-    return line.replace(pathRegex, (file) => {
+    let replacedLine = line.replace(pathRegex, (file) => {
       // If the file contains `</span>`, it means the file path contains ANSI codes.
       // We need to move the `</span>` to the end of the file path.
       const hasClosingSpan =
@@ -32,6 +35,12 @@ export function convertLinksInHtml(text: string, root?: string): string {
 
       return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
     });
+
+    replacedLine = replacedLine.replace(urlRegex, (url) => {
+      return `<a class="url-link" href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`;
+    });
+
+    return replacedLine;
   });
 
   return replacedLines.join('\n');
@@ -92,9 +101,9 @@ export function genOverlayHTML(errors: string[], root?: string) {
 .content::-webkit-scrollbar {
   display: none;
 }
-.file-link {
+.file-link,
+.url-link {
   cursor: pointer;
-  color: #6eecf7;
   text-decoration: underline;
   text-underline-offset: 3px;
   &:hover {
@@ -103,6 +112,12 @@ export function genOverlayHTML(errors: string[], root?: string) {
   &:active {
     opacity: 0.6;
   }
+}
+.file-link {
+  color: #6eecf7;
+}
+.url-link {
+  color: #eff986;
 }
 .close {
   position: absolute;

--- a/packages/core/tests/overlay.test.ts
+++ b/packages/core/tests/overlay.test.ts
@@ -152,13 +152,20 @@ describe('convertLinksInHtml', () => {
     expect(convertLinksInHtml(ansiHTML(input), root)).toEqual(expected);
   });
 
+  it('should convert URL to HTML', () => {
+    const input = 'See https://example.com for more information';
+    const expected =
+      'See <a class="url-link" href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a> for more information';
+    expect(convertLinksInHtml(ansiHTML(input))).toEqual(expected);
+  });
+
   it('should convert multiple lines as expected', () => {
     const input = `
     See https://example.com
     at error (/path/to/src/index.js:4:1)`;
 
     expect(convertLinksInHtml(ansiHTML(input))).toEqual(`
-    See https://example.com
+    See <a class="url-link" href="https://example.com" target="_blank" rel="noopener noreferrer">https://example.com</a>
     at error (<a class="file-link" data-file="/path/to/src/index.js:4:1">/path/to/src/index.js:4:1</a>)`);
   });
 });

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -65,6 +65,8 @@ mrmime
 mYbzBtlg6o
 napi
 nolyfill
+noopener
+noreferrer
 nosources
 ntqry
 nuxt


### PR DESCRIPTION
## Summary

Add support for clicking links in error logs when rendering the error overlay:

<img width="1010" alt="Screenshot 2025-04-09 at 13 42 16" src="https://github.com/user-attachments/assets/f1503bcf-44f2-41be-b950-3e42bab814d8" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
