### PR TITLE
chore: remove ignored config

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -457,7 +457,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -911,7 +910,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -1291,7 +1289,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "target": "node",
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -1660,7 +1657,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -60,8 +60,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
         });
 
         chain.watchOptions({
-          // Ignore watching files in node_modules to reduce memory usage and make startup faster
-          ignored: /[\\/](?:\.git|node_modules)[\\/]/,
           // Remove the delay before rebuilding once the first file changed
           aggregateTimeout: 0,
         });

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -36,7 +36,6 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -70,7 +69,6 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -462,7 +462,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -477,7 +477,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -996,7 +995,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -1395,7 +1393,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "target": "node",
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;
@@ -1892,7 +1889,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   ],
   "watchOptions": {
     "aggregateTimeout": 0,
-    "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
   },
 }
 `;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1715,7 +1715,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     ],
     "watchOptions": {
       "aggregateTimeout": 0,
-      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
     },
   },
   {
@@ -2092,7 +2091,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "target": "node",
     "watchOptions": {
       "aggregateTimeout": 0,
-      "ignored": /\\[\\\\\\\\/\\]\\(\\?:\\\\\\.git\\|node_modules\\)\\[\\\\\\\\/\\]/,
     },
   },
 ]


### PR DESCRIPTION
## Summary

Since Rspack v1.2.0, node_modules and .git directories are excluded by default, which means we no longer need to set `watchOptions.ignored` in Rsbuild.

## Related Links

- https://rspack.dev/config/watch#watchoptionsignored

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
