### PR TITLE
docs: fix typo in lightningcss-loader page

### DIFF
--- a/website/docs/en/config/tools/lightningcss-loader.mdx
+++ b/website/docs/en/config/tools/lightningcss-loader.mdx
@@ -26,7 +26,7 @@ export default {
   tools: {
     lightningcssLoader: {
       exclude: {
-        vendorPrefixes: false,
+        vendorPrefixes: true,
       },
     },
   },
@@ -42,7 +42,7 @@ export default {
   tools: {
     lightningcssLoader: (config) => {
       config.exclude = {
-        vendorPrefixes: false,
+        vendorPrefixes: true,
       };
       return config;
     },

--- a/website/docs/zh/config/tools/lightningcss-loader.mdx
+++ b/website/docs/zh/config/tools/lightningcss-loader.mdx
@@ -26,7 +26,7 @@ export default {
   tools: {
     lightningcssLoader: {
       exclude: {
-        vendorPrefixes: false,
+        vendorPrefixes: true,
       },
     },
   },
@@ -42,7 +42,7 @@ export default {
   tools: {
     lightningcssLoader: (config) => {
       config.exclude = {
-        vendorPrefixes: false,
+        vendorPrefixes: true,
       };
       return config;
     },


### PR DESCRIPTION
## Summary

To disable vendor prefixes, you need set the value to `true`.

## Related Links

<!--- Provide links of related issues or pages -->

`null`


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
