### PR TITLE
fix(mf): allow to set `server.cors` with MF Rsbuild plugin

### DIFF
--- a/e2e/cases/module-federation-v2/host/rsbuild.config.ts
+++ b/e2e/cases/module-federation-v2/host/rsbuild.config.ts
@@ -13,6 +13,11 @@ export default defineConfig({
       shared: ['react', 'react-dom'],
     }),
   ],
+  server: {
+    cors: {
+      origin: 'https://localhost',
+    },
+  },
   dev: {
     writeToDisk: true,
   },

--- a/e2e/cases/module-federation-v2/remote/rsbuild.config.ts
+++ b/e2e/cases/module-federation-v2/remote/rsbuild.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
     }),
   ],
   server: {
+    cors: {
+      origin: 'https://localhost',
+    },
     port: Number(process.env.REMOTE_PORT) || 3002,
   },
   dev: {

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -101,14 +101,6 @@ export function pluginModuleFederation(): RsbuildPlugin {
       api.modifyRsbuildConfig((config) => {
         const { moduleFederation } = config;
 
-        if (api.isPluginExists('rsbuild:module-federation-enhanced')) {
-          // Allow remote modules to be loaded by setting CORS headers
-          // This is required for MF to work properly across different origins
-          // TODO: remove this after https://github.com/module-federation/core/pull/3635 is released
-          config.server ||= {};
-          config.server.cors = true;
-        }
-
         if (!moduleFederation?.options) {
           return;
         }


### PR DESCRIPTION
## Summary

As https://github.com/module-federation/core/pull/3635 has been released, we can remove the temp code and allow users to set custom `server.cors` configuration.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
