### PR TITLE
fix: patch open to maintaining Node 16.10 compatibility

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -101,7 +101,7 @@
     "ws": "^8.18.3"
   },
   "engines": {
-    "node": ">=16.17.0"
+    "node": ">=16.10.0"
   },
   "publishConfig": {
     "access": "public",

--- a/patches/open@10.1.2.patch
+++ b/patches/open@10.1.2.patch
@@ -1,0 +1,14 @@
+diff --git a/index.js b/index.js
+index 6b55785fc17441f784da3681d3a5234d9eb97290..560a78112ddd8ae6f26f914de55a10a540a61f7b 100644
+--- a/index.js
++++ b/index.js
+@@ -4,7 +4,8 @@ import path from 'node:path';
+ import {fileURLToPath} from 'node:url';
+ import util from 'node:util';
+ import childProcess from 'node:child_process';
+-import fs, {constants as fsConstants} from 'node:fs/promises';
++import fs from 'node:fs/promises';
++import {constants as fsConstants} from 'node:fs';
+ import isWsl from 'is-wsl';
+ import defineLazyProperty from 'define-lazy-prop';
+ import defaultBrowser from 'default-browser';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ patchedDependencies:
   http-proxy@1.18.1:
     hash: 424b689da454f1f336d635615733f30568882789c1173f861c30f95ba8b05723
     path: patches/http-proxy@1.18.1.patch
+  open@10.1.2:
+    hash: 0c2b5a73ded8138281dec15e6b97b8c9671e376ffe1946f5c9294489ca6a4a96
+    path: patches/open@10.1.2.patch
   postcss-loader@8.1.1:
     hash: 7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47
     path: patches/postcss-loader@8.1.1.patch
@@ -680,7 +683,7 @@ importers:
         version: 2.4.1
       open:
         specifier: ^10.1.2
-        version: 10.1.2
+        version: 10.1.2(patch_hash=0c2b5a73ded8138281dec15e6b97b8c9671e376ffe1946f5c9294489ca6a4a96)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -8176,7 +8179,7 @@ snapshots:
       fs-extra: 11.3.0
       json-cycle: 1.5.0
       lodash: 4.17.21
-      open: 10.1.2
+      open: 10.1.2(patch_hash=0c2b5a73ded8138281dec15e6b97b8c9671e376ffe1946f5c9294489ca6a4a96)
       sirv: 2.0.4
       socket.io: 4.8.1
       source-map: 0.7.4
@@ -11684,7 +11687,7 @@ snapshots:
 
   only@0.0.2: {}
 
-  open@10.1.2:
+  open@10.1.2(patch_hash=0c2b5a73ded8138281dec15e6b97b8c9671e376ffe1946f5c9294489ca6a4a96):
     dependencies:
       default-browser: 5.2.1
       define-lazy-prop: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,20 +1,22 @@
 packages:
-  - 'website'
-  - 'e2e/**'
-  - 'scripts/**'
-  - 'packages/**'
-  - 'examples/**'
+  - website
+  - e2e/**
+  - scripts/**
+  - packages/**
+  - examples/**
   - '!**/compiled/**'
   - '!**/dist-types/**'
   - '!**/create-rsbuild/template-*/**'
   - '!**/test-temp-*/**'
 
+hoistPattern: []
+
 patchedDependencies:
-  'css-loader@7.1.2': 'patches/css-loader@7.1.2.patch'
-  'file-loader': 'patches/file-loader@6.2.0.patch'
-  'http-proxy@1.18.1': 'patches/http-proxy@1.18.1.patch'
-  'postcss-loader@8.1.1': 'patches/postcss-loader@8.1.1.patch'
-  'url-loader': 'patches/url-loader@4.1.1.patch'
+  css-loader@7.1.2: patches/css-loader@7.1.2.patch
+  file-loader: patches/file-loader@6.2.0.patch
+  http-proxy@1.18.1: patches/http-proxy@1.18.1.patch
+  postcss-loader@8.1.1: patches/postcss-loader@8.1.1.patch
+  url-loader: patches/url-loader@4.1.1.patch
+  open@10.1.2: patches/open@10.1.2.patch
 
 strictPeerDependencies: false
-hoistPattern: []


### PR DESCRIPTION
## Summary

- Revert "fix: update Node.js engine requirement to >=16.17.0 (https://github.com/web-infra-dev/rsbuild/pull/5567)
- patch open to maintaining Node < 16.17 compatibility

## Related Links

https://github.com/web-infra-dev/rsbuild/issues/5566#issuecomment-3051920591

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
