### PR TITLE
fix(create-rsbuild): update ESLint config in React templates

### DIFF
--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -67,7 +67,7 @@ rspackOnlyTest(
       },
     );
     expect(pkgJson.devDependencies.eslint).toBeTruthy();
-    expect(pkgJson.devDependencies['eslint-plugin-react']).toBeTruthy();
+    expect(pkgJson.devDependencies['eslint-plugin-react-hooks']).toBeTruthy();
     expect(existsSync(join(dir, 'eslint.config.mjs'))).toBeTruthy();
     await clean();
   },

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -29,7 +29,7 @@
     "bump": "npx bumpp --no-tag"
   },
   "dependencies": {
-    "create-rstack": "1.5.2"
+    "create-rstack": "1.5.4"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,8 +742,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.5.2
-        version: 1.5.2
+        specifier: 1.5.4
+        version: 1.5.4
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3752,8 +3752,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.5.2:
-    resolution: {integrity: sha512-z8F7Rnl7j8IDbDHWYn5K1KWkXZkELFEBfmCs1P2xbbeWCbnUhI7a988WOxCu7p0pPK4e+iqJnGGTTmCMqT0UiA==}
+  create-rstack@1.5.4:
+    resolution: {integrity: sha512-f5zD531v4rO0BePPoDJOTH9QqatGO27wdq29KL+leQun8vK19qU8GhGukNnFHCTas674SjTUADaDYSfEH7OXiw==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9733,7 +9733,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  create-rstack@1.5.2: {}
+  create-rstack@1.5.4: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

Update `create-rstack` to v1.5.4 to update the default ESLint config in React templates.

## Related Links

https://github.com/rspack-contrib/create-rstack/releases/tag/v1.5.4

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
