### PR TITLE
fix(security): update http-proxy-middleware to 2.0.9

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,7 @@
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
     "html-rspack-plugin": "6.0.5",
-    "http-proxy-middleware": "^2.0.7",
+    "http-proxy-middleware": "^2.0.9",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",
     "on-finished": "2.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -676,8 +676,8 @@ importers:
         specifier: 6.0.5
         version: 6.0.5(@rspack/core@1.3.6(@swc/helpers@0.5.17))
       http-proxy-middleware:
-        specifier: ^2.0.7
-        version: 2.0.7
+        specifier: ^2.0.9
+        version: 2.0.9
       launch-editor-middleware:
         specifier: ^2.10.0
         version: 2.10.0
@@ -4630,8 +4630,8 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
-  http-proxy-middleware@2.0.7:
-    resolution: {integrity: sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==}
+  http-proxy-middleware@2.0.9:
+    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
       '@types/express': ^4.17.13
@@ -10955,7 +10955,7 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
-  http-proxy-middleware@2.0.7:
+  http-proxy-middleware@2.0.9:
     dependencies:
       '@types/http-proxy': 1.17.16
       http-proxy: 1.18.1(patch_hash=424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723)


### PR DESCRIPTION
## Summary
In http-proxy-middleware before 2.0.8 and 3.x before 3.0.4, writeBody can be called twice because "else if" is not used.

## Related Links
https://nvd.nist.gov/vuln/detail/CVE-2025-32996

## Checklist

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
