### PR TITLE
docs: remove incremental from build perf guide

### DIFF
--- a/website/docs/en/guide/basic/upgrade-rsbuild.mdx
+++ b/website/docs/en/guide/basic/upgrade-rsbuild.mdx
@@ -2,7 +2,12 @@
 
 This section explains how to upgrade the project's Rsbuild dependencies to the latest version.
 
-> Please see [Releases](/community/releases/index) to understand the Rsbuild release strategy.
+:::tip
+
+- See [Releases](/community/releases/index) to learn about Rsbuild's release strategy.
+- See [npm - @rsbuild/core](https://npmjs.com/package/@rsbuild/core) to view the latest version.
+
+:::
 
 ## Using taze
 
@@ -21,9 +26,9 @@ The result will look similar to:
 ```bash
 rsbuild - 3 patch
 
-  @rsbuild/core               dev  ~2mo  ^0.6.0  →  ^0.6.15
-  @rsbuild/plugin-react       dev  ~2mo  ^0.6.0  →  ^0.6.15
-  @rsbuild/plugin-type-check  dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/core               dev  ~1mo  ^1.0.0  →  ^1.2.0
+  @rsbuild/plugin-react       dev  ~1mo  ^1.0.0  →  ^1.2.0
+  @rsbuild/plugin-type-check  dev  ~1mo  ^1.0.0  →  ^1.2.0
 
 ℹ changes written to package.json, run npm i to install updates.
 ```

--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -14,6 +14,10 @@ Please refer to the [Performance Building Analysis](/guide/debug/build-profiling
 
 The following are some general optimization methods, which can speed up the development build and production build.
 
+### Upgrade Rsbuild
+
+Upgrading to the latest version of Rsbuild can benefit from the latest performance optimizations, see [Upgrade Rsbuild](/guide/basic/upgrade-rsbuild) section for more details.
+
 ### Enable persistent cache
 
 Rsbuild provides [performance.buildCache](/config/performance/build-cache) configuration, which can significantly improve the speed of rebuilding.
@@ -45,24 +49,6 @@ export default {
 ```
 
 > Please refer to [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
-
-### Enable incremental build
-
-Rspack provides experimental [experiments.incremental](https://rspack.dev/config/experiments#experimentsincremental) configuration, which can improve the HMR speed in development mode.
-
-```ts title="rsbuild.config.ts"
-const isDev = process.env.NODE_ENV === 'development';
-
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        incremental: isDev,
-      },
-    },
-  },
-};
-```
 
 ### Source map format
 

--- a/website/docs/zh/guide/basic/upgrade-rsbuild.mdx
+++ b/website/docs/zh/guide/basic/upgrade-rsbuild.mdx
@@ -2,7 +2,12 @@
 
 本章节介绍如何升级项目中的 Rsbuild 依赖到最新版本。
 
-> 请参考 [版本发布](/community/releases/index) 来了解 Rsbuild 的版本发布策略。
+:::tip
+
+- 参考 [版本发布](/community/releases/index) 来了解 Rsbuild 的版本发布策略。
+- 参考 [npm - @rsbuild/core](https://npmjs.com/package/@rsbuild/core) 查看当前的最新版本。
+
+:::
 
 ## 使用 Taze
 
@@ -21,9 +26,9 @@ npx taze --include /rsbuild/ -w
 ```bash
 rsbuild - 3 patch
 
-  @rsbuild/core               dev  ~2mo  ^0.6.0  →  ^0.6.15
-  @rsbuild/plugin-react       dev  ~2mo  ^0.6.0  →  ^0.6.15
-  @rsbuild/plugin-type-check  dev  ~2mo  ^0.6.0  →  ^0.6.15
+  @rsbuild/core               dev  ~1mo  ^1.0.0  →  ^1.2.0
+  @rsbuild/plugin-react       dev  ~1mo  ^1.0.0  →  ^1.2.0
+  @rsbuild/plugin-type-check  dev  ~1mo  ^1.0.0  →  ^1.2.0
 
 ℹ changes written to package.json, run npm i to install updates.
 ```

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -14,6 +14,10 @@ Rsbuild 默认对构建性能进行了充分优化，但是随着使用场景变
 
 以下是一些通用的优化方法，对开发模式和生产模式均有提速效果。
 
+### 升级 Rsbuild
+
+升级 Rsbuild 到最新版本，可以获得最新的性能优化，参考 [升级 Rsbuild](/guide/basic/upgrade-rsbuild) 章节。
+
 ### 开启持久化缓存
 
 Rsbuild 提供了 [performance.buildCache](/config/performance/build-cache) 配置，开启后可以显著提升重构建的速度。
@@ -45,24 +49,6 @@ export default {
 ```
 
 > 请参考 [dev.lazyCompilation](/config/dev/lazy-compilation) 了解更多。
-
-### 开启增量构建
-
-Rspack 提供了实验性的 [experiments.incremental](https://rspack.dev/zh/config/experiments#experimentsincremental) 配置，开启后可以提升开发阶段 HMR 的速度。
-
-```ts title="rsbuild.config.ts"
-const isDev = process.env.NODE_ENV === 'development';
-
-export default {
-  tools: {
-    rspack: {
-      experiments: {
-        incremental: isDev,
-      },
-    },
-  },
-};
-```
 
 ### Source map 格式
 


### PR DESCRIPTION
## Summary

The `experiments.incremental` config has been enabled by default and we can remove it from the build performance guide.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5167

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
