### PR TITLE
perf: use dynamic import for node:dns

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -469,9 +469,9 @@ export function getServerTerminator(
   server: Server | Http2SecureServer,
 ): () => Promise<void> {
   let listened = false;
-  const pendingSockets = new Set<net.Socket>();
+  const pendingSockets = new Set<Socket>();
 
-  const onConnection = (socket: net.Socket) => {
+  const onConnection = (socket: Socket) => {
     pendingSockets.add(socket);
     socket.on('close', () => {
       pendingSockets.delete(socket);

--- a/packages/core/src/server/hmrFallback.ts
+++ b/packages/core/src/server/hmrFallback.ts
@@ -1,4 +1,3 @@
-import { promises as dns } from 'node:dns';
 import type { DevConfig, ServerConfig } from '../types/config';
 import { isWildcardHost } from './helper';
 
@@ -12,6 +11,7 @@ import { isWildcardHost } from './helper';
 export async function getLocalhostResolvedAddress(): Promise<
   string | undefined
 > {
+  const { promises: dns } = await import('node:dns');
   const [defaultLookup, explicitLookup] = await Promise.all([
     dns.lookup('localhost'),
     dns.lookup('localhost', { verbatim: true }),


### PR DESCRIPTION
## Summary

Dynamically importing the `node:dns` module for better performance..

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
