### PR TITLE
docs: add `compress.filter` option

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -420,7 +420,7 @@ export type PublicDir = false | PublicDirOptions | PublicDirOptions[];
  */
 export type CompressOptions = {
   /**
-   * Determines whether a response should be compressed.
+   * A function that determines whether a response should be compressed.
    * @param req - The incoming HTTP request
    * @param res - The outgoing HTTP response
    * @returns `true` to compress the response, `false` to skip compression

--- a/website/docs/en/config/server/compress.mdx
+++ b/website/docs/en/config/server/compress.mdx
@@ -1,6 +1,15 @@
 # server.compress
 
-- **Type:** `boolean`
+- **Type:**
+
+```ts
+type Compress =
+  | boolean
+  | {
+      filter?: (req: IncomingMessage, res: ServerResponse) => boolean;
+    };
+```
+
 - **Default:** `true`
 
 Configure whether to enable [gzip compression](https://developer.mozilla.org/en-US/docs/Glossary/gzip_compression) for static assets served by the dev server or preview server.
@@ -13,6 +22,33 @@ To disable the gzip compression, set `compress` to `false`:
 export default {
   server: {
     compress: false,
+  },
+};
+```
+
+## Options
+
+### filter
+
+- **Type:** `(req: IncomingMessage, res: ServerResponse) => boolean`
+- **Default:** `undefined`
+- **Version:** `>= v1.4.4`
+
+A function that determines whether a response should be compressed.
+
+Returns `true` to compress the response, `false` to skip compression.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    compress: {
+      filter: (req) => {
+        if (req.url.includes('/foo')) {
+          return false;
+        }
+        return true;
+      },
+    },
   },
 };
 ```

--- a/website/docs/en/config/server/compress.mdx
+++ b/website/docs/en/config/server/compress.mdx
@@ -43,7 +43,7 @@ export default {
   server: {
     compress: {
       filter: (req) => {
-        if (req.url.includes('/foo')) {
+        if (req.url?.includes('/foo')) {
           return false;
         }
         return true;

--- a/website/docs/zh/config/server/compress.mdx
+++ b/website/docs/zh/config/server/compress.mdx
@@ -1,6 +1,15 @@
 # server.compress
 
-- **类型：** `boolean`
+- **类型：**
+
+```ts
+type Compress =
+  | boolean
+  | {
+      filter?: (req: IncomingMessage, res: ServerResponse) => boolean;
+    };
+```
+
 - **默认值：** `true`
 
 配置开发和预览服务器是否对静态资源启用 [gzip 压缩](https://developer.mozilla.org/en-US/docs/Glossary/gzip_compression)。
@@ -13,6 +22,33 @@
 export default {
   server: {
     compress: false,
+  },
+};
+```
+
+## 选项
+
+### filter
+
+- **类型：** `(req: IncomingMessage, res: ServerResponse) => boolean`
+- **默认值：** `undefined`
+- **版本：** `>= v1.4.4`
+
+用于决定 response 是否需要被压缩的函数。
+
+返回 `true` 表示需要压缩该 response，返回 `false` 表示跳过压缩。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    compress: {
+      filter: (req) => {
+        if (req.url.includes('/foo')) {
+          return false;
+        }
+        return true;
+      },
+    },
   },
 };
 ```

--- a/website/docs/zh/config/server/compress.mdx
+++ b/website/docs/zh/config/server/compress.mdx
@@ -43,7 +43,7 @@ export default {
   server: {
     compress: {
       filter: (req) => {
-        if (req.url.includes('/foo')) {
+        if (req.url?.includes('/foo')) {
           return false;
         }
         return true;


### PR DESCRIPTION
## Summary

- Added a detailed explanation and example usage of the `server.compress.filter` function in the options section.
- Updated the `server.compress` type definition to include the new `filter` function.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5520

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
