### PR TITLE
fix: source map files should always be excluded from resource hints

### DIFF
--- a/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
+++ b/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
@@ -42,7 +42,6 @@ import { type ResourceType, getResourceType } from './getResourceType';
 const defaultOptions: ResourceHintsOptions = {
   type: 'async-chunks',
   dedupe: true,
-  exclude: /.map$/,
 };
 
 type LinkType = 'preload' | 'prefetch';
@@ -159,15 +158,18 @@ function generateLinks(
         );
 
   // Flatten the list of files.
-  const allFiles = htmlChunks.reduce(
-    (accumulated: string[], chunk) =>
-      accumulated.concat([
-        ...chunk.files,
-        // source map files are inside auxiliaryFiles
-        ...(chunk.auxiliaryFiles || []),
-      ]),
-    [],
-  );
+  const allFiles = htmlChunks
+    .reduce(
+      (accumulated: string[], chunk) =>
+        accumulated.concat([
+          ...chunk.files,
+          // source map files are inside auxiliaryFiles
+          ...(chunk.auxiliaryFiles || []),
+        ]),
+      [],
+    )
+    // source map files should always be excluded
+    .filter((file) => !file.endsWith('.map'));
 
   const uniqueFiles = new Set<string>(allFiles);
   const filteredFiles = applyFilter(

--- a/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
+++ b/packages/core/src/rspack/resource-hints/HtmlResourceHintsPlugin.ts
@@ -163,7 +163,7 @@ function generateLinks(
       (accumulated: string[], chunk) =>
         accumulated.concat([
           ...chunk.files,
-          // source map files are inside auxiliaryFiles
+          // related assets are inside auxiliaryFiles
           ...(chunk.auxiliaryFiles || []),
         ]),
       [],

--- a/website/docs/en/config/performance/prefetch.mdx
+++ b/website/docs/en/config/performance/prefetch.mdx
@@ -185,6 +185,6 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `/.map$/`
+- **Default:** `undefined`
 
 A extra filter to determine which resources to exclude, the usage is similar to `include`.

--- a/website/docs/en/config/performance/preload.mdx
+++ b/website/docs/en/config/performance/preload.mdx
@@ -185,7 +185,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **Default:** `/.map$/`
+- **Default:** `undefined`
 
 A extra filter to determine which resources to exclude, the usage is similar to `include`.
 

--- a/website/docs/zh/config/performance/prefetch.mdx
+++ b/website/docs/zh/config/performance/prefetch.mdx
@@ -185,6 +185,6 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `/.map$/`
+- **默认值：** `undefined`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。

--- a/website/docs/zh/config/performance/preload.mdx
+++ b/website/docs/zh/config/performance/preload.mdx
@@ -185,7 +185,7 @@ type ResourceHintsFilter =
   | Array<string | RegExp | ((filename: string) => boolean)>;
 ```
 
-- **默认值：** `/.map$/`
+- **默认值：** `undefined`
 
 一个额外的过滤器，用于指定哪些资源会被排除，用法与 `include` 类似。
 


### PR DESCRIPTION
## Summary

When using `performance.prefetch` or `performance.preload`, the source map files should always be excluded, regardless of whether the user has configured a custom exclude option.

## Related Links

Fix Modern.js E2E cases: https://github.com/web-infra-dev/modern.js/actions/runs/14632877492/job/41058294609

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
