### PR TITLE
test(e2e): enable reloading env files case

### DIFF
--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -31,9 +31,12 @@ rspackOnlyTest(
     };`,
     );
 
-    delete process.env.NODE_ENV;
     const devProcess = exec('npx rsbuild dev', {
       cwd: __dirname,
+      env: {
+        ...process.env,
+        NODE_ENV: 'development',
+      },
     });
 
     await expectFile(distIndex);

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,25 +1,26 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 import { remove } from 'fs-extra';
 
-// Skipped as it occasionally failed in CI
-test.skip('should restart dev server when .env file is changed', async () => {
-  const dist = path.join(__dirname, 'dist');
-  const configFile = path.join(__dirname, 'rsbuild.config.mjs');
-  const envLocalFile = path.join(__dirname, '.env.local');
-  const distIndex = path.join(dist, 'static/js/index.js');
+rspackOnlyTest(
+  'should restart dev server when .env file is changed',
+  async () => {
+    const dist = path.join(__dirname, 'dist');
+    const configFile = path.join(__dirname, 'rsbuild.config.mjs');
+    const envLocalFile = path.join(__dirname, '.env.local');
+    const distIndex = path.join(dist, 'static/js/index.js');
 
-  await remove(dist);
-  await remove(configFile);
-  await remove(envLocalFile);
+    await remove(dist);
+    await remove(configFile);
+    await remove(envLocalFile);
 
-  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
-  fs.writeFileSync(
-    configFile,
-    `export default {
+    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
+    fs.writeFileSync(
+      configFile,
+      `export default {
       dev: {
         writeToDisk: true,
       },
@@ -28,21 +29,22 @@ test.skip('should restart dev server when .env file is changed', async () => {
       },
       server: { port: ${await getRandomPort()} }
     };`,
-  );
+    );
 
-  delete process.env.NODE_ENV;
-  const devProcess = exec('npx rsbuild dev', {
-    cwd: __dirname,
-  });
+    delete process.env.NODE_ENV;
+    const devProcess = exec('npx rsbuild dev', {
+      cwd: __dirname,
+    });
 
-  await expectFile(distIndex);
-  expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
+    await expectFile(distIndex);
+    expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
 
-  await remove(distIndex);
+    await remove(distIndex);
 
-  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
-  await expectFile(distIndex);
-  expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');
+    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
+    await expectFile(distIndex);
+    expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');
 
-  devProcess.kill();
-});
+    devProcess.kill();
+  },
+);


### PR DESCRIPTION
## Summary

This pull request enables the `reload-env` E2E test and removes the previous `test.skip` directive.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
