### PR TITLE
perf: lazy import node crypto

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -1,4 +1,3 @@
-import crypto from 'node:crypto';
 import { posix } from 'node:path';
 import { URL } from 'node:url';
 import deepmerge from 'deepmerge';
@@ -366,7 +365,8 @@ export const addCompilationError = (
   );
 };
 
-export function hash(data: string): string {
+export async function hash(data: string): Promise<string> {
+  const crypto = await import('node:crypto');
   // Available in Node.js v20.12.0
   // faster than `crypto.createHash()` when hashing a smaller amount of data (<= 5MB)
   if (crypto.hash) {

--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -149,7 +149,7 @@ export const pluginCache = (): RsbuildPlugin => ({
 
       // set cache name to avoid cache conflicts between different environments
       const cacheVersion = useDigest
-        ? `${environment.name}-${env}-${hash(JSON.stringify(cacheConfig.cacheDigest))}`
+        ? `${environment.name}-${env}-${await hash(JSON.stringify(cacheConfig.cacheDigest))}`
         : `${environment.name}-${env}`;
 
       if (bundlerType === 'rspack') {


### PR DESCRIPTION
## Summary

Switching from sync to async imports of the `crypto` module. Additionally, it updates the `hash` function to return a `Promise` and adjusts its usage accordingly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
