### PR TITLE
fix: duplicated build started logs

### DIFF
--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -119,7 +119,11 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   });
 
   if (context.action === 'build') {
-    compiler.hooks.run.tap('rsbuild:run', () => {
+    // When there are multiple compilers, we only need to print the start log once
+    const firstCompiler = isMultiCompiler
+      ? (compiler as Rspack.MultiCompiler).compilers[0]
+      : compiler;
+    firstCompiler.hooks.run.tap('rsbuild:run', () => {
       logger.info('build started...');
       logRspackVersion();
     });


### PR DESCRIPTION
## Summary

Fix the issue of duplicate build start logs being printed when running `rsbuild build` and using the `environments` configuration.

<img width="613" alt="Screenshot 2025-07-07 at 12 54 05" src="https://github.com/user-attachments/assets/abc45d0d-8c9d-4b85-b7c3-def6bb6be826" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
