### PR TITLE
Fix `server.open: false` keeps to open page

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -40,7 +40,7 @@ const loadConfig = async (root: string) => {
     config.mode = commonOpts.mode;
   }
 
-  if (commonOpts.open && !config.server?.open) {
+  if (commonOpts.open && config.server?.open === undefined) {
     config.server.open = commonOpts.open;
   }
 

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -33,6 +33,16 @@ export default {
 };
 ```
 
+- Prevent to open any page:
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    open: false,
+  },
+};
+```
+
 - Open the specified page:
 
 ```ts title="rsbuild.config.ts"


### PR DESCRIPTION
## Summary

When `server.open` is set to `false`, then page keeps opening in browser.

Expected: 
- page to not open

Actual behavior:
- page is opening
- condition in the code, sets `open` to be `true` if it matches any falsy value.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
