### PR TITLE
feat: support get manifest via environment API

### DIFF
--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -126,3 +126,66 @@ test('should allow to access manifest data in environment context after dev buil
 
   await rsbuild.close();
 });
+
+test('should allow to access manifest data in environment API', async ({
+  page,
+}) => {
+  let webManifest: Record<string, any> | undefined = {};
+  let nodeManifest: Record<string, any> | undefined = {};
+
+  const rsbuild = await dev({
+    cwd: fixtures,
+    page,
+    rsbuildConfig: {
+      output: {
+        filenameHash: false,
+      },
+      environments: {
+        web: {
+          output: {
+            manifest: true,
+          },
+        },
+        node: {
+          output: {
+            target: 'node',
+            manifest: 'manifest-node.json',
+          },
+        },
+      },
+      dev: {
+        setupMiddlewares: [
+          (middlewares, { environments }) => {
+            middlewares.unshift(async (_req, _res, next) => {
+              webManifest = await environments.web.getManifest();
+              nodeManifest = await environments.node.getManifest();
+              next();
+            });
+          },
+        ],
+      },
+    },
+  });
+
+  // should visit base url correctly
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  // main.js, main.js.map, index.html
+  expect(Object.keys(webManifest.allFiles).length).toBe(3);
+  expect(webManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/static/js/index.js'],
+    },
+    html: ['/index.html'],
+  });
+
+  // main.js, main.js.map
+  expect(Object.keys(nodeManifest.allFiles).length).toBe(2);
+  expect(nodeManifest.entries.index).toMatchObject({
+    initial: {
+      js: ['/index.js'],
+    },
+  });
+
+  await rsbuild.close();
+});

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -292,6 +292,17 @@ export async function createDevServer<
             await waitFirstCompileDone;
             return lastStats[environment.index];
           },
+          getManifest: async <T>() => {
+            if (!environment.config.output.manifest) {
+              throw new Error(
+                `${color.dim('[rsbuild:server]')} Can not call ` +
+                  `${color.yellow('getManifest')} when ` +
+                  `${color.yellow('output.manifest')} is not enabled`,
+              );
+            }
+            await waitFirstCompileDone;
+            return context.environments[name].manifest as T;
+          },
           loadBundle: async <T>(entryName: string) => {
             if (!compilationManager) {
               throw new Error(

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1502,6 +1502,13 @@ export type EnvironmentAPI = {
      * Get the compiled HTML template.
      */
     getTransformedHtml: (entryName: string) => Promise<string>;
+
+    /**
+     * Manifest data. Only available when `output.manifest` config option is enabled
+     */
+    getManifest: <
+      T extends Record<string, unknown> = ManifestData,
+    >() => Promise<T>;
   };
 };
 

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -214,7 +214,7 @@ export type EnvironmentContext = {
    * Manifest data. Only available when:
    * - The `output.manifest` config is enabled
    * - The build has completed, accessible in hooks like `onAfterBuild`,
-   * `onDevCompileDone` and `onAfterEnvironmentCompile`
+   * `onDevCompileDone` and `onAfterEnvironmentCompile` or in the Environment API
    */
   manifest?: Record<string, unknown> | ManifestData;
 };

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -180,7 +180,7 @@ api.onAfterEnvironmentCompile(({ environment }) => {
 });
 ```
 
-The manifest data is only available after the build has completed, you can access it in the following hooks:
+The manifest data is only available after the build has completed, you can access it in the following hooks and APIs:
 
 - [onAfterBuild](/plugins/dev/hooks#onafterbuild)
 - [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
@@ -188,6 +188,7 @@ The manifest data is only available after the build has completed, you can acces
 - [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
 - [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
 - [onExit](/plugins/dev/hooks#onexit)
+- [getManifest](/api/javascript-api/environment-api#getmanifest)
 
 ## Environment API
 
@@ -201,6 +202,9 @@ type EnvironmentAPI = {
     getStats: () => Promise<Stats>;
     loadBundle: <T = unknown>(entryName: string) => Promise<T>;
     getTransformedHtml: (entryName: string) => Promise<string>;
+    getManifest: <
+      T extends Record<string, unknown> = ManifestData,
+    >() => Promise<T | undefined>;
   };
 };
 ```
@@ -262,3 +266,25 @@ const html = await environments.web.getTransformedHtml('main');
 ```
 
 This method returns the complete HTML string, including all resources and content injected through HTML plugins.
+
+### getManifest
+
+When the [output.manifest](/config/output/manifest) configuration is enabled, the manifest of the current environment can be available through the `getManifest` API.
+
+- **Type:**
+
+```ts
+type GetManifest: <
+      T extends Record<string, unknown> = ManifestData,
+    >() => Promise<T | undefined>;
+```
+
+- **Example:**
+
+```ts
+const webManifest = await environments.web.getManifest();
+
+console.log(webManifest.entries);
+```
+
+The return value of this method refers to [Manifest structure](/config/output/manifest#manifest-structure).

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -79,7 +79,7 @@ type ManifestList = {
 
 ## Access via hooks
 
-You can access the generated manifest data through Rsbuild's [hooks](/plugins/dev/hooks).
+You can access the generated manifest data through Rsbuild's [hooks](/plugins/dev/hooks) and [Environment API](/api/javascript-api/environment-api).
 
 For example:
 

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -181,7 +181,7 @@ api.onAfterEnvironmentCompile(({ environment }) => {
 });
 ```
 
-manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks 中访问：
+manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks 和 APIs 中访问：
 
 - [onAfterBuild](/plugins/dev/hooks#onafterbuild)
 - [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
@@ -189,10 +189,11 @@ manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks �
 - [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
 - [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
 - [onExit](/plugins/dev/hooks#onexit)
+- [getManifest](/api/javascript-api/environment-api#getmanifest)
 
 ## Environment API
 
-Environment API 包了一些与多环境构建相关的 API。
+Environment API 提供一些与多环境构建相关的 API。
 
 你可以通过 [rsbuild.createDevServer()](/api/javascript-api/instance#rsbuildcreatedevserver) 或 [dev.setupMiddlewares](/config/dev/setup-middlewares) 使用 environment API，这允许你在服务端获取特定环境下的构建产物信息。
 
@@ -202,6 +203,9 @@ type EnvironmentAPI = {
     getStats: () => Promise<Stats>;
     loadBundle: <T = unknown>(entryName: string) => Promise<T>;
     getTransformedHtml: (entryName: string) => Promise<string>;
+    getManifest: <
+      T extends Record<string, unknown> = ManifestData,
+    >() => Promise<T | undefined>;
   };
 };
 ```
@@ -263,3 +267,25 @@ const html = await environments.web.getTransformedHtml('main');
 ```
 
 该方法会返回完整的 HTML 字符串，包含了所有通过 HTML 插件注入的资源和内容。
+
+### getManifest
+
+当开启 [output.manifest](/config/output/manifest) 配置时，可通过 `getManifest` API 获取当前环境的产物清单。
+
+- **类型：**
+
+```ts
+type GetManifest: <
+      T extends Record<string, unknown> = ManifestData,
+    >() => Promise<T | undefined>;
+```
+
+- **示例：**
+
+```ts
+const webManifest = await environments.web.getManifest();
+
+console.log(webManifest.entries);
+```
+
+该方法的返回结果参考 [Manifest 结构](/config/output/manifest#manifest-结构)。

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -79,7 +79,7 @@ type ManifestList = {
 
 ## 通过 hooks 访问
 
-你可以通过 Rsbuild 的 [hooks](/plugins/dev/hooks) 访问生成的 manifest 数据。
+你可以通过 Rsbuild 的 [hooks](/plugins/dev/hooks) 或 [Environment API](/api/javascript-api/environment-api) 访问生成的 manifest 数据。
 
 例如：
 


### PR DESCRIPTION
## Summary

support get manifest via environment API.

```ts
const webManifest = await environments.web.getManifest();

console.log(webManifest.entries);
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
