### PR TITLE
docs: clarify methods to access environment context

### DIFF
--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -8,7 +8,7 @@ Here you can find all the environment related APIs.
 
 Environment context is a read-only object that provides some context information about the current environment.
 
-In Rsbuild's [Plugin hooks](/plugins/dev/hooks#plugin-hooks), you can get the environment context object through the `environment` or `environments` parameter.
+- **Type:**
 
 ```ts
 type EnvironmentContext = {
@@ -22,6 +22,11 @@ type EnvironmentContext = {
   manifest?: Record<string, unknown> | ManifestData;
 };
 ```
+
+You can get the environment context through the following ways:
+
+1. In Rsbuild's [Plugin hooks](/plugins/dev/hooks#plugin-hooks), you can get the environment context object through the `environment` or `environments` parameter.
+2. In the [Environment API](#environment-api-1), it is available via `environments.context`.
 
 ### name
 
@@ -210,8 +215,7 @@ type EnvironmentAPI = {
 
 You can get context information related to the current environment through the Environment API.
 
-- **Type:** `EnvironmentContext`
-
+- **Type:** [EnvironmentContext](#environment-context)
 - **Example:**
 
 ```ts

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -6,9 +6,9 @@
 
 ## Environment context
 
-Environment context 是一个只读对象，提供一些和当前环境有关的上下文信息。
+Environment context 是一个只读对象，提供一些和当前 environment 有关的上下文信息。
 
-在 Rsbuild 的 [Plugin hooks](/plugins/dev/hooks#plugin-hooks) 中，你可以通过 `environment` 或 `environments` 入参获取 environment context 对象。
+- **类型：**
 
 ```ts
 type EnvironmentContext = {
@@ -22,6 +22,11 @@ type EnvironmentContext = {
   manifest?: Record<string, unknown> | ManifestData;
 };
 ```
+
+Environment context 可以通过以下方式获取：
+
+1. 在 Rsbuild 的 [Plugin hooks](/plugins/dev/hooks#plugin-hooks) 中，你可以通过 `environment` 或 `environments` 入参获取 environment context 对象。
+2. 在 [Environment API](#environment-api-1) 中，可以通过 `environments.context` 获取。
 
 ### name
 
@@ -211,8 +216,7 @@ type EnvironmentAPI = {
 
 你可以通过 Environment API 获取和当前环境有关的上下文信息。
 
-- **类型：** `EnvironmentContext`
-
+- **类型：** [EnvironmentContext](#environment-context)
 - **示例：**
 
 ```ts


### PR DESCRIPTION
## Summary

Added two ways to access the environment context: via Rsbuild's plugin hooks and the Environment API, with corresponding links for better guidance.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
