### PR TITLE
feat: allow CLI shortcuts help option to accept custom string

### DIFF
--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -76,7 +76,7 @@ export function setupCliShortcuts({
     logger.log(
       help === true
         ? `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`
-        : `  ➜ ${help}`,
+        : `  ➜ ${help}\n`,
     );
   }
 

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -15,7 +15,7 @@ export function setupCliShortcuts({
   restartServer,
   customShortcuts,
 }: {
-  help?: boolean;
+  help?: boolean | string;
   openPage: () => Promise<void>;
   closeServer: () => Promise<void>;
   printUrls: () => void;
@@ -74,7 +74,9 @@ export function setupCliShortcuts({
 
   if (help) {
     logger.log(
-      `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`,
+      help === true
+        ? `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`
+        : `  ➜ ${help}`,
     );
   }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1608,9 +1608,12 @@ export interface DevConfig {
         custom?: (shortcuts: CliShortcut[]) => CliShortcut[];
         /**
          * Whether to print the help hint when the server is started.
+         * - `true`: Print the default help hint.
+         * - `false`: Disable the help hint.
+         * - `string`: Print a custom help hint.
          * @default true
          */
-        help?: boolean;
+        help?: boolean | string;
       };
   /**
    * Provides the ability to execute a custom function and apply custom middlewares.

--- a/website/docs/en/config/dev/cli-shortcuts.mdx
+++ b/website/docs/en/config/dev/cli-shortcuts.mdx
@@ -33,7 +33,7 @@ Press `h + Enter` to show all shortcuts:
 
 - Enable:
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: true,
@@ -43,7 +43,7 @@ export default {
 
 - Disable:
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: false,
@@ -57,7 +57,7 @@ export default {
 
 - Add custom shortcuts:
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
@@ -80,7 +80,7 @@ export default {
 
 - Disable some shortcuts:
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
@@ -94,19 +94,31 @@ export default {
 
 ## Print help
 
-`help` option can be used to control whether to print the help hint when the server is started:
+`help` option can be used to control whether to print the help hint when the server is started, the default help hint is:
 
 ```bash
   ➜ press h + enter to show shortcuts
 ```
 
-- Disable:
+- Disable the help hint:
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
       help: false,
+    },
+  },
+};
+```
+
+- Print a custom help hint:
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    cliShortcuts: {
+      help: 'type "h + enter" to view available commands',
     },
   },
 };

--- a/website/docs/zh/config/dev/cli-shortcuts.mdx
+++ b/website/docs/zh/config/dev/cli-shortcuts.mdx
@@ -6,7 +6,7 @@
 type CliShortcuts =
   | boolean
   | {
-      help?: boolean;
+      help?: boolean | string;
       custom?: (shortcuts: CliShortcut[]) => CliShortcut[];
     };
 ```
@@ -33,7 +33,7 @@ type CliShortcuts =
 
 - 启用：
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: true,
@@ -43,7 +43,7 @@ export default {
 
 - 禁用：
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: false,
@@ -57,7 +57,7 @@ export default {
 
 - 添加自定义快捷键：
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
@@ -80,7 +80,7 @@ export default {
 
 - 禁用部分快捷键：
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
@@ -94,19 +94,31 @@ export default {
 
 ## 打印帮助
 
-`help` 选项可以控制是否在启动服务器时打印帮助提示：
+`help` 选项可以控制是否在启动服务器时打印帮助提示，默认打印的帮助提示为：
 
 ```bash
   ➜ press h + enter to show shortcuts
 ```
 
-- 禁用：
+- 禁用帮助提示：
 
-```js
+```ts title="rsbuild.config.ts"
 export default {
   dev: {
     cliShortcuts: {
       help: false,
+    },
+  },
+};
+```
+
+- 输出自定义的帮助提示：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    cliShortcuts: {
+      help: 'type "h + enter" to view available commands',
     },
   },
 };


### PR DESCRIPTION
## Summary

Allow the CLI shortcuts `help` option to accept custom string:

```ts title="rsbuild.config.ts"
export default {
  dev: {
    cliShortcuts: {
      help: 'type "h + enter" to view available commands',
    },
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
