### PR TITLE
feat: streamline setupMiddlewares usage

### DIFF
--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -154,15 +154,13 @@ test('should allow to access manifest data in environment API', async ({
         },
       },
       dev: {
-        setupMiddlewares: [
-          (middlewares, { environments }) => {
-            middlewares.unshift(async (_req, _res, next) => {
-              webManifest = environments.web.context.manifest;
-              nodeManifest = environments.node.context.manifest;
-              next();
-            });
-          },
-        ],
+        setupMiddlewares: (middlewares, { environments }) => {
+          middlewares.unshift(async (_req, _res, next) => {
+            webManifest = environments.web.context.manifest;
+            nodeManifest = environments.node.context.manifest;
+            next();
+          });
+        },
       },
     },
   });

--- a/e2e/cases/server/custom-server/scripts/pureServer.mjs
+++ b/e2e/cases/server/custom-server/scripts/pureServer.mjs
@@ -12,20 +12,18 @@ export async function startDevServerPure(fixtures) {
       },
       dev: {
         printUrls: false,
-        setupMiddlewares: [
-          (middlewares) => {
-            middlewares.unshift((req, res, next) => {
-              if (req.url === '/test') {
-                res.writeHead(302, {
-                  Location: '/bbb',
-                });
-                res.end();
-              } else {
-                next();
-              }
-            });
-          },
-        ],
+        setupMiddlewares: (middlewares) => {
+          middlewares.unshift((req, res, next) => {
+            if (req.url === '/test') {
+              res.writeHead(302, {
+                Location: '/bbb',
+              });
+              res.end();
+            } else {
+              next();
+            }
+          });
+        },
       },
     },
   });

--- a/e2e/cases/server/environments/index.test.ts
+++ b/e2e/cases/server/environments/index.test.ts
@@ -51,25 +51,23 @@ test('server environment api', async ({ page }) => {
     cwd,
     rsbuildConfig: {
       dev: {
-        setupMiddlewares: [
-          (middlewares, server) => {
-            middlewares.unshift(async (req, _res, next) => {
-              if (req.url === '/') {
-                const webStats = await server.environments.web.getStats();
+        setupMiddlewares: (middlewares, server) => {
+          middlewares.unshift(async (req, _res, next) => {
+            if (req.url === '/') {
+              const webStats = await server.environments.web.getStats();
 
-                expect(webStats.toJson().name).toBe('web');
+              expect(webStats.toJson().name).toBe('web');
 
-                assertionsCount++;
-                const web1Stats = await server.environments.web1.getStats();
+              assertionsCount++;
+              const web1Stats = await server.environments.web1.getStats();
 
-                expect(web1Stats.toJson().name).toBe('web1');
-                assertionsCount++;
-              }
+              expect(web1Stats.toJson().name).toBe('web1');
+              assertionsCount++;
+            }
 
-              next();
-            });
-          },
-        ],
+            next();
+          });
+        },
       },
       environments: {
         web: {},

--- a/e2e/cases/server/fallback/index.test.ts
+++ b/e2e/cases/server/fallback/index.test.ts
@@ -32,22 +32,20 @@ test('OPTIONS request should response correctly with middleware responses', asyn
         cors: false,
       },
       dev: {
-        setupMiddlewares: [
-          (middlewares) => {
-            middlewares.push((req, res, next) => {
-              if (req.method === 'OPTIONS') {
-                res.statusCode = 200;
-                res.setHeader(
-                  'access-control-allow-origin',
-                  'https://example.com',
-                );
-                res.end();
-                return;
-              }
-              next();
-            });
-          },
-        ],
+        setupMiddlewares: (middlewares) => {
+          middlewares.push((req, res, next) => {
+            if (req.method === 'OPTIONS') {
+              res.statusCode = 200;
+              res.setHeader(
+                'access-control-allow-origin',
+                'https://example.com',
+              );
+              res.end();
+              return;
+            }
+            next();
+          });
+        },
       },
     },
   });

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -12,14 +12,12 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
     page,
     rsbuildConfig: {
       dev: {
-        setupMiddlewares: [
-          (middlewares) => {
-            middlewares.unshift((_req, _res, next) => {
-              count++;
-              next();
-            });
-          },
-        ],
+        setupMiddlewares: (middlewares) => {
+          middlewares.unshift((_req, _res, next) => {
+            count++;
+            next();
+          });
+        },
       },
     },
   });
@@ -47,15 +45,13 @@ test('should apply to trigger page reload via the `static-changed` type of sockW
     page,
     rsbuildConfig: {
       dev: {
-        setupMiddlewares: [
-          (middlewares, server) => {
-            middlewares.unshift((_req, _res, next) => {
-              count++;
-              next();
-            });
-            reloadPage = () => server.sockWrite('static-changed');
-          },
-        ],
+        setupMiddlewares: (middlewares, server) => {
+          middlewares.unshift((_req, _res, next) => {
+            count++;
+            next();
+          });
+          reloadPage = () => server.sockWrite('static-changed');
+        },
       },
     },
   });

--- a/e2e/cases/server/ssr-type-module/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-type-module/rsbuild.config.ts
@@ -25,24 +25,22 @@ export const serverRender =
 export default defineConfig({
   plugins: [pluginReact()],
   dev: {
-    setupMiddlewares: [
-      ({ unshift }, serverAPI) => {
-        const serverRenderMiddleware = serverRender(serverAPI);
+    setupMiddlewares: ({ unshift }, serverAPI) => {
+      const serverRenderMiddleware = serverRender(serverAPI);
 
-        unshift(async (req, res, next) => {
-          if (req.method === 'GET' && req.url === '/') {
-            try {
-              await serverRenderMiddleware(req, res, next);
-            } catch (err) {
-              logger.error('SSR render error, downgrade to CSR...\n', err);
-              next();
-            }
-          } else {
+      unshift(async (req, res, next) => {
+        if (req.method === 'GET' && req.url === '/') {
+          try {
+            await serverRenderMiddleware(req, res, next);
+          } catch (err) {
+            logger.error('SSR render error, downgrade to CSR...\n', err);
             next();
           }
-        });
-      },
-    ],
+        } else {
+          next();
+        }
+      });
+    },
   },
   environments: {
     web: {

--- a/e2e/cases/server/ssr/rsbuild.config.ts
+++ b/e2e/cases/server/ssr/rsbuild.config.ts
@@ -25,24 +25,22 @@ export const serverRender =
 export default defineConfig({
   plugins: [pluginReact()],
   dev: {
-    setupMiddlewares: [
-      ({ unshift }, serverAPI) => {
-        const serverRenderMiddleware = serverRender(serverAPI);
+    setupMiddlewares: ({ unshift }, serverAPI) => {
+      const serverRenderMiddleware = serverRender(serverAPI);
 
-        unshift(async (req, res, next) => {
-          if (req.method === 'GET' && req.url === '/') {
-            try {
-              await serverRenderMiddleware(req, res, next);
-            } catch (err) {
-              logger.error('SSR render error, downgrade to CSR...\n', err);
-              next();
-            }
-          } else {
+      unshift(async (req, res, next) => {
+        if (req.method === 'GET' && req.url === '/') {
+          try {
+            await serverRenderMiddleware(req, res, next);
+          } catch (err) {
+            logger.error('SSR render error, downgrade to CSR...\n', err);
             next();
           }
-        });
-      },
-    ],
+        } else {
+          next();
+        }
+      });
+    },
   },
   environments: {
     web: {

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, join } from 'node:path';
 import { rspack } from '@rspack/core';
 import { normalizePublicDirs } from '../defaultConfig';
-import { pick } from '../helpers';
+import { castArray, pick } from '../helpers';
 import { logger } from '../logger';
 import type {
   DevConfig,
@@ -52,7 +52,7 @@ const applySetupMiddlewares = (
   const before: RequestHandler[] = [];
   const after: RequestHandler[] = [];
 
-  for (const handler of setupMiddlewares) {
+  for (const handler of castArray(setupMiddlewares)) {
     handler(
       {
         unshift: (...handlers) => before.unshift(...handlers),

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1638,7 +1638,7 @@ export interface DevConfig {
   /**
    * Provides the ability to execute a custom function and apply custom middlewares.
    */
-  setupMiddlewares?: SetupMiddlewaresFn[];
+  setupMiddlewares?: SetupMiddlewaresFn | SetupMiddlewaresFn[];
   /**
    * Controls whether the build output from development mode is written to disk.
    * @default false

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -11,15 +11,15 @@ type SetupMiddlewaresServer = {
   environments: EnvironmentAPI;
 };
 
-type SetupMiddlewares = Array<
-  (
-    middlewares: {
-      unshift: (...handlers: RequestHandler[]) => void;
-      push: (...handlers: RequestHandler[]) => void;
-    },
-    server: SetupMiddlewaresServer,
-  ) => void
->;
+type SetupMiddlewaresFn = (
+  middlewares: {
+    unshift: (...handlers: RequestHandler[]) => void;
+    push: (...handlers: RequestHandler[]) => void;
+  },
+  server: SetupMiddlewaresServer,
+) => void;
+
+type SetupMiddlewares = SetupMiddlewaresFn | SetupMiddlewaresFn[];
 ```
 
 - **Default:** `undefined`
@@ -35,19 +35,17 @@ The order among several different types of middleware is: `unshift` => internal 
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.unshift((req, res, next) => {
-          console.log('first');
-          next();
-        });
+    setupMiddlewares: (middlewares, server) => {
+      middlewares.unshift((req, res, next) => {
+        console.log('first');
+        next();
+      });
 
-        middlewares.push((req, res, next) => {
-          console.log('last');
-          next();
-        });
-      },
-    ],
+      middlewares.push((req, res, next) => {
+        console.log('last');
+        next();
+      });
+    },
   },
 };
 ```
@@ -63,15 +61,13 @@ Provides Rsbuild's [environment API](/api/javascript-api/environment-api#environ
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, { environments }) => {
-        middlewares.unshift(async (req, _res, next) => {
-          const webStats = await environments.web.getStats();
-          console.log(webStats.toJson({ all: false }));
-          next();
-        });
-      },
-    ],
+    setupMiddlewares: (middlewares, { environments }) => {
+      middlewares.unshift(async (req, _res, next) => {
+        const webStats = await environments.web.getStats();
+        console.log(webStats.toJson({ all: false }));
+        next();
+      });
+    },
   },
 };
 ```
@@ -85,13 +81,11 @@ For example, if you send a `'static-changed'` message, the page will reload.
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, { sockWrite }) => {
-        if (someCondition) {
-          sockWrite('static-changed');
-        }
-      },
-    ],
+    setupMiddlewares: (middlewares, { sockWrite }) => {
+      if (someCondition) {
+        sockWrite('static-changed');
+      }
+    },
   },
 };
 ```

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -162,13 +162,11 @@ Rsbuild provides three ways to register middleware:
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.push((req, res, next) => {
-          next();
-        });
-      },
-    ],
+    setupMiddlewares: (middlewares, server) => {
+      middlewares.push((req, res, next) => {
+        next();
+      });
+    },
   },
 };
 ```
@@ -214,11 +212,9 @@ app.use(expressMiddleware);
 
 export default {
   dev: {
-    setupMiddlewares: [
-      (middleware) => {
-        middleware.unshift(app);
-      },
-    ],
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift(app);
+    },
   },
 };
 ```

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -11,15 +11,15 @@ type SetupMiddlewaresServer = {
   environments: EnvironmentAPI;
 };
 
-type SetupMiddlewares = Array<
-  (
-    middlewares: {
-      unshift: (...handlers: RequestHandler[]) => void;
-      push: (...handlers: RequestHandler[]) => void;
-    },
-    server: SetupMiddlewaresServer,
-  ) => void
->;
+type SetupMiddlewaresFn = (
+  middlewares: {
+    unshift: (...handlers: RequestHandler[]) => void;
+    push: (...handlers: RequestHandler[]) => void;
+  },
+  server: SetupMiddlewaresServer,
+) => void;
+
+type SetupMiddlewares = SetupMiddlewaresFn | SetupMiddlewaresFn[];
 ```
 
 - **默认值：** `undefined`
@@ -35,19 +35,17 @@ type SetupMiddlewares = Array<
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.unshift((req, res, next) => {
-          console.log('first');
-          next();
-        });
+    setupMiddlewares: (middlewares, server) => {
+      middlewares.unshift((req, res, next) => {
+        console.log('first');
+        next();
+      });
 
-        middlewares.push((req, res, next) => {
-          console.log('last');
-          next();
-        });
-      },
-    ],
+      middlewares.push((req, res, next) => {
+        console.log('last');
+        next();
+      });
+    },
   },
 };
 ```
@@ -63,15 +61,13 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, { environments }) => {
-        middlewares.unshift(async (req, _res, next) => {
-          const webStats = await environments.web.getStats();
-          console.log(webStats.toJson({ all: false }));
-          next();
-        });
-      },
-    ],
+    setupMiddlewares: (middlewares, { environments }) => {
+      middlewares.unshift(async (req, _res, next) => {
+        const webStats = await environments.web.getStats();
+        console.log(webStats.toJson({ all: false }));
+        next();
+      });
+    },
   },
 };
 ```
@@ -85,13 +81,11 @@ export default {
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, { sockWrite }) => {
-        if (someCondition) {
-          sockWrite('static-changed');
-        }
-      },
-    ],
+    setupMiddlewares: (middlewares, { sockWrite }) => {
+      if (someCondition) {
+        sockWrite('static-changed');
+      }
+    },
   },
 };
 ```

--- a/website/docs/zh/guide/basic/server.mdx
+++ b/website/docs/zh/guide/basic/server.mdx
@@ -162,13 +162,11 @@ Rsbuild 提供了三种方式来注册中间件：
 ```ts title="rsbuild.config.ts"
 export default {
   dev: {
-    setupMiddlewares: [
-      (middlewares, server) => {
-        middlewares.push((req, res, next) => {
-          next();
-        });
-      },
-    ],
+    setupMiddlewares: (middlewares, server) => {
+      middlewares.push((req, res, next) => {
+        next();
+      });
+    },
   },
 };
 ```
@@ -214,11 +212,9 @@ app.use(expressMiddleware);
 
 export default {
   dev: {
-    setupMiddlewares: [
-      (middleware) => {
-        middleware.unshift(app);
-      },
-    ],
+    setupMiddlewares: (middlewares) => {
+      middlewares.unshift(app);
+    },
   },
 };
 ```


### PR DESCRIPTION
## Summary

The `dev.setupMiddlewares` requires the user to pass an array which is redundant.

This PR allows `dev.setupMiddlewares` to pass a function directly to streamline usage.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
