### PR TITLE
perf: update vm imports to use named imports and dynamic require

### DIFF
--- a/packages/core/src/server/runner/cjs.ts
+++ b/packages/core/src/server/runner/cjs.ts
@@ -1,6 +1,5 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import vm from 'node:vm';
 import { BasicRunner } from './basic';
 import type {
   BasicGlobalContext,
@@ -87,6 +86,7 @@ export class CommonJsRunner extends BasicRunner {
 
   protected createCjsRequirer(): RunnerRequirer {
     const requireCache = Object.create(null);
+    const vm = require('node:vm') as typeof import('node:vm');
 
     return (currentDirectory, modulePath, context = {}) => {
       const file = context.file || this.getFile(modulePath, currentDirectory);

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -1,11 +1,13 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
-import vm, { type SourceTextModule } from 'node:vm';
-import { asModule } from './asModule';
-
+import type { SourceTextModule } from 'node:vm';
 import { color } from '../../helpers';
+import { asModule } from './asModule';
 import { CommonJsRunner } from './cjs';
 import { EsmMode, type RunnerRequirer } from './type';
+
+const require = createRequire(import.meta.url);
 
 export class EsmRunner extends CommonJsRunner {
   protected createRunner(): void {
@@ -38,6 +40,8 @@ export class EsmRunner extends CommonJsRunner {
   protected createEsmRequirer(): RunnerRequirer {
     const esmCache = new Map<string, SourceTextModule>();
     const esmIdentifier = this._options.name;
+    const vm = require('node:vm') as typeof import('node:vm');
+
     return (currentDirectory, modulePath, context = {}) => {
       if (!vm.SourceTextModule) {
         throw new Error(


### PR DESCRIPTION
## Summary

Update the `node:vm` imports to use named imports and dynamic require for better performance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
