### PR TITLE
chore: remove watchpack-related environment variable

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -94,10 +94,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // enable Rspack config schema validation, unrecognized keys are allowed
         process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-unrecognized-keys';
 
-        // improve kill process performance
-        // https://github.com/web-infra-dev/rspack/pull/5486
-        process.env.WATCHPACK_WATCHER_LIMIT ||= '20';
-
         // TODO: we can remove it after Rspack incremental is enabled by default
         if (api.context.bundlerType === 'rspack') {
           chain.experiments({


### PR DESCRIPTION
## Summary

The `process.env.WATCHPACK_WATCHER_LIMIT` is no longer required since Rspack 1.3.9, see https://github.com/web-infra-dev/rspack/pull/10236

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
