### PR TITLE
fix(cli): increase arrow spacing

### DIFF
--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -27,7 +27,7 @@ rspackOnlyTest('should display shortcuts as expected in dev', async () => {
   logs = [];
   devProcess.stdin?.write('u\n');
   await expectPoll(() =>
-    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
+    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
   ).toBeTruthy();
 
   // restart server
@@ -37,7 +37,7 @@ rspackOnlyTest('should display shortcuts as expected in dev', async () => {
     logs.some((log) => log.includes('restarting server')),
   ).toBeTruthy();
   await expectPoll(() =>
-    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
+    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
   ).toBeTruthy();
 
   devProcess.kill();
@@ -68,7 +68,7 @@ rspackOnlyTest('should display shortcuts as expected in preview', async () => {
   logs = [];
   devProcess.stdin?.write('u\n');
   await expectPoll(() =>
-    logs.some((log) => log.includes('➜ Local:    http://localhost:')),
+    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
   ).toBeTruthy();
 
   devProcess.kill();

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -266,7 +266,7 @@ test('should print server urls when HTML is disabled but printUrls is a custom f
   });
 
   const localLog = rsbuild.logs.find((log) =>
-    log.includes(`➜ Local:    http://localhost:${rsbuild.port}`),
+    log.includes(`➜  Local:    http://localhost:${rsbuild.port}`),
   );
 
   expect(localLog).toBeTruthy();

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -74,8 +74,8 @@ export async function setupCliShortcuts({
   if (help) {
     logger.log(
       help === true
-        ? `  ➜ ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`
-        : `  ➜ ${help}\n`,
+        ? `  ➜  ${color.dim('press')} ${color.bold('h + enter')} ${color.dim('to show shortcuts')}\n`
+        : `  ➜  ${help}\n`,
     );
   }
 

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -146,7 +146,7 @@ function getURLMessages(
     return urls
       .map(({ label, url }) => {
         const normalizedPathname = normalizeUrl(`${url}${pathname}`);
-        const prefix = `➜ ${color.dim(label.padEnd(10))}`;
+        const prefix = `➜  ${color.dim(label.padEnd(10))}`;
         return `  ${prefix}${color.cyan(normalizedPathname)}\n`;
       })
       .join('');
@@ -158,7 +158,7 @@ function getURLMessages(
     if (index > 0) {
       message += '\n';
     }
-    message += `  ${`➜ ${label}`}\n`;
+    message += `  ${`➜  ${label}`}\n`;
 
     for (const r of routes) {
       message += `  ${color.dim('-')} ${color.dim(

--- a/packages/core/tests/server.test.ts
+++ b/packages/core/tests/server.test.ts
@@ -185,8 +185,8 @@ test('printServerURLs', () => {
   });
 
   expect(message!).toMatchInlineSnapshot(`
-    "  ➜ local     http://localhost:3000/
-      ➜ network   http://192.168.0.1:3000/
+    "  ➜  local     http://localhost:3000/
+      ➜  network   http://192.168.0.1:3000/
     "
   `);
 
@@ -220,12 +220,12 @@ test('printServerURLs', () => {
   });
 
   expect(message!).toMatchInlineSnapshot(`
-    "  ➜ local
+    "  ➜  local
       - index    http://localhost:3000/
       - foo      http://localhost:3000/html/foo
       - bar      http://localhost:3000/bar
 
-      ➜ network
+      ➜  network
       - index    http://192.168.0.1:3000/
       - foo      http://192.168.0.1:3000/html/foo
       - bar      http://192.168.0.1:3000/bar


### PR DESCRIPTION
## Summary

When I run the project locally, the arrows and prompts are a bit tight, this should be a problem in windows environment, it behaves well in mac.

But I found that vite doesn't have this kind of problem, I checked the source code and found that they use two spaces, I don't know if it's adopted or not, I'll create a PR first, I hope to cause disturbance.

https://github.com/vitejs/vite/blob/6bc8bf634d4a2c9915da9813963dd80a4186daeb/packages/vite/src/node/logger.ts#L176

before：


| windows powershell  | windows wsl |
|--------------|--------------|
| <img width="109" height="227" alt="image" src="https://github.com/user-attachments/assets/b824f823-6a1d-4738-81fb-8374b0d90814" /> | <img width="155" height="224" alt="image" src="https://github.com/user-attachments/assets/5534198f-621e-4e4c-95de-694d235f7700" /> |


after：
<img width="146" height="132" alt="image" src="https://github.com/user-attachments/assets/d7117b14-b1b7-492c-99ab-79cf19656e4d" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
