### PR TITLE
chore(cache): change cache enabled message to debug log

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
-import { color, findExists, hash, isFileExists } from '../helpers';
+import { findExists, hash, isFileExists } from '../helpers';
 import { logger } from '../logger';
 import type {
   BuildCacheOptions,
@@ -177,11 +177,8 @@ export const pluginCache = (): RsbuildPlugin => ({
     });
 
     api.onAfterCreateCompiler(() => {
-      // Tell user that the cache is enabled and it's experimental
       if (cacheEnabled && api.context.bundlerType === 'rspack') {
-        logger.info(
-          `Rspack persistent cache enabled ${color.dim('(experimental)')}`,
-        );
+        logger.debug('Rspack persistent cache enabled');
       }
     });
   },


### PR DESCRIPTION
## Summary

Updated the log level to `debug` for the message indicating that Rspack persistent cache is enabled, since the Rspack persistent cache is now more stable.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
