### PR TITLE
test(e2e): add lazy compilation '<port>' placeholder case

### DIFF
--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,0 +1,41 @@
+import {
+  dev,
+  expectPoll,
+  gotoPage,
+  proxyConsole,
+  rspackOnlyTest,
+} from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+rspackOnlyTest(
+  'should replace port placeholder with actual port',
+  async ({ page }) => {
+    // TODO fix this case on Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
+    const { logs, restore } = proxyConsole();
+    const rsbuild = await dev({
+      cwd: __dirname,
+    });
+
+    await gotoPage(page, rsbuild, 'page1');
+    await expect(page.locator('#test')).toHaveText('Page 1');
+    await expectPoll(() =>
+      logs.some((log) => log.includes('building src/page1/index.js')),
+    ).toBeTruthy();
+    expect(
+      logs.some((log) => log.includes('building src/page2/index.js')),
+    ).toBeFalsy();
+
+    await gotoPage(page, rsbuild, 'page2');
+    await expect(page.locator('#test')).toHaveText('Page 2');
+    await expectPoll(() =>
+      logs.some((log) => log.includes('building src/page2/index.js')),
+    ).toBeTruthy();
+
+    await rsbuild.close();
+    restore();
+  },
+);

--- a/e2e/cases/lazy-compilation/port-placeholder/rsbuild.config.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/rsbuild.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  source: {
+    entry: {
+      page1: './src/page1/index.js',
+      page2: './src/page2/index.js',
+    },
+  },
+  dev: {
+    lazyCompilation: {
+      serverUrl: 'http://localhost:<port>',
+    },
+  },
+});

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page1/App.jsx
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page1/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div id="test">Page 1</div>;
+};
+
+export default App;

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page1/index.js
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page1/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page2/App.jsx
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page2/App.jsx
@@ -1,0 +1,5 @@
+const App = () => {
+  return <div id="test">Page 2</div>;
+};
+
+export default App;

--- a/e2e/cases/lazy-compilation/port-placeholder/src/page2/index.js
+++ b/e2e/cases/lazy-compilation/port-placeholder/src/page2/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}


### PR DESCRIPTION
## Summary

Add lazy compilation '<port>' placeholder case for https://github.com/web-infra-dev/rsbuild/pull/5035.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
