### PR TITLE
feat: improve lazy compilation options for single entry

### DIFF
--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -16,10 +16,26 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         return;
       }
 
-      chain.experiments({
-        ...chain.get('experiments'),
-        lazyCompilation: options,
-      });
+      if (options === true) {
+        const entries = chain.entryPoints.entries() || {};
+
+        // If there is only one entry, do not enable lazy compilation for entries
+        // this can reduce the rebuild time
+        if (Object.keys(entries).length <= 1) {
+          chain.experiments({
+            ...chain.get('experiments'),
+            lazyCompilation: {
+              entries: false,
+              imports: true,
+            },
+          });
+        }
+      } else {
+        chain.experiments({
+          ...chain.get('experiments'),
+          lazyCompilation: options,
+        });
+      }
     });
   },
 });

--- a/website/docs/en/config/dev/lazy-compilation.mdx
+++ b/website/docs/en/config/dev/lazy-compilation.mdx
@@ -63,6 +63,7 @@ export default {
   dev: {
     lazyCompilation: {
       imports: true,
+      // If there is only one entry, Rsbuild will not enable the entries option by default
       entries: true,
     },
   },

--- a/website/docs/zh/config/dev/lazy-compilation.mdx
+++ b/website/docs/zh/config/dev/lazy-compilation.mdx
@@ -63,6 +63,7 @@ export default {
   dev: {
     lazyCompilation: {
       imports: true,
+      // 如果只有一个入口，则 Rsbuild 默认不启用 entries 选项
       entries: true,
     },
   },


### PR DESCRIPTION
## Summary

If there is only one entry, do not enable lazy compilation for entries, this can reduce the rebuild time and provide better DX.

## Related Links

- https://github.com/web-infra-dev/rspress/pull/2286

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
