### PR TITLE
feat: narrow Rspack configuration type for `tools.rspack`

### DIFF
--- a/e2e/cases/config/configure-rspack/index.test.ts
+++ b/e2e/cases/config/configure-rspack/index.test.ts
@@ -10,7 +10,7 @@ rspackOnlyTest(
       rsbuildConfig: {
         tools: {
           rspack: (config, { rspack }) => {
-            config.plugins?.push(
+            config.plugins.push(
               new rspack.DefinePlugin({
                 ENABLE_TEST: JSON.stringify(true),
               }),
@@ -38,7 +38,7 @@ rspackOnlyTest(
           rspack: async (config, { rspack }) => {
             return new Promise<void>((resolve) => {
               setTimeout(() => {
-                config.plugins?.push(
+                config.plugins.push(
                   new rspack.DefinePlugin({
                     ENABLE_TEST: JSON.stringify(true),
                   }),

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -1,5 +1,8 @@
 import { rspack } from '@rspack/core';
-import { reduceConfigsAsyncWithContext } from 'reduce-configs';
+import {
+  type ConfigChainAsyncWithContext,
+  reduceConfigsAsyncWithContext,
+} from 'reduce-configs';
 import { merge } from 'webpack-merge';
 import { CHAIN_ID, modifyBundlerChain } from '../configChain';
 import { castArray, color, getNodeEnv } from '../helpers';
@@ -10,6 +13,7 @@ import type {
   InternalContext,
   ModifyChainUtils,
   ModifyRspackConfigUtils,
+  NarrowedRspackConfig,
   RsbuildTarget,
   Rspack,
 } from '../types';
@@ -41,13 +45,19 @@ async function modifyRspackConfig(
 
   [currentConfig] = await context.hooks.modifyRspackConfig.callChain({
     environment: utils.environment.name,
-    args: [rspackConfig, utils],
+    args: [rspackConfig as NarrowedRspackConfig, utils],
   });
 
   if (utils.environment.config.tools?.rspack) {
+    const toolsRspackConfig = utils.environment.config.tools
+      .rspack as ConfigChainAsyncWithContext<
+      NarrowedRspackConfig,
+      ModifyRspackConfigUtils
+    >;
+
     currentConfig = await reduceConfigsAsyncWithContext({
-      initial: currentConfig,
-      config: utils.environment.config.tools.rspack,
+      initial: currentConfig as NarrowedRspackConfig,
+      config: toolsRspackConfig,
       ctx: utils,
       mergeFn: (...args: Rspack.Configuration[]) => {
         // Update the reference of the current config

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -8,10 +8,11 @@ import type RspackChain from '../../compiled/rspack-chain';
 import type { ChainIdentifier } from '../configChain';
 import type {
   ModifyRspackConfigUtils,
+  NarrowedRspackConfig,
   NormalizedConfig,
   NormalizedEnvironmentConfig,
   RsbuildConfig,
-  WebpackMerge,
+  RspackMerge,
 } from './config';
 import type { RsbuildContext } from './context';
 import type {
@@ -135,7 +136,7 @@ export type AsyncHook<Callback extends (...args: any[]) => T, T = any> = {
 };
 
 export type ModifyRspackConfigFn = (
-  config: Rspack.Configuration,
+  config: NarrowedRspackConfig,
   utils: ModifyRspackConfigUtils,
 ) => MaybePromise<Rspack.Configuration | void>;
 
@@ -163,7 +164,7 @@ export type ModifyWebpackConfigUtils = ModifyWebpackChainUtils & {
     plugins: WebpackPluginInstance | WebpackPluginInstance[],
   ) => void;
   removePlugin: (pluginName: string) => void;
-  mergeConfig: WebpackMerge;
+  mergeConfig: RspackMerge;
 };
 
 export type ModifyWebpackChainFn = (

--- a/website/docs/en/config/source/exclude.mdx
+++ b/website/docs/en/config/source/exclude.mdx
@@ -33,7 +33,7 @@ If you want certain files to be excluded and not bundled into the outputs, you c
 export default {
   tools: {
     rspack: (config, { rspack }) => {
-      config.plugins?.push(
+      config.plugins.push(
         new rspack.IgnorePlugin({
           resourceRegExp: /^\.\/locale$/,
           contextRegExp: /moment$/,

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -54,7 +54,6 @@ If you need to override a configuration rather than merge it with the default va
 export default {
   tools: {
     rspack: (config) => {
-      config.resolve ||= {};
       config.resolve.alias ||= {};
       config.resolve.alias['@util'] = 'src/util';
       return config;
@@ -74,7 +73,7 @@ export default {
   tools: {
     rspack: async (config) => {
       const { default: ESLintPlugin } = await import('eslint-webpack-plugin');
-      config.plugins?.push(new ESLintPlugin());
+      config.plugins.push(new ESLintPlugin());
       return config;
     },
   },
@@ -208,7 +207,7 @@ The Rspack instance. For example:
 export default {
   tools: {
     rspack: (config, { rspack }) => {
-      config.plugins?.push(new rspack.BannerPlugin());
+      config.plugins.push(new rspack.BannerPlugin());
       return config;
     },
   },

--- a/website/docs/en/plugins/dev/index.mdx
+++ b/website/docs/en/plugins/dev/index.mdx
@@ -53,7 +53,7 @@ const rsbuildPlugin = () => ({
   name: 'example',
   setup(api) {
     api.modifyRspackConfig((config) => {
-      config.plugins?.push(new RspackExamplePlugin());
+      config.plugins.push(new RspackExamplePlugin());
     });
   },
 });
@@ -212,7 +212,6 @@ export const pluginUploadDist = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyRsbuildConfig((config) => {
       // try to disable minimize.
-      config.output ||= {};
       config.output.minify = false;
       // but also can be enable by other plugins...
     });
@@ -292,7 +291,7 @@ export const pluginEslint = (options?: Options): RsbuildPlugin => ({
   name: 'plugin-eslint',
   setup(api) {
     api.modifyRspackConfig((config) => {
-      config.plugins?.push(
+      config.plugins.push(
         new ESLintRspackPlugin({
           // plugins options
         }),

--- a/website/docs/zh/config/source/exclude.mdx
+++ b/website/docs/zh/config/source/exclude.mdx
@@ -33,7 +33,7 @@ export default {
 export default {
   tools: {
     rspack: (config, { rspack }) => {
-      config.plugins?.push(
+      config.plugins.push(
         new rspack.IgnorePlugin({
           resourceRegExp: /^\.\/locale$/,
           contextRegExp: /moment$/,

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -54,7 +54,6 @@ export default {
 export default {
   tools: {
     rspack: (config) => {
-      config.resolve ||= {};
       config.resolve.alias ||= {};
       config.resolve.alias['@util'] = 'src/util';
       return config;
@@ -74,7 +73,7 @@ export default {
   tools: {
     rspack: async (config) => {
       const { default: ESLintPlugin } = await import('eslint-webpack-plugin');
-      config.plugins?.push(new ESLintPlugin());
+      config.plugins.push(new ESLintPlugin());
       return config;
     },
   },
@@ -208,7 +207,7 @@ export default {
 export default {
   tools: {
     rspack: (config, { rspack }) => {
-      config.plugins?.push(new rspack.BannerPlugin());
+      config.plugins.push(new rspack.BannerPlugin());
       return config;
     },
   },

--- a/website/docs/zh/plugins/dev/index.mdx
+++ b/website/docs/zh/plugins/dev/index.mdx
@@ -53,7 +53,7 @@ const rsbuildPlugin = () => ({
   name: 'example',
   setup(api) {
     api.modifyRspackConfig((config) => {
-      config.plugins?.push(new RspackExamplePlugin());
+      config.plugins.push(new RspackExamplePlugin());
     });
   },
 });
@@ -211,7 +211,6 @@ export const pluginUploadDist = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyRsbuildConfig((config) => {
       // 关闭代码压缩
-      config.output ||= {};
       config.output.minify = false;
       // 轮到其它插件修改配置...
     });
@@ -291,7 +290,7 @@ export const pluginEslint = (options?: Options): RsbuildPlugin => ({
   name: 'plugin-eslint',
   setup(api) {
     api.modifyRspackConfig((config) => {
-      config.plugins?.push(
+      config.plugins.push(
         new ESLintRspackPlugin({
           // plugins options
         }),


### PR DESCRIPTION
## Summary

This PR aims to improve DX by narrow the type of `Rspack.Configuration` to make it easier to use `tools.rspack` function. 

These properties are set by Rsbuild by default so they are non-nullable. A possible edge case is that a plugin removes these fields, but this is unlikely to happen.

- With `Rspack.Configuration`, the `plugins` property is nullable:

```js
tools: {
  rspack(config) {
    if (!config.plugins) {
      config.plugins = [];
    }
    config.plugins.push(new SomePlugin());
  }
}
```

- With `NarrowedRspackConfig`, the `plugins` property is non-nullable:

```js
tools: {
  rspack(config) {
    config.plugins.push(new SomePlugin());
  }
}
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
