### PR TITLE
docs(environments): add note on server and dev options limitations

### DIFF
--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -30,6 +30,10 @@ type Environments = {
 
 - **Default:** `undefined`
 
+:::tip
+`environments` does not support configuring `server` options and some `dev` options, because multiple environments share the same server instance.
+:::
+
 ## Example
 
 Configure Rsbuild configuration for `web` (client) and `node` (SSR) environments:

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -30,6 +30,10 @@ type Environments = {
 
 - **默认值：** `undefined`
 
+:::tip
+`environments` 中不支持配置 `server` 选项以及一部分 `dev` 选项，因为多个 environment 共享同一个 server 实例。
+:::
+
 ## 示例
 
 分别为 `web` (client) 和 `node` (SSR) 环境配置 Rsbuild：


### PR DESCRIPTION
## Summary

Add note on server and dev options limitations when using the `environments` configuration.

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/5111

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
