### PR TITLE
perf(cache): switch hash algorithm to SHA-256 and adjust output length

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -94,7 +94,6 @@ async function getBuildDependencies(
     buildDependencies.browserslistrc = [browserslistConfig];
   }
 
-  console.time('find tailwind config');
   const tailwindExts = ['ts', 'js', 'cjs', 'mjs'];
   const configs = tailwindExts.map((ext) =>
     join(context.rootPath, `tailwind.config.${ext}`),
@@ -104,7 +103,6 @@ async function getBuildDependencies(
   if (tailwindConfig) {
     buildDependencies.tailwindcss = [tailwindConfig];
   }
-  console.timeEnd('find tailwind config');
 
   return {
     ...buildDependencies,

--- a/packages/core/tests/__snapshots__/cache.test.ts.snap
+++ b/packages/core/tests/__snapshots__/cache.test.ts.snap
@@ -37,7 +37,7 @@ exports[`plugin-cache > 'should apply cacheDigest' 1`] = `
         "type": "filesystem",
       },
       "type": "persistent",
-      "version": "web-test-c29a5747",
+      "version": "web-test-fa1844c2988ad15a",
     },
   },
   "plugins": [


### PR DESCRIPTION
## Summary

- Replaced the MD5 hashing algorithm with SHA-256 in the `hash` function for generating digest hashes.
- Increases the hash length from 8 to 16 characters for better security.

## Related Links

- https://lemire.me/blog/2025/01/11/javascript-hashing-speed-comparison-md5-versus-sha-256/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
