### PR TITLE
chore(workflow): fix e2e script name

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check-dependency-version": "pnpx check-dependency-version-consistency . --ignore-dep loader-utils",
     "check-spell": "pnpx cspell && heading-case",
     "dev:doc": "cd website && pnpm run dev",
-    "e2e": "cd ./e2e && pnpm test",
+    "e2e": "cd ./e2e && pnpm e2e",
     "e2e:rspack": "cd ./e2e && pnpm e2e:rspack",
     "e2e:webpack": "cd ./e2e && pnpm e2e:webpack",
     "format": "prettier --write . && heading-case --write",


### PR DESCRIPTION
## Summary

Fix the root e2e script name, should be `pnpm e2e`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
