### PR TITLE
docs: fix invalid browserslist query example

### DIFF
--- a/website/docs/en/guide/advanced/browserslist.mdx
+++ b/website/docs/en/guide/advanced/browserslist.mdx
@@ -170,7 +170,7 @@ For desktop web applications, if you need to be compatible with IE 11 browsers, 
 ```yaml title=".browserslistrc"
 > 0.5%
 not dead
-Internet Explorer 11
+IE 11
 ```
 
 The above Browserslist will compile the code to the ES5. For the specific browser list, please check [browserslist.dev](https://browserslist.dev/?q=PiAwLjUlLCBub3QgZGVhZCwgSUUgMTE%3D).


### PR DESCRIPTION
## Summary

Fix an invalid browserslist query example, `Internet Explorer 11` should be `IE 11`.

![image](https://github.com/user-attachments/assets/e50d242b-1f07-4769-8801-038f5cadf1f9)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
