### PR TITLE
fix(open): skip opening browser in CodeSandbox

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -183,6 +183,13 @@ export async function open({
   config: NormalizedConfig;
   clearCache?: boolean;
 }): Promise<void> {
+  // Skip auto-opening browser in CodeSandbox since it's already
+  // a web-based environment.
+  const isCodesandbox = process.env.CSB === 'true';
+  if (isCodesandbox) {
+    return;
+  }
+
   const { targets, before } = normalizeOpenConfig(config);
 
   if (clearCache) {


### PR DESCRIPTION
## Summary

I removed this condition in https://github.com/web-infra-dev/rsbuild/pull/5500, but after testing I think it would be better to add it back, since we should not open a new tab for `localhost:3000`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
