### PR TITLE
fix: should not apply incremental config to webpack

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -24,7 +24,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -483,7 +482,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -937,7 +935,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1317,7 +1314,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -101,10 +101,12 @@ export const pluginBasic = (): RsbuildPlugin => ({
         process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
 
         // TODO: we can remove it after Rspack incremental is enabled by default
-        chain.experiments({
-          ...chain.get('experiments'),
-          incremental: true,
-        });
+        if (api.context.bundlerType === 'rspack') {
+          chain.experiments({
+            ...chain.get('experiments'),
+            incremental: true,
+          });
+        }
       },
     );
   },


### PR DESCRIPTION
## Summary

The `incremental` config is Rspack-specific and should not be set when using `@rsbuild/webpack`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5167

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
