### PR TITLE
feat: add new `modifyHTML` hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
@@ -23,6 +23,10 @@ const createPlugin = () => {
       api.modifyBundlerChain((_chain, { environment }) => {
         names.push(`ModifyBundlerChain ${environment.name}`);
       });
+      api.modifyHTML((html, { environment }) => {
+        names.push(`ModifyHTML ${environment.name}`);
+        return html;
+      });
       api.modifyHTMLTags((tags, { environment }) => {
         names.push(`ModifyHTMLTags ${environment.name}`);
         return tags;
@@ -108,6 +112,7 @@ rspackOnlyTest(
       'BeforeBuild',
       'BeforeEnvironmentCompile web',
       'ModifyHTMLTags web',
+      'ModifyHTML web',
       'AfterEnvironmentCompile web',
       'AfterBuild',
     ]);
@@ -122,6 +127,7 @@ rspackOnlyTest(
       'BeforeBuild',
       'BeforeEnvironmentCompile node',
       'ModifyHTMLTags node',
+      'ModifyHTML node',
       'AfterEnvironmentCompile node',
       'AfterBuild',
     ]);
@@ -185,6 +191,7 @@ rspackOnlyTest(
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile web',
       'ModifyHTMLTags web',
+      'ModifyHTML web',
       'AfterEnvironmentCompile web',
       'OnDevCompileDone',
       'OnCloseDevServer',
@@ -204,6 +211,7 @@ rspackOnlyTest(
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile node',
       'ModifyHTMLTags node',
+      'ModifyHTML node',
       'AfterEnvironmentCompile node',
       'OnDevCompileDone',
       'OnCloseDevServer',

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -23,6 +23,10 @@ const createPlugin = () => {
       api.modifyBundlerChain(() => {
         names.push('ModifyBundlerChain');
       });
+      api.modifyHTML((html) => {
+        names.push('ModifyHTML');
+        return html;
+      });
       api.modifyHTMLTags((tags) => {
         names.push('ModifyHTMLTags');
         return tags;
@@ -110,10 +114,12 @@ rspackOnlyTest(
       'AfterCreateCompiler',
       'BeforeBuild',
       'ModifyHTMLTags',
+      'ModifyHTML',
       'AfterBuild',
       // below hooks should called when rebuild
       'BeforeBuild',
       'ModifyHTMLTags',
+      'ModifyHTML',
       'AfterBuild',
     ]);
 

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -23,6 +23,10 @@ const createPlugin = () => {
       api.modifyBundlerChain(() => {
         names.push('ModifyBundlerChain');
       });
+      api.modifyHTML((html) => {
+        names.push('ModifyHTML');
+        return html;
+      });
       api.modifyHTMLTags((tags) => {
         names.push('ModifyHTMLTags');
         return tags;
@@ -100,6 +104,7 @@ rspackOnlyTest(
       'BeforeBuild',
       'BeforeEnvironmentCompile',
       'ModifyHTMLTags',
+      'ModifyHTML',
       'AfterEnvironmentCompile',
       'AfterBuild',
       'OnCloseBuild',
@@ -136,6 +141,7 @@ rspackOnlyTest(
       'BeforeBuild',
       'BeforeEnvironmentCompile',
       'ModifyHTMLTags',
+      'ModifyHTML',
       'AfterEnvironmentCompile',
       'AfterBuild',
       'OnCloseBuild',
@@ -183,6 +189,7 @@ rspackOnlyTest(
       'AfterCreateCompiler',
       'BeforeEnvironmentCompile',
       'ModifyHTMLTags',
+      'ModifyHTML',
       'AfterEnvironmentCompile',
       'OnDevCompileDone',
       'OnCloseDevServer',

--- a/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
@@ -1,0 +1,75 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+rspackOnlyTest('should allow plugin to modify HTML content', async () => {
+  const myPlugin: RsbuildPlugin = {
+    name: 'my-plugin',
+    setup(api) {
+      api.modifyHTML((html, { compilation, filename }) => {
+        return html.replace(
+          '<body>',
+          `<body>
+            <div>${filename}</div>
+            <div>assets: ${Object.keys(compilation.assets).length}</div>
+            `,
+        );
+      });
+    },
+  };
+
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      plugins: [myPlugin],
+    },
+  });
+
+  const files = await rsbuild.getDistFiles();
+  const indexHTML = Object.keys(files).find(
+    (file) => file.includes('index') && file.endsWith('.html'),
+  );
+
+  const html = files[indexHTML!];
+
+  expect(html.includes('<div>index.html</div>')).toBeTruthy();
+  expect(html.includes('<div>assets: 2</div>')).toBeTruthy();
+});
+
+rspackOnlyTest(
+  'should run modifyHTML hook after modifyHTMLTags hook',
+  async () => {
+    const myPlugin: RsbuildPlugin = {
+      name: 'my-plugin',
+      setup(api) {
+        api.modifyHTMLTags((tags) => {
+          tags.bodyTags.push({
+            tag: 'div',
+            children: 'foo',
+          });
+          return tags;
+        });
+        api.modifyHTML((html) => {
+          return html.replace('foo', 'bar');
+        });
+      },
+    };
+
+    const rsbuild = await build({
+      cwd: __dirname,
+      rsbuildConfig: {
+        plugins: [myPlugin],
+      },
+    });
+
+    const files = await rsbuild.getDistFiles();
+    const indexHTML = Object.keys(files).find(
+      (file) => file.includes('index') && file.endsWith('.html'),
+    );
+
+    const html = files[indexHTML!];
+
+    expect(html.includes('foo')).toBeFalsy();
+    expect(html.includes('bar')).toBeTruthy();
+  },
+);

--- a/e2e/cases/plugin-api/plugin-modify-html/src/index.css
+++ b/e2e/cases/plugin-api/plugin-modify-html/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/plugin-api/plugin-modify-html/src/index.js
+++ b/e2e/cases/plugin-api/plugin-modify-html/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+console.log('hello');

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -365,8 +365,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "version": 5,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -818,8 +818,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
       "version": 5,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -83,13 +83,7 @@ async function applyDefaultPlugins(
     // cleanOutput plugin should before the html plugin
     pluginCleanOutput(),
     pluginAsset(),
-    pluginHtml((environment: string) => async (...args) => {
-      const result = await context.hooks.modifyHTMLTags.callChain({
-        environment,
-        args,
-      });
-      return result[0];
-    }),
+    pluginHtml(context),
     pluginAppIcon(),
     pluginWasm(),
     pluginMoment(),

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -8,6 +8,7 @@ import type {
   InternalContext,
   ModifyBundlerChainFn,
   ModifyEnvironmentConfigFn,
+  ModifyHTMLFn,
   ModifyHTMLTagsFn,
   ModifyRsbuildConfigFn,
   ModifyRspackConfigFn,
@@ -203,6 +204,7 @@ export function initHooks(): {
   onAfterCreateCompiler: AsyncHook<OnAfterCreateCompilerFn>;
   onBeforeCreateCompiler: AsyncHook<OnBeforeCreateCompilerFn>;
   /**  The following hooks are related to the environment */
+  modifyHTML: EnvironmentAsyncHook<ModifyHTMLFn>;
   modifyHTMLTags: EnvironmentAsyncHook<ModifyHTMLTagsFn>;
   modifyRspackConfig: EnvironmentAsyncHook<ModifyRspackConfigFn>;
   modifyBundlerChain: EnvironmentAsyncHook<ModifyBundlerChainFn>;
@@ -226,6 +228,7 @@ export function initHooks(): {
     onBeforeStartProdServer: createAsyncHook<OnBeforeStartProdServerFn>(),
     onAfterCreateCompiler: createAsyncHook<OnAfterCreateCompilerFn>(),
     onBeforeCreateCompiler: createAsyncHook<OnBeforeCreateCompilerFn>(),
+    modifyHTML: createEnvironmentAsyncHook<ModifyHTMLFn>(),
     modifyHTMLTags: createEnvironmentAsyncHook<ModifyHTMLTagsFn>(),
     modifyRspackConfig: createEnvironmentAsyncHook<ModifyRspackConfigFn>(),
     modifyBundlerChain: createEnvironmentAsyncHook<ModifyBundlerChainFn>(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,8 @@ export type {
   ModifyChainUtils,
   ModifyEnvironmentConfigFn,
   ModifyEnvironmentConfigUtils,
+  ModifyHTMLContext,
+  ModifyHTMLFn,
   ModifyHTMLTagsContext,
   ModifyHTMLTagsFn,
   ModifyRsbuildConfigUtils,

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -357,6 +357,11 @@ export function initPluginAPI({
     onAfterStartProdServer: hooks.onAfterStartProdServer.tap,
     onBeforeStartProdServer: hooks.onBeforeStartProdServer.tap,
     modifyRsbuildConfig: hooks.modifyRsbuildConfig.tap,
+    modifyHTML: (handler) =>
+      hooks.modifyHTML.tapEnvironment({
+        environment,
+        handler,
+      }),
     modifyHTMLTags: (handler) =>
       hooks.modifyHTMLTags.tapEnvironment({
         environment,

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -20,7 +20,7 @@ import {
 import type {
   HtmlConfig,
   HtmlRspackPlugin,
-  ModifyHTMLTagsFn,
+  InternalContext,
   NormalizedEnvironmentConfig,
   RsbuildPlugin,
 } from '../types';
@@ -212,9 +212,7 @@ const getTagConfig = (
   };
 };
 
-export const pluginHtml = (
-  modifyTagsFn?: (environment: string) => ModifyHTMLTagsFn,
-): RsbuildPlugin => ({
+export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
   name: 'rsbuild:html',
 
   setup(api) {
@@ -327,7 +325,7 @@ export const pluginHtml = (
           .use(RsbuildHtmlPlugin, [
             htmlInfoMap,
             () => environment,
-            modifyTagsFn?.(environment.name),
+            () => context,
           ]);
 
         if (config.html) {

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -103,12 +103,7 @@ export type OnAfterCreateCompilerFn<
 
 export type OnExitFn = (context: { exitCode: number }) => void;
 
-type HTMLTags = {
-  headTags: HtmlBasicTag[];
-  bodyTags: HtmlBasicTag[];
-};
-
-export type ModifyHTMLTagsContext = {
+export type ModifyHTMLContext = {
   /**
    * The Compilation object of Rspack.
    */
@@ -118,11 +113,6 @@ export type ModifyHTMLTagsContext = {
    */
   compiler: Rspack.Compiler;
   /**
-   * URL prefix of assets.
-   * @example 'https://example.com/'
-   */
-  assetPrefix: string;
-  /**
    * The name of the HTML file, relative to the dist directory.
    * @example 'index.html'
    */
@@ -131,6 +121,27 @@ export type ModifyHTMLTagsContext = {
    * The environment context for current build.
    */
   environment: EnvironmentContext;
+};
+
+export type ModifyHTMLFn = (
+  html: string,
+  context: ModifyHTMLContext,
+) => MaybePromise<string>;
+
+type HTMLTags = {
+  headTags: HtmlBasicTag[];
+  bodyTags: HtmlBasicTag[];
+};
+
+export type ModifyHTMLTagsContext = Pick<
+  ModifyHTMLContext,
+  'compilation' | 'compiler' | 'filename' | 'environment'
+> & {
+  /**
+   * URL prefix of assets.
+   * @example 'https://example.com/'
+   */
+  assetPrefix: string;
 };
 
 export type ModifyHTMLTagsFn = (

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -19,6 +19,7 @@ import type {
   ModifyBundlerChainFn,
   ModifyChainUtils,
   ModifyEnvironmentConfigFn,
+  ModifyHTMLFn,
   ModifyHTMLTagsFn,
   ModifyRsbuildConfigFn,
   OnAfterBuildFn,
@@ -509,7 +510,15 @@ export type RsbuildPluginAPI = Readonly<{
    */
   modifyEnvironmentConfig: PluginHook<ModifyEnvironmentConfigFn>;
   /**
+   * Modify the final HTML content. The hook receives a context object that
+   * contains the HTML content, and you can return a new HTML string to
+   * replace the original one.
+   * This hook is triggered after the `modifyHTMLTags` hook.
+   */
+  modifyHTML: PluginHook<ModifyHTMLFn>;
+  /**
    * Modify the tags that are injected into the HTML.
+   * This hook is triggered before the `modifyHTML` hook.
    */
   modifyHTMLTags: PluginHook<ModifyHTMLTagsFn>;
   /**

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -417,8 +417,8 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -417,8 +417,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -926,8 +926,8 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -1829,8 +1829,8 @@ exports[`tools.rspack > should match snapshot 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": [Function],
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {

--- a/packages/core/tests/__snapshots__/hooks.test.ts.snap
+++ b/packages/core/tests/__snapshots__/hooks.test.ts.snap
@@ -14,6 +14,7 @@ exports[`initHooks > should init hooks correctly 1`] = `
   "onBeforeStartProdServer",
   "onAfterCreateCompiler",
   "onBeforeCreateCompiler",
+  "modifyHTML",
   "modifyHTMLTags",
   "modifyRspackConfig",
   "modifyBundlerChain",

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -79,8 +79,8 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "foo": {
@@ -157,8 +157,8 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -214,8 +214,8 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -272,8 +272,8 @@ exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -329,8 +329,8 @@ exports[`plugin-html > should enable minify in production 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -386,8 +386,8 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -443,8 +443,8 @@ exports[`plugin-html > should stop injecting <script> if inject is '() => false'
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -500,8 +500,8 @@ exports[`plugin-html > should stop injecting <script> if inject is 'false' 1`] =
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "index": {
@@ -558,8 +558,8 @@ exports[`plugin-html > should support environment html config 1`] = `
         "version": 6,
       },
       RsbuildHtmlPlugin {
+        "getContext": [Function],
         "getEnvironment": [Function],
-        "modifyTagsFn": undefined,
         "name": "RsbuildHtmlPlugin",
         "options": {
           "main": {
@@ -612,8 +612,8 @@ exports[`plugin-html > should support environment html config 1`] = `
         "version": 6,
       },
       RsbuildHtmlPlugin {
+        "getContext": [Function],
         "getEnvironment": [Function],
-        "modifyTagsFn": undefined,
         "name": "RsbuildHtmlPlugin",
         "options": {
           "index": {
@@ -705,8 +705,8 @@ exports[`plugin-html > should support multi entry 1`] = `
       "version": 6,
     },
     RsbuildHtmlPlugin {
+      "getContext": [Function],
       "getEnvironment": [Function],
-      "modifyTagsFn": undefined,
       "name": "RsbuildHtmlPlugin",
       "options": {
         "foo": {


### PR DESCRIPTION
## Summary

Add a new `modifyHTML` hook to modify the final HTML content.

- The hook receives a context object that contains the HTML content, and you can return a new HTML string to replace the original one.
- This hook is triggered after the `modifyHTMLTags` hook.

Example:

```js
const myPlugin: RsbuildPlugin = {
  name: 'my-plugin',
  setup(api) {
    api.modifyHTMLTags((tags) => {
      tags.bodyTags.push({
        tag: 'div',
        children: 'foo',
      });
      return tags;
    });
    api.modifyHTML((html) => {
      return html.replace('foo', 'bar');
    });
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
