### PR TITLE
docs: correct default `buildDependencies`

### DIFF
--- a/website/docs/en/config/performance/build-cache.mdx
+++ b/website/docs/en/config/performance/build-cache.mdx
@@ -100,11 +100,11 @@ Rsbuild will use the following configuration files as the default build dependen
 
 - `package.json`
 - `tsconfig.json`
-- `rsbuild.config.*`
+- `.env`, `.env.*`
 - `.browserslistrc`
 - `tailwindcss.config.*`
 
-When using Rsbuild CLI, it will also automatically add `.env` and `.env.*` files to the build dependencies.
+When using Rsbuild CLI, it will also automatically add the Rsbuild configuration file (`rsbuild.config.*`) to the build dependencies.
 
 When you add other build dependencies, Rsbuild merges these custom dependencies with the default dependencies and passes them to Rspack.
 

--- a/website/docs/zh/config/performance/build-cache.mdx
+++ b/website/docs/zh/config/performance/build-cache.mdx
@@ -100,11 +100,11 @@ Rsbuild 会将以下配置文件作为默认的构建依赖：
 
 - `package.json`
 - `tsconfig.json`
-- `rsbuild.config.*`
+- `env`, `.env.*`
 - `.browserslistrc`
 - `tailwindcss.config.*`
 
-在使用 Rsbuild CLI 时，它还会自动将 `.env` 和 `.env.*` 文件添加到构建依赖中。
+在使用 Rsbuild CLI 时，它还会自动将 Rsbuild 配置文件（`rsbuild.config.*`）添加到构建依赖中。
 
 当你添加其他构建依赖时，Rsbuild 会将这些自定义依赖与默认依赖合并，并传递给 Rspack。
 


### PR DESCRIPTION
## Summary

The `.env` and `.env.*` files are included in `buildDependencies` within the `createRsbuild` function. This setup allows these files to be utilized by frameworks built on top of Rsbuild, such as Rspeedy and Rslib.

https://github.com/web-infra-dev/rsbuild/blob/045c4e45dfce3d0d0fc5dc27a8777c5fb1874f4a/packages/core/src/createRsbuild.ts#L140-L150

In contrast, the `rsbuild.config.*` files are added to `buildDependencies` within the `loadConfig` function.

https://github.com/web-infra-dev/rsbuild/blob/045c4e45dfce3d0d0fc5dc27a8777c5fb1874f4a/packages/core/src/config.ts#L449-L452

However, this does not apply to Rspeedy, as it does not utilize the `loadConfig` function from Rsbuild.

It does work in Rslib and Rspress (using `rslib.config.*` and `rspress.config.*`), so I'm uncertain if the current explanation for `rsbuild.config.*` is sufficiently clear.

## Related Links

See https://github.com/lynx-family/lynx-stack/pull/766

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or **not required**).
- [x] Documentation updated (or not required).
