### PR TITLE
docs: improve manifest data access instructions

### DIFF
--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -162,10 +162,7 @@ api.modifyRspackConfig((config, { environment }) => {
 
 The manifest data. Only available when the [output.manifest](/config/output/manifest) config is enabled.
 
-You should access the manifest data after the build has completed, using hooks like [onAfterBuild](/plugins/dev/hooks#onafterbuild), [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone) and [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile).
-
 - **Type:** `Record<string, unknown> | ManifestData | undefined`
-
 - **Example:**
 
 ```js
@@ -182,6 +179,15 @@ api.onAfterEnvironmentCompile(({ environment }) => {
   console.log(environment.manifest);
 });
 ```
+
+The manifest data is only available after the build has completed, you can access it in the following hooks:
+
+- [onAfterBuild](/plugins/dev/hooks#onafterbuild)
+- [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
+- [onCloseBuild](/plugins/dev/hooks#onclosebuild)
+- [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
+- [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
+- [onExit](/plugins/dev/hooks#onexit)
 
 ## Environment API
 

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -163,10 +163,7 @@ api.modifyRspackConfig((config, { environment }) => {
 
 manifest 文件数据。仅在 [output.manifest](/config/output/manifest) 配置被启用时才能访问。
 
-你应该在构建完成后访问 manifest 数据，使用 hooks 如 [onAfterBuild](/plugins/dev/hooks#onafterbuild)、[onDevCompileDone](/plugins/dev/hooks#ondevcompiledone) 和 [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)。
-
 - **类型：** `Record<string, unknown> | ManifestData | undefined`
-
 - **示例：**
 
 ```js
@@ -183,6 +180,15 @@ api.onAfterEnvironmentCompile(({ environment }) => {
   console.log(environment.manifest);
 });
 ```
+
+manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks 中访问：
+
+- [onAfterBuild](/plugins/dev/hooks#onafterbuild)
+- [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
+- [onCloseBuild](/plugins/dev/hooks#onclosebuild)
+- [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
+- [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
+- [onExit](/plugins/dev/hooks#onexit)
 
 ## Environment API
 


### PR DESCRIPTION
## Summary

Removed the earlier explanation about accessing manifest data after the build and replaced it with a more detailed list of hooks where the data can be accessed, including `onAfterBuild`, `onAfterEnvironmentCompile`, `onCloseBuild`, `onCloseDevServer`, `onDevCompileDone`, and `onExit`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
