### PR TITLE
fix: enable Lightning CSS `errorRecovery` option

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -40,6 +40,7 @@ export const getLightningCSSLoaderOptions = (
 
   const initialOptions: Rspack.LightningcssLoaderOptions = {
     targets,
+    errorRecovery: true,
   };
 
   if (minify) {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -63,6 +63,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -94,6 +95,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -38,6 +38,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -69,6 +70,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -212,6 +214,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -243,6 +246,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -304,6 +308,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -350,6 +355,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -419,6 +425,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -465,6 +472,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -63,6 +63,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -94,6 +95,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -541,6 +543,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -572,6 +575,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "minify": true,
               "targets": [
                 "chrome >= 87",
@@ -839,6 +843,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "_args": [
           {
             "minimizerOptions": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -1462,6 +1467,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",
@@ -1493,6 +1499,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           {
             "loader": "builtin:lightningcss-loader",
             "options": {
+              "errorRecovery": true,
               "targets": [
                 "chrome >= 87",
                 "edge >= 88",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1358,6 +1358,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "loader": "builtin:lightningcss-loader",
               "options": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -1389,6 +1390,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "loader": "builtin:lightningcss-loader",
               "options": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -46,6 +46,7 @@ describe('plugin-minimize', () => {
           "_args": [
             {
               "minimizerOptions": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -204,6 +205,7 @@ describe('plugin-minimize', () => {
           "_args": [
             {
               "minimizerOptions": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -264,6 +266,7 @@ describe('plugin-minimize', () => {
           "_args": [
             {
               "minimizerOptions": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",
@@ -318,6 +321,7 @@ describe('plugin-minimize', () => {
           "_args": [
             {
               "minimizerOptions": {
+                "errorRecovery": true,
                 "targets": [
                   "chrome >= 87",
                   "edge >= 88",

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -35,6 +35,7 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -74,6 +75,7 @@ exports[`plugin-less > should add less-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -140,6 +142,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -179,6 +182,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -248,6 +252,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -290,6 +295,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -356,6 +362,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -395,6 +402,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -461,6 +469,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -507,6 +516,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -35,6 +35,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -82,6 +83,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -156,6 +158,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -203,6 +206,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -280,6 +284,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -330,6 +335,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -404,6 +410,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -452,6 +459,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -35,6 +35,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -67,6 +68,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -126,6 +128,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",
@@ -161,6 +164,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       {
         "loader": "builtin:lightningcss-loader",
         "options": {
+          "errorRecovery": true,
           "targets": [
             "chrome >= 87",
             "edge >= 88",

--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -5,14 +5,13 @@
 
 ```ts
 const defaultOptions = {
-  // use current browserslist config
+  errorRecovery: true,
+  // use current project's browserslist config
   targets: browserslist,
   // minify is enabled when output.injectStyles is true and in production mode
   minify: config.mode === 'production' && config.output.injectStyles,
 };
 ```
-
-- **Version:** `>= 1.0.0`
 
 You can set the options for [builtin:lightningcss-loader](https://rspack.dev/guide/features/builtin-lightningcss-loader) through `tools.lightningcssLoader`.
 

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -5,14 +5,13 @@
 
 ```ts
 const defaultOptions = {
+  errorRecovery: true,
   // 使用当前项目的 browserslist 配置
   targets: browserslist,
   // 在生产模式，且 output.injectStyles 为 true 时，minify 会被启用
   minify: config.mode === 'production' && config.output.injectStyles,
 };
 ```
-
-- **版本：** `>= 1.0.0`
 
 通过 `tools.lightningcssLoader` 可以设置 [builtin:lightningcss-loader](https://rspack.dev/guide/features/builtin-lightningcss-loader) 的选项。
 


### PR DESCRIPTION
## Summary

Enable Lightning CSS `errorRecovery` option to fix an issue introduced in Rspack 1.3.5.

## Related Links

- resolve https://github.com/web-infra-dev/rspack/issues/10056
- resolve https://github.com/youzan/vant/issues/13441
- related https://github.com/web-infra-dev/rspack/pull/10076

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
