### PR TITLE
fix: lazy compilation port replacement

### DIFF
--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,29 +1,32 @@
-import { dev, expectPoll, gotoPage } from '@e2e/helper';
+import { dev, expectPoll, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should replace port placeholder with actual port', async ({ page }) => {
-  if (process.platform === 'win32') {
-    test.skip();
-  }
+rspackOnlyTest(
+  'should replace port placeholder with actual port',
+  async ({ page }) => {
+    if (process.platform === 'win32') {
+      test.skip();
+    }
 
-  const rsbuild = await dev({
-    cwd: __dirname,
-  });
+    const rsbuild = await dev({
+      cwd: __dirname,
+    });
 
-  await gotoPage(page, rsbuild, 'page1');
-  await expect(page.locator('#test')).toHaveText('Page 1');
-  await expectPoll(() =>
-    rsbuild.logs.some((log) => log.includes('building src/page1/index.js')),
-  ).toBeTruthy();
-  expect(
-    rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
-  ).toBeFalsy();
+    await gotoPage(page, rsbuild, 'page1');
+    await expect(page.locator('#test')).toHaveText('Page 1');
+    await expectPoll(() =>
+      rsbuild.logs.some((log) => log.includes('building src/page1/index.js')),
+    ).toBeTruthy();
+    expect(
+      rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
+    ).toBeFalsy();
 
-  await gotoPage(page, rsbuild, 'page2');
-  await expect(page.locator('#test')).toHaveText('Page 2');
-  await expectPoll(() =>
-    rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
-  ).toBeTruthy();
+    await gotoPage(page, rsbuild, 'page2');
+    await expect(page.locator('#test')).toHaveText('Page 2');
+    await expectPoll(() =>
+      rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
+    ).toBeTruthy();
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,10 +1,7 @@
 import { dev, expectPoll, gotoPage } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-// TODO: fixme
-test.skip('should replace port placeholder with actual port', async ({
-  page,
-}) => {
+test('should replace port placeholder with actual port', async ({ page }) => {
   if (process.platform === 'win32') {
     test.skip();
   }

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -1,3 +1,4 @@
+import { replacePortPlaceholder } from '../server/open';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginLazyCompilation = (): RsbuildPlugin => ({
@@ -32,6 +33,26 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
           return;
         }
       }
+
+      // replace port placeholder in `serverUrl` with actual port
+      if (
+        typeof options === 'object' &&
+        typeof options.serverUrl === 'string' &&
+        api.context.devServer
+      ) {
+        chain.experiments({
+          ...chain.get('experiments'),
+          lazyCompilation: {
+            ...options,
+            serverUrl: replacePortPlaceholder(
+              options.serverUrl,
+              api.context.devServer.port,
+            ),
+          },
+        });
+        return;
+      }
+
       chain.experiments({
         ...chain.get('experiments'),
         lazyCompilation: options,

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -22,7 +22,6 @@ import {
   getRequestLoggerMiddleware,
   viewingServedFilesMiddleware,
 } from './middlewares';
-import { replacePortPlaceholder } from './open';
 import { createProxyMiddleware } from './proxy';
 
 export type RsbuildDevMiddlewareOptions = {
@@ -129,21 +128,10 @@ const applyDefaultMiddlewares = async ({
     dev.lazyCompilation &&
     compilationManager
   ) {
-    const { compiler } = compilationManager;
-
-    if (
-      typeof dev.lazyCompilation === 'object' &&
-      typeof dev.lazyCompilation.serverUrl === 'string' &&
-      context.devServer
-    ) {
-      dev.lazyCompilation.serverUrl = replacePortPlaceholder(
-        dev.lazyCompilation.serverUrl,
-        context.devServer.port,
-      );
-    }
-
     middlewares.push(
-      rspack.experiments.lazyCompilationMiddleware(compiler) as RequestHandler,
+      rspack.experiments.lazyCompilationMiddleware(
+        compilationManager.compiler,
+      ) as RequestHandler,
     );
   }
 


### PR DESCRIPTION
## Summary

- Moved the lazy compilation port placeholder replacement logic from `devMiddlewares.ts` to `lazyCompilation.ts`, ensuring it is applied consistently. 
- Re-enabled the previously skipped E2E test for verifying the replacement of the port placeholder with the actual port.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
