### PR TITLE
feat: enhance sockWrite type to include 'static-changed'

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -9,7 +9,7 @@ import {
 } from '../helpers';
 import { formatStatsMessages } from '../helpers/format';
 import { logger } from '../logger';
-import type { DevConfig, Rspack } from '../types';
+import type { DevConfig, Rspack, SockWriteType } from '../types';
 import { getCompilationId } from './helper';
 import { genOverlayHTML } from './overlay';
 
@@ -24,7 +24,7 @@ function isEqualSet(a: Set<string>, b: Set<string>): boolean {
 const CHECK_SOCKETS_INTERVAL = 30000;
 
 interface SocketMessage {
-  type: string;
+  type: SockWriteType;
   compilationId?: string;
   data?: Record<string, any> | string | boolean;
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1446,9 +1446,16 @@ export type EnvironmentAPI = {
   };
 };
 
+export type SockWriteType = 'static-changed' | (string & {});
+
 export type SetupMiddlewaresServer = {
+  /**
+   * Allows middleware to send some message to HMR client, and then the HMR
+   * client will take different actions depending on the message type.
+   * - `static-changed`: The page will reload.
+   */
   sockWrite: (
-    type: string,
+    type: SockWriteType,
     data?: string | boolean | Record<string, any>,
   ) => void;
   environments: EnvironmentAPI;

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -58,6 +58,8 @@ In the `setupMiddlewares` function, you can access the `server` object, which pr
 
 ### sockWrite
 
+- **Type:** `(type: 'static-changed') => void`
+
 `sockWrite` allows middleware to send some message to HMR client, and then the HMR client will take different actions depending on the message type.
 
 For example, if you send a `'static-changed'` message, the page will reload.
@@ -79,6 +81,8 @@ export default {
 > Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.
 
 ### environments
+
+- **Type:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
 
 `environments` includes Rsbuild's [environment API](/api/javascript-api/environment-api#environment-api), which allows you to get the build outputs information for a specific environment in the server side.
 

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -58,6 +58,8 @@ export default {
 
 ### sockWrite
 
+- **类型:** `(type: 'static-changed') => void`
+
 `sockWrite` 允许中间件向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
 
 例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
@@ -79,6 +81,8 @@ export default {
 > 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。
 
 ### environments
+
+- **类型:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
 
 `environments` 包含 Rsbuild 的 [environment API](/api/javascript-api/environment-api#environment-api)，这允许你在服务端获取特定环境下的构建产物信息。
 


### PR DESCRIPTION
## Summary

- Added a new type, `SockWriteType`, which restricts the `sockWrite` function's `type` parameter to `'static-changed'` or other string values. Updated the `sockWrite` function to use this new type.
- Updated the `sockWrite` section to include the new type definition and clarified its usage.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
