### PR TITLE
docs: update creation instructions to link to create-rsbuild

### DIFF
--- a/website/docs/en/guide/framework/preact.mdx
+++ b/website/docs/en/guide/framework/preact.mdx
@@ -4,7 +4,7 @@ In this document, you will learn how to build a Preact application using Rsbuild
 
 ## Create a Preact application
 
-Use `create-rsbuild` to create a Preact application with Rsbuild. Run the following command:
+Use [create-rsbuild](/guide/start/quick-start#create-an-rsbuild-application) to create a Preact application with Rsbuild. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/en/guide/framework/react.mdx
+++ b/website/docs/en/guide/framework/react.mdx
@@ -4,7 +4,7 @@ In this document, you will learn how to build a React application using Rsbuild.
 
 ## Create a React application
 
-Use `create-rsbuild` to create a React application with Rsbuild. Run the following command:
+Use [create-rsbuild](/guide/start/quick-start#create-an-rsbuild-application) to create a React application with Rsbuild. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/en/guide/framework/solid.mdx
+++ b/website/docs/en/guide/framework/solid.mdx
@@ -4,7 +4,7 @@ In this document, you will learn how to build a Solid application using Rsbuild.
 
 ## Create a Solid application
 
-Use `create-rsbuild` to create a Solid application with Rsbuild. Run the following command:
+Use [create-rsbuild](/guide/start/quick-start#create-an-rsbuild-application) to create a Solid application with Rsbuild. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/en/guide/framework/svelte.mdx
+++ b/website/docs/en/guide/framework/svelte.mdx
@@ -4,7 +4,7 @@ In this document, you will learn how to build a Svelte application using Rsbuild
 
 ## Create a Svelte application
 
-Use `create-rsbuild` to create a Svelte application with Rsbuild. Run the following command:
+Use [create-rsbuild](/guide/start/quick-start#create-an-rsbuild-application) to create a Svelte application with Rsbuild. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/en/guide/framework/vue.mdx
+++ b/website/docs/en/guide/framework/vue.mdx
@@ -4,7 +4,7 @@ In this document, you will learn how to build a Vue 3 or Vue 2 application using
 
 ## Create a Vue application
 
-Use `create-rsbuild` to create a Vue application with Rsbuild. Run the following command:
+Use [create-rsbuild](/guide/start/quick-start#create-an-rsbuild-application) to create a Vue application with Rsbuild. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -33,7 +33,7 @@ nvm use --lts
 
 ## Create an Rsbuild application
 
-Use `create-rsbuild` to create a new Rsbuild application. Run the following command:
+Use [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) to create a new Rsbuild application. Run the following command:
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/framework/preact.mdx
+++ b/website/docs/zh/guide/framework/preact.mdx
@@ -4,7 +4,7 @@
 
 ## 创建 Preact 应用
 
-使用 `create-rsbuild` 来创建一个基于 Rsbuild 的 Preact 应用，运行以下命令：
+使用 [create-rsbuild](/guide/start/quick-start#创建-rsbuild-应用) 来创建一个基于 Rsbuild 的 Preact 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/framework/react.mdx
+++ b/website/docs/zh/guide/framework/react.mdx
@@ -4,7 +4,7 @@
 
 ## 创建 React 应用
 
-使用 `create-rsbuild` 来创建一个基于 Rsbuild 的 React 应用，运行以下命令：
+使用 [create-rsbuild](/guide/start/quick-start#创建-rsbuild-应用) 来创建一个基于 Rsbuild 的 React 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/framework/solid.mdx
+++ b/website/docs/zh/guide/framework/solid.mdx
@@ -4,7 +4,7 @@
 
 ## 创建 Solid 应用
 
-使用 `create-rsbuild` 来创建一个基于 Rsbuild 的 Solid 应用，运行以下命令：
+使用 [create-rsbuild](/guide/start/quick-start#创建-rsbuild-应用) 来创建一个基于 Rsbuild 的 Solid 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/framework/svelte.mdx
+++ b/website/docs/zh/guide/framework/svelte.mdx
@@ -4,7 +4,7 @@
 
 ## 创建 Svelte 应用
 
-使用 `create-rsbuild` 来创建一个基于 Rsbuild 的 Svelte 应用，运行以下命令：
+使用 [create-rsbuild](/guide/start/quick-start#创建-rsbuild-应用) 来创建一个基于 Rsbuild 的 Svelte 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/framework/vue.mdx
+++ b/website/docs/zh/guide/framework/vue.mdx
@@ -4,7 +4,7 @@
 
 ## 创建 Vue 应用
 
-使用 `create-rsbuild` 来创建一个基于 Rsbuild 的 Vue 应用，运行以下命令：
+使用 [create-rsbuild](/guide/start/quick-start#创建-rsbuild-应用) 来创建一个基于 Rsbuild 的 Vue 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -33,7 +33,7 @@ nvm use --lts
 
 ## 创建 Rsbuild 应用
 
-使用 `create-rsbuild` 来创建一个 Rsbuild 应用，运行以下命令：
+使用 [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) 来创建一个 Rsbuild 应用，运行以下命令：
 
 import { PackageManagerTabs } from '@theme';
 


### PR DESCRIPTION
## Summary

- Updated the quick-start guide to use an external link to the `create-rsbuild` package on npm
- Updated links in framework-specific guides for Preact, React, Solid, Svelte, and Vue to point to the relevant section in the quick-start guide

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
