### PR TITLE
docs: enable domain redirection

### DIFF
--- a/website/docs/public/netlify.toml
+++ b/website/docs/public/netlify.toml
@@ -1,9 +1,9 @@
 # Redirect rsbuild.dev to rsbuild.rs
-# [[redirects]]
-# from = "https://rsbuild.dev/*"
-# to = "https://rsbuild.rs/:splat"
-# status = 301
-# force = true
+[[redirects]]
+from = "https://rsbuild.dev/*"
+to = "https://rsbuild.rs/:splat"
+status = 301
+force = true
 
 [[redirects]]
 from = "/*"


### PR DESCRIPTION
## Summary

Now that DNS propagation should be complete and we can enable domain redirection.

- https://www.whatsmydns.net/#NS/rsbuild.rs:

![image](https://github.com/user-attachments/assets/78194dc3-55b4-4879-ace9-06bfd681a12c)

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5327

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
