### PR TITLE
fix: correct plugin modification warning logic

### DIFF
--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -33,7 +33,8 @@ async function modifyRsbuildConfig(context: InternalContext) {
   );
   context.config = modified;
 
-  if (modified.plugins?.length !== pluginsCount) {
+  const newPluginsCount = modified.plugins?.length ?? 0;
+  if (newPluginsCount !== pluginsCount) {
     logger.warn(
       `${color.dim('[rsbuild]')} Cannot change plugins via ${color.yellow(
         'modifyRsbuildConfig',


### PR DESCRIPTION
## Summary

Correct the plugin modification warning logic, if the `modifiedConfig.plugins` is `undefined`, we should not print a warning.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5293

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
