### PR TITLE
feat(core): add `logLevel` config

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -24,7 +24,7 @@ export async function runCLI(): Promise<void> {
     npm_execpath.includes('npx-cli.js') ||
     npm_execpath.includes('.bun')
   ) {
-    console.log();
+    logger.log();
   }
 
   logger.greet(`  ${`Rsbuild v${RSBUILD_VERSION}`}\n`);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -167,6 +167,10 @@ export async function createRsbuild(
     ? await options.rsbuildConfig()
     : options.rsbuildConfig || {};
 
+  if (config.logLevel) {
+    logger.level = config.logLevel;
+  }
+
   applyEnvsToConfig(config, envs);
 
   const resolvedOptions: ResolvedCreateRsbuildOptions = {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1776,6 +1776,14 @@ export interface RsbuildConfig extends EnvironmentConfig {
    */
   root?: string;
   /**
+   * Specify the log level.
+   * - 'info': show 'info', 'start', 'success', 'ready', 'warn' and 'error' logs.
+   * - 'warn': show 'warn' and 'error' logs.
+   * - 'error': only show 'error' logs.
+   * @default 'info'
+   */
+  logLevel?: 'info' | 'warn' | 'error';
+  /**
    * Options for local development.
    */
   dev?: DevConfig;


### PR DESCRIPTION
## Summary

Adding support for configurable log levels, which is syntactic sugar for `logger.level = '...'`.

It is worth noting that the current `logLevel` still has some limitations. Since the `logger` object is a global singleton, if the user creates multiple Rsbuild instances at the same time, they must set the same `logLevel` value.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/1582

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
