### PR TITLE
docs: update Rslib website URL

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1183,8 +1183,8 @@ importers:
         specifier: 2.0.0-beta.6
         version: 2.0.0-beta.6(rspress@2.0.0-beta.6(@types/react@19.1.5)(acorn@8.14.0)(webpack@5.99.9))
       '@rstack-dev/doc-ui':
-        specifier: 1.10.3
-        version: 1.10.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: 1.10.4
+        version: 1.10.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@shikijs/transformers':
         specifier: ^3.4.2
         version: 3.4.2
@@ -2953,8 +2953,8 @@ packages:
     resolution: {integrity: sha512-JaIbF2Ohuucx8HirpqvkrF8ap17GobUr02GejowdJ3zK0tR2EkcgjAy6kjBAn4P4gr6cHhbqyFxqRTImVad2rg==}
     engines: {node: '>=18.0.0'}
 
-  '@rstack-dev/doc-ui@1.10.3':
-    resolution: {integrity: sha512-V3j7bMGlA5+Ii01LLu9htu3HEl3RqTcLoCYu63Caow7kczNDNIY77AGQThYUYekTHCfy4mGh0a9xN2xXudeBXg==}
+  '@rstack-dev/doc-ui@1.10.4':
+    resolution: {integrity: sha512-NJmJJFKE/nJDUFx/4sLsfGLzv+QGDlV5foUNYy4GshsCmefWhMYV/1GT/TfqHjIkKyXo0x5fPNVypMUiHpARPg==}
 
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
@@ -9213,7 +9213,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@rstack-dev/doc-ui@1.10.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@rstack-dev/doc-ui@1.10.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       framer-motion: 12.11.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -148,7 +148,7 @@ To migrate from an existing project to Rsbuild, refer to the following guides:
 - [Migrate from Vue CLI](/guide/migration/vue-cli)
 - [Migrate from Vite](/guide/migration/vite)
 - [Migrate from Modern.js Builder](/guide/migration/modern-builder)
-- [Migrate from Tsup to Rslib](https://lib.rsbuild.dev/guide/migration/tsup)
+- [Migrate from Tsup to Rslib](https://rslib.rs/guide/migration/tsup)
 - [Migrate from Storybook to Storybook Rsbuild](https://rspack.dev/guide/migration/storybook)
 
 ### Other projects

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -148,7 +148,7 @@ Templates:
 - [从 Vue CLI 迁移](/guide/migration/vue-cli)
 - [从 Vite 迁移](/guide/migration/vite)
 - [从 Modern.js Builder 迁移](/guide/migration/modern-builder)
-- [从 Tsup 迁移到 Rslib](https://lib.rsbuild.dev/zh/guide/migration/tsup)
+- [从 Tsup 迁移到 Rslib](https://rslib.rs/zh/guide/migration/tsup)
 - [从 Storybook 迁移到 Storybook Rsbuild](https://rspack.dev/zh/guide/migration/storybook)
 
 ### 其他项目

--- a/website/package.json
+++ b/website/package.json
@@ -14,7 +14,7 @@
     "@rspress/plugin-client-redirects": "2.0.0-beta.6",
     "@rspress/plugin-algolia": "2.0.0-beta.6",
     "@rspress/plugin-rss": "2.0.0-beta.6",
-    "@rstack-dev/doc-ui": "1.10.3",
+    "@rstack-dev/doc-ui": "1.10.4",
     "@shikijs/transformers": "^3.4.2",
     "@types/node": "^22.15.21",
     "@types/react": "^19.1.5",

--- a/website/theme/components/HomeFooter.tsx
+++ b/website/theme/components/HomeFooter.tsx
@@ -73,7 +73,7 @@ function useFooterData() {
         },
         {
           title: 'Rstest',
-          link: 'https://github.com/web-infra-dev/rstest',
+          link: 'https://rstest.rs',
         },
       ],
     },

--- a/website/theme/components/HomeFooter.tsx
+++ b/website/theme/components/HomeFooter.tsx
@@ -69,7 +69,7 @@ function useFooterData() {
         },
         {
           title: 'Rslib',
-          link: 'https://lib.rsbuild.dev/',
+          link: 'https://rslib.rs/',
         },
         {
           title: 'Rstest',


### PR DESCRIPTION
## Summary

Update Rslib website URL, Rslib now uses the shorter [rslib.rs](https://rslib.rs/) instead of lib.rsbuild.dev

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
