### PR TITLE
feat(create-rsbuild): update .gitignore to include rspack profile

### DIFF
--- a/packages/create-rsbuild/template-common/gitignore
+++ b/packages/create-rsbuild/template-common/gitignore
@@ -7,6 +7,9 @@
 node_modules
 dist/
 
+# Profile
+.rspack-profile-*/
+
 # IDE
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
## Summary

Updates the `.gitignore` file in the `template-common` directory to add patterns to ignore `rspack` profile directories (`.rspack-profile-*`).

## Related Links

- https://rsbuild.rs/guide/debug/build-profiling#rspack-profiling

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
