### PR TITLE
perf: disable bundler info injection

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -29,7 +29,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { isDev, target, bundler, environment, CHAIN_ID }) => {
+      (chain, { env, isDev, target, bundler, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);
@@ -82,7 +82,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             .use(bundler.HotModuleReplacementPlugin);
         }
 
-        if (isDev) {
+        if (env === 'development') {
           // Set correct path for source map
           // this helps VS Code break points working correctly in monorepo
           chain.output.devtoolModuleFilenameTemplate(

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -29,7 +29,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { env, isDev, target, bundler, environment, CHAIN_ID }) => {
+      (chain, { isDev, target, bundler, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -97,6 +97,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             rspackFuture: {
               bundlerInfo: {
                 // TODO: SRI requires `__webpack_require__`
+                // https://github.com/web-infra-dev/rspack/issues/10783
                 force: Boolean(config.security.sri.enable),
               },
             },

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -97,7 +97,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             rspackFuture: {
               bundlerInfo: {
                 // TODO: SRI requires `__webpack_require__`
-                force: Boolean(config.security.sri),
+                force: Boolean(config.security.sri.enable),
               },
             },
           });

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -91,6 +91,17 @@ export const pluginBasic = (): RsbuildPlugin => ({
           );
         }
 
+        if (api.context.bundlerType === 'rspack') {
+          chain.experiments({
+            ...chain.get('experiments'),
+            rspackFuture: {
+              bundlerInfo: {
+                force: false,
+              },
+            },
+          });
+        }
+
         // Disable Rspack's config schema validation to improve performance.
         // Rsbuild has ensured that the built-in Rspack configuration is correct
         // through TypeScript, so we no longer need to perform schema validation

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -82,7 +82,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             .use(bundler.HotModuleReplacementPlugin);
         }
 
-        if (env === 'development') {
+        if (isDev) {
           // Set correct path for source map
           // this helps VS Code break points working correctly in monorepo
           chain.output.devtoolModuleFilenameTemplate(

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -96,7 +96,8 @@ export const pluginBasic = (): RsbuildPlugin => ({
             ...chain.get('experiments'),
             rspackFuture: {
               bundlerInfo: {
-                force: false,
+                // TODO: SRI requires `__webpack_require__`
+                force: Boolean(config.security.sri),
               },
             },
           });

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -4,6 +4,13 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
+  "experiments": {
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
+  },
   "infrastructureLogging": {
     "level": "error",
   },
@@ -41,6 +48,13 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
+  "experiments": {
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
+  },
   "infrastructureLogging": {
     "level": "error",
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,6 +11,11 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,6 +11,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -495,6 +500,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1007,6 +1017,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1413,6 +1428,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "rspackFuture": {
+      "bundlerInfo": {
+        "force": false,
+      },
+    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1306,6 +1306,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
+      "rspackFuture": {
+        "bundlerInfo": {
+          "force": false,
+        },
+      },
     },
     "infrastructureLogging": {
       "level": "error",
@@ -1730,6 +1735,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
+      "rspackFuture": {
+        "bundlerInfo": {
+          "force": false,
+        },
+      },
     },
     "infrastructureLogging": {
       "level": "error",


### PR DESCRIPTION
## Summary

This PR disables the default bundler info injection to reduce bundle size. This removes the Rspack version information from the bundle code and is not noticeable to users.

- before:

```txt
File (web)                           Size      Gzip   
dist/static/js/index.a18d906c.js     0.37 kB   0.28 kB
```

- after:

```txt
File (web)                           Size      Gzip   
dist/static/js/index.c2760cca.js     0.18 kB   0.17 kB
```

## Related Links

- https://rspack.rs/config/experiments#rspackfuturebundlerinfo
- https://github.com/web-infra-dev/rspack/issues/10783

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
