### PR TITLE
fix(types): failed to resolve prebundled types

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -16,7 +16,6 @@ export default {
   externals: {
     '@rspack/core': '@rspack/core',
     '@rspack/lite-tapable': '@rspack/lite-tapable',
-    webpack: 'webpack',
     typescript: 'typescript',
   },
   dependencies: [
@@ -105,6 +104,15 @@ export default {
     },
     {
       name: 'webpack-bundle-analyzer',
+      externals: {
+        webpack: 'webpack',
+      },
+      afterBundle(task) {
+        // webpack type does not exist, use `@rspack/core` instead
+        replaceFileContent(join(task.distPath, 'index.d.ts'), (content) =>
+          content.replace("from 'webpack'", 'from "@rspack/core"'),
+        );
+      },
     },
     {
       name: 'rsbuild-dev-middleware',
@@ -130,6 +138,25 @@ export default {
       copyDts: true,
       externals: {
         picocolors: '../picocolors',
+      },
+      afterBundle(task) {
+        // source-map-js type does not exist, use a stub instead
+        replaceFileContent(join(task.distPath, 'lib/postcss.d.ts'), (content) =>
+          content.replace("from 'source-map-js'", 'from "./source-map-js"'),
+        );
+        replaceFileContent(
+          join(task.distPath, 'lib/previous-map.d.ts'),
+          (content) =>
+            content.replace("from 'source-map-js'", 'from "./source-map-js"'),
+        );
+        fs.writeFileSync(
+          join(task.distPath, 'lib/source-map-js.d.ts'),
+          `
+export type RawSourceMap = unknown;
+export type SourceMapConsumer = unknown;
+export type SourceMapGenerator = unknown;
+`,
+        );
       },
     },
     {


### PR DESCRIPTION
## Summary

There are some invalid types in the prebundled packages that prevent users from setting `skipLibCheck: false` in tsconfig.json.

These type issues are hard to address, so we are using the prebundle config to hack them. We may find a better solution in the long run.

<img width="1296" alt="Screenshot 2025-04-14 at 21 04 44" src="https://github.com/user-attachments/assets/96fa92a1-35ac-44a9-943e-4e1075cccaa7" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
