### PR TITLE
chore(hmr): remove 'still-ok' socket message type

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -177,7 +177,6 @@ function onMessage(e: MessageEvent<string>) {
         clearOverlay();
       }
       break;
-    case 'still-ok':
     case 'ok':
       handleSuccess();
       break;

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -314,7 +314,7 @@ export class SocketServer {
 
     if (shouldEmit) {
       return this.sockWrite({
-        type: 'still-ok',
+        type: 'ok',
         compilationId,
       });
     }


### PR DESCRIPTION
## Summary

Remove `'still-ok'` socket message type, as it has exactly the same effect as `'ok'` in Rsbuild.

## Related Links

- https://github.com/facebook/create-react-app/pull/1377

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
