### PR TITLE
fix(socketServer): use clearTimeout instead of clearInterval

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -85,7 +85,7 @@ export class SocketServer {
 
   private clearHeartbeatTimer(): void {
     if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
+      clearTimeout(this.heartbeatTimer);
       this.heartbeatTimer = null;
     }
   }


### PR DESCRIPTION
## Summary

https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/src/server/socketServer.ts#L79
```
    if (this.heartbeatTimer !== null) {
      this.heartbeatTimer = setTimeout(
        this.checkSockets,
        CHECK_SOCKETS_INTERVAL,
      ).unref();
    }
```
I see that heartbeatTimer is created by setTimeout, so should clearTimeout be used when recycling and clearing? I guess this may be left by using setInterval before.
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
