### PR TITLE
feat: enhance error messages with color for better visibility

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -211,7 +211,7 @@ export async function createRsbuild(
     if (checkDistDir) {
       if (!existsSync(distPath)) {
         throw new Error(
-          `[rsbuild:preview] The output directory ${color.yellow(
+          `${color.dim('[rsbuild:preview]')} The output directory ${color.yellow(
             distPath,
           )} does not exist, please build the project before previewing.`,
         );
@@ -219,7 +219,7 @@ export async function createRsbuild(
 
       if (isEmptyDir(distPath)) {
         throw new Error(
-          `[rsbuild:preview] The output directory ${color.yellow(
+          `${color.dim('[rsbuild:preview]')} The output directory ${color.yellow(
             distPath,
           )} is empty, please build the project before previewing.`,
         );

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -256,7 +256,9 @@ export function getFilename(
       return filename.assets ?? `[name]${hash}[ext]`;
     default:
       throw new Error(
-        `[rsbuild:config] unknown key ${type} in "output.filename"`,
+        `${color.dim('[rsbuild:config]')} unknown key ${color.yellow(
+          type,
+        )} in ${color.yellow('output.filename')}`,
       );
   }
 }

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -2,7 +2,7 @@ import { join, posix } from 'node:path';
 import type { Compiler } from '@rspack/core';
 import { LOADER_PATH } from './constants';
 import { createPublicContext } from './createContext';
-import { removeLeadingSlash } from './helpers';
+import { color, removeLeadingSlash } from './helpers';
 import { exitHook } from './helpers/exitHook';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import { logger } from './logger';
@@ -42,7 +42,7 @@ export function getHTMLPathByEntry(
 
   if (prefix.startsWith('/')) {
     logger.warn(
-      `Absolute path is not recommended at \`output.distPath.html\`: "${prefix}", please use relative path instead.`,
+      `${color.dim('[rsbuild:config]')} Absolute path is not recommended at ${color.yellow(`output.distPath.html: "${prefix}"`)}, use relative path instead.`,
     );
   }
 
@@ -88,7 +88,9 @@ const mapProcessAssetsStage = (
     case 'report':
       return Compilation.PROCESS_ASSETS_STAGE_REPORT;
     default:
-      throw new Error(`[rsbuild] Invalid process assets stage: ${stage}`);
+      throw new Error(
+        `${color.dim('[rsbuild]')} Invalid process assets stage: ${stage}`,
+      );
   }
 };
 
@@ -114,7 +116,7 @@ export function initPluginAPI({
 
         if (!config) {
           throw new Error(
-            `[rsbuild] Cannot find normalized config by environment: ${options.environment}.`,
+            `${color.dim('[rsbuild]')} Cannot find normalized config by environment: ${options.environment}.`,
           );
         }
         return config;
@@ -122,7 +124,9 @@ export function initPluginAPI({
       return context.normalizedConfig;
     }
     throw new Error(
-      '[rsbuild] Cannot access normalized config until modifyRsbuildConfig is called.',
+      `${color.dim('[rsbuild]')} Cannot access normalized config until ${color.yellow(
+        'modifyRsbuildConfig',
+      )} is called.`,
     );
   }
 
@@ -135,7 +139,9 @@ export function initPluginAPI({
       case 'normalized':
         return getNormalizedConfig();
     }
-    throw new Error('[rsbuild] `getRsbuildConfig` get an invalid type param.');
+    throw new Error(
+      `${color.dim('[rsbuild]')} ${color.yellow('getRsbuildConfig')} get an invalid type param.`,
+    );
   }) as GetRsbuildConfig;
 
   const exposed: Array<{ id: string | symbol; api: any }> = [];

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -191,7 +191,7 @@ export async function loadConfig({
 
     if (result === undefined) {
       throw new Error(
-        '[rsbuild:loadConfig] The config function must return a config object.',
+        `${color.dim('[rsbuild:loadConfig]')} The config function must return a config object.`,
       );
     }
 
@@ -203,7 +203,7 @@ export async function loadConfig({
 
   if (!isObject(configExport)) {
     throw new Error(
-      `[rsbuild:loadConfig] The config must be an object or a function that returns an object, get ${color.yellow(
+      `${color.dim('[rsbuild:loadConfig]')} The config must be an object or a function that returns an object, get ${color.yellow(
         configExport,
       )}`,
     );

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { parse } from 'dotenv';
 import { expand } from 'dotenv-expand';
-import { getNodeEnv, isFileSync } from './helpers';
+import { color, getNodeEnv, isFileSync } from './helpers';
 import { logger } from './logger';
 
 export type LoadEnvOptions = {
@@ -77,7 +77,9 @@ export function loadEnv({
 }: LoadEnvOptions = {}): LoadEnvResult {
   if (mode === 'local') {
     throw new Error(
-      `[rsbuild:loadEnv] 'local' cannot be used as a value for env mode, because ".env.local" represents a temporary local file. Please use another value.`,
+      `${color.dim('[rsbuild:loadEnv]')} ${color.yellow('local')} cannot be used as a value for env mode, because ${color.yellow(
+        '.env.local',
+      )} represents a temporary local file. Please use another value.`,
     );
   }
 

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -14,7 +14,9 @@ function validatePlugin(plugin: unknown) {
 
   if (type !== 'object' || plugin === null) {
     throw new Error(
-      `[rsbuild:plugin] Expect Rsbuild plugin instance to be an object, but got ${type}.`,
+      `${color.dim('[rsbuild:plugin]')} Expect Rsbuild plugin instance to be an object, but got ${color.yellow(
+        type,
+      )}.`,
     );
   }
 
@@ -48,7 +50,9 @@ function validatePlugin(plugin: unknown) {
   }
 
   throw new Error(
-    `[rsbuild:plugin] Expect the setup function of Rsbuild plugin to be a function, but got ${type}.`,
+    `${color.dim('[rsbuild:plugin]')} Expect the setup function of Rsbuild plugin to be a function, but got ${color.yellow(
+      type,
+    )}.`,
   );
 }
 
@@ -156,7 +160,11 @@ export const pluginDagSort = (plugins: PluginMeta[]): PluginMeta[] => {
   function getPlugin(name: string) {
     const targets = plugins.filter((item) => item.instance.name === name);
     if (!targets.length) {
-      throw new Error(`[rsbuild:plugin] Plugin "${name}" not existed`);
+      throw new Error(
+        `${color.dim('[rsbuild:plugin]')} Plugin "${color.yellow(
+          name,
+        )}" not existed`,
+      );
     }
     return targets;
   }
@@ -211,9 +219,9 @@ export const pluginDagSort = (plugins: PluginMeta[]): PluginMeta[] => {
     }
 
     throw new Error(
-      `[rsbuild:plugin] Plugins dependencies has loop: ${Object.keys(
-        restInRingPoints,
-      ).join(',')}`,
+      `${color.dim('[rsbuild:plugin]')} Plugins dependencies has loop: ${color.yellow(
+        Object.keys(restInRingPoints).join(','),
+      )}`,
     );
   }
 

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -102,7 +102,11 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
           if (icon.target === 'web-app-manifest' && !appIcon.name) {
             addCompilationError(
               compilation,
-              `[rsbuild:app-icon] "appIcon.name" is required when "target" is "web-app-manifest".`,
+              `${color.dim('[rsbuild:app-icon]')} ${color.yellow(
+                '"appIcon.name"',
+              )} is required when ${color.yellow('"target"')} is ${color.yellow(
+                '"web-app-manifest"',
+              )}.`,
             );
             continue;
           }
@@ -111,7 +115,9 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             if (!compilation.inputFileSystem) {
               addCompilationError(
                 compilation,
-                `[rsbuild:app-icon] Failed to read the icon file as "compilation.inputFileSystem" is not available.`,
+                `${color.dim('[rsbuild:app-icon]')} Failed to read the icon file as ${color.yellow(
+                  '"compilation.inputFileSystem"',
+                )} is not available.`,
               );
               continue;
             }
@@ -121,7 +127,9 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             ) {
               addCompilationError(
                 compilation,
-                `[rsbuild:app-icon] Failed to find the icon file at "${color.cyan(icon.absolutePath)}".`,
+                `${color.dim('[rsbuild:app-icon]')} Failed to find the icon file at ${color.yellow(
+                  icon.absolutePath,
+                )}.`,
               );
               continue;
             }
@@ -133,7 +141,9 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
             if (!source) {
               addCompilationError(
                 compilation,
-                `[rsbuild:app-icon] Failed to read the icon file at "${color.cyan(icon.absolutePath)}".`,
+                `${color.dim('[rsbuild:app-icon]')} Failed to read the icon file at ${color.yellow(
+                  icon.absolutePath,
+                )}.`,
               );
               continue;
             }

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -3,7 +3,7 @@ import deepmerge from 'deepmerge';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
 import type { AcceptedPlugin, PluginCreator } from '../../compiled/postcss';
 import { CSS_REGEX, LOADER_PATH } from '../constants';
-import { castArray, getFilename } from '../helpers';
+import { castArray, color, getFilename } from '../helpers';
 import { getCompiledPath } from '../helpers/path';
 import { getCssExtractPlugin } from '../pluginHelper';
 import type {
@@ -197,7 +197,9 @@ const getPostcssLoaderOptions = async ({
 
       if (typeof options !== 'object' || options === null) {
         throw new Error(
-          `[rsbuild:css] \`postcssOptions\` function must return a PostCSSOptions object, got "${typeof options}".`,
+          `${color.dim('[rsbuild:css]')} \`postcssOptions\` function must return a PostCSSOptions object, got ${color.yellow(
+            typeof options,
+          )}.`,
         );
       }
 

--- a/packages/core/src/plugins/define.ts
+++ b/packages/core/src/plugins/define.ts
@@ -20,9 +20,11 @@ function checkProcessEnvSecurity(define: Define) {
     }
 
     logger.warn(
-      color.yellow(
-        `[rsbuild:config] The "source.define" option includes an object with the key ${JSON.stringify(pathKey)} under "process.env", indicating potential exposure of all environment variables. This can lead to security risks and should be avoided.`,
-      ),
+      `${color.dim('[rsbuild:config]')} The ${color.yellow(
+        '"source.define"',
+      )} option includes an object with the key ${color.yellow(
+        JSON.stringify(pathKey),
+      )} under ${color.yellow('"process.env"')}, indicating potential exposure of all environment variables. This can lead to security risks and should be avoided.`,
     );
   };
 

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -35,9 +35,9 @@ export const pluginEntry = (): RsbuildPlugin => ({
     api.onBeforeCreateCompiler(({ bundlerConfigs }) => {
       if (bundlerConfigs.every((config) => !config.entry)) {
         throw new Error(
-          `[rsbuild:config] Could not find any entry module, please make sure that ${color.cyan(
+          `${color.dim('[rsbuild:config]')} Could not find any entry module, please make sure that ${color.yellow(
             'src/index.(ts|js|tsx|jsx|mts|cts|mjs|cjs)',
-          )} exists, or customize entry through the ${color.cyan(
+          )} exists, or customize entry through the ${color.yellow(
             'source.entry',
           )} configuration.`,
         );

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -76,7 +76,7 @@ export async function getTemplate(
     // Check if custom template exists
     if (!(await isFileExists(absolutePath))) {
       throw new Error(
-        `[rsbuild:html] Failed to resolve HTML template, please check if the file exists: ${color.cyan(
+        `${color.dim('[rsbuild:html]')} Failed to resolve HTML template, check if the file exists: ${color.yellow(
           absolutePath,
         )}`,
       );

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -1,5 +1,5 @@
 import type { FileDescriptor } from '../../compiled/rspack-manifest-plugin';
-import { isObject } from '../helpers';
+import { color, isObject } from '../helpers';
 import { logger } from '../logger';
 import { recursiveChunkEntryNames } from '../rspack/resource-hints/doesChunkBelongToHtml';
 import type {
@@ -133,7 +133,7 @@ const generateManifest =
       }
 
       throw new Error(
-        '[rsbuild:manifest] `manifest.generate` function must return a valid manifest object.',
+        `${color.dim('[rsbuild:manifest]')} \`manifest.generate\` function must return a valid manifest object.`,
       );
     }
 
@@ -217,7 +217,11 @@ export const pluginManifest = (): RsbuildPlugin => ({
 
       if (uniqueFilenames.size !== filenames.length) {
         logger.warn(
-          `[rsbuild:manifest] The \`manifest.filename\` option must be unique when there are multiple environments (${environmentNames.join(', ')}), otherwise the manifest file will be overwritten.`,
+          `${color.dim('[rsbuild:manifest]')} The ${color.yellow(
+            '"manifest.filename"',
+          )} option must be unique when there are multiple environments (${environmentNames.join(
+            ', ',
+          )}), otherwise the manifest file will be overwritten.`,
         );
       }
 

--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
+import { color } from '../helpers';
 import type { RsbuildPlugin } from '../types';
-
 const getFilename = (resourcePath: string) => {
   let basename = '';
 
@@ -29,7 +29,7 @@ export const pluginNodeAddons = (): RsbuildPlugin => ({
 
         if (name === null) {
           throw new Error(
-            `[rsbuild:node-addons] Failed to load Node.js addon: "${resourcePath}"`,
+            `${color.dim('[rsbuild:node-addons]')} Failed to load Node.js addon: ${color.yellow(resourcePath)}`,
           );
         }
 

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -29,7 +29,9 @@ function applyAlias({
   // TODO: remove `source.alias` in the next major version
   if (config.source.alias) {
     logger.warn(
-      `[rsbuild:config] ${color.yellow('"source.alias"')} config is deprecated, use ${color.yellow('"resolve.alias"')} instead.`,
+      `${color.dim('[rsbuild:config]')} The ${color.yellow(
+        '"source.alias"',
+      )} config is deprecated, use ${color.yellow('"resolve.alias"')} instead.`,
     );
     mergedAlias = reduceConfigs({
       initial: mergedAlias,
@@ -41,7 +43,11 @@ function applyAlias({
     for (const pkgName of config.resolve.dedupe) {
       if (mergedAlias[pkgName]) {
         logger.debug(
-          `[rsbuild:resolve] The package "${pkgName}" is already in the alias config, dedupe option for "${pkgName}" will be ignored.`,
+          `${color.dim('[rsbuild:resolve]')} The package ${color.yellow(
+            pkgName,
+          )} is already in the alias config, dedupe option for ${color.yellow(
+            pkgName,
+          )} will be ignored.`,
         );
         continue;
       }
@@ -73,7 +79,11 @@ function applyAlias({
           }
         } catch (e) {
           logger.debug(
-            `[rsbuild:resolve] The package "${pkgName}" is not resolved in the project, dedupe option for "${pkgName}" will be ignored.`,
+            `${color.dim('[rsbuild:resolve]')} The package ${color.yellow(
+              pkgName,
+            )} is not resolved in the project, dedupe option for ${color.yellow(
+              pkgName,
+            )} will be ignored.`,
           );
           continue;
         }
@@ -143,7 +153,9 @@ export const pluginResolve = (): RsbuildPlugin => ({
 
         if (config.source.aliasStrategy) {
           logger.warn(
-            `[rsbuild:config] ${color.yellow('"source.aliasStrategy"')} config is deprecated, use ${color.yellow('"resolve.aliasStrategy"')} instead.`,
+            `${color.dim('[rsbuild:config]')} The ${color.yellow(
+              '"source.aliasStrategy"',
+            )} config is deprecated, use ${color.yellow('"resolve.aliasStrategy"')} instead.`,
           );
         }
 

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -9,7 +9,13 @@ import {
   PLUGIN_SWC_NAME,
   SCRIPT_REGEX,
 } from '../constants';
-import { castArray, cloneDeep, isFunction, isWebTarget } from '../helpers';
+import {
+  castArray,
+  cloneDeep,
+  color,
+  isFunction,
+  isWebTarget,
+} from '../helpers';
 import type {
   NormalizedEnvironmentConfig,
   NormalizedSourceConfig,
@@ -262,6 +268,10 @@ export function applySwcDecoratorConfig(
       swcConfig.jsc.transform.decoratorVersion = '2022-03';
       break;
     default:
-      throw new Error(`[rsbuild:swc] Unknown decorators version: ${version}`);
+      throw new Error(
+        `${color.dim('[rsbuild:swc]')} Unknown decorators version: ${color.yellow(
+          version,
+        )}`,
+      );
   }
 }

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -89,7 +89,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
   if (!(await isSatisfyRspackVersion(rspack.rspackVersion))) {
     throw new Error(
-      `[rsbuild] The current Rspack version does not meet the requirements, the minimum supported version of Rspack is ${color.green(
+      `${color.dim('[rsbuild]')} The current Rspack version does not meet the requirements, the minimum supported version of Rspack is ${color.green(
         rspackMinVersion,
       )}`,
     );

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -35,7 +35,9 @@ async function modifyRsbuildConfig(context: InternalContext) {
 
   if (modified.plugins?.length !== pluginsCount) {
     logger.warn(
-      '[rsbuild] Cannot change plugins via `modifyRsbuildConfig` as plugins are already initialized when it executes.',
+      `${color.dim('[rsbuild]')} Cannot change plugins via ${color.yellow(
+        'modifyRsbuildConfig',
+      )} as plugins are already initialized when it executes.`,
     );
   }
 
@@ -132,7 +134,9 @@ const initEnvironmentConfigs = (
 
     if (!Object.keys(resolvedEnvironments).length) {
       throw new Error(
-        `[rsbuild:config] The current build is specified to run only in the ${color.yellow(specifiedEnvironments?.join(','))} environment, but the configuration of the specified environment was not found.`,
+        `${color.dim('[rsbuild:config]')} The current build is specified to run only in the ${color.yellow(
+          specifiedEnvironments?.join(','),
+        )} environment, but the configuration of the specified environment was not found.`,
       );
     }
     return resolvedEnvironments;
@@ -142,7 +146,9 @@ const initEnvironmentConfigs = (
 
   if (!isEnvironmentEnabled(defaultEnvironmentName)) {
     throw new Error(
-      `[rsbuild:config] The current build is specified to run only in the ${color.yellow(specifiedEnvironments?.join(','))} environment, but the configuration of the specified environment was not found.`,
+      `${color.dim('[rsbuild:config]')} The current build is specified to run only in the ${color.yellow(
+        specifiedEnvironments?.join(','),
+      )} environment, but the configuration of the specified environment was not found.`,
     );
   }
 
@@ -163,7 +169,9 @@ const initEnvironmentConfigs = (
 const validateRsbuildConfig = (config: NormalizedConfig) => {
   if (config.server.base && !config.server.base.startsWith('/')) {
     throw new Error(
-      `[rsbuild:config] The "server.base" option should start with a slash, for example: "/base"`,
+      `${color.dim('[rsbuild:config]')} The ${color.yellow(
+        '"server.base"',
+      )} option should start with a slash, for example: "/base"`,
     );
   }
 };

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -165,7 +165,7 @@ function validateRspackConfig(config: Rspack.Configuration) {
       ) {
         const name = color.bold(color.yellow(plugin.name));
         throw new Error(
-          `[rsbuild:plugin] "${name}" appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
+          `${color.dim('[rsbuild:plugin]')} "${color.yellow(name)}" appears to be an Rsbuild plugin. It cannot be used as an Rspack plugin.`,
         );
       }
     }
@@ -173,7 +173,9 @@ function validateRspackConfig(config: Rspack.Configuration) {
 
   if (config.devServer) {
     logger.warn(
-      `[rsbuild:config] Find invalid Rspack config: "${color.yellow('devServer')}". Note that Rspack's "devServer" config is not supported by Rsbuild. You can use Rsbuild's "dev" config to configure the Rsbuild dev server.`,
+      `${color.dim('[rsbuild:config]')} Find invalid Rspack config: "${color.yellow(
+        'devServer',
+      )}". Note that Rspack's "devServer" config is not supported by Rsbuild. You can use Rsbuild's "dev" config to configure the Rsbuild dev server.`,
     );
   }
 }

--- a/packages/core/src/rspack/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack/RsbuildHtmlPlugin.ts
@@ -265,7 +265,9 @@ export class RsbuildHtmlPlugin {
       if (!compilation.inputFileSystem) {
         addCompilationError(
           compilation,
-          `[rsbuild:html] Failed to read the favicon file as "compilation.inputFileSystem" is not available.`,
+          `${color.dim('[rsbuild:html]')} Failed to read the favicon file as ${color.yellow(
+            'compilation.inputFileSystem',
+          )} is not available.`,
         );
         return null;
       }
@@ -288,7 +290,9 @@ export class RsbuildHtmlPlugin {
 
         addCompilationError(
           compilation,
-          `[rsbuild:html] Failed to read the favicon file at "${color.cyan(filename)}".`,
+          `${color.dim('[rsbuild:html]')} Failed to read the favicon file at ${color.yellow(
+            filename,
+          )}.`,
         );
         return null;
       }

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -65,7 +65,9 @@ export function setupCliShortcuts({
 
     if (!Array.isArray(shortcuts)) {
       throw new Error(
-        '[rsbuild:config] `dev.cliShortcuts` must return an array of shortcuts.',
+        `${color.dim('[rsbuild:config]')} ${color.yellow(
+          'dev.cliShortcuts',
+        )} option must return an array of shortcuts.`,
       );
     }
   }

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type Connect from '../../compiled/connect/index.js';
-import { getPublicPathFromCompiler, isMultiCompiler } from '../helpers';
+import { color, getPublicPathFromCompiler, isMultiCompiler } from '../helpers';
 import { logger } from '../logger';
 import { onBeforeRestartServer, restartDevServer } from '../restart';
 import type {
@@ -175,7 +175,9 @@ export async function createDevServer<
     const compiler = customCompiler || (await createCompiler());
 
     if (!compiler) {
-      throw new Error('[rsbuild:server] Failed to get compiler instance.');
+      throw new Error(
+        `${color.dim('[rsbuild:server]')} Failed to get compiler instance.`,
+      );
     }
 
     const publicPaths = isMultiCompiler(compiler)
@@ -282,7 +284,9 @@ export async function createDevServer<
           getStats: async () => {
             if (!compilationManager) {
               throw new Error(
-                '[rsbuild:server] Can not call `getStats` when `runCompile` is false',
+                `${color.dim('[rsbuild:server]')} Can not call ` +
+                  `${color.yellow('getStats')} when ` +
+                  `${color.yellow('runCompile')} is false`,
               );
             }
             await waitFirstCompileDone;
@@ -291,7 +295,9 @@ export async function createDevServer<
           loadBundle: async <T>(entryName: string) => {
             if (!compilationManager) {
               throw new Error(
-                '[rsbuild:server] Can not call `loadBundle` when `runCompile` is false',
+                `${color.dim('[rsbuild:server]')} Can not call ` +
+                  `${color.yellow('loadBundle')} when ` +
+                  `${color.yellow('runCompile')} is false`,
               );
             }
             await waitFirstCompileDone;
@@ -307,7 +313,9 @@ export async function createDevServer<
           getTransformedHtml: async (entryName: string) => {
             if (!compilationManager) {
               throw new Error(
-                '[rsbuild:server] Can not call `getTransformedHtml` when `runCompile` is false',
+                `${color.dim('[rsbuild:server]')} Can not call ` +
+                  `${color.yellow('getTransformedHtml')} when ` +
+                  `${color.yellow('runCompile')} is false`,
               );
             }
             await waitFirstCompileDone;
@@ -350,7 +358,8 @@ export async function createDevServer<
     listen: async () => {
       if (!httpServer) {
         throw new Error(
-          '[rsbuild:server] Can not listen dev server as `server.middlewareMode` is enabled.',
+          `${color.dim('[rsbuild:server]')} Can not listen dev server as ` +
+            `${color.yellow('server.middlewareMode')} is enabled.`,
         );
       }
 

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { color } from 'src/helpers';
+import { color } from '../helpers';
 import type { EnvironmentContext, Rspack } from '../types';
 import { run } from './runner';
 

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { color } from 'src/helpers';
 import type { EnvironmentContext, Rspack } from '../types';
 import { run } from './runner';
 
@@ -20,7 +21,11 @@ export const loadBundle = async <T>(
   });
 
   if (!entrypoints?.[entryName]) {
-    throw new Error(`[rsbuild:loadBundle] Can't find entry: "${entryName}"`);
+    throw new Error(
+      `${color.dim('[rsbuild:loadBundle]')} Can't find entry: ${color.yellow(
+        entryName,
+      )}`,
+    );
   }
 
   const { chunks: entryChunks = [] } = entrypoints[entryName];
@@ -38,14 +43,18 @@ export const loadBundle = async <T>(
 
   if (files.length === 0) {
     throw new Error(
-      `[rsbuild:loadBundle] Failed to get bundle by entryName: "${entryName}"`,
+      `${color.dim('[rsbuild:loadBundle]')} Failed to get bundle by entryName: ${color.yellow(
+        entryName,
+      )}`,
     );
   }
 
   // An entrypoint should have only one entryChunk, but there may be some boundary cases
   if (files.length > 1) {
     throw new Error(
-      `[rsbuild:loadBundle] Only support load single entry chunk, but got ${files.length}: ${files.join(',')}`,
+      `${color.dim('[rsbuild:loadBundle]')} Only support load single entry chunk, but got ${color.yellow(
+        files.length,
+      )}: ${files.join(',')}`,
     );
   }
 
@@ -73,7 +82,9 @@ export const getTransformedHtml = async (
 
   if (!htmlPath) {
     throw new Error(
-      `[rsbuild:getTransformedHtml] Failed to get HTML file by entryName: "${entryName}"`,
+      `${color.dim('[rsbuild:getTransformedHtml]')} Failed to get HTML file by entryName: ${color.yellow(
+        entryName,
+      )}`,
     );
   }
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -208,7 +208,7 @@ export function printServerURLs({
 
     if (!Array.isArray(newUrls)) {
       throw new Error(
-        `[rsbuild:config] "server.printUrls" must return an array, but got ${typeof newUrls}.`,
+        `${color.dim('[rsbuild:config]')} "server.printUrls" must return an array, but got ${typeof newUrls}.`,
       );
     }
 
@@ -292,7 +292,9 @@ export const getPort = async ({
   if (port !== original) {
     if (strictPort) {
       throw new Error(
-        `[rsbuild:server] Port "${original}" is occupied, please choose another one.`,
+        `${color.dim('[rsbuild:server]')} Port ${color.yellow(
+          original,
+        )} is occupied, please choose another one.`,
       );
     }
   }

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { STATIC_PATH } from '../constants';
-import { canParse, castArray } from '../helpers';
+import { canParse, castArray, color } from '../helpers';
 import { logger } from '../logger';
 import type { NormalizedConfig, Routes } from '../types';
 import { getHostInUrl } from './helper';
@@ -139,7 +139,9 @@ export function resolveUrl(str: string, base: string): string {
     return url.href;
   } catch (e) {
     throw new Error(
-      '[rsbuild:open]: Invalid input: not a valid URL or pathname',
+      `${color.dim('[rsbuild:open]')} Invalid input: ${color.yellow(
+        str,
+      )} is not a valid URL or pathname`,
     );
   }
 }

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import type { CompilerOptions, Runner } from './type';
 
+import { color } from 'src/helpers';
 import type {
   BasicGlobalContext,
   BasicModuleScope,
@@ -125,7 +126,7 @@ export abstract class BasicRunner implements Runner {
     this.requirers.set(
       'entry',
       (_currentDirectory, _modulePath, _context = {}) => {
-        throw new Error('[rsbuild:runner] Not implement');
+        throw new Error(`${color.dim('[rsbuild:runner]')} Not implemented`);
       },
     );
   }

--- a/packages/core/src/server/runner/basic.ts
+++ b/packages/core/src/server/runner/basic.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import type { CompilerOptions, Runner } from './type';
 
-import { color } from 'src/helpers';
+import { color } from '../../helpers';
 import type {
   BasicGlobalContext,
   BasicModuleScope,

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -3,6 +3,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import vm, { type SourceTextModule } from 'node:vm';
 import { asModule } from './asModule';
 
+import { color } from 'src/helpers';
 import { CommonJsRunner } from './cjs';
 import { EsmMode, type RunnerRequirer } from './type';
 
@@ -40,7 +41,7 @@ export class EsmRunner extends CommonJsRunner {
     return (currentDirectory, modulePath, context = {}) => {
       if (!vm.SourceTextModule) {
         throw new Error(
-          '[rsbuild:runner] Running ESM bundle needs add Node.js option "--experimental-vm-modules".',
+          `${color.dim('[rsbuild:runner]')} Running ESM bundle needs add Node.js option ${color.yellow('--experimental-vm-modules')}.`,
         );
       }
       const _require = this.getRequire();

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -3,7 +3,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import vm, { type SourceTextModule } from 'node:vm';
 import { asModule } from './asModule';
 
-import { color } from 'src/helpers';
+import { color } from '../../helpers';
 import { CommonJsRunner } from './cjs';
 import { EsmMode, type RunnerRequirer } from './type';
 

--- a/packages/core/src/server/runner/index.ts
+++ b/packages/core/src/server/runner/index.ts
@@ -2,6 +2,7 @@
  * The following code is modified based on @rspack/test-tools/runner
  *
  */
+import { color } from 'src/helpers';
 import { EsmRunner } from './esm';
 import type { Runner, RunnerFactory, RunnerFactoryOptions } from './type';
 
@@ -24,7 +25,9 @@ export class BasicRunnerFactory implements RunnerFactory {
       compilerOptions.target === 'webworker'
     ) {
       throw new Error(
-        `[rsbuild:runner] Not support run "${compilerOptions.target}" resource in Rsbuild server`,
+        `${color.dim('[rsbuild:runner]')} Not support run ${color.yellow(
+          compilerOptions.target,
+        )} resource in Rsbuild server`,
       );
     }
     return new EsmRunner(runnerOptions);

--- a/packages/core/src/server/runner/index.ts
+++ b/packages/core/src/server/runner/index.ts
@@ -1,8 +1,7 @@
 /**
  * The following code is modified based on @rspack/test-tools/runner
- *
  */
-import { color } from 'src/helpers';
+import { color } from '../../helpers';
 import { EsmRunner } from './esm';
 import type { Runner, RunnerFactory, RunnerFactoryOptions } from './type';
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -59,7 +59,7 @@ export type EnvironmentAsyncHook<
    * Registers a callback function to be executed when the hook is triggered.
    * The callback can be a plain function or a HookDescriptor that includes execution order.
    * The callback will be executed in all environments by default.
-   * If you need to specify the environment, please use `tapEnvironment`
+   * If you need to specify the environment, use `tapEnvironment`
    * @param cb The callback function or hook descriptor to register
    */
   tap: (cb: Callback | HookDescriptor<Callback>) => void;


### PR DESCRIPTION
## Summary

Improves error and warning messages by standardizing the formatting and enhancing readability using the `color` utility. The changes ensure that messages are consistently styled with dimmed prefixes and highlighted key elements.

## Example

- before:

<img width="1146" alt="Screenshot 2025-05-22 at 11 16 55" src="https://github.com/user-attachments/assets/e2af1dae-3dec-4407-a83a-51f2ea8815cd" />

- after:

<img width="1210" alt="Screenshot 2025-05-22 at 11 18 57" src="https://github.com/user-attachments/assets/f453171f-d044-42e3-84d6-777a0c7e19a5" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
