### PR TITLE
fix(mf): allow to set `server.cors` with built-in MF plugin

### DIFF
--- a/e2e/cases/module-federation/host/rsbuild.config.ts
+++ b/e2e/cases/module-federation/host/rsbuild.config.ts
@@ -7,4 +7,9 @@ export default defineConfig({
   moduleFederation: {
     options: mfConfig,
   },
+  server: {
+    cors: {
+      origin: 'https://localhost',
+    },
+  },
 });

--- a/e2e/cases/module-federation/index.test.ts
+++ b/e2e/cases/module-federation/index.test.ts
@@ -56,6 +56,39 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
+  'should allow to set `server.cors` config',
+  async ({ request }) => {
+    writeButtonCode();
+
+    const remotePort = await getRandomPort();
+    process.env.REMOTE_PORT = remotePort.toString();
+
+    const remoteApp = await dev({
+      cwd: remote,
+    });
+    const hostApp = await dev({
+      cwd: host,
+    });
+
+    // Check CORS headers
+    const remoteResponse = await request.get(
+      `http://127.0.0.1:${remoteApp.port}`,
+    );
+    expect(remoteResponse.headers()['access-control-allow-origin']).toEqual(
+      'https://localhost',
+    );
+
+    const hostResponse = await request.get(`http://127.0.0.1:${hostApp.port}`);
+    expect(hostResponse.headers()['access-control-allow-origin']).toEqual(
+      'https://localhost',
+    );
+
+    await hostApp.close();
+    await remoteApp.close();
+  },
+);
+
+rspackOnlyTest(
   'should run module federation in development mode with server.base',
   async ({ page }) => {
     writeButtonCode();

--- a/e2e/cases/module-federation/remote/rsbuild.config.ts
+++ b/e2e/cases/module-federation/remote/rsbuild.config.ts
@@ -5,6 +5,9 @@ import { mfConfig } from './moduleFederation.config';
 export default defineConfig({
   plugins: [pluginReact()],
   server: {
+    cors: {
+      origin: 'https://localhost',
+    },
     port: Number(process.env.REMOTE_PORT) || 3002,
   },
   moduleFederation: {

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -107,12 +107,16 @@ export function pluginModuleFederation(): RsbuildPlugin {
 
         // Change some default configs for remote modules
         if (moduleFederation.options.exposes) {
+          const userConfig = api.getRsbuildConfig('original');
+
           config.dev ||= {};
           config.server ||= {};
 
           // Allow remote modules to be loaded by setting CORS headers
           // This is required for MF to work properly across different origins
-          config.server.cors = true;
+          if (userConfig.server?.cors === undefined) {
+            config.server.cors = true;
+          }
 
           // For remote modules, Rsbuild should send the ws request to the provider's dev server.
           // This allows the provider to do HMR when the provider module is loaded in the consumer's page.
@@ -123,9 +127,8 @@ export function pluginModuleFederation(): RsbuildPlugin {
 
           // Change the default assetPrefix to `true` for remote modules.
           // This ensures that the remote module's assets can be requested by consumer apps with the correct URL.
-          const originalConfig = api.getRsbuildConfig('original');
           if (
-            originalConfig.dev?.assetPrefix === undefined &&
+            userConfig.dev?.assetPrefix === undefined &&
             config.dev.assetPrefix === config.server?.base
           ) {
             config.dev.assetPrefix = true;


### PR DESCRIPTION
## Summary

When MF application sets both `server.cors` and `moduleFederation.options`, `server.cors` should read the value set by the user instead of forcing it to `true`.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5200

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
