### PR TITLE
fix: output.filename config merging

### DIFF
--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -22,7 +22,11 @@ const isOverridePath = (key: string) => {
     const realKey = key.split('.').slice(2).join('.');
     return OVERRIDE_PATHS.includes(realKey);
   }
-  return OVERRIDE_PATHS.includes(key);
+  return (
+    OVERRIDE_PATHS.includes(key) ||
+    // output.filename.* supports function but we should not merge them as array
+    key.startsWith('output.filename.')
+  );
 };
 
 const merge = (x: unknown, y: unknown, path = ''): unknown => {

--- a/packages/core/tests/mergeConfig.test.ts
+++ b/packages/core/tests/mergeConfig.test.ts
@@ -390,4 +390,32 @@ describe('mergeRsbuildConfig', () => {
       },
     });
   });
+
+  test('should merge output.filename.js as expected', async () => {
+    const fn = () => 'custom-output2.js';
+    expect(
+      mergeRsbuildConfig(
+        {
+          output: {
+            filename: {
+              js: 'custom-output.js',
+            },
+          },
+        },
+        {
+          output: {
+            filename: {
+              js: fn,
+            },
+          },
+        },
+      ),
+    ).toEqual({
+      output: {
+        filename: {
+          js: fn,
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

When merging the `output.filename.*` configuration of the string type and function type, we should use the override strategy instead of  chaining strategy to output a valid configuration.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
