### PR TITLE
chore(biome): specify a relative path to the schema inside the package

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.4/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "assist": {
     "actions": {
       "source": {


### PR DESCRIPTION
## Summary
Maybe it is also a good practice to `specify the relative path of the @biomejs/biome package`. I searched many repositories in github that use this method. The advantage of doing this is that there is no need to manually update the corresponding version.

![image](https://github.com/user-attachments/assets/ed53bafa-ffe4-4cf3-9705-17011547fefb)
![image](https://github.com/user-attachments/assets/642b2bc9-df11-4999-8e53-ce6631c404ed)

## Related Links
https://biomejs.dev/reference/configuration/#schema
<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
