### PR TITLE
feat: support use `rspack` in `tools.bundlerChain`

### DIFF
--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
@@ -46,3 +46,31 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
 
   await rsbuild.close();
 });
+
+rspackOnlyTest(
+  'should allow to use rspack in tools.bundlerChain',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        tools: {
+          bundlerChain: (chain, { rspack }) => {
+            chain.resolve.alias.set('@common', join(__dirname, 'src/common'));
+
+            chain.plugin('define').use(rspack.DefinePlugin, [
+              {
+                ENABLE_TEST: JSON.stringify(true),
+              },
+            ]);
+          },
+        },
+      },
+    });
+
+    const testEl = page.locator('#test-define');
+    await expect(testEl).toHaveText('aaaaa');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -58,7 +58,7 @@ rspackOnlyTest(
           bundlerChain: (chain, { rspack }) => {
             chain.resolve.alias.set('@common', join(__dirname, 'src/common'));
 
-            chain.plugin('define').use(rspack.DefinePlugin, [
+            chain.plugin('extra-define').use(rspack.DefinePlugin, [
               {
                 ENABLE_TEST: JSON.stringify(true),
               },

--- a/e2e/cases/config/bundler-chain/src/index.js
+++ b/e2e/cases/config/bundler-chain/src/index.js
@@ -6,4 +6,11 @@ testEl.innerHTML = `Hello Rsbuild! ${test}`;
 
 document.body.appendChild(testEl);
 
+if (ENABLE_TEST === true) {
+  const testDefine = document.createElement('div');
+  testDefine.id = 'test-define';
+  testDefine.innerHTML = 'aaaaa';
+  document.body.appendChild(testDefine);
+}
+
 window.aa = 2;

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -68,8 +68,6 @@ export async function getConfigUtils(
   return {
     ...chainUtils,
 
-    rspack,
-
     mergeConfig: merge,
 
     addRules(rules) {
@@ -132,6 +130,7 @@ export function getChainUtils(
   const nodeEnv = getNodeEnv();
 
   return {
+    rspack,
     environment,
     env: nodeEnv,
     target,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -10,7 +10,6 @@ import type {
   RuleSetCondition,
   SwcJsMinimizerRspackPluginOptions,
   SwcLoaderOptions,
-  rspack,
 } from '@rspack/core';
 import type { ChokidarOptions } from '../../compiled/chokidar/index.js';
 import type cors from '../../compiled/cors/index.js';
@@ -93,7 +92,6 @@ export type ModifyRspackConfigUtils = ModifyChainUtils & {
   ) => void;
   removePlugin: (pluginName: string) => void;
   mergeConfig: WebpackMerge;
-  rspack: typeof rspack;
 };
 
 export type ToolsRspackConfig = ConfigChainAsyncWithContext<

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,3 +1,4 @@
+import type { rspack } from '@rspack/core';
 import type { ChainIdentifier } from '..';
 import type RspackChain from '../../compiled/rspack-chain';
 import type { RsbuildDevServer } from '../server/devServer';
@@ -212,6 +213,7 @@ export type ModifyChainUtils = {
   isWebWorker: boolean;
   CHAIN_ID: ChainIdentifier;
   environment: EnvironmentContext;
+  rspack: typeof rspack;
   HtmlPlugin: typeof HtmlRspackPlugin;
 };
 

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -151,7 +151,7 @@ The Rspack instance. For example:
 export default {
   tools: {
     bundlerChain: (chain, { rspack }) => {
-      chain.plugin('define').use(rspack.DefinePlugin, [
+      chain.plugin('extra-define').use(rspack.DefinePlugin, [
         {
           'process.env': {
             NODE_ENV: JSON.stringify(process.env.NODE_ENV),

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -141,6 +141,28 @@ export default {
 };
 ```
 
+### rspack
+
+- **Type:** `Rspack`
+
+The Rspack instance. For example:
+
+```js
+export default {
+  tools: {
+    bundlerChain: (chain, { rspack }) => {
+      chain.plugin('define').use(rspack.DefinePlugin, [
+        {
+          'process.env': {
+            NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+          },
+        },
+      ]);
+    },
+  },
+};
+```
+
 ### HtmlPlugin
 
 - **Type:** `typeof import('html-rspack-plugin')`

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -141,6 +141,28 @@ export default {
 };
 ```
 
+### rspack
+
+- **类型：** `Rspack`
+
+通过这个参数你可以拿到 Rspack 实例。比如：
+
+```js
+export default {
+  tools: {
+    bundlerChain: (chain, { rspack }) => {
+      chain.plugin('define').use(rspack.DefinePlugin, [
+        {
+          'process.env': {
+            NODE_ENV: JSON.stringify(process.env.NODE_ENV),
+          },
+        },
+      ]);
+    },
+  },
+};
+```
+
 ### HtmlPlugin
 
 - **类型：** `typeof import('html-rspack-plugin')`

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -151,7 +151,7 @@ export default {
 export default {
   tools: {
     bundlerChain: (chain, { rspack }) => {
-      chain.plugin('define').use(rspack.DefinePlugin, [
+      chain.plugin('extra-define').use(rspack.DefinePlugin, [
         {
           'process.env': {
             NODE_ENV: JSON.stringify(process.env.NODE_ENV),


### PR DESCRIPTION
## Summary

Support use `rspack` in `tools.bundlerChain`.
```js
export default {
  tools: {
    bundlerChain: (chain, { rspack }) => {
      chain.plugin('define').use(rspack.DefinePlugin, [
        {
          'process.env': {
            NODE_ENV: JSON.stringify(process.env.NODE_ENV),
          },
        },
      ]);
    },
  },
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
