### PR TITLE
fix(plugin-svelte): should transpile JS code in .svelte files

### DIFF
--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -114,16 +114,26 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             },
           };
 
-          chain.module
+          const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
+          const swcUse = jsRule.uses.get(CHAIN_ID.USE.SWC);
+          const svelteRule = chain.module
             .rule(CHAIN_ID.RULE.SVELTE)
-            .test(/\.svelte$/)
+            .test(/\.svelte$/);
+
+          if (svelte5 && jsRule) {
+            svelteRule
+              .use(CHAIN_ID.USE.SWC)
+              .loader(swcUse.get('loader'))
+              .options(swcUse.get('options'));
+          }
+
+          svelteRule
             .use(CHAIN_ID.USE.SVELTE)
             .loader(loaderPath)
-            .options(svelteLoaderOptions);
+            .options(svelteLoaderOptions)
+            .end();
 
-          const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
           if (svelte5 && jsRule) {
-            const swcUse = jsRule.uses.get(CHAIN_ID.USE.SWC);
             const regexp = /\.(?:svelte\.js|svelte\.ts)$/;
 
             jsRule.exclude.add(regexp);

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -232,6 +232,37 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
     "test": /\\\\\\.svelte\\$/,
     "use": [
       {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+      {
         "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
         "options": {
           "compilerOptions": {
@@ -297,6 +328,37 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
     "test": /\\\\\\.svelte\\$/,
     "use": [
       {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+      {
         "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
         "options": {
           "compilerOptions": {
@@ -317,6 +379,37 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
   {
     "test": /\\\\\\.svelte\\$/,
     "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
       {
         "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
         "options": {
@@ -343,6 +436,37 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
     "test": /\\\\\\.svelte\\$/,
     "use": [
       {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
+      {
         "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
         "options": {
           "compilerOptions": {
@@ -367,6 +491,37 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
   {
     "test": /\\\\\\.svelte\\$/,
     "use": [
+      {
+        "loader": "builtin:swc-loader",
+        "options": {
+          "env": {
+            "mode": undefined,
+            "targets": [
+              "chrome >= 87",
+              "edge >= 88",
+              "firefox >= 78",
+              "safari >= 14",
+            ],
+          },
+          "isModule": "unknown",
+          "jsc": {
+            "experimental": {
+              "cacheRoot": "<ROOT>/packages/plugin-svelte/tests/node_modules/.cache/.swc",
+              "keepImportAttributes": true,
+            },
+            "externalHelpers": true,
+            "parser": {
+              "decorators": true,
+              "syntax": "typescript",
+              "tsx": false,
+            },
+            "transform": {
+              "decoratorVersion": "2022-03",
+              "legacyDecorator": false,
+            },
+          },
+        },
+      },
       {
         "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
         "options": {


### PR DESCRIPTION
## Summary

Use `swc-loader` to transpile JavaScript code in `.svelte` files to ensure that the compiled JS code can be downgraded as expected.

More test cases will be added in later PRs.

## Related Links

https://discord.com/channels/977448667919286283/1167025132905173063/1373701903644622878

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
