### PR TITLE
feat: allow to access manifest data in plugin hooks

### DIFF
--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -1,0 +1,120 @@
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import type { RsbuildPluginAPI } from '@rsbuild/core';
+
+const fixtures = __dirname;
+
+test('should allow to access manifest data in environment context after prod build', async () => {
+  let webManifest: Record<string, any> = {};
+  let nodeManifest: Record<string, any> = {};
+
+  await build({
+    cwd: fixtures,
+    rsbuildConfig: {
+      output: {
+        manifest: true,
+        filenameHash: false,
+      },
+      environments: {
+        web: {},
+        node: {
+          output: {
+            target: 'node',
+          },
+        },
+      },
+      plugins: [
+        {
+          name: 'test',
+          setup(api: RsbuildPluginAPI) {
+            api.onAfterBuild(({ environments }) => {
+              if (environments.web.manifest) {
+                webManifest = environments.web.manifest;
+              }
+              if (environments.node.manifest) {
+                nodeManifest = environments.node.manifest;
+              }
+            });
+          },
+        },
+      ],
+    },
+  });
+
+  // main.js, index.html
+  expect(Object.keys(webManifest.allFiles).length).toBe(2);
+  expect(webManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/static/js/index.js'],
+    },
+    html: ['/index.html'],
+  });
+
+  // main.js
+  expect(Object.keys(nodeManifest.allFiles).length).toBe(1);
+  expect(nodeManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/index.js'],
+    },
+  });
+});
+
+test('should allow to access manifest data in environment context after dev build', async ({
+  page,
+}) => {
+  let webManifest: Record<string, any> = {};
+  let nodeManifest: Record<string, any> = {};
+
+  const rsbuild = await dev({
+    cwd: fixtures,
+    page,
+    rsbuildConfig: {
+      output: {
+        manifest: true,
+        filenameHash: false,
+      },
+      environments: {
+        web: {},
+        node: {
+          output: {
+            target: 'node',
+          },
+        },
+      },
+      plugins: [
+        {
+          name: 'test',
+          setup(api: RsbuildPluginAPI) {
+            api.onDevCompileDone(({ environments }) => {
+              if (environments.web.manifest) {
+                webManifest = environments.web.manifest;
+              }
+              if (environments.node.manifest) {
+                nodeManifest = environments.node.manifest;
+              }
+            });
+          },
+        },
+      ],
+    },
+  });
+
+  // main.js, main.js.map, index.html
+  expect(Object.keys(webManifest.allFiles).length).toBe(3);
+  expect(webManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/static/js/index.js'],
+    },
+    html: ['/index.html'],
+  });
+
+  // main.js, main.js.map
+  expect(Object.keys(nodeManifest.allFiles).length).toBe(2);
+  expect(nodeManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/index.js'],
+    },
+  });
+
+  await rsbuild.close();
+});

--- a/e2e/cases/output/manifest-environment/src/index.ts
+++ b/e2e/cases/output/manifest-environment/src/index.ts
@@ -1,0 +1,1 @@
+console.log('hello!');

--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -30,7 +30,7 @@ test('should generate manifest file in output', async () => {
 
   const manifest = JSON.parse(manifestContent);
 
-  // main.js、index.html
+  // main.js, index.html
   expect(Object.keys(manifest.allFiles).length).toBe(2);
 
   expect(manifest.entries.index).toMatchObject({
@@ -63,7 +63,7 @@ test('should generate manifest file at specified path', async () => {
 
   const parsed = JSON.parse(manifestContent);
 
-  // main.js、index.html
+  // main.js, index.html
   expect(Object.keys(parsed.allFiles).length).toBe(2);
 });
 
@@ -91,7 +91,7 @@ test('should generate manifest file when target is node', async () => {
 
   const manifest = JSON.parse(manifestContent);
 
-  // main.js、index.html
+  // main.js, index.html
   expect(Object.keys(manifest.allFiles).length).toBe(1);
 
   expect(manifest.entries.index).toMatchObject({

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -34,7 +34,7 @@ test('should generate prefetch link when prefetch is defined', async () => {
     name.endsWith('.html'),
   )!;
 
-  // test.js、test.css、image.png
+  // test.js, test.css, image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(3);
 
   expect(
@@ -226,7 +226,7 @@ test('should generate prefetch link by config (distinguish html)', async () => {
     name.endsWith('page1.html'),
   )!;
 
-  // icon.png、test.js、test.css、image.png
+  // icon.png、test.js, test.css, image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(4);
 
   const assetFileName = Object.keys(files).find((file) =>
@@ -245,7 +245,7 @@ test('should generate prefetch link by config (distinguish html)', async () => {
     name.endsWith('page2.html'),
   )!;
 
-  // test.js、test.css、image.png
+  // test.js, test.css, image.png
   expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
 });
 

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -31,7 +31,7 @@ test('should generate preload link when preload is defined', async () => {
     name.endsWith('.html'),
   )!;
 
-  // test.js、test.css、image.png
+  // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
 
   expect(
@@ -115,7 +115,7 @@ test('should generate preload link with crossOrigin', async () => {
     name.endsWith('.html'),
   )!;
 
-  // test.js、test.css、image.png
+  // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
 
   expect(
@@ -156,7 +156,7 @@ test('should generate preload link without crossOrigin when same origin', async 
     name.endsWith('.html'),
   )!;
 
-  // test.js、test.css、image.png
+  // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
 
   expect(

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -110,7 +110,7 @@ export async function updateEnvironmentContext(
     const entry = config.source.entry ?? {};
     const htmlPaths = getEnvironmentHTMLPaths(entry, config);
 
-    const environmentContext = {
+    const environmentContext: EnvironmentContext = {
       index,
       name,
       distPath: getAbsoluteDistPath(context.rootPath, config),
@@ -126,10 +126,14 @@ export async function updateEnvironmentContext(
       get(target, prop: keyof EnvironmentContext) {
         return target[prop];
       },
-      set(_, prop: keyof EnvironmentContext) {
-        logger.error(
-          `EnvironmentContext is readonly, you can not assign to the "environment.${prop}" prop.`,
-        );
+      set(target, prop: keyof EnvironmentContext, newValue) {
+        if (prop === 'manifest') {
+          target[prop] = newValue;
+        } else {
+          logger.error(
+            `EnvironmentContext is readonly, you can not assign to the "environment.${prop}" prop.`,
+          );
+        }
         return true;
       },
     });

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -2,6 +2,7 @@ import type { FileDescriptor } from '../../compiled/rspack-manifest-plugin';
 import { isObject } from '../helpers';
 import { recursiveChunkEntryNames } from '../rspack/resource-hints/doesChunkBelongToHtml';
 import type {
+  EnvironmentContext,
   ManifestByEntry,
   ManifestConfig,
   ManifestData,
@@ -10,7 +11,11 @@ import type {
 } from '../types';
 
 const generateManifest =
-  (htmlPaths: Record<string, string>, manifestOptions: ManifestObjectConfig) =>
+  (
+    htmlPaths: Record<string, string>,
+    manifestOptions: ManifestObjectConfig,
+    environment: EnvironmentContext,
+  ) =>
   (_seed: Record<string, any>, files: FileDescriptor[]) => {
     const chunkEntries = new Map<string, FileDescriptor[]>();
 
@@ -122,6 +127,7 @@ const generateManifest =
       });
 
       if (isObject(generatedManifest)) {
+        environment.manifest = generatedManifest;
         return generatedManifest;
       }
 
@@ -130,6 +136,7 @@ const generateManifest =
       );
     }
 
+    environment.manifest = manifestData;
     return manifestData;
   };
 
@@ -187,7 +194,7 @@ export const pluginManifest = (): RsbuildPlugin => ({
           fileName: manifestOptions.filename,
           filter,
           writeToFileEmit: isDev && writeToDisk !== true,
-          generate: generateManifest(htmlPaths, manifestOptions),
+          generate: generateManifest(htmlPaths, manifestOptions, environment),
         },
       ]);
     });

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -1,5 +1,5 @@
 import type { rspack } from '@rspack/core';
-import type { ChainIdentifier } from '..';
+import type { ChainIdentifier, ManifestData } from '..';
 import type RspackChain from '../../compiled/rspack-chain';
 import type { RsbuildDevServer } from '../server/devServer';
 import type {
@@ -199,6 +199,13 @@ export type EnvironmentContext = {
    * The normalized Rsbuild config for the current environment.
    */
   config: NormalizedEnvironmentConfig;
+  /**
+   * Manifest data. Only available when:
+   * - The `output.manifest` config option is enabled
+   * - The build process has completed, accessible in hooks like `onAfterBuild`,
+   * `onDevCompileDone` and `onAfterEnvironmentCompile`
+   */
+  manifest?: Record<string, unknown> | ManifestData;
 };
 
 export type ModifyChainUtils = {


### PR DESCRIPTION
## Summary

Add a new `manifest` property to the environment context object to allow plugin hooks to access manifest data.

Only available when:

- The `output.manifest` config option is enabled
- The build process has completed, accessible in hooks like `onAfterBuild`, `onDevCompileDone` and `onAfterEnvironmentCompile`

```js
const plugin = {
  name: 'test',
  setup(api: RsbuildPluginAPI) {
    api.onAfterBuild(({ environments }) => {
      console.log(environments.web.manifest);
      console.log(environments.node.manifest);
    });
  },
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
