### PR TITLE
docs: add note on Node.js 16 support

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -32,6 +32,10 @@ nvm install --lts
 nvm use --lts
 ```
 
+:::tip
+Node.js 16 will no longer be supported by Rsbuild ≥ 1.5.
+:::
+
 ## Create an Rsbuild application
 
 Use [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) to create a new Rsbuild application. Run the following command:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -32,6 +32,10 @@ nvm install --lts
 nvm use --lts
 ```
 
+:::tip
+Rsbuild >= 1.5 将不再支持 Node.js 16。
+:::
+
 ## 创建 Rsbuild 应用
 
 使用 [create-rsbuild](https://www.npmjs.com/package/create-rsbuild) 来创建一个 Rsbuild 应用，运行以下命令：


### PR DESCRIPTION
## Summary

This pull request updates the documentation for Rsbuild's quick start guide to inform users about the upcoming deprecation of Node.js 16 in Rsbuild v1.5 and later.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
