### PR TITLE
fix: update rspackMinVersion to 1.2.4 for SRI support

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -19,7 +19,8 @@ export * from './stats';
 
 export { color };
 
-export const rspackMinVersion = '1.0.0';
+// `SubresourceIntegrityPlugin` added in Rspack v1.2.4
+export const rspackMinVersion = '1.2.4';
 
 export const getNodeEnv = () => process.env.NODE_ENV as string;
 export const setNodeEnv = (env: string): void => {

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -79,6 +79,11 @@ const compareSemver = (version1: string, version2: string) => {
   return 0;
 };
 
+/**
+ * If the application overrides the Rspack version to a lower one,
+ * we should check that the Rspack version is greater than the minimum
+ * supported version.
+ */
 export const isSatisfyRspackVersion = async (
   originalVersion: string,
 ): Promise<boolean> => {

--- a/packages/core/tests/rspackVersion.test.ts
+++ b/packages/core/tests/rspackVersion.test.ts
@@ -6,7 +6,7 @@ describe('rspack version', () => {
 
     expect(await isSatisfyRspackVersion(rspackMinVersion)).toBeTruthy();
 
-    expect(await isSatisfyRspackVersion('1.0.0')).toBeTruthy();
+    expect(await isSatisfyRspackVersion('10.0.0')).toBeTruthy();
 
     expect(
       await isSatisfyRspackVersion('0.2.7-canary-efa0dc6-20230817005622'),


### PR DESCRIPTION
## Summary

Update the `rspackMinVersion` to 1.2.4 as Rspack's SubresourceIntegrityPlugin plugin was introduced in v1.2.4.

## Related Links

- https://rspack.dev/plugins/rspack/subresource-integrity-plugin

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
