### PR TITLE
docs(website): use useI18nUrl to avoid useHookAtTopLevel error

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -64,9 +64,6 @@
       },
       "nursery": {
         "useUniqueElementIds": "off"
-      },
-      "correctness": {
-        "useHookAtTopLevel": "off"
       }
     }
   }

--- a/website/theme/components/Overview.tsx
+++ b/website/theme/components/Overview.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'rspress/theme';
 import styles from './Overview.module.scss';
-import { useUrl } from './utils';
+import { useI18nUrl } from './utils';
 
 export interface GroupItem {
   text: string;
@@ -15,6 +15,8 @@ export interface Group {
 declare const OVERVIEW_GROUPS: Group[];
 
 export default function Overview() {
+  const tUrl = useI18nUrl();
+
   const Nodes = OVERVIEW_GROUPS.map((group) => (
     <div key={group.name} className={styles.overviewGroups}>
       <div className={styles.group}>
@@ -22,7 +24,7 @@ export default function Overview() {
         <ul>
           {group.items.map((item) => (
             <li key={item.text}>
-              <Link href={useUrl(item.link)}>{item.text}</Link>
+              <Link href={tUrl(item.link)}>{item.text}</Link>
             </li>
           ))}
         </ul>

--- a/website/theme/components/Step.tsx
+++ b/website/theme/components/Step.tsx
@@ -1,16 +1,19 @@
 import { Link } from 'rspress/theme';
 import styles from './Step.module.scss';
-import { useUrl } from './utils';
+import { useI18nUrl } from './utils';
 
-const Step = (props: { href: string; title: string; description: string }) => {
-  const isExternal = props.href.startsWith('http');
+interface StepProps {
+  href: string;
+  title: string;
+  description: string;
+}
+const Step = ({ href, title, description }: StepProps) => {
+  const tUrl = useI18nUrl();
+  const isExternal = href.startsWith('http');
   return (
-    <Link
-      className={styles.step}
-      href={isExternal ? props.href : useUrl(props.href)}
-    >
-      <p className={styles.title}>{props.title}</p>
-      <p className={styles.description}>{props.description}</p>
+    <Link className={styles.step} href={isExternal ? href : tUrl(href)}>
+      <p className={styles.title}>{title}</p>
+      <p className={styles.description}>{description}</p>
     </Link>
   );
 };


### PR DESCRIPTION
## Summary

## Related Links

<!--- Provide links of related issues or pages -->

https://github.com/web-infra-dev/rsbuild/blob/main/website/theme/components/utils.ts#L12C1-L21C2
```
export function useI18nUrl() {
  const lang = useLang();
  const {
    siteData: { lang: defaultLang },
  } = usePageData();
  return useCallback(
    (url: string) => withBase(lang === defaultLang ? url : `/${lang}${url}`),
    [lang, defaultLang],
  );
}
```

The main benefits of this function are:

**Encapsulation of logic:** It encapsulates the logic for generating localized URLs based on the current language and default language, making your components cleaner and more maintainable.

**Hook compliance:**  By returning a memoized function via useCallback, it allows you to use the returned function anywhere in your component (including loops and callbacks) without violating React's hooks rules.

**Performance optimization:**  The returned function is memoized and will only change when lang or defaultLang changes, preventing unnecessary re-renders or recalculations.

**Reusability:**  You can use the returned function to generate multiple URLs within the same component efficiently.


## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
