### PR TITLE
perf: update html-rspack-plugin to 6.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "deepmerge": "^4.3.1",
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
-    "html-rspack-plugin": "6.0.5",
+    "html-rspack-plugin": "6.1.0",
     "http-proxy-middleware": "^2.0.9",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,8 +667,8 @@ importers:
         specifier: 12.0.2
         version: 12.0.2
       html-rspack-plugin:
-        specifier: 6.0.5
-        version: 6.0.5(@rspack/core@1.3.8(@swc/helpers@0.5.17))
+        specifier: 6.1.0
+        version: 6.1.0(@rspack/core@1.3.8(@swc/helpers@0.5.17))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -4586,8 +4586,8 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  html-rspack-plugin@6.0.5:
-    resolution: {integrity: sha512-TNPHTtwulMANkE8Vc5l5EOIU27YcW68Xi7ADinErlpW5H6PxlsS4b7XiFApoX0ytZgUJDE7qsUl4srayWJtdAA==}
+  html-rspack-plugin@6.1.0:
+    resolution: {integrity: sha512-D4I5guWEeJr63Y5yBNBSFPGcBshn+4z/OGdHzpLzoV1pdVPuPc9CXJL42EqvKscVy1FMbSS65im+upifiFhHAQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10906,7 +10906,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-rspack-plugin@6.0.5(@rspack/core@1.3.8(@swc/helpers@0.5.17)):
+  html-rspack-plugin@6.1.0(@rspack/core@1.3.8(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Update html-rspack-plugin to 6.1.0 to ensure the child compiler cache can work as expected.

## Related Links

- https://github.com/rspack-contrib/html-rspack-plugin/releases/tag/v6.1.0
- https://github.com/rspack-contrib/html-rspack-plugin/pull/39
- https://github.com/web-infra-dev/rsbuild/issues/5176

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
