### PR TITLE
fix: update Node.js engine requirement to >=16.17.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,7 @@
     "ws": "^8.18.3"
   },
   "engines": {
-    "node": ">=16.10.0"
+    "node": ">=16.17.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Update Node.js engine requirement to >=16.17.0 to allow using `import { constants } from 'node:fs/promises';`

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/5566
- https://github.com/sindresorhus/open/blob/main/index.js#L7
- https://nodejs.org/api/fs.html#fspromisesconstants


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
