### PR TITLE
fix(plugin-react): profiling not work with React 19

### DIFF
--- a/e2e/cases/plugin-react/enable-profiler/index.test.ts
+++ b/e2e/cases/plugin-react/enable-profiler/index.test.ts
@@ -3,8 +3,7 @@ import { expect, test } from '@playwright/test';
 
 const fixtures = __dirname;
 
-// TODO: broken by React 19
-test.skip('should render element with enabled profiler correctly', async ({
+test('should render element with enabled profiler correctly', async ({
   page,
 }) => {
   const rsbuild = await build({


### PR DESCRIPTION
## Summary

Fix profiling not work with React 19, we need to alias `react-dom/client$` to `react-dom/profiling`.

## Related Links

- https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977?permalink_comment_id=5603760#gistcomment-5603760
- https://github.com/facebook/react/issues/32992

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
