### PR TITLE
chore: enable `noUncheckedSideEffectImports` in tsconfig.json

### DIFF
--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -16,7 +16,8 @@
     /* type checking */
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "noUncheckedSideEffectImports": true
   },
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Base"


### PR DESCRIPTION
## Summary

To avoid side effect imports, enable the `noUncheckedSideEffectImports` setting in tsconfig.json for Rsbuild packages.

## Related Links

- https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
