### PR TITLE
feat: support dev.lazyCompilation.serverUrl use <port>

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, join } from 'node:path';
 import rspack from '@rspack/core';
 import { normalizePublicDirs } from '../config';
+import { DEFAULT_PORT } from '../constants';
 import { isMultiCompiler } from '../helpers';
 import { logger } from '../logger';
 import type {
@@ -22,6 +23,7 @@ import {
   getRequestLoggerMiddleware,
   viewingServedFilesMiddleware,
 } from './middlewares';
+import { replacePortPlaceholder } from './open';
 import { createProxyMiddleware } from './proxy';
 
 export type RsbuildDevMiddlewareOptions = {
@@ -119,6 +121,18 @@ const applyDefaultMiddlewares = async ({
     compilationManager
   ) {
     const { compiler } = compilationManager;
+
+    if (
+      typeof dev.lazyCompilation === 'object' &&
+      typeof dev.lazyCompilation.serverUrl === 'string'
+    ) {
+      const port = context.devServer?.port || server.port || DEFAULT_PORT;
+
+      dev.lazyCompilation.serverUrl = replacePortPlaceholder(
+        dev.lazyCompilation.serverUrl,
+        port,
+      );
+    }
 
     middlewares.push(
       rspack.experiments.lazyCompilationMiddleware(


### PR DESCRIPTION
## Summary
Although Rsbuild doesn't directly support setting [dev.lazyCompilation](https://rsbuild.dev/config/dev/lazy-compilation) with a custom `serverUrl`, we can leverage `api.modifyRsbuildConfig` to modify both `assetPrefix` and `dev.lazyCompilation.serverUrl`. However, there's an inconsistency: `assetPrefix` will find and replace `<port>` placeholders, while `dev.lazyCompilation.serverUrl` does not perform this replacement, leading to configuration mismatches.

```js
dev: {
    assetPrefix: 'http://xxx:<port>/',
    lazyCompilation: {
      serverUrl: 'http://xxx:<port>/'
      // ...
    }
},
```

Therefore, in the `lazyCompilationMiddleware`, we need to check if <port> is present in the URL, and if so, we need to replace it.

## Related Links
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
