### PR TITLE
feat(plugin-less): update webpackImporter type to support 'only'

### DIFF
--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -30,7 +30,14 @@ export type LessLoaderOptions = {
         loaderContext: Rspack.LoaderContext<LessLoaderOptions>,
       ) => string | Promise<string>);
   sourceMap?: boolean;
-  webpackImporter?: boolean;
+  /**
+   * Enables or disables the built-in Rspack resolver.
+   * - If disabled, aliases and `@import` from node_modules will not work.
+   * - If set to `only`, only the built-in Rspack resolver will be used
+   * and `resolve.extensionAlias` can work.
+   * @default true
+   */
+  webpackImporter?: boolean | 'only';
   implementation?: unknown;
 };
 


### PR DESCRIPTION
## Summary

Updated the `webpackImporter` property to support a new `only` option, allowing exclusive use of the built-in Rspack resolver. Added detailed documentation to clarify its behavior and default value.

## Related Links

- https://github.com/webpack-contrib/less-loader/pull/562

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
