### PR TITLE
feat: add `mimetype` option to `api.transform`

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-mime-type/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-mime-type/index.test.ts
@@ -1,0 +1,14 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow plugin to match data uri modules with `mimetype`',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+
+    const indexJs = await rsbuild.getIndexFile();
+    expect(indexJs.content).toContain('data-uri-bar');
+  },
+);

--- a/e2e/cases/plugin-api/plugin-transform-mime-type/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-mime-type/myPlugin.ts
@@ -1,0 +1,10 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
+      return code.replace('data-uri-foo', 'data-uri-bar');
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-mime-type/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-transform-mime-type/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { myPlugin } from './myPlugin';
+
+export default defineConfig({
+  plugins: [myPlugin],
+});

--- a/e2e/cases/plugin-api/plugin-transform-mime-type/src/index.js
+++ b/e2e/cases/plugin-api/plugin-transform-mime-type/src/index.js
@@ -1,0 +1,3 @@
+import text from 'data:text/javascript,export default "data-uri-foo"';
+
+console.log(text);

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -292,6 +292,9 @@ export function initPluginAPI({
           if (descriptor.with) {
             rule.with(descriptor.with);
           }
+          if (descriptor.mimetype) {
+            rule.mimetype(descriptor.mimetype);
+          }
 
           const loaderName = descriptor.raw
             ? 'transformRawLoader.mjs'

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -374,7 +374,7 @@ export type TransformDescriptor = {
   with?: Record<string, Rspack.RuleSetCondition>;
   /**
    * Matches modules based on MIME type instead of file extension. It's primarily
-   * useful for data URI modules (like `data:text/javascript,export default 'foo'`).
+   * useful for data URI module (like `data:text/javascript,...`).
    * @see https://rspack.dev/config/module#rulemimetype
    */
   mimetype?: Rspack.RuleSetCondition;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -349,9 +349,8 @@ export type TransformDescriptor = {
    */
   raw?: boolean;
   /**
-   * Used to mark the layer of the matching module.
-   * A group of modules could be united in one layer which could then be used in
-   * split chunks, stats or entry options.
+   * Marks the layer of the matching module, can be used to group a group of
+   * modules into one layer
    * @see https://rspack.dev/config/module#rulelayer
    */
   layer?: string;
@@ -363,15 +362,22 @@ export type TransformDescriptor = {
   issuerLayer?: string;
   /**
    * Matches all modules that match this resource, and will match against Resource
-   * (the absolute path without query and fragment) of the module that issued the current module.
+   * (the absolute path without query and fragment) of the module that issued the
+   * current module.
    * @see https://rspack.dev/config/module#ruleissuer
    */
   issuer?: Rspack.RuleSetCondition;
   /**
-   * `with` can be used in conjunction with [import attributes](https://github.com/tc39/proposal-import-attributes).
+   * Matches [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with)
    * @see https://rspack.dev/config/module#rulewith
    */
   with?: Record<string, Rspack.RuleSetCondition>;
+  /**
+   * Matches modules based on MIME type instead of file extension. It's primarily
+   * useful for data URI modules (like `data:text/javascript,export default 'foo'`).
+   * @see https://rspack.dev/config/module#rulemimetype
+   */
+  mimetype?: Rspack.RuleSetCondition;
 };
 
 export type TransformHook = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -218,6 +218,7 @@ type TransformDescriptor = {
   issuer?: RuleSetCondition;
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
+  mimetype?: RuleSetCondition;
 };
 ```
 
@@ -263,7 +264,7 @@ api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
 });
 ```
 
-- `layer`: mark the layer of the matching module, can be used to group a group of modules into one layer, the same as Rspack's [Rule.layer](https://rspack.dev/config/module#rulelayer).
+- `layer`: marks the layer of the matching module, can be used to group a group of modules into one layer, the same as Rspack's [Rule.layer](https://rspack.dev/config/module#rulelayer).
 
 ```js
 api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
@@ -271,7 +272,7 @@ api.transform({ test: /\.md$/, layer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuerLayer`: match the layer of the module that issues the current module, the same as Rspack's [Rule.issuerLayer](https://rspack.dev/config/module#ruleissuerlayer).
+- `issuerLayer`: matches the layer of the module that issues the current module, the same as Rspack's [Rule.issuerLayer](https://rspack.dev/config/module#ruleissuerlayer).
 
 ```js
 api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
@@ -279,7 +280,7 @@ api.transform({ test: /\.md$/, issuerLayer: 'foo' }, ({ code }) => {
 });
 ```
 
-- `issuer`: match the absolute path of the module that issues the current module, the same as Rspack's [Rule.issuer](https://rspack.dev/config/module#ruleissuer).
+- `issuer`: matches the absolute path of the module that issues the current module, the same as Rspack's [Rule.issuer](https://rspack.dev/config/module#ruleissuer).
 
 ```js
 api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
@@ -287,10 +288,18 @@ api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
 });
 ```
 
-- `with`: match [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with), the same as Rspack's [Rule.with](https://rspack.dev/config/module#rulewith).
+- `with`: matches [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with), the same as Rspack's [Rule.with](https://rspack.dev/config/module#rulewith).
 
 ```js
 api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
+  // ...
+});
+```
+
+- `mimetype`: Matches modules based on MIME type instead of file extension. It's primarily useful for data URI modules (like `data:text/javascript,export default 'foo'`), the same as Rspack's [Rule.mimetype](https://rspack.dev/config/module#rulemimetype).
+
+```js
+api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
   // ...
 });
 ```

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -296,7 +296,7 @@ api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
 });
 ```
 
-- `mimetype`: Matches modules based on MIME type instead of file extension. It's primarily useful for data URI modules (like `data:text/javascript,export default 'foo'`), the same as Rspack's [Rule.mimetype](https://rspack.dev/config/module#rulemimetype).
+- `mimetype`: Matches modules based on MIME type instead of file extension. It's primarily useful for data URI module (like `data:text/javascript,...`), the same as Rspack's [Rule.mimetype](https://rspack.dev/config/module#rulemimetype).
 
 ```js
 api.transform({ mimetype: 'text/javascript' }, ({ code }) => {

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -216,6 +216,7 @@ type TransformDescriptor = {
   issuer?: RuleSetCondition;
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
+  mimetype?: RuleSetCondition;
 };
 ```
 
@@ -289,6 +290,14 @@ api.transform({ test: /\.md$/, issuer: /\.js$/ }, ({ code }) => {
 
 ```js
 api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
+  // ...
+});
+```
+
+- `mimetype`：根据 MIME 类型（而非文件扩展名）匹配模块。主要用于 data URI 模块（例如 `data:text/javascript,export default 'foo'`），等同于 Rspack 的 [Rule.mimetype](https://rspack.dev/zh/config/module#rulemimetype)。
+
+```js
+api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
   // ...
 });
 ```

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -294,7 +294,7 @@ api.transform({ test: /\.md$/, with: { type: 'url' } }, ({ code }) => {
 });
 ```
 
-- `mimetype`：根据 MIME 类型（而非文件扩展名）匹配模块。主要用于 data URI 模块（例如 `data:text/javascript,export default 'foo'`），等同于 Rspack 的 [Rule.mimetype](https://rspack.dev/zh/config/module#rulemimetype)。
+- `mimetype`：根据 MIME 类型（而非文件扩展名）匹配模块。主要用于 data URI 模块（例如 `data:text/javascript,...`），等同于 Rspack 的 [Rule.mimetype](https://rspack.dev/zh/config/module#rulemimetype)。
 
 ```js
 api.transform({ mimetype: 'text/javascript' }, ({ code }) => {


### PR DESCRIPTION
## Summary

Added `mimetype` support in the `api.transform`, allowing plugins to match modules based on MIME type, particularly useful for data URI modules (e.g., `data:text/javascript,...`.

```ts
import type { RsbuildPlugin } from '@rsbuild/core';

export const myPlugin: RsbuildPlugin = {
  name: 'my-plugin',
  setup(api) {
    api.transform({ mimetype: 'text/javascript' }, ({ code }) => {
      return code.replace('data-uri-foo', 'data-uri-bar');
    });
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
