### PR TITLE
perf: enable Rspack incremental build by default

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "e2e": "pnpm e2e:rspack && pnpm e2e:webpack",
-    "e2e:rspack": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" EXPERIMENTAL_RSPACK_INCREMENTAL=true playwright test",
+    "e2e:rspack": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" playwright test",
     "e2e:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
   },
   "dependencies": {

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -483,7 +483,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": false,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -937,7 +937,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": false,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1317,7 +1317,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": false,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -24,6 +24,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -482,6 +483,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -935,6 +937,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1314,6 +1317,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": false,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -100,13 +100,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // https://github.com/web-infra-dev/rspack/pull/5486
         process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
 
-        // This is temporary, we will remove it after Rspack incremental is stable
-        if (process.env.EXPERIMENTAL_RSPACK_INCREMENTAL) {
-          chain.experiments({
-            ...chain.get('experiments'),
-            incremental: isDev,
-          });
-        }
+        // TODO: we can remove it after Rspack incremental is enabled by default
+        chain.experiments({
+          ...chain.get('experiments'),
+          incremental: isDev,
+        });
       },
     );
   },

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -103,7 +103,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // TODO: we can remove it after Rspack incremental is enabled by default
         chain.experiments({
           ...chain.get('experiments'),
-          incremental: isDev,
+          incremental: true,
         });
       },
     );

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -4,6 +4,9 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "incremental": true,
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -42,6 +45,9 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
+  "experiments": {
+    "incremental": false,
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -46,7 +46,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
   "experiments": {
-    "incremental": false,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,6 +11,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,6 +11,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -492,6 +493,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": false,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1010,6 +1012,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1408,6 +1411,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -493,7 +493,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": false,
+    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1306,6 +1306,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
+      "incremental": true,
     },
     "infrastructureLogging": {
       "level": "error",
@@ -1722,6 +1723,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
+      "incremental": true,
     },
     "infrastructureLogging": {
       "level": "error",


### PR DESCRIPTION
## Summary

- Enable Rspack incremental build by default because it is stable enough and can bring HMR performance improvements.
- Removed the `EXPERIMENTAL_RSPACK_INCREMENTAL` environment variable

If you run into any issues, you can switch to the safe and stable incremental, which is consistent with previous behavior, by adding the following configuration:

```js
export default defineConfig({
  tools: {
    rspack: {
      experiments: {
        incremental: 'safe',
      },
    },
  },
});
```

## Related Links

- https://rspack.dev/config/experiments#experimentsincremental

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
