### PR TITLE
docs: refine source.include and clarify compilation behavior

### DIFF
--- a/website/docs/en/config/source/include.mdx
+++ b/website/docs/en/config/source/include.mdx
@@ -6,18 +6,16 @@ Specify additional JavaScript files that need to be compiled by [SWC](/guide/con
 
 ## Default value
 
-To avoid double compilation, by default, Rsbuild's built-in [swc-loader](https://rspack.rs/guide/features/builtin-swc-loader) compiles the following files:
+By default, Rsbuild's built-in [swc-loader](https://rspack.rs/guide/features/builtin-swc-loader) compiles the following files:
 
 - TypeScript and JSX files in any directory, matching file extensions `.ts`, `.tsx`, `.jsx`, `.mts`, `.cts`.
-- JavaScript files in the [root](/config/root) directory, excluding the `node_modules` directory, matching file extensions `.js`, `.mjs`, `.cjs`.
+- JavaScript files that are not in the `node_modules` directory, matching file extensions `.js`, `.mjs`, `.cjs`.
 
 The default value of `source.include` can be expressed as:
 
 ```ts
 const defaultInclude = [
-  {
-    and: [rootPath, { not: /[\\/]node_modules[\\/]/ }],
-  },
+  { not: /[\\/]node_modules[\\/]/ },
   /\.(?:ts|tsx|jsx|mts|cts)$/,
 ];
 ```
@@ -85,28 +83,6 @@ export default {
     include: [
       /node_modules[\\/]query-string[\\/]/,
       /node_modules[\\/]decode-uri-component[\\/]/,
-    ],
-  },
-};
-```
-
-## Compile libraries in monorepo
-
-When developing in monorepo, if you need to refer to other modules in monorepo, you can add the corresponding module to `source.include`:
-
-```ts title="rsbuild.config.ts"
-import path from 'node:path';
-
-const packagesDir = path.resolve(__dirname, '../../packages');
-
-export default {
-  source: {
-    include: [
-      // Compile all files in monorepo's package directory
-      // It is recommended to exclude the node_modules
-      {
-        and: [packagesDir, { not: /[\\/]node_modules[\\/]/ }],
-      },
     ],
   },
 };

--- a/website/docs/en/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/en/guide/advanced/browser-compatibility.mdx
@@ -122,19 +122,9 @@ if (!String.prototype.replaceAll) {
 
 ## Compilation scope
 
-Rsbuild categorizes modules into three types:
+By default, Rsbuild uses [SWC](/guide/configuration/swc) to compile all JavaScript and TypeScript modules, but excludes JavaScript modules in the `node_modules` directory.
 
-1. Source code in the current project
-2. Third-party dependency installed via npm
-3. Modules outside the current project (such as modules from other directories in a monorepo)
-
-By default, Rsbuild uses [SWC](/guide/configuration/swc) to transform source code in the current project, as well as all TS and JSX modules in all directories. Other modules are not processed by SWC.
-
-The rationale behind this design:
-
-- Transforming all third-party dependencies would impact build performance
-- Most third-party dependencies are already pre-compiled, and redundant transformation may introduce issues
-- Code outside the current project may already be compiled or require different compilation configs
+This approach is designed to avoid impacting build performance when downgrading all third-party dependencies while also preventing potential issues arising from redundantly downgrading pre-compiled third-party dependencies.
 
 ### Source code
 
@@ -156,31 +146,7 @@ export default {
 };
 ```
 
-Refer to [source.include](/config/source/include) document for detailed usage.
-
-### Non-current project modules
-
-When you need to compile a JavaScript module outside the current project, then you also need to configure [source.include](/config/source/include).
-
-For example, to compile a module under the `packages` directory in the monorepo, add the following config:
-
-```ts title="rsbuild.config.ts"
-import path from 'node:path';
-
-const packagesDir = path.resolve(__dirname, '../../packages');
-
-export default {
-  source: {
-    include: [
-      // Compile all files in monorepo's package directory
-      // It is recommended to exclude the node_modules
-      {
-        and: [packagesDir, { not: /[\\/]node_modules[\\/]/ }],
-      },
-    ],
-  },
-};
-```
+See [source.include](/config/source/include) for detailed usage.
 
 ## Polyfill mode
 

--- a/website/docs/zh/config/source/include.mdx
+++ b/website/docs/zh/config/source/include.mdx
@@ -6,18 +6,16 @@
 
 ## 默认值
 
-为了避免二次编译，默认情况下，Rsbuild 内置的 [swc-loader](https://rspack.rs/zh/guide/features/builtin-swc-loader) 会编译以下文件：
+默认情况下，Rsbuild 内置的 [swc-loader](https://rspack.rs/zh/guide/features/builtin-swc-loader) 会编译以下文件：
 
 - 任意目录下的 TypeScript 和 JSX 文件，匹配的文件后缀为 `.ts`、`.tsx`、`.jsx`、`.mts`、`.cts`。
-- [root](/config/root) 目录下的 JavaScript 文件，但不包含 `node_modules` 目录，匹配的文件后缀为 `.js`、`.mjs`、`.cjs`。
+- 非 `node_modules` 目录下的 JavaScript 文件，匹配的文件后缀为 `.js`、`.mjs`、`.cjs`。
 
 `source.include` 的默认值可以表示为：
 
 ```ts
 const defaultInclude = [
-  {
-    and: [rootPath, { not: /[\\/]node_modules[\\/]/ }],
-  },
+  { not: /[\\/]node_modules[\\/]/ }
   /\.(?:ts|tsx|jsx|mts|cts)$/,
 ];
 ```
@@ -85,28 +83,6 @@ export default {
     include: [
       /node_modules[\\/]query-string[\\/]/,
       /node_modules[\\/]decode-uri-component[\\/]/,
-    ],
-  },
-};
-```
-
-## 编译 monorepo 中的其他模块
-
-在 monorepo 中进行开发时，如果需要引用 monorepo 中的其他 JavaScript 模块，也可以在 `source.include` 中进行配置:
-
-```ts title="rsbuild.config.ts"
-import path from 'node:path';
-
-const packagesDir = path.resolve(__dirname, '../../packages');
-
-export default {
-  source: {
-    include: [
-      // 编译 Monorepo 的 package 目录下的所有文件
-      // 建议排除 node_modules
-      {
-        and: [packagesDir, { not: /[\\/]node_modules[\\/]/ }],
-      },
     ],
   },
 };

--- a/website/docs/zh/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/browser-compatibility.mdx
@@ -122,19 +122,9 @@ if (!String.prototype.replaceAll) {
 
 ## 编译范围
 
-Rsbuild 将模块分为三类：
+默认情况下，Rsbuild 使用 [SWC](/guide/configuration/swc) 编译所有 JavaScript 和 TypeScript 模块，但排除了 `node_modules` 目录下的 JavaScript 模块。
 
-1. 当前项目中的源代码
-2. 通过 npm 安装的第三方依赖
-3. 非当前项目的模块（如 monorepo 中其他目录的模块）
-
-默认情况下，Rsbuild 使用 [SWC](/guide/configuration/swc) 对当前项目中的源代码，以及所有目录下的 TS 和 JSX 模块进行编译，其他模块不会经过 SWC 处理。
-
-这样设计的原因：
-
-- 对所有第三方依赖降级会影响构建性能
-- 大多数第三方依赖已预编译，重复降级可能引入问题
-- 非当前项目的模块可能已编译完成，或需要不同的编译配置
+采用这种设计，是为了避免对所有第三方依赖进行降级时影响构建性能，同时防止对已预编译的第三方依赖进行重复降级而引入潜在问题。
 
 ### 源代码
 
@@ -157,30 +147,6 @@ export default {
 ```
 
 查看 [source.include](/config/source/include) 文档来了解更详细的用法。
-
-### 非当前项目的模块
-
-当你需要编译非当前项目的 JavaScript 模块，那么也需要配置 [source.include](/config/source/include)。
-
-比如，编译 monorepo 中 `packages` 目录下的某个模块，可以添加如下配置：
-
-```ts title="rsbuild.config.ts"
-import path from 'node:path';
-
-const packagesDir = path.resolve(__dirname, '../../packages');
-
-export default {
-  source: {
-    include: [
-      // Compile all files in monorepo's package directory
-      // It is recommended to exclude the node_modules
-      {
-        and: [packagesDir, { not: /[\\/]node_modules[\\/]/ }],
-      },
-    ],
-  },
-};
-```
 
 ## Polyfill 方案
 


### PR DESCRIPTION
## Summary

Revised the description of Rsbuild's default compilation settings to clarify that JavaScript files outside the `node_modules` directory are compiled, and simplified the code snippet for the default value of `source.include`.

Removed the section explaining how to configure `source.include` for compiling monorepo libraries, which is no longer needed.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5344

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
