### PR TITLE
docs: add Rstest to homepage

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,8 +1183,8 @@ importers:
         specifier: 2.0.0-beta.5
         version: 2.0.0-beta.5
       '@rstack-dev/doc-ui':
-        specifier: 1.8.0
-        version: 1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.10.0
+        version: 1.10.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@shikijs/transformers':
         specifier: ^3.4.0
         version: 3.4.0
@@ -2779,8 +2779,8 @@ packages:
     resolution: {integrity: sha512-cgS/hQVF6q1HLcaGG79TMtenPeaRjp/1oUKZ9yr5YkhWYsAiVday0Ie4dtH98IVOCV9BW520GIBfcYGVyUwxLw==}
     engines: {node: '>=18.0.0'}
 
-  '@rstack-dev/doc-ui@1.8.0':
-    resolution: {integrity: sha512-ejQxDIX/nghX/k6g0Uhmvw/1Y2vNlMfA82Jb9zlhh8pwGQ4jwXTFIFwkfVW09NuLg2RlLOAONLPfrCYZ91x8Wg==}
+  '@rstack-dev/doc-ui@1.10.0':
+    resolution: {integrity: sha512-PRACISyGl8vnqQ1occngpVIfDT0ShKtpi+Tb/HIG7KK+WBV4DaZeNsN1JC5+LHWObEgYsyemCTwxHA9+i3PKIw==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -4338,8 +4338,8 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
-  framer-motion@12.6.5:
-    resolution: {integrity: sha512-MKvnWov0paNjvRJuIy6x418w23tFqRfS6CXHhZrCiSEpXVlo/F+usr8v4/3G6O0u7CpsaO1qop+v4Ip7PRCBqQ==}
+  framer-motion@12.11.4:
+    resolution: {integrity: sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5341,11 +5341,11 @@ packages:
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
 
-  motion-dom@12.6.5:
-    resolution: {integrity: sha512-jpM9TQLXzYMWMJ7Ec7sAj0iis8oIuu6WvjI3yNKJLdrZyrsI/b2cRInDVL8dCl683zQQq19DpL9cSMP+k8T1NA==}
+  motion-dom@12.11.4:
+    resolution: {integrity: sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==}
 
-  motion-utils@12.6.5:
-    resolution: {integrity: sha512-IsOeKsOF+FWBhxQEDFBO6ZYC8/jlidmVbbLpe9/lXSA9j9kzGIMUuIBx2SZY+0reAS0DjZZ1i7dJp4NHrjocPw==}
+  motion-utils@12.9.4:
+    resolution: {integrity: sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -8872,9 +8872,9 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       react-syntax-highlighter: 15.6.1(react@19.1.0)
 
-  '@rstack-dev/doc-ui@1.8.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rstack-dev/doc-ui@1.10.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      framer-motion: 12.6.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      framer-motion: 12.11.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - react
@@ -10558,10 +10558,10 @@ snapshots:
 
   format@0.2.2: {}
 
-  framer-motion@12.6.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  framer-motion@12.11.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      motion-dom: 12.6.5
-      motion-utils: 12.6.5
+      motion-dom: 12.11.4
+      motion-utils: 12.9.4
       tslib: 2.8.1
     optionalDependencies:
       react: 19.1.0
@@ -11886,11 +11886,11 @@ snapshots:
 
   moment@2.30.1: {}
 
-  motion-dom@12.6.5:
+  motion-dom@12.11.4:
     dependencies:
-      motion-utils: 12.6.5
+      motion-utils: 12.9.4
 
-  motion-utils@12.6.5: {}
+  motion-utils@12.9.4: {}
 
   mri@1.2.0: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@rspress/plugin-client-redirects": "2.0.0-beta.5",
     "@rspress/plugin-rss": "2.0.0-beta.5",
     "@rspress/plugin-shiki": "2.0.0-beta.5",
-    "@rstack-dev/doc-ui": "1.8.0",
+    "@rstack-dev/doc-ui": "1.10.0",
     "@shikijs/transformers": "^3.4.0",
     "@types/node": "^22.15.17",
     "@types/react": "^19.1.3",

--- a/website/theme/components/HomeFooter.tsx
+++ b/website/theme/components/HomeFooter.tsx
@@ -71,6 +71,10 @@ function useFooterData() {
           title: 'Rslib',
           link: 'https://lib.rsbuild.dev/',
         },
+        {
+          title: 'Rstest',
+          link: 'https://github.com/web-infra-dev/rstest',
+        },
       ],
     },
     {
@@ -87,6 +91,10 @@ function useFooterData() {
         {
           title: 'Twitter (X)',
           link: 'https://twitter.com/rspack_dev',
+        },
+        {
+          title: 'Bluesky',
+          link: 'https://bsky.app/profile/rspack.dev',
         },
         {
           title: 'Awesome Rspack',

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,26 +1,12 @@
-import {
-  containerStyle,
-  descStyle,
-  innerContainerStyle,
-  titleAndDescStyle,
-  titleStyle,
-} from '@rstack-dev/doc-ui/section-style';
+import { containerStyle } from '@rstack-dev/doc-ui/section-style';
 import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
 import { useLang } from 'rspress/runtime';
-import { useI18n } from 'rspress/runtime';
 
 export function ToolStack() {
-  const t = useI18n<typeof import('i18n')>();
   const lang = useLang();
   return (
     <section className={containerStyle}>
-      <div className={innerContainerStyle}>
-        <div className={titleAndDescStyle}>
-          <h1 className={titleStyle}>{t('toolStackTitle')}</h1>
-          <p className={descStyle}>{t('toolStackDesc')}</p>
-        </div>
-        <BaseToolStack lang={lang} />
-      </div>
+      <BaseToolStack lang={lang} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Update @rstack-dev/doc-ui to 1.10.0 to add Rstest to homepage.
- This update also includes some UI and text improvements.

Related: https://github.com/rspack-contrib/rstack-doc-ui/releases

## Rstack List

### Before

<img width="1472" alt="Screenshot 2025-05-15 at 22 09 54" src="https://github.com/user-attachments/assets/984c7df8-05f3-41ea-a743-8384400cfe72" />

### After

![image](https://github.com/user-attachments/assets/965ec88d-8087-48ed-b8ee-a897ed76fa1d)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
