### PR TITLE
feat: allow log level to be silent

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "prebundle": "1.3.3",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.2.0",
-    "rslog": "^1.2.3",
+    "rslog": "^1.2.6",
     "rspack-chain": "^1.2.5",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1780,9 +1780,10 @@ export interface RsbuildConfig extends EnvironmentConfig {
    * - 'info': show 'info', 'start', 'success', 'ready', 'warn' and 'error' logs.
    * - 'warn': show 'warn' and 'error' logs.
    * - 'error': only show 'error' logs.
+   * - 'silent': disable all logs.
    * @default 'info'
    */
-  logLevel?: 'info' | 'warn' | 'error';
+  logLevel?: 'info' | 'warn' | 'error' | 'silent';
   /**
    * Options for local development.
    */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -703,8 +703,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0(webpack@5.99.9)
       rslog:
-        specifier: ^1.2.3
-        version: 1.2.3
+        specifier: ^1.2.6
+        version: 1.2.6
       rspack-chain:
         specifier: ^1.2.5
         version: 1.2.5
@@ -5756,9 +5756,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rslog@1.2.3:
-    resolution: {integrity: sha512-antALPJaKBRPBU1X2q9t085K4htWDOOv/K1qhTUk7h0l1ePU/KbDqKJn19eKP0dk7PqMioeA0+fu3gyPXCsXxQ==}
-    engines: {node: '>=14.17.6'}
+  rslog@1.2.6:
+    resolution: {integrity: sha512-TGqKQNWVdVTQBG8dtIhdzJheYMCQy4JNG778OmyQAHc3NksEPK0ESexnHm/5EHC7BYAjYkc0r9SDI9PnKtzodw==}
 
   rspack-chain@1.2.5:
     resolution: {integrity: sha512-wF5yv3Z4hz5yE4ynx9XMBCfV57DzLH5YvUGpZoba815EqZX2frX/4hyhTJMO4qBYw91ifLQi+O5G+c34YJVY/g==}
@@ -7467,7 +7466,7 @@ snapshots:
       '@swc/helpers': 0.5.17
       caniuse-lite: 1.0.30001721
       lodash: 4.17.21
-      rslog: 1.2.3
+      rslog: 1.2.6
 
   '@module-federation/bridge-react-webpack-plugin@0.15.0':
     dependencies:
@@ -8105,7 +8104,7 @@ snapshots:
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.2.3
+      rslog: 1.2.6
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - '@rspack/core'
@@ -12014,7 +12013,7 @@ snapshots:
       mrmime: 2.0.1
       on-finished: 2.4.1
       range-parser: 1.2.1
-      rslog: 1.2.3
+      rslog: 1.2.6
     optionalDependencies:
       webpack: 5.99.9
 
@@ -12037,7 +12036,7 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  rslog@1.2.3: {}
+  rslog@1.2.6: {}
 
   rspack-chain@1.2.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Upgraded `rslog` dependency from version `^1.2.3` to `^1.2.6`.
- Added a new `silent` log level to the `logLevel` config.

## Related Links

- https://github.com/rspack-contrib/rslog/releases
- https://github.com/rspack-contrib/rslog/pull/34

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
