### PR TITLE
chore: update rspack import statements to use named import

### DIFF
--- a/packages/core/src/pluginHelper.ts
+++ b/packages/core/src/pluginHelper.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 /**
  * This file is used to get/set the global instance for html-plugin and css-extract plugin.
  */
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 import type { HtmlRspackPlugin } from './types';
 
 const require = createRequire(import.meta.url);

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 import { color } from '../helpers';
 import { logger } from '../logger';
 import type { RsbuildPlugin } from '../types';

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,5 +1,5 @@
 import { isAbsolute, join } from 'node:path';
-import rspack from '@rspack/core';
+import { rspack } from '@rspack/core';
 import { normalizePublicDirs } from '../defaultConfig';
 import { isMultiCompiler, pick } from '../helpers';
 import { logger } from '../logger';


### PR DESCRIPTION
## Summary

This pull request updates the way `rspack` is imported across multiple files, replace the default import of `rspack` with a named import.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
