### PR TITLE
docs: add StackBlitz example to quick start

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -1,10 +1,11 @@
 # Quick start
 
-## Online example
+## Online examples
 
-We provide an online example based on Rsbuild. The example gives an intuitive feel for the build performance of Rspack and the development experience of Rsbuild:
+We provide online examples based on Rsbuild. The examples give an intuitive feel for the build performance of Rspack and the development experience of Rsbuild:
 
-- [Rsbuild CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
+- [StackBlitz example](https://stackblitz.com/~/github.com/rspack-contrib/rsbuild-stackblitz-example)
+- [CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
 
 ## Setup environment
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -4,7 +4,8 @@
 
 我们提供了基于 Rsbuild 的在线示例，通过示例项目，你可以直观感受 Rspack 的构建性能和 Rsbuild 的开发体验：
 
-- [Rsbuild CodeSandbox 示例](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
+- [StackBlitz 示例](https://stackblitz.com/~/github.com/rspack-contrib/rsbuild-stackblitz-example)
+- [CodeSandbox 示例](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
 
 ## 环境准备
 


### PR DESCRIPTION
## Summary

Add the StackBlitz example to quick start documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
