### PR TITLE
test: add case for HTML template caching

### DIFF
--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -1,0 +1,69 @@
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import type { RsbuildPlugin } from '@rsbuild/core';
+import fse from 'fs-extra';
+
+// https://github.com/web-infra-dev/rsbuild/issues/5176
+rspackOnlyTest(
+  'should not re-compile templates when the template is not changed',
+  async ({ page }) => {
+    let count = 0;
+
+    const targetDir = join(__dirname, 'test-temp-src');
+    await fse.remove(targetDir);
+    await fs.cp(join(__dirname, 'src'), targetDir, {
+      recursive: true,
+    });
+
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        root: targetDir,
+        source: {
+          entry: {
+            index: './index.js',
+            bar: './bar.js',
+          },
+        },
+        html: {
+          template: ({ entryName }) => `./${entryName}.html`,
+        },
+        plugins: [
+          {
+            name: 'test-plugin',
+            setup(api) {
+              api.transform({ test: /\.html$/ }, ({ code }) => {
+                count++;
+                return `export default \`${code}\`;`;
+              });
+            },
+          } satisfies RsbuildPlugin,
+        ],
+      },
+    });
+
+    await expect(page.locator('#root')).toHaveText('foo');
+    expect(count).toEqual(2);
+
+    // Re-compile the template when the template is changed
+    const indexHtmlPath = join(targetDir, 'index.html');
+    const indexHtml = await fs.readFile(indexHtmlPath, 'utf-8');
+    await fs.writeFile(indexHtmlPath, indexHtml.replace('foo', 'foo2'));
+    await expect(page.locator('#root')).toHaveText('foo2');
+    // The count will be 4 as the childCompiler in html-rspack-plugin
+    // will compile all the templates
+    expect(count).toEqual(4);
+
+    const indexJsPath = join(targetDir, 'index.js');
+    const indexJs = await fs.readFile(indexJsPath, 'utf-8');
+    await fs.writeFile(indexJsPath, indexJs.replace('foo', 'foo3'));
+    await expect(page.locator('#content')).toHaveText('foo3');
+    // The count should not change if the templates are not changed
+    expect(count).toEqual(4);
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import fse from 'fs-extra';
 
@@ -9,6 +9,10 @@ import fse from 'fs-extra';
 rspackOnlyTest(
   'should not re-compile templates when the template is not changed',
   async ({ page }) => {
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     let count = 0;
 
     const targetDir = join(__dirname, 'test-temp-src');

--- a/e2e/cases/html/template-cache/src/bar.html
+++ b/e2e/cases/html/template-cache/src/bar.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <head> </head>
+  <body>
+    <div id="root">bar</div>
+  </body>
+</html>

--- a/e2e/cases/html/template-cache/src/bar.js
+++ b/e2e/cases/html/template-cache/src/bar.js
@@ -1,0 +1,1 @@
+document.querySelector('#content').innerHTML = 'bar';

--- a/e2e/cases/html/template-cache/src/index.html
+++ b/e2e/cases/html/template-cache/src/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+  <head> </head>
+  <body>
+    <div id="root">foo</div>
+    <div id="content"></div>
+  </body>
+</html>

--- a/e2e/cases/html/template-cache/src/index.js
+++ b/e2e/cases/html/template-cache/src/index.js
@@ -1,0 +1,1 @@
+document.querySelector('#content').innerHTML = 'foo';


### PR DESCRIPTION
## Summary

Added a new E2E test to verify that templates are not recompiled unless modified.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5177
- https://github.com/web-infra-dev/rsbuild/issues/5176

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
