### PR TITLE
docs: clarify execution order with `modifyHTML` and `html.tags`

### DIFF
--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -529,7 +529,7 @@ const myPlugin = () => ({
 
 ### modifyHTMLTags
 
-Modify the tags that are injected into the HTML. This hook is triggered before the [modifyHTML](#modifyhtml) hook.
+Modify the tags that are injected into the HTML.
 
 - **Type:**
 
@@ -616,6 +616,16 @@ const tagsPlugin = () => ({
   },
 });
 ```
+
+:::tip
+
+When using `modifyHTML`, `modifyHTMLTags` and `html.tags` options together, the execution order is as follows:
+
+1. [modifyHTML](#modifyhtml)
+2. [modifyHTMLTags](#modifyhtmltags)
+3. [html.tags](/config/html/tags)
+
+:::
 
 ### onBeforeCreateCompiler
 

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -619,7 +619,7 @@ const tagsPlugin = () => ({
 
 :::tip
 
-When using `modifyHTML`, `modifyHTMLTags` and `html.tags` options together, the execution order is as follows:
+When using `modifyHTML`, `modifyHTMLTags`, and `html.tags` options together, the execution order is as follows:
 
 1. [modifyHTML](#modifyhtml)
 2. [modifyHTMLTags](#modifyhtmltags)

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -615,7 +615,7 @@ const tagsPlugin = () => ({
 
 :::tip
 
-当同时使用 `modifyHTML`，`modifyHTMLTags` 和 `html.tags` 选项时， 执行顺序如下：
+当同时使用 `modifyHTML`，`modifyHTMLTags` 和 `html.tags` 选项时，执行顺序如下：
 
 1. [modifyHTML](#modifyhtml)
 2. [modifyHTMLTags](#modifyhtmltags)

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -525,7 +525,7 @@ const myPlugin = () => ({
 
 ### modifyHTMLTags
 
-修改注入到 HTML 中的标签。这个钩子在 [modifyHTML](#modifyhtml) 钩子之前触发。
+修改注入到 HTML 中的标签。
 
 - **类型：**
 
@@ -612,6 +612,16 @@ const tagsPlugin = () => ({
   },
 });
 ```
+
+:::tip
+
+当同时使用 `modifyHTML`，`modifyHTMLTags` 和 `html.tags` 选项时， 执行顺序如下：
+
+1. [modifyHTML](#modifyhtml)
+2. [modifyHTMLTags](#modifyhtmltags)
+3. [html.tags](/config/html/tags)
+
+:::
 
 ### onBeforeCreateCompiler
 


### PR DESCRIPTION
## Summary

Added a tip explaining the execution order when using `modifyHTML`, `modifyHTMLTags`, and `html.tags` options together.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
