### PR TITLE
fix(type): make the PostCSS plugin type loose

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -144,10 +144,10 @@ const getPostcssLoaderOptions = async ({
   root: string;
   postcssrcCache: PostcssrcCache;
 }): Promise<PostCSSLoaderOptions> => {
-  const extraPlugins: AcceptedPlugin[] = [];
+  const extraPlugins: unknown[] = [];
 
   const utils = {
-    addPlugins(plugins: AcceptedPlugin | AcceptedPlugin[]) {
+    addPlugins(plugins: unknown | unknown[]) {
       extraPlugins.push(...castArray(plugins));
     },
   };
@@ -181,7 +181,9 @@ const getPostcssLoaderOptions = async ({
     // initialize the plugin to avoid multiple initialization
     // https://github.com/web-infra-dev/rsbuild/issues/3618
     options.plugins = options.plugins.map((plugin) =>
-      isPostcssPluginCreator(plugin) ? plugin() : plugin,
+      isPostcssPluginCreator(plugin as AcceptedPlugin)
+        ? (plugin as PluginCreator<unknown>)()
+        : plugin,
     );
 
     // always use postcss-load-config to load external config

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -40,7 +40,6 @@ import type {
   CSSLoaderOptions,
   HtmlRspackPlugin,
   PostCSSLoaderOptions,
-  PostCSSPlugin,
   StyleLoaderOptions,
   WebpackConfig,
 } from './thirdParty';
@@ -61,7 +60,7 @@ export type ToolsBundlerChainConfig = OneOrMany<
 
 export type ToolsPostCSSLoaderConfig = ConfigChainWithContext<
   PostCSSLoaderOptions,
-  { addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void }
+  { addPlugins: (plugins: unknown | unknown[]) => void }
 >;
 
 export type ToolsCSSLoaderConfig = ConfigChain<CSSLoaderOptions>;

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -19,7 +19,7 @@ export type { WebpackConfig };
 
 export type PostCSSOptions = ProcessOptions & {
   config?: boolean;
-  plugins?: AcceptedPlugin[];
+  plugins?: unknown[];
 };
 
 export type PostCSSLoaderOptions = {


### PR DESCRIPTION
## Summary

When user passes a PostCSS plugin to `tools.postcss` config, the plugin may depend on a different version of PostCSS, which can cause type errors. This PR loosens the PostCSS plugin type to resolve type issue. 

## Related Links

Fix ecosystem CI: https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/15458968100/job/43516378827

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
