### PR TITLE
fix: improve formatting of minutes in build time

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -342,8 +342,19 @@ export const prettyTime = (seconds: number): string => {
     return `${format(seconds.toFixed(1))} s`;
   }
 
-  const minutes = seconds / 60;
-  return `${format(minutes.toFixed(2))} m`;
+  const minutes = Math.floor(seconds / 60);
+  const minutesLabel = `${format(minutes.toFixed(0))} m`;
+  const remainingSeconds = seconds % 60;
+
+  if (remainingSeconds === 0) {
+    return minutesLabel;
+  }
+
+  const secondsLabel = `${format(
+    remainingSeconds.toFixed(remainingSeconds % 1 === 0 ? 0 : 1),
+  )} s`;
+
+  return `${minutesLabel} ${secondsLabel}`;
 };
 
 /**

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -91,8 +91,10 @@ test('should pretty time correctly', () => {
   expect(prettyTime(0.1234)).toEqual('0.12 s');
   expect(prettyTime(1.234)).toEqual('1.23 s');
   expect(prettyTime(12.34)).toEqual('12.3 s');
-  expect(prettyTime(123.4)).toEqual('2.06 m');
-  expect(prettyTime(1234)).toEqual('20.57 m');
+  expect(prettyTime(120)).toEqual('2 m');
+  expect(prettyTime(123.4)).toEqual('2 m 3.4 s');
+  expect(prettyTime(1234)).toEqual('20 m 34 s');
+  expect(prettyTime(1234.5)).toEqual('20 m 34.5 s');
 });
 
 describe('pick', () => {


### PR DESCRIPTION
## Summary

Updates the `prettyTime` function to improve how time is formatted for better readability and accuracy.

- before: `20.57 m`
- after: `20 m 34 s`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
