### PR TITLE
test(e2e): remove Windows-specific skip from Rsdoctor plugin test

### DIFF
--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -1,5 +1,5 @@
 import { proxyConsole, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import { type Rspack, createRsbuild } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { matchPlugin } from '@scripts/test-helper';
@@ -7,11 +7,6 @@ import { matchPlugin } from '@scripts/test-helper';
 rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
   async () => {
-    // https://github.com/microsoft/playwright/issues/31140
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const { logs, restore } = proxyConsole();
     process.env.RSDOCTOR = 'true';
 


### PR DESCRIPTION
## Summary

Remove Windows-specific skip from Rsdoctor plugin test as we have updated playwright to latest version.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/4331

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
