### PR TITLE
feat(types): add type declarations for normal CSS module

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -296,3 +296,28 @@ declare module '*.module.stylus' {
   const classes: CSSModuleClasses;
   export default classes;
 }
+
+/**
+ * CSS
+ */
+declare module '*.css' {}
+/**
+ * @requires [@rsbuild/plugin-sass](https://npmjs.com/package/@rsbuild/plugin-sass)
+ */
+declare module '*.scss' {}
+/**
+ * @requires [@rsbuild/plugin-sass](https://npmjs.com/package/@rsbuild/plugin-sass)
+ */
+declare module '*.sass' {}
+/**
+ * @requires [@rsbuild/plugin-stylus](https://npmjs.com/package/@rsbuild/plugin-stylus)
+ */
+declare module '*.less' {}
+/**
+ * @requires [@rsbuild/plugin-stylus](https://npmjs.com/package/@rsbuild/plugin-stylus)
+ */
+declare module '*.styl' {}
+/**
+ * @requires [@rsbuild/plugin-stylus](https://npmjs.com/package/@rsbuild/plugin-stylus)
+ */
+declare module '*.stylus' {}

--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -310,7 +310,7 @@ declare module '*.scss' {}
  */
 declare module '*.sass' {}
 /**
- * @requires [@rsbuild/plugin-stylus](https://npmjs.com/package/@rsbuild/plugin-stylus)
+ * @requires [@rsbuild/plugin-less](https://npmjs.com/package/@rsbuild/plugin-less)
  */
 declare module '*.less' {}
 /**


### PR DESCRIPTION
## Summary

Add type declarations for normal CSS module, this is required when TypeScript's new `noUncheckedSideEffectImports` option is enabled.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/5380
- https://www.typescriptlang.org/tsconfig/#noUncheckedSideEffectImports

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
