### PR TITLE
feat: allow to get raw JS content with `?raw`

### DIFF
--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -2,6 +2,7 @@ import { promises } from 'node:fs';
 import { join } from 'node:path';
 import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
+import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
 test('should allow to get raw asset content with `?raw` in development mode', async ({
@@ -56,6 +57,50 @@ test('should allow to get raw SVG content with `?raw` when using pluginSvgr', as
       join(__dirname, '../../../assets/circle.svg'),
       'utf-8',
     ),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to get raw JS content with `?raw`', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.rawJs')).toEqual(
+    await promises.readFile(join(__dirname, 'src/foo.js'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to get raw TS content with `?raw`', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.rawTs')).toEqual(
+    await promises.readFile(join(__dirname, 'src/bar.ts'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});
+
+test('should allow to get raw TSX content with `?raw` and using pluginReact', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      plugins: [pluginReact()],
+    },
+  });
+
+  expect(await page.evaluate('window.rawTsx')).toEqual(
+    await promises.readFile(join(__dirname, 'src/baz.tsx'), 'utf-8'),
   );
 
   await rsbuild.close();

--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -87,21 +87,3 @@ test('should allow to get raw TS content with `?raw`', async ({ page }) => {
 
   await rsbuild.close();
 });
-
-test('should allow to get raw TSX content with `?raw` and using pluginReact', async ({
-  page,
-}) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      plugins: [pluginReact()],
-    },
-  });
-
-  expect(await page.evaluate('window.rawTsx')).toEqual(
-    await promises.readFile(join(__dirname, 'src/baz.tsx'), 'utf-8'),
-  );
-
-  await rsbuild.close();
-});

--- a/e2e/cases/assets/raw-query/src/bar.ts
+++ b/e2e/cases/assets/raw-query/src/bar.ts
@@ -1,0 +1,3 @@
+export function bar(): string {
+  return 'bar';
+}

--- a/e2e/cases/assets/raw-query/src/baz.tsx
+++ b/e2e/cases/assets/raw-query/src/baz.tsx
@@ -1,0 +1,3 @@
+export function baz() {
+  return <div>baz</div>;
+}

--- a/e2e/cases/assets/raw-query/src/foo.js
+++ b/e2e/cases/assets/raw-query/src/foo.js
@@ -1,0 +1,3 @@
+export function foo() {
+  return 'foo';
+}

--- a/e2e/cases/assets/raw-query/src/index.js
+++ b/e2e/cases/assets/raw-query/src/index.js
@@ -1,3 +1,9 @@
 import img from '@assets/circle.svg?raw';
+import rawTs from './bar.ts?raw';
+import rawTsx from './baz.tsx?raw';
+import rawJs from './foo.js?raw';
 
 window.rawImg = img;
+window.rawJs = rawJs;
+window.rawTs = rawTs;
+window.rawTsx = rawTsx;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -111,8 +111,16 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -556,8 +564,16 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -1000,8 +1016,16 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -1374,8 +1398,16 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -43,6 +43,8 @@ export const CHAIN_ID = {
     ADDITIONAL_ASSETS: 'additional-assets',
     /** Rule for js */
     JS: 'js',
+    /** Rule for raw js */
+    JS_RAW: 'js-raw',
     /** Rule for data uri encoded javascript */
     JS_DATA_URI: 'js-data-uri',
     /** Rule for ts */

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -108,7 +108,16 @@ export const pluginSwc = (): RsbuildPlugin => ({
           .type('javascript/auto')
           // When using `new URL('./path/to/foo.js', import.meta.url)`,
           // the module should be treated as an asset module rather than a JS module.
-          .dependency({ not: 'url' });
+          .dependency({ not: 'url' })
+          // exclude `import './foo.css?raw'` and `import './foo.css?inline'`
+          .resourceQuery({ not: /raw|inline/ });
+
+        // Support for `import rawJs from "a.js?raw"`
+        chain.module
+          .rule(CHAIN_ID.RULE.JS_RAW)
+          .test(SCRIPT_REGEX)
+          .type('asset/source')
+          .resourceQuery(/raw/);
 
         const dataUriRule = chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -123,6 +123,9 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -158,6 +161,11 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -123,6 +123,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -158,6 +161,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -594,6 +602,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -629,6 +640,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -1069,6 +1085,9 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           },
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -1100,6 +1119,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {
@@ -1494,6 +1518,9 @@ exports[`tools.rspack > should match snapshot 1`] = `
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
+        "resourceQuery": {
+          "not": /raw\\|inline/,
+        },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
         "use": [
@@ -1529,6 +1556,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             },
           },
         ],
+      },
+      {
+        "resourceQuery": /raw/,
+        "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+        "type": "asset/source",
       },
       {
         "mimetype": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1418,6 +1418,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
             /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1453,6 +1456,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -1805,6 +1813,9 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1836,6 +1847,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -20,6 +20,9 @@ exports[`plugin-swc > should add browserslist 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -52,6 +55,11 @@ exports[`plugin-swc > should add browserslist 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -125,6 +133,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -167,6 +178,11 @@ exports[`plugin-swc > should add pluginImport 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -242,6 +258,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -254,6 +273,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "mimetype": {
@@ -291,6 +315,9 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -326,6 +353,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "mimetype": {
@@ -394,6 +426,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
         "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
       },
     },
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -438,6 +473,11 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "mimetype": {
@@ -513,6 +553,9 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
       },
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -551,6 +594,11 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "mimetype": {
@@ -622,6 +670,9 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -667,6 +718,11 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -753,6 +809,9 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -788,6 +847,11 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -864,6 +928,9 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -895,6 +962,11 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -967,6 +1039,9 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1002,6 +1077,11 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -1084,6 +1164,9 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
             },
           },
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1120,6 +1203,11 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -1205,6 +1293,9 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
             },
           },
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1242,6 +1333,11 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -1329,6 +1425,9 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               "core-js": "<ROOT>/node_modules/<PNPM_INNER>/core-js",
             },
           },
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1365,6 +1464,11 @@ exports[`plugin-swc > should has correct core-js 1`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {
@@ -1445,6 +1549,9 @@ exports[`plugin-swc > should has correct core-js 2`] = `
             },
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
+          "resourceQuery": {
+            "not": /raw\\|inline/,
+          },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
           "use": [
@@ -1476,6 +1583,11 @@ exports[`plugin-swc > should has correct core-js 2`] = `
               },
             },
           ],
+        },
+        {
+          "resourceQuery": /raw/,
+          "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+          "type": "asset/source",
         },
         {
           "mimetype": {

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -15,6 +15,9 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     /node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
   ],
+  "resourceQuery": {
+    "not": /raw\\|inline/,
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -95,6 +98,9 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resourceQuery": {
+    "not": /raw\\|inline/,
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -175,6 +181,9 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resourceQuery": {
+    "not": /raw\\|inline/,
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -250,6 +259,9 @@ exports[`plugins/babel > should set babel-loader 1`] = `
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resourceQuery": {
+    "not": /raw\\|inline/,
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [
@@ -327,6 +339,9 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
     },
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
+  "resourceQuery": {
+    "not": /raw\\|inline/,
+  },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
   "use": [

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -19,6 +19,9 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -60,6 +63,11 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
       },
     ],
   },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
+  },
 ]
 `;
 
@@ -97,6 +105,9 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -137,6 +148,11 @@ exports[`plugins/react > should work with swc-loader 1`] = `
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
 ]
 `;

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -22,6 +22,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -57,6 +60,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
@@ -128,6 +136,9 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
     ],
+    "resourceQuery": {
+      "not": /raw\\|inline/,
+    },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
     "use": [
@@ -163,6 +174,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
         },
       },
     ],
+  },
+  {
+    "resourceQuery": /raw/,
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+    "type": "asset/source",
   },
   {
     "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,


### PR DESCRIPTION
## Summary

Add support for importing the raw content of JavaScript, TypeScript, and JSX files through the `?raw` query parameter. This makes the `?raw` query more general and intuitive.

```ts
import rawJs from './script1.js?raw';
import rawTs from './script2.ts?raw';
import rawJsx from './script3.jsx?raw';
import rawTsx from './script4.tsx?raw';

console.log(rawJs); // The raw content of the JS file
console.log(rawTs); // The raw content of the TS file
console.log(rawJsx); // The raw content of the JSX file
console.log(rawTsx); // The raw content of the TSX file
```

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/2665

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
