### PR TITLE
test(e2e): improve test helpers naming

### DIFF
--- a/e2e/cases/alias/alias-by-target/index.test.ts
+++ b/e2e/cases/alias/alias-by-target/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to set alias by build target', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const fileNames = Object.keys(files);
   const webIndex = fileNames.find(
     (file) => file.includes('static/js') && file.endsWith('index.js'),

--- a/e2e/cases/alias/legacy-alias/index.test.ts
+++ b/e2e/cases/alias/legacy-alias/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to use the legacy `source.alias` config', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const fileNames = Object.keys(files);
   const webIndex = fileNames.find(
     (file) => file.includes('static/js') && file.endsWith('index.js'),

--- a/e2e/cases/assets/addtional-assets/index.test.ts
+++ b/e2e/cases/assets/addtional-assets/index.test.ts
@@ -16,7 +16,7 @@ test('should allow to configure additional assets and match by RegExp', async ()
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   const indexJs = await rsbuild.getIndexFile();
@@ -40,7 +40,7 @@ test('should allow to configure additional assets and match by path', async () =
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   const indexJs = await rsbuild.getIndexFile();
@@ -67,7 +67,7 @@ test('should allow to disable emit for additional assets', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/assets/custom-dist-path/index.test.ts
+++ b/e2e/cases/assets/custom-dist-path/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to custom dist path of different files', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   // JS

--- a/e2e/cases/assets/emit-assets/index.test.ts
+++ b/e2e/cases/assets/emit-assets/index.test.ts
@@ -10,7 +10,7 @@ test('should allow to disable emit assets for node target', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(isIncludeFile(filenames, 'dist/static/image/icon.png')).toBeTruthy();
@@ -25,7 +25,7 @@ test('should allow to disable emit assets for json assets', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(isIncludeFile(filenames, 'dist/static/assets/test.json')).toBeTruthy();

--- a/e2e/cases/assets/filename-function/index.test.ts
+++ b/e2e/cases/assets/filename-function/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to custom filename by function', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   // JS

--- a/e2e/cases/assets/filename-hash/index.test.ts
+++ b/e2e/cases/assets/filename-hash/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow to set hash format to fullhash', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   let firstHash = '';

--- a/e2e/cases/assets/filename-template-path/index.test.ts
+++ b/e2e/cases/assets/filename-template-path/index.test.ts
@@ -5,7 +5,7 @@ test('should allow filename.image: "[path]"', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
   // Image
   expect(

--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const filenames = Object.keys(files);
 
     const test1 = filenames.find((filename) =>

--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const filenames = Object.keys(files);
 
     const test1 = filenames.find((filename) =>

--- a/e2e/cases/browserslist/extends-browserslist/index.test.ts
+++ b/e2e/cases/browserslist/extends-browserslist/index.test.ts
@@ -9,7 +9,7 @@ test('extends browserslist and downgrade the syntax', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexFile =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/browserslist/package-config-array/index.test.ts
+++ b/e2e/cases/browserslist/package-config-array/index.test.ts
@@ -6,7 +6,7 @@ test('should read browserslist array from package.json', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexFile =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/browserslist/package-config-object/index.test.ts
+++ b/e2e/cases/browserslist/package-config-object/index.test.ts
@@ -6,7 +6,7 @@ test('should read browserslist string from package.json', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexFile =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/browserslist/package-config-string/index.test.ts
+++ b/e2e/cases/browserslist/package-config-string/index.test.ts
@@ -6,7 +6,7 @@ test('should read browserslist string from package.json', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexFile =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/cli/base/index.test.ts
+++ b/e2e/cases/cli/base/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run allow to specify base path', async () => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should run allow to specify base path', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(

--- a/e2e/cases/cli/basic/index.test.ts
+++ b/e2e/cases/cli/basic/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command correctly', async () => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should run build command correctly', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('index.html'))).toBeTruthy();

--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 const nodeVersion = process.version.slice(1).split('.')[0];
@@ -19,7 +19,7 @@ conditionalTest('should use Node.js native loader to load config', async () => {
     },
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist-custom'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist-custom'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.length > 1).toBeTruthy();

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist-custom'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist-custom'));
     const outputFiles = Object.keys(outputs);
 
     expect(outputFiles.length > 1).toBeTruthy();
@@ -24,7 +24,7 @@ rspackOnlyTest(
     execSync(`npx rsbuild build --config ${absPath}`, {
       cwd: __dirname,
     });
-    const outputs = await globContentJSON(path.join(__dirname, 'dist-custom'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist-custom'));
     const outputFiles = Object.keys(outputs);
 
     expect(outputFiles.length > 1).toBeTruthy();

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command correctly', async () => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should run build command correctly', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('index.html'))).toBeTruthy();

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -14,7 +14,7 @@ rspackOnlyTest('should allow to export function in config file', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(targetDir);
+  const outputs = await readDirContents(targetDir);
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.length > 1).toBeTruthy();

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { removeSync } from 'fs-extra';
 
@@ -16,7 +16,7 @@ rspackOnlyTest('should run inspect command correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await globContentJSON(path.join(__dirname, 'dist/.rsbuild'));
+  const files = await readDirContents(path.join(__dirname, 'dist/.rsbuild'));
   const fileNames = Object.keys(files);
 
   const rsbuildConfig = fileNames.find((item) =>
@@ -43,7 +43,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await globContentJSON(path.join(__dirname, 'dist/.rsbuild'));
+    const files = await readDirContents(path.join(__dirname, 'dist/.rsbuild'));
     const fileNames = Object.keys(files);
 
     const rsbuildConfig = fileNames.find((item) =>
@@ -68,7 +68,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist/foo'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist/foo'));
     const outputFiles = Object.keys(outputs);
 
     expect(

--- a/e2e/cases/cli/mode/index.test.ts
+++ b/e2e/cases/cli/mode/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist'));
     const outputFiles = Object.keys(outputs);
 
     // no filename hash in development mode
@@ -30,7 +30,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist'));
     const outputFiles = Object.keys(outputs);
 
     // no filename hash in development mode

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -11,7 +11,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist-prod'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist-prod'));
     const outputFiles = Object.keys(outputs);
 
     expect(outputFiles.length > 1).toBeTruthy();

--- a/e2e/cases/cli/root/index.test.ts
+++ b/e2e/cases/cli/root/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'test', 'dist'));
+    const outputs = await readDirContents(path.join(__dirname, 'test', 'dist'));
     const outputFiles = Object.keys(outputs);
 
     expect(
@@ -26,7 +26,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const outputs = await globContentJSON(path.join(__dirname, 'test', 'dist'));
+    const outputs = await readDirContents(path.join(__dirname, 'test', 'dist'));
     const outputFiles = Object.keys(outputs);
 
     expect(

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
@@ -10,7 +10,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await globContentJSON(path.join(__dirname, 'dist'));
+    const files = await readDirContents(path.join(__dirname, 'dist'));
     const outputFiles = Object.keys(files);
 
     expect(

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build Vue SFC correctly', async () => {
@@ -8,7 +8,7 @@ rspackOnlyTest('should build Vue SFC correctly', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('index.html'))).toBeTruthy();

--- a/e2e/cases/css/configure-css-extract/index.test.ts
+++ b/e2e/cases/css/configure-css-extract/index.test.ts
@@ -5,7 +5,7 @@ test('should allow to configure options of CSSExtractPlugin', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const content =
     files[Object.keys(files).find((file) => file.endsWith('my-css.css'))!];
 

--- a/e2e/cases/css/css-assets/index.test.ts
+++ b/e2e/cases/css/css-assets/index.test.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 import { build } from '@e2e/helper';
-import { globContentJSON } from '@e2e/helper';
+import { readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should build CSS assets correctly', async () => {
   await expect(build({ cwd: __dirname })).resolves.toBeDefined();
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(

--- a/e2e/cases/css/css-layers/index.test.ts
+++ b/e2e/cases/css/css-layers/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should bundle CSS layers as expected in build', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];
@@ -27,7 +27,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-minify-options/index.test.ts
+++ b/e2e/cases/css/css-minify-options/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow to custom CSS minify options', async () => {
     cwd: __dirname,
     rsbuildConfig: {},
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-minimize/index.test.ts
+++ b/e2e/cases/css/css-minimize/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should minimize CSS correctly by default', async () => {
     cwd: __dirname,
     rsbuildConfig: {},
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should compile CSS Modules composes correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];
@@ -27,7 +27,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -18,7 +18,7 @@ test('injectStyles', async ({ page }) => {
   });
 
   // injectStyles worked
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
 
   expect(cssFiles.length).toBe(0);

--- a/e2e/cases/css/css-modules-exports-global/index.test.ts
+++ b/e2e/cases/css/css-modules-exports-global/index.test.ts
@@ -35,7 +35,7 @@ rspackOnlyTest(
 
     await rsbuild.close();
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];
     expect(content).toMatch(/\.foo-\w{6}{color:red}\.bar{color:#00f}/);

--- a/e2e/cases/css/css-modules-global/index.test.ts
+++ b/e2e/cases/css/css-modules-global/index.test.ts
@@ -5,7 +5,7 @@ test('should compile CSS Modules with :global() correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-modules-mode/index.test.ts
+++ b/e2e/cases/css/css-modules-mode/index.test.ts
@@ -12,7 +12,7 @@ test('should compile CSS Modules global mode correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should compile CSS Modules correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];
@@ -30,7 +30,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];
@@ -54,7 +54,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];
@@ -78,7 +78,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/emit-css/index.test.ts
+++ b/e2e/cases/css/emit-css/index.test.ts
@@ -10,7 +10,7 @@ test('should not emit CSS files when build node target', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   // preserve CSS Modules mapping
   const jsContent =
@@ -31,7 +31,7 @@ test('should allow to emit CSS with output.emitCss when build node target', asyn
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   // preserve CSS Modules mapping
   const jsContent =
@@ -51,7 +51,7 @@ test('should not emit CSS files when build web-worker target', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   // preserve CSS Modules mapping
   const jsContent =
@@ -72,7 +72,7 @@ test('should allow to emit CSS with output.emitCss when build web-worker target'
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   // preserve CSS Modules mapping
   const jsContent =
@@ -93,7 +93,7 @@ test('should allow to disable CSS emit with output.emitCss when build web target
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   // preserve CSS Modules mapping
   const jsContent =

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -7,7 +7,7 @@ rspackOnlyTest('should allow to enable Rspack experiments.css', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const content =
     files[Object.keys(files).find((file) => file.endsWith('index.css'))!];
 
@@ -32,7 +32,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const content =
       files[Object.keys(files).find((file) => file.endsWith('index.js'))!];
     expect(content).toContain('color:red');

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest('should compile common CSS import correctly', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
   // there will be a deprecation log for `~`.

--- a/e2e/cases/css/import-loaders/index.test.ts
+++ b/e2e/cases/css/import-loaders/index.test.ts
@@ -7,7 +7,7 @@ rspackOnlyTest(
     const rsbuild = await build({
       cwd: __dirname,
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/inject-styles-lightningcss/index.test.ts
+++ b/e2e/cases/css/inject-styles-lightningcss/index.test.ts
@@ -11,7 +11,7 @@ rspackOnlyTest(
     });
 
     // injectStyles worked
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     // should inline minified CSS
     const indexJsFile = Object.keys(files).find(

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -14,7 +14,7 @@ rspackOnlyTest(
     });
 
     // injectStyles worked
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
     expect(cssFiles.length).toBe(0);
 
@@ -112,7 +112,7 @@ rspackOnlyTest(
     });
 
     // injectStyles worked
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
     expect(cssFiles.length).toBe(0);
 

--- a/e2e/cases/css/lightningcss-disabled/index.test.ts
+++ b/e2e/cases/css/lightningcss-disabled/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
     const rsbuild = await build({
       cwd: __dirname,
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest('should emit multiple CSS files correctly', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const entry1CSS = Object.keys(files).find(
     (file) => file.includes('entry1') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest('should compile nested npm import correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
   expect(files[cssFiles]).toEqual(

--- a/e2e/cases/css/postcss-config-ts/index.test.ts
+++ b/e2e/cases/css/postcss-config-ts/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should load postcss.config.ts correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexCssFile = Object.keys(files).find(
     (file) => file.includes('index.') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/css/postcss-function-options-merge/index.test.ts
+++ b/e2e/cases/css/postcss-function-options-merge/index.test.ts
@@ -11,7 +11,7 @@ test('should merge `postcssOptions` function with `postcss.config.ts` as expecte
   const barCssExpected =
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}}';
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const fooCssFile = Object.keys(files).find(
     (file) => file.includes('foo.') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/css/postcss-function-options/index.test.ts
+++ b/e2e/cases/css/postcss-function-options/index.test.ts
@@ -11,7 +11,7 @@ test('should allow to use `postcssOptions` function to apply different postcss c
   const barCssExpected =
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}}';
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const fooCssFile = Object.keys(files).find(
     (file) => file.includes('foo.') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/css/relative-import/index.test.ts
+++ b/e2e/cases/css/relative-import/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should compile CSS relative imports correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/resolve-alias/index.test.ts
+++ b/e2e/cases/css/resolve-alias/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should compile CSS with alias correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -8,7 +8,7 @@ rspackOnlyTest('should resolve ts paths correctly in SCSS file', async () => {
       cwd: __dirname,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/css/resolve-url-loader/index.test.ts
+++ b/e2e/cases/css/resolve-url-loader/index.test.ts
@@ -5,7 +5,7 @@ test('should resolve relative asset correctly in SCSS file', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/environments/outputs/index.test.ts
+++ b/e2e/cases/environments/outputs/index.test.ts
@@ -23,7 +23,7 @@ test('should apply multiple dist path correctly', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/environments/plugins/index.test.ts
+++ b/e2e/cases/environments/plugins/index.test.ts
@@ -42,7 +42,7 @@ test('should add single environment plugin correctly', async ({ page }) => {
 
   await expect(page.locator('#test1')).toHaveText('Hello Rsbuild!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -12,7 +12,7 @@ test('should emit apple-touch-icon to dist path', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
@@ -41,7 +41,7 @@ test('should emit manifest.webmanifest to dist path', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
@@ -91,7 +91,7 @@ test('should allow to specify URL as icon', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestPath = Object.keys(files).find((file) =>
     file.endsWith('manifest.webmanifest'),
@@ -150,7 +150,7 @@ test('should allow to specify target for each icon', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
@@ -212,7 +212,7 @@ test('should allow to customize manifest filename', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const manifestPath = Object.keys(files).find((file) =>
     file.endsWith('manifest.json'),
   );
@@ -253,7 +253,7 @@ test('should append dev.assetPrefix to icon URL', async ({ page }) => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
@@ -314,7 +314,7 @@ test('should append output.assetPrefix to icon URL', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
@@ -369,7 +369,7 @@ test('should apply asset prefix to apple-touch-icon URL', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const {
     origin: { bundlerConfigs },

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -10,7 +10,7 @@ test('should not apply crossOrigin by default', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
@@ -30,7 +30,7 @@ test('should apply crossOrigin when crossorigin is "anonymous" and not same orig
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/html/custom-filename/index.test.ts
+++ b/e2e/cases/html/custom-filename/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, globContentJSON } from '@e2e/helper';
+import { build, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to custom HTML filename', async () => {
@@ -7,7 +7,7 @@ test('should allow to custom HTML filename', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(join(__dirname, 'dist'));
+  const outputs = await readDirContents(join(__dirname, 'dist'));
   const fooFile = Object.keys(outputs).find((item) =>
     item.includes('custom-foo.html'),
   );

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -11,7 +11,7 @@ test('should emit local favicon to dist path', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('/icon.png')),
@@ -32,7 +32,7 @@ test('should allow `html.favicon` to be an absolute path', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('/icon.png')),
@@ -53,7 +53,7 @@ test('should add type attribute for SVG favicon', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).some((file) => file.endsWith('/mobile.svg')),
@@ -79,7 +79,7 @@ test('should apply asset prefix to favicon URL', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
@@ -98,7 +98,7 @@ test('should allow favicon to be a CDN URL', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
@@ -127,7 +127,7 @@ test('should generate favicon via function correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, globContentJSON } from '@e2e/helper';
+import { build, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to generate HTML with filename hash using filename.html', async () => {
@@ -14,7 +14,7 @@ test('should allow to generate HTML with filename hash using filename.html', asy
     },
   });
 
-  const outputs = await globContentJSON(join(__dirname, 'dist'));
+  const outputs = await readDirContents(join(__dirname, 'dist'));
   const htmlFilename = Object.keys(outputs).find((item) =>
     item.endsWith('.html'),
   );
@@ -35,7 +35,7 @@ test('should allow to generate HTML with filename hash using tools.htmlPlugin', 
     },
   });
 
-  const outputs = await globContentJSON(join(__dirname, 'dist'));
+  const outputs = await readDirContents(join(__dirname, 'dist'));
   const htmlFilename = Object.keys(outputs).find((item) =>
     item.endsWith('.html'),
   );

--- a/e2e/cases/html/html-loader/index.test.ts
+++ b/e2e/cases/html/html-loader/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const filenames = Object.keys(files);
 
     expect(
@@ -30,7 +30,7 @@ rspackOnlyTest('should allow to use html-loader in production', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/html/html-tags/basic/index.test.ts
+++ b/e2e/cases/html/html-tags/basic/index.test.ts
@@ -6,7 +6,7 @@ test('should inject tags correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexHtml =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should inject tags with function usage correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexHtml =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];

--- a/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to inject tags by entry name', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHTML =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -18,7 +18,7 @@ test('injection script order should be as expected', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
@@ -52,7 +52,7 @@ rspackOnlyTest('should set inject via function correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -15,7 +15,7 @@ rspackOnlyTest(
         },
       },
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const html =
       files[Object.keys(files).find((file) => file.endsWith('index.html'))!];

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -22,7 +22,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.html'))!];

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should apply defer by default', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
@@ -21,7 +21,7 @@ test('should remove defer when scriptLoading is "blocking"', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
@@ -37,7 +37,7 @@ test('should allow to set scriptLoading to "module"', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/html/template-escape/index.test.ts
+++ b/e2e/cases/html/template-escape/index.test.ts
@@ -5,7 +5,7 @@ test('should escape template parameters correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -8,7 +8,7 @@ rspackOnlyTest(
     const rsbuild = await build({
       cwd: __dirname,
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const indexHtml =
       files[Object.keys(files).find((file) => file.endsWith('index.html'))!];

--- a/e2e/cases/html/template-with-script/index.test.ts
+++ b/e2e/cases/html/template-with-script/index.test.ts
@@ -6,7 +6,7 @@ test('should compile template with es template correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const indexHtml =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -25,7 +25,7 @@ test('should set template via function correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -85,7 +85,7 @@ test('should set template via tools.htmlPlugin correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -11,7 +11,7 @@ test('should generate default title correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -30,7 +30,7 @@ test('should allow setting empty title to unset the default title', async () => 
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -49,7 +49,7 @@ test('should generate title correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -69,7 +69,7 @@ test('should generate title correctly when using custom HTML template', async ()
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -89,7 +89,7 @@ test('should generate title correctly when using htmlPlugin.options.title', asyn
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -113,7 +113,7 @@ test('should generate title via function correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const fooHtml =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
@@ -137,7 +137,7 @@ test('should not inject title if template already contains a title', async () =>
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const html =
     files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];

--- a/e2e/cases/javascript-api/register-plugin/index.test.ts
+++ b/e2e/cases/javascript-api/register-plugin/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { globContentJSON, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
@@ -16,7 +16,7 @@ rspackOnlyTest(
 
     await rsbuild.build();
 
-    const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+    const outputs = await readDirContents(path.join(__dirname, 'dist'));
     const outputFiles = Object.keys(outputs);
 
     expect(

--- a/e2e/cases/less/exclude-with-helper/index.test.ts
+++ b/e2e/cases/less/exclude-with-helper/index.test.ts
@@ -16,7 +16,7 @@ test('exclude specified less file with addExcludes', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
   const lessFiles = Object.keys(files).filter((file) => file.endsWith('.less'));
 

--- a/e2e/cases/less/exclude/index.test.ts
+++ b/e2e/cases/less/exclude/index.test.ts
@@ -16,7 +16,7 @@ test('exclude specified less file with exclude option', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
   const lessFiles = Object.keys(files).filter((file) => file.endsWith('.less'));
 

--- a/e2e/cases/less/import/index.test.ts
+++ b/e2e/cases/less/import/index.test.ts
@@ -6,7 +6,7 @@ test('should compile less import correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
   expect(files[cssFiles]).toEqual('body{background-color:red}');

--- a/e2e/cases/less/inline-js/index.test.ts
+++ b/e2e/cases/less/inline-js/index.test.ts
@@ -6,7 +6,7 @@ test('should compile less inline js correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
   expect(files[cssFiles]).toEqual('body{opacity:.2}');

--- a/e2e/cases/less/npm-import/index.test.ts
+++ b/e2e/cases/less/npm-import/index.test.ts
@@ -14,7 +14,7 @@ test('should compile less npm import correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
   expect(files[cssFiles]).toEqual('html{height:100%}body{color:red}');

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -9,7 +9,7 @@ test('should allow to set development mode when building', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // should not have filename hash in development mode
   const indexFile = Object.keys(files).find((key) =>
@@ -37,7 +37,7 @@ test('should allow to set none mode when building', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // should not have filename hash in none mode
   const indexFile = Object.keys(files).find((key) =>
@@ -64,7 +64,7 @@ test('should allow to set production mode when starting dev server', async ({
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // should have filename hash in production mode
   const indexFile = Object.keys(files).find((key) =>

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -8,7 +8,7 @@ test('should compile Node addons correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const addonFile = Object.keys(files).find((file) =>
     file.endsWith('test.darwin.node'),
   );
@@ -56,7 +56,7 @@ test('should compile Node addons in the node_modules correctly', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const addonFile = Object.keys(files).find((file) =>
     file.endsWith('other.node'),
   );

--- a/e2e/cases/nonce/basic/index.test.ts
+++ b/e2e/cases/nonce/basic/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should apply nonce to script and style tags', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
   expect(html).toContain(`<script defer nonce="CSP_NONCE_PLACEHOLDER">`);
@@ -40,7 +40,7 @@ rspackOnlyTest('should apply environment nonce', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('dist/index.html'))!];
   expect(html).toContain(`<script defer nonce="CSP_NONCE_PLACEHOLDER">`);

--- a/e2e/cases/nonce/dynamic-chunk/index.test.ts
+++ b/e2e/cases/nonce/dynamic-chunk/index.test.ts
@@ -36,7 +36,7 @@ test('should apply nonce to preload script tags', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/nonce/with-rem/index.test.ts
+++ b/e2e/cases/nonce/with-rem/index.test.ts
@@ -5,7 +5,7 @@ test('should inject rem runtime code with nonce', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const html =
     files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
   expect(html).toContain(

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -14,7 +14,7 @@ test('should allow to set output.charset to ascii', async ({ page }) => {
 
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [, content] = Object.entries(files).find(
     ([name]) => name.endsWith('.js') && name.includes('static/js/index'),
@@ -41,7 +41,7 @@ test('should allow to set output.charset to utf8', async ({ page }) => {
 
   expect(await page.evaluate('window.a')).toBe('你好 world!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [, content] = Object.entries(files).find(
     ([name]) => name.endsWith('.js') && name.includes('static/js/index'),

--- a/e2e/cases/output/externals/tests/index.test.ts
+++ b/e2e/cases/output/externals/tests/index.test.ts
@@ -48,7 +48,7 @@ test('should not external dependencies when target is web worker', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/output/inline-chunk/index.test.ts
+++ b/e2e/cases/output/inline-chunk/index.test.ts
@@ -40,7 +40,7 @@ test('inline all scripts should work and emit all source maps', async ({
   // test runtime
   expect(await page.evaluate('window.test')).toBe('aaaa');
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no entry chunks or runtime chunks in output
   expect(
@@ -68,7 +68,7 @@ test('using RegExp to inline scripts', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no index.js in output
   expect(
@@ -96,7 +96,7 @@ test('inline scripts by filename and file size', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no index.js in output
   expect(
@@ -122,7 +122,7 @@ test('using RegExp to inline styles', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no index.css in output
   expect(
@@ -144,7 +144,7 @@ test('inline styles by filename and file size', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no index.css in output
   expect(
@@ -242,7 +242,7 @@ test('inline scripts does not work when enable is false', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // all index.js in output
   expect(
@@ -271,7 +271,7 @@ test('inline styles does not work when enable is false', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // all index.css in output
   expect(
@@ -298,7 +298,7 @@ test('inline chunk works in production mode when enable is auto', async () => {
       tools: toolsConfig,
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   // no index.js in output
   expect(

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -20,7 +20,7 @@ rspackOnlyTest('legalComments linked (default)', async ({ page }) => {
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const LicenseContent =
     files[
@@ -65,7 +65,7 @@ test('legalComments none', async ({ page }) => {
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const LicenseFile = Object.keys(files).find(
     (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
@@ -104,7 +104,7 @@ test('legalComments inline', async ({ page }) => {
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild!');
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const LicenseFile = Object.keys(files).find(
     (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),

--- a/e2e/cases/output/manifest-async-chunks/index.test.ts
+++ b/e2e/cases/output/manifest-async-chunks/index.test.ts
@@ -19,7 +19,7 @@ test('should generate manifest for async chunks correctly', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];

--- a/e2e/cases/output/manifest-generate/index.test.ts
+++ b/e2e/cases/output/manifest-generate/index.test.ts
@@ -31,7 +31,7 @@ test('should allow to custom generate manifest data in production build', async 
     rsbuildConfig,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const manifestContent =
     files[
       Object.keys(files).find((file) => file.endsWith('my-manifest.json'))!
@@ -57,7 +57,7 @@ test('should allow to custom generate manifest data in dev', async ({
     rsbuildConfig,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const manifestContent =
     files[
       Object.keys(files).find((file) => file.endsWith('my-manifest.json'))!

--- a/e2e/cases/output/manifest-single-vendor/index.test.ts
+++ b/e2e/cases/output/manifest-single-vendor/index.test.ts
@@ -8,7 +8,7 @@ test('should generate manifest with single vendor as expected', async () => {
     cwd: fixtures,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];

--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -21,7 +21,7 @@ test('should generate manifest file in output', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
@@ -82,7 +82,7 @@ test('should generate manifest file when target is node', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
@@ -123,7 +123,7 @@ test('should always write manifest to disk when in dev mode', async ({
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
@@ -151,7 +151,7 @@ test('should allow to filter files in manifest', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const manifestContent =
     files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
@@ -187,7 +187,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const manifestContent =
       files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];

--- a/e2e/cases/output/source-map/index.test.ts
+++ b/e2e/cases/output/source-map/index.test.ts
@@ -40,7 +40,7 @@ async function testSourceMapType(devtool: Rspack.Configuration['devtool']) {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
   const [, jsMapContent] = Object.entries(files).find(
     ([name]) => name.includes('static/js/') && name.endsWith('.js.map'),
   )!;
@@ -101,7 +101,7 @@ test('should not generate source map by default in production build', async () =
     cwd: fixtures,
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const jsMapFiles = Object.keys(files).filter((files) =>
     files.endsWith('.js.map'),
@@ -123,7 +123,7 @@ test('should generate source map if `output.sourceMap` is true', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const jsMapFiles = Object.keys(files).filter((files) =>
     files.endsWith('.js.map'),
@@ -145,7 +145,7 @@ test('should not generate source map if `output.sourceMap` is false', async () =
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const jsMapFiles = Object.keys(files).filter((files) =>
     files.endsWith('.js.map'),
@@ -165,7 +165,7 @@ test('should generate source map correctly in development build', async ({
     page,
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const jsMapFile = Object.keys(files).find((files) =>
     files.endsWith('.js.map'),
@@ -200,7 +200,7 @@ test('should allow to only generate source map for CSS files', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const jsMapFiles = Object.keys(files).filter((files) =>
     files.endsWith('.js.map'),

--- a/e2e/cases/performance/bundle-analyzer/index.test.ts
+++ b/e2e/cases/performance/bundle-analyzer/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, dev, globContentJSON, proxyConsole } from '@e2e/helper';
+import { build, dev, proxyConsole, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should emit bundle analyze report correctly when dev', async ({
@@ -15,7 +15,7 @@ test('should emit bundle analyze report correctly when dev', async ({
   const testEl = page.locator('#test');
   await expect(testEl).toHaveText('Hello Rsbuild!');
 
-  const files = await globContentJSON(join(__dirname, 'dist'));
+  const files = await readDirContents(join(__dirname, 'dist'));
   const filePaths = Object.keys(files).filter((file) =>
     file.endsWith('report-web.html'),
   );
@@ -37,7 +37,7 @@ test('should emit bundle analyze report correctly when build', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filePaths = Object.keys(files).filter((file) =>
     file.endsWith('report-web.html'),
   );

--- a/e2e/cases/performance/dns-prefetch/index.test.ts
+++ b/e2e/cases/performance/dns-prefetch/index.test.ts
@@ -6,7 +6,7 @@ test('should generate dnsPrefetch link when dnsPrefetch is defined', async () =>
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),

--- a/e2e/cases/performance/external-helpers/index.test.ts
+++ b/e2e/cases/performance/external-helpers/index.test.ts
@@ -21,7 +21,7 @@ test('should externalHelpers by default', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const content =
     files[

--- a/e2e/cases/performance/moment-locale/index.test.ts
+++ b/e2e/cases/performance/moment-locale/index.test.ts
@@ -28,7 +28,7 @@ test('removeMomentLocale false (default)', async () => {
     runServer: false,
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const fileName = Object.keys(files).find(
     (file) => file.includes('moment-js') && file.endsWith('.js.map'),
@@ -67,7 +67,7 @@ test('removeMomentLocale true', async () => {
     runServer: false,
   });
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const fileName = Object.keys(files).find(
     (file) => file.includes('moment-js') && file.endsWith('.js.map'),

--- a/e2e/cases/performance/preconnect/index.test.ts
+++ b/e2e/cases/performance/preconnect/index.test.ts
@@ -6,7 +6,7 @@ test('should generate preconnect link when preconnect is defined', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('.html'),

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -7,7 +7,7 @@ const expectConsoleType = async (
   rsbuild: Awaited<ReturnType<typeof build>>,
   consoleType: Record<string, boolean>,
 ) => {
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexFile = Object.keys(files).find(
     (name) => name.includes('index.') && name.endsWith('.js'),
   )!;

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -24,7 +24,7 @@ test('should generate prefetch link when prefetch is defined', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find(
     (file) =>
@@ -65,7 +65,7 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find(
     (file) =>
@@ -102,7 +102,7 @@ test('should generate prefetch link with include', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/image'),
@@ -141,7 +141,7 @@ test('should generate prefetch link with include array', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/image'),
@@ -180,7 +180,7 @@ test('should generate prefetch link with exclude array', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/image'),
@@ -220,7 +220,7 @@ test('should generate prefetch link by config (distinguish html)', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [, content] = Object.entries(files).find(([name]) =>
     name.endsWith('page1.html'),
@@ -271,7 +271,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const [, content] = Object.entries(files).find(([name]) =>
       name.endsWith('.html'),
     )!;
@@ -309,7 +309,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const [, content] = Object.entries(files).find(([name]) =>
       name.endsWith('.html'),
     )!;

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -21,7 +21,7 @@ test('should generate preload link when preload is defined', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find(
     (file) =>
@@ -62,7 +62,7 @@ test('should generate preload link with duplicate', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const initialFileName = Object.keys(files).find(
     (file) =>
@@ -105,7 +105,7 @@ test('should generate preload link with crossOrigin', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find(
     (file) =>
@@ -146,7 +146,7 @@ test('should generate preload link without crossOrigin when same origin', async 
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find(
     (file) =>
@@ -186,7 +186,7 @@ test('should generate preload link with include', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/image'),
@@ -225,7 +225,7 @@ test('should generate preload link with include array', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const asyncFileName = Object.keys(files).find((file) =>
     file.includes('/static/image/image'),
@@ -268,7 +268,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const [, content] = Object.entries(files).find(([name]) =>
       name.endsWith('.html'),
     )!;
@@ -306,7 +306,7 @@ rspackOnlyTest(
       },
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const [, content] = Object.entries(files).find(([name]) =>
       name.endsWith('.html'),
     )!;

--- a/e2e/cases/performance/single-vendor-splitting/index.test.ts
+++ b/e2e/cases/performance/single-vendor-splitting/index.test.ts
@@ -7,7 +7,7 @@ test('should allow to use `forceSplitting` when chunkSplit is "single-vendor"', 
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const jsFiles = Object.keys(files)
     .filter((name) => name.endsWith('.js'))

--- a/e2e/cases/performance/split-chunk-all-in-one/index.test.ts
+++ b/e2e/cases/performance/split-chunk-all-in-one/index.test.ts
@@ -6,7 +6,7 @@ test('chunkSplit all-in-one', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   // expect only one bundle (end with .js)
   const filePaths = Object.keys(files).filter((file) => file.endsWith('.js'));
 

--- a/e2e/cases/performance/split-chunk-by-module/index.test.ts
+++ b/e2e/cases/performance/split-chunk-by-module/index.test.ts
@@ -19,7 +19,7 @@ test('should generate module chunks when chunkSplit is "split-by-module"', async
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [reactFile] = Object.entries(files).find(
     ([name, content]) =>

--- a/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
+++ b/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
@@ -19,7 +19,7 @@ test('should generate vendor chunk when chunkSplit is "single-vendor"', async ()
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const [vendorFile] = Object.entries(files).find(
     ([name, content]) => name.includes('vendor') && content.includes('React'),

--- a/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, getHrefByEntryName } from '@e2e/helper';
+import { buildEntryUrl, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
@@ -38,8 +38,8 @@ test('should run onBeforeStartDevServer hooks and add custom middleware', async 
     },
   });
 
-  const testUrl = getHrefByEntryName('test', rsbuild.port);
-  const test2Url = getHrefByEntryName('test2', rsbuild.port);
+  const testUrl = buildEntryUrl('test', rsbuild.port);
+  const test2Url = buildEntryUrl('test2', rsbuild.port);
 
   await page.goto(testUrl);
   await expect(page.content()).resolves.toContain('Hello, world!');

--- a/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow plugin to modify HTML tags', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexHTML = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.html'),
   );

--- a/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
@@ -11,7 +11,7 @@ rspackOnlyTest('should process assets when target is web', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.js'),
   );
@@ -28,7 +28,7 @@ rspackOnlyTest('should not process assets when target is not web', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.js'),
   );

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow plugin to process assets', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.js'),
   );

--- a/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow plugin to process assets', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.js'),
   );

--- a/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
@@ -6,7 +6,7 @@ test('should allow plugin to transform code by environments', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const webJs = Object.keys(files).find(
     (file) =>
       file.includes('index') &&

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
@@ -6,7 +6,7 @@ test('should allow plugin to transform code by targets', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const webJs = Object.keys(files).find(
     (file) =>
       file.includes('index') &&

--- a/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
@@ -8,7 +8,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const indexCss = Object.keys(files).find(
       (file) => file.includes('index') && file.endsWith('.css'),
     );

--- a/e2e/cases/plugin-api/plugin-transform/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform/index.test.ts
@@ -6,7 +6,7 @@ rspackOnlyTest('should allow plugin to transform code', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('index') && file.endsWith('.js'),
   );

--- a/e2e/cases/polyfill/basic/index.test.ts
+++ b/e2e/cases/polyfill/basic/index.test.ts
@@ -30,7 +30,7 @@ test('should add polyfill when set polyfill entry (default)', async ({
 
   await rsbuild.close();
 
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
 
   const content = getPolyfillContent(files);
 
@@ -64,7 +64,7 @@ rspackOnlyTest(
 
     await rsbuild.close();
 
-    const files = await rsbuild.unwrapOutputJSON(false);
+    const files = await rsbuild.getDistFiles(false);
 
     const content = getPolyfillContent(files);
 

--- a/e2e/cases/polyfill/browserslist/index.test.ts
+++ b/e2e/cases/polyfill/browserslist/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { build, dev, globContentJSON } from '@e2e/helper';
+import { build, dev, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { getPolyfillContent } from '../helper';
 
@@ -11,7 +11,7 @@ test('should read browserslist for development env correctly', async ({
     page,
   });
 
-  const outputs = await globContentJSON(join(__dirname, 'dist'));
+  const outputs = await readDirContents(join(__dirname, 'dist'));
   const content = getPolyfillContent(outputs);
 
   expect(content.includes('es.string.replace-all')).toBeFalsy();
@@ -24,7 +24,7 @@ test('should read browserslist for production env correctly', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(join(__dirname, 'dist'));
+  const outputs = await readDirContents(join(__dirname, 'dist'));
   const content = getPolyfillContent(outputs);
 
   expect(content.includes('es.string.replace-all')).toBeTruthy();

--- a/e2e/cases/react/split-chunk/index.test.ts
+++ b/e2e/cases/react/split-chunk/index.test.ts
@@ -10,7 +10,7 @@ test('should split react chunks correctly', async () => {
     plugins: [pluginReact()],
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('lib-react'))).toBeTruthy();
   expect(filesNames.find((file) => file.includes('lib-router'))).toBeTruthy();
@@ -29,7 +29,7 @@ test('should not split react chunks when strategy is `all-in-one`', async () => 
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('lib-react'))).toBeFalsy();
   expect(filesNames.find((file) => file.includes('lib-router'))).toBeFalsy();
@@ -55,7 +55,7 @@ test('should not override user defined cache groups', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('my-react'))).toBeTruthy();
 });

--- a/e2e/cases/sass/exclude-with-helper/index.test.ts
+++ b/e2e/cases/sass/exclude-with-helper/index.test.ts
@@ -16,7 +16,7 @@ test('exclude specified sass file with addExcludes', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
   const scssFiles = Object.keys(files).filter((file) => file.endsWith('.scss'));
 

--- a/e2e/cases/sass/exclude/index.test.ts
+++ b/e2e/cases/sass/exclude/index.test.ts
@@ -16,7 +16,7 @@ test('exclude specified sass file with exclude option', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).filter((file) => file.endsWith('.css'));
   const scssFiles = Object.keys(files).filter((file) => file.endsWith('.scss'));
 

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -202,7 +202,7 @@ test('should copy publicDir to the environment distDir when multiple environment
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(
@@ -245,7 +245,7 @@ test('should copy publicDir to the node distDir when copyOnBuild is specified as
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(
@@ -280,7 +280,7 @@ test('should copy publicDir to root dist when environment dist path has a parent
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/source/entry-description-object/index.test.ts
+++ b/e2e/cases/source/entry-description-object/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, globContentJSON } from '@e2e/helper';
+import { build, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to set entry description object', async () => {
@@ -7,7 +7,7 @@ test('should allow to set entry description object', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(

--- a/e2e/cases/source/entry-disable-html/index.test.ts
+++ b/e2e/cases/source/entry-disable-html/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, globContentJSON } from '@e2e/helper';
+import { build, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to disable HTML for specific entry', async () => {
@@ -7,7 +7,7 @@ test('should allow to disable HTML for specific entry', async () => {
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(outputFiles.find((item) => item.includes('foo.html'))).toBeTruthy();

--- a/e2e/cases/source/entry-empty-object/index.test.ts
+++ b/e2e/cases/source/entry-empty-object/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { build, globContentJSON } from '@e2e/helper';
+import { build, readDirContents } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should set default entry when entry is set to an empty object', async () => {
@@ -7,7 +7,7 @@ test('should set default entry when entry is set to an empty object', async () =
     cwd: __dirname,
   });
 
-  const outputs = await globContentJSON(path.join(__dirname, 'dist'));
+  const outputs = await readDirContents(path.join(__dirname, 'dist'));
   const outputFiles = Object.keys(outputs);
 
   expect(

--- a/e2e/cases/source/multiple-entry/index.test.ts
+++ b/e2e/cases/source/multiple-entry/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to set entry by build target', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const fileNames = Object.keys(files);
   const webIndex = fileNames.find(
     (file) => file.includes('static/js') && file.endsWith('index.js'),

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -89,7 +89,7 @@ export function shareTest(
       ...otherConfigs,
       rsbuildConfig: { ...config },
     });
-    const files = await rsbuild.unwrapOutputJSON(false);
+    const files = await rsbuild.getDistFiles(false);
     expect(files[findEntry(files)]).toContain('transformImport test succeed');
   });
 }

--- a/e2e/cases/source/plugin-import/index.test.ts
+++ b/e2e/cases/source/plugin-import/index.test.ts
@@ -23,7 +23,7 @@ test('should import with template config', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
   const entry = findEntry(files);
   expect(files[entry]).toContain('transformImport test succeed');
 });
@@ -41,7 +41,7 @@ test('should not transformImport by default', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON(false);
+  const files = await rsbuild.getDistFiles(false);
   const entry = findEntry(files);
   expect(files[entry]).toContain('test succeed');
 });

--- a/e2e/cases/sri/algotithm/index.test.ts
+++ b/e2e/cases/sri/algotithm/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const html =
       files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/sri/basic/index.test.ts
+++ b/e2e/cases/sri/basic/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const html =
       files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/sri/preload/index.test.ts
+++ b/e2e/cases/sri/preload/index.test.ts
@@ -9,7 +9,7 @@ rspackOnlyTest(
       page,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const html =
       files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 

--- a/e2e/cases/stylus/basic/index.test.ts
+++ b/e2e/cases/stylus/basic/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should compile stylus correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/stylus/environment/index.test.ts
+++ b/e2e/cases/stylus/environment/index.test.ts
@@ -7,7 +7,7 @@ rspackOnlyTest(
     const rsbuild = await build({
       cwd: __dirname,
     });
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
 
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/stylus/rem/index.test.ts
+++ b/e2e/cases/stylus/rem/index.test.ts
@@ -5,7 +5,7 @@ rspackOnlyTest('should compile stylus and rem correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.css'))!];

--- a/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-id-prefix/index.test.ts
@@ -7,7 +7,7 @@ test('should add id prefix after svgo minification', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('/index.') && file.endsWith('.js'),
   );

--- a/e2e/cases/svg/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/svg/svgo-minify-view-box/index.test.ts
@@ -9,7 +9,7 @@ test('should preserve viewBox after svgo minification', async () => {
 
   const rsbuild = await build(buildOpts);
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('/index.') && file.endsWith('.js'),
   );

--- a/e2e/cases/svg/svgr-disable-emit-asset/index.test.ts
+++ b/e2e/cases/svg/svgr-disable-emit-asset/index.test.ts
@@ -6,7 +6,7 @@ test('should import svg with SVGR plugin and query URL correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
 
   expect(

--- a/e2e/cases/svg/svgr-hash-digest/index.test.ts
+++ b/e2e/cases/svg/svgr-hash-digest/index.test.ts
@@ -10,7 +10,7 @@ test('should generate the same hash digest for the same SVG', async ({
     page,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   expect(
     Object.keys(files).filter((key) => key.endsWith('.svg')).length,

--- a/e2e/cases/tailwindcss/basic/index.test.ts
+++ b/e2e/cases/tailwindcss/basic/index.test.ts
@@ -6,7 +6,7 @@ test('should generate tailwindcss utilities correctly', async () => {
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexCssFile = Object.keys(files).find(
     (file) => file.includes('index.') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/tailwindcss/mjs/index.test.ts
+++ b/e2e/cases/tailwindcss/mjs/index.test.ts
@@ -6,7 +6,7 @@ test('should generate tailwindcss utilities with mjs config correctly', async ()
     cwd: __dirname,
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const indexCssFile = Object.keys(files).find(
     (file) => file.includes('index.') && file.endsWith('.css'),
   )!;

--- a/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
+++ b/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
@@ -8,7 +8,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await rsbuild.unwrapOutputJSON();
+    const files = await rsbuild.getDistFiles();
     const indexCssFile = Object.keys(files).find(
       (file) => file.includes('index.') && file.endsWith('.css'),
     )!;

--- a/e2e/cases/vue/split-chunks/index.test.ts
+++ b/e2e/cases/vue/split-chunks/index.test.ts
@@ -10,7 +10,7 @@ test('should split vue chunks correctly', async () => {
     plugins: [pluginVue()],
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('lib-vue'))).toBeTruthy();
   expect(filesNames.find((file) => file.includes('lib-router'))).toBeTruthy();
@@ -29,7 +29,7 @@ test('should not split vue chunks when strategy is `all-in-one`', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('lib-vue'))).toBeFalsy();
   expect(filesNames.find((file) => file.includes('lib-router'))).toBeFalsy();
@@ -55,7 +55,7 @@ test('should not override user defined cache groups', async () => {
     },
   });
 
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filesNames = Object.keys(files);
   expect(filesNames.find((file) => file.includes('my-vue'))).toBeTruthy();
 });

--- a/e2e/cases/wasm/index.test.ts
+++ b/e2e/cases/wasm/index.test.ts
@@ -8,7 +8,7 @@ test('should allow to import wasm file', async ({ page }) => {
     cwd: root,
     page,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const wasmFile = Object.keys(files).find((file) =>
     file.endsWith('.module.wasm'),
@@ -32,7 +32,7 @@ test('should allow to dynamic import wasm file', async () => {
   const rsbuild = await build({
     cwd: root,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const wasmFile = Object.keys(files).find((file) =>
     file.endsWith('.module.wasm'),
@@ -50,7 +50,7 @@ test('should allow to use new URL to get path of wasm file', async ({
     cwd: root,
     page,
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
 
   const wasmFile = Object.keys(files).find((file) =>
     file.endsWith('.module.wasm'),

--- a/e2e/cases/web-worker/web-worker-target/index.test.ts
+++ b/e2e/cases/web-worker/web-worker-target/index.test.ts
@@ -11,7 +11,7 @@ test('should build web-worker target correctly', async () => {
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
   const jsFiles = filenames.filter((item) => item.endsWith('.js'));
 
@@ -31,7 +31,7 @@ test('should build web-worker target with dynamicImport correctly', async () => 
       },
     },
   });
-  const files = await rsbuild.unwrapOutputJSON();
+  const files = await rsbuild.getDistFiles();
   const filenames = Object.keys(files);
   const jsFiles = filenames.filter((item) => item.endsWith('.js'));
 

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -49,7 +49,11 @@ const convertPath = (path: string) => {
   return path;
 };
 
-export const globContentJSON = async (path: string, options?: GlobOptions) => {
+/**
+ * Read the contents of a directory and return a map of
+ * file paths to their contents.
+ */
+export const readDirContents = async (path: string, options?: GlobOptions) => {
   const files = await glob(convertPath(join(path, '**/*')), options);
   const ret: Record<string, string> = {};
 
@@ -64,9 +68,15 @@ export const globContentJSON = async (path: string, options?: GlobOptions) => {
   return ret;
 };
 
+/**
+ * Expect a file to exist
+ */
 export const expectFile = (dir: string) =>
   expectPoll(() => fs.existsSync(dir)).toBeTruthy();
 
+/**
+ * Proxy the console methods to capture the logs
+ */
 export const proxyConsole = (
   types: ConsoleType | ConsoleType[] = ['log', 'warn', 'info', 'error'],
   keepAnsi = false,


### PR DESCRIPTION
## Summary

This pull request updates multiple E2E test cases to replace the usage of the `unwrapOutputJSON` and `globContentJSON` methods with `getDistFiles` and `readDirContents`. This change standardizes the approach for accessing build output files across the test suite.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
