### PR TITLE
feat: reload server when tsconfig.json is changed

### DIFF
--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -1,0 +1,42 @@
+import { exec } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  expectFile,
+  getRandomPort,
+  gotoPage,
+  rspackOnlyTest,
+} from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+import fse from 'fs-extra';
+import { tempConfig } from './rsbuild.config';
+
+rspackOnlyTest(
+  'should watch tsconfig.json and reload the server when it changes',
+  async ({ page }) => {
+    const dist = join(__dirname, 'dist');
+
+    await fse.remove(dist);
+    await fse.remove(tempConfig);
+    await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
+
+    const port = await getRandomPort();
+    const childProcess = exec('npx rsbuild dev', {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        PORT: String(port),
+      },
+    });
+
+    await expectFile(dist);
+    await gotoPage(page, { port });
+    await expect(page.locator('#content')).toHaveText('foo');
+
+    const tsconfigContent = await readFile(tempConfig, 'utf-8');
+    await writeFile(tempConfig, tsconfigContent.replace('foo', 'bar'));
+    await expect(page.locator('#content')).toHaveText('bar');
+
+    childProcess.kill();
+  },
+);

--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -7,13 +7,17 @@ import {
   gotoPage,
   rspackOnlyTest,
 } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import fse from 'fs-extra';
 import { tempConfig } from './rsbuild.config';
 
 rspackOnlyTest(
   'should watch tsconfig.json and reload the server when it changes',
   async ({ page }) => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
     const dist = join(__dirname, 'dist');
 
     await fse.remove(dist);

--- a/e2e/cases/alias/tsconfig-paths-reload/rsbuild.config.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/rsbuild.config.ts
@@ -1,0 +1,16 @@
+import { join } from 'node:path';
+import { defineConfig } from '@rsbuild/core';
+
+export const tempConfig = join(__dirname, 'test-temp-tsconfig.json');
+
+export default defineConfig({
+  dev: {
+    writeToDisk: true,
+  },
+  source: {
+    tsconfigPath: tempConfig,
+  },
+  server: {
+    port: Number(process.env.PORT),
+  },
+});

--- a/e2e/cases/alias/tsconfig-paths-reload/src/bar/test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/src/bar/test.ts
@@ -1,0 +1,1 @@
+export const content = 'bar';

--- a/e2e/cases/alias/tsconfig-paths-reload/src/foo/test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/src/foo/test.ts
@@ -1,0 +1,1 @@
+export const content = 'foo';

--- a/e2e/cases/alias/tsconfig-paths-reload/src/index.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/src/index.ts
@@ -1,0 +1,6 @@
+import { content } from '@/content';
+
+const testAliasEl = document.createElement('div');
+testAliasEl.id = 'content';
+testAliasEl.innerHTML = content;
+document.body.appendChild(testAliasEl);

--- a/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
+++ b/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "paths": {
+      "@/content": ["src/foo/test.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -24,7 +24,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const process = exec(`npx rsbuild build --watch -c ${tempConfigFile}`, {
+  const childProcess = exec(`npx rsbuild build --watch -c ${tempConfigFile}`, {
     cwd: __dirname,
   });
 
@@ -51,5 +51,5 @@ rspackOnlyTest('should support restart build when config changed', async () => {
   await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
-  process.kill();
+  childProcess.kill();
 });

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -13,7 +13,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const process = exec('npx rsbuild build --watch', {
+  const childProcess = exec('npx rsbuild build --watch', {
     cwd: __dirname,
   });
 
@@ -25,5 +25,5 @@ rspackOnlyTest('should support watch mode for build command', async () => {
   await expectFile(distIndexFile);
   expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
 
-  process.kill();
+  childProcess.kill();
 });

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -30,7 +30,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const process = exec('npx rsbuild dev', {
+    const childProcess = exec('npx rsbuild dev', {
       cwd: __dirname,
     });
 
@@ -53,6 +53,6 @@ rspackOnlyTest(
 
     await expectFile(dist2);
 
-    process.kill();
+    childProcess.kill();
   },
 );

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/index.test.ts
@@ -12,11 +12,11 @@ rspackOnlyTest('should run onExit hook before process exit', async () => {
 
   await new Promise<void>((resolve, reject) => {
     const timeoutId = setTimeout(() => {
-      process.kill();
+      childProcess.kill();
       reject(new Error('Process timeout'));
     }, 3000);
 
-    const process = exec('node ./run.mjs', { cwd: __dirname }, (error) => {
+    const childProcess = exec('node ./run.mjs', { cwd: __dirname }, (error) => {
       if (error) {
         clearTimeout(timeoutId);
         reject(error);

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -246,8 +246,7 @@ export async function initRsbuildConfig({
   // to ensure `paths` alias can be updated
   if (
     tsconfigPaths.size &&
-    normalizedBaseConfig.resolve.aliasStrategy === 'prefer-tsconfig' &&
-    Array.isArray(normalizedBaseConfig.dev.watchFiles)
+    normalizedBaseConfig.resolve.aliasStrategy === 'prefer-tsconfig'
   ) {
     normalizedBaseConfig.dev.watchFiles.push({
       paths: Array.from(tsconfigPaths),


### PR DESCRIPTION
## Summary

The paths field in tsconfig.json affects the build result, so when the content of tsconfig.json changes, Rsbuild should reload the dev server to load the new tsconfig.json. This PR adds the paths of tsconfig.json files to `dev.watchFiles` to achieve this.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
