### PR TITLE
chore: remove baseUrl option from tsconfig

### DIFF
--- a/e2e/cases/alias/jsconfig-paths/jsconfig.json
+++ b/e2e/cases/alias/jsconfig-paths/jsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/common/*": ["./src/common/*"]

--- a/e2e/cases/alias/tsconfig-paths-references/tsconfig.app.json
+++ b/e2e/cases/alias/tsconfig-paths-references/tsconfig.app.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/common/*": ["./src/common/*"]

--- a/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
+++ b/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/content": ["src/foo/test.ts"]

--- a/e2e/cases/alias/tsconfig-paths-specify-config/tsconfig.custom.json
+++ b/e2e/cases/alias/tsconfig-paths-specify-config/tsconfig.custom.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/common/*": ["./src/common/*"]

--- a/e2e/cases/alias/tsconfig-paths-specify-config/tsconfig.json
+++ b/e2e/cases/alias/tsconfig-paths-specify-config/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src"]

--- a/e2e/cases/alias/tsconfig-paths/tsconfig.json
+++ b/e2e/cases/alias/tsconfig-paths/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/common/*": ["./src/common/*"]

--- a/e2e/cases/babel/decorator/tsconfig.json
+++ b/e2e/cases/babel/decorator/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/cache/build-dependencies/tsconfig.json
+++ b/e2e/cases/cache/build-dependencies/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/cache/cache-digest/tsconfig.json
+++ b/e2e/cases/cache/cache-digest/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/cli/base/tsconfig.json
+++ b/e2e/cases/cli/base/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/cli/basic/tsconfig.json
+++ b/e2e/cases/cli/basic/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/cli/build-watch-restart/tsconfig.json
+++ b/e2e/cases/cli/build-watch-restart/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/cli/build-watch/tsconfig.json
+++ b/e2e/cases/cli/build-watch/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/cli/falsy-plugins/tsconfig.json
+++ b/e2e/cases/cli/falsy-plugins/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/cli/mode/tsconfig.json
+++ b/e2e/cases/cli/mode/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/e2e/cases/cli/reload-config/tsconfig.json
+++ b/e2e/cases/cli/reload-config/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/cli/reload-env/tsconfig.json
+++ b/e2e/cases/cli/reload-env/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/css/css-modules-dom/tsconfig.json
+++ b/e2e/cases/css/css-modules-dom/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "tests", "index.test.ts"]

--- a/e2e/cases/css/inject-styles/tsconfig.json
+++ b/e2e/cases/css/inject-styles/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "tests"]

--- a/e2e/cases/css/resolve-ts-paths/tsconfig.json
+++ b/e2e/cases/css/resolve-ts-paths/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "src/*": ["./src/*"]

--- a/e2e/cases/html/combined/tsconfig.json
+++ b/e2e/cases/html/combined/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "*.test.ts"]

--- a/e2e/cases/html/minify/tsconfig.json
+++ b/e2e/cases/html/minify/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src"]

--- a/e2e/cases/javascript-api/build-and-load-env/index.test.ts
+++ b/e2e/cases/javascript-api/build-and-load-env/index.test.ts
@@ -1,6 +1,6 @@
+import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
-import { rspackOnlyTest } from 'scripts';
 
 rspackOnlyTest('should not load env by default', async () => {
   const rsbuild = await createRsbuild({

--- a/e2e/cases/javascript-api/build/index.test.ts
+++ b/e2e/cases/javascript-api/build/index.test.ts
@@ -1,6 +1,6 @@
+import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
-import { rspackOnlyTest } from 'scripts';
 
 rspackOnlyTest(
   'should allow to call `build` and get stats object',

--- a/e2e/cases/javascript-api/caller-name/index.test.ts
+++ b/e2e/cases/javascript-api/caller-name/index.test.ts
@@ -1,6 +1,6 @@
+import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { createRsbuild } from '@rsbuild/core';
-import { rspackOnlyTest } from 'scripts';
 
 rspackOnlyTest(
   'should allow to set caller name and use it in plugins',

--- a/e2e/cases/javascript-api/sock-write/index.test.ts
+++ b/e2e/cases/javascript-api/sock-write/index.test.ts
@@ -1,5 +1,5 @@
+import { expectPoll, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
-import { expectPoll, gotoPage, rspackOnlyTest } from 'scripts';
 
 rspackOnlyTest(
   'should allow to call `sockWrite` after creating dev server',

--- a/e2e/cases/performance/resource-hints-prefetch/tsconfig.json
+++ b/e2e/cases/performance/resource-hints-prefetch/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "index.test.ts"]

--- a/e2e/cases/performance/resource-hints-preload/tsconfig.json
+++ b/e2e/cases/performance/resource-hints-preload/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src", "index.test.ts"]

--- a/e2e/cases/react/disable-fast-refresh/tsconfig.json
+++ b/e2e/cases/react/disable-fast-refresh/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist"
   },
   "include": ["src"]

--- a/e2e/cases/resolve/extension-alias-js/tsconfig.json
+++ b/e2e/cases/resolve/extension-alias-js/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/resolve/extension-alias-jsx/tsconfig.json
+++ b/e2e/cases/resolve/extension-alias-jsx/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/resolve/extensions/tsconfig.json
+++ b/e2e/cases/resolve/extensions/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/source/define/tsconfig.json
+++ b/e2e/cases/source/define/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/syntax/top-level-await/tsconfig.json
+++ b/e2e/cases/syntax/top-level-await/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "module": "ES2022",
     "target": "ES2017",

--- a/e2e/cases/typescript/const-enum/tsconfig.json
+++ b/e2e/cases/typescript/const-enum/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/e2e/cases/wasm/tsconfig.json
+++ b/e2e/cases/wasm/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["wasm-basic/src/*"]

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "baseUrl": "./",
     "outDir": "./dist",
     "paths": {
       "@/*": ["./src/*"]

--- a/packages/compat/plugin-webpack-swc/tests/tsconfig.json
+++ b/packages/compat/plugin-webpack-swc/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/compat/plugin-webpack-swc/tsconfig.json
+++ b/packages/compat/plugin-webpack-swc/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -425,7 +425,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "plugins": [
       TsconfigPathsPlugin {
         "absoluteBaseUrl": "<ROOT>/packages/compat/webpack/tests",
-        "baseUrl": "./",
+        "baseUrl": undefined,
         "extensions": [
           ".ts",
           ".tsx",
@@ -876,7 +876,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "plugins": [
       TsconfigPathsPlugin {
         "absoluteBaseUrl": "<ROOT>/packages/compat/webpack/tests",
-        "baseUrl": "./",
+        "baseUrl": undefined,
         "extensions": [
           ".ts",
           ".tsx",
@@ -1260,7 +1260,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "plugins": [
       TsconfigPathsPlugin {
         "absoluteBaseUrl": "<ROOT>/packages/compat/webpack/tests",
-        "baseUrl": "./",
+        "baseUrl": undefined,
         "extensions": [
           ".ts",
           ".tsx",
@@ -1627,7 +1627,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "plugins": [
       TsconfigPathsPlugin {
         "absoluteBaseUrl": "<ROOT>/packages/compat/webpack/tests",
-        "baseUrl": "./",
+        "baseUrl": undefined,
         "extensions": [
           ".ts",
           ".tsx",

--- a/packages/compat/webpack/tests/tsconfig.json
+++ b/packages/compat/webpack/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/compat/webpack/tsconfig.json
+++ b/packages/compat/webpack/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true
   },

--- a/packages/core/tests/tsconfig.json
+++ b/packages/core/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts", "../src/env.d.ts"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "declarationDir": "./dist-types",
     "composite": true,

--- a/packages/create-rsbuild/tsconfig.json
+++ b/packages/create-rsbuild/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
-    "outDir": "./dist",
-    "baseUrl": "./"
+    "outDir": "./dist"
   },
   "include": ["src"]
 }

--- a/packages/plugin-babel/tests/tsconfig.json
+++ b/packages/plugin-babel/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-less/tests/tsconfig.json
+++ b/packages/plugin-less/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-less/tsconfig.json
+++ b/packages/plugin-less/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-preact/tests/tsconfig.json
+++ b/packages/plugin-preact/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-preact/tsconfig.json
+++ b/packages/plugin-preact/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-react/tests/tsconfig.json
+++ b/packages/plugin-react/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-sass/tests/tsconfig.json
+++ b/packages/plugin-sass/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-solid/tests/tsconfig.json
+++ b/packages/plugin-solid/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-stylus/tests/tsconfig.json
+++ b/packages/plugin-stylus/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-svelte/tests/tsconfig.json
+++ b/packages/plugin-svelte/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-svgr/tests/tsconfig.json
+++ b/packages/plugin-svgr/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/packages/plugin-vue/tests/tsconfig.json
+++ b/packages/plugin-vue/tests/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "baseUrl": "./",
     "types": ["@rstest/core/globals"]
   },
   "include": ["./**/*.ts"]

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "isolatedDeclarations": true

--- a/scripts/test-helper/tsconfig.json
+++ b/scripts/test-helper/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@rsbuild/config/tsconfig-node16",
   "compilerOptions": {
     "outDir": "./dist",
-    "baseUrl": "./",
     "rootDir": "src",
     "composite": true,
     "types": ["@rstest/core/globals"]

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -9,8 +9,7 @@
       "@zh/*": ["./docs/zh/*"],
       "@en/*": ["./docs/en/*"],
       "i18n": ["./i18n.json"]
-    },
-    "baseUrl": "./"
+    }
   },
   "mdx": {
     "checkMdx": true


### PR DESCRIPTION
## Summary

Remove baseUrl option from tsconfig, it's useless and will be removed in future.

## Related Links

- https://github.com/microsoft/typescript-go/issues/474#issuecomment-2715789096

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
