### PR TITLE
chore(website): remove unused useUrl helper

### DIFF
--- a/website/theme/components/utils.ts
+++ b/website/theme/components/utils.ts
@@ -1,14 +1,6 @@
 import { useCallback } from 'react';
 import { useLang, usePageData, withBase } from 'rspress/runtime';
 
-export function useUrl(url: string) {
-  const lang = useLang();
-  const {
-    siteData: { lang: defaultLang },
-  } = usePageData();
-  return withBase(lang === defaultLang ? url : `/${lang}${url}`);
-}
-
 export function useI18nUrl() {
   const lang = useLang();
   const {


### PR DESCRIPTION
## Summary

Remove unused `useUrl` helper from website.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5453

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
