### PR TITLE
chore: move all pnpm settings to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,14 +55,5 @@
   "engines": {
     "node": ">=18.0.0",
     "pnpm": ">=10.12.1"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "css-loader@7.1.2": "patches/css-loader@7.1.2.patch",
-      "file-loader": "patches/file-loader@6.2.0.patch",
-      "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch",
-      "postcss-loader@8.1.1": "patches/postcss-loader@8.1.1.patch",
-      "url-loader": "patches/url-loader@4.1.1.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,10 @@ packages:
   - '!**/dist-types/**'
   - '!**/create-rsbuild/template-*/**'
   - '!**/test-temp-*/**'
+
+patchedDependencies:
+  'css-loader@7.1.2': 'patches/css-loader@7.1.2.patch'
+  'file-loader': 'patches/file-loader@6.2.0.patch'
+  'http-proxy@1.18.1': 'patches/http-proxy@1.18.1.patch'
+  'postcss-loader@8.1.1': 'patches/postcss-loader@8.1.1.patch'
+  'url-loader': 'patches/url-loader@4.1.1.patch'


### PR DESCRIPTION
## Summary
I noticed that it seems the best approach seems to be to move all the settings to pnpm-workspace.yaml.


![image](https://github.com/user-attachments/assets/0a8b9860-dd3c-4840-a86d-0e2a57a193eb)


## Related Links

https://github.com/orgs/pnpm/discussions/9037

https://github.com/pnpm/pnpm/blob/main/pnpm-workspace.yaml#L334

https://github.com/vitejs/vite/pull/19895/files
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
