### PR TITLE
test(e2e): remove temporary plugin

### DIFF
--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -3,7 +3,7 @@ import { platform } from 'node:os';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import { expect, test } from '@playwright/test';
-import type { ConsoleType, LogLevel } from '@rsbuild/core';
+import type { ConsoleType } from '@rsbuild/core';
 import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
@@ -77,7 +77,6 @@ export const expectFile = (dir: string) =>
 export type ProxyConsoleOptions = {
   types?: ConsoleType | ConsoleType[];
   keepAnsi?: boolean;
-  logLevel?: LogLevel | 'verbose';
 };
 
 export type ProxyConsoleResult = {

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -201,27 +201,6 @@ export async function dev({
 
   const rsbuild = await createRsbuild(options, plugins);
 
-  rsbuild.addPlugins([
-    {
-      // fix HMR problem temporary (only appears in rsbuild repo, because css-loader is not in node_modules/ )
-      // https://github.com/web-infra-dev/rspack/issues/5723
-      name: 'fix-react-refresh-in-rsbuild',
-      setup(api) {
-        api.modifyBundlerChain({
-          order: 'post',
-          handler: (chain, { CHAIN_ID }) => {
-            if (chain.plugins.has(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)) {
-              chain.plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH).tap((config) => {
-                config[0].exclude = [/node_modules/, /css-loader/];
-                return config;
-              });
-            }
-          },
-        });
-      },
-    },
-  ]);
-
   const wait = waitFirstCompileDone
     ? new Promise<void>((resolve) => {
         rsbuild.onDevCompileDone(({ isFirstCompile }) => {


### PR DESCRIPTION
## Summary

Deleted the `fix-react-refresh-in-rsbuild` plugin, which was a temporary solution to address HMR issues with the `css-loader`. This cleanup simplifies the codebase and removes a workaround specific to the repository. 

## Related Links

 https://github.com/web-infra-dev/rspack/issues/5723

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
