### PR TITLE
docs: update quick-start to include multiple values example

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -116,6 +116,9 @@ npx create-rsbuild --dir my-app --template react
 
 # Using abbreviations
 npx create-rsbuild -d my-app -t react
+
+# Specify multiple tools
+npx create-rsbuild -d my-app -t react --tools eslint --tools prettier
 ```
 
 All the CLI flags of `create-rsbuild`:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -116,6 +116,9 @@ npx create-rsbuild --dir my-app --template react
 
 # 使用缩写
 npx create-rsbuild -d my-app -t react
+
+# 指定多个 tools
+npx create-rsbuild -d my-app -t react --tools eslint --tools prettier
 ```
 
 `create-rsbuild` 完整的 CLI 选项如下：


### PR DESCRIPTION
## Summary

Added an example showing how to use the `--tools` flag to specify multiple tools (e.g., `eslint` and `prettier`) when running `npx create-rsbuild`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
