### PR TITLE
fix: Use `hostname` to determine local or network

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -399,8 +399,8 @@ const NETWORK_LABEL = 'Network:  ';
 
 const getUrlLabel = (url: string) => {
   try {
-    const { host } = new URL(url);
-    return isLoopbackHost(host) ? LOCAL_LABEL : NETWORK_LABEL;
+    const { hostname } = new URL(url);
+    return isLoopbackHost(hostname) ? LOCAL_LABEL : NETWORK_LABEL;
   } catch {
     return NETWORK_LABEL;
   }


### PR DESCRIPTION
## Summary

## Related Links

Use `hostname` to determine local or network

<img width="451" alt="image" src="https://github.com/user-attachments/assets/dd86e815-3620-42d1-b329-2630eb5d76a2" />

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
