### PR TITLE
chore: replace deprecated method

### DIFF
--- a/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlPreloadOrPrefetchPlugin.ts
@@ -192,7 +192,7 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   apply(compiler: Compiler): void {
     compiler.hooks.compilation.tap(this.name, (compilation) => {
       getHTMLPlugin()
-        .getHooks(compilation)
+        .getCompilationHooks(compilation)
         .beforeAssetTagGeneration.tap(
           `HTML${upperFirst(this.type)}Plugin`,
           (htmlPluginData) => {


### PR DESCRIPTION
## Summary

The `getHooks` methods has been deprecated by `html-rspack-plugin`, use `getCompilationHooks` instead.

## Related Links

See https://github.com/rspack-contrib/html-rspack-plugin/blob/524d20714b07bfe06e9cae53e80f45f69591ca72/typings.d.ts#L22

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
