### PR TITLE
docs: add client and serverUrl options to lazy compilation

### DIFF
--- a/website/docs/en/config/dev/lazy-compilation.mdx
+++ b/website/docs/en/config/dev/lazy-compilation.mdx
@@ -18,6 +18,14 @@ type LazyCompilationOptions =
        * Specify which imported modules should be lazily compiled.
        */
       test?: RegExp | ((m: Module) => boolean);
+      /**
+       * The path to a custom runtime code that overrides the default lazy compilation client.
+       */
+      client?: string;
+      /**
+       * Tells the client the server URL that needs to be requested.
+       */
+      serverUrl?: string;
     };
 ```
 
@@ -97,3 +105,21 @@ export default {
 ```
 
 When the `imports` option is enabled, all async modules will only be compiled when requested. If your project is a single-page application (SPA) and you have split the routes using dynamic import, this will significantly speed up the startup time.
+
+### Server URL
+
+Use [lazyCompilation.serverUrl](https://rspack.dev/config/experiments#lazycompilationserverurl) to tell the client the server URL that needs to be requested.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    lazyCompilation: {
+      serverUrl: 'http://localhost:<port>',
+    },
+  },
+};
+```
+
+:::tip
+Rsbuild will replace the `<port>` placeholder with the actual port number the server is listening on.
+:::

--- a/website/docs/zh/config/dev/lazy-compilation.mdx
+++ b/website/docs/zh/config/dev/lazy-compilation.mdx
@@ -18,6 +18,14 @@ type LazyCompilationOptions =
        * 指定哪些导入的模块应该被延迟编译
        */
       test?: RegExp | ((m: Module) => boolean);
+      /**
+       * 指定一个自定义的运行时代码路径，用于覆盖默认的 lazy compilation client
+       */
+      client?: string;
+      /**
+       * 指定 client 需要请求的 server URL
+       */
+      serverUrl?: string;
     };
 ```
 
@@ -97,3 +105,21 @@ export default {
 ```
 
 开启 `imports` 选项后，所有的异步模块只有在被请求时才触发编译。如果你的项目是一个单页应用（SPA），并通过 dynamic import 进行了路由拆分，那么 dev 启动时间会有明显提升。
+
+### Server URL
+
+通过 [lazyCompilation.serverUrl](https://rspack.dev/zh/config/experiments#lazycompilationserverurl) 指定 client 需要请求的 server URL：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    lazyCompilation: {
+      serverUrl: 'http://localhost:<port>',
+    },
+  },
+};
+```
+
+:::tip
+Rsbuild 会自动将 `<port>` 占位符替换为 server 实际监听的端口号。
+:::


### PR DESCRIPTION
## Summary

- Add client and serverUrl options to lazy compilation
- Add tip for the `<port>` placeholder.

## Related Links

- https://rspack.dev/config/experiments#lazycompilationserverurl
- https://github.com/web-infra-dev/rsbuild/pull/5035

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
