### PR TITLE
fix(types): type error when importing SVG file with React query

### DIFF
--- a/packages/create-rsbuild/template-react-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react-ts/src/env.d.ts
@@ -4,5 +4,4 @@ declare module "*.svg?react" {
   import React from "react";
   const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
-  export { ReactComponent };
 }

--- a/packages/create-rsbuild/template-react-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react-ts/src/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="@rsbuild/core/types" />
+
+declare module "*.svg?react" {
+  import React from "react";
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+  export { ReactComponent };
+}

--- a/packages/create-rsbuild/template-react18-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react18-ts/src/env.d.ts
@@ -4,5 +4,4 @@ declare module "*.svg?react" {
   import React from "react";
   const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   export default ReactComponent;
-  export { ReactComponent };
 }

--- a/packages/create-rsbuild/template-react18-ts/src/env.d.ts
+++ b/packages/create-rsbuild/template-react18-ts/src/env.d.ts
@@ -1,1 +1,8 @@
 /// <reference types="@rsbuild/core/types" />
+
+declare module "*.svg?react" {
+  import React from "react";
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+  export { ReactComponent };
+}


### PR DESCRIPTION
## Summary

Before

<img width="1926" height="878" alt="3fe95f57ce0bd3382afc64e4d2c26f4f" src="https://github.com/user-attachments/assets/05872b4e-d3e5-4168-8e86-0c955f53d834" />

After

<img width="2000" height="820" alt="fdecce2522b6d9b56bb37d417fde7f14" src="https://github.com/user-attachments/assets/56f81ea5-ff5b-4302-aafb-4c72db8e3d34" />


type declaration should go in template project since `rsbuild/core` doesn't depend on React
