### PR TITLE
chore(plugin-vue): rm unused webpack deps

### DIFF
--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -28,8 +28,7 @@
     "bump": "npx bumpp --no-tag"
   },
   "dependencies": {
-    "vue-loader": "^17.4.2",
-    "webpack": "^5.99.9"
+    "vue-loader": "^17.4.2"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
@@ -37,8 +36,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.16.4",
     "typescript": "^5.8.3",
-    "vue": "^3.5.17",
-    "webpack": "^5.99.9"
+    "vue": "^3.5.17"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1102,9 +1102,6 @@ importers:
       vue-loader:
         specifier: ^17.4.2
         version: 17.4.2(vue@3.5.17(typescript@5.8.3))(webpack@5.99.9)
-      webpack:
-        specifier: ^5.99.9
-        version: 5.99.9
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
It looks like webpack is not used, and the product will not change after deleting it.

Or it seems that only one is enough, and there is no need to use both.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
