### PR TITLE
fix(plugin-react): skip React Refresh injection for raw JS content

### DIFF
--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -87,3 +87,21 @@ test('should allow to get raw TS content with `?raw`', async ({ page }) => {
 
   await rsbuild.close();
 });
+
+test('should allow to get raw TSX content with `?raw` and using pluginReact', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+    rsbuildConfig: {
+      plugins: [pluginReact()],
+    },
+  });
+
+  expect(await page.evaluate('window.rawTsx')).toEqual(
+    await promises.readFile(join(__dirname, 'src/baz.tsx'), 'utf-8'),
+  );
+
+  await rsbuild.close();
+});

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -35,6 +35,12 @@ export type PluginReactOptions = {
   enableProfiler?: boolean;
   /**
    * Options passed to `@rspack/plugin-react-refresh`
+   * @default
+   * {
+   *   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+   *   exclude: [/[\\/]node_modules[\\/]/],
+   *   resourceQuery: { not: /raw/ },
+   * }
    * @see https://rspack.rs/guide/tech/react#rspackplugin-react-refresh
    */
   reactRefreshOptions?: ReactRefreshOptions;

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -74,6 +74,7 @@ export const applyBasicReactSupport = (
           {
             include: [SCRIPT_REGEX],
             exclude: [NODE_MODULES_REGEX],
+            resourceQuery: { not: /raw/ },
             ...options.reactRefreshOptions,
           },
         ]);

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -221,6 +221,7 @@ type ReactRefreshOptions = {
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
   exclude: [/[\\/]node_modules[\\/]/],
+  resourceQuery: { not: /raw/ },
 };
 ```
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -223,6 +223,7 @@ type ReactRefreshOptions = {
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
   exclude: [/[\\/]node_modules[\\/]/],
+  resourceQuery: { not: /raw/ },
 };
 ```
 


### PR DESCRIPTION
## Summary

Excluding raw JS modules from React Refresh processing to ensure that the `?raw` query can get the original file content.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5353

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
