### PR TITLE
fix(types): failed to resolve webpack types

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -1,3 +1,4 @@
+/** @ts-ignore `webpack` type only exists when `@rsbuild/webpack` is installed */
 import type {
   RuleSetRule,
   Configuration as WebpackConfig,
@@ -138,6 +139,7 @@ export type ModifyRspackConfigFn = (
 ) => MaybePromise<Rspack.Configuration | void>;
 
 export type ModifyWebpackChainUtils = ModifyChainUtils & {
+  /** @ts-ignore `webpack` type only exists when `@rsbuild/webpack` is installed */
   webpack: typeof import('webpack');
   CHAIN_ID: ChainIdentifier;
   /**

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -2,6 +2,7 @@ import type {
   CssExtractRspackLoaderOptions,
   CssExtractRspackPluginOptions,
 } from '@rspack/core';
+/** @ts-ignore `webpack` type only exists when `@rsbuild/webpack` is installed */
 import type { Configuration as WebpackConfig } from 'webpack';
 import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin/index.js';
 import type { AcceptedPlugin, ProcessOptions } from '../../compiled/postcss';


### PR DESCRIPTION
## Summary

Fix failed to resolve webpack types when setting `skipLibCheck: false` in tsconfig.json. The `webpack` type only exists when `@rsbuild/webpack` is installed and it should be removed in Rsbuild 2.0.

![image](https://github.com/user-attachments/assets/5274e7e6-6f78-4cf5-8e42-04893ae73206)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
