### PR TITLE
fix: add warning for modifying plugins in `modifyRsbuildConfig`

### DIFF
--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -25,11 +25,19 @@ import { generateRspackConfig } from './rspackConfig';
 
 async function modifyRsbuildConfig(context: InternalContext) {
   logger.debug('modify Rsbuild config');
+
+  const pluginsCount = context.config.plugins?.length ?? 0;
   const [modified] = await context.hooks.modifyRsbuildConfig.callChain(
     context.config,
     { mergeRsbuildConfig },
   );
   context.config = modified;
+
+  if (modified.plugins?.length !== pluginsCount) {
+    logger.warn(
+      '[rsbuild] Cannot change plugins via `modifyRsbuildConfig` as plugins are already initialized when it executes.',
+    );
+  }
 
   logger.debug('modify Rsbuild config done');
 }


### PR DESCRIPTION
## Summary

Added a check to compare the plugin count before and after the `modifyRsbuildConfig` hook execution. If the plugin count changes, a warning is logged to inform users that modifying plugins at this stage is not allowed.

<img width="1216" alt="Screenshot 2025-05-21 at 22 34 05" src="https://github.com/user-attachments/assets/4e425b3b-3931-4fb2-9d36-df6a0708ec07" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
