### PR TITLE
perf(hash): use `crypto.hash` in higher versions of Node

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto';
 import { posix } from 'node:path';
 import { URL } from 'node:url';
 import deepmerge from 'deepmerge';
@@ -356,3 +357,13 @@ export const addCompilationError = (
     new compilation.compiler.webpack.WebpackError(message),
   );
 };
+
+export function hash(data: string) {
+  // Available in Node.js v20.12.0
+  // faster than `crypto.createHash()` when hashing a smaller amount of data (<= 5MB)
+  if (crypto.hash) {
+    return crypto.hash('sha256', data, 'hex').slice(0, 16);
+  }
+  const hasher = crypto.createHash('sha256');
+  return hasher.update(data).digest('hex').slice(0, 16);
+}

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -358,7 +358,7 @@ export const addCompilationError = (
   );
 };
 
-export function hash(data: string) {
+export function hash(data: string): string {
   // Available in Node.js v20.12.0
   // faster than `crypto.createHash()` when hashing a smaller amount of data (<= 5MB)
   if (crypto.hash) {

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -1,7 +1,6 @@
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { color, findExists, isFileExists } from '../helpers';
+import { color, findExists, hash, isFileExists } from '../helpers';
 import { logger } from '../logger';
 import type {
   BuildCacheOptions,
@@ -43,11 +42,6 @@ async function validateWebpackCache(
 
   await fs.promises.mkdir(cacheDirectory, { recursive: true });
   await fs.promises.writeFile(configFile, JSON.stringify(buildDependencies));
-}
-
-function hash(digest: Array<string | undefined>) {
-  const hasher = crypto.createHash('sha256');
-  return hasher.update(JSON.stringify(digest)).digest('hex').slice(0, 16);
 }
 
 function getCacheDirectory(
@@ -155,7 +149,7 @@ export const pluginCache = (): RsbuildPlugin => ({
 
       // set cache name to avoid cache conflicts between different environments
       const cacheVersion = useDigest
-        ? `${environment.name}-${env}-${hash(cacheConfig.cacheDigest!)}`
+        ? `${environment.name}-${env}-${hash(JSON.stringify(cacheConfig.cacheDigest))}`
         : `${environment.name}-${env}`;
 
       if (bundlerType === 'rspack') {


### PR DESCRIPTION
## Summary

- Use `crypto.hash` in higher versions of Node:

> A utility for creating one-shot hash digests of data. It can be faster than the object-based crypto.createHash() when hashing a smaller amount of data (<= 5MB) that's readily available.
> https://nodejs.org/api/crypto.html#cryptohashalgorithm-data-outputencoding

- Extract the hash helper.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
