### PR TITLE
docs: add example for migrating config hook

### DIFF
--- a/website/docs/en/guide/migration/cra.mdx
+++ b/website/docs/en/guide/migration/cra.mdx
@@ -136,7 +136,7 @@ export default {
 
 Please refer to the [SVGR plugin](/plugins/list/plugin-svgr) documentation to learn how to use SVGR in Rsbuild.
 
-## Configuration migration
+## Config migration
 
 Here is the corresponding Rsbuild configuration for [CRA configuration](https://create-react-app.dev/docs/advanced-configuration/):
 

--- a/website/docs/en/guide/migration/modern-builder.mdx
+++ b/website/docs/en/guide/migration/modern-builder.mdx
@@ -109,7 +109,7 @@ export default {
 
 If you are a user of other frameworks, you can refer to [Rsbuild Plugin List](/plugins/list/index) to select the corresponding framework plugin.
 
-## Configuration migration
+## Config migration
 
 Most configs in Rsbuild and Builder are consistent, with only a few adjustments.
 

--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -27,3 +27,44 @@ Rsbuild's plugin API covers most of the Vite and Rollup plugin hooks, for exampl
 | `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml), [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags)                       |
 
 See [Plugin system](/plugins/dev/index) for more details.
+
+## Update config
+
+Rsbuild and Vite provide different configuration options. When migrating Vite plugins, you need to adjust them according to Rsbuild's configuration options.
+
+For example, replace Vite's `define` option with Rsbuild's [source.define](/config/source/define) option.
+
+- Vite plugin:
+
+```ts title="vite.config.ts"
+const vitePlugin = {
+  name: 'my-plugin',
+  config: (config) => {
+    config.define = {
+      ...config.define,
+      FOO: '"foo"',
+    };
+  },
+};
+```
+
+- Rsbuild plugin:
+
+```ts title="rsbuild.config.ts"
+const rsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.modifyRsbuildConfig((config) => {
+      config.source ||= {};
+      config.source.define = {
+        ...config.source.define,
+        FOO: '"foo"',
+      };
+    });
+  },
+};
+```
+
+:::tip
+See [Config migration](/guide/migration/vite#config-migration) to learn how to migrate Vite configurations to Rsbuild.
+:::

--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -28,7 +28,7 @@ Rsbuild's plugin API covers most of the Vite and Rollup plugin hooks, for exampl
 
 See [Plugin system](/plugins/dev/index) for more details.
 
-## Update config
+## `config` hook
 
 Rsbuild and Vite provide different configuration options. When migrating Vite plugins, you need to adjust them according to Rsbuild's configuration options.
 

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -100,7 +100,7 @@ Most common Vite plugins can be easily migrated to Rsbuild plugins, such as:
 
 You can refer to [Plugin List](/plugins/list/index) to learn more about available plugins.
 
-## Configuration migration
+## Config migration
 
 Here is the corresponding Rsbuild configuration for Vite configuration:
 

--- a/website/docs/en/guide/migration/vue-cli.mdx
+++ b/website/docs/en/guide/migration/vue-cli.mdx
@@ -86,7 +86,7 @@ In the HTML template, if you are using the `BASE_URL` variable from Vue CLI, rep
 
 This completes the basic migration from Vue CLI to Rsbuild. You can now run the `npm run serve` command to try starting the dev server.
 
-## Configuration migration
+## Config migration
 
 Here is the corresponding Rsbuild configuration for Vue CLI configuration:
 

--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -45,7 +45,7 @@ export default defineConfig({
 
 > See [Configure Rsbuild](/guide/configuration/rsbuild) for more.
 
-## Configuration migration
+## Config migration
 
 In a webpack project, there might be some complex `webpack.config.js` configuration files.
 

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -27,3 +27,44 @@ Rsbuild 的插件 API 覆盖了大部分的 Vite 和 Rollup 插件 hooks，例�
 | `transformIndexHtml` | [modifyHTML](/plugins/dev/hooks#modifyhtml), [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags)                       |
 
 请参考 [插件系统](/plugins/dev/index) 文档来了解更多。
+
+## 修改配置
+
+Rsbuild 与 Vite 提供了不同的配置项，在迁移 Vite 插件时，需要根据 Rsbuild 的配置项进行调整。
+
+例如，将 Vite 的 `define` 选项替换为 Rsbuild 的 [source.define](/config/source/define) 选项。
+
+- Vite 插件：
+
+```ts title="vite.config.ts"
+const vitePlugin = {
+  name: 'my-plugin',
+  config: (config) => {
+    config.define = {
+      ...config.define,
+      FOO: '"foo"',
+    };
+  },
+};
+```
+
+- Rsbuild 插件：
+
+```ts title="rsbuild.config.ts"
+const rsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.modifyRsbuildConfig((config) => {
+      config.source ||= {};
+      config.source.define = {
+        ...config.source.define,
+        FOO: '"foo"',
+      };
+    });
+  },
+};
+```
+
+:::tip
+查看 [配置迁移](/guide/migration/vite#配置迁移) 了解如何将 Vite 的配置迁移到 Rsbuild。
+:::

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -28,7 +28,7 @@ Rsbuild 的插件 API 覆盖了大部分的 Vite 和 Rollup 插件 hooks，例�
 
 请参考 [插件系统](/plugins/dev/index) 文档来了解更多。
 
-## 修改配置
+## `config` 钩子
 
 Rsbuild 与 Vite 提供了不同的配置项，在迁移 Vite 插件时，需要根据 Rsbuild 的配置项进行调整。
 


### PR DESCRIPTION
## Summary

This pull request updates the migration guides to provide an example to guide users in migrating the `config` hook to Rsbuild.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
