### PR TITLE
chore: rename HtmlResourceHintsPlugin

### DIFF
--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -152,9 +152,9 @@ export const CHAIN_ID = {
     BUNDLE_ANALYZER: 'bundle-analyze',
     /** ModuleFederationPlugin */
     MODULE_FEDERATION: 'module-federation',
-    /** htmlPrefetchPlugin */
+    /** HtmlResourceHintsPlugin (prefetch) */
     HTML_PREFETCH: 'html-prefetch-plugin',
-    /** htmlPreloadPlugin */
+    /** HtmlResourceHintsPlugin (preload) */
     HTML_PRELOAD: 'html-preload-plugin',
     /** CssExtractRspackPlugin */
     MINI_CSS_EXTRACT: 'mini-css-extract',

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -1,4 +1,4 @@
-import { HtmlPreloadOrPrefetchPlugin } from '../rspack/preload/HtmlPreloadOrPrefetchPlugin';
+import { HtmlResourceHintsPlugin } from '../rspack/preload/HtmlResourceHintsPlugin';
 import type { HtmlBasicTag, PreconnectOption, RsbuildPlugin } from '../types';
 
 const generateLinks = (
@@ -55,13 +55,13 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       if (prefetch) {
         chain
           .plugin(CHAIN_ID.PLUGIN.HTML_PREFETCH)
-          .use(HtmlPreloadOrPrefetchPlugin, [prefetch, 'prefetch', HTMLCount]);
+          .use(HtmlResourceHintsPlugin, [prefetch, 'prefetch', HTMLCount]);
       }
 
       if (preload) {
         chain
           .plugin(CHAIN_ID.PLUGIN.HTML_PRELOAD)
-          .use(HtmlPreloadOrPrefetchPlugin, [preload, 'preload', HTMLCount]);
+          .use(HtmlResourceHintsPlugin, [preload, 'preload', HTMLCount]);
       }
     });
   },

--- a/packages/core/src/rspack/preload/HtmlResourceHintsPlugin.ts
+++ b/packages/core/src/rspack/preload/HtmlResourceHintsPlugin.ts
@@ -24,7 +24,7 @@ import type {
 } from '@rspack/core';
 import { ensureAssetPrefix, upperFirst } from '../../helpers';
 import { getHTMLPlugin } from '../../pluginHelper';
-import type { HtmlRspackPlugin, PreloadOrPrefetchOption } from '../../types';
+import type { HtmlRspackPlugin, ResourceHintsOption } from '../../types';
 import {
   type As,
   type BeforeAssetTagGenerationHtmlPluginData,
@@ -61,7 +61,7 @@ function filterResourceHints(
 }
 
 function generateLinks(
-  options: PreloadOrPrefetchOption,
+  options: ResourceHintsOption,
   type: LinkType,
   compilation: Compilation,
   htmlPluginData: BeforeAssetTagGenerationHtmlPluginData,
@@ -165,10 +165,10 @@ function generateLinks(
   return links;
 }
 
-export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
-  readonly options: PreloadOrPrefetchOption;
+export class HtmlResourceHintsPlugin implements RspackPluginInstance {
+  readonly options: ResourceHintsOption;
 
-  name = 'HtmlPreloadOrPrefetchPlugin';
+  name = 'HtmlResourceHintsPlugin';
 
   resourceHints: HtmlRspackPlugin.HtmlTagObject[] = [];
 
@@ -177,7 +177,7 @@ export class HtmlPreloadOrPrefetchPlugin implements RspackPluginInstance {
   HTMLCount: number;
 
   constructor(
-    options: true | PreloadOrPrefetchOption,
+    options: true | ResourceHintsOption,
     type: LinkType,
     HTMLCount: number,
   ) {

--- a/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/preload/helpers/doesChunkBelongToHtml.ts
@@ -17,14 +17,14 @@
  */
 
 import type { Chunk, ChunkGroup, Compilation } from '@rspack/core';
-import type { PreloadOrPrefetchOption } from '../../../types';
+import type { ResourceHintsOption } from '../../../types';
 import type { BeforeAssetTagGenerationHtmlPluginData } from './type';
 
 interface DoesChunkBelongToHtmlOptions {
   chunk: Chunk;
   compilation?: Compilation;
   htmlPluginData: BeforeAssetTagGenerationHtmlPluginData;
-  pluginOptions?: PreloadOrPrefetchOption;
+  pluginOptions?: ResourceHintsOption;
 }
 
 function recursiveChunkGroup(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -586,15 +586,15 @@ export type PreloadIncludeType =
 
 export type Filter = Array<string | RegExp> | ((filename: string) => boolean);
 
-export interface PreloadOrPrefetchOption {
+export interface ResourceHintsOption {
   type?: PreloadIncludeType;
   include?: Filter;
   exclude?: Filter;
   dedupe?: boolean;
 }
-export type PreloadOption = PreloadOrPrefetchOption;
+export type PreloadOption = ResourceHintsOption;
 
-export type PrefetchOption = Omit<PreloadOrPrefetchOption, 'dedupe'>;
+export type PrefetchOption = Omit<ResourceHintsOption, 'dedupe'>;
 
 export interface PerformanceConfig {
   /**


### PR DESCRIPTION
## Summary

This pull request refactors the naming and structure of the `HtmlPreloadOrPrefetchPlugin` to improve clarity and consistency.

The plugin has been renamed to `HtmlResourceHintsPlugin`, and associated types and identifiers have been updated accordingly. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
