### PR TITLE
docs: add logLevel config

### DIFF
--- a/website/docs/en/config/log-level.mdx
+++ b/website/docs/en/config/log-level.mdx
@@ -1,0 +1,36 @@
+# logLevel
+
+- **Type:** `'info' | 'warn' | 'error' | 'silent'`
+- **Default:** `'info'`
+- **Version:** `>= 1.4.0`
+
+Specify the log level of Rsbuild, the default value is `info`.
+
+## Example
+
+Set `logLevel` to `warn` and Rsbuild will only output `warn` and `error` level logs:
+
+```ts title="rsbuild.config.ts"
+export default {
+  logLevel: 'warn',
+};
+```
+
+Set `logLevel` to `error` and Rsbuild will only output `error` level logs:
+
+```ts title="rsbuild.config.ts"
+export default {
+  logLevel: 'error',
+};
+```
+
+## Optional values
+
+- `info`: Output all logs
+- `warn`: Output `warn` and `error` level logs
+- `error`: Output `error` level logs
+- `silent`: Do not output any logs
+
+## Limitations
+
+Currently, you cannot set different log levels for each Rsbuild instance, because Rsbuild has a global shared [logger](/api/javascript-api/core#logger) instance, and all Rsbuild instances will share this logger instance.

--- a/website/docs/zh/config/log-level.mdx
+++ b/website/docs/zh/config/log-level.mdx
@@ -1,0 +1,36 @@
+# logLevel
+
+- **类型：** `'info' | 'warn' | 'error' | 'silent'`
+- **默认值：** `'info'`
+- **版本：** `>= 1.4.0`
+
+指定 Rsbuild 的日志级别，默认值为 `info`。
+
+## 示例
+
+将 `logLevel` 配置为 `warn` 后，Rsbuild 只会输出 `warn` 和 `error` 级别的日志：
+
+```ts title="rsbuild.config.ts"
+export default {
+  logLevel: 'warn',
+};
+```
+
+将 `logLevel` 配置为 `error` 后，Rsbuild 只会输出 `error` 级别的日志：
+
+```ts title="rsbuild.config.ts"
+export default {
+  logLevel: 'error',
+};
+```
+
+## 可选值
+
+- `info`：输出所有日志
+- `warn`：输出 `warn` 和 `error` 级别的日志
+- `error`：输出 `error` 级别的日志
+- `silent`：不输出任何日志
+
+## 局限性
+
+目前你无法为每一个 Rsbuild 实例设置不同的日志级别，因为 Rsbuild 内部有一个全局共享的 [logger](/api/javascript-api/core#logger) 实例，所有 Rsbuild 实例都会共享这个 logger 实例。

--- a/website/theme/rsbuildPluginOverview.ts
+++ b/website/theme/rsbuildPluginOverview.ts
@@ -31,6 +31,10 @@ export const rsbuildPluginOverview: RsbuildPlugin = {
             link: '/config/plugins',
           },
           {
+            text: 'logLevel',
+            link: '/config/log-level',
+          },
+          {
             text: 'environments',
             link: '/config/environments',
           },


### PR DESCRIPTION
## Summary

Added a new section to document the `logLevel` config. This includes its type, default value, supported versions, example configurations, optional values, and current limitations.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5423

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
