### PR TITLE
chore(types): limit readonly config to two level

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -47,9 +47,9 @@ import type {
   ConfigChain,
   ConfigChainMergeContext,
   ConfigChainWithContext,
-  DeepReadonly,
   MaybePromise,
   OneOrMany,
+  TwoLevelReadonly,
 } from './utils';
 
 export type ToolsSwcConfig = ConfigChain<SwcLoaderOptions>;
@@ -1802,7 +1802,7 @@ export type MergedEnvironmentConfig = {
 /**
  * The normalized Rsbuild environment config.
  */
-export type NormalizedEnvironmentConfig = DeepReadonly<
+export type NormalizedEnvironmentConfig = TwoLevelReadonly<
   Omit<MergedEnvironmentConfig, 'dev'> & {
     dev: NormalizedDevConfig;
     server: NormalizedServerConfig;

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -4,9 +4,16 @@ export type OneOrMany<T> = T | T[];
 
 export type MaybePromise<T> = T | Promise<T>;
 
-export type DeepReadonly<T> = keyof T extends never
+/**
+ * Creates a type with readonly properties at the first and second levels only.
+ */
+export type TwoLevelReadonly<T> = keyof T extends never
   ? T
-  : { readonly [k in keyof T]: DeepReadonly<T[k]> };
+  : {
+      readonly [k in keyof T]: T[k] extends object
+        ? { readonly [p in keyof T[k]]: T[k][p] }
+        : T[k];
+    };
 
 export type ConfigChain<T> = OneOrMany<T | ((config: T) => T | void)>;
 


### PR DESCRIPTION
## Summary

During the process of updating config types, I discovered that `DeepReadonly` type was causing more trouble than providing benefits, which led me to decide to replace it with a second-level Readonly to reduce type complexity. I guess this might also improve type inference performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
