### PR TITLE
fix: do not generate resource hints for inlined assets

### DIFF
--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -248,3 +248,67 @@ test('should generate prefetch link by config (distinguish html)', async () => {
   // test.js、test.css、image.png
   expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
 });
+
+test('should not generate prefetch link for inlined assets', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      output: {
+        inlineScripts: true,
+        inlineStyles: true,
+      },
+      performance: {
+        prefetch: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // image.png
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+});
+
+test('should not generate prefetch link for inlined assets with test option', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      output: {
+        inlineScripts: {
+          enable: 'auto',
+          test: /\.js$/,
+        },
+        inlineStyles: {
+          enable: 'auto',
+          test: /\.css$/,
+        },
+      },
+      performance: {
+        prefetch: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // image.png
+  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+});

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -249,66 +249,72 @@ test('should generate prefetch link by config (distinguish html)', async () => {
   expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
 });
 
-test('should not generate prefetch link for inlined assets', async () => {
-  const rsbuild = await build({
-    cwd: fixtures,
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          main: join(fixtures, 'src/page1/index.ts'),
+rspackOnlyTest(
+  'should not generate prefetch link for inlined assets',
+  async () => {
+    const rsbuild = await build({
+      cwd: fixtures,
+      plugins: [pluginReact()],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            main: join(fixtures, 'src/page1/index.ts'),
+          },
+        },
+        output: {
+          inlineScripts: true,
+          inlineStyles: true,
+        },
+        performance: {
+          prefetch: true,
         },
       },
-      output: {
-        inlineScripts: true,
-        inlineStyles: true,
-      },
-      performance: {
-        prefetch: true,
-      },
-    },
-  });
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+    const files = await rsbuild.unwrapOutputJSON();
+    const [, content] = Object.entries(files).find(([name]) =>
+      name.endsWith('.html'),
+    )!;
 
-  // image.png
-  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
-});
+    // image.png
+    expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+  },
+);
 
-test('should not generate prefetch link for inlined assets with test option', async () => {
-  const rsbuild = await build({
-    cwd: fixtures,
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          main: join(fixtures, 'src/page1/index.ts'),
+rspackOnlyTest(
+  'should not generate prefetch link for inlined assets with test option',
+  async () => {
+    const rsbuild = await build({
+      cwd: fixtures,
+      plugins: [pluginReact()],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            main: join(fixtures, 'src/page1/index.ts'),
+          },
+        },
+        output: {
+          inlineScripts: {
+            enable: 'auto',
+            test: /\.js$/,
+          },
+          inlineStyles: {
+            enable: 'auto',
+            test: /\.css$/,
+          },
+        },
+        performance: {
+          prefetch: true,
         },
       },
-      output: {
-        inlineScripts: {
-          enable: 'auto',
-          test: /\.js$/,
-        },
-        inlineStyles: {
-          enable: 'auto',
-          test: /\.css$/,
-        },
-      },
-      performance: {
-        prefetch: true,
-      },
-    },
-  });
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+    const files = await rsbuild.unwrapOutputJSON();
+    const [, content] = Object.entries(files).find(([name]) =>
+      name.endsWith('.html'),
+    )!;
 
-  // image.png
-  expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
-});
+    // image.png
+    expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
+  },
+);

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -245,3 +245,67 @@ test('should generate preload link with include array', async () => {
     ),
   ).toBeTruthy();
 });
+
+test('should not generate preload link for inlined assets', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      output: {
+        inlineScripts: true,
+        inlineStyles: true,
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // image.png
+  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+});
+
+test('should not generate preload link for inlined assets with test option', async () => {
+  const rsbuild = await build({
+    cwd: fixtures,
+    plugins: [pluginReact()],
+    rsbuildConfig: {
+      source: {
+        entry: {
+          main: join(fixtures, 'src/page1/index.ts'),
+        },
+      },
+      output: {
+        inlineScripts: {
+          enable: 'auto',
+          test: /\.js$/,
+        },
+        inlineStyles: {
+          enable: 'auto',
+          test: /\.css$/,
+        },
+      },
+      performance: {
+        preload: true,
+      },
+    },
+  });
+
+  const files = await rsbuild.unwrapOutputJSON();
+  const [, content] = Object.entries(files).find(([name]) =>
+    name.endsWith('.html'),
+  )!;
+
+  // image.png
+  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+});

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build } from '@e2e/helper';
+import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginReact } from '@rsbuild/plugin-react';
 
@@ -246,66 +246,72 @@ test('should generate preload link with include array', async () => {
   ).toBeTruthy();
 });
 
-test('should not generate preload link for inlined assets', async () => {
-  const rsbuild = await build({
-    cwd: fixtures,
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          main: join(fixtures, 'src/page1/index.ts'),
+rspackOnlyTest(
+  'should not generate preload link for inlined assets',
+  async () => {
+    const rsbuild = await build({
+      cwd: fixtures,
+      plugins: [pluginReact()],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            main: join(fixtures, 'src/page1/index.ts'),
+          },
+        },
+        output: {
+          inlineScripts: true,
+          inlineStyles: true,
+        },
+        performance: {
+          preload: true,
         },
       },
-      output: {
-        inlineScripts: true,
-        inlineStyles: true,
-      },
-      performance: {
-        preload: true,
-      },
-    },
-  });
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+    const files = await rsbuild.unwrapOutputJSON();
+    const [, content] = Object.entries(files).find(([name]) =>
+      name.endsWith('.html'),
+    )!;
 
-  // image.png
-  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
-});
+    // image.png
+    expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+  },
+);
 
-test('should not generate preload link for inlined assets with test option', async () => {
-  const rsbuild = await build({
-    cwd: fixtures,
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      source: {
-        entry: {
-          main: join(fixtures, 'src/page1/index.ts'),
+rspackOnlyTest(
+  'should not generate preload link for inlined assets with test option',
+  async () => {
+    const rsbuild = await build({
+      cwd: fixtures,
+      plugins: [pluginReact()],
+      rsbuildConfig: {
+        source: {
+          entry: {
+            main: join(fixtures, 'src/page1/index.ts'),
+          },
+        },
+        output: {
+          inlineScripts: {
+            enable: 'auto',
+            test: /\.js$/,
+          },
+          inlineStyles: {
+            enable: 'auto',
+            test: /\.css$/,
+          },
+        },
+        performance: {
+          preload: true,
         },
       },
-      output: {
-        inlineScripts: {
-          enable: 'auto',
-          test: /\.js$/,
-        },
-        inlineStyles: {
-          enable: 'auto',
-          test: /\.css$/,
-        },
-      },
-      performance: {
-        preload: true,
-      },
-    },
-  });
+    });
 
-  const files = await rsbuild.unwrapOutputJSON();
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+    const files = await rsbuild.unwrapOutputJSON();
+    const [, content] = Object.entries(files).find(([name]) =>
+      name.endsWith('.html'),
+    )!;
 
-  // image.png
-  expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
-});
+    // image.png
+    expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
+  },
+);

--- a/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
+++ b/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
@@ -163,7 +163,7 @@ function generateLinks(
     (accumulated: string[], chunk) =>
       accumulated.concat([
         ...chunk.files,
-        // sourcemap files are inside auxiliaryFiles in webpack5
+        // source map files are inside auxiliaryFiles
         ...(chunk.auxiliaryFiles || []),
       ]),
     [],


### PR DESCRIPTION
## Summary

If the asset is inlined via `output.inlineScripts` or `output.inlineStyles`, it will be added to the HTML content directly, so we need to exclude it from the resource hints.

Example:

```js
export default {
  output: {
    inlineScripts: {
      enable: 'auto',
      test: /\.js$/,
    },
    inlineStyles: {
      enable: 'auto',
      test: /\.css$/,
    },
  },
  performance: {
    preload: true,
  },
}
```

Note that the function usage of `inlineScripts` and `inlineStyles` is not yet supported, as it requires the `size` param.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
