### PR TITLE
docs: enhance rsbuild.context with access methods

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -4,7 +4,30 @@ This section describes all the properties and methods on the Rsbuild instance ob
 
 ## rsbuild.context
 
-`rsbuild.context` is a read-only object that provides some context information.
+`rsbuild.context` is a read-only object that provides some context information, which can be accessed in two ways:
+
+1. Access through the `context` property of the Rsbuild instance:
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+
+const rsbuild = createRsbuild({
+  // ...
+});
+
+console.log(rsbuild.context);
+```
+
+2. Access through the [api.context](/plugins/dev/core#apicontext) of the Rsbuild plugin:
+
+```ts
+export const myPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    console.log(api.context);
+  },
+};
+```
 
 ### context.version
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -4,7 +4,30 @@
 
 ## rsbuild.context
 
-`rsbuild.context` 是一个只读对象，提供一些上下文信息。
+`context` 是一个只读对象，提供一些上下文信息，能够通过两种方式访问：
+
+1. 通过 Rsbuild 实例的 `context` 属性访问：
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+
+const rsbuild = createRsbuild({
+  // ...
+});
+
+console.log(rsbuild.context);
+```
+
+2. 通过 Rsbuild 插件的 [api.context](/plugins/dev/core#apicontext) 访问：
+
+```ts
+export const myPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    console.log(api.context);
+  },
+};
+```
 
 ### context.version
 


### PR DESCRIPTION
## Summary

Expanded the description of `rsbuild.context` to include two methods of accessing the property (via the `context` property of the Rsbuild instance and via the `api.context` in plugins) and added code examples.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
