### PR TITLE
docs: configuring multiple environments manifest files

### DIFF
--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -252,3 +252,48 @@ export default {
   },
 };
 ```
+
+## Multiple environments
+
+When using [environments](/config/environments) and configuring multiple environments, please specify an unique `manifest.filename` value for each environment to prevent manifest files from different environments from overwriting each other.
+
+For example, use the default `manifest.json` for the `web` environment and use `manifest-node.json` for the `node` environment:
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      output: {
+        manifest: true,
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        manifest: {
+          filename: 'manifest-node.json',
+        },
+      },
+    },
+  },
+};
+```
+
+You can also choose to generate the manifest file for a specific environment:
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      output: {
+        manifest: true,
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+    },
+  },
+};
+```

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -252,3 +252,48 @@ export default {
   },
 };
 ```
+
+## 多个环境
+
+在使用 [environments](/config/environments) 并配置多个环境时，请为每个环境指定独立的 `manifest.filename` 值，以防止不同环境生成的 manifest 文件相互覆盖。
+
+例如，为 `web` 环境使用默认的 `manifest.json`，同时为 `node` 环境使用 `manifest-node.json`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      output: {
+        manifest: true,
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+        manifest: {
+          filename: 'manifest-node.json',
+        },
+      },
+    },
+  },
+};
+```
+
+你也可以选择性地仅为特定环境生成 manifest 文件：
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      output: {
+        manifest: true,
+      },
+    },
+    node: {
+      output: {
+        target: 'node',
+      },
+    },
+  },
+};
+```


### PR DESCRIPTION
## Summary

Added a new section explaining how to configure unique `manifest.filename` values for multiple environments to prevent overwriting.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5165

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
