### PR TITLE
feat: normalize tsconfigPath in environment configuration

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -98,10 +98,7 @@ export async function updateEnvironmentContext(
   context.environments ||= {};
 
   for (const [index, [name, config]] of Object.entries(configs).entries()) {
-    const tsconfigPath = config.source.tsconfigPath
-      ? getAbsolutePath(context.rootPath, config.source.tsconfigPath)
-      : undefined;
-
+    const { tsconfigPath } = config.source;
     const browserslist = await getBrowserslistByEnvironment(
       context.rootPath,
       config,


### PR DESCRIPTION
## Summary

Normalize the `source.tsconfigPath` in environment configuration:

```js
api.modifyRspackConfig((config, { environment }) => {
  console.log(environment.config.source.tsconfigPath); // -> Now is absolute path
  return config;
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
