### PR TITLE
fix(deps): revert @rspack/core to 1.4.2

### DIFF
--- a/e2e/cases/sri/async-chunks/index.test.ts
+++ b/e2e/cases/sri/async-chunks/index.test.ts
@@ -1,7 +1,6 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-// TODO: fix this test
 rspackOnlyTest(
   'generate integrity for async script tags in prod build',
   async ({ page }) => {

--- a/e2e/cases/sri/async-chunks/index.test.ts
+++ b/e2e/cases/sri/async-chunks/index.test.ts
@@ -1,22 +1,23 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
 // TODO: fix this test
-test.skip('generate integrity for async script tags in prod build', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'generate integrity for async script tags in prod build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-  const { content } = await rsbuild.getIndexFile();
+    const { content } = await rsbuild.getIndexFile();
 
-  expect(content.includes('sriHashes={') && content.includes('"sha384-')).toBe(
-    true,
-  );
+    expect(
+      content.includes('sriHashes={') && content.includes('"sha384-'),
+    ).toBe(true);
 
-  const testEl = page.locator('#root');
-  await expect(testEl).toHaveText('foo');
-  await rsbuild.close();
-});
+    const testEl = page.locator('#root');
+    await expect(testEl).toHaveText('foo');
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/sri/preload/index.test.ts
+++ b/e2e/cases/sri/preload/index.test.ts
@@ -1,7 +1,6 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-// TODO: fix this test
 rspackOnlyTest(
   'generate integrity for preload tags in prod build',
   async ({ page }) => {

--- a/e2e/cases/sri/preload/index.test.ts
+++ b/e2e/cases/sri/preload/index.test.ts
@@ -1,24 +1,25 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
 // TODO: fix this test
-test.skip('generate integrity for preload tags in prod build', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'generate integrity for preload tags in prod build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
 
-  const files = await rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const files = await rsbuild.getDistFiles();
+    const html =
+      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
 
-  expect(html).toMatch(
-    /<link href="\/static\/js\/async\/foo\.\w{8}\.js" rel="preload" as="script" integrity="sha384-[A-Za-z0-9+/=]+"/,
-  );
+    expect(html).toMatch(
+      /<link href="\/static\/js\/async\/foo\.\w{8}\.js" rel="preload" as="script" integrity="sha384-[A-Za-z0-9+/=]+"/,
+    );
 
-  const testEl = page.locator('#root');
-  await expect(testEl).toHaveText('Hello Rsbuild!');
-  await rsbuild.close();
-});
+    const testEl = page.locator('#root');
+    await expect(testEl).toHaveText('Hello Rsbuild!');
+    await rsbuild.close();
+  },
+);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,7 +52,7 @@
     "bump": "npx bumpp --no-tag"
   },
   "dependencies": {
-    "@rspack/core": "1.4.4",
+    "@rspack/core": "1.4.2",
     "@rspack/lite-tapable": "~1.0.1",
     "@swc/helpers": "^0.5.17",
     "core-js": "~3.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -600,8 +600,8 @@ importers:
   packages/core:
     dependencies:
       '@rspack/core':
-        specifier: 1.4.4
-        version: 1.4.4(@swc/helpers@0.5.17)
+        specifier: 1.4.2
+        version: 1.4.2(@swc/helpers@0.5.17)
       '@rspack/lite-tapable':
         specifier: ~1.0.1
         version: 1.0.1
@@ -656,7 +656,7 @@ importers:
         version: 2.8.5
       css-loader:
         specifier: 7.1.2
-        version: 7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@1.4.4(@swc/helpers@0.5.17))(webpack@5.99.9)
+        version: 7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@1.4.2(@swc/helpers@0.5.17))(webpack@5.99.9)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -665,7 +665,7 @@ importers:
         version: 12.0.2
       html-rspack-plugin:
         specifier: 6.1.2
-        version: 6.1.2(@rspack/core@1.4.4(@swc/helpers@0.5.17))
+        version: 6.1.2(@rspack/core@1.4.2(@swc/helpers@0.5.17))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -692,7 +692,7 @@ importers:
         version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.8.0)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9)
+        version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.2(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9)
       prebundle:
         specifier: 1.3.4
         version: 1.3.4(typescript@5.8.3)
@@ -710,7 +710,7 @@ importers:
         version: 1.2.6
       rspack-manifest-plugin:
         specifier: 5.0.3
-        version: 5.0.3(@rspack/core@1.4.4(@swc/helpers@0.5.17))
+        version: 5.0.3(@rspack/core@1.4.2(@swc/helpers@0.5.17))
       sirv:
         specifier: ^3.0.1
         version: 3.0.1
@@ -9743,7 +9743,7 @@ snapshots:
 
   cspell-ban-words@0.0.4: {}
 
-  css-loader@7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@1.4.4(@swc/helpers@0.5.17))(webpack@5.99.9):
+  css-loader@7.1.2(patch_hash=f108465818eeda8955fecc4aa57dbfd6219c34a7a876fc224f229836292996a6)(@rspack/core@1.4.2(@swc/helpers@0.5.17))(webpack@5.99.9):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -9754,7 +9754,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 1.4.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.2(@swc/helpers@0.5.17)
       webpack: 5.99.9
 
   css-select@4.3.0:
@@ -10549,11 +10549,11 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.42.0
 
-  html-rspack-plugin@6.1.2(@rspack/core@1.4.4(@swc/helpers@0.5.17)):
+  html-rspack-plugin@6.1.2(@rspack/core@1.4.2(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
-      '@rspack/core': 1.4.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.2(@swc/helpers@0.5.17)
 
   html-to-text@9.0.5:
     dependencies:
@@ -11816,14 +11816,14 @@ snapshots:
       postcss: 8.5.6
       yaml: 2.8.0
 
-  postcss-loader@8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.4(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9):
+  postcss-loader@8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.2(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.99.9):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.8.3)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
     optionalDependencies:
-      '@rspack/core': 1.4.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.2(@swc/helpers@0.5.17)
       webpack: 5.99.9
     transitivePeerDependencies:
       - typescript
@@ -12207,11 +12207,11 @@ snapshots:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.0.3(@rspack/core@1.4.4(@swc/helpers@0.5.17)):
+  rspack-manifest-plugin@5.0.3(@rspack/core@1.4.2(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:
-      '@rspack/core': 1.4.4(@swc/helpers@0.5.17)
+      '@rspack/core': 1.4.2(@swc/helpers@0.5.17)
 
   rspack-plugin-virtual-module@1.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

Revert @rspack/core to v1.4.2 to fix the SRI issue (see test cases).

We cannot revert @rspack/core to v1.4.3 as SWC breaks the `ie 11` browserslist in this release.
## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5546
- https://github.com/web-infra-dev/rsbuild/pull/5532

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
