### PR TITLE
fix: narrow watchFiles type in normalized config

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -112,19 +112,21 @@ export async function init({
       const files: string[] = [];
       const config = rsbuild.getNormalizedConfig();
 
-      if (config.dev?.watchFiles) {
-        for (const watchFilesConfig of castArray(config.dev.watchFiles)) {
-          if (watchFilesConfig.type !== 'reload-server') {
+      if (config.dev.watchFiles) {
+        for (const watchConfig of config.dev.watchFiles) {
+          if (watchConfig.type !== 'reload-server') {
             continue;
           }
 
-          const paths = castArray(watchFilesConfig.paths);
-          if (watchFilesConfig.options) {
+          const paths = Array.isArray(watchConfig.paths)
+            ? watchConfig.paths
+            : [watchConfig.paths];
+          if (watchConfig.options) {
             watchFilesForRestart({
               files: paths,
               rsbuild,
               isBuildWatch,
-              watchOptions: watchFilesConfig.options,
+              watchOptions: watchConfig.options,
             });
           } else {
             files.push(...paths);

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -118,9 +118,7 @@ export async function init({
             continue;
           }
 
-          const paths = Array.isArray(watchConfig.paths)
-            ? watchConfig.paths
-            : [watchConfig.paths];
+          const paths = castArray(watchConfig.paths);
           if (watchConfig.options) {
             watchFilesForRestart({
               files: paths,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -53,6 +53,7 @@ const require = createRequire(import.meta.url);
 const getDefaultDevConfig = (): NormalizedDevConfig => ({
   hmr: true,
   liveReload: true,
+  watchFiles: [],
   // Temporary placeholder, default: `${server.base}`
   assetPrefix: DEFAULT_ASSET_PREFIX,
   writeToDisk: false,
@@ -305,13 +306,20 @@ export const normalizeConfig = (config: RsbuildConfig): NormalizedConfig => {
       : 'none';
   };
 
-  return mergeRsbuildConfig(
+  const mergedConfig = mergeRsbuildConfig(
     {
       ...createDefaultConfig(),
       mode: getMode(),
     },
     config,
-  ) as unknown as NormalizedConfig;
+  ) as Required<RsbuildConfig>;
+
+  const { watchFiles } = mergedConfig.dev;
+  if (!Array.isArray(watchFiles)) {
+    mergedConfig.dev.watchFiles = [watchFiles!];
+  }
+
+  return mergedConfig as unknown as NormalizedConfig;
 };
 
 export type ConfigParams = {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -314,9 +314,9 @@ export const normalizeConfig = (config: RsbuildConfig): NormalizedConfig => {
     config,
   ) as Required<RsbuildConfig>;
 
-  const { watchFiles } = mergedConfig.dev;
+  const { watchFiles } = mergedConfig.dev as NormalizedDevConfig;
   if (!Array.isArray(watchFiles)) {
-    mergedConfig.dev.watchFiles = [watchFiles!];
+    mergedConfig.dev.watchFiles = [watchFiles];
   }
 
   return mergedConfig as unknown as NormalizedConfig;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1633,13 +1633,14 @@ export interface DevConfig {
   lazyCompilation?: boolean | Rspack.LazyCompilationOptions;
 }
 
-export type NormalizedDevConfig = DevConfig &
+export type NormalizedDevConfig = Omit<DevConfig, 'watchFiles'> &
   Required<
     Pick<
       DevConfig,
       'hmr' | 'liveReload' | 'assetPrefix' | 'writeToDisk' | 'cliShortcuts'
     >
   > & {
+    watchFiles: WatchFiles[];
     client: NormalizedClientConfig;
   };
 

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -15,6 +15,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "hmr": true,
     "lazyCompilation": true,
     "liveReload": true,
+    "watchFiles": [],
     "writeToDisk": false,
   },
   "html": {
@@ -159,6 +160,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "hmr": true,
     "lazyCompilation": false,
     "liveReload": true,
+    "watchFiles": [],
     "writeToDisk": false,
   },
   "html": {
@@ -303,6 +305,7 @@ exports[`environment config > should print environment config when inspect confi
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -443,6 +446,7 @@ exports[`environment config > should print environment config when inspect confi
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -603,6 +607,7 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -743,6 +748,7 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -884,6 +890,7 @@ exports[`environment config > should support modify environment config by api.mo
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -1028,6 +1035,7 @@ exports[`environment config > should support modify single environment config by
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {
@@ -1168,6 +1176,7 @@ exports[`environment config > should support modify single environment config by
       },
       "hmr": true,
       "liveReload": true,
+      "watchFiles": [],
       "writeToDisk": false,
     },
     "html": {


### PR DESCRIPTION
## Summary

This PR ensures that the `dev.watchFiles` option is always normalized into an array, making it easier to consume.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
