### PR TITLE
fix: correct highlighting of filename log

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -5,7 +5,7 @@ const formatFileName = (fileName: string) => {
   // add default column add lines for linking
   return /:\d+:\d+/.test(fileName)
     ? `File: ${color.cyan(fileName)}\n`
-    : `File: ${color.cyan(fileName)}:1:1\n`;
+    : `File: ${color.cyan(`${fileName}:1:1`)}\n`;
 };
 
 function resolveFileName(stats: StatsError) {


### PR DESCRIPTION
## Summary

Correct the highlighting of filename log.

- before:

<img width="931" alt="Screenshot 2025-04-21 at 22 32 30" src="https://github.com/user-attachments/assets/81fb8d13-d7f0-498c-aa11-9ff585245419" />

- after:

<img width="936" alt="Screenshot 2025-04-21 at 22 32 15" src="https://github.com/user-attachments/assets/fd2af89d-4f3c-42ee-94d0-807d6e12657a" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
