### PR TITLE
docs: update `context.devServer` with examples

### DIFF
--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -15,10 +15,29 @@ export type RsbuildContext = {
   distPath: string;
   /** Absolute path of cache files. */
   cachePath: string;
-  /** Info of dev server  */
+  /**
+   * Dev server information when running in dev mode.
+   * Available after the dev server has been created.
+   *
+   * @example
+   * ```ts
+   * import { createRsbuild } from '@rsbuild/core';
+   *
+   * async function main() {
+   *   const rsbuild = createRsbuild({
+   *     // ...
+   *   });
+   *   await rsbuild.startDevServer();
+   *   console.log(rsbuild.context.devServer); // { hostname: 'localhost', port: 3000, https: false }
+   * }
+   * ```
+   */
   devServer?: {
+    /** The hostname the server is running on. */
     hostname: string;
+    /** The port number the server is listening on. */
     port: number;
+    /** Whether the server is using HTTPS protocol. */
     https: boolean;
   };
   /**

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -106,7 +106,7 @@ Here are some tools based on Rsbuild that have already set the `callerName` valu
 
 ### context.devServer
 
-Dev server information, including the current dev server hostname and port number.
+Dev server information when running in dev mode. Available after the dev server has been created.
 
 - **Type:**
 
@@ -114,7 +114,23 @@ Dev server information, including the current dev server hostname and port numbe
 type DevServer = {
   hostname: string;
   port: number;
+  https: boolean;
 };
+```
+
+- **Example:**
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+
+async function main() {
+  const rsbuild = createRsbuild({
+    // ...
+  });
+  await rsbuild.startDevServer();
+
+  console.log(rsbuild.context.devServer); // { hostname: 'localhost', port: 3000, https: false }
+}
 ```
 
 ### context.action

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -106,7 +106,7 @@ export const myPlugin = {
 
 ### context.devServer
 
-Dev server 相关信息，包含了当前 dev server 的 hostname 和端口号。
+在开发模式下运行时的 dev server 信息。仅在 dev server 创建后可访问。
 
 - **类型：**
 
@@ -114,7 +114,23 @@ Dev server 相关信息，包含了当前 dev server 的 hostname 和端口号�
 type DevServer = {
   hostname: string;
   port: number;
+  https: boolean;
 };
+```
+
+- **示例：**
+
+```ts
+import { createRsbuild } from '@rsbuild/core';
+
+async function main() {
+  const rsbuild = createRsbuild({
+    // ...
+  });
+  await rsbuild.startDevServer();
+
+  console.log(rsbuild.context.devServer); // { hostname: 'localhost', port: 3000, https: false }
+}
 ```
 
 ### context.action


### PR DESCRIPTION
## Summary

Enhanced the `devServer` property in `RsbuildContext` to include detailed comments, an example usage, and descriptions for its fields (`hostname`, `port`, and `https`)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
