### PR TITLE
perf: remove node:assert import

### DIFF
--- a/packages/core/src/plugins/splitChunks.ts
+++ b/packages/core/src/plugins/splitChunks.ts
@@ -1,4 +1,3 @@
-import assert from 'node:assert';
 import { NODE_MODULES_REGEX } from '../constants';
 import type {
   ChunkSplit,
@@ -6,6 +5,7 @@ import type {
   Polyfill,
   RsbuildPlugin,
   Rspack,
+  SplitBySize,
   SplitChunks,
 } from '../types';
 
@@ -150,8 +150,8 @@ function splitByModule(ctx: SplitChunksContext): SplitChunks {
 }
 
 function splitBySize(ctx: SplitChunksContext): SplitChunks {
-  const { override, forceSplittingGroups, defaultConfig, userConfig } = ctx;
-  assert(userConfig.strategy === 'split-by-size');
+  const { override, forceSplittingGroups, defaultConfig, userConfig } =
+    ctx as SplitChunksContext & { userConfig: SplitBySize };
 
   return {
     ...defaultConfig,


### PR DESCRIPTION
## Summary

Replacing an `assert` statement with a TypeScript type assertion and removing the imports accordingly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
