### PR TITLE
test: speed up UT by external `@rsbuild/core`

### DIFF
--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     // TODO: try to find closest tsconfig.json
     tsconfigPath: 'packages/core/tsconfig.json',
   },
+  output: {
+    externals: ['@rsbuild/core'],
+  },
   name: 'node',
   globals: true,
   restoreMocks: true,


### PR DESCRIPTION
## Summary

test: speed up UT by external `@rsbuild/core`.

`@rsbuild/core` has already been built, so there is no need to build it again in test.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
