### PR TITLE
test(e2e): use valid browserslist value

### DIFF
--- a/e2e/cases/source/source-exclude/index.test.ts
+++ b/e2e/cases/source/source-exclude/index.test.ts
@@ -14,7 +14,7 @@ test('should not compile specified file when source.exclude', async () => {
         exclude: [path.resolve(__dirname, './src/test.js')],
       },
       output: {
-        overrideBrowserslist: ['ie 11'],
+        overrideBrowserslist: ['android >= 4.4'],
       },
     },
   });


### PR DESCRIPTION
## Summary

Use a valid browserslist value instead of using the dead IE in our E2E case.

## Related Links

https://github.com/swc-project/swc/issues/1377#issuecomment-789633974

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
