### PR TITLE
fix: call `compiler.close` when having errors

### DIFF
--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -53,24 +53,21 @@ export const build = async (
     stats?: Rspack.Stats | Rspack.MultiStats;
   }>((resolve, reject) => {
     compiler.run((err, stats) => {
-      if (err) {
-        reject(err);
-      } else if (stats?.hasErrors()) {
-        reject(new Error(RSPACK_BUILD_ERROR));
-      }
-      // If there is a compilation error, the close method should not be called.
-      // Otherwise the bundler may generate an invalid cache.
-      else {
-        // When using run or watch, call close and wait for it to finish before calling run or watch again.
-        // Concurrent compilations will corrupt the output files.
-        compiler.close((closeErr) => {
-          if (closeErr) {
-            logger.error(closeErr);
-          }
+      // When using run or watch, call close and wait for it to finish before calling run or watch again.
+      // Concurrent compilations will corrupt the output files.
+      compiler.close((closeErr) => {
+        if (closeErr) {
+          logger.error('Failed to close compiler: ', closeErr);
+        }
 
+        if (err) {
+          reject(err);
+        } else if (stats?.hasErrors()) {
+          reject(new Error(RSPACK_BUILD_ERROR));
+        } else {
           resolve({ stats });
-        });
-      }
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Persistent cache of Rspack is implemented in Rust and we should always call `compiler.close` after building.

## Related Links

The same as https://github.com/web-infra-dev/rspack/pull/10154

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
