### PR TITLE
feat(CLI): add --logLevel flag

### DIFF
--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,0 +1,21 @@
+import { execSync } from 'node:child_process';
+import { rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest('should run build command with log level: info', async () => {
+  const result = execSync('npx rsbuild build --logLevel info', {
+    cwd: __dirname,
+  }).toString();
+
+  expect(result).toContain('build started...');
+  expect(result).toContain('built in');
+});
+
+rspackOnlyTest('should run build command with log level: warn', async () => {
+  const result = execSync('npx rsbuild build --logLevel warn', {
+    cwd: __dirname,
+  }).toString();
+
+  expect(result).not.toContain('build started...');
+  expect(result).not.toContain('built in');
+});

--- a/e2e/cases/cli/log-level/src/index.js
+++ b/e2e/cases/cli/log-level/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -3,7 +3,7 @@ import type { ConfigLoader } from '../loadConfig';
 import { logger } from '../logger';
 import { RSPACK_BUILD_ERROR } from '../provider/build';
 import { onBeforeRestartServer } from '../restart';
-import type { RsbuildMode } from '../types';
+import type { LogLevel, RsbuildMode } from '../types';
 import { init } from './init';
 
 export type CommonOptions = {
@@ -19,6 +19,7 @@ export type CommonOptions = {
   host?: string;
   port?: number;
   environment?: string[];
+  logLevel?: LogLevel;
 };
 
 export type BuildOptions = CommonOptions & {
@@ -56,6 +57,10 @@ const applyCommonOptions = (cli: CAC) => {
     .option(
       '-m, --mode <mode>',
       'specify the build mode, can be `development`, `production` or `none`',
+    )
+    .option(
+      '--log-level <level>',
+      'specify the log level, can be `info`, `warn`, `error` or `silent`',
     )
     .option(
       '--env-mode <mode>',

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -40,6 +40,10 @@ const loadConfig = async (root: string) => {
     config.mode = commonOpts.mode;
   }
 
+  if (commonOpts.logLevel) {
+    config.logLevel = commonOpts.logLevel;
+  }
+
   if (commonOpts.open && !config.server?.open) {
     config.server.open = commonOpts.open;
   }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1762,6 +1762,8 @@ export interface EnvironmentConfig {
   plugins?: RsbuildPlugins;
 }
 
+export type LogLevel = 'info' | 'warn' | 'error' | 'silent';
+
 /**
  * The Rsbuild config.
  * */
@@ -1783,7 +1785,7 @@ export interface RsbuildConfig extends EnvironmentConfig {
    * - 'silent': disable all logs.
    * @default 'info'
    */
-  logLevel?: 'info' | 'warn' | 'error' | 'silent';
+  logLevel?: LogLevel;
   /**
    * Options for local development.
    */

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -36,6 +36,7 @@ Rsbuild CLI provides several common flags that can be used with all commands:
 | `--env-dir <dir>`          | Specify the directory to load `.env` files, see [Env directory](/guide/advanced/env-vars#env-directory)                                         |
 | `--environment <name>`     | Specify the name of environment to build, see [Build specified environment](/guide/advanced/environments#build-specified-environment)           |
 | `-h, --help`               | Display help for command                                                                                                                        |
+| `--log-level <level>`      | Specify the log level, can be `info`, `warn`, `error` or `silent`, see [logLevel](/config/logLevel)                                             |
 | `-m, --mode <mode>`        | Specify the build mode (`development`, `production` or `none`), see [mode](/config/mode)                                                        |
 | `--no-env`                 | Disable loading `.env` files                                                                                                                    |
 | `-r, --root <root>`        | Specify the project root directory                                                                                                              |

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -36,7 +36,7 @@ Rsbuild CLI provides several common flags that can be used with all commands:
 | `--env-dir <dir>`          | Specify the directory to load `.env` files, see [Env directory](/guide/advanced/env-vars#env-directory)                                         |
 | `--environment <name>`     | Specify the name of environment to build, see [Build specified environment](/guide/advanced/environments#build-specified-environment)           |
 | `-h, --help`               | Display help for command                                                                                                                        |
-| `--log-level <level>`      | Specify the log level, can be `info`, `warn`, `error` or `silent`, see [logLevel](/config/logLevel)                                             |
+| `--log-level <level>`      | Specify the log level, can be `info`, `warn`, `error` or `silent`, see [logLevel](/config/log-level)                                            |
 | `-m, --mode <mode>`        | Specify the build mode (`development`, `production` or `none`), see [mode](/config/mode)                                                        |
 | `--no-env`                 | Disable loading `.env` files                                                                                                                    |
 | `-r, --root <root>`        | Specify the project root directory                                                                                                              |

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -36,6 +36,7 @@ Rsbuild CLI 提供了一些公共选项，可以用于所有命令：
 | `--env-dir <dir>`          | 指定目录来加载 `.env` 文件，详见 [Env 目录](/guide/advanced/env-vars#env-目录)                                  |
 | `--environment <name>`     | 指定需要构建的 environment 名称，详见 [构建指定环境](/guide/advanced/environments#构建指定环境)                 |
 | `-h, --help`               | 显示命令帮助                                                                                                    |
+| `--log-level <level>`      | 指定日志级别，可以是 `info`，`warn`，`error` 或 `silent`，详见 [logLevel](/config/logLevel)                     |
 | `-m, --mode <mode>`        | 指定构建模式，可以是 `development`，`production` 或 `none`，详见 [mode](/config/mode)                           |
 | `--no-env`                 | 禁用 `.env` 文件的加载                                                                                          |
 | `-r, --root <root>`        | 指定项目根目录，可以是绝对路径或者相对于 cwd 的路径                                                             |

--- a/website/docs/zh/guide/basic/cli.mdx
+++ b/website/docs/zh/guide/basic/cli.mdx
@@ -36,7 +36,7 @@ Rsbuild CLI 提供了一些公共选项，可以用于所有命令：
 | `--env-dir <dir>`          | 指定目录来加载 `.env` 文件，详见 [Env 目录](/guide/advanced/env-vars#env-目录)                                  |
 | `--environment <name>`     | 指定需要构建的 environment 名称，详见 [构建指定环境](/guide/advanced/environments#构建指定环境)                 |
 | `-h, --help`               | 显示命令帮助                                                                                                    |
-| `--log-level <level>`      | 指定日志级别，可以是 `info`，`warn`，`error` 或 `silent`，详见 [logLevel](/config/logLevel)                     |
+| `--log-level <level>`      | 指定日志级别，可以是 `info`，`warn`，`error` 或 `silent`，详见 [logLevel](/config/log-level)                    |
 | `-m, --mode <mode>`        | 指定构建模式，可以是 `development`，`production` 或 `none`，详见 [mode](/config/mode)                           |
 | `--no-env`                 | 禁用 `.env` 文件的加载                                                                                          |
 | `-r, --root <root>`        | 指定项目根目录，可以是绝对路径或者相对于 cwd 的路径                                                             |


### PR DESCRIPTION
## Summary

Add a new `--log-level` flag to the Rsbuild CLI, allowing users to specify the verbosity of logs (`info`, `warn`, `error`, or `silent`).

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
