### PR TITLE
feat: add warnings for deprecated `source.alias` config

### DIFF
--- a/e2e/cases/alias/legacy-alias/index.test.ts
+++ b/e2e/cases/alias/legacy-alias/index.test.ts
@@ -1,7 +1,8 @@
-import { build } from '@e2e/helper';
+import { build, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should allow to use the legacy `source.alias` config', async () => {
+  const { logs, restore } = proxyConsole();
   const rsbuild = await build({
     cwd: __dirname,
   });
@@ -17,4 +18,9 @@ test('should allow to use the legacy `source.alias` config', async () => {
 
   expect(files[webIndex!]).toContain('for web target');
   expect(files[nodeIndex!]).toContain('for node target');
+
+  expect(
+    logs.some((log) => log.includes('"source.alias" config is deprecated')),
+  ).toBeTruthy();
+  restore();
 });

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -96,7 +96,6 @@ let swcHelpersPath: string;
 
 const getDefaultSourceConfig = (): NormalizedSourceConfig => {
   return {
-    alias: {},
     define: {},
     preEntry: [],
     decorators: {

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import { dirname, sep } from 'node:path';
 import { reduceConfigs } from 'reduce-configs';
-import { castArray } from '../helpers';
+import { castArray, color } from '../helpers';
 import { ensureAbsolutePath } from '../helpers/path';
 import { logger } from '../logger';
 import type {
@@ -27,10 +27,15 @@ function applyAlias({
   });
 
   // TODO: remove `source.alias` in the next major version
-  mergedAlias = reduceConfigs({
-    initial: mergedAlias,
-    config: config.source.alias,
-  });
+  if (config.source.alias) {
+    logger.warn(
+      `[rsbuild:config] ${color.yellow('"source.alias"')} config is deprecated, use ${color.yellow('"resolve.alias"')} instead.`,
+    );
+    mergedAlias = reduceConfigs({
+      initial: mergedAlias,
+      config: config.source.alias,
+    });
+  }
 
   if (config.resolve.dedupe) {
     for (const pkgName of config.resolve.dedupe) {
@@ -135,6 +140,12 @@ export const pluginResolve = (): RsbuildPlugin => ({
           .rule(CHAIN_ID.RULE.MJS)
           .test(/\.m?js/)
           .resolve.set('fullySpecified', false);
+
+        if (config.source.aliasStrategy) {
+          logger.warn(
+            `[rsbuild:config] ${color.yellow('"source.aliasStrategy"')} config is deprecated, use ${color.yellow('"resolve.aliasStrategy"')} instead.`,
+          );
+        }
 
         const aliasStrategy =
           config.source.aliasStrategy ?? config.resolve.aliasStrategy;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -321,11 +321,6 @@ type TransformImportFn = (
 
 export interface NormalizedSourceConfig extends SourceConfig {
   define: Define;
-  /**
-   * @deprecated Use `resolve.alias` instead.
-   * `source.alias` will be removed in v2.0.0.
-   */
-  alias: ConfigChain<Alias>;
   preEntry: string[];
   decorators: Required<Decorators>;
 }


### PR DESCRIPTION
## Summary

Add warnings for the deprecated `source.alias` and `source.aliasStrategy` configuration options in favor of `resolve.alias` and `resolve.aliasStrategy`. 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
