### PR TITLE
docs: Update typescript.mdx with fixed typo in `isolatedModules ` example

### DIFF
--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -25,7 +25,7 @@ Unlike the native TypeScript compiler, tools like SWC and Babel compile each fil
 ```json title="tsconfig.json"
 {
   "compilerOptions": {
-    "verbatimModuleSyntax": true
+    "isolatedModules": true
   }
 }
 ```


### PR DESCRIPTION
## Summary

Fixes a typo in the tsconfig.json example for `isolatedModules` (for older typescript versions)

<img width="406" alt="image" src="https://github.com/user-attachments/assets/e3195a13-eff0-4fe2-9e9e-0b9b5e7f547d" />


## Related Links

Typo introduced in https://github.com/web-infra-dev/rsbuild/pull/5399

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
