### PR TITLE
docs: clarify Rsbuild profiling folder generation

### DIFF
--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -68,4 +68,6 @@ When the build command is executed, or the dev command is exited with `CTRL + D`
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/). In development mode, it is generated only when exiting the process through [`h + Enter`](/config/dev/cli-shortcuts).
 - `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development mode yet)
 
-> For more information about Rspack build profiling, refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).
+:::tip
+For more information about Rspack build profiling, refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).
+:::

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -68,4 +68,4 @@ When the build command is executed, or the dev command is exited with `CTRL + D`
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/). In development mode, it is generated only when exiting the process through [`h + Enter`](/config/dev/cli-shortcuts).
 - `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development mode yet)
 
-> For more information about Rspack build performance analysis, please refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).
+> For more information about Rspack build profiling, refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -62,7 +62,7 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 }
 ```
 
-The command will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
+When the build command is executed, or the dev command is exited with `CTRL + D`, Rsbuild will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/). In development mode, it is generated only when exiting the process through [`h + Enter`](/config/dev/cli-shortcuts).

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -68,4 +68,6 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 - `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。开发模式下仅在通过 [`h + Enter`](/config/dev/cli-shortcuts) 退出时生成。
 - `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时（开发模式下暂不支持）。
 
-> 关于 Rspack 构建性能分析的更多用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。
+:::tip
+关于 Rspack 构建性能分析的更多用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。
+:::

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -62,10 +62,10 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 }
 ```
 
-执行该命令后，会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
+当 build 命令执行完成，或是 dev 命令通过 `CTRL + D` 退出后，Rsbuild 会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
 
 - `trace.json`：使用 tracing 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看。
 - `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。开发模式下仅在通过 [`h + Enter`](/config/dev/cli-shortcuts) 退出时生成。
 - `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时（开发模式下暂不支持）。
 
-> 更多 Rspack 构建性能分析用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。
+> 关于 Rspack 构建性能分析的更多用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。


### PR DESCRIPTION
## Summary

Update documentation to clarify when the build profiling files are generated and add a tip section for additional information.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
