### PR TITLE
feat: improve alignment of total output size

### DIFF
--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -30,7 +30,6 @@ test.describe('should print file size correctly', async () => {
 
     expect(logs.some((log) => log.includes('index.html'))).toBeTruthy();
     expect(logs.some((log) => log.includes('Total:'))).toBeTruthy();
-    expect(logs.some((log) => log.includes('gzip:'))).toBeTruthy();
   });
 
   test('should print size of multiple environments correctly', async () => {
@@ -97,10 +96,6 @@ test.describe('should print file size correctly', async () => {
     expect(
       logs.some((log) => log.includes('Total:') && log.includes('kB')),
     ).toBeTruthy();
-
-    expect(
-      logs.some((log) => log.includes('gzip:') && log.includes('kB')),
-    ).toBeTruthy();
   });
 
   test('printFileSize: false should not print logs', async () => {
@@ -115,7 +110,6 @@ test.describe('should print file size correctly', async () => {
 
     expect(logs.some((log) => log.includes('index.html'))).toBeFalsy();
     expect(logs.some((log) => log.includes('Total:'))).toBeFalsy();
-    expect(logs.some((log) => log.includes('gzip:'))).toBeFalsy();
   });
 
   test('printFileSize.detail: false should work', async () => {
@@ -132,7 +126,6 @@ test.describe('should print file size correctly', async () => {
 
     expect(logs.some((log) => log.includes('index.html'))).toBeFalsy();
     expect(logs.some((log) => log.includes('Total:'))).toBeTruthy();
-    expect(logs.some((log) => log.includes('gzip:'))).toBeTruthy();
   });
 
   test('printFileSize.total: false should work', async () => {
@@ -149,7 +142,6 @@ test.describe('should print file size correctly', async () => {
 
     expect(logs.some((log) => log.includes('index.html'))).toBeTruthy();
     expect(logs.some((log) => log.includes('Total:'))).toBeFalsy();
-    expect(logs.some((log) => log.includes('gzip:'))).toBeFalsy();
   });
 
   test('should print dist folder correctly if it is not a subdir of root', async () => {
@@ -188,7 +180,6 @@ test.describe('should print file size correctly', async () => {
 
     expect(logs.some((log) => log.includes('index.html'))).toBeTruthy();
     expect(logs.some((log) => log.includes('Total:'))).toBeTruthy();
-    expect(logs.some((log) => log.includes('gzip:'))).toBeFalsy();
   });
 
   test('should allow to filter assets by name', async () => {

--- a/e2e/cases/print-file-size/with-error/index.test.ts
+++ b/e2e/cases/print-file-size/with-error/index.test.ts
@@ -20,7 +20,5 @@ test('should not print file size if has errors', async () => {
   }
 
   expect(logs.some((log) => log.includes('Total:'))).toBeFalsy();
-  expect(logs.some((log) => log.includes('gzip:'))).toBeFalsy();
-
   restore();
 });

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -28,7 +28,7 @@ The default output log is as follows:
   dist/index.html                         0.39 kB     0.25 kB
   dist/static/css/index.2960ac62.css      0.35 kB     0.26 kB
 
-  Total: 143.0 kB (gzip: 46.3 kB)
+                                 Total:   143.0 kB    46.3 kB
 ```
 
 ## Disable outputs

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -28,7 +28,7 @@ type PrintFileSizeOptions =
   dist/index.html                         0.39 kB     0.25 kB
   dist/static/css/index.2960ac62.css      0.35 kB     0.26 kB
 
-  Total: 143.0 kB (gzip: 46.3 kB)
+                                 Total:   143.0 kB    46.3 kB
 ```
 
 ## 禁用输出


### PR DESCRIPTION
## Summary

Improve the alignment of total output size.

### Before

<img width="681" src="https://github.com/user-attachments/assets/7877686d-eaf4-418d-8753-c52b8b2d95b2" />

### After

<img width="710"  src="https://github.com/user-attachments/assets/44b3e88d-8323-4bd0-bbaf-6cade2807d6a" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
