### PR TITLE
refactor: replace querystring parse with URLSearchParams

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -1,6 +1,5 @@
 import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
-import { parse } from 'node:querystring';
 import type Ws from '../../compiled/ws/index.js';
 import {
   getAllStatsErrors,
@@ -96,6 +95,7 @@ export class SocketServer {
     this.clearHeartbeatTimer();
 
     const { default: ws } = await import('../../compiled/ws/index.js');
+
     this.wsServer = new ws.Server({
       noServer: true,
       path: this.options.client?.path,
@@ -117,7 +117,7 @@ export class SocketServer {
 
       this.onConnect(
         socket,
-        queryStr ? (parse(queryStr) as Record<string, string>) : {},
+        queryStr ? Object.fromEntries(new URLSearchParams(queryStr)) : {},
       );
     });
   }


### PR DESCRIPTION
## Summary

Rplacing the Node.js `querystring` module with `URLSearchParams` and removing the import. The performance difference should be minimal in this scenario.

> querystring is more performant than [<URLSearchParams>](https://nodejs.org/api/url.html#class-urlsearchparams) but is not a standardized API. Use [<URLSearchParams>](https://nodejs.org/api/url.html#class-urlsearchparams) when performance is not critical or when compatibility with browser code is desirable. See https://nodejs.org/api/querystring.html#query-string

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
