### PR TITLE
fix: ensure that raw query of styles can be accurately matched

### DIFF
--- a/e2e/cases/assets/raw-query/src/index.js
+++ b/e2e/cases/assets/raw-query/src/index.js
@@ -1,7 +1,7 @@
 import img from '@assets/circle.svg?raw';
 import rawTs from './bar.ts?raw';
 import rawTsx from './baz.tsx?raw';
-import normalJs from './foo.js?other_raw';
+import normalJs from './foo.js?not-raw';
 import rawJs from './foo.js?raw';
 
 window.rawImg = img;

--- a/e2e/cases/css/inline-query/index.test.ts
+++ b/e2e/cases/css/inline-query/index.test.ts
@@ -11,6 +11,8 @@ rspackOnlyTest(
 
     const aInline: string = await page.evaluate('window.aInline');
     const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
 
     expect(
       aInline.includes('.header-class') && aInline.includes('color: red'),
@@ -18,6 +20,7 @@ rspackOnlyTest(
     expect(
       bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
     ).toBe(true);
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },
@@ -31,12 +34,16 @@ rspackOnlyTest(
       page,
     });
 
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
+
     expect(await page.evaluate('window.aInline')).toBe(
       '.header-class{color:red}',
     );
     expect(await page.evaluate('window.bInline')).toBe(
       '.title-class{font-size:14px}',
     );
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },

--- a/e2e/cases/css/inline-query/src/index.js
+++ b/e2e/cases/css/inline-query/src/index.js
@@ -1,5 +1,7 @@
 import aInline from './a.css?inline';
 import bInline from './b.module.css?inline';
+import bStyles from './b.module.css?not-inline';
 
 window.aInline = aInline;
 window.bInline = bInline;
+window.bStyles = bStyles;

--- a/e2e/cases/css/raw-query/index.test.ts
+++ b/e2e/cases/css/raw-query/index.test.ts
@@ -10,6 +10,7 @@ test('should allow to import raw CSS files in development mode', async ({
     cwd: __dirname,
     page,
   });
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
 
   expect(await page.evaluate('window.aRaw')).toBe(
     readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
@@ -17,6 +18,7 @@ test('should allow to import raw CSS files in development mode', async ({
   expect(await page.evaluate('window.bRaw')).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });
@@ -29,12 +31,15 @@ test('should allow to import raw CSS files in production mode', async ({
     page,
   });
 
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
   expect(await page.evaluate('window.aRaw')).toBe(
     readFileSync(path.join(__dirname, 'src/a.css'), 'utf-8'),
   );
   expect(await page.evaluate('window.bRaw')).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.css'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });

--- a/e2e/cases/css/raw-query/src/index.js
+++ b/e2e/cases/css/raw-query/src/index.js
@@ -1,5 +1,7 @@
 import aRaw from './a.css?raw';
+import bStyles from './b.module.css?not-raw';
 import bRaw from './b.module.css?raw';
 
 window.aRaw = aRaw;
 window.bRaw = bRaw;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-less/inline-query/index.test.ts
+++ b/e2e/cases/plugin-less/inline-query/index.test.ts
@@ -11,6 +11,8 @@ rspackOnlyTest(
 
     const aInline: string = await page.evaluate('window.aInline');
     const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
 
     expect(
       aInline.includes('.header-class') && aInline.includes('color: red'),
@@ -18,6 +20,7 @@ rspackOnlyTest(
     expect(
       bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
     ).toBe(true);
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },
@@ -31,12 +34,14 @@ rspackOnlyTest(
       page,
     });
 
-    expect(await page.evaluate('window.aInline')).toBe(
-      '.header-class{color:red}',
-    );
-    expect(await page.evaluate('window.bInline')).toBe(
-      '.title-class{font-size:14px}',
-    );
+    const aInline: string = await page.evaluate('window.aInline');
+    const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
+
+    expect(aInline).toBe('.header-class{color:red}');
+    expect(bInline).toBe('.title-class{font-size:14px}');
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },

--- a/e2e/cases/plugin-less/inline-query/src/index.js
+++ b/e2e/cases/plugin-less/inline-query/src/index.js
@@ -1,5 +1,7 @@
 import aInline from './a.less?inline';
 import bInline from './b.module.less?inline';
+import bStyles from './b.module.less?not-inline';
 
 window.aInline = aInline;
 window.bInline = bInline;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-less/raw-query/index.test.ts
+++ b/e2e/cases/plugin-less/raw-query/index.test.ts
@@ -11,12 +11,15 @@ test('should allow to import raw Less files in development mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.less'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });
@@ -29,12 +32,15 @@ test('should allow to import raw Less files in production mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.less'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.less'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });

--- a/e2e/cases/plugin-less/raw-query/src/index.js
+++ b/e2e/cases/plugin-less/raw-query/src/index.js
@@ -1,5 +1,7 @@
 import aRaw from './a.less?raw';
+import bStyles from './b.module.less?not-raw';
 import bRaw from './b.module.less?raw';
 
 window.aRaw = aRaw;
 window.bRaw = bRaw;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-sass/inline-query/index.test.ts
+++ b/e2e/cases/plugin-sass/inline-query/index.test.ts
@@ -11,6 +11,8 @@ rspackOnlyTest(
 
     const aInline: string = await page.evaluate('window.aInline');
     const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
 
     expect(
       aInline.includes('.header-class') && aInline.includes('color: red'),
@@ -18,6 +20,7 @@ rspackOnlyTest(
     expect(
       bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
     ).toBe(true);
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },
@@ -31,12 +34,14 @@ rspackOnlyTest(
       page,
     });
 
-    expect(await page.evaluate('window.aInline')).toBe(
-      '.header-class{color:red}',
-    );
-    expect(await page.evaluate('window.bInline')).toBe(
-      '.title-class{font-size:14px}',
-    );
+    const aInline: string = await page.evaluate('window.aInline');
+    const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
+
+    expect(aInline).toBe('.header-class{color:red}');
+    expect(bInline).toBe('.title-class{font-size:14px}');
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },

--- a/e2e/cases/plugin-sass/inline-query/src/index.js
+++ b/e2e/cases/plugin-sass/inline-query/src/index.js
@@ -1,5 +1,7 @@
 import aInline from './a.scss?inline';
 import bInline from './b.module.scss?inline';
+import bStyles from './b.module.scss?not-inline';
 
 window.aInline = aInline;
 window.bInline = bInline;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-sass/raw-query/index.test.ts
+++ b/e2e/cases/plugin-sass/raw-query/index.test.ts
@@ -11,12 +11,15 @@ test('should allow to import raw Sass files in development mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.scss'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.scss'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.scss'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });
@@ -29,12 +32,15 @@ test('should allow to import raw Sass files in production mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.scss'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.scss'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.scss'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });

--- a/e2e/cases/plugin-sass/raw-query/src/index.js
+++ b/e2e/cases/plugin-sass/raw-query/src/index.js
@@ -1,5 +1,7 @@
 import aRaw from './a.scss?raw';
+import bStyles from './b.module.scss?not-raw';
 import bRaw from './b.module.scss?raw';
 
 window.aRaw = aRaw;
 window.bRaw = bRaw;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-stylus/inline-query/index.test.ts
+++ b/e2e/cases/plugin-stylus/inline-query/index.test.ts
@@ -11,6 +11,8 @@ rspackOnlyTest(
 
     const aInline: string = await page.evaluate('window.aInline');
     const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
 
     expect(
       aInline.includes('.header-class') && aInline.includes('color: red'),
@@ -18,6 +20,7 @@ rspackOnlyTest(
     expect(
       bInline.includes('.title-class') && bInline.includes('font-size: 14px'),
     ).toBe(true);
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },
@@ -31,12 +34,14 @@ rspackOnlyTest(
       page,
     });
 
-    expect(await page.evaluate('window.aInline')).toBe(
-      '.header-class{color:red}',
-    );
-    expect(await page.evaluate('window.bInline')).toBe(
-      '.title-class{font-size:14px}',
-    );
+    const aInline: string = await page.evaluate('window.aInline');
+    const bInline: string = await page.evaluate('window.bInline');
+    const bStyles: Record<string, string> =
+      await page.evaluate('window.bStyles');
+
+    expect(aInline).toBe('.header-class{color:red}');
+    expect(bInline).toBe('.title-class{font-size:14px}');
+    expect(bStyles['title-class']).toBeTruthy();
 
     await rsbuild.close();
   },

--- a/e2e/cases/plugin-stylus/inline-query/src/index.js
+++ b/e2e/cases/plugin-stylus/inline-query/src/index.js
@@ -1,5 +1,7 @@
 import aInline from './a.styl?inline';
 import bInline from './b.module.styl?inline';
+import bStyles from './b.module.styl?not-inline';
 
 window.aInline = aInline;
 window.bInline = bInline;
+window.bStyles = bStyles;

--- a/e2e/cases/plugin-stylus/raw-query/index.test.ts
+++ b/e2e/cases/plugin-stylus/raw-query/index.test.ts
@@ -11,12 +11,15 @@ test('should allow to import raw Stylus files in development mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.styl'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });
@@ -29,12 +32,15 @@ test('should allow to import raw Stylus files in production mode', async ({
     page,
   });
 
-  expect(await page.evaluate('window.aRaw')).toBe(
-    readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'),
-  );
-  expect(await page.evaluate('window.bRaw')).toBe(
+  const aRaw: string = await page.evaluate('window.aRaw');
+  const bRaw: string = await page.evaluate('window.bRaw');
+  const bStyles: Record<string, string> = await page.evaluate('window.bStyles');
+
+  expect(aRaw).toBe(readFileSync(path.join(__dirname, 'src/a.styl'), 'utf-8'));
+  expect(bRaw).toBe(
     readFileSync(path.join(__dirname, 'src/b.module.styl'), 'utf-8'),
   );
+  expect(bStyles['title-class']).toBeTruthy();
 
   await rsbuild.close();
 });

--- a/e2e/cases/plugin-stylus/raw-query/src/index.js
+++ b/e2e/cases/plugin-stylus/raw-query/src/index.js
@@ -1,5 +1,7 @@
 import aRaw from './a.styl?raw';
+import bStyles from './b.module.styl?not-raw';
 import bRaw from './b.module.styl?raw';
 
 window.aRaw = aRaw;
 window.bRaw = bRaw;
+window.bStyles = bStyles;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -50,7 +50,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -79,7 +82,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -96,7 +99,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -504,7 +507,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -533,7 +539,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -550,7 +556,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -955,7 +961,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -985,7 +994,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1002,7 +1011,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -1337,7 +1346,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -1367,7 +1379,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1384,7 +1396,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -47,6 +47,8 @@ export const HTML_REGEX: RegExp = /\.html$/;
 export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
 export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 export const CSS_REGEX: RegExp = /\.css$/;
+export const RAW_QUERY_REGEX: RegExp = /^\?raw$/;
+export const INLINE_QUERY_REGEX: RegExp = /^\?inline$/;
 export const NODE_MODULES_REGEX: RegExp = /[\\/]node_modules[\\/]/;
 
 // Plugins

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -2,7 +2,12 @@ import path, { posix } from 'node:path';
 import deepmerge from 'deepmerge';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
 import type { AcceptedPlugin, PluginCreator } from '../../compiled/postcss';
-import { CSS_REGEX, LOADER_PATH } from '../constants';
+import {
+  CSS_REGEX,
+  INLINE_QUERY_REGEX,
+  LOADER_PATH,
+  RAW_QUERY_REGEX,
+} from '../constants';
 import { castArray, color, getFilename } from '../helpers';
 import { getCompiledPath } from '../helpers/path';
 import { getCssExtractPlugin } from '../pluginHelper';
@@ -282,20 +287,20 @@ export const pluginCss = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' })
           // exclude `import './foo.css?raw'` and `import './foo.css?inline'`
-          .resourceQuery({ not: /raw|inline/ });
+          .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] });
 
         // Support for `import inlineCss from "a.css?inline"`
         inlineRule
           .test(CSS_REGEX)
           .type('javascript/auto')
-          .resourceQuery(/inline/);
+          .resourceQuery(INLINE_QUERY_REGEX);
 
         // Support for `import rawCss from "a.css?raw"`
         chain.module
           .rule(CHAIN_ID.RULE.CSS_RAW)
           .test(CSS_REGEX)
           .type('asset/source')
-          .resourceQuery(/raw/);
+          .resourceQuery(RAW_QUERY_REGEX);
 
         const emitCss = config.output.emitCss ?? target === 'web';
 

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -7,6 +7,7 @@ import { reduceConfigs } from 'reduce-configs';
 import {
   NODE_MODULES_REGEX,
   PLUGIN_SWC_NAME,
+  RAW_QUERY_REGEX,
   SCRIPT_REGEX,
 } from '../constants';
 import {
@@ -110,9 +111,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
-        // Match the `?raw` query
-        const rawRegex = /^\?raw$/;
-
         const rule = chain.module
           .rule(CHAIN_ID.RULE.JS)
           .test(SCRIPT_REGEX)
@@ -121,14 +119,14 @@ export const pluginSwc = (): RsbuildPlugin => ({
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' })
           // exclude `import './foo.js?raw'`
-          .resourceQuery({ not: rawRegex });
+          .resourceQuery({ not: RAW_QUERY_REGEX });
 
         // Support for `import rawJs from "a.js?raw"`
         chain.module
           .rule(CHAIN_ID.RULE.JS_RAW)
           .test(SCRIPT_REGEX)
           .type('asset/source')
-          .resourceQuery(rawRegex);
+          .resourceQuery(RAW_QUERY_REGEX);
 
         const dataUriRule = chain.module
           .rule(CHAIN_ID.RULE.JS_DATA_URI)

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -42,7 +42,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -83,7 +86,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -112,7 +115,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -12,7 +12,10 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -53,7 +56,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -82,7 +85,7 @@ exports[`plugin-css > should use custom cssModules rule when using output.cssMod
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -115,7 +118,10 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -145,7 +151,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -162,7 +168,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -188,7 +194,10 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -229,7 +238,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -258,7 +267,7 @@ exports[`plugin-css injectStyles > should use css-loader + style-loader when inj
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -282,7 +291,10 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -338,7 +350,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     "resolve": {
       "preferRelative": true,
     },
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
     "type": "javascript/auto",
@@ -382,7 +394,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.css\\$/,
     "type": "asset/source",
   },
@@ -399,7 +411,10 @@ exports[`should ensure isolation of PostCSS config objects between different bui
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
@@ -455,7 +470,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     "resolve": {
       "preferRelative": true,
     },
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "sideEffects": true,
     "test": /\\\\\\.css\\$/,
     "type": "javascript/auto",
@@ -499,7 +514,7 @@ exports[`should ensure isolation of PostCSS config objects between different bui
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.css\\$/,
     "type": "asset/source",
   },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -42,7 +42,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -83,7 +86,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -112,7 +115,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -531,7 +534,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -572,7 +578,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -602,7 +608,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -1048,7 +1054,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -1078,7 +1087,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1095,7 +1104,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },
@@ -1468,7 +1477,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "preferRelative": true,
         },
         "resourceQuery": {
-          "not": /raw\\|inline/,
+          "not": [
+            /\\^\\\\\\?raw\\$/,
+            /\\^\\\\\\?inline\\$/,
+          ],
         },
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
@@ -1509,7 +1521,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "resolve": {
           "preferRelative": true,
         },
-        "resourceQuery": /inline/,
+        "resourceQuery": /\\^\\\\\\?inline\\$/,
         "sideEffects": true,
         "test": /\\\\\\.css\\$/,
         "type": "javascript/auto",
@@ -1538,7 +1550,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         ],
       },
       {
-        "resourceQuery": /raw/,
+        "resourceQuery": /\\^\\\\\\?raw\\$/,
         "test": /\\\\\\.css\\$/,
         "type": "asset/source",
       },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1337,7 +1337,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "preferRelative": true,
           },
           "resourceQuery": {
-            "not": /raw\\|inline/,
+            "not": [
+              /\\^\\\\\\?raw\\$/,
+              /\\^\\\\\\?inline\\$/,
+            ],
           },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
@@ -1378,7 +1381,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "resolve": {
             "preferRelative": true,
           },
-          "resourceQuery": /inline/,
+          "resourceQuery": /\\^\\\\\\?inline\\$/,
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
           "type": "javascript/auto",
@@ -1407,7 +1410,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.css\\$/,
           "type": "asset/source",
         },
@@ -1766,7 +1769,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "preferRelative": true,
           },
           "resourceQuery": {
-            "not": /raw\\|inline/,
+            "not": [
+              /\\^\\\\\\?raw\\$/,
+              /\\^\\\\\\?inline\\$/,
+            ],
           },
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
@@ -1796,7 +1802,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "resolve": {
             "preferRelative": true,
           },
-          "resourceQuery": /inline/,
+          "resourceQuery": /\\^\\\\\\?inline\\$/,
           "sideEffects": true,
           "test": /\\\\\\.css\\$/,
           "type": "javascript/auto",
@@ -1813,7 +1819,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           ],
         },
         {
-          "resourceQuery": /raw/,
+          "resourceQuery": /\\^\\\\\\?raw\\$/,
           "test": /\\\\\\.css\\$/,
           "type": "asset/source",
         },

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,10 @@ exports[`plugin-less > should add less-loader 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -60,7 +63,7 @@ exports[`plugin-less > should add less-loader 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -100,7 +103,7 @@ exports[`plugin-less > should add less-loader 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.less\\$/,
     "type": "asset/source",
   },
@@ -117,7 +120,10 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -167,7 +173,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -207,7 +213,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.less\\$/,
     "type": "asset/source",
   },
@@ -227,7 +233,10 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -280,7 +289,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
     "exclude": [
       /node_modules/,
     ],
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -320,7 +329,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.less\\$/,
     "type": "asset/source",
   },
@@ -337,7 +346,10 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -387,7 +399,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -427,7 +439,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.less\\$/,
     "type": "asset/source",
   },
@@ -444,7 +456,10 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.less\\$/,
@@ -501,7 +516,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -548,7 +563,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.less\\$/,
     "type": "asset/source",
   },

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -99,6 +99,8 @@ export const pluginSass = (
 
   setup(api) {
     const { rewriteUrls = true, include = /\.s(?:a|c)ss$/ } = pluginOptions;
+    const RAW_QUERY_REGEX: RegExp = /^\?raw$/;
+    const INLINE_QUERY_REGEX: RegExp = /^\?inline$/;
 
     api.onAfterCreateCompiler(({ compiler }) => {
       patchCompilerGlobalLocation(compiler);
@@ -121,7 +123,7 @@ export const pluginSass = (
         .rule(findRuleId(chain, CHAIN_ID.RULE.SASS))
         .test(include)
         // exclude `import './foo.scss?raw'` and `import './foo.scss?inline'`
-        .resourceQuery({ not: /raw|inline/ })
+        .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] })
         .sideEffects(true)
         .resolve.preferRelative(true)
         .end();
@@ -135,7 +137,7 @@ export const pluginSass = (
         ? chain.module
             .rule(findRuleId(chain, CHAIN_ID.RULE.SASS_INLINE))
             .test(include)
-            .resourceQuery(/inline/)
+            .resourceQuery(INLINE_QUERY_REGEX)
         : null;
 
       // Support for importing raw Sass files
@@ -143,7 +145,7 @@ export const pluginSass = (
         .rule(CHAIN_ID.RULE.SASS_RAW)
         .test(include)
         .type('asset/source')
-        .resourceQuery(/raw/);
+        .resourceQuery(RAW_QUERY_REGEX);
 
       // Update the normal rule and the inline rule
       const updateRules = (

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,10 @@ exports[`plugin-sass > should add sass-loader 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
@@ -68,7 +71,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -116,7 +119,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "type": "asset/source",
   },
@@ -133,7 +136,10 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
@@ -191,7 +197,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -239,7 +245,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "type": "asset/source",
   },
@@ -259,7 +265,10 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
@@ -320,7 +329,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
     "exclude": [
       /node_modules/,
     ],
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -368,7 +377,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "type": "asset/source",
   },
@@ -385,7 +394,10 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
@@ -444,7 +456,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -493,7 +505,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "type": "asset/source",
   },

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -72,6 +72,9 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
   name: PLUGIN_STYLUS_NAME,
 
   setup(api) {
+    const RAW_QUERY_REGEX: RegExp = /^\?raw$/;
+    const INLINE_QUERY_REGEX: RegExp = /^\?inline$/;
+
     api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
@@ -90,7 +93,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         .rule(CHAIN_ID.RULE.STYLUS)
         .test(test)
         // exclude `import './foo.styl?raw'` and `import './foo.stylus?inline'`
-        .resourceQuery({ not: /raw|inline/ })
+        .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] })
         .sideEffects(true)
         .resolve.preferRelative(true)
         .end();
@@ -104,7 +107,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         ? chain.module
             .rule(CHAIN_ID.RULE.STYLUS_INLINE)
             .test(test)
-            .resourceQuery(/inline/)
+            .resourceQuery(INLINE_QUERY_REGEX)
         : null;
 
       // Support for importing raw Stylus files
@@ -112,7 +115,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
         .rule(CHAIN_ID.RULE.STYLUS_RAW)
         .test(test)
         .type('asset/source')
-        .resourceQuery(/raw/);
+        .resourceQuery(RAW_QUERY_REGEX);
 
       // Update the normal rule and the inline rule
       const updateRules = (

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -10,7 +10,10 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
@@ -53,7 +56,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {
@@ -86,7 +89,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "type": "asset/source",
   },
@@ -103,7 +106,10 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
       "preferRelative": true,
     },
     "resourceQuery": {
-      "not": /raw\\|inline/,
+      "not": [
+        /\\^\\\\\\?raw\\$/,
+        /\\^\\\\\\?inline\\$/,
+      ],
     },
     "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
@@ -149,7 +155,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     ],
   },
   {
-    "resourceQuery": /inline/,
+    "resourceQuery": /\\^\\\\\\?inline\\$/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {
@@ -185,7 +191,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
     ],
   },
   {
-    "resourceQuery": /raw/,
+    "resourceQuery": /\\^\\\\\\?raw\\$/,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "type": "asset/source",
   },


### PR DESCRIPTION
## Summary

Enhance the handling of resource queries (`raw` and `inline`). This ensures stricter validation for raw and inline imports.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5538

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
