### PR TITLE
test(e2e): fix manifest name conflict warning

### DIFF
--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -12,14 +12,18 @@ test('should allow to access manifest data in environment context after prod bui
     cwd: fixtures,
     rsbuildConfig: {
       output: {
-        manifest: true,
         filenameHash: false,
       },
       environments: {
-        web: {},
+        web: {
+          output: {
+            manifest: true,
+          },
+        },
         node: {
           output: {
             target: 'node',
+            manifest: 'manifest-node.json',
           },
         },
       },
@@ -70,14 +74,18 @@ test('should allow to access manifest data in environment context after dev buil
     page,
     rsbuildConfig: {
       output: {
-        manifest: true,
         filenameHash: false,
       },
       environments: {
-        web: {},
+        web: {
+          output: {
+            manifest: true,
+          },
+        },
         node: {
           output: {
             target: 'node',
+            manifest: 'manifest-node.json',
           },
         },
       },


### PR DESCRIPTION
## Summary

Fix manifest name conflict warning when running E2E test:

<img width="1183" alt="Screenshot 2025-05-08 at 13 47 39" src="https://github.com/user-attachments/assets/500e9fcf-873c-4d8c-bb73-513cc14a5c89" />

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5165

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
