### PR TITLE
feat(server): add `compress.level` option

### DIFF
--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -24,9 +24,7 @@ export const gzipMiddleware =
   ({
     filter,
     level = zlib.constants.Z_BEST_SPEED,
-  }: {
-    level?: number;
-  } & CompressOptions = {}): RequestHandler =>
+  }: CompressOptions = {}): RequestHandler =>
   (req, res, next): void => {
     if (filter && filter(req, res) === false) {
       next();

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -105,10 +105,11 @@ export class RsbuildProdServer {
     // compression is placed after proxy middleware to avoid breaking SSE (Server-Sent Events),
     // but before other middlewares to ensure responses are properly compressed
     if (compress) {
+      const { constants } = await import('node:zlib');
       this.middlewares.use(
         gzipMiddleware({
           // simulates the common gzip compression rates
-          level: 6,
+          level: constants.Z_DEFAULT_COMPRESSION,
           ...(typeof compress === 'object' ? compress : undefined),
         }),
       );

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -426,6 +426,16 @@ export type CompressOptions = {
    * @returns `true` to compress the response, `false` to skip compression
    */
   filter?: (req: IncomingMessage, res: ServerResponse) => boolean;
+  /**
+   * The level of zlib compression to apply to responses.
+   * A higher level will result in better compression, but will take longer to complete.
+   * A lower level will result in less compression, but will be much faster.
+   * This is an integer in the range of 0 (no compression) to 9 (maximum compression).
+   * @default
+   * - 1 (fastest) for dev server (also known as `zlib.constants.Z_BEST_SPEED`)
+   * - 6 for preview server (also known as `zlib.constants.Z_DEFAULT_COMPRESSION`)
+   */
+  level?: number;
 };
 
 export interface ServerConfig {

--- a/website/docs/en/config/server/compress.mdx
+++ b/website/docs/en/config/server/compress.mdx
@@ -14,7 +14,7 @@ type Compress =
 
 Configure whether to enable [gzip compression](https://developer.mozilla.org/en-US/docs/Glossary/gzip_compression) for static assets served by the dev server or preview server.
 
-## Disable
+## Disable compression
 
 To disable the gzip compression, set `compress` to `false`:
 
@@ -53,8 +53,28 @@ export default {
 };
 ```
 
-## Compression level
+### level
 
-Rsbuild dev server uses [zlib.constants.Z_BEST_SPEED](https://nodejs.org/api/zlib.html#constants) as the default compression level, which provides the best compression performance. The preview server sets `level` to `6` by default.
+- **Type:** `number`
+- **Default:**
+  - Dev server: `1` (zlib.constants.Z_BEST_SPEED)
+  - Preview server: `6` (zlib.constants.Z_DEFAULT_COMPRESSION)
+- **Version:** `>= v1.4.4`
 
-Note that in actual production environments, web servers like Nginx or Apache are commonly used, which may utilize different compression levels. Therefore, you might observe differences between the file sizes after gzip compression in your local environment compared to production.
+Used to set the level of zlib compression applied to responses. A higher level will result in better compression, but will take longer to complete; a lower level will result in less compression, but will be much faster. This value is an integer in the range of 0 (no compression) to 9 (maximum compression).
+
+Rsbuild dev server uses [zlib.constants.Z_BEST_SPEED](https://nodejs.org/api/zlib.html#constants) as the default compression level, which provides the best compression performance. The preview server sets `level` to [zlib.constants.Z_DEFAULT_COMPRESSION](https://nodejs.org/api/zlib.html#constants) by default.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    compress: {
+      level: 6,
+    },
+  },
+};
+```
+
+:::tip
+In actual production environments, web servers like Nginx or Apache are commonly used, which may utilize different compression levels. Therefore, you might observe differences between the file sizes after gzip compression in your local environment compared to production.
+:::

--- a/website/docs/zh/config/server/compress.mdx
+++ b/website/docs/zh/config/server/compress.mdx
@@ -14,7 +14,7 @@ type Compress =
 
 配置开发和预览服务器是否对静态资源启用 [gzip 压缩](https://developer.mozilla.org/en-US/docs/Glossary/gzip_compression)。
 
-## 禁用
+## 禁用压缩
 
 如果你需要禁用 gzip 压缩，可以将 `compress` 设置为 `false`：
 
@@ -34,7 +34,7 @@ export default {
 - **默认值：** `undefined`
 - **版本：** `>= v1.4.4`
 
-用于决定 response 是否需要被压缩的函数。
+一个过滤函数，用于决定 response 是否需要被压缩。
 
 返回 `true` 表示需要压缩该 response，返回 `false` 表示跳过压缩。
 
@@ -53,8 +53,28 @@ export default {
 };
 ```
 
-## 压缩级别
+### level
 
-Rsbuild 的开发服务器默认采用 [zlib.constants.Z_BEST_SPEED](https://nodejs.org/api/zlib.html#constants) 作为压缩级别，这提供了最佳的压缩性能；预览服务器默认将 `level` 设置为 `6`。
+- **类型：** `number`
+- **默认值：**
+  - 开发服务器：`1` (zlib.constants.Z_BEST_SPEED)
+  - 预览服务器：`6` (zlib.constants.Z_DEFAULT_COMPRESSION)
+- **版本：** `>= v1.4.4`
 
-注意，在实际生产环境中，通常会使用 Nginx 或 Apache 等 Web 服务器，它们可能使用不同的压缩级别，因此你可能会发现本地环境中使用 gzip 压缩后的文件大小与生产环境存在差异。
+用于设置应用于响应的 zlib 压缩级别。更高的级别会产生更好的压缩效果，但需要更长时间完成；更低的级别压缩效果较差，但速度更快。该值是一个范围在 0（无压缩）到 9（最大压缩）之间的整数。
+
+Rsbuild 的开发服务器默认采用 [zlib.constants.Z_BEST_SPEED](https://nodejs.org/api/zlib.html#constants) 作为压缩级别，这提供了最佳的压缩性能；预览服务器默认将 `level` 设置为 [zlib.constants.Z_DEFAULT_COMPRESSION](https://nodejs.org/api/zlib.html#constants)。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    compress: {
+      level: 6,
+    },
+  },
+};
+```
+
+:::tip
+在实际生产环境中，通常会使用 Nginx 或 Apache 等 Web 服务器，它们可能使用不同的压缩级别，因此你可能会发现本地环境中使用 gzip 压缩后的文件大小与生产环境存在差异。
+:::


### PR DESCRIPTION
## Summary

- Added a new `compress.level` option to set the level of zlib compression to apply to responses.
- Updated the documentation to provide a detailed explanation of the `level` option, including its type, default values, and usage examples.

## Related Links

- https://github.com/expressjs/compression?tab=readme-ov-file#level

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
