### PR TITLE
fix(create-rsbuild): correct ESLint template name in react18-ts preset

### DIFF
--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -70,7 +70,7 @@ function mapESLintTemplate(templateName: string): ESLintTemplateName {
     case 'react18-js':
       return 'react-js';
     case 'react18-ts':
-      return 'react-js';
+      return 'react-ts';
   }
   const language = templateName.split('-')[1];
   return `vanilla-${language}` as ESLintTemplateName;


### PR DESCRIPTION
## Summary
#5390 
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
