### PR TITLE
perf: make inline chunk matching faster

### DIFF
--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -52,10 +52,14 @@ function updateSourceMappingURL({
   return source;
 }
 
-function matchTests(name: string, source: string, tests: InlineChunkTest[]) {
+function matchTests(
+  name: string,
+  asset: Rspack.sources.Source,
+  tests: InlineChunkTest[],
+) {
   return tests.some((test) => {
     if (isFunction(test)) {
-      const size = source.length;
+      const size = asset.size();
       return test({ name, size });
     }
     return test.exec(name);
@@ -91,12 +95,12 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
         return tag;
       }
 
-      const source = asset.source().toString();
-      const shouldInline = matchTests(scriptName, source, scriptTests);
+      const shouldInline = matchTests(scriptName, asset, scriptTests);
       if (!shouldInline) {
         return tag;
       }
 
+      const source = asset.source().toString();
       const ret: HtmlBasicTag = {
         tag: 'script',
         children: updateSourceMappingURL({
@@ -141,12 +145,12 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
         return tag;
       }
 
-      const source = asset.source().toString();
-      const shouldInline = matchTests(linkName, source, styleTests);
+      const shouldInline = matchTests(linkName, asset, styleTests);
       if (!shouldInline) {
         return tag;
       }
 
+      const source = asset.source().toString();
       const ret: HtmlBasicTag = {
         tag: 'style',
         children: updateSourceMappingURL({


### PR DESCRIPTION
## Summary

Make inline chunk matching faster:

- No need to call `asset.source().toString()` if the asset is not matched.
- Use `asset.size()` to get size, it's faster than `asset.source().toString().length`.

<img width="716" alt="Screenshot 2025-04-20 at 17 47 19" src="https://github.com/user-attachments/assets/78cb2e3b-1245-480d-a291-1fb786419cdc" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
