### PR TITLE
chore: update ansiHTML to use named export

### DIFF
--- a/packages/core/src/server/ansiHTML.ts
+++ b/packages/core/src/server/ansiHTML.ts
@@ -61,5 +61,3 @@ export function ansiHTML(text: string): string {
 
   return ret;
 }
-
-export default ansiHTML;

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { getRelativePath } from '../helpers';
-import ansiHTML from './ansiHTML';
+import { ansiHTML } from './ansiHTML';
 import { escapeHtml } from './helper';
 
 export function convertLinksInHtml(text: string, root?: string): string {


### PR DESCRIPTION
## Summary

Changed the export of the `ansiHTML` module from a default export to a named export, this module accidentally has two duplicate exports.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
