### PR TITLE
fix(plugin-svelte): correct loader order for transforming *.svelte.js files

### DIFF
--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -152,13 +152,13 @@ export function pluginSvelte(options: PluginSvelteOptions = {}): RsbuildPlugin {
             chain.module
               .rule('svelte-js')
               .test(regexp)
-              .use(CHAIN_ID.USE.SVELTE)
-              .loader(loaderPath)
-              .options(svelteLoaderOptions)
-              .end()
               .use(CHAIN_ID.USE.SWC)
               .loader(swcUse.get('loader'))
-              .options(swcUse.get('options'));
+              .options(swcUse.get('options'))
+              .end()
+              .use(CHAIN_ID.USE.SVELTE)
+              .loader(loaderPath)
+              .options(svelteLoaderOptions);
           }
         },
       );

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -73,21 +73,6 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-        "options": {
-          "compilerOptions": {
-            "dev": false,
-          },
-          "emitCss": false,
-          "hotReload": false,
-          "preprocess": {
-            "markup": [Function],
-            "script": [Function],
-            "style": [Function],
-          },
-        },
-      },
-      {
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
@@ -118,6 +103,21 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
             },
+          },
+        },
+      },
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
           },
         },
       },
@@ -193,21 +193,6 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     "test": /\\\\\\.\\(\\?:svelte\\\\\\.js\\|svelte\\\\\\.ts\\)\\$/,
     "use": [
       {
-        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
-        "options": {
-          "compilerOptions": {
-            "dev": false,
-          },
-          "emitCss": false,
-          "hotReload": false,
-          "preprocess": {
-            "markup": [Function],
-            "script": [Function],
-            "style": [Function],
-          },
-        },
-      },
-      {
         "loader": "builtin:swc-loader",
         "options": {
           "env": {
@@ -238,6 +223,21 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
             },
+          },
+        },
+      },
+      {
+        "loader": "<ROOT>/node_modules/<PNPM_INNER>/svelte-loader/index.js",
+        "options": {
+          "compilerOptions": {
+            "dev": false,
+          },
+          "emitCss": false,
+          "hotReload": false,
+          "preprocess": {
+            "markup": [Function],
+            "script": [Function],
+            "style": [Function],
           },
         },
       },


### PR DESCRIPTION
## Summary

Fix the incorrect loader order for transforming *.svelte.js files.

Run the `svelte-loader` before the `swc-loader`; otherwise, the Svelte compiler may report an error in some cases.

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/5509

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
