### PR TITLE
docs: fix inaccurate expression in import wasm module

### DIFF
--- a/website/docs/en/guide/basic/wasm-assets.mdx
+++ b/website/docs/en/guide/basic/wasm-assets.mdx
@@ -8,7 +8,7 @@ WebAssembly (Wasm) is a portable, high-performance binary format designed to exe
 
 ## Import
 
-You can import a WebAssembly module directly in a JavaScript file:
+You can reference a WebAssembly module in a JavaScript file using named imports:
 
 ```js title="index.js"
 import { add } from './add.wasm';

--- a/website/docs/zh/guide/basic/wasm-assets.mdx
+++ b/website/docs/zh/guide/basic/wasm-assets.mdx
@@ -8,7 +8,7 @@ WebAssembly（缩写为 wasm）是一种可移植、高性能的字节码格式�
 
 ## 引用方式
 
-你可以直接在 JavaScript 文件中引用一个 WebAssembly 模块：
+你可以在 JavaScript 文件中通过具名导入来引用一个 WebAssembly 模块：
 
 ```js title="index.js"
 import { add } from './add.wasm';


### PR DESCRIPTION
## Summary

fix inaccurate expression in import wasm module. use `named import` instead of `directly`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
