### PR TITLE
feat: update open to v10 and improve error handling

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,7 +92,6 @@
     // some loaders still depend on loader-utils v2
     'loader-utils',
     // pure ESM packages can not be used now
-    'open',
     'ansi-escapes',
     'cli-truncate',
     'patch-console',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist-types/index.d.ts",
-      "import": "./dist/index.cjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./client/hmr": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
   "exports": {
     ".": {
       "types": "./dist-types/index.d.ts",
-      "import": "./dist/index.js",
+      "import": "./dist/index.cjs",
       "require": "./dist/index.cjs"
     },
     "./client/hmr": {
@@ -80,7 +80,7 @@
     "launch-editor-middleware": "^2.10.0",
     "mrmime": "^2.0.1",
     "on-finished": "2.4.1",
-    "open": "^8.4.0",
+    "open": "^10.1.2",
     "picocolors": "^1.1.1",
     "postcss": "^8.5.6",
     "postcss-load-config": "6.0.1",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -19,7 +19,6 @@ export default {
     typescript: 'typescript',
   },
   dependencies: [
-    'open',
     'ws',
     'on-finished',
     'connect',

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -100,8 +100,7 @@ async function openBrowser(url: string): Promise<boolean> {
   // Fallback to open
   // It will always open new tab
   try {
-    const { default: open } = await import('../../compiled/open/index.js');
-    const { apps } = open;
+    const { default: open, apps } = await import('open');
 
     const options = browser
       ? {

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -1,3 +1,4 @@
+import { apps, default as baseOpen } from 'open';
 import { STATIC_PATH } from '../constants';
 import { canParse, castArray, color } from '../helpers';
 import { logger } from '../logger';
@@ -100,8 +101,6 @@ async function openBrowser(url: string): Promise<boolean> {
   // Fallback to open
   // It will always open new tab
   try {
-    const { default: open, apps } = await import('open');
-
     const options = browser
       ? {
           app: {
@@ -111,7 +110,7 @@ async function openBrowser(url: string): Promise<boolean> {
         }
       : {};
 
-    const childProcess = await open(url, options);
+    const childProcess = await baseOpen(url, options);
     childProcess.on('error', (err) => {
       logger.error('Failed to launch browser in child process', err);
     });

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -181,14 +181,6 @@ export async function open({
 }): Promise<void> {
   const { targets, before } = normalizeOpenConfig(config);
 
-  // Skip open in codesandbox. After being bundled, the `open` package will
-  // try to call system xdg-open, which will cause an error on codesandbox.
-  // https://github.com/codesandbox/codesandbox-client/issues/6642
-  const isCodesandbox = process.env.CSB === 'true';
-  if (isCodesandbox) {
-    return;
-  }
-
   if (clearCache) {
     clearOpenedURLs();
   }

--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -110,10 +110,15 @@ async function openBrowser(url: string): Promise<boolean> {
           },
         }
       : {};
-    await open(url, options);
+
+    const childProcess = await open(url, options);
+    childProcess.on('error', (err) => {
+      logger.error('Failed to launch browser in child process', err);
+    });
+
     return true;
   } catch (err) {
-    logger.error('Failed to open start URL.');
+    logger.error('Failed to launch browser.');
     logger.error(err);
     return false;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -679,8 +679,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1
       open:
-        specifier: ^8.4.0
-        version: 8.4.2
+        specifier: ^10.1.2
+        version: 10.1.2
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1


### PR DESCRIPTION
## Summary

- Update `open` from v8 to v10
- Since open v10 is a pure ESM package, we use Rslib to bundle it instead of using `prebundle`.
- Removed the check for CodeSandbox, since Rslib no longer bundles the [xdg-open](https://github.com/sindresorhus/open/blob/main/xdg-open) script of the `open` package, we should no longer need to recognize CodeSandbox (this requires further testing)
- Add error handling for child process errors.
- This PR should fix the open error on StackBlitz:

![image](https://github.com/user-attachments/assets/f6726846-f39b-4c4f-abcc-a6bd5a179c42)

## Related Links

- https://github.com/sindresorhus/open/releases
- https://github.com/sindresorhus/open/blob/39f7d2d4812f56ef77b2affec8e2110c89c27224/index.js#L204-L229
- https://github.com/vitejs/vite/pull/16726
- https://github.com/sindresorhus/open/issues/359

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
