### PR TITLE
docs: update inlineScripts and inlineStyles

### DIFF
--- a/website/docs/en/config/output/inline-scripts.mdx
+++ b/website/docs/en/config/output/inline-scripts.mdx
@@ -3,14 +3,14 @@
 - **Type:**
 
 ```ts
-export type InlineChunkTestFunction = (params: {
+type InlineChunkTestFunction = (params: {
   size: number;
   name: string;
 }) => boolean;
 
-export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+type InlineChunkTest = RegExp | InlineChunkTestFunction;
 
-export type InlineChunkConfig =
+type InlineChunkConfig =
   | boolean
   | InlineChunkTest
   | { enable?: boolean | 'auto'; test: InlineChunkTest };

--- a/website/docs/en/config/output/inline-scripts.mdx
+++ b/website/docs/en/config/output/inline-scripts.mdx
@@ -3,17 +3,17 @@
 - **Type:**
 
 ```ts
-type InlineScriptsTest =
-  | RegExp
-  | ((params: { size: number; name: string }) => boolean);
+export type InlineChunkTestFunction = (params: {
+  size: number;
+  name: string;
+}) => boolean;
 
-type InlineScripts =
+export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+
+export type InlineChunkConfig =
   | boolean
-  | InlineScriptsTest
-  | {
-      enable?: boolean | 'auto';
-      test: InlineScriptsTest;
-    };
+  | InlineChunkTest
+  | { enable?: boolean | 'auto'; test: InlineChunkTest };
 ```
 
 - **Default:** `false`

--- a/website/docs/en/config/output/inline-styles.mdx
+++ b/website/docs/en/config/output/inline-styles.mdx
@@ -3,17 +3,17 @@
 - **Type:**
 
 ```ts
-type InlineStylesTest =
-  | RegExp
-  | ((params: { size: number; name: string }) => boolean);
+export type InlineChunkTestFunction = (params: {
+  size: number;
+  name: string;
+}) => boolean;
 
-type InlineStyles =
+export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+
+export type InlineChunkConfig =
   | boolean
-  | InlineStylesTest
-  | {
-      enable?: boolean | 'auto';
-      test: InlineStylesTest;
-    };
+  | InlineChunkTest
+  | { enable?: boolean | 'auto'; test: InlineChunkTest };
 ```
 
 - **Default:** `false`

--- a/website/docs/en/config/output/inline-styles.mdx
+++ b/website/docs/en/config/output/inline-styles.mdx
@@ -3,14 +3,14 @@
 - **Type:**
 
 ```ts
-export type InlineChunkTestFunction = (params: {
+type InlineChunkTestFunction = (params: {
   size: number;
   name: string;
 }) => boolean;
 
-export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+type InlineChunkTest = RegExp | InlineChunkTestFunction;
 
-export type InlineChunkConfig =
+type InlineChunkConfig =
   | boolean
   | InlineChunkTest
   | { enable?: boolean | 'auto'; test: InlineChunkTest };

--- a/website/docs/zh/config/output/inline-scripts.mdx
+++ b/website/docs/zh/config/output/inline-scripts.mdx
@@ -3,14 +3,14 @@
 - **类型：**
 
 ```ts
-export type InlineChunkTestFunction = (params: {
+type InlineChunkTestFunction = (params: {
   size: number;
   name: string;
 }) => boolean;
 
-export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+type InlineChunkTest = RegExp | InlineChunkTestFunction;
 
-export type InlineChunkConfig =
+type InlineChunkConfig =
   | boolean
   | InlineChunkTest
   | { enable?: boolean | 'auto'; test: InlineChunkTest };

--- a/website/docs/zh/config/output/inline-scripts.mdx
+++ b/website/docs/zh/config/output/inline-scripts.mdx
@@ -3,17 +3,17 @@
 - **类型：**
 
 ```ts
-type InlineScriptsTest =
-  | RegExp
-  | ((params: { size: number; name: string }) => boolean);
+export type InlineChunkTestFunction = (params: {
+  size: number;
+  name: string;
+}) => boolean;
 
-type InlineScripts =
+export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+
+export type InlineChunkConfig =
   | boolean
-  | InlineScriptsTest
-  | {
-      enable?: boolean | 'auto';
-      test: InlineScriptsTest;
-    };
+  | InlineChunkTest
+  | { enable?: boolean | 'auto'; test: InlineChunkTest };
 ```
 
 - **默认值：** `false`

--- a/website/docs/zh/config/output/inline-styles.mdx
+++ b/website/docs/zh/config/output/inline-styles.mdx
@@ -3,17 +3,17 @@
 - **类型：**
 
 ```ts
-type InlineStylesTest =
-  | RegExp
-  | ((params: { size: number; name: string }) => boolean);
+export type InlineChunkTestFunction = (params: {
+  size: number;
+  name: string;
+}) => boolean;
 
-type InlineStyles =
+export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+
+export type InlineChunkConfig =
   | boolean
-  | InlineStylesTest
-  | {
-      enable?: boolean | 'auto';
-      test: InlineStylesTest;
-    };
+  | InlineChunkTest
+  | { enable?: boolean | 'auto'; test: InlineChunkTest };
 ```
 
 - **默认值：** `false`

--- a/website/docs/zh/config/output/inline-styles.mdx
+++ b/website/docs/zh/config/output/inline-styles.mdx
@@ -3,14 +3,14 @@
 - **类型：**
 
 ```ts
-export type InlineChunkTestFunction = (params: {
+type InlineChunkTestFunction = (params: {
   size: number;
   name: string;
 }) => boolean;
 
-export type InlineChunkTest = RegExp | InlineChunkTestFunction;
+type InlineChunkTest = RegExp | InlineChunkTestFunction;
 
-export type InlineChunkConfig =
+type InlineChunkConfig =
   | boolean
   | InlineChunkTest
   | { enable?: boolean | 'auto'; test: InlineChunkTest };


### PR DESCRIPTION
## Summary
`InlineStyles` and `inlineScripts` types have been deprecated, but the documentation hasn't been updated yet.

## Related Links

<!--- Provide links of related issues or pages -->

- https://rsbuild.dev/config/output/inline-scripts#outputinlinescripts
- https://rsbuild.dev/config/output/inline-styles#outputinlinestyles
- https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/src/types/config.ts#L1198

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
