### PR TITLE
fix(plugin-svgr): SVGs generated with different hash

### DIFF
--- a/e2e/cases/svg/svgr-hash-digest/index.test.ts
+++ b/e2e/cases/svg/svgr-hash-digest/index.test.ts
@@ -1,0 +1,20 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+// https://github.com/web-infra-dev/rsbuild/issues/4610
+test('should generate the same hash digest for the same SVG', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+
+  expect(
+    Object.keys(files).filter((key) => key.endsWith('.svg')).length,
+  ).toEqual(1);
+
+  await rsbuild.close();
+});

--- a/e2e/cases/svg/svgr-hash-digest/rsbuild.config.ts
+++ b/e2e/cases/svg/svgr-hash-digest/rsbuild.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+import { pluginSvgr } from '@rsbuild/plugin-svgr';
+
+export default defineConfig({
+  plugins: [
+    pluginReact(),
+    pluginSvgr({
+      mixedImport: true,
+    }),
+  ],
+  output: {
+    dataUriLimit: 0,
+  },
+});

--- a/e2e/cases/svg/svgr-hash-digest/src/index.js
+++ b/e2e/cases/svg/svgr-hash-digest/src/index.js
@@ -1,0 +1,4 @@
+import svg1 from '@assets/circle.svg';
+import svg2 from '@assets/circle.svg?url';
+
+console.log(svg1, svg2);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:doc": "cd website && pnpm run build",
     "change": "changeset",
     "changeset": "changeset",
-    "check-dependency-version": "pnpx check-dependency-version-consistency .",
+    "check-dependency-version": "pnpx check-dependency-version-consistency . --ignore-dep loader-utils",
     "check-spell": "pnpx cspell && heading-case",
     "dev:doc": "cd website && pnpm run dev",
     "e2e": "cd ./e2e && pnpm test",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "patchedDependencies": {
       "css-loader@7.1.2": "patches/css-loader@7.1.2.patch",
       "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch",
-      "postcss-loader@8.1.1": "patches/postcss-loader@8.1.1.patch"
+      "postcss-loader@8.1.1": "patches/postcss-loader@8.1.1.patch",
+      "url-loader": "patches/url-loader@4.1.1.patch",
+      "file-loader": "patches/file-loader@6.2.0.patch"
     }
   }
 }

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -33,7 +33,7 @@
     "@svgr/plugin-jsx": "8.1.0",
     "@svgr/plugin-svgo": "8.1.0",
     "deepmerge": "^4.3.1",
-    "loader-utils": "^2.0.4"
+    "loader-utils": "^3.3.1"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/plugin-svgr/prebundle.config.mjs
+++ b/packages/plugin-svgr/prebundle.config.mjs
@@ -2,13 +2,6 @@
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-// The package size of `schema-utils` is large, and validate has a performance overhead of tens of ms.
-// So we skip the validation and let TypeScript to ensure type safety.
-const writeEmptySchemaUtils = (task) => {
-  const schemaUtilsPath = join(task.distPath, 'schema-utils.js');
-  writeFileSync(schemaUtilsPath, 'module.exports.validate = () => {};');
-};
-
 /** @type {import('prebundle').Config} */
 export default {
   prettier: true,
@@ -17,28 +10,22 @@ export default {
       name: 'file-loader',
       ignoreDts: true,
       externals: {
-        'schema-utils': './schema-utils',
         'loader-utils': 'loader-utils',
       },
-      afterBundle: writeEmptySchemaUtils,
     },
     {
       name: 'url-loader',
       ignoreDts: true,
       externals: {
-        'schema-utils': './schema-utils',
         'loader-utils': 'loader-utils',
       },
       afterBundle(task) {
-        writeEmptySchemaUtils(task);
-
         const filePath = join(task.distPath, 'index.js');
         const content = readFileSync(filePath, 'utf-8');
         const newContent = content.replace(
           /['"]file-loader['"]/,
           'require.resolve("../file-loader")',
         );
-
         if (newContent !== content) {
           writeFileSync(filePath, newContent);
         }

--- a/patches/file-loader@6.2.0.patch
+++ b/patches/file-loader@6.2.0.patch
@@ -1,0 +1,29 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 1390102e57cacd2f334ccd8992bea23d40817b88..0000000000000000000000000000000000000000
+diff --git a/dist/index.js b/dist/index.js
+index ec5d5b0eda115042642d64b8873021db24aba9f3..939d5bf423dd831c268bfa0f581e2c598a455b2f 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -10,20 +10,12 @@ var _path = _interopRequireDefault(require("path"));
+ 
+ var _loaderUtils = require("loader-utils");
+ 
+-var _schemaUtils = require("schema-utils");
+-
+-var _options = _interopRequireDefault(require("./options.json"));
+-
+ var _utils = require("./utils");
+ 
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ 
+ function loader(content) {
+-  const options = (0, _loaderUtils.getOptions)(this);
+-  (0, _schemaUtils.validate)(_options.default, options, {
+-    name: 'File Loader',
+-    baseDataPath: 'options'
+-  });
++  const options = this.getOptions() || {};
+   const context = options.context || this.rootContext;
+   const name = options.name || '[contenthash].[ext]';
+   const url = (0, _loaderUtils.interpolateName)(this, name, {

--- a/patches/url-loader@4.1.1.patch
+++ b/patches/url-loader@4.1.1.patch
@@ -1,0 +1,37 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+deleted file mode 100644
+index 768f7f35c56f282c7c0cda7a4c1c5e7e0b113560..0000000000000000000000000000000000000000
+diff --git a/dist/index.js b/dist/index.js
+index 7d977a6ece276d360bcb857cad9950252353da46..a2e19ed214a00950b3ea4c27eec7f890ef3e14f8 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -8,16 +8,10 @@ exports.raw = void 0;
+ 
+ var _path = _interopRequireDefault(require("path"));
+ 
+-var _loaderUtils = require("loader-utils");
+-
+-var _schemaUtils = require("schema-utils");
+-
+ var _mimeTypes = _interopRequireDefault(require("mime-types"));
+ 
+ var _normalizeFallback = _interopRequireDefault(require("./utils/normalizeFallback"));
+ 
+-var _options = _interopRequireDefault(require("./options.json"));
+-
+ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+ 
+ function shouldTransform(limit, size) {
+@@ -87,11 +81,7 @@ function getEncodedData(generator, mimetype, encoding, content, resourcePath) {
+ 
+ function loader(content) {
+   // Loader Options
+-  const options = (0, _loaderUtils.getOptions)(this) || {};
+-  (0, _schemaUtils.validate)(_options.default, options, {
+-    name: 'URL Loader',
+-    baseDataPath: 'options'
+-  }); // No limit or within the specified limit
++  const options = this.getOptions() || {};
+ 
+   if (shouldTransform(options.limit, content.length)) {
+     const {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -425,9 +425,6 @@ importers:
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
-      '@rsbuild/plugin-svgr':
-        specifier: workspace:*
-        version: link:../../packages/plugin-svgr
       '@types/react':
         specifier: ^19.1.0
         version: 19.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ patchedDependencies:
   css-loader@7.1.2:
     hash: f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6
     path: patches/css-loader@7.1.2.patch
+  file-loader:
+    hash: c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30
+    path: patches/file-loader@6.2.0.patch
   http-proxy@1.18.1:
     hash: 424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723
     path: patches/http-proxy@1.18.1.patch
   postcss-loader@8.1.1:
     hash: 7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47
     path: patches/postcss-loader@8.1.1.patch
+  url-loader:
+    hash: 4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f
+    path: patches/url-loader@4.1.1.patch
 
 importers:
 
@@ -419,6 +425,9 @@ importers:
       '@rsbuild/plugin-react':
         specifier: workspace:*
         version: link:../../packages/plugin-react
+      '@rsbuild/plugin-svgr':
+        specifier: workspace:*
+        version: link:../../packages/plugin-svgr
       '@types/react':
         specifier: ^19.1.0
         version: 19.1.0
@@ -1045,8 +1054,8 @@ importers:
         specifier: ^4.3.1
         version: 4.3.1
       loader-utils:
-        specifier: ^2.0.4
-        version: 2.0.4
+        specifier: ^3.3.1
+        version: 3.3.1
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -1062,7 +1071,7 @@ importers:
         version: 22.14.0
       file-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.98.0)
+        version: 6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.98.0)
       prebundle:
         specifier: 1.3.3
         version: 1.3.3(typescript@5.8.3)
@@ -1074,7 +1083,7 @@ importers:
         version: 5.8.3
       url-loader:
         specifier: 4.1.1
-        version: 4.1.1(file-loader@6.2.0(webpack@5.98.0))(webpack@5.98.0)
+        version: 4.1.1(patch_hash=4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f)(file-loader@6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.98.0))(webpack@5.98.0)
 
   packages/plugin-vue:
     dependencies:
@@ -5101,6 +5110,10 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
+
+  loader-utils@3.3.1:
+    resolution: {integrity: sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==}
+    engines: {node: '>= 12.13.0'}
 
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
@@ -10660,7 +10673,7 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  file-loader@6.2.0(webpack@5.98.0):
+  file-loader@6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.98.0):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
@@ -11496,6 +11509,8 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
+
+  loader-utils@3.3.1: {}
 
   locate-character@3.0.0: {}
 
@@ -13632,14 +13647,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.98.0))(webpack@5.98.0):
+  url-loader@4.1.1(patch_hash=4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f)(file-loader@6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.98.0))(webpack@5.98.0):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.98.0
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.98.0)
+      file-loader: 6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.98.0)
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- Update `loader-utils` to v3 to allow `@rsbuild/plugin-svg` to use the same hash function (`xxhash64`) as Rsbuild, see https://github.com/webpack/loader-utils/releases/tag/v3.0.0
- Since `file-loader` and `url-loader` are no longer maintained, patch `file-loader` and `url-loader` to be compatible with `loader-utils` v3.

## Related Links

fix https://github.com/web-infra-dev/rsbuild/issues/4610

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
