### PR TITLE
docs: add webSocketToken to documentation

### DIFF
--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -220,7 +220,7 @@ export type EnvironmentContext = {
   /**
    * WebSocket authentication token, used to authenticate WebSocket connections and
    * prevent unauthorized access. Only available in the development mode, and is
-   * empty string in the production mode.
+   * an empty string in the production mode.
    */
   webSocketToken: string;
 };

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -218,9 +218,9 @@ export type EnvironmentContext = {
    */
   manifest?: Record<string, unknown> | ManifestData;
   /**
-   * WebSocket authentication token - cryptographically secure random identifier
-   * used to authenticate WebSocket connections and prevent unauthorized access.
-   * Only generated in the development mode, and is empty string in the production mode.
+   * WebSocket authentication token, used to authenticate WebSocket connections and
+   * prevent unauthorized access. Only available in the development mode, and is
+   * empty string in the production mode.
    */
   webSocketToken: string;
 };

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -194,6 +194,22 @@ The manifest data is only available after the build has completed, you can acces
 - [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
 - [onExit](/plugins/dev/hooks#onexit)
 
+### webSocketToken
+
+WebSocket authentication token, used to authenticate WebSocket connections and prevent unauthorized access.
+
+Only available in the development mode, and is empty string in the production mode.
+
+- **Type:** `string`
+
+When you need to establish a WebSocket connection with the Rsbuild dev server in the browser, you need to use this token as a query parameter.
+
+```js
+const { webSocketToken } = environments.web.context;
+
+const webSocketUrl = `ws://localhost:${port}${pathname}?token=${webSocketToken}`;
+```
+
 ## Environment API
 
 Environment API provides some APIs related to the multi-environment build.

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -201,6 +201,7 @@ WebSocket authentication token, used to authenticate WebSocket connections and p
 Only available in the development mode, and is an empty string in the production mode.
 
 - **Type:** `string`
+- **Version:** Added in v1.4.4
 
 When you need to establish a WebSocket connection with the Rsbuild dev server in the browser, you need to use this token as a query parameter.
 

--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -198,7 +198,7 @@ The manifest data is only available after the build has completed, you can acces
 
 WebSocket authentication token, used to authenticate WebSocket connections and prevent unauthorized access.
 
-Only available in the development mode, and is empty string in the production mode.
+Only available in the development mode, and is an empty string in the production mode.
 
 - **Type:** `string`
 

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -195,6 +195,22 @@ manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks �
 - [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
 - [onExit](/plugins/dev/hooks#onexit)
 
+### webSocketToken
+
+WebSocket 认证 token，用于认证 WebSocket 连接，防止未授权访问。
+
+仅在开发模式下可用，生产模式下为空字符串。
+
+- **类型：** `string`
+
+当你需要在浏览器中建立与 Rsbuild dev server 的 WebSocket 连接时，需要使用这个 token 作为 query 参数。
+
+```js
+const { webSocketToken } = environments.web.context;
+
+const webSocketUrl = `ws://localhost:${port}${pathname}?token=${webSocketToken}`;
+```
+
 ## Environment API
 
 Environment API 提供一些与多环境构建相关的 API。

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -202,6 +202,7 @@ WebSocket 认证 token，用于认证 WebSocket 连接，防止未授权访问�
 仅在开发模式下可用，生产模式下为空字符串。
 
 - **类型：** `string`
+- **版本：** 添加于 v1.4.4
 
 当你需要在浏览器中建立与 Rsbuild dev server 的 WebSocket 连接时，需要使用这个 token 作为 query 参数。
 


### PR DESCRIPTION
## Summary

Added a new section explaining `webSocketToken`, including its type, usage, and an example of establishing a WebSocket connection with the Rsbuild dev server.

## Related Links

- https://github.com/web-infra-dev/rsbuild/discussions/5527
- https://github.com/web-infra-dev/rsbuild/pull/5531

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
