### PR TITLE
docs: fix use-bundler-chain anchor

### DIFF
--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -28,7 +28,7 @@ The built-in Rspack config in Rsbuild may change with iterations, and these chan
 
 ## Examples
 
-Please refer to: [RspackChain examples](/guide/configuration/rspack#use-rspack-chain).
+Please refer to: [RspackChain examples](/guide/configuration/rspack#use-bundler-chain).
 
 ## Utils
 

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -28,7 +28,7 @@ Rsbuild 内置的 Rspack 配置会随着迭代而发生变化，这些变化不�
 
 ## 示例
 
-参考：[RspackChain 示例](/guide/configuration/rspack#使用-rspack-chain)。
+参考：[RspackChain 示例](/guide/configuration/rspack#使用-bundler-chain)。
 
 ## 工具对象
 

--- a/website/docs/zh/guide/configuration/rspack.mdx
+++ b/website/docs/zh/guide/configuration/rspack.mdx
@@ -72,7 +72,7 @@ export default {
 
 :::
 
-## 使用 Rspack chain
+## 使用 Bundler chain
 
 import RspackChain from '@zh/shared/rspackChain.mdx';
 


### PR DESCRIPTION
## Summary

There seems to be a problem with the anchor jump in the rsbuild documentation. Steps to reproduce: 
1. Open https://rsbuild.rs/config/tools/bundler-chain
2. Click on "RspackChain examples" 
3. Does not accurately jump to "Use bundler chain"

## Related Links

https://rsbuild.rs/config/tools/bundler-chain

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
