### PR TITLE
docs: update setupMiddlewares for clarity and usage examples

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1636,7 +1636,7 @@ export interface DevConfig {
         help?: boolean | string;
       };
   /**
-   * Provides the ability to execute a custom function and apply custom middlewares.
+   * Used to add custom middleware to the dev server.
    */
   setupMiddlewares?: SetupMiddlewaresFn | SetupMiddlewaresFn[];
   /**

--- a/website/docs/en/config/dev/setup-middlewares.mdx
+++ b/website/docs/en/config/dev/setup-middlewares.mdx
@@ -23,14 +23,18 @@ type SetupMiddlewares = SetupMiddlewaresFn | SetupMiddlewaresFn[];
 ```
 
 - **Default:** `undefined`
+- **Version:** `>= 1.4.0`
 
-Provides the ability to execute a custom function and apply custom middleware.
+Used to add custom middleware to the dev server.
 
-> See [Dev Server - Middleware](/guide/basic/server#middleware) for more information.
+> See [Dev server - Middleware](/guide/basic/server#middleware) for more information.
 
-## Execution order
+## Basic Usage
 
-The order among several different types of middleware is: `unshift` => internal middleware => `push`.
+`setupMiddlewares` function receives a `middlewares` array, you can add custom middleware by `unshift` and `push` methods:
+
+- Use `unshift` to prepend middleware to the array, executed earlier than the built-in middleware.
+- Use `push` to append middleware to the array, executed later than the built-in middleware.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -50,9 +54,30 @@ export default {
 };
 ```
 
+`setupMiddlewares` also supports passing an array, each item of which is a function to setup middlewares:
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middlewares) => {
+        // ...
+      },
+      (middlewares) => {
+        // ...
+      },
+    ],
+  },
+};
+```
+
+:::tip
+In versions before Rsbuild 1.4.0, `setupMiddlewares` must pass an array.
+:::
+
 ## Context object
 
-In the `setupMiddlewares` function, you can access the `context` object, which provides some server context and APIs.
+The second parameter of the `setupMiddlewares` function is the `context` object, which provides some server context and APIs.
 
 ### environments
 

--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -1,4 +1,4 @@
-# Server
+# Dev server
 
 Rsbuild comes with a built-in dev server designed to improve the development experience. When you run the `rsbuild dev` or `rsbuild preview` commands, the server will start, providing features such as page preview, routing, and hot module reloading.
 

--- a/website/docs/zh/config/dev/setup-middlewares.mdx
+++ b/website/docs/zh/config/dev/setup-middlewares.mdx
@@ -23,14 +23,18 @@ type SetupMiddlewares = SetupMiddlewaresFn | SetupMiddlewaresFn[];
 ```
 
 - **默认值：** `undefined`
+- **版本：** `>= 1.4.0`
 
-提供执行自定义函数和应用自定义中间件的能力。
+用于在开发服务器中添加自定义的中间件。
 
 > 查看 [开发服务器 - 中间件](/guide/basic/server#中间件) 了解更多。
 
-## 执行顺序
+## 基本用法
 
-中间件的执行顺序是: `unshift` => 内置中间件 => `push`。
+`setupMiddlewares` 函数接收一个 `middlewares` 数组，你可以通过 `unshift` 和 `push` 方法来添加自定义的中间件：
+
+- 使用 `unshift` 在数组开头添加中间件，早于内置中间件执行。
+- 使用 `push` 在数组末尾添加中间件，晚于内置中间件执行。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -50,9 +54,30 @@ export default {
 };
 ```
 
+`setupMiddlewares` 也支持传入一个数组，数组中的每一项都是一个用于配置中间件的函数：
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    setupMiddlewares: [
+      (middlewares) => {
+        // ...
+      },
+      (middlewares) => {
+        // ...
+      },
+    ],
+  },
+};
+```
+
+:::tip
+在 Rsbuild 1.4.0 之前的版本中，`setupMiddlewares` 必须传入一个数组。
+:::
+
 ## Context 对象
 
-在 `setupMiddlewares` 函数中，你可以访问到 `context` 对象，该对象提供了一些服务器上下文和 API。
+`setupMiddlewares` 函数的第二个参数是 `context` 对象，该对象提供了一些服务器上下文和 API。
 
 ### environments
 


### PR DESCRIPTION
## Summary

- Added a version note indicating that `setupMiddlewares` is supported from version 1.4.0 and clarified its usage for adding middleware via `unshift` and `push`.
- Introduced an example for passing an array of middleware setup functions and noted the behavior in versions before 1.4.0.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/5463

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
