### PR TITLE
feat: support output extra configs when `inspectConfig`

### DIFF
--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -177,3 +177,32 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
 
   restore();
 });
+
+rspackOnlyTest('should generate extra config files', async () => {
+  const { logs, restore } = proxyConsole();
+
+  const rsbuild = await createRsbuild({
+    cwd: __dirname,
+  });
+  await rsbuild.inspectConfig({
+    writeToDisk: true,
+    extraConfigs: {
+      rstest: {
+        include: ['**/*.test.ts'],
+      },
+    },
+  });
+
+  const rstestConfig = path.resolve(
+    __dirname,
+    './dist/.rsbuild/rstest.config.mjs',
+  );
+
+  expect(fs.existsSync(rstestConfig)).toBeTruthy();
+
+  expect(logs.some((log) => log.includes('Rstest Config:'))).toBeTruthy();
+
+  await remove(rstestConfig);
+
+  restore();
+});

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -96,6 +96,11 @@ export type InspectConfigOptions = {
    * @default false
    */
   writeToDisk?: boolean;
+
+  /**
+   * extra configurations to be output.
+   */
+  extraConfigs?: Record<string, unknown>;
 };
 
 export type InspectConfigResult<B extends 'rspack' | 'webpack' = 'rspack'> = {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -96,9 +96,17 @@ export type InspectConfigOptions = {
    * @default false
    */
   writeToDisk?: boolean;
-
   /**
-   * extra configurations to be output.
+   * Extra configurations to be output.
+   * - key: The name of the configuration
+   * - value: The configuration object
+   * @example
+   * extraConfigs: {
+   *   // Output `rstest.config.mjs` file
+   *   'rstest': {
+   *     // ...
+   *   },
+   * }
    */
   extraConfigs?: Record<string, unknown>;
 };

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -676,7 +676,9 @@ type InspectConfigOptions = {
    */
   writeToDisk?: boolean;
   /**
-   * extra configurations to be output.
+   * Extra configurations to be output.
+   * - key: The name of the configuration
+   * - value: The configuration object
    */
   extraConfigs?: Record<string, unknown>;
 };

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -675,6 +675,10 @@ type InspectConfigOptions = {
    * @default false
    */
   writeToDisk?: boolean;
+  /**
+   * extra configurations to be output.
+   */
+  extraConfigs?: Record<string, unknown>;
 };
 
 async function InspectConfig(options?: InspectConfigOptions): Promise<{

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -699,6 +699,8 @@ type InspectConfigOptions = {
   writeToDisk?: boolean;
   /**
    * 需要额外输出的配置
+   * - key: 配置的名称
+   * - value: 配置对象
    */
   extraConfigs?: Record<string, unknown>;
 };

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -697,6 +697,10 @@ type InspectConfigOptions = {
    * @default false
    */
   writeToDisk?: boolean;
+  /**
+   * 需要额外输出的配置
+   */
+  extraConfigs?: Record<string, unknown>;
 };
 
 async function InspectConfig(options?: InspectConfigOptions): Promise<{


### PR DESCRIPTION
## Summary

support output extra configs when `inspectConfig`. For example, some upper-level framework configurations(rstest, etc.).

![image](https://github.com/user-attachments/assets/7245a2cb-5c30-48eb-9509-52ff0adff806)

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
