### PR TITLE
test: update plugin tests to use createRsbuild

### DIFF
--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -256,46 +256,81 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
 
 exports[`plugins/babel > should set babel-loader 1`] = `
 {
-  "module": {
-    "rules": [
-      {
-        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
-            "options": {
-              "babelrc": false,
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "2022-03",
-                  },
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-              ],
-            },
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "and": [
+        "<ROOT>/packages/plugin-babel/tests",
+        {
+          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+        },
+      ],
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  "type": "javascript/auto",
+  "use": [
+    {
+      "loader": "builtin:swc-loader",
+      "options": {
+        "env": {
+          "mode": undefined,
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+        "isModule": "unknown",
+        "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+            "keepImportAttributes": true,
           },
+          "externalHelpers": true,
+          "parser": {
+            "decorators": true,
+            "syntax": "typescript",
+            "tsx": false,
+          },
+          "transform": {
+            "decoratorVersion": "2022-03",
+            "legacyDecorator": false,
+          },
+        },
+      },
+    },
+    {
+      "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+      "options": {
+        "babelrc": false,
+        "compact": false,
+        "configFile": false,
+        "plugins": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+            {
+              "version": "2022-03",
+            },
+          ],
+        ],
+        "presets": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+            {
+              "allExtensions": true,
+              "allowDeclareFields": true,
+              "allowNamespaces": true,
+              "isTSX": true,
+              "optimizeConstEnums": true,
+            },
+          ],
         ],
       },
-    ],
-  },
-  "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
     },
   ],
 }
@@ -303,57 +338,92 @@ exports[`plugins/babel > should set babel-loader 1`] = `
 
 exports[`plugins/babel > should set babel-loader when config is add 1`] = `
 {
-  "module": {
-    "rules": [
-      {
-        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
-            "options": {
-              "babelrc": false,
-              "cacheCompression": false,
-              "cacheDirectory": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/babel-loader",
-              "cacheIdentifier": "test",
-              "compact": false,
-              "configFile": false,
-              "plugins": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
-                  {
-                    "version": "2022-03",
-                  },
-                ],
-                [
-                  "babel-plugin-import",
-                  {
-                    "libraryDirectory": "es",
-                    "libraryName": "my-components",
-                    "style": true,
-                  },
-                ],
-              ],
-              "presets": [
-                [
-                  "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
-                  {
-                    "allExtensions": true,
-                    "allowDeclareFields": true,
-                    "allowNamespaces": true,
-                    "isTSX": true,
-                    "optimizeConstEnums": true,
-                  },
-                ],
-              ],
-            },
+  "dependency": {
+    "not": "url",
+  },
+  "include": [
+    {
+      "and": [
+        "<ROOT>/packages/plugin-babel/tests",
+        {
+          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+        },
+      ],
+    },
+    /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+  ],
+  "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  "type": "javascript/auto",
+  "use": [
+    {
+      "loader": "builtin:swc-loader",
+      "options": {
+        "env": {
+          "mode": undefined,
+          "targets": [
+            "chrome >= 87",
+            "edge >= 88",
+            "firefox >= 78",
+            "safari >= 14",
+          ],
+        },
+        "isModule": "unknown",
+        "jsc": {
+          "experimental": {
+            "cacheRoot": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/.swc",
+            "keepImportAttributes": true,
           },
+          "externalHelpers": true,
+          "parser": {
+            "decorators": true,
+            "syntax": "typescript",
+            "tsx": false,
+          },
+          "transform": {
+            "decoratorVersion": "2022-03",
+            "legacyDecorator": false,
+          },
+        },
+      },
+    },
+    {
+      "loader": "<ROOT>/packages/plugin-babel/compiled/babel-loader/index.js",
+      "options": {
+        "babelrc": false,
+        "cacheCompression": false,
+        "cacheDirectory": "<ROOT>/packages/plugin-babel/tests/node_modules/.cache/babel-loader",
+        "cacheIdentifier": "test",
+        "compact": false,
+        "configFile": false,
+        "plugins": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/plugin-proposal-decorators/lib/index.js",
+            {
+              "version": "2022-03",
+            },
+          ],
+          [
+            "babel-plugin-import",
+            {
+              "libraryDirectory": "es",
+              "libraryName": "my-components",
+              "style": true,
+            },
+          ],
+        ],
+        "presets": [
+          [
+            "<ROOT>/node_modules/<PNPM_INNER>/@babel/preset-typescript/lib/index.js",
+            {
+              "allExtensions": true,
+              "allowDeclareFields": true,
+              "allowNamespaces": true,
+              "isTSX": true,
+              "optimizeConstEnums": true,
+            },
+          ],
         ],
       },
-    ],
-  },
-  "plugins": [
-    {
-      "name": "RsbuildCorePlugin",
     },
   ],
 }

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -1,5 +1,6 @@
+import { createRsbuild } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
-import { createStubRsbuild, matchRules } from '@scripts/test-helper';
+import { matchRules } from '@scripts/test-helper';
 import { describe, expect, it } from 'vitest';
 import { type PluginSvgrOptions, pluginSvgr } from '../src';
 
@@ -54,13 +55,14 @@ describe('svgr', () => {
   ];
 
   it.each(cases)('$name', async (item) => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
+    const rsbuild = await createRsbuild({
+      cwd: import.meta.dirname,
+      rsbuildConfig: {
+        plugins: [pluginSvgr(item.pluginConfig), pluginReact()],
+      },
     });
 
-    rsbuild.addPlugins([pluginSvgr(item.pluginConfig), pluginReact()]);
-
-    const config = await rsbuild.unwrapConfig();
-    expect(matchRules(config, 'a.svg')[0]).toMatchSnapshot();
+    const config = await rsbuild.initConfigs();
+    expect(matchRules(config[0], 'a.svg')[0]).toMatchSnapshot();
   });
 });

--- a/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-vue/tests/__snapshots__/index.test.ts.snap
@@ -2,76 +2,55 @@
 
 exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 1`] = `
 {
-  "module": {
-    "rules": [
-      {
-        "test": /\\\\\\.vue\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
-            "options": {
-              "compilerOptions": {
-                "preserveWhitespace": false,
-              },
-              "experimentalInlineMatchResource": true,
-            },
-          },
-        ],
-      },
-      {
-        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
-      },
-    ],
-  },
-  "plugins": [
+  "test": /\\\\\\.vue\\$/,
+  "use": [
     {
-      "name": "RsbuildCorePlugin",
+      "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
+      "options": {
+        "compilerOptions": {
+          "preserveWhitespace": false,
+        },
+        "experimentalInlineMatchResource": true,
+      },
     },
-    Plugin {},
   ],
-  "resolve": {
-    "extensions": [
-      ".vue",
-    ],
+}
+`;
+
+exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 2`] = `null`;
+
+exports[`plugin-vue > should add vue-loader and VueLoaderPlugin correctly 3`] = `
+{
+  "alias": {
+    "@swc/helpers": "<ROOT>/node_modules/<PNPM_INNER>/@swc/helpers",
   },
+  "extensions": [
+    ".ts",
+    ".tsx",
+    ".mjs",
+    ".js",
+    ".jsx",
+    ".json",
+    ".vue",
+  ],
 }
 `;
 
 exports[`plugin-vue > should allow to configure vueLoader options 1`] = `
 {
-  "module": {
-    "rules": [
-      {
-        "test": /\\\\\\.vue\\$/,
-        "use": [
-          {
-            "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
-            "options": {
-              "compilerOptions": {
-                "preserveWhitespace": false,
-              },
-              "experimentalInlineMatchResource": true,
-              "hotReload": false,
-            },
-          },
-        ],
-      },
-      {
-        "test": /\\\\\\.\\(\\?:css\\|postcss\\|pcss\\)\\$/,
-      },
-    ],
-  },
-  "plugins": [
+  "test": /\\\\\\.vue\\$/,
+  "use": [
     {
-      "name": "RsbuildCorePlugin",
+      "loader": "<ROOT>/node_modules/<PNPM_INNER>/vue-loader/dist/index.js",
+      "options": {
+        "compilerOptions": {
+          "preserveWhitespace": false,
+        },
+        "experimentalInlineMatchResource": true,
+        "hotReload": false,
+      },
     },
-    Plugin {},
   ],
-  "resolve": {
-    "extensions": [
-      ".vue",
-    ],
-  },
 }
 `;
 

--- a/packages/plugin-vue/tests/index.test.ts
+++ b/packages/plugin-vue/tests/index.test.ts
@@ -1,33 +1,35 @@
 import { createRsbuild } from '@rsbuild/core';
-import { createStubRsbuild } from '@scripts/test-helper';
-import { matchPlugin } from '@scripts/test-helper';
+import { matchPlugin, matchRules } from '@scripts/test-helper';
 import { pluginVue } from '../src';
 
 describe('plugin-vue', () => {
   it('should add vue-loader and VueLoaderPlugin correctly', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [pluginVue()],
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [pluginVue()],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
+    const config = await rsbuild.initConfigs();
 
-    expect(config).toMatchSnapshot();
+    expect(matchRules(config[0], 'a.vue')[0]).toMatchSnapshot();
+    expect(matchPlugin(config[0], 'VueLoaderPlugin')).toMatchSnapshot();
+    expect(config[0].resolve).toMatchSnapshot();
   });
 
   it('should allow to configure vueLoader options', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-      plugins: [
-        pluginVue({
-          vueLoaderOptions: {
-            hotReload: false,
-          },
-        }),
-      ],
+    const rsbuild = await createRsbuild({
+      rsbuildConfig: {
+        plugins: [
+          pluginVue({
+            vueLoaderOptions: {
+              hotReload: false,
+            },
+          }),
+        ],
+      },
     });
-    const config = await rsbuild.unwrapConfig();
-
-    expect(config).toMatchSnapshot();
+    const config = await rsbuild.initConfigs();
+    expect(matchRules(config[0], 'a.vue')[0]).toMatchSnapshot();
   });
 
   it('should define feature flags correctly', async () => {


### PR DESCRIPTION
## Summary

Update plugin unit tests to use `createRsbuild` instead of `createStubRsbuild`.

`createRsbuild` as a real-world API can better reflect the changes in user scenarios.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
