### PR TITLE
fix(create-rsbuild): missing env.d.ts in some templates

### DIFF
--- a/packages/create-rsbuild/template-preact-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-preact-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />

--- a/packages/create-rsbuild/template-vanilla-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-vanilla-ts/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@rsbuild/core/types" />


### PR DESCRIPTION
## Summary

Fix missing `env.d.ts` in some templates.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/5380

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
