### PR TITLE
docs: update raw import JSDoc to include scripts

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -233,6 +233,9 @@ declare module '*?url' {
  * @example
  * import logo from './logo.svg?inline'
  * console.log(logo) // 'data:image/svg+xml;base64,...'
+ *
+ * import inlineCss from './style.css?inline';
+ * console.log(inlineCss); // Compiled CSS content
  */
 declare module '*?inline' {
   const content: string;
@@ -241,10 +244,17 @@ declare module '*?inline' {
 
 /**
  * Imports the raw content of the file as a string.
- * @note Only works for static assets and CSS files by default.
+ * @note Only works for static assets, CSS files, and scripts
+ * (JS, TS, JSX, TSX) by default.
  * @example
  * import raw from './logo.svg?raw'
  * console.log(raw) // '<svg viewBox="0 0 24 24">...</svg>'
+ *
+ * import rawJs from './script.js?raw'
+ * console.log(rawJs) // 'console.log("Hello world");'
+ *
+ * import rawCss from './style.css?raw'
+ * console.log(rawCss) // 'body { background: red; }'
  */
 declare module '*?raw' {
   const content: string;

--- a/website/docs/en/guide/styling/css-usage.mdx
+++ b/website/docs/en/guide/styling/css-usage.mdx
@@ -166,7 +166,7 @@ Rsbuild supports importing compiled CSS files as strings in JavaScript by using 
 ```js
 import inlineCss from './style.css?inline';
 
-console.log(inlineCss); // Output the compiled CSS file content
+console.log(inlineCss); // Compiled CSS content
 ```
 
 Using `import "*.css?inline"` has the following behaviors:

--- a/website/docs/zh/guide/styling/css-usage.mdx
+++ b/website/docs/zh/guide/styling/css-usage.mdx
@@ -166,7 +166,7 @@ Rsbuild 支持通过 `?inline` 查询参数引用 CSS 文件编译后的内容�
 ```js
 import inlineCss from './style.css?inline';
 
-console.log(inlineCss); // 输出编译后的 CSS 文件内容
+console.log(inlineCss); // 编译后的 CSS 内容
 ```
 
 使用 `import "*.css?inline"` 的行为如下：


### PR DESCRIPTION
## Summary

Update the raw import JSDoc to include scripts.

## Related Links

https://rsbuild.rs/guide/basic/static-assets#import-as-string

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
