### PR TITLE
fix: display gzip size for markdown files

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -84,7 +84,7 @@ const coloringAssetName = (assetName: string) => {
 };
 
 const COMPRESSIBLE_REGEX =
-  /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest)$/i;
+  /\.(?:js|css|html|json|svg|txt|xml|xhtml|wasm|manifest|md)$/i;
 
 const isCompressible = (assetName: string) =>
   COMPRESSIBLE_REGEX.test(assetName);


### PR DESCRIPTION
## Summary

When using Rspress's LLMs plugin, many markdown files will be emitted, and Rsbuild should display the gzip size of these markdown files.

Fix:

<img width="898" alt="Screenshot 2025-05-27 at 22 12 27" src="https://github.com/user-attachments/assets/0da8be0a-2c78-43b7-b9ad-d330c4f4d629" />


## Related Links

https://v2.rspress.dev/plugin/official-plugins/llms

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
