### PR TITLE
docs: enable Rspack profiling on Windows

### DIFF
--- a/website/docs/en/config/performance/bundle-analyze.mdx
+++ b/website/docs/en/config/performance/bundle-analyze.mdx
@@ -31,7 +31,7 @@ Add the environment variable `BUNDLE_ANALYZE=true`, for example:
 }
 ```
 
-Since the Windows system does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
+As Windows does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
 
 ```json title="package.json"
 {

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -48,6 +48,20 @@ Rsbuild supports the use of the `RSPACK_PROFILE` environment variable for Rspack
 }
 ```
 
+As Windows does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
+
+```json title="package.json"
+{
+  "scripts": {
+    "dev:profile": "cross-env RSPACK_PROFILE=ALL rsbuild dev",
+    "build:profile": "cross-env RSPACK_PROFILE=ALL rsbuild build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
 The command will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).

--- a/website/docs/en/guide/debug/rsdoctor.mdx
+++ b/website/docs/en/guide/debug/rsdoctor.mdx
@@ -25,7 +25,7 @@ import { PackageManagerTabs } from '@theme';
 }
 ```
 
-Since the Windows system does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
+As Windows does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
 
 ```json title="package.json"
 {

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -182,7 +182,7 @@ Set `REACT_PROFILER=true` when running build script:
 }
 ```
 
-Since the Windows system does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
+As Windows does not support the above usage, you can also use [cross-env](https://npmjs.com/package/cross-env) to set environment variables. This ensures compatibility across different systems:
 
 ```json title="package.json"
 {

--- a/website/docs/zh/config/performance/bundle-analyze.mdx
+++ b/website/docs/zh/config/performance/bundle-analyze.mdx
@@ -31,7 +31,7 @@ const defaultConfig = {
 }
 ```
 
-由于 Windows 系统不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
 
 ```json title="package.json"
 {

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -48,6 +48,20 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 }
 ```
 
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+
+```json title="package.json"
+{
+  "scripts": {
+    "dev:profile": "cross-env RSPACK_PROFILE=ALL rsbuild dev",
+    "build:profile": "cross-env RSPACK_PROFILE=ALL rsbuild build"
+  },
+  "devDependencies": {
+    "cross-env": "^7.0.0"
+  }
+}
+```
+
 执行该命令后，会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
 
 - `trace.json`：使用 tracing 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看。

--- a/website/docs/zh/guide/debug/rsdoctor.mdx
+++ b/website/docs/zh/guide/debug/rsdoctor.mdx
@@ -25,7 +25,7 @@ import { PackageManagerTabs } from '@theme';
 }
 ```
 
-由于 Windows 系统不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
 
 ```json title="package.json"
 {

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -184,7 +184,7 @@ pluginReact({
 }
 ```
 
-由于 Windows 系统不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
+由于 Windows 不支持上述用法，你也可以使用 [cross-env](https://npmjs.com/package/cross-env) 来设置环境变量，这可以确保在不同的操作系统中都能正常使用：
 
 ```json title="package.json"
 {


### PR DESCRIPTION
## Summary

This pull request includes changes to improve Rspack profiling guide with Windows by recommending the use of `cross-env` for setting environment variables.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
