### PR TITLE
docs: add more hooks to migration guide

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -263,11 +263,12 @@ Rsbuild's plugin API covers most of the Vite and Rollup plugin hooks, for exampl
 | `transform`          | [transform](/plugins/dev/core#apitransform)                                                                            |
 | `config`             | [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig)                                                          |
 | `configResolved`     | [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig)                                                        |
+| `configEnvironment`  | [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig)                                                  |
 | `configureServer`    | [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver)                                                    |
 | `buildStart`         | [onBeforeBuild](/plugins/dev/hooks#onbeforebuild), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) |
 | `buildEnd`           | [onAfterBuild](/plugins/dev/hooks#onafterbuild), [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)               |
 | `closeBundle`        | [onCloseBuild](/plugins/dev/hooks#onclosebuild), [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)               |
-| `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml)                                                                            |
+| `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml), [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags)                       |
 
 See [Plugin system](/plugins/dev/index) for more details.
 

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -263,11 +263,12 @@ Rsbuild 的插件 API 覆盖了大部分的 Vite 和 Rollup 插件 hooks，例�
 | `transform`          | [transform](/plugins/dev/core#apitransform)                                                                            |
 | `config`             | [modifyRsbuildConfig](/plugins/dev/hooks#modifyrsbuildconfig)                                                          |
 | `configResolved`     | [getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig)                                                        |
+| `configEnvironment`  | [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig)                                                  |
 | `configureServer`    | [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver)                                                    |
 | `buildStart`         | [onBeforeBuild](/plugins/dev/hooks#onbeforebuild), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) |
 | `buildEnd`           | [onAfterBuild](/plugins/dev/hooks#onafterbuild), [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)               |
 | `closeBundle`        | [onCloseBuild](/plugins/dev/hooks#onclosebuild), [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)               |
-| `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml)                                                                            |
+| `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml), [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags)                       |
 
 请参考 [插件系统](/plugins/dev/index) 文档来了解更多。
 


### PR DESCRIPTION
## Summary

Add more hooks to migration guide:

- Added `configEnvironment` hook with a link to `modifyEnvironmentConfig`
- Expanded the description of `transformIndexHtml` to include the `modifyHTMLTags` hook.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
