### PR TITLE
fix: ensure that raw query of scripts can be accurately matched

### DIFF
--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -105,3 +105,14 @@ test('should allow to get raw TSX content with `?raw` and using pluginReact', as
 
   await rsbuild.close();
 });
+
+test('should not get raw JS content with query other than `?raw`', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+  expect(await page.evaluate('window.normalJs')).toEqual('foo');
+  await rsbuild.close();
+});

--- a/e2e/cases/assets/raw-query/src/foo.js
+++ b/e2e/cases/assets/raw-query/src/foo.js
@@ -1,3 +1,1 @@
-export function foo() {
-  return 'foo';
-}
+export default 'foo';

--- a/e2e/cases/assets/raw-query/src/index.js
+++ b/e2e/cases/assets/raw-query/src/index.js
@@ -1,9 +1,11 @@
 import img from '@assets/circle.svg?raw';
 import rawTs from './bar.ts?raw';
 import rawTsx from './baz.tsx?raw';
+import normalJs from './foo.js?other_raw';
 import rawJs from './foo.js?raw';
 
 window.rawImg = img;
 window.rawJs = rawJs;
 window.rawTs = rawTs;
 window.rawTsx = rawTsx;
+window.normalJs = normalJs;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -112,13 +112,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -565,13 +565,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -1017,13 +1017,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -1399,13 +1399,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -118,14 +118,14 @@ export const pluginSwc = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' })
           // exclude `import './foo.js?raw'`
-          .resourceQuery({ not: /raw/ });
+          .resourceQuery({ not: /^\?raw$/ });
 
         // Support for `import rawJs from "a.js?raw"`
         chain.module
           .rule(CHAIN_ID.RULE.JS_RAW)
           .test(SCRIPT_REGEX)
           .type('asset/source')
-          .resourceQuery(/raw/);
+          .resourceQuery(/^\?raw$/);
 
         const dataUriRule = chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -110,6 +110,9 @@ export const pluginSwc = (): RsbuildPlugin => ({
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
+        // Match the `?raw` query
+        const rawRegex = /^\?raw$/;
+
         const rule = chain.module
           .rule(CHAIN_ID.RULE.JS)
           .test(SCRIPT_REGEX)
@@ -118,14 +121,14 @@ export const pluginSwc = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' })
           // exclude `import './foo.js?raw'`
-          .resourceQuery({ not: /^\?raw$/ });
+          .resourceQuery({ not: rawRegex });
 
         // Support for `import rawJs from "a.js?raw"`
         chain.module
           .rule(CHAIN_ID.RULE.JS_RAW)
           .test(SCRIPT_REGEX)
           .type('asset/source')
-          .resourceQuery(/^\?raw$/);
+          .resourceQuery(rawRegex);
 
         const dataUriRule = chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -128,7 +128,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
@@ -170,7 +170,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -128,7 +128,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
@@ -170,7 +170,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -617,7 +617,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
@@ -659,7 +659,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -1110,7 +1110,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
@@ -1148,7 +1148,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },
@@ -1554,7 +1554,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
           /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
         ],
         "resourceQuery": {
-          "not": /raw/,
+          "not": /\\^\\\\\\?raw\\$/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "javascript/auto",
@@ -1596,7 +1596,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
         "type": "asset/source",
       },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1423,7 +1423,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1465,7 +1465,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1828,7 +1828,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1866,7 +1866,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -21,7 +21,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -60,7 +60,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -140,7 +140,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -189,7 +189,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -271,7 +271,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -287,7 +287,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -328,7 +328,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -370,7 +370,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -445,7 +445,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
       },
     },
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -496,7 +496,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -578,7 +578,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
       /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -623,7 +623,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -701,7 +701,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -753,7 +753,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -846,7 +846,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -888,7 +888,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -971,7 +971,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1009,7 +1009,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1088,7 +1088,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1130,7 +1130,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1219,7 +1219,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
             },
           },
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1262,7 +1262,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1354,7 +1354,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
             },
           },
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1398,7 +1398,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1492,7 +1492,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
             },
           },
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1535,7 +1535,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },
@@ -1622,7 +1622,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
             /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
           ],
           "resourceQuery": {
-            "not": /raw/,
+            "not": /\\^\\\\\\?raw\\$/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "javascript/auto",
@@ -1660,7 +1660,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
           "type": "asset/source",
         },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -16,7 +16,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
     /node_modules\\[\\\\\\\\/\\]query-string\\[\\\\\\\\/\\]/,
   ],
   "resourceQuery": {
-    "not": /raw/,
+    "not": /\\^\\\\\\?raw\\$/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
@@ -102,7 +102,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "resourceQuery": {
-    "not": /raw/,
+    "not": /\\^\\\\\\?raw\\$/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
@@ -188,7 +188,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "resourceQuery": {
-    "not": /raw/,
+    "not": /\\^\\\\\\?raw\\$/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
@@ -269,7 +269,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "resourceQuery": {
-    "not": /raw/,
+    "not": /\\^\\\\\\?raw\\$/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",
@@ -352,7 +352,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
     /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
   ],
   "resourceQuery": {
-    "not": /raw/,
+    "not": /\\^\\\\\\?raw\\$/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
   "type": "javascript/auto",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -20,7 +20,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -67,7 +67,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -109,7 +109,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -156,7 +156,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -23,7 +23,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -65,7 +65,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },
@@ -143,7 +143,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       /node_modules\\[\\\\\\\\/\\]svelte\\[\\\\\\\\/\\]/,
     ],
     "resourceQuery": {
-      "not": /raw/,
+      "not": /\\^\\\\\\?raw\\$/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "javascript/auto",
@@ -185,7 +185,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
     "type": "asset/source",
   },


### PR DESCRIPTION
## Summary

Updated the regex for scripts resource queries to precisely match `?raw` by using `/^\?raw$/`. This ensures stricter validation for raw imports.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
