### PR TITLE
perf: disable Rspack config schema validation

### DIFF
--- a/e2e/cases/config/rspack-config-validate/index.test.ts
+++ b/e2e/cases/config/rspack-config-validate/index.test.ts
@@ -23,6 +23,9 @@ rspackOnlyTest('should validate Rspack config by default', async () => {
 });
 
 rspackOnlyTest('should warn when passing unrecognized keys', async () => {
+  const value = process.env.RSPACK_CONFIG_VALIDATE;
+  process.env.RSPACK_CONFIG_VALIDATE = 'loose-unrecognized-keys';
+
   const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {
@@ -41,6 +44,8 @@ rspackOnlyTest('should warn when passing unrecognized keys', async () => {
     ),
   );
   await rsbuild.close();
+
+  process.env.RSPACK_CONFIG_VALIDATE = value;
 });
 
 rspackOnlyTest('should allow to override Rspack config validate', async () => {

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from '@playwright/test';
 
+// Enable Rspack's config schema validation
+process.env.RSPACK_CONFIG_VALIDATE = 'strict';
+
 export default defineConfig({
   // Retry on CI
   retries: process.env.CI ? 3 : 0,

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -91,8 +91,11 @@ export const pluginBasic = (): RsbuildPlugin => ({
           );
         }
 
-        // enable Rspack config schema validation, unrecognized keys are allowed
-        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-unrecognized-keys';
+        // Disable Rspack's config schema validation to improve performance.
+        // Rsbuild has ensured that the built-in Rspack configuration is correct
+        // through TypeScript, so we no longer need to perform schema validation
+        // at runtime. This can be manually enabled via `RSPACK_CONFIG_VALIDATE=strict'
+        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-silent';
       },
     );
   },


### PR DESCRIPTION
## Summary

Disable Rspack's config schema validation to improve performance.

Rsbuild has ensured that the built-in Rspack configuration is correct through TypeScript, so it is usually redundant to perform schema validation at runtime. Disabling schema validation can improve performance by 20ms to 30ms.

This can be manually enabled via `RSPACK_CONFIG_VALIDATE=strict`:

```bash
RSPACK_CONFIG_VALIDATE=strict rsbuild build
```

## Related Links

See https://github.com/web-infra-dev/rspack/pull/10768 for performance comparison.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
