### PR TITLE
docs: add link to middleware guide

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -109,7 +109,7 @@ const applyDefaultMiddlewares = async ({
     });
   }
 
-  // Apply proxy middlewares
+  // Apply proxy middleware
   // each proxy configuration creates its own middleware instance
   if (server.proxy) {
     const { middlewares: proxyMiddlewares, upgrade } =
@@ -122,7 +122,7 @@ const applyDefaultMiddlewares = async ({
   }
 
   // compression is placed after proxy middleware to avoid breaking SSE (Server-Sent Events),
-  // but before other middlewares to ensure responses are properly compressed
+  // but before other middleware to ensure responses are properly compressed
   if (server.compress) {
     middlewares.push(gzipMiddleware());
   }
@@ -208,9 +208,9 @@ const applyDefaultMiddlewares = async ({
   }
 
   // Execute callbacks returned by the `onBeforeStartDevServer` hook.
-  // This is the ideal place for users to add custom middlewares because:
-  // 1. It runs after most of the default middlewares
-  // 2. It runs before fallback middlewares
+  // This is the ideal place for users to add custom middleware because:
+  // 1. It runs after most of the default middleware
+  // 2. It runs before fallback middleware
   // This ensures custom middleware can intercept requests before any fallback handling
   for (const callback of postCallbacks) {
     callback();
@@ -269,7 +269,7 @@ export const getDevMiddlewares = async (
     middlewares.push(await getRequestLoggerMiddleware());
   }
 
-  // Order: setupMiddlewares.unshift => internal middlewares => setupMiddlewares.push
+  // Order: setupMiddlewares.unshift => internal middleware => setupMiddlewares.push
   const { before, after } = applySetupMiddlewares(
     options.dev,
     environments,

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -90,7 +90,7 @@ export class RsbuildProdServer {
       });
     }
 
-    // Apply proxy middlewares
+    // Apply proxy middleware
     // each proxy configuration creates its own middleware instance
     if (proxy) {
       const { middlewares, upgrade } = await createProxyMiddleware(proxy);

--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -50,7 +50,7 @@ type EnvironmentAPI = {
 type RsbuildDevServer = {
   /**
    * The `connect` app instance.
-   * Can be used to attach custom middlewares to the dev server.
+   * Can be used to attach custom middleware to the dev server.
    */
   middlewares: Connect.Server;
   /**
@@ -152,7 +152,7 @@ async function startDevServer() {
   // Create Rsbuild dev server instance
   const rsbuildServer = await rsbuild.createDevServer();
 
-  // Apply Rsbuild's built-in middlewares
+  // Apply Rsbuild's built-in middleware
   app.use(rsbuildServer.middlewares);
 
   const server = app.listen(rsbuildServer.port, async () => {

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -24,13 +24,13 @@ type SetupMiddlewares = Array<
 
 - **Default:** `undefined`
 
-Provides the ability to execute a custom function and apply custom middlewares.
+Provides the ability to execute a custom function and apply custom middleware.
 
-> See [Dev Server - Middlewares](/guide/basic/server#middlewares) for more information.
+> See [Dev Server - Middleware](/guide/basic/server#middleware) for more information.
 
 ## Execution order
 
-The order among several different types of middleware is: `unshift` => internal middlewares => `push`.
+The order among several different types of middleware is: `unshift` => internal middleware => `push`.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -58,7 +58,7 @@ In the `setupMiddlewares` function, you can access the `server` object, which pr
 
 ### sockWrite
 
-`sockWrite` allows middlewares to send some message to HMR client, and then the HMR client will take different actions depending on the message type.
+`sockWrite` allows middleware to send some message to HMR client, and then the HMR client will take different actions depending on the message type.
 
 For example, if you send a `'static-changed'` message, the page will reload.
 

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -2,7 +2,7 @@
 
 - **Type:**
 
-```ts title="rsbuild.config.ts"
+```ts
 type SetupMiddlewaresServer = {
   sockWrite: (
     type: string,
@@ -25,6 +25,8 @@ type SetupMiddlewares = Array<
 - **Default:** `undefined`
 
 Provides the ability to execute a custom function and apply custom middlewares.
+
+> See [Dev Server - Middlewares](/guide/basic/server#middlewares) for more information.
 
 ## Execution order
 

--- a/website/docs/en/config/server/middleware-mode.mdx
+++ b/website/docs/en/config/server/middleware-mode.mdx
@@ -31,7 +31,7 @@ async function startDevServer() {
   // Create Rsbuild dev server instance
   const rsbuildServer = await rsbuild.createDevServer();
 
-  // Apply Rsbuild's built-in middlewares
+  // Apply Rsbuild's built-in middleware
   app.use(rsbuildServer.middlewares);
 }
 ```

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -290,7 +290,7 @@ export async function startDevServer() {
     }
   });
 
-  // Apply Rsbuild’s built-in middlewares
+  // Apply Rsbuild’s built-in middleware
   app.use(rsbuildServer.middlewares);
 
   // ...

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -149,13 +149,13 @@ Below are the Rsbuild configs that correspond to the Rspack CLI's `devServer` co
 
 > For more configurations, please refer to [Config Overview](/config/index).
 
-## Middlewares
+## Middleware
 
-Rsbuild's middlewares implementation is built on [connect](https://github.com/senchalabs/connect), a lightweight HTTP server framework, and uses the standard Node.js `request` and `response` objects for handling HTTP interactions.
+Rsbuild's middleware implementation is built on [connect](https://github.com/senchalabs/connect), a lightweight HTTP server framework, and uses the standard Node.js `request` and `response` objects for handling HTTP interactions.
 
-### Register middlewares
+### Register middleware
 
-Rsbuild provides three ways to register middlewares:
+Rsbuild provides three ways to register middleware:
 
 1. Use the [dev.setupMiddlewares](/config/dev/setup-middlewares) configuration.
 
@@ -173,7 +173,7 @@ export default {
 };
 ```
 
-2. In the Rsbuild plugin, you can register middlewares through the [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) hook.
+2. In the Rsbuild plugin, you can register middleware through the [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) hook.
 
 ```ts
 const myPlugin = () => ({
@@ -187,7 +187,7 @@ const myPlugin = () => ({
 });
 ```
 
-3. When using the Rsbuild JavaScript API, you can create a dev server instance through the [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver) method and use the `use` method to register middlewares.
+3. When using the Rsbuild JavaScript API, you can create a dev server instance through the [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver) method and use the `use` method to register middleware.
 
 ```ts
 const server = await rsbuild.createDevServer();

--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -54,14 +54,14 @@ Here are all the main features supported by Rsbuild.
 
 ## Server
 
-| Features          | Description                                                                    | Links                                                            |
-| ----------------- | ------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| Public dir        | Use the public directory as the directory for serving public assets by default | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul>  |
-| SSR               | Optional feature, implement server-side rendering                              | <ul><li>[SSR](/guide/advanced/ssr)</li></ul>                     |
-| Proxy             | Optional feature, proxy requests to the specified service                      | <ul><li>[server.proxy](/config/server/proxy)</li></ul>           |
-| Open page         | Optional feature, automatically open page in browser when starting server      | <ul><li>[server.open](/config/server/open)</li></ul>             |
-| HTTPS             | Optional feature, enable HTTPS server                                          | <ul><li>[server.https](/config/server/https)</li></ul>           |
-| Custom middleware | Optional feature, use custom middlewares                                       | <ul><li>[Middlewares](/guide/basic/server#middlewares)</li></ul> |
+| Features          | Description                                                                    | Links                                                           |
+| ----------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| Public dir        | Use the public directory as the directory for serving public assets by default | <ul><li>[server.publicDir](/config/server/public-dir)</li></ul> |
+| SSR               | Optional feature, implement server-side rendering                              | <ul><li>[SSR](/guide/advanced/ssr)</li></ul>                    |
+| Proxy             | Optional feature, proxy requests to the specified service                      | <ul><li>[server.proxy](/config/server/proxy)</li></ul>          |
+| Open page         | Optional feature, automatically open page in browser when starting server      | <ul><li>[server.open](/config/server/open)</li></ul>            |
+| HTTPS             | Optional feature, enable HTTPS server                                          | <ul><li>[server.https](/config/server/https)</li></ul>          |
+| Custom middleware | Optional feature, use custom middleware                                        | <ul><li>[Middleware](/guide/basic/server#middleware)</li></ul>  |
 
 ## UI framework
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -121,7 +121,7 @@ When executing the `rsbuild preview` command or `rsbuild.preview()` method, Rsbu
 In Rsbuild, some of the plugin hooks are global hooks. The execution of these hooks is often related to Rsbuild's own startup process or global logic and is shared under all environments. Such as:
 
 - `modifyRsbuildConfig` is used to modify the basic configuration of Rsbuild. The basic configuration will eventually be merged with the environment configuration;
-- `onBeforeStartDevServer` and `onAfterStartDevServer` are related to the Rsbuild dev server startup process, all environments share Rsbuild's dev server, middlewares, and WebSocket.
+- `onBeforeStartDevServer` and `onAfterStartDevServer` are related to the Rsbuild dev server startup process, all environments share Rsbuild's dev server, middleware, and WebSocket.
 
 Correspondingly, there are some plugin hooks that are related to the current environment. These hooks are executed with a specific environment context and are triggered multiple times depending on the environment.
 
@@ -754,9 +754,9 @@ const myPlugin = () => ({
 });
 ```
 
-#### Register middlewares
+#### Register middleware
 
-A common usage scenario is to register custom middlewares in `onBeforeStartDevServer`:
+A common usage scenario is to register custom middleware in `onBeforeStartDevServer`:
 
 ```ts
 const myPlugin = () => ({
@@ -770,16 +770,16 @@ const myPlugin = () => ({
 });
 ```
 
-When `onBeforeStartDevServer` is called, the default middlewares of Rsbuild are not registered yet, so the middlewares you add will run before the default middlewares.
+When `onBeforeStartDevServer` is called, the default middleware of Rsbuild are not registered yet, so the middleware you add will run before the default middleware.
 
-`onBeforeStartDevServer` allows you to return a callback function, which will be called when the default middlewares of Rsbuild are registered. The middlewares you register in the callback function will run after the default middlewares.
+`onBeforeStartDevServer` allows you to return a callback function, which will be called when the default middleware of Rsbuild are registered. The middleware you register in the callback function will run after the default middleware.
 
 ```ts
 const myPlugin = () => ({
   setup(api) {
     api.onBeforeStartDevServer(({ server }) => {
       // the returned callback will be called when the default
-      // middlewares are registered
+      // middleware are registered
       return () => {
         server.middlewares.use((req, res, next) => {
           next();

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -26,6 +26,8 @@ type SetupMiddlewares = Array<
 
 提供执行自定义函数和应用自定义中间件的能力。
 
+> 查看 [开发服务器 - 中间件](/guide/basic/server#中间件) 了解更多。
+
 ## 执行顺序
 
 中间件的执行顺序是: `unshift` => 内置中间件 => `push`。

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -290,7 +290,7 @@ export async function startDevServer() {
     }
   });
 
-  // Apply Rsbuild’s built-in middlewares
+  // Apply Rsbuild’s built-in middleware
   app.use(rsbuildServer.middlewares);
 
   // ...

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -121,7 +121,7 @@
 在 Rsbuild 中，有一些插件 hooks 是全局 hooks，这些 hook 的执行往往和 Rsbuild 自身的启动流程或全局逻辑相关，在所有 environment 下共享。如：
 
 - `modifyRsbuildConfig` 用来修改 Rsbuild 的基础配置，基础配置最终会和 environment 配置合并；
-- `onBeforeStartDevServer`、`onAfterStartDevServer` 和 Rsbuild dev server 启动流程相关，所有 environments 共享 Rsbuild 的 dev server、middlewares、WebSocket。
+- `onBeforeStartDevServer`、`onAfterStartDevServer` 和 Rsbuild dev server 启动流程相关，所有 environments 共享 Rsbuild 的开发服务器、中间件、WebSocket。
 
 与之对应的，有一些插件 hooks 是和当前 environment 相关的 hook，这些 hook 执行时会带有特定的 environment 上下文，并根据 environment 的不同而触发多次。
 
@@ -775,7 +775,7 @@ const myPlugin = () => ({
   setup(api) {
     api.onBeforeStartDevServer(({ server }) => {
       // the returned callback will be called when the default
-      // middlewares are registered
+      // middleware are registered
       return () => {
         server.middlewares.use((req, res, next) => {
           next();


### PR DESCRIPTION
## Summary

- Add link to middleware guide.
- Standardizes the terminology across the codebase and documentation by replacing "middlewares" with "middleware", see https://english.stackexchange.com/questions/257120/middleware-vs-middlewares

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
