### PR TITLE
fix: update Node.js engine requirement to >=16.10

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,7 @@
     "ws": "^8.18.1"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.10.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -36,7 +36,7 @@
     "typescript": "^5.8.3"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=16.10.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Update Node.js engine requirement to >=16.10 to correctly load Rspack bindings:

<img width="1218" alt="Screenshot 2025-04-16 at 11 08 24" src="https://github.com/user-attachments/assets/3d379421-ab8f-4766-b44c-6ba93d6b93fc" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
