### PR TITLE
fix: prevent circular references in recursiveChunkGroup

### DIFF
--- a/packages/core/src/rspack/resource-hints/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack/resource-hints/doesChunkBelongToHtml.ts
@@ -29,13 +29,23 @@ interface DoesChunkBelongToHtmlOptions {
 
 function recursiveChunkGroup(
   chunkGroup: ChunkGroup,
+  visited = new Set<ChunkGroup>(),
 ): Array<string | undefined> {
+  // check if the chunkGroup has been visited to prevent circular reference
+  if (visited.has(chunkGroup)) {
+    return [];
+  }
+  visited.add(chunkGroup);
+
   const parents = chunkGroup.getParents();
   if (!parents.length) {
     // EntryPoint
     return [chunkGroup.name];
   }
-  return parents.flatMap((chunkParent) => recursiveChunkGroup(chunkParent));
+
+  return parents.flatMap((chunkParent) =>
+    recursiveChunkGroup(chunkParent, visited),
+  );
 }
 
 export function recursiveChunkEntryNames(chunk: Chunk): string[] {


### PR DESCRIPTION
## Summary

Updates the `recursiveChunkGroup` function to prevent circular references when traversing chunk groups. The change introduces a `visited` set to track visited `ChunkGroup` instances.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/5106

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
