### PR TITLE
fix: update html-rspack-plugin to 6.1.2 to fix template parsing

### DIFF
--- a/e2e/cases/server/base-url-env-var/index.test.ts
+++ b/e2e/cases/server/base-url-env-var/index.test.ts
@@ -1,54 +1,54 @@
-import test from 'node:test';
-import { build, dev } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-// TODO: fix this test
-test.skip('should define BASE_URL env var correctly in dev', async ({
-  page,
-}) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      html: {
-        template: './src/index.html',
+rspackOnlyTest(
+  'should define BASE_URL env var correctly in dev',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        html: {
+          template: './src/index.html',
+        },
+        server: {
+          base: '/base',
+        },
       },
-      server: {
-        base: '/base',
+    });
+
+    // should define `process.env.BASE_URL` correctly
+    await expect(page.locator('#public-base-path-process')).toHaveText('/base');
+
+    // should define `import.meta.env.BASE_URL` correctly
+    await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should define BASE_URL env var correctly in build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        html: {
+          template: './src/index.html',
+        },
+        server: {
+          base: '/base',
+        },
       },
-    },
-  });
+    });
 
-  // should define `process.env.BASE_URL` correctly
-  await expect(page.locator('#public-base-path-process')).toHaveText('/base');
+    // should define `process.env.BASE_URL` correctly
+    await expect(page.locator('#public-base-path-process')).toHaveText('/base');
 
-  // should define `import.meta.env.BASE_URL` correctly
-  await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
+    // should define `import.meta.env.BASE_URL` correctly
+    await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
 
-  await rsbuild.close();
-});
-
-test.skip('should define BASE_URL env var correctly in build', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      html: {
-        template: './src/index.html',
-      },
-      server: {
-        base: '/base',
-      },
-    },
-  });
-
-  // should define `process.env.BASE_URL` correctly
-  await expect(page.locator('#public-base-path-process')).toHaveText('/base');
-
-  // should define `import.meta.env.BASE_URL` correctly
-  await expect(page.locator('#public-base-path-meta')).toHaveText('/base');
-
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "deepmerge": "^4.3.1",
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
-    "html-rspack-plugin": "6.1.1",
+    "html-rspack-plugin": "6.1.2",
     "http-proxy-middleware": "^2.0.9",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,7 +75,7 @@
     "deepmerge": "^4.3.1",
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
-    "html-rspack-plugin": "6.1.0",
+    "html-rspack-plugin": "6.1.1",
     "http-proxy-middleware": "^2.0.9",
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,8 +667,8 @@ importers:
         specifier: 12.0.2
         version: 12.0.2
       html-rspack-plugin:
-        specifier: 6.1.1
-        version: 6.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))
+        specifier: 6.1.2
+        version: 6.1.2(@rspack/core@1.3.9(@swc/helpers@0.5.17))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -4648,8 +4648,8 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  html-rspack-plugin@6.1.1:
-    resolution: {integrity: sha512-/W5SdElUUgEmV9UDKpME+tcIt2tVt7ZVs7wzIbhzO6TKHJjFsIaYejx08cpPkG6YuVvbZXQ09uW6dVkNBb8Bvg==}
+  html-rspack-plugin@6.1.2:
+    resolution: {integrity: sha512-30xlM6snYGpHJQnrE83miP0MaZEDAsmqEJj0I2IOPbzUSxU5Cct9D+6cM1bOZfc+C9XQZ9syB/ATKimyz2hWcw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -11018,7 +11018,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-rspack-plugin@6.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17)):
+  html-rspack-plugin@6.1.2(@rspack/core@1.3.9(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -667,8 +667,8 @@ importers:
         specifier: 12.0.2
         version: 12.0.2
       html-rspack-plugin:
-        specifier: 6.1.0
-        version: 6.1.0(@rspack/core@1.3.9(@swc/helpers@0.5.17))
+        specifier: 6.1.1
+        version: 6.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -4648,8 +4648,8 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  html-rspack-plugin@6.1.0:
-    resolution: {integrity: sha512-D4I5guWEeJr63Y5yBNBSFPGcBshn+4z/OGdHzpLzoV1pdVPuPc9CXJL42EqvKscVy1FMbSS65im+upifiFhHAQ==}
+  html-rspack-plugin@6.1.1:
+    resolution: {integrity: sha512-/W5SdElUUgEmV9UDKpME+tcIt2tVt7ZVs7wzIbhzO6TKHJjFsIaYejx08cpPkG6YuVvbZXQ09uW6dVkNBb8Bvg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -11018,7 +11018,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.39.0
 
-  html-rspack-plugin@6.1.0(@rspack/core@1.3.9(@swc/helpers@0.5.17)):
+  html-rspack-plugin@6.1.1(@rspack/core@1.3.9(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

Since Rspack 1.3.9, the `with` statement cannot be used in SWC's strict mode. When the HTML template contains code like `import.meta.*`, the SWC parser will report an error.

![image](https://github.com/user-attachments/assets/8d7ada28-0a5c-4370-9819-a21381185465)

This PR updates html-rspack-plugin to 6.1.1 to fix the template parsing error.

## Related Links

- https://github.com/rspack-contrib/html-rspack-plugin/releases
- https://github.com/rspack-contrib/html-rspack-plugin/pull/40
- https://github.com/web-infra-dev/rsbuild/pull/5188

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
