### PR TITLE
fix: `onExit` hook should be called with CTRL+C

### DIFF
--- a/packages/core/src/helpers/exitHook.ts
+++ b/packages/core/src/helpers/exitHook.ts
@@ -1,0 +1,48 @@
+import process from 'node:process';
+
+type Callback = (exitCode: number) => void;
+
+const callbacks = new Set<Callback>();
+
+let isCalled = false;
+let isRegistered = false;
+
+function exit(signal: number, type: 'SIGINT' | 'SIGTERM' | 'exit') {
+  if (isCalled) {
+    return;
+  }
+
+  isCalled = true;
+  const exitCode = 128 + signal;
+  for (const callback of callbacks) {
+    callback(exitCode);
+  }
+
+  if (type === 'SIGINT') {
+    const listeners = process.listeners('SIGINT');
+    // If some other listeners are registered, do not exit the process
+    if (Array.isArray(listeners) && listeners.length <= 1) {
+      process.exit(exitCode);
+    }
+  }
+}
+
+export function exitHook(onExit: Callback): () => void {
+  callbacks.add(onExit);
+
+  if (!isRegistered) {
+    isRegistered = true;
+    // CTRL+C
+    // Use `process.on` instead of `process.once` to disable
+    // Node.js default exit behavior
+    process.on('SIGINT', exit.bind(undefined, 2, 'SIGINT'));
+    // CTRL+D or `kill` command
+    process.once('SIGTERM', exit.bind(undefined, 15, 'SIGTERM'));
+    // process.exit or others
+    process.once('exit', exit.bind(undefined, -128, 'exit'));
+  }
+
+  return () => {
+    callbacks.delete(onExit);
+  };
+}

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -3,6 +3,7 @@ import type { Compiler } from '@rspack/core';
 import { LOADER_PATH } from './constants';
 import { createPublicContext } from './createContext';
 import { removeLeadingSlash } from './helpers';
+import { exitHook } from './helpers/exitHook';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import { logger } from './logger';
 import { isPluginMatchEnvironment } from './pluginManager';
@@ -322,7 +323,7 @@ export function initPluginAPI({
 
   const onExit: typeof hooks.onExit.tap = (cb) => {
     if (!onExitListened) {
-      process.on('exit', () => {
+      exitHook(() => {
         hooks.onExit.callBatch();
       });
       onExitListened = true;

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -62,7 +62,7 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 }
 ```
 
-When the build command is executed, or the dev command is exited with `CTRL + D`, Rsbuild will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
+When the build command is finished, or the dev server is shutdown, Rsbuild will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/). In development mode, it is generated only when exiting the process through [`h + Enter`](/config/dev/cli-shortcuts).

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -62,7 +62,7 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 }
 ```
 
-当 build 命令执行完成，或是 dev 命令通过 `CTRL + D` 退出后，Rsbuild 会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
+当 build 命令执行完成，或是 dev server 被关闭时，Rsbuild 会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
 
 - `trace.json`：使用 tracing 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看。
 - `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。开发模式下仅在通过 [`h + Enter`](/config/dev/cli-shortcuts) 退出时生成。


### PR DESCRIPTION
## Summary

- Listen to the `SIGINT` process event to ensure the `onExit` hook can be called with CTRL+C.
- Update the build profiling guide as `CTRL+C` has been supported.

## Related Links

- https://stackoverflow.com/questions/21864127/nodejs-process-hangs-on-exit-ctrlc/21948167#21948167
- https://github.com/web-infra-dev/rsbuild/issues/2112

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
