### PR TITLE
fix: ensure that raw query of assets can be accurately matched

### DIFF
--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -13,7 +13,7 @@ test('should allow to get raw asset content with `?raw` in development mode', as
     page,
   });
 
-  expect(await page.evaluate('window.rawImg')).toEqual(
+  expect(await page.evaluate('window.rawSvg')).toEqual(
     await promises.readFile(
       join(__dirname, '../../../assets/circle.svg'),
       'utf-8',
@@ -31,7 +31,7 @@ test('should allow to get raw asset content with `?raw` in production mode', asy
     page,
   });
 
-  expect(await page.evaluate('window.rawImg')).toEqual(
+  expect(await page.evaluate('window.rawSvg')).toEqual(
     await promises.readFile(
       join(__dirname, '../../../assets/circle.svg'),
       'utf-8',
@@ -52,7 +52,7 @@ test('should allow to get raw SVG content with `?raw` when using pluginSvgr', as
     },
   });
 
-  expect(await page.evaluate('window.rawImg')).toEqual(
+  expect(await page.evaluate('window.rawSvg')).toEqual(
     await promises.readFile(
       join(__dirname, '../../../assets/circle.svg'),
       'utf-8',
@@ -102,6 +102,23 @@ test('should allow to get raw TSX content with `?raw` and using pluginReact', as
   expect(await page.evaluate('window.rawTsx')).toEqual(
     await promises.readFile(join(__dirname, 'src/baz.tsx'), 'utf-8'),
   );
+
+  await rsbuild.close();
+});
+
+test('should not get raw SVG content with query other than `?raw`', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(
+    (await page.evaluate<string>('window.normalSvg')).startsWith(
+      'data:image/svg+xml',
+    ),
+  ).toBe(true);
 
   await rsbuild.close();
 });

--- a/e2e/cases/assets/raw-query/src/index.js
+++ b/e2e/cases/assets/raw-query/src/index.js
@@ -1,10 +1,12 @@
-import img from '@assets/circle.svg?raw';
+import normalSvg from '@assets/circle.svg?not-raw';
+import rawSvg from '@assets/circle.svg?raw';
 import rawTs from './bar.ts?raw';
 import rawTsx from './baz.tsx?raw';
 import normalJs from './foo.js?not-raw';
 import rawJs from './foo.js?raw';
 
-window.rawImg = img;
+window.rawSvg = rawSvg;
+window.normalSvg = normalSvg;
 window.rawJs = rawJs;
 window.rawTs = rawTs;
 window.rawTsx = rawTsx;

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -139,7 +139,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -170,7 +170,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -201,7 +201,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -232,7 +232,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -595,7 +595,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -626,7 +626,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -657,7 +657,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -688,7 +688,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1050,7 +1050,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1081,7 +1081,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1112,7 +1112,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1143,7 +1143,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1435,7 +1435,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1466,7 +1466,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1497,7 +1497,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1528,7 +1528,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -143,11 +143,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -174,11 +174,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -205,11 +205,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -236,11 +236,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -599,11 +599,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -630,11 +630,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -661,11 +661,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -692,11 +692,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1054,11 +1054,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1085,11 +1085,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1116,11 +1116,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1147,11 +1147,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1439,11 +1439,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1470,11 +1470,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1501,11 +1501,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1532,11 +1532,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -8,6 +8,8 @@ import {
   AUDIO_EXTENSIONS,
   FONT_EXTENSIONS,
   IMAGE_EXTENSIONS,
+  INLINE_QUERY_REGEX,
+  RAW_QUERY_REGEX,
   VIDEO_EXTENSIONS,
 } from '../constants';
 import { getFilename } from '../helpers';
@@ -40,20 +42,20 @@ const chainStaticAssetRule = ({
   rule
     .oneOf(`${assetType}-asset-url`)
     .type('asset/resource')
-    .resourceQuery(/(__inline=false|url)/)
+    .resourceQuery(/^\?(__inline=false|url)$/)
     .set('generator', generatorOptions);
 
   // get inlined base64 content: "foo.png?inline"
   rule
     .oneOf(`${assetType}-asset-inline`)
     .type('asset/inline')
-    .resourceQuery(/inline/);
+    .resourceQuery(INLINE_QUERY_REGEX);
 
   // get raw content: "foo.png?raw"
   rule
     .oneOf(`${assetType}-asset-raw`)
     .type('asset/source')
-    .resourceQuery(/raw/);
+    .resourceQuery(RAW_QUERY_REGEX);
 
   // the asset will be inlined if fileSize < dataUrlCondition.maxSize
   rule

--- a/packages/core/tests/__snapshots__/asset.test.ts.snap
+++ b/packages/core/tests/__snapshots__/asset.test.ts.snap
@@ -10,15 +10,15 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -41,15 +41,15 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -72,15 +72,15 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -103,15 +103,15 @@ exports[`plugin-asset > should add image rules correctly 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -151,15 +151,15 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "generator": {
               "filename": "[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -182,15 +182,15 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -213,15 +213,15 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -244,15 +244,15 @@ exports[`plugin-asset > should add image rules correctly 2`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -292,15 +292,15 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "generator": {
               "filename": "foo/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -323,15 +323,15 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -354,15 +354,15 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -385,15 +385,15 @@ exports[`plugin-asset > should allow to use distPath.image to modify dist path 1
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -433,15 +433,15 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "generator": {
               "filename": "static/image/foo[ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -464,15 +464,15 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -495,15 +495,15 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -526,15 +526,15 @@ exports[`plugin-asset > should allow to use filename.image to modify filename 1`
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -230,15 +230,15 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -261,15 +261,15 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -292,15 +292,15 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -323,15 +323,15 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -234,11 +234,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -265,11 +265,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -296,11 +296,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -327,11 +327,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -726,11 +726,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -757,11 +757,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -788,11 +788,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -819,11 +819,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1214,11 +1214,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1245,11 +1245,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1276,11 +1276,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1307,11 +1307,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1669,11 +1669,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1700,11 +1700,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1731,11 +1731,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {
@@ -1762,11 +1762,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "type": "asset/resource",
           },
           {
-            "resourceQuery": /inline/,
+            "resourceQuery": /\\^\\\\\\?inline\\$/,
             "type": "asset/inline",
           },
           {
-            "resourceQuery": /raw/,
+            "resourceQuery": /\\^\\\\\\?raw\\$/,
             "type": "asset/source",
           },
           {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -230,7 +230,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -261,7 +261,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -292,7 +292,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -323,7 +323,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -722,7 +722,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -753,7 +753,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -784,7 +784,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -815,7 +815,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1210,7 +1210,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1241,7 +1241,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1272,7 +1272,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1303,7 +1303,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1665,7 +1665,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/image/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1696,7 +1696,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/svg/[name].[contenthash:8].svg",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1727,7 +1727,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/media/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {
@@ -1758,7 +1758,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
             "generator": {
               "filename": "static/font/[name].[contenthash:8][ext]",
             },
-            "resourceQuery": /\\(__inline=false\\|url\\)/,
+            "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
             "type": "asset/resource",
           },
           {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1525,15 +1525,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/image/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1556,15 +1556,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/svg/[name].[contenthash:8].svg",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1587,15 +1587,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/media/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1618,15 +1618,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/font/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1925,15 +1925,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/image/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1956,15 +1956,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/svg/[name].[contenthash:8].svg",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -1987,15 +1987,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/media/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {
@@ -2018,15 +2018,15 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "generator": {
                 "filename": "static/font/[name].[contenthash:8][ext]",
               },
-              "resourceQuery": /\\(__inline=false\\|url\\)/,
+              "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
               "type": "asset/resource",
             },
             {
-              "resourceQuery": /inline/,
+              "resourceQuery": /\\^\\\\\\?inline\\$/,
               "type": "asset/inline",
             },
             {
-              "resourceQuery": /raw/,
+              "resourceQuery": /\\^\\\\\\?raw\\$/,
               "type": "asset/source",
             },
             {

--- a/packages/plugin-react/src/index.ts
+++ b/packages/plugin-react/src/index.ts
@@ -39,7 +39,7 @@ export type PluginReactOptions = {
    * {
    *   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
    *   exclude: [/[\\/]node_modules[\\/]/],
-   *   resourceQuery: { not: /raw/ },
+   *   resourceQuery: { not: /^\?raw$/ },
    * }
    * @see https://rspack.rs/guide/tech/react#rspackplugin-react-refresh
    */

--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -74,7 +74,7 @@ export const applyBasicReactSupport = (
           {
             include: [SCRIPT_REGEX],
             exclude: [NODE_MODULES_REGEX],
-            resourceQuery: { not: /raw/ },
+            resourceQuery: { not: /^\?raw$/ },
             ...options.reactRefreshOptions,
           },
         ]);

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -178,21 +178,21 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
       rule
         .oneOf(CHAIN_ID.ONE_OF.SVG_URL)
         .type('asset/resource')
-        .resourceQuery(/(__inline=false|url)/)
+        .resourceQuery(/^\?(__inline=false|url)$/)
         .set('generator', generatorOptions);
 
       // get inlined base64 content: "foo.svg?inline"
       rule
         .oneOf(CHAIN_ID.ONE_OF.SVG_INLINE)
         .type('asset/inline')
-        .resourceQuery(/inline/);
+        .resourceQuery(/^\?inline$/);
 
       // get raw content: "foo.svg?raw"
       if (CHAIN_ID.ONE_OF.SVG_RAW) {
         rule
           .oneOf(CHAIN_ID.ONE_OF.SVG_RAW)
           .type('asset/source')
-          .resourceQuery(/raw/);
+          .resourceQuery(/^\?raw$/);
       }
 
       // force to react component: "foo.svg?react"

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -7,15 +7,15 @@ exports[`svgr > configure SVGR options 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
       "type": "asset/resource",
     },
     {
-      "resourceQuery": /inline/,
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
     },
     {
-      "resourceQuery": /raw/,
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
     {
@@ -107,15 +107,15 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
       "type": "asset/resource",
     },
     {
-      "resourceQuery": /inline/,
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
     },
     {
-      "resourceQuery": /raw/,
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
     {
@@ -274,15 +274,15 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
       "type": "asset/resource",
     },
     {
-      "resourceQuery": /inline/,
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
     },
     {
-      "resourceQuery": /raw/,
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
     {
@@ -441,15 +441,15 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
       "type": "asset/resource",
     },
     {
-      "resourceQuery": /inline/,
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
     },
     {
-      "resourceQuery": /raw/,
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
     {
@@ -608,15 +608,15 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
       "generator": {
         "filename": "static/svg/[name].[contenthash:8].svg",
       },
-      "resourceQuery": /\\(__inline=false\\|url\\)/,
+      "resourceQuery": /\\^\\\\\\?\\(__inline=false\\|url\\)\\$/,
       "type": "asset/resource",
     },
     {
-      "resourceQuery": /inline/,
+      "resourceQuery": /\\^\\\\\\?inline\\$/,
       "type": "asset/inline",
     },
     {
-      "resourceQuery": /raw/,
+      "resourceQuery": /\\^\\\\\\?raw\\$/,
       "type": "asset/source",
     },
     {

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -273,7 +273,8 @@ api.transform({ test: /\.md$/, environments: ['web'] }, ({ code }) => {
 - `resourceQuery`: matches module's query, the same as Rspack's [Rule.resourceQuery](https://rspack.rs/config/module#ruleresourcequery).
 
 ```js
-api.transform({ resourceQuery: /raw/ }, ({ code }) => {
+// match raw query: "foo.ext?raw"
+api.transform({ resourceQuery: /^\?raw$/ }, ({ code }) => {
   // ...
 });
 ```

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -221,7 +221,7 @@ type ReactRefreshOptions = {
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
   exclude: [/[\\/]node_modules[\\/]/],
-  resourceQuery: { not: /raw/ },
+  resourceQuery: { not: /^\?raw$/ },
 };
 ```
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -271,7 +271,8 @@ api.transform({ test: /\.md$/, environments: ['web'] }, ({ code }) => {
 - `resourceQuery`：匹配模块的 query，等价于 Rspack 的 [Rule.resourceQuery](https://rspack.rs/zh/config/module#ruleresourcequery)。
 
 ```js
-api.transform({ resourceQuery: /raw/ }, ({ code }) => {
+// 匹配 raw query: "foo.ext?raw"
+api.transform({ resourceQuery: /^\?raw$/ }, ({ code }) => {
   // ...
 });
 ```

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -223,7 +223,7 @@ type ReactRefreshOptions = {
 const defaultOptions = {
   include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
   exclude: [/[\\/]node_modules[\\/]/],
-  resourceQuery: { not: /raw/ },
+  resourceQuery: { not: /^\?raw$/ },
 };
 ```
 


### PR DESCRIPTION
## Summary

Improving query matching for raw and inline asset content, ensuring stricter regex patterns, and adding new test cases for edge scenarios.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5538

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
