### PR TITLE
chore: move pnpm config from .npmrc to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 registry = 'https://registry.npmjs.org/'
-strict-peer-dependencies=false
-hoist-pattern[]=[]

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,3 +15,6 @@ patchedDependencies:
   'http-proxy@1.18.1': 'patches/http-proxy@1.18.1.patch'
   'postcss-loader@8.1.1': 'patches/postcss-loader@8.1.1.patch'
   'url-loader': 'patches/url-loader@4.1.1.patch'
+
+strictPeerDependencies: false
+hoistPattern: []


### PR DESCRIPTION
## Summary

Move pnpm config from .npmrc to pnpm-workspace.yaml, fix the npm warning:

<img width="1205" alt="Screenshot 2025-06-28 at 09 48 30" src="https://github.com/user-attachments/assets/ed23229b-4370-4555-aaf4-96a74a378b36" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
