### PR TITLE
perf: minify the prebundled webpack-bundle-analyzer

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,7 +85,7 @@
     "postcss": "^8.5.6",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.1.1",
-    "prebundle": "1.3.3",
+    "prebundle": "1.3.4",
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.3.0",
     "rslog": "^1.2.8",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -103,6 +103,7 @@ export default {
     },
     {
       name: 'webpack-bundle-analyzer',
+      minify: true,
       externals: {
         webpack: 'webpack',
       },

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -44,7 +44,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.33",
     "babel-loader": "10.0.0",
-    "prebundle": "1.3.3",
+    "prebundle": "1.3.4",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -40,7 +40,7 @@
     "@types/less": "^3.0.8",
     "less": "^4.3.0",
     "less-loader": "^12.3.0",
-    "prebundle": "1.3.3",
+    "prebundle": "1.3.4",
     "typescript": "^5.8.3"
   },
   "peerDependencies": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.33",
     "@types/sass-loader": "^8.0.9",
-    "prebundle": "1.3.3",
+    "prebundle": "1.3.4",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.8.3"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.15.33",
     "file-loader": "6.2.0",
-    "prebundle": "1.3.3",
+    "prebundle": "1.3.4",
     "svgo": "^3.3.2",
     "typescript": "^5.8.3",
     "url-loader": "4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,8 +816,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.27.7)(webpack@5.99.9)
       prebundle:
-        specifier: 1.3.3
-        version: 1.3.3(typescript@5.8.3)
+        specifier: 1.3.4
+        version: 1.3.4(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -850,8 +850,8 @@ importers:
         specifier: ^12.3.0
         version: 12.3.0(@rspack/core@1.4.1(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.99.9)
       prebundle:
-        specifier: 1.3.3
-        version: 1.3.3(typescript@5.8.3)
+        specifier: 1.3.4
+        version: 1.3.4(typescript@5.8.3)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -946,8 +946,8 @@ importers:
         specifier: ^8.0.9
         version: 8.0.9
       prebundle:
-        specifier: 1.3.3
-        version: 1.3.3(typescript@5.8.3)
+        specifier: 1.3.4
+        version: 1.3.4(typescript@5.8.3)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1082,8 +1082,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.99.9)
       prebundle:
-        specifier: 1.3.3
-        version: 1.3.3(typescript@5.8.3)
+        specifier: 1.3.4
+        version: 1.3.4(typescript@5.8.3)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -5437,17 +5437,8 @@ packages:
   preact@10.26.9:
     resolution: {integrity: sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==}
 
-  prebundle@1.3.3:
-    resolution: {integrity: sha512-r9XaHCFjCWoFtxzbj0g1mb7Ur8JOasgjbb7UbK+bP0k/xHDvI7Ti9AOkrsx0dw5UkmOJ1LocfNY58tSc5Iei8A==}
-    hasBin: true
-
   prebundle@1.3.4:
     resolution: {integrity: sha512-CvIY8z+JvAZAezZs9fsulu3QPW9tVBJvH2Aq8Ak13eEdFi4Q613yrBwAWG4s0RID5qKCjKHblW6pwyUddVOd4A==}
-    hasBin: true
-
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
-    engines: {node: '>=14'}
     hasBin: true
 
   prettier@3.6.1:
@@ -11638,16 +11629,6 @@ snapshots:
 
   preact@10.26.9: {}
 
-  prebundle@1.3.3(typescript@5.8.3):
-    dependencies:
-      '@vercel/ncc': 0.38.3
-      prettier: 3.5.3
-      rollup: 4.42.0
-      rollup-plugin-dts: 6.2.1(rollup@4.42.0)(typescript@5.8.3)
-      terser: 5.42.0
-    transitivePeerDependencies:
-      - typescript
-
   prebundle@1.3.4(typescript@5.8.3):
     dependencies:
       '@vercel/ncc': 0.38.3
@@ -11657,8 +11638,6 @@ snapshots:
       terser: 5.42.0
     transitivePeerDependencies:
       - typescript
-
-  prettier@3.5.3: {}
 
   prettier@3.6.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -694,8 +694,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.1(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9)
       prebundle:
-        specifier: 1.3.3
-        version: 1.3.3(typescript@5.8.3)
+        specifier: 1.3.4
+        version: 1.3.4(typescript@5.8.3)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -5439,6 +5439,10 @@ packages:
 
   prebundle@1.3.3:
     resolution: {integrity: sha512-r9XaHCFjCWoFtxzbj0g1mb7Ur8JOasgjbb7UbK+bP0k/xHDvI7Ti9AOkrsx0dw5UkmOJ1LocfNY58tSc5Iei8A==}
+    hasBin: true
+
+  prebundle@1.3.4:
+    resolution: {integrity: sha512-CvIY8z+JvAZAezZs9fsulu3QPW9tVBJvH2Aq8Ak13eEdFi4Q613yrBwAWG4s0RID5qKCjKHblW6pwyUddVOd4A==}
     hasBin: true
 
   prettier@3.5.3:
@@ -11638,6 +11642,16 @@ snapshots:
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.5.3
+      rollup: 4.42.0
+      rollup-plugin-dts: 6.2.1(rollup@4.42.0)(typescript@5.8.3)
+      terser: 5.42.0
+    transitivePeerDependencies:
+      - typescript
+
+  prebundle@1.3.4(typescript@5.8.3):
+    dependencies:
+      '@vercel/ncc': 0.38.3
+      prettier: 3.6.1
       rollup: 4.42.0
       rollup-plugin-dts: 6.2.1(rollup@4.42.0)(typescript@5.8.3)
       terser: 5.42.0


### PR DESCRIPTION
## Summary

This PR minifies the pre-bundled webpack-bundle-analyzer to reduce install size (474KB -> 231KB).

We do not enable minification for most pre-bundle packages, which is for debugging convenience. However, given that the size of webpack-bundle-analyzer is quite large and it is not part of the core feature, we can compress it to reduce its size.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
