### PR TITLE
docs: update plugin example to use named export

### DIFF
--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -26,13 +26,11 @@ type RsbuildPlugin = {
 
 You can import this type from `@rsbuild/core`:
 
-```ts
+```ts title="pluginFoo.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
 
-export default (): RsbuildPlugin => ({
+export const pluginFoo = (): RsbuildPlugin => ({
   name: 'plugin-foo',
-
-  pre: ['plugin-bar'],
 
   setup(api) {
     api.onAfterBuild(() => {

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -24,13 +24,11 @@ type RsbuildPlugin = {
 
 你可以从 `@rsbuild/core` 中导入该类型：
 
-```ts
+```ts title="pluginFoo.ts"
 import type { RsbuildPlugin } from '@rsbuild/core';
 
-export default (): RsbuildPlugin => ({
+export const pluginFoo = (): RsbuildPlugin => ({
   name: 'plugin-foo',
-
-  pre: ['plugin-bar'],
 
   setup(api) {
     api.onAfterBuild(() => {


### PR DESCRIPTION
## Related Links

It is recommended to use named export to export an Rsbuild plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
