### PR TITLE
test(e2e): fix unstable rspack profile cases

### DIFF
--- a/e2e/cases/rspack-profile/dev.mjs
+++ b/e2e/cases/rspack-profile/dev.mjs
@@ -22,6 +22,10 @@ async function main() {
     },
   });
 
+  rsbuild.onDevCompileDone(() => {
+    process.exit(0);
+  });
+
   await rsbuild.startDevServer();
 }
 

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -64,6 +64,7 @@ rspackOnlyTest(
         RSPACK_PROFILE: 'OVERVIEW',
       },
       stdio: ['pipe', 'pipe', 'pipe'],
+      shell: true,
     });
 
     await expectProfileFile(buildProcess);

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -1,4 +1,4 @@
-import { exec } from 'node:child_process';
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
@@ -15,76 +15,57 @@ test.afterAll(() => {
   }
 });
 
+const expectProfileFile = async (
+  childProcess: ChildProcessWithoutNullStreams,
+) => {
+  const logs: string[] = [];
+
+  childProcess.stdout.on('data', (data) => {
+    const output = data.toString().trim();
+    logs.push(stripAnsi(output));
+  });
+
+  await expectPoll(() =>
+    logs.some((log) => log.includes('profile file saved to')),
+  ).toBeTruthy();
+
+  const profileFile = logs
+    .find((log) => log.includes('profile file saved to'))
+    ?.split('profile file saved to')[1]
+    ?.trim();
+
+  expect(fs.existsSync(profileFile!)).toBeTruthy();
+  childProcess.kill();
+};
+
 rspackOnlyTest(
-  'should generator rspack profile as expected in dev',
+  'should generate rspack profile as expected in dev',
   async () => {
-    const devProcess = exec('node ./dev.mjs', {
+    const devProcess = spawn('node', ['./dev.mjs'], {
       cwd: __dirname,
       env: {
         ...process.env,
         RSPACK_PROFILE: 'OVERVIEW',
       },
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const logs: string[] = [];
-
-    devProcess.stdout?.on('data', (data) => {
-      const output = data.toString().trim();
-      logs.push(stripAnsi(output));
-    });
-
-    await expectPoll(() =>
-      logs.some((log) => log.includes('built in')),
-    ).toBeTruthy();
-
-    // quit process
-    devProcess.stdin?.write('q\n');
-    await expectPoll(() =>
-      logs.some((log) => log.includes('profile file saved to')),
-    ).toBeTruthy();
-
-    const profileFile = logs
-      .find((log) => log.includes('profile file saved to'))
-      ?.split('profile file saved to')[1]
-      ?.trim();
-
-    expect(fs.existsSync(profileFile!)).toBeTruthy();
-    devProcess.kill();
+    await expectProfileFile(devProcess);
   },
 );
 
 rspackOnlyTest(
-  'should generator rspack profile as expected in build',
+  'should generate rspack profile as expected in build',
   async () => {
-    const buildProcess = exec('npx rsbuild build', {
+    const buildProcess = spawn('npx', ['rsbuild', 'build'], {
       cwd: __dirname,
       env: {
         ...process.env,
         RSPACK_PROFILE: 'OVERVIEW',
       },
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
 
-    const logs: string[] = [];
-
-    buildProcess.stdout?.on('data', (data) => {
-      const output = data.toString().trim();
-      logs.push(stripAnsi(output));
-    });
-
-    await expectPoll(() =>
-      logs.some((log) => log.includes('built in')),
-    ).toBeTruthy();
-
-    await expectPoll(() =>
-      logs.some((log) => log.includes('profile file saved to')),
-    ).toBeTruthy();
-
-    const profileFile = logs
-      .find((log) => log.includes('profile file saved to'))
-      ?.split('profile file saved to')[1]
-      ?.trim();
-
-    expect(fs.existsSync(profileFile!)).toBeTruthy();
-    buildProcess.kill();
+    await expectProfileFile(buildProcess);
   },
 );


### PR DESCRIPTION
## Summary

Fix the unstable rspack profile E2E cases, see:

<img width="1216" alt="Screenshot 2025-06-28 at 09 51 48" src="https://github.com/user-attachments/assets/7bfe17cb-1551-491f-8245-4bd7ea143a12" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
