### PR TITLE
feat: support for accessing exit code in `onExit` hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -24,7 +24,7 @@ rspackOnlyTest('should run onExit hook before process exit', async () => {
       }
 
       try {
-        expect(fs.readFileSync(distFile, 'utf-8')).toEqual('1');
+        expect(fs.readFileSync(distFile, 'utf-8')).toEqual('0');
         clearTimeout(timeoutId);
         resolve();
       } catch (err) {

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
@@ -20,8 +20,8 @@ const write = (str) => {
 const plugin = {
   name: 'test-plugin',
   setup(api) {
-    api.onExit(() => {
-      write('1');
+    api.onExit(({ exitCode }) => {
+      write(exitCode.toString());
     });
   },
 };

--- a/packages/core/src/helpers/exitHook.ts
+++ b/packages/core/src/helpers/exitHook.ts
@@ -1,3 +1,4 @@
+import { constants } from 'node:os';
 import process from 'node:process';
 
 type Callback = (exitCode: number) => void;
@@ -7,13 +8,12 @@ const callbacks = new Set<Callback>();
 let isCalled = false;
 let isRegistered = false;
 
-function exit(signal: number, type: 'SIGINT' | 'SIGTERM' | 'exit') {
+function exit(exitCode: number, type: 'SIGINT' | 'SIGTERM' | 'exit') {
   if (isCalled) {
     return;
   }
 
   isCalled = true;
-  const exitCode = 128 + signal;
   for (const callback of callbacks) {
     callback(exitCode);
   }
@@ -21,6 +21,7 @@ function exit(signal: number, type: 'SIGINT' | 'SIGTERM' | 'exit') {
   if (type === 'SIGINT') {
     const listeners = process.listeners('SIGINT');
     // If some other listeners are registered, do not exit the process
+    // https://stackoverflow.com/questions/21864127/nodejs-process-hangs-on-exit-ctrlc/21948167
     if (Array.isArray(listeners) && listeners.length <= 1) {
       process.exit(exitCode);
     }
@@ -35,11 +36,17 @@ export function exitHook(onExit: Callback): () => void {
     // CTRL+C
     // Use `process.on` instead of `process.once` to disable
     // Node.js default exit behavior
-    process.on('SIGINT', exit.bind(undefined, 2, 'SIGINT'));
+    process.on('SIGINT', () => {
+      exit(constants.signals.SIGINT + 128, 'SIGINT');
+    });
     // CTRL+D or `kill` command
-    process.once('SIGTERM', exit.bind(undefined, 15, 'SIGTERM'));
+    process.once('SIGTERM', () => {
+      exit(constants.signals.SIGTERM + 128, 'SIGTERM');
+    });
     // process.exit or others
-    process.once('exit', exit.bind(undefined, -128, 'exit'));
+    process.once('exit', (exitCode) => {
+      exit(exitCode, 'exit');
+    });
   }
 
   return () => {

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -323,8 +323,8 @@ export function initPluginAPI({
 
   const onExit: typeof hooks.onExit.tap = (cb) => {
     if (!onExitListened) {
-      exitHook(() => {
-        hooks.onExit.callBatch();
+      exitHook((exitCode) => {
+        hooks.onExit.callBatch({ exitCode });
       });
       onExitListened = true;
     }

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -101,7 +101,7 @@ export type OnAfterCreateCompilerFn<
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
-export type OnExitFn = () => void;
+export type OnExitFn = (context: { exitCode: number }) => void;
 
 type HTMLTags = {
   headTags: HtmlBasicTag[];

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -829,8 +829,8 @@ import OnExit from '@en/shared/onExit.mdx';
 - **Example:**
 
 ```ts
-rsbuild.onExit(() => {
-  console.log('exit!');
+rsbuild.onExit(({ exitCode }) => {
+  console.log('exit: ', exitCode);
 });
 ```
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -866,8 +866,8 @@ import OnExit from '@en/shared/onExit.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onExit(() => {
-      console.log('exit!');
+    api.onExit(({ exitCode }) => {
+      console.log('exit: ', exitCode);
     });
   },
 });

--- a/website/docs/en/shared/onExit.mdx
+++ b/website/docs/en/shared/onExit.mdx
@@ -3,5 +3,5 @@ Called when the process is going to exit, this hook can only execute synchronous
 - **Type:**
 
 ```ts
-function OnExit(callback: () => void): void;
+function OnExit(callback: (context: { exitCode: number }) => void): void;
 ```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -851,8 +851,8 @@ import OnExit from '@zh/shared/onExit.mdx';
 - **示例：**
 
 ```ts
-rsbuild.onExit(() => {
-  console.log('exit!');
+rsbuild.onExit(({ exitCode }) => {
+  console.log('exit: ', exitCode);
 });
 ```
 

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -862,8 +862,8 @@ import OnExit from '@zh/shared/onExit.mdx';
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onExit(() => {
-      console.log('exit!');
+    api.onExit(({ exitCode }) => {
+      console.log('exit: ', exitCode);
     });
   },
 });

--- a/website/docs/zh/shared/onExit.mdx
+++ b/website/docs/zh/shared/onExit.mdx
@@ -3,5 +3,5 @@
 - **类型：**
 
 ```ts
-function OnExit(callback: () => void): void;
+function OnExit(callback: (context: { exitCode: number }) => void): void;
 ```


### PR DESCRIPTION
## Summary

Add support for accessing the exit code in the `onExit` hook:

```js
const myPlugin = () => ({
  setup(api) {
    api.onExit(({ exitCode }) => {
      console.log('exit: ', exitCode);
    });
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
