### PR TITLE
chore(deps): update @rslib/core to 0.9.2

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@types/lodash": "^4.17.17",
     "@types/semver": "^7.7.0",
     "typescript": "^5.8.3",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "ansi-escapes": "4.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,7 +59,7 @@
     "jiti": "^2.4.2"
   },
   "devDependencies": {
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@types/connect": "3.4.38",
     "@types/cors": "^2.8.18",
     "@types/node": "^22.15.30",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -39,7 +39,7 @@
     "@rsbuild/plugin-solid": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@types/node": "^22.15.30",
     "typescript": "^5.8.3"
   },

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "babel-loader": "10.0.0",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.8",
     "less": "^4.3.0",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@types/node": "^22.15.30",
     "preact": "^10.26.8",
     "typescript": "^5.8.3"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "typescript": "^5.8.3"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "@types/sass-loader": "^8.0.9",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "typescript": "^5.8.3"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "typescript": "^5.8.3"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "svelte": "^5.33.14",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "file-loader": "6.2.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.30",
     "typescript": "^5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,8 +530,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@types/lodash':
         specifier: ^4.17.17
         version: 4.17.17
@@ -573,8 +573,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../../scripts/test-helper
@@ -613,8 +613,8 @@ importers:
         version: 2.4.2
     devDependencies:
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -764,8 +764,8 @@ importers:
         specifier: workspace:*
         version: link:../plugin-vue
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30
@@ -804,8 +804,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -835,8 +835,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -875,8 +875,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30
@@ -900,8 +900,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -934,8 +934,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -974,8 +974,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1005,8 +1005,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1030,8 +1030,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1070,8 +1070,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1107,8 +1107,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1128,8 +1128,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
       '@types/node':
         specifier: ^22.15.30
         version: 22.15.30
@@ -1156,8 +1156,8 @@ importers:
         version: 2.0.1
     devDependencies:
       '@rslib/core':
-        specifier: 0.9.1
-        version: 0.9.1(typescript@5.8.3)
+        specifier: 0.9.2
+        version: 0.9.2(typescript@5.8.3)
 
   website:
     devDependencies:
@@ -2454,6 +2454,11 @@ packages:
     engines: {node: '>=16.10.0'}
     hasBin: true
 
+  '@rsbuild/core@1.4.0-beta.2':
+    resolution: {integrity: sha512-cgMGolvlPkDghi0+tuoN5pYZERhOuOHQWXwxVU963/f5BSrXDRtwH6QzUevmUVyh+i1zFE5OdWM3YyVCahvG2Q==}
+    engines: {node: '>=16.10.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.5':
     resolution: {integrity: sha512-g6kZsAREO7c3KEBXRnLbOovIEL/TQDMls2QQFpaGxHx1K7pJB5nNmY1XpTzLCch62xfmBV4crOde0Dow6NAshg==}
     peerDependencies:
@@ -2535,8 +2540,8 @@ packages:
   '@rsdoctor/utils@1.1.3':
     resolution: {integrity: sha512-pygyA6wInU7VmWW2gihyhw5qIetSDtr3aFyzNsV+0VUduSUtZEsKnEz3JUzxvX23W34PapqjRDyfuMqphFsnKg==}
 
-  '@rslib/core@0.9.1':
-    resolution: {integrity: sha512-aa/LXYxr49lCNm/b0B4CQoTB5286MPglGsE5/YFoY0VwIcKJdMz0zBJ4DsPwh27/fcfDQvmN1+J9tzjt9TxQtQ==}
+  '@rslib/core@0.9.2':
+    resolution: {integrity: sha512-C5mZroofHKJiHl7V/b2hIp9WnFXRrKFnfOP/Aw+7DcxgH/ur593MypG3Zg5mVcaJv6OG36oNbvUtJ6+Wk5yqog==}
     engines: {node: '>=16.7.0'}
     hasBin: true
     peerDependencies:
@@ -5839,8 +5844,8 @@ packages:
       webpack:
         optional: true
 
-  rsbuild-plugin-dts@0.9.1:
-    resolution: {integrity: sha512-04pkKrebuajsCpC8Vj2z4n6NFFxUYAdUdqSQRFGkGhdmururoDFYW0k9+ZQq9XrSQTlB01F/HFv5mAc0dwG/Qg==}
+  rsbuild-plugin-dts@0.9.2:
+    resolution: {integrity: sha512-mVpf4J/auMSBy5iBNDaxTB8yYipENRTMUq8bQQJQdvzFuH2arQXrQ874ukEJ67XUZXhmxvc7ooEAR3UWKNiPtQ==}
     engines: {node: '>=16.7.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8191,6 +8196,14 @@ snapshots:
       core-js: 3.42.0
       jiti: 2.4.2
 
+  '@rsbuild/core@1.4.0-beta.2':
+    dependencies:
+      '@rspack/core': 1.3.15(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.42.0
+      jiti: 2.4.2
+
   '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@packages+core)':
     dependencies:
       '@babel/core': 7.27.4
@@ -8381,10 +8394,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rslib/core@0.9.1(typescript@5.8.3)':
+  '@rslib/core@0.9.2(typescript@5.8.3)':
     dependencies:
-      '@rsbuild/core': 1.3.22
-      rsbuild-plugin-dts: 0.9.1(@rsbuild/core@1.3.22)(typescript@5.8.3)
+      '@rsbuild/core': 1.4.0-beta.2
+      rsbuild-plugin-dts: 0.9.2(@rsbuild/core@1.4.0-beta.2)(typescript@5.8.3)
       tinyglobby: 0.2.14
     optionalDependencies:
       typescript: 5.8.3
@@ -12289,10 +12302,10 @@ snapshots:
     optionalDependencies:
       webpack: 5.99.9
 
-  rsbuild-plugin-dts@0.9.1(@rsbuild/core@1.3.22)(typescript@5.8.3):
+  rsbuild-plugin-dts@0.9.2(@rsbuild/core@1.4.0-beta.2)(typescript@5.8.3):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.3.22
+      '@rsbuild/core': 1.4.0-beta.2
       magic-string: 0.30.17
       picocolors: 1.1.1
       tinyglobby: 0.2.14

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.9.1",
+    "@rslib/core": "0.9.2",
     "@types/node": "^22.15.30",
     "typescript": "^5.8.3"
   }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -32,7 +32,7 @@
     "upath": "2.0.1"
   },
   "devDependencies": {
-    "@rslib/core": "0.9.1"
+    "@rslib/core": "0.9.2"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Update @rslib/core to 0.9.2 to use the new ESM output.

- before:

```
File (esm_index)   Size       
dist/index.js      416.6 kB
```

- after:

```
File (esm_index)   Size       
dist/index.js      389.1 kB
```

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v0.9.2

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
