### PR TITLE
chore: remove useless incremental config

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -93,14 +93,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
         // enable Rspack config schema validation, unrecognized keys are allowed
         process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-unrecognized-keys';
-
-        // TODO: we can remove it after Rspack incremental is enabled by default
-        if (api.context.bundlerType === 'rspack') {
-          chain.experiments({
-            ...chain.get('experiments'),
-            incremental: true,
-          });
-        }
       },
     );
   },

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -4,9 +4,6 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "experiments": {
-    "incremental": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -44,9 +41,6 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
-  "experiments": {
-    "incremental": true,
-  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,7 +11,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,7 +11,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -490,7 +489,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -997,7 +995,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1398,7 +1395,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "incremental": true,
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1306,7 +1306,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
-      "incremental": true,
     },
     "infrastructureLogging": {
       "level": "error",
@@ -1725,7 +1724,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
-      "incremental": true,
     },
     "infrastructureLogging": {
       "level": "error",


### PR DESCRIPTION
## Summary

Rspack 1.4.0-beta.0 enables `incremental` by default and we can remove the `incremental` config from Rsbuild.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/10623

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
