### PR TITLE
Revert "fix(type): make the PostCSS plugin type loose (#5364)"

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -144,10 +144,10 @@ const getPostcssLoaderOptions = async ({
   root: string;
   postcssrcCache: PostcssrcCache;
 }): Promise<PostCSSLoaderOptions> => {
-  const extraPlugins: unknown[] = [];
+  const extraPlugins: AcceptedPlugin[] = [];
 
   const utils = {
-    addPlugins(plugins: unknown | unknown[]) {
+    addPlugins(plugins: AcceptedPlugin | AcceptedPlugin[]) {
       extraPlugins.push(...castArray(plugins));
     },
   };
@@ -181,9 +181,7 @@ const getPostcssLoaderOptions = async ({
     // initialize the plugin to avoid multiple initialization
     // https://github.com/web-infra-dev/rsbuild/issues/3618
     options.plugins = options.plugins.map((plugin) =>
-      isPostcssPluginCreator(plugin as AcceptedPlugin)
-        ? (plugin as PluginCreator<unknown>)()
-        : plugin,
+      isPostcssPluginCreator(plugin) ? plugin() : plugin,
     );
 
     // always use postcss-load-config to load external config

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -40,6 +40,7 @@ import type {
   CSSLoaderOptions,
   HtmlRspackPlugin,
   PostCSSLoaderOptions,
+  PostCSSPlugin,
   StyleLoaderOptions,
   WebpackConfig,
 } from './thirdParty';
@@ -60,7 +61,7 @@ export type ToolsBundlerChainConfig = OneOrMany<
 
 export type ToolsPostCSSLoaderConfig = ConfigChainWithContext<
   PostCSSLoaderOptions,
-  { addPlugins: (plugins: unknown | unknown[]) => void }
+  { addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void }
 >;
 
 export type ToolsCSSLoaderConfig = ConfigChain<CSSLoaderOptions>;

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -19,7 +19,7 @@ export type { WebpackConfig };
 
 export type PostCSSOptions = ProcessOptions & {
   config?: boolean;
-  plugins?: unknown[];
+  plugins?: AcceptedPlugin[];
 };
 
 export type PostCSSLoaderOptions = {


### PR DESCRIPTION
This reverts commit 87728718d62f68fed711183136941f98b95bd597.

## Summary

Revert https://github.com/web-infra-dev/rsbuild/pull/5364

This change does not fix the ecosystem CI. And considering that PostCSS types do not change frequently, it may be a better approach to let users upgrade the PostCSS version.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
