### PR TITLE
docs: add section on vite-tsconfig-paths support

### DIFF
--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -254,6 +254,12 @@ for (const path of context.keys()) {
 }
 ```
 
+## vite-tsconfig-paths
+
+Rsbuild supports TypeScript's `paths` option as alias out of the box, so you can remove the `vite-tsconfig-paths` dependency directly.
+
+See [Path aliases](/guide/advanced/alias) for more details.
+
 ## Migrating Vite plugins
 
 Rsbuild's plugin API covers most of the Vite and Rollup plugin hooks, for example:

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -254,6 +254,12 @@ for (const path of context.keys()) {
 }
 ```
 
+## vite-tsconfig-paths
+
+Rsbuild 开箱即用地支持 TypeScript 的 `paths` 选项作为 alias 别名，因此你可以直接移除 `vite-tsconfig-paths` 依赖。
+
+参考 [路径别名](/guide/advanced/alias) 来了解更多。
+
 ## 迁移 Vite 插件
 
 Rsbuild 的插件 API 覆盖了大部分的 Vite 和 Rollup 插件 hooks，例如：


### PR DESCRIPTION
## Summary

Provide information about Rsbuild's built-in support for TypeScript path aliases and the removal of the `vite-tsconfig-paths` dependency.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
