### PR TITLE
fix: remove logging.json from profiling results

### DIFF
--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -82,7 +82,6 @@ rspackOnlyTest(
     expect(
       fs.existsSync(path.join(profileDir!, 'jscpuprofile.json')),
     ).toBeTruthy();
-    expect(fs.existsSync(path.join(profileDir!, 'logging.json'))).toBeTruthy();
 
     buildProcess.kill();
   },

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -32,7 +32,7 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
 
     /**
      * RSPACK_PROFILE=ALL
-     * RSPACK_PROFILE=TRACE|CPU|LOGGING
+     * RSPACK_PROFILE=TRACE|CPU
      */
     const RSPACK_PROFILE = process.env.RSPACK_PROFILE?.toUpperCase();
 
@@ -50,9 +50,6 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
 
     const enableCPUProfile =
       RSPACK_PROFILE === 'ALL' || RSPACK_PROFILE.includes('CPU');
-
-    const enableLogging =
-      RSPACK_PROFILE === 'ALL' || RSPACK_PROFILE.includes('LOGGING');
 
     const onStart = async () => {
       // Note: Cannot obtain accurate `api.context.distPath` before config initialization
@@ -86,23 +83,6 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
       }
     });
     api.onBeforeStartDevServer(onStart);
-
-    api.onAfterBuild(async ({ stats }) => {
-      const loggingFilePath = path.join(
-        api.context.distPath,
-        profileDirName,
-        'logging.json',
-      );
-
-      if (enableLogging && stats) {
-        const logging = stats.toJson({
-          all: false,
-          logging: 'verbose',
-          loggingTrace: true,
-        });
-        await fs.promises.writeFile(loggingFilePath, JSON.stringify(logging));
-      }
-    });
 
     api.onExit(() => {
       if (enableProfileTrace) {

--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -62,11 +62,10 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 }
 ```
 
-When the build command is finished, or the dev server is shutdown, Rsbuild will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `logging.json`, `trace.json` and `jscpuprofile.json` files:
+When the build command is finished, or the dev server is shutdown, Rsbuild will generate a `rspack-profile-${timestamp}` folder in the dist folder, and it will contain `trace.json` and `jscpuprofile.json` files:
 
 - `trace.json`: The time spent on each phase of the Rust side is recorded at a granular level using tracing and can be viewed using [ui.perfetto.dev](https://ui.perfetto.dev/).
 - `jscpuprofile.json`: The time spent at each stage on the JavaScript side is recorded at a granular level using [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) and can be viewed using [speedscope.app](https://www.speedscope.app/).
-- `logging.json`: Includes some logging information that keeps a coarse-grained record of how long each phase of the build took. (Not supported in development mode yet)
 
 :::tip
 For more information about Rspack build profiling, refer to [Rspack - Profiling](https://rspack.dev/contribute/development/profiling).

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -62,11 +62,10 @@ Rsbuild 支持使用 `RSPACK_PROFILE` 环境变量来对 Rspack 进行构建性�
 }
 ```
 
-当 build 命令执行完成，或是 dev server 被关闭时，Rsbuild 会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `logging.json`、`trace.json` 和 `jscpuprofile.json` 三个文件：
+当 build 命令执行完成，或是 dev server 被关闭时，Rsbuild 会在产物目录下生成一个 `rspack-profile-${timestamp}` 文件夹，该文件夹下会包含 `trace.json` 和 `jscpuprofile.json` 文件：
 
 - `trace.json`：使用 tracing 细粒度地记录了 Rust 侧各个阶段的耗时，可以使用 [ui.perfetto.dev](https://ui.perfetto.dev/) 进行查看。
 - `jscpuprofile.json`：使用 [Node.js inspector](https://nodejs.org/dist/latest-v18.x/docs/api/inspector.html) 细粒度地记录了 JavaScript 侧的各个阶段的耗时，可以使用 [speedscope.app](https://www.speedscope.app/) 进行查看。
-- `logging.json`：包含一些日志信息，粗粒度地记录了构建的各个阶段耗时（开发模式下暂不支持）。
 
 :::tip
 关于 Rspack 构建性能分析的更多用法，可参考 [Rspack - Profiling](https://rspack.dev/contribute/development/profiling)。


### PR DESCRIPTION
## Summary

Remove the logging.json file from profiling results, it is no longer required with Rspack's new tracing implementation, see https://rspack.dev/contribute/development/tracing

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
