### PR TITLE
feat: expose `defaultAllowedOrigins` from core

### DIFF
--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -1,5 +1,10 @@
 import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { defaultAllowedOrigins } from '@rsbuild/core';
+
+test('should expose `defaultAllowedOrigins`', async () => {
+  expect(defaultAllowedOrigins).toBeInstanceOf(RegExp);
+});
 
 test('should include CORS headers for dev server if `cors` is `true`', async ({
   page,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -78,8 +78,18 @@ const getDefaultDevConfig = (): NormalizedDevConfig => ({
  * - localhost
  * - 127.0.0.1
  * - [::1]
+ *
+ * Can be used in `server.cors.origin` config.
+ * @example
+ * ```ts
+ * server: {
+ *   cors: {
+ *     origin: [defaultAllowedOrigins, 'https://example.com'],
+ *   },
+ * }
+ * ```
  */
-export const LOCAL_ORIGINS_REGEX: RegExp =
+export const defaultAllowedOrigins: RegExp =
   /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
 
 const getDefaultServerConfig = (): NormalizedServerConfig => ({
@@ -92,7 +102,7 @@ const getDefaultServerConfig = (): NormalizedServerConfig => ({
   printUrls: true,
   strictPort: false,
   cors: {
-    origin: LOCAL_ORIGINS_REGEX,
+    origin: defaultAllowedOrigins,
   },
   middlewareMode: false,
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export type { Rspack };
 export { logger } from './logger';
 export { mergeRsbuildConfig } from './mergeConfig';
 export { ensureAssetPrefix } from './helpers';
+export { defaultAllowedOrigins } from './config';
 
 // Constants
 export { PLUGIN_SWC_NAME, PLUGIN_CSS_NAME } from './constants';

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -1,5 +1,5 @@
 import { rspack } from '@rspack/core';
-import { LOCAL_ORIGINS_REGEX } from '../src/config';
+import { defaultAllowedOrigins } from '../src/config';
 import {
   isClientCompiler,
   setupServerHooks,
@@ -310,33 +310,33 @@ describe('test dev server', () => {
 });
 
 test('local origins regex', () => {
-  expect(LOCAL_ORIGINS_REGEX.test('http://localhost:3000')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('http://foo.localhost:3000')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('http://127.0.0.1:3000')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('http://[::1]:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://localhost:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://foo.localhost:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://127.0.0.1:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://[::1]:3000')).toBeTruthy();
 
   // HTTPS protocols
-  expect(LOCAL_ORIGINS_REGEX.test('https://localhost:3000')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('https://127.0.0.1:8080')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('https://foo.localhost:3000')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('https://[::1]:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('https://localhost:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('https://127.0.0.1:8080')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('https://foo.localhost:3000')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('https://[::1]:3000')).toBeTruthy();
 
   // Without port
-  expect(LOCAL_ORIGINS_REGEX.test('http://localhost')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('https://127.0.0.1')).toBeTruthy();
-  expect(LOCAL_ORIGINS_REGEX.test('http://[::1]')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://localhost')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('https://127.0.0.1')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://[::1]')).toBeTruthy();
 
   // Multi-level subdomains
   expect(
-    LOCAL_ORIGINS_REGEX.test('http://test.dev.localhost:8000'),
+    defaultAllowedOrigins.test('http://test.dev.localhost:8000'),
   ).toBeTruthy();
 
   // High port
-  expect(LOCAL_ORIGINS_REGEX.test('http://localhost:65535')).toBeTruthy();
+  expect(defaultAllowedOrigins.test('http://localhost:65535')).toBeTruthy();
 
   // Invalid cases
-  expect(LOCAL_ORIGINS_REGEX.test('http://example.com')).toBeFalsy();
-  expect(LOCAL_ORIGINS_REGEX.test('http://192.168.1.1:3000')).toBeFalsy();
-  expect(LOCAL_ORIGINS_REGEX.test('ftp://localhost:21')).toBeFalsy();
-  expect(LOCAL_ORIGINS_REGEX.test('localhost')).toBeFalsy(); //
+  expect(defaultAllowedOrigins.test('http://example.com')).toBeFalsy();
+  expect(defaultAllowedOrigins.test('http://192.168.1.1:3000')).toBeFalsy();
+  expect(defaultAllowedOrigins.test('ftp://localhost:21')).toBeFalsy();
+  expect(defaultAllowedOrigins.test('localhost')).toBeFalsy(); //
 });

--- a/website/docs/en/config/server/cors.mdx
+++ b/website/docs/en/config/server/cors.mdx
@@ -3,13 +3,15 @@
 - **Type:** `boolean | import('cors').CorsOptions`
 
 ```ts
-const defaultCorsOptions = {
+const defaultAllowedOrigins =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+const defaultOptions = {
   // Default allowed:
   // - localhost
   // - 127.0.0.1
   // - [::1]
-  origin:
-    /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
+  origin: defaultAllowedOrigins,
 };
 ```
 
@@ -35,6 +37,21 @@ export default {
     cors: {
       // Configures the `Access-Control-Allow-Origin` CORS response header
       origin: 'https://example.com',
+    },
+  },
+};
+```
+
+- Keep the default origin config of Rsbuild and add additional origins:
+
+```ts title="rsbuild.config.ts"
+// `defaultAllowedOrigins` is the default origin value of Rsbuild
+import { defaultAllowedOrigins } from '@rsbuild/core';
+
+export default {
+  server: {
+    cors: {
+      origin: [defaultAllowedOrigins, 'https://example.com'],
     },
   },
 };

--- a/website/docs/zh/config/server/cors.mdx
+++ b/website/docs/zh/config/server/cors.mdx
@@ -4,13 +4,15 @@
 - **默认值：**
 
 ```ts
-const defaultCorsOptions = {
+const defaultAllowedOrigins =
+  /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/;
+
+const defaultOptions = {
   // 默认允许：
   // - localhost
   // - 127.0.0.1
   // - [::1]
-  origin:
-    /^https?:\/\/(?:(?:[^:]+\.)?localhost|127\.0\.0\.1|\[::1\])(?::\d+)?$/,
+  origin: defaultAllowedOrigins,
 };
 ```
 
@@ -36,6 +38,21 @@ export default {
     cors: {
       // 配置 `Access-Control-Allow-Origin` CORS 响应头
       origin: 'https://example.com',
+    },
+  },
+};
+```
+
+- 保留 Rsbuild 默认的 origin 配置，并添加额外的 origin：
+
+```ts title="rsbuild.config.ts"
+// `defaultAllowedOrigins` 为 Rsbuild 默认的 origin 值
+import { defaultAllowedOrigins } from '@rsbuild/core';
+
+export default {
+  server: {
+    cors: {
+      origin: [defaultAllowedOrigins, 'https://example.com'],
     },
   },
 };


### PR DESCRIPTION
## Summary

Exposes `defaultAllowedOrigins` from core to allow users to easily add additional origins while keeping the default localhost origins.

```ts title="rsbuild.config.ts"
import { defaultAllowedOrigins } from '@rsbuild/core';

export default {
  server: {
    cors: {
      origin: [defaultAllowedOrigins, 'https://example.com'],
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
