### PR TITLE
docs: add example for disabling NODE_ENV injection

### DIFF
--- a/e2e/cases/mode/define/index.test.ts
+++ b/e2e/cases/mode/define/index.test.ts
@@ -1,4 +1,4 @@
-import { build } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should define vars in production mode correctly', async () => {
@@ -55,7 +55,7 @@ test('should define vars in none mode correctly', async () => {
   expect(file.content).not.toContain("console.log('import.meta.env.PROD');");
 });
 
-test('should allow to disable NODE_ENV injection', async () => {
+rspackOnlyTest('should allow to disable NODE_ENV injection', async () => {
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {

--- a/e2e/cases/mode/define/index.test.ts
+++ b/e2e/cases/mode/define/index.test.ts
@@ -54,3 +54,21 @@ test('should define vars in none mode correctly', async () => {
   expect(file.content).not.toContain("console.log('import.meta.env.DEV');");
   expect(file.content).not.toContain("console.log('import.meta.env.PROD');");
 });
+
+test('should allow to disable NODE_ENV injection', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      tools: {
+        rspack: {
+          optimization: { nodeEnv: false },
+        },
+      },
+    },
+  });
+
+  const file = await rsbuild.getIndexFile();
+  expect(file.content).toContain(
+    'console.log("process.env.NODE_ENV",process.env.NODE_ENV)',
+  );
+});

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild by default injects the some env variables into the code using [source.de
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env): This variable is injected by Rspack. For details, please refer to [Rspack - optimization.nodeEnv](https://rspack.dev/config/optimization#optimizationnodeenv))
+- [process.env.NODE_ENV](#processenvnode_env)
 
 ### import.meta.env.MODE
 
@@ -183,6 +183,18 @@ if (false) {
 ```
 
 During code minification, `if (false) { ... }` will be recognized as invalid code and removed automatically.
+
+#### Custom NODE_ENV
+
+`process.env.NODE_ENV` is injected by Rspack by default. If you need to disable the injection or custom the value, use the [optimization.nodeEnv](https://rspack.dev/config/optimization#optimizationnodeenv) option of Rspack:
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: { optimization: { nodeEnv: false } },
+  },
+};
+```
 
 ## `.env` File
 

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -20,7 +20,7 @@ Rsbuild 默认通过 [source.define](#使用-define) 向代码中注入以下环
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
-- [process.env.NODE_ENV](#processenvnode_env)：该变量由 Rspack 注入，如需关闭或修改，可参考 [Rspack - optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv)
+- [process.env.NODE_ENV](#processenvnode_env)
 
 ### import.meta.env.MODE
 
@@ -183,6 +183,20 @@ if (false) {
 ```
 
 在代码压缩过程中，`if (false) { ... }` 会被识别为无效代码，并被自动移除。
+
+#### 自定义 NODE_ENV
+
+`process.env.NODE_ENV` 是由 Rspack 默认注入的，如果需要关闭注入或自定义它的值，可以使用 Rspack 的 [optimization.nodeEnv](https://rspack.dev/zh/config/optimization#optimizationnodeenv) 选项：
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      optimization: { nodeEnv: false },
+    },
+  },
+};
+```
 
 ## `.env` 文件
 


### PR DESCRIPTION
## Summary

- Add example for disabling NODE_ENV injection to documentation.
- Add an E2E case for it.

## Related Links

- https://github.com/web-infra-dev/rsbuild/discussions/5007

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
