### PR TITLE
chore: remove duplicated path helper

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { loadConfig as baseLoadConfig } from '../config';
 import { createRsbuild } from '../createRsbuild';
-import { castArray, getAbsolutePath } from '../helpers';
+import { castArray, ensureAbsolutePath } from '../helpers';
 import { logger } from '../logger';
 import { watchFilesForRestart } from '../restart';
 import type { RsbuildInstance } from '../types';
@@ -86,7 +86,9 @@ export async function init({
 
   try {
     const cwd = process.cwd();
-    const root = commonOpts.root ? getAbsolutePath(cwd, commonOpts.root) : cwd;
+    const root = commonOpts.root
+      ? ensureAbsolutePath(cwd, commonOpts.root)
+      : cwd;
 
     const rsbuild = await createRsbuild({
       cwd: root,

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { loadConfig } from 'browserslist-load-config';
 import { withDefaultConfig } from './config';
 import { DEFAULT_BROWSERSLIST, ROOT_DIST_DIR } from './constants';
-import { getAbsolutePath, getCommonParentPath } from './helpers/path';
+import { ensureAbsolutePath, getCommonParentPath } from './helpers/path';
 import { initHooks } from './hooks';
 import { getHTMLPathByEntry } from './initPlugins';
 import { logger } from './logger';
@@ -22,7 +22,7 @@ function getAbsoluteDistPath(
   config: RsbuildConfig | NormalizedConfig | NormalizedEnvironmentConfig,
 ) {
   const dirRoot = config.output?.distPath?.root ?? ROOT_DIST_DIR;
-  return getAbsolutePath(cwd, dirRoot);
+  return ensureAbsolutePath(cwd, dirRoot);
 }
 
 // using cache to avoid multiple calls to loadConfig
@@ -188,7 +188,7 @@ export async function createContext(
 ): Promise<InternalContext> {
   const { cwd } = options;
   const rootPath = userConfig.root
-    ? getAbsolutePath(cwd, userConfig.root)
+    ? ensureAbsolutePath(cwd, userConfig.root)
     : cwd;
   const rsbuildConfig = await withDefaultConfig(rootPath, userConfig);
   const cachePath = join(rootPath, 'node_modules', '.cache');

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -1,11 +1,7 @@
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import { isAbsolute, join, relative, sep } from 'node:path';
 import { COMPILED_PATH } from '../constants';
 
-export function getAbsolutePath(base: string, filepath: string): string {
-  return isAbsolute(filepath) ? filepath : join(base, filepath);
-}
-
-export function getRelativePath(base: string, filepath: string): string {
+export function toRelativePath(base: string, filepath: string): string {
   const relativePath = relative(base, filepath);
 
   if (relativePath === '') {
@@ -48,9 +44,9 @@ export const getCompiledPath = (packageName: string): string =>
  * @returns Resolved absolute file path.
  */
 export const ensureAbsolutePath = (base: string, filePath: string): string =>
-  isAbsolute(filePath) ? filePath : resolve(base, filePath);
+  isAbsolute(filePath) ? filePath : join(base, filePath);
 
-export const pathnameParse = (publicPath: string): string => {
+export const getPathnameFromUrl = (publicPath: string): string => {
   try {
     return publicPath ? new URL(publicPath).pathname : publicPath;
   } catch (err) {

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -4,7 +4,7 @@ import {
   updateContextByNormalizedConfig,
   updateEnvironmentContext,
 } from '../createContext';
-import { camelCase, color, getAbsolutePath, pick } from '../helpers';
+import { camelCase, color, ensureAbsolutePath, pick } from '../helpers';
 import { isDebug, logger } from '../logger';
 import { mergeRsbuildConfig } from '../mergeConfig';
 import { initPlugins } from '../pluginManager';
@@ -229,7 +229,7 @@ export async function initRsbuildConfig({
 
     // Ensure the `tsconfigPath` is an absolute path
     if (tsconfigPath) {
-      normalizedEnvironmentConfig.source.tsconfigPath = getAbsolutePath(
+      normalizedEnvironmentConfig.source.tsconfigPath = ensureAbsolutePath(
         context.rootPath,
         tsconfigPath,
       );

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -3,7 +3,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
 import { HTML_REGEX } from '../constants';
 import { isMultiCompiler } from '../helpers';
-import { pathnameParse } from '../helpers/path';
+import { getPathnameFromUrl } from '../helpers/path';
 import type {
   EnvironmentContext,
   NextFunction,
@@ -185,7 +185,7 @@ export class CompilationManager {
 
     const { base } = serverConfig;
     const assetPrefixes = publicPaths
-      .map(pathnameParse)
+      .map(getPathnameFromUrl)
       .map((prefix) =>
         base && base !== '/' ? stripBase(prefix, base) : prefix,
       );

--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { getRelativePath } from '../helpers';
+import { toRelativePath } from '../helpers';
 import { ansiHTML } from './ansiHTML';
 import { escapeHtml } from './helper';
 
@@ -31,7 +31,7 @@ export function convertLinksInHtml(text: string, root?: string): string {
       const absolutePath =
         root && !isAbsolute ? path.join(root, filePath) : filePath;
       const relativePath =
-        root && isAbsolute ? getRelativePath(root, filePath) : filePath;
+        root && isAbsolute ? toRelativePath(root, filePath) : filePath;
 
       return `<a class="file-link" data-file="${absolutePath}">${relativePath}</a>${suffix}`;
     });

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type Connect from '../../compiled/connect/index.js';
-import { pathnameParse } from '../helpers/path';
+import { getPathnameFromUrl } from '../helpers/path';
 import { logger } from '../logger';
 import type {
   InternalContext,
@@ -193,7 +193,7 @@ export async function startProdServer(
       output: {
         path: context.distPath,
         assetPrefixes: Object.values(context.environments).map((e) =>
-          pathnameParse(e.config.output.assetPrefix),
+          getPathnameFromUrl(e.config.output.assetPrefix),
         ),
       },
       serverConfig,


### PR DESCRIPTION
## Summary

Remove duplicated path helper, `getAbsolutePath` and `ensureAbsolutePath` provide the same functionality and can be merged into one.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
