### PR TITLE
docs: update dev server API documentation

### DIFF
--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -24,7 +24,51 @@ const server = await rsbuild.createDevServer();
 console.log('the server is ', server);
 ```
 
-## API interface
+## Example
+
+### Integrate with custom server
+
+Here is an example of integrating [express](https://expressjs.com/) with Rsbuild dev server:
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+import express from 'express';
+
+async function startDevServer() {
+  // Init Rsbuild
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      server: {
+        middlewareMode: true,
+      },
+    },
+  });
+  const app = express();
+
+  // Create Rsbuild dev server instance
+  const rsbuildServer = await rsbuild.createDevServer();
+
+  // Apply Rsbuild's built-in middleware
+  app.use(rsbuildServer.middlewares);
+
+  const server = app.listen(rsbuildServer.port, async () => {
+    // Notify Rsbuild that the custom server has started
+    await rsbuildServer.afterListen();
+  });
+
+  rsbuildServer.connectWebSocket({ server });
+}
+```
+
+For detailed usage, please refer to:
+
+- [Example code](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs).
+- [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
+- [server.middlewareMode](/config/server/middleware-mode)
+
+## API
+
+### Type definitions
 
 ```ts
 type EnvironmentAPI = {
@@ -88,10 +132,12 @@ type RsbuildDevServer = {
    */
   afterListen: () => Promise<void>;
   /**
-   * Activate socket connection.
+   * Activates the WebSocket connection.
    * This ensures that HMR works properly.
    */
-  connectWebSocket: (options: { server: HTTPServer }) => void;
+  connectWebSocket: (options: {
+    server: import('node:http').Server | import('node:http2').Http2SecureServer;
+  }) => void;
   /**
    * Close the Rsbuild server.
    */
@@ -134,66 +180,17 @@ function CreateDevServer(
 ): Promise<RsbuildDevServer>;
 ```
 
-### sockWrite
-
-- **Type:** `(type: 'static-changed') => void`
-
-Sends some message to HMR client, and then the HMR client will take different actions depending on the message type.
-
-For example, if you send a `'static-changed'` message, the page will reload.
-
-```ts
-const rsbuildServer = await rsbuild.createDevServer();
-if (someCondition) {
-  rsbuildServer.sockWrite('static-changed');
-}
-```
-
-> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.
-
-## Example
-
-### Integrate with custom server
-
-Here is an example of integrating [express](https://expressjs.com/) with Rsbuild dev server:
-
-```ts
-import { createRsbuild } from '@rsbuild/core';
-import express from 'express';
-
-async function startDevServer() {
-  // Init Rsbuild
-  const rsbuild = await createRsbuild({
-    rsbuildConfig: {
-      server: {
-        middlewareMode: true,
-      },
-    },
-  });
-  const app = express();
-
-  // Create Rsbuild dev server instance
-  const rsbuildServer = await rsbuild.createDevServer();
-
-  // Apply Rsbuild's built-in middleware
-  app.use(rsbuildServer.middlewares);
-
-  const server = app.listen(rsbuildServer.port, async () => {
-    // Notify Rsbuild that the custom server has started
-    await rsbuildServer.afterListen();
-  });
-
-  rsbuildServer.connectWebSocket({ server });
-}
-```
-
-For detailed usage, please refer to:
-
-- [Example code](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs).
-- [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
-- [server.middlewareMode](/config/server/middleware-mode)
-
 ### connectWebSocket
+
+- **Type:**
+
+```ts
+type ConnectWebSocket = (options: {
+  server: import('node:http').Server | import('node:http2').Http2SecureServer;
+}) => void;
+```
+
+Activates the WebSocket connection. This ensures that HMR works properly.
 
 Rsbuild has a builtin WebSocket handler to support HMR:
 
@@ -212,3 +209,33 @@ const httpServer = app.listen(rsbuildServer.port);
 
 rsbuildServer.connectWebSocket({ server: httpServer });
 ```
+
+### environments
+
+- **Type:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
+
+Provides Rsbuild's [environment API](/api/javascript-api/environment-api#environment-api), which allows you to get the build outputs information for a specific environment in the server side.
+
+```ts title="rsbuild.config.ts"
+const rsbuildServer = await rsbuild.createDevServer();
+const webStats = await rsbuildServer.environments.web.getStats();
+
+console.log(webStats.toJson({ all: false }));
+```
+
+### sockWrite
+
+- **Type:** `(type: 'static-changed') => void`
+
+Sends some message to HMR client, and then the HMR client will take different actions depending on the message type.
+
+For example, if you send a `'static-changed'` message, the page will reload.
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+if (someCondition) {
+  rsbuildServer.sockWrite('static-changed');
+}
+```
+
+> Sending `content-changed` and `static-changed` have the same effect. Since `content-changed` has been deprecated, please use `static-changed` instead.

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -56,6 +56,26 @@ export default {
 
 In the `setupMiddlewares` function, you can access the `server` object, which provides some server APIs.
 
+### environments
+
+Provides Rsbuild's [environment API](/api/javascript-api/environment-api#environment-api), see [Dev server API - environments](/api/javascript-api/dev-server-api#environments) for more details.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middlewares, { environments }) => {
+        middlewares.unshift(async (req, _res, next) => {
+          const webStats = await environments.web.getStats();
+          console.log(webStats.toJson({ all: false }));
+          next();
+        });
+      },
+    ],
+  },
+};
+```
+
 ### sockWrite
 
 Sends some message to HMR client, see [Dev server API - sockWrite](/api/javascript-api/dev-server-api#sockwrite) for more details.
@@ -66,34 +86,10 @@ For example, if you send a `'static-changed'` message, the page will reload.
 export default {
   dev: {
     setupMiddlewares: [
-      (middlewares, server) => {
+      (middlewares, { sockWrite }) => {
         if (someCondition) {
-          server.sockWrite('static-changed');
+          sockWrite('static-changed');
         }
-      },
-    ],
-  },
-};
-```
-
-### environments
-
-- **Type:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
-
-`environments` includes Rsbuild's [environment API](/api/javascript-api/environment-api#environment-api), which allows you to get the build outputs information for a specific environment in the server side.
-
-```ts title="rsbuild.config.ts"
-export default {
-  dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.unshift(async (req, _res, next) => {
-          const webStats = await server.environments.web.getStats();
-
-          console.log(webStats.toJson({ all: false }));
-
-          next();
-        });
       },
     ],
   },

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -24,7 +24,51 @@ const server = await rsbuild.createDevServer();
 console.log('the server is ', server);
 ```
 
-## API 定义
+## 示例
+
+### 与自定义 server 集成
+
+下面是一个在 [express](https://expressjs.com/) 中集成 Rsbuild dev server 的例子:
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+import express from 'express';
+
+async function startDevServer() {
+  // 初始化 Rsbuild
+  const rsbuild = await createRsbuild({
+    rsbuildConfig: {
+      server: {
+        middlewareMode: true,
+      },
+    },
+  });
+  const app = express();
+
+  // 创建 Rsbuild dev server 实例
+  const rsbuildServer = await rsbuild.createDevServer();
+
+  // 使用 Rsbuild 的内置中间件
+  app.use(rsbuildServer.middlewares);
+
+  const server = app.listen(rsbuildServer.port, async () => {
+    // 通知 Rsbuild 自定义 Server 已启动
+    await rsbuildServer.afterListen();
+  });
+
+  rsbuildServer.connectWebSocket({ server });
+}
+```
+
+更多用法可参考：
+
+- [示例代码](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs)。
+- [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
+- [server.middlewareMode](/config/server/middleware-mode)
+
+## API
+
+### 类型定义
 
 ```ts
 type EnvironmentAPI = {
@@ -88,10 +132,12 @@ type RsbuildDevServer = {
    */
   afterListen: () => Promise<void>;
   /**
-   * 激活 socket 连接
+   * 激活 WebSocket 连接
    * 这确保了 HMR 正常工作
    */
-  connectWebSocket: (options: { server: HTTPServer }) => void;
+  connectWebSocket: (options: {
+    server: import('node:http').Server | import('node:http2').Http2SecureServer;
+  }) => void;
   /**
    * 关闭 Rsbuild server
    */
@@ -133,66 +179,17 @@ function CreateDevServer(
 ): Promise<RsbuildDevServer>;
 ```
 
-### sockWrite
-
-- **类型:** `(type: 'static-changed') => void`
-
-向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
-
-例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
-
-```ts
-const rsbuildServer = await rsbuild.createDevServer();
-if (someCondition) {
-  rsbuildServer.sockWrite('static-changed');
-}
-```
-
-> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。
-
-## 示例
-
-### 与自定义 server 集成
-
-下面是一个在 [express](https://expressjs.com/) 中集成 Rsbuild dev server 的例子:
-
-```ts
-import { createRsbuild } from '@rsbuild/core';
-import express from 'express';
-
-async function startDevServer() {
-  // 初始化 Rsbuild
-  const rsbuild = await createRsbuild({
-    rsbuildConfig: {
-      server: {
-        middlewareMode: true,
-      },
-    },
-  });
-  const app = express();
-
-  // 创建 Rsbuild dev server 实例
-  const rsbuildServer = await rsbuild.createDevServer();
-
-  // 使用 Rsbuild 的内置中间件
-  app.use(rsbuildServer.middlewares);
-
-  const server = app.listen(rsbuildServer.port, async () => {
-    // 通知 Rsbuild 自定义 Server 已启动
-    await rsbuildServer.afterListen();
-  });
-
-  rsbuildServer.connectWebSocket({ server });
-}
-```
-
-更多用法可参考：
-
-- [示例代码](https://github.com/rspack-contrib/rstack-examples/blob/main/rsbuild/express/server.mjs)。
-- [rsbuild.createDevServer](/api/javascript-api/instance#rsbuildcreatedevserver)
-- [server.middlewareMode](/config/server/middleware-mode)
-
 ### connectWebSocket
+
+- **类型:**
+
+```ts
+type ConnectWebSocket = (options: {
+  server: import('node:http').Server | import('node:http2').Http2SecureServer;
+}) => void;
+```
+
+激活 WebSocket 连接，这确保了 HMR 正常工作。
 
 Rsbuild 内置了 WebSocket 处理器以支持 HMR 功能：
 
@@ -209,3 +206,33 @@ const httpServer = app.listen(rsbuildServer.port);
 
 rsbuildServer.connectWebSocket({ server: httpServer });
 ```
+
+### environments
+
+- **Type:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
+
+提供 Rsbuild 的 [environment API](/api/javascript-api/environment-api#environment-api)，这允许你在服务端获取特定环境下的构建产物信息。
+
+```ts title="rsbuild.config.ts"
+const rsbuildServer = await rsbuild.createDevServer();
+const webStats = await rsbuildServer.environments.web.getStats();
+
+console.log(webStats.toJson({ all: false }));
+```
+
+### sockWrite
+
+- **类型:** `(type: 'static-changed') => void`
+
+向 HMR 客户端传递一些消息，HMR 客户端将根据接收到的消息类型进行不同的处理。
+
+例如，如果你发送一个 `'static-changed'` 的消息，页面将会重新加载。
+
+```ts
+const rsbuildServer = await rsbuild.createDevServer();
+if (someCondition) {
+  rsbuildServer.sockWrite('static-changed');
+}
+```
+
+> 发送 `content-changed` 与 `static-changed` 具有相同的效果。由于 `content-changed` 已经被弃用，请优先使用 `static-changed`。

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -56,6 +56,26 @@ export default {
 
 在 `setupMiddlewares` 函数中，你可以访问到 `server` 对象，该对象提供了一些服务器 API。
 
+### environments
+
+提供 Rsbuild 的 [environment API](/api/javascript-api/environment-api#environment-api)，详见 [Dev server API - environments](/api/javascript-api/dev-server-api#environments)。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middlewares, { environments }) => {
+        middlewares.unshift(async (req, _res, next) => {
+          const webStats = await environments.web.getStats();
+          console.log(webStats.toJson({ all: false }));
+          next();
+        });
+      },
+    ],
+  },
+};
+```
+
 ### sockWrite
 
 向 HMR 客户端传递一些消息，详见 [Dev server API - sockWrite](/api/javascript-api/dev-server-api#sockwrite)。
@@ -66,34 +86,10 @@ export default {
 export default {
   dev: {
     setupMiddlewares: [
-      (middlewares, server) => {
+      (middlewares, { sockWrite }) => {
         if (someCondition) {
-          server.sockWrite('static-changed');
+          sockWrite('static-changed');
         }
-      },
-    ],
-  },
-};
-```
-
-### environments
-
-- **类型:** [EnvironmentAPI](/api/javascript-api/environment-api#environment-api)
-
-`environments` 包含 Rsbuild 的 [environment API](/api/javascript-api/environment-api#environment-api)，这允许你在服务端获取特定环境下的构建产物信息。
-
-```ts title="rsbuild.config.ts"
-export default {
-  dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.unshift(async (req, _res, next) => {
-          const webStats = await server.environments.web.getStats();
-
-          console.log(webStats.toJson({ all: false }));
-
-          next();
-        });
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Updated dev server API documentation to improve clarity and provide additional examples.
- Updated the `connectWebSocket` doc to include `node:http.Server` and `node:http2.Http2SecureServer` types

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
