### PR TITLE
docs: disable domain redirection

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,9 +1,9 @@
 # Redirect rsbuild.dev to rsbuild.rs
-[[redirects]]
-from = "https://rsbuild.dev/*"
-to = "https://rsbuild.rs/:splat"
-status = 301
-force = true
+# [[redirects]]
+# from = "https://rsbuild.dev/*"
+# to = "https://rsbuild.rs/:splat"
+# status = 301
+# force = true
 
 [[redirects]]
 from = "/*"


### PR DESCRIPTION
## Summary

Disable domain redirection as DNS records need time to propagate (spread) across DNS servers worldwide. 

https://www.whatsmydns.net/#NS/rsbuild.rs

![image](https://github.com/user-attachments/assets/460d3a75-dbac-4222-aa6e-8359d9012427)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
