### PR TITLE
feat(create-rsbuild): enable `verbatimModuleSyntax` in tsconfig

### DIFF
--- a/e2e/cases/server/overlay-type-errors/tsconfig.json
+++ b/e2e/cases/server/overlay-type-errors/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "strict": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "moduleResolution": "bundler"
   },
   "include": ["src"]

--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "strict": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "react-jsx",
     "strict": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -7,7 +7,7 @@
     "jsxImportSource": "vue",
     "strict": true,
     "skipLibCheck": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "useDefineForClassFields": true

--- a/packages/create-rsbuild/template-lit-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-lit-ts/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-preact-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-preact-ts/tsconfig.json
@@ -10,7 +10,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-react-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react-ts/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-react18-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-react18-ts/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-solid-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-solid-ts/tsconfig.json
@@ -10,7 +10,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -4,14 +4,11 @@
     "target": "ES2020",
     "noEmit": true,
     "skipLibCheck": true,
-    // svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
-    // to enforce using `import type` instead of `import` for Types.
-    "verbatimModuleSyntax": true,
     "useDefineForClassFields": true,
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vanilla-ts/tsconfig.json
@@ -9,7 +9,7 @@
     /* modules */
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "allowImportingTsExtensions": true,
 

--- a/packages/create-rsbuild/template-vue2-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue2-ts/tsconfig.json
@@ -9,7 +9,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/create-rsbuild/template-vue3-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-vue3-ts/tsconfig.json
@@ -10,7 +10,7 @@
 
     /* modules */
     "module": "ESNext",
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -9,7 +9,7 @@
     /* modules */
     "module": "ES2020",
     "esModuleInterop": true,
-    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
 

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -25,7 +25,7 @@ Unlike the native TypeScript compiler, tools like SWC and Babel compile each fil
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "isolatedModules": true
+    "verbatimModuleSyntax": true
   }
 }
 ```

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -25,7 +25,7 @@ Rsbuild 默认使用 [SWC](/guide/configuration/swc) 来转译 TypeScript 代码
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "isolatedModules": true
+    "verbatimModuleSyntax": true
   }
 }
 ```


### PR DESCRIPTION
## Description

Update default tsconfig.json to enable the `verbatimModuleSyntax` option. It is recommended and will supersede `isolatedModules`.

## Related Links

- https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax
- https://github.com/microsoft/TypeScript/issues/51479#issuecomment-1335765803

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
