### PR TITLE
docs: add note on missing core-js polyfills

### DIFF
--- a/website/docs/en/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/en/guide/advanced/browser-compatibility.mdx
@@ -148,7 +148,7 @@ export default {
 
 See [source.include](/config/source/include) for detailed usage.
 
-## Polyfill mode
+## Polyfills
 
 Rsbuild compiles JavaScript code using SWC and supports injecting polyfills such as [core-js](https://github.com/zloirock/core-js) and [@swc/helpers](https://npmjs.com/package/@swc/helpers).
 
@@ -231,3 +231,11 @@ export default {
   },
 };
 ```
+
+### Missing polyfills
+
+It should be noted that core-js cannot provide polyfills for all JavaScript APIs. Some APIs cannot be fully simulated through polyfills due to the complexity of their underlying implementation or performance considerations.
+
+The most typical example is the `Proxy` object. Since `Proxy` requires engine-level support to implement object operation interception, its behavior cannot be fully simulated through pure JavaScript code, so core-js does not provide a polyfill for `Proxy`.
+
+See [core-js - Missing polyfills](https://github.com/zloirock/core-js?tab=readme-ov-file#missing-polyfills) to understand which APIs core-js cannot provide polyfills for.

--- a/website/docs/zh/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/zh/guide/advanced/browser-compatibility.mdx
@@ -148,7 +148,7 @@ export default {
 
 查看 [source.include](/config/source/include) 文档来了解更详细的用法。
 
-## Polyfill 方案
+## Polyfills
 
 Rsbuild 通过 SWC 编译 JavaScript 代码，并支持注入 [core-js](https://github.com/zloirock/core-js)、[@swc/helpers](https://npmjs.com/package/@swc/helpers) 等 polyfills。
 
@@ -231,3 +231,11 @@ export default {
   },
 };
 ```
+
+### 缺少的 polyfill
+
+需要注意的是，core-js 并不能提供所有 JavaScript API 的 polyfill。有一些 API 由于其底层实现的复杂性或者性能考虑，是无法通过 polyfill 来完全模拟的。
+
+最典型的例子是 `Proxy` 对象。由于 `Proxy` 需要引擎级别的支持来实现对象操作的拦截，无法通过纯 JavaScript 代码来完全模拟其行为，因此 core-js 并不提供 `Proxy` 的 polyfill。
+
+请查看 [core-js - Missing polyfills](https://github.com/zloirock/core-js?tab=readme-ov-file#missing-polyfills) 来了解 core-js 无法提供哪些 API 的 polyfill。


### PR DESCRIPTION
## Summary

Improve clarity and provide additional information about missing core-js polyfills.

## Related Links

- https://github.com/zloirock/core-js?tab=readme-ov-file#missing-polyfills

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
