### PR TITLE
fix: correct environment check

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -29,7 +29,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      (chain, { env, isDev, target, bundler, environment, CHAIN_ID }) => {
+      (chain, { isDev, target, bundler, environment, CHAIN_ID }) => {
         const { config } = environment;
 
         chain.name(environment.name);
@@ -82,7 +82,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             .use(bundler.HotModuleReplacementPlugin);
         }
 
-        if (env === 'development') {
+        if (isDev) {
           // Set correct path for source map
           // this helps VS Code break points working correctly in monorepo
           chain.output.devtoolModuleFilenameTemplate(

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1349,6 +1349,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "[name].js",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "[name].js",
     "hashFunction": "xxhash64",
     "library": {


### PR DESCRIPTION
## Summary

Correct environment check for `devtoolModuleFilenameTemplate`. Using `isDev` (mode) to judge will be more accurate than using NODE_ENV.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
