### PR TITLE
fix(types): make PostCSSPlugin type loose

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -39,8 +39,8 @@ import type {
   CSSLoaderModulesOptions,
   CSSLoaderOptions,
   HtmlRspackPlugin,
+  LoosePostCSSPlugin,
   PostCSSLoaderOptions,
-  PostCSSPlugin,
   StyleLoaderOptions,
   WebpackConfig,
 } from './thirdParty';
@@ -61,7 +61,7 @@ export type ToolsBundlerChainConfig = OneOrMany<
 
 export type ToolsPostCSSLoaderConfig = ConfigChainWithContext<
   PostCSSLoaderOptions,
-  { addPlugins: (plugins: PostCSSPlugin | PostCSSPlugin[]) => void }
+  { addPlugins: (plugins: LoosePostCSSPlugin | LoosePostCSSPlugin[]) => void }
 >;
 
 export type ToolsCSSLoaderConfig = ConfigChain<CSSLoaderOptions>;

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -17,9 +17,16 @@ export interface CSSExtractOptions {
 
 export type { WebpackConfig };
 
+/**
+ * A loose PostCSS plugin type that accepts plugins from different
+ * PostCSS versions. This helps avoid type conflicts when user
+ * projects use different PostCSS versions.
+ */
+export type LoosePostCSSPlugin = any;
+
 export type PostCSSOptions = ProcessOptions & {
   config?: boolean;
-  plugins?: AcceptedPlugin[];
+  plugins?: LoosePostCSSPlugin[];
 };
 
 export type PostCSSLoaderOptions = {


### PR DESCRIPTION
## Summary

Use a loose PostCSS plugin type that accepts plugins from different PostCSS versions. This helps avoid type conflicts when user projects use different PostCSS versions.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/5439

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
