### PR TITLE
fix: ensure log level can work for all logs

### DIFF
--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,21 +1,28 @@
 import { execSync } from 'node:child_process';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command with log level: info', async () => {
-  const result = execSync('npx rsbuild build --logLevel info', {
-    cwd: __dirname,
-  }).toString();
+  const result = stripAnsi(
+    execSync('npx rsbuild build --logLevel info', {
+      cwd: __dirname,
+    }).toString(),
+  );
 
+  expect(result).toContain('Rsbuild v');
   expect(result).toContain('build started...');
   expect(result).toContain('built in');
 });
 
 rspackOnlyTest('should run build command with log level: warn', async () => {
-  const result = execSync('npx rsbuild build --logLevel warn', {
-    cwd: __dirname,
-  }).toString();
+  const result = stripAnsi(
+    execSync('npx rsbuild build --logLevel warn', {
+      cwd: __dirname,
+    }).toString(),
+  );
 
+  expect(result).not.toContain('Rsbuild v');
   expect(result).not.toContain('build started...');
   expect(result).not.toContain('built in');
 });

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger';
+import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
 
 function initNodeEnv() {
@@ -15,6 +16,17 @@ export async function runCLI(): Promise<void> {
 
   // make it easier to identify the process via activity monitor or other tools
   process.title = 'rsbuild-node';
+
+  // ensure log level is set before any log is printed
+  const logLevelIndex = process.argv.findIndex(
+    (item) => item === '--log-level' || item === '--logLevel',
+  );
+  if (logLevelIndex !== -1) {
+    const level = process.argv[logLevelIndex + 1];
+    if (level && ['warn', 'error', 'silent'].includes(level)) {
+      logger.level = level as LogLevel;
+    }
+  }
 
   // Print a blank line to keep the greet log nice.
   // Some package managers automatically output a blank line, some do not.


### PR DESCRIPTION
## Summary

Added logic to parse `--log-level` flag in the `runCLI` function, ensuring the log level is set (`warn`, `error`, or `silent`) before any logs are printed.

## Related Links

 https://github.com/web-infra-dev/rsbuild/issues/5194

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
