### PR TITLE
fix: disable bundle info when SRI is enabled

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -96,9 +96,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             ...chain.get('experiments'),
             rspackFuture: {
               bundlerInfo: {
-                // TODO: SRI requires `__webpack_require__`
-                // https://github.com/web-infra-dev/rspack/issues/10783
-                force: Boolean(config.security.sri.enable),
+                force: false,
               },
             },
           });


### PR DESCRIPTION
## Summary

Since https://github.com/web-infra-dev/rspack/issues/10783 has been resolved in Rspack 1.4.1, we can now disable the bundler info in all cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
