### PR TITLE
fix: avoid colon in output config file name

### DIFF
--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -101,6 +101,8 @@ export async function outputInspectConfigFiles({
 }): Promise<void> {
   const { outputPath } = inspectOptions;
 
+  const escapeOutputName = (name: string) => name.replace(/[:]/g, '_');
+
   const files = [
     ...rawEnvironmentConfigs.map(({ name, content }) => {
       if (rawEnvironmentConfigs.length === 1) {
@@ -113,7 +115,7 @@ export async function outputInspectConfigFiles({
           content,
         };
       }
-      const outputFile = `rsbuild.config.${name}.mjs`;
+      const outputFile = `rsbuild.config.${escapeOutputName(name)}.mjs`;
       const outputFilePath = join(outputPath, outputFile);
 
       return {
@@ -123,7 +125,7 @@ export async function outputInspectConfigFiles({
       };
     }),
     ...rawBundlerConfigs.map(({ name, content }) => {
-      const outputFile = `${configType}.config.${name}.mjs`;
+      const outputFile = `${configType}.config.${escapeOutputName(name)}.mjs`;
       let outputFilePath = join(outputPath, outputFile);
 
       // if filename is conflict, add a random id to the filename.

--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -101,7 +101,7 @@ export async function outputInspectConfigFiles({
 }): Promise<void> {
   const { outputPath } = inspectOptions;
 
-  const escapeOutputName = (name: string) => name.replace(/[:]/g, '_');
+  const formatOutputName = (name: string) => name.replace(/[:]/g, '_');
 
   const files = [
     ...rawEnvironmentConfigs.map(({ name, content }) => {
@@ -115,7 +115,7 @@ export async function outputInspectConfigFiles({
           content,
         };
       }
-      const outputFile = `rsbuild.config.${escapeOutputName(name)}.mjs`;
+      const outputFile = `rsbuild.config.${formatOutputName(name)}.mjs`;
       const outputFilePath = join(outputPath, outputFile);
 
       return {
@@ -125,7 +125,7 @@ export async function outputInspectConfigFiles({
       };
     }),
     ...rawBundlerConfigs.map(({ name, content }) => {
-      const outputFile = `${configType}.config.${escapeOutputName(name)}.mjs`;
+      const outputFile = `${configType}.config.${formatOutputName(name)}.mjs`;
       let outputFilePath = join(outputPath, outputFile);
 
       // if filename is conflict, add a random id to the filename.


### PR DESCRIPTION
## Summary

avoid colon in output config file name.

![image](https://github.com/user-attachments/assets/86cd3204-53e1-404e-b71a-efaa4010cdd6)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
