### PR TITLE
feat: support lazy compilation in multi environments

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, join } from 'node:path';
 import { rspack } from '@rspack/core';
 import { normalizePublicDirs } from '../defaultConfig';
-import { isMultiCompiler, pick } from '../helpers';
+import { pick } from '../helpers';
 import { logger } from '../logger';
 import type {
   DevConfig,
@@ -143,10 +143,7 @@ const applyDefaultMiddlewares = async ({
     }
 
     middlewares.push(
-      rspack.experiments.lazyCompilationMiddleware(
-        // TODO: support for multi compiler
-        isMultiCompiler(compiler) ? compiler.compilers[0] : compiler,
-      ) as RequestHandler,
+      rspack.experiments.lazyCompilationMiddleware(compiler) as RequestHandler,
     );
   }
 


### PR DESCRIPTION
## Summary

`lazyCompilationMiddleware` now supports lazy compilation when using multiple compiler.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/9828

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
