### PR TITLE
fix(create-rsbuild): change the target of Svelte apps to es2022

### DIFF
--- a/packages/create-rsbuild/template-svelte-js/.browserslistrc
+++ b/packages/create-rsbuild/template-svelte-js/.browserslistrc
@@ -1,0 +1,4 @@
+Chrome >= 107
+Edge >= 107
+Firefox >= 104
+Safari >= 16

--- a/packages/create-rsbuild/template-svelte-ts/.browserslistrc
+++ b/packages/create-rsbuild/template-svelte-ts/.browserslistrc
@@ -1,0 +1,4 @@
+Chrome >= 107
+Edge >= 107
+Firefox >= 104
+Safari >= 16

--- a/packages/create-rsbuild/template-svelte-ts/tsconfig.json
+++ b/packages/create-rsbuild/template-svelte-ts/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
-    "target": "ES2020",
+    "lib": ["DOM", "ES2022"],
+    "target": "ES2022",
     "noEmit": true,
     "skipLibCheck": true,
     "useDefineForClassFields": true,


### PR DESCRIPTION
## Summary

Change the target of Svelte apps to es2022 to ensure that Svelte compiler can work as expected.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/5509
- https://stackoverflow.com/questions/77992577/svelte-5-using-state-for-class-field-in-typescript/77992992#77992992
- https://developer.mozilla.org/en-US/docs/Glossary/Baseline/Compatibility

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
