### PR TITLE
refactor: normalize config types in compilation manager

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -10,7 +10,7 @@ function formatURL(config: NormalizedClientConfig) {
   const port = config.port || location.port;
   const protocol =
     config.protocol || (location.protocol === 'https:' ? 'wss' : 'ws');
-  const pathname = config.path || '/rsbuild-hmr';
+  const pathname = config.path;
 
   if (typeof URL !== 'undefined') {
     const url = new URL('http://localhost');

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -7,9 +7,9 @@ import { getPathnameFromUrl } from '../helpers/path';
 import type {
   EnvironmentContext,
   NextFunction,
-  DevConfig as OriginDevConfig,
+  NormalizedDevConfig,
+  NormalizedServerConfig,
   Rspack,
-  ServerConfig,
 } from '../types';
 import {
   type CompilationMiddleware,
@@ -23,22 +23,16 @@ const require = createRequire(import.meta.url);
 type Options = {
   publicPaths: string[];
   environments: Record<string, EnvironmentContext>;
-  dev: OriginDevConfig;
-  server: ServerConfig;
+  dev: NormalizedDevConfig;
+  server: NormalizedServerConfig;
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
-};
-
-type DevConfig = Omit<OriginDevConfig, 'writeToDisk'> & {
-  writeToDisk?:
-    | boolean
-    | ((filename: string, compilationName?: string) => boolean);
 };
 
 // allow to configure dev.writeToDisk in environments
 const formatDevConfig = (
-  config: OriginDevConfig,
+  config: NormalizedDevConfig,
   environments: Record<string, EnvironmentContext>,
-): DevConfig => {
+): NormalizedDevConfig => {
   const writeToDiskValues = Object.values(environments).map(
     (env) => env.config.dev.writeToDisk,
   );
@@ -64,7 +58,7 @@ const formatDevConfig = (
   };
 };
 
-function getClientPaths(devConfig: DevConfig) {
+function getClientPaths(devConfig: NormalizedDevConfig) {
   const clientPaths: string[] = [];
 
   if (!devConfig.hmr && !devConfig.liveReload) {
@@ -90,9 +84,9 @@ export class CompilationManager {
 
   public outputFileSystem: Rspack.OutputFileSystem;
 
-  private devConfig: DevConfig;
+  private devConfig: NormalizedDevConfig;
 
-  private serverConfig: ServerConfig;
+  private serverConfig: NormalizedServerConfig;
 
   public compiler: Rspack.Compiler | Rspack.MultiCompiler;
 


### PR DESCRIPTION
## Summary

- Normalize config types in compilation manager to align type usage across files.
- Removed unused default value in `formatURL`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
