### PR TITLE
feat(server): support for `server.sockWrite`

### DIFF
--- a/e2e/cases/javascript-api/sock-write/index.test.ts
+++ b/e2e/cases/javascript-api/sock-write/index.test.ts
@@ -1,0 +1,28 @@
+import { createRsbuild } from '@rsbuild/core';
+import { expectPoll, gotoPage, rspackOnlyTest } from 'scripts';
+
+rspackOnlyTest(
+  'should allow to call `sockWrite` after creating dev server',
+  async ({ page }) => {
+    let count = 0;
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+
+    const server = await rsbuild.createDevServer();
+
+    server.middlewares.use((_req, _res, next) => {
+      count++;
+      next();
+    });
+
+    await server.listen();
+    await gotoPage(page, server);
+    expectPoll(() => count > 0).toBeTruthy();
+
+    const previousCount = count;
+    server.sockWrite('static-changed');
+    expectPoll(() => count > previousCount).toBeTruthy();
+    await server.close();
+  },
+);

--- a/e2e/cases/javascript-api/sock-write/src/index.js
+++ b/e2e/cases/javascript-api/sock-write/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -9,7 +9,8 @@ import {
 } from '../helpers';
 import { formatStatsMessages } from '../helpers/format';
 import { logger } from '../logger';
-import type { DevConfig, Rspack, SockWriteType } from '../types';
+import type { DevConfig, Rspack } from '../types';
+import type { SockWriteType } from './devServer';
 import { getCompilationId } from './helper';
 import { genOverlayHTML } from './overlay';
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -20,6 +20,7 @@ import type {
 import type RspackChain from '../../compiled/rspack-chain';
 import type { FileDescriptor } from '../../compiled/rspack-manifest-plugin';
 import type { BundleAnalyzerPlugin } from '../../compiled/webpack-bundle-analyzer/index.js';
+import type { RsbuildDevServer } from '../server/devServer';
 import type {
   ModifyBundlerChainUtils,
   ModifyChainUtils,
@@ -1446,20 +1447,10 @@ export type EnvironmentAPI = {
   };
 };
 
-export type SockWriteType = 'static-changed' | (string & {});
-
-export type SetupMiddlewaresServer = {
-  /**
-   * Allows middleware to send some message to HMR client, and then the HMR
-   * client will take different actions depending on the message type.
-   * - `static-changed`: The page will reload.
-   */
-  sockWrite: (
-    type: SockWriteType,
-    data?: string | boolean | Record<string, any>,
-  ) => void;
-  environments: EnvironmentAPI;
-};
+export type SetupMiddlewaresServer = Pick<
+  RsbuildDevServer,
+  'sockWrite' | 'environments'
+>;
 
 export type SetupMiddlewaresFn = (
   middlewares: {

--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -104,6 +104,12 @@ type RsbuildDevServer = {
    * Open URL in the browser after starting the server.
    */
   open: () => Promise<void>;
+  /**
+   * Allows middleware to send some message to HMR client, and then the HMR
+   * client will take different actions depending on the message type.
+   * - `static-changed`: The page will reload.
+   */
+  sockWrite: SockWrite;
 };
 
 type CreateDevServerOptions = {
@@ -127,6 +133,23 @@ function CreateDevServer(
   options?: CreateDevServerOptions,
 ): Promise<RsbuildDevServer>;
 ```
+
+### sockWrite
+
+- **Type:** `(type: 'static-changed') => void`
+
+Sends some message to HMR client, and then the HMR client will take different actions depending on the message type.
+
+For example, if you send a `'static-changed'` message, the page will reload.
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+if (someCondition) {
+  rsbuildServer.sockWrite('static-changed');
+}
+```
+
+> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.
 
 ## Example
 

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -58,9 +58,7 @@ In the `setupMiddlewares` function, you can access the `server` object, which pr
 
 ### sockWrite
 
-- **Type:** `(type: 'static-changed') => void`
-
-`sockWrite` allows middleware to send some message to HMR client, and then the HMR client will take different actions depending on the message type.
+Sends some message to HMR client, see [Dev server API - sockWrite](/api/javascript-api/dev-server-api#sockwrite) for more details.
 
 For example, if you send a `'static-changed'` message, the page will reload.
 
@@ -77,8 +75,6 @@ export default {
   },
 };
 ```
-
-> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.
 
 ### environments
 

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -104,6 +104,11 @@ type RsbuildDevServer = {
    * 启动服务器后，在浏览器中打开 URL
    */
   open: () => Promise<void>;
+  /**
+   * 允许中间件向 HMR 客户端发送一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
+   * - `static-changed`: 页面将会重新加载。
+   */
+  sockWrite: SockWrite;
 };
 
 type CreateDevServerOptions = {
@@ -127,6 +132,23 @@ function CreateDevServer(
   options?: CreateDevServerOptions,
 ): Promise<RsbuildDevServer>;
 ```
+
+### sockWrite
+
+- **类型:** `(type: 'static-changed') => void`
+
+向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
+
+例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+if (someCondition) {
+  rsbuildServer.sockWrite('static-changed');
+}
+```
+
+> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。
 
 ## 示例
 

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -58,9 +58,7 @@ export default {
 
 ### sockWrite
 
-- **类型:** `(type: 'static-changed') => void`
-
-`sockWrite` 允许中间件向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
+向 HMR 客户端传递一些消息，详见 [Dev server API - sockWrite](/api/javascript-api/dev-server-api#sockwrite)。
 
 例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
 
@@ -77,8 +75,6 @@ export default {
   },
 };
 ```
-
-> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。
 
 ### environments
 


### PR DESCRIPTION
## Summary

Added a `sockWrite` method to the `RsbuildDevServer` API, enabling middleware to send messages (e.g., `'static-changed'`) to the HMR client to trigger actions like page reloads.

This is consistent with the `sockWrite` function in the `setupMiddlewares` config, and now developers can call it through the JS API.

```ts
const rsbuildServer = await rsbuild.createDevServer();
if (someCondition) {
  rsbuildServer.sockWrite('static-changed');
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
