### PR TITLE
test(e2e): clean up temporary files after tests

### DIFF
--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,8 +1,17 @@
 import fs from 'node:fs';
-import path from 'node:path';
+import path, { join } from 'node:path';
 import { createRsbuild, proxyConsole, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
-import { remove } from 'fs-extra';
+import { expect, test } from '@playwright/test';
+import { remove, removeSync } from 'fs-extra';
+
+test.afterAll(() => {
+  const files = fs.readdirSync(__dirname);
+  for (const file of files) {
+    if (file.startsWith('test-temp') || file.startsWith('dist')) {
+      removeSync(join(__dirname, file));
+    }
+  }
+});
 
 const rsbuildConfig = path.resolve(
   __dirname,

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -1,8 +1,19 @@
 import { exec } from 'node:child_process';
 import fs from 'node:fs';
+import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expectPoll, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { removeSync } from 'fs-extra';
+
+test.afterAll(() => {
+  const files = fs.readdirSync(__dirname);
+  for (const file of files) {
+    if (file.startsWith('.rspack-profile')) {
+      removeSync(join(__dirname, file));
+    }
+  }
+});
 
 rspackOnlyTest(
   'should generator rspack profile as expected in dev',


### PR DESCRIPTION
## Summary

Adds cleanup logic to E2E tests, use the `test.afterAll` hooks to clean up test artifacts.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
