### PR TITLE
feat: let SWC compile modules outside the project

### DIFF
--- a/e2e/cases/source/source-include/index.test.ts
+++ b/e2e/cases/source/source-include/index.test.ts
@@ -1,10 +1,8 @@
-import path from 'node:path';
 import { build, proxyConsole } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
-import { normalizeToPosixPath } from '@scripts/test-helper';
 
-test('should not compile file which outside of project by default', async () => {
+test('should compile modules outside of project by default', async () => {
   const { logs, restore } = proxyConsole();
   await expect(
     build({
@@ -16,30 +14,8 @@ test('should not compile file which outside of project by default', async () => 
         },
       },
     }),
-  ).rejects.toThrowError('[@rsbuild/plugin-check-syntax]');
-
-  restore();
-
-  expect(logs.find((log) => log.includes('ERROR 1'))).toBeTruthy();
-  expect(
-    logs.find(
-      (log) =>
-        log.includes('source:') &&
-        normalizeToPosixPath(log).includes('/dist/static/js/index'),
-    ),
-  ).toBeTruthy();
-});
-
-test('should compile specified file when source.include', async () => {
-  await expect(
-    build({
-      cwd: __dirname,
-      plugins: [pluginCheckSyntax()],
-      rsbuildConfig: {
-        source: {
-          include: [path.resolve(__dirname, '../test.js')],
-        },
-      },
-    }),
   ).resolves.toBeDefined();
+
+  expect(logs.find((log) => log.includes('Syntax check passed'))).toBeTruthy();
+  restore();
 });

--- a/e2e/cases/source/test.js
+++ b/e2e/cases/source/test.js
@@ -1,3 +1,4 @@
+// This file is used by the test case: source-include
 export const printLog = () => {
   const arr = [1, 2, 3, 4, [5, 6, [7, 8]]];
   console.log(arr, arr.flat());

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -106,12 +106,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/compat/webpack/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
@@ -557,12 +552,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/compat/webpack/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
@@ -1006,12 +996,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/compat/webpack/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
@@ -1385,12 +1370,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/compat/webpack/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -20,7 +20,6 @@ import type {
   NormalizedEnvironmentConfig,
   NormalizedSourceConfig,
   Polyfill,
-  RsbuildContext,
   RsbuildPlugin,
   RsbuildTarget,
   RspackChain,
@@ -35,19 +34,15 @@ function applyScriptCondition({
   rule,
   isDev,
   config,
-  context,
   rsbuildTarget,
 }: {
   rule: RspackChain.Rule;
   isDev: boolean;
   config: NormalizedEnvironmentConfig;
-  context: RsbuildContext;
   rsbuildTarget: RsbuildTarget;
 }): void {
   // compile all modules in the app directory, exclude node_modules
-  rule.include.add({
-    and: [context.rootPath, { not: NODE_MODULES_REGEX }],
-  });
+  rule.include.add({ not: NODE_MODULES_REGEX });
 
   // always compile TS and JSX files.
   // otherwise, it may cause compilation errors and incorrect output
@@ -125,7 +120,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
           rule,
           isDev,
           config,
-          context: api.context,
           rsbuildTarget: target,
         });
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -118,12 +118,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         },
         "include": [
           {
-            "and": [
-              "<ROOT>",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -118,12 +118,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/core/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
@@ -595,12 +590,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/core/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
@@ -1075,12 +1065,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/core/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
@@ -1504,12 +1489,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         },
         "include": [
           {
-            "and": [
-              "<ROOT>/packages/core/tests",
-              {
-                "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-              },
-            ],
+            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1413,12 +1413,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           },
           "include": [
             {
-              "and": [
-                "<ROOT>",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
             /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
@@ -1806,12 +1801,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           },
           "include": [
             {
-              "and": [
-                "<ROOT>",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -16,12 +16,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -126,12 +121,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -248,12 +238,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
     },
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/core/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
@@ -302,12 +287,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
     },
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/core/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
@@ -405,12 +385,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
     ],
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/core/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
@@ -534,12 +509,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
     ],
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/core/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
@@ -648,12 +618,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -784,12 +749,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -900,12 +860,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -1008,12 +963,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -1125,12 +1075,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -1251,12 +1196,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -1380,12 +1320,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
@@ -1506,12 +1441,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
           },
           "include": [
             {
-              "and": [
-                "<ROOT>/packages/core/tests",
-                {
-                  "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-                },
-              ],
+              "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -10,12 +10,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
   ],
   "include": [
     {
-      "and": [
-        "<ROOT>/packages/plugin-babel/tests",
-        {
-          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-        },
-      ],
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     /node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
@@ -96,12 +91,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
   ],
   "include": [
     {
-      "and": [
-        "<ROOT>/packages/plugin-babel/tests",
-        {
-          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-        },
-      ],
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
@@ -181,12 +171,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
   ],
   "include": [
     {
-      "and": [
-        "<ROOT>/packages/plugin-babel/tests",
-        {
-          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-        },
-      ],
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
@@ -261,12 +246,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
   },
   "include": [
     {
-      "and": [
-        "<ROOT>/packages/plugin-babel/tests",
-        {
-          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-        },
-      ],
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
@@ -343,12 +323,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
   },
   "include": [
     {
-      "and": [
-        "<ROOT>/packages/plugin-babel/tests",
-        {
-          "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-        },
-      ],
+      "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -14,12 +14,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
     },
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/plugin-react/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
@@ -97,12 +92,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     },
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/plugin-react/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -17,12 +17,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     ],
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/plugin-svelte/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
@@ -128,12 +123,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     ],
     "include": [
       {
-        "and": [
-          "<ROOT>/packages/plugin-svelte/tests",
-          {
-            "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
-          },
-        ],
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,


### PR DESCRIPTION
## Summary

This PR changes the default `source.include` behavior to make SWC compile modules outside the project, which ensures that JavaScript modules in the monorepo can be compiled correctly to avoid compatibility issues.

While this may slightly increase compile times in certain cases within a monorepo, it can help to improve the stability and browser compatibility of web apps.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
