### PR TITLE
feat: export `HtmlTag` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,6 +71,7 @@ export type {
   HtmlConfig,
   HtmlFallback,
   HtmlRspackPlugin,
+  HtmlTag,
   HtmlTagContext,
   HtmlTagDescriptor,
   HtmlTagHandler,


### PR DESCRIPTION
## Summary

Export the `HtmlTag` type from '@rsbuild/core'.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
