### PR TITLE
fix: allow to replace HTML plugin option object

### DIFF
--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -13,7 +13,7 @@ import {
   isPlainObject,
 } from '../helpers';
 import {
-  type HtmlInfo,
+  type HtmlExtraData,
   RsbuildHtmlPlugin,
   type TagConfig,
 } from '../rspack/RsbuildHtmlPlugin';
@@ -229,7 +229,7 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
         const entryNames = Object.keys(entries).filter((entryName) =>
           Boolean(htmlPaths[entryName]),
         );
-        const htmlInfoMap: Record<string, HtmlInfo> = {};
+        const extraDataList: HtmlExtraData[] = [];
 
         const finalOptions = await Promise.all(
           entryNames.map(async (entryName) => {
@@ -275,23 +275,25 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
               pluginOptions.chunksSortMode = 'manual';
             }
 
-            const htmlInfo: HtmlInfo = {};
-            htmlInfoMap[entryName] = htmlInfo;
+            const extraData: HtmlExtraData = {
+              entryName,
+            };
+            extraDataList.push(extraData);
 
             if (templateContent) {
-              htmlInfo.templateContent = templateContent;
+              extraData.templateContent = templateContent;
             }
 
             const tagConfig = getTagConfig(environment.config);
             if (tagConfig) {
-              htmlInfo.tagConfig = tagConfig;
+              extraData.tagConfig = tagConfig;
             }
 
             pluginOptions.title = getTitle(entryName, config);
 
             const favicon = getFavicon(entryName, config);
             if (favicon) {
-              htmlInfo.favicon = favicon;
+              extraData.favicon = favicon;
             }
 
             const finalOptions = reduceConfigsWithContext({
@@ -313,17 +315,31 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
           }),
         );
 
+        const extraDataMap = new WeakMap<object, HtmlExtraData>();
+
         // keep html entry plugin registration order stable based on entryNames
         entryNames.forEach((entryName, index) => {
+          const pluginInstance = new HtmlPlugin(finalOptions[index]);
+          const extraData = extraDataList.find(
+            (item) => item.entryName === entryName,
+          );
+
           chain
             .plugin(`${CHAIN_ID.PLUGIN.HTML}-${entryName}`)
-            .use(HtmlPlugin, [finalOptions[index]]);
+            .use(pluginInstance);
+
+          if (extraData) {
+            extraDataMap.set(pluginInstance, extraData);
+          }
         });
+
+        const getExtraData = (pluginInstance: object) =>
+          extraDataMap.get(pluginInstance);
 
         chain
           .plugin('rsbuild-html-plugin')
           .use(RsbuildHtmlPlugin, [
-            htmlInfoMap,
+            getExtraData,
             () => environment,
             () => context,
           ]);

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
-import type { EntryDescription } from '@rspack/core';
+import type { EntryDescription, RspackPluginInstance } from '@rspack/core';
 import {
   reduceConfigsMergeContext,
   reduceConfigsWithContext,
@@ -315,7 +315,7 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
           }),
         );
 
-        const extraDataMap = new WeakMap<object, HtmlExtraData>();
+        const extraDataMap = new WeakMap<RspackPluginInstance, HtmlExtraData>();
 
         // keep html entry plugin registration order stable based on entryNames
         entryNames.forEach((entryName, index) => {
@@ -333,7 +333,7 @@ export const pluginHtml = (context: InternalContext): RsbuildPlugin => ({
           }
         });
 
-        const getExtraData = (pluginInstance: object) =>
+        const getExtraData = (pluginInstance: RspackPluginInstance) =>
           extraDataMap.get(pluginInstance);
 
         chain

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -69,13 +69,12 @@ export const FILE_ATTRS = {
   script: 'src',
 };
 
-export type HtmlInfo = {
+export type HtmlExtraData = {
+  entryName: string;
   favicon?: string;
   tagConfig?: TagConfig;
   templateContent?: string;
 };
-
-export type RsbuildHtmlPluginOptions = Record<string, HtmlInfo>;
 
 export type AlterAssetTagGroupsData = {
   headTags: HtmlTagObject[];
@@ -240,17 +239,17 @@ export class RsbuildHtmlPlugin {
 
   readonly getEnvironment: () => EnvironmentContext;
 
-  readonly options: RsbuildHtmlPluginOptions;
+  readonly getExtraData: (pluginInstance: object) => HtmlExtraData | undefined;
 
   readonly getContext: () => InternalContext;
 
   constructor(
-    options: RsbuildHtmlPluginOptions,
+    getExtraData: (pluginInstance: object) => HtmlExtraData | undefined,
     getEnvironment: () => EnvironmentContext,
     getContext: () => InternalContext,
   ) {
     this.name = 'RsbuildHtmlPlugin';
-    this.options = options;
+    this.getExtraData = getExtraData;
     this.getEnvironment = getEnvironment;
     this.getContext = getContext;
   }
@@ -342,14 +341,14 @@ export class RsbuildHtmlPlugin {
       const hooks = getHTMLPlugin().getCompilationHooks(compilation);
 
       hooks.alterAssetTagGroups.tapPromise(this.name, async (data) => {
-        const entryName = data.plugin.options?.entryName;
+        const extraData = this.getExtraData(data.plugin);
 
-        if (!entryName) {
+        if (!extraData) {
           return data;
         }
 
         const { headTags, bodyTags } = data;
-        const { favicon, tagConfig, templateContent } = this.options[entryName];
+        const { favicon, tagConfig, entryName, templateContent } = extraData;
 
         if (!hasTitle(templateContent)) {
           addTitleTag(headTags, data.plugin.options?.title);

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { promisify } from 'node:util';
-import type { Compilation, Compiler } from '@rspack/core';
+import type { Compilation, Compiler, RspackPluginInstance } from '@rspack/core';
 import {
   addCompilationError,
   color,
@@ -239,12 +239,16 @@ export class RsbuildHtmlPlugin {
 
   readonly getEnvironment: () => EnvironmentContext;
 
-  readonly getExtraData: (pluginInstance: object) => HtmlExtraData | undefined;
+  readonly getExtraData: (
+    pluginInstance: RspackPluginInstance,
+  ) => HtmlExtraData | undefined;
 
   readonly getContext: () => InternalContext;
 
   constructor(
-    getExtraData: (pluginInstance: object) => HtmlExtraData | undefined,
+    getExtraData: (
+      pluginInstance: RspackPluginInstance,
+    ) => HtmlExtraData | undefined,
     getEnvironment: () => EnvironmentContext,
     getContext: () => InternalContext,
   ) {


### PR DESCRIPTION
## Summary

Updates the HTML plugin to allow to replace HTML plugin option object.

In the previous implementation, `options.entryName` was used as the identifier, and RsbuildHtmlPlugin would not work properly when users used a custom plugin options object. This PR introduces a WeakMap to fix this.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
