### PR TITLE
docs: add example for migrating HTML hook

### DIFF
--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -36,7 +36,7 @@ For example, replace Vite's `define` option with Rsbuild's [source.define](/conf
 
 - Vite plugin:
 
-```ts title="vite.config.ts"
+```ts title="vitePlugin.ts"
 const vitePlugin = {
   name: 'my-plugin',
   config: (config) => {
@@ -50,7 +50,7 @@ const vitePlugin = {
 
 - Rsbuild plugin:
 
-```ts title="rsbuild.config.ts"
+```ts title="rsbuildPlugin.ts"
 const rsbuildPlugin = {
   name: 'my-plugin',
   setup(api) {
@@ -68,3 +68,44 @@ const rsbuildPlugin = {
 :::tip
 See [Config migration](/guide/migration/vite#config-migration) to learn how to migrate Vite configurations to Rsbuild.
 :::
+
+## `transformIndexHtml` hook
+
+Vite's `transformIndexHtml` hook corresponds to two hooks in Rsbuild:
+
+- [modifyHTML](/plugins/dev/hooks#modifyhtml): for modifying HTML content
+- [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags): for modifying HTML tags
+
+Here's an example of replacing the HTML title.
+
+- Vite Plugin:
+
+```js title="vitePlugin.ts"
+const htmlPlugin = () => {
+  return {
+    name: 'html-plugin',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<title>(.*?)<\/title>/,
+        `<title>Title replaced!</title>`,
+      );
+    },
+  };
+};
+```
+
+- Rsbuild Plugin:
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = {
+  name: 'html-plugin',
+  setup(api) {
+    api.modifyHTML((html) => {
+      return html.replace(
+        /<title>(.*?)<\/title>/,
+        `<title>Title replaced!</title>`,
+      );
+    });
+  },
+};
+```

--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -80,7 +80,7 @@ Here's an example of replacing the HTML title.
 
 - Vite Plugin:
 
-```js title="vitePlugin.ts"
+```ts title="vitePlugin.ts"
 const htmlPlugin = () => {
   return {
     name: 'html-plugin',

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -80,7 +80,7 @@ Vite 的 `transformIndexHtml` 钩子对应了 Rsbuild 的两个钩子：
 
 - Vite 插件：
 
-```js title="vitePlugin.ts"
+```ts title="vitePlugin.ts"
 const htmlPlugin = () => {
   return {
     name: 'html-plugin',

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -36,7 +36,7 @@ Rsbuild 与 Vite 提供了不同的配置项，在迁移 Vite 插件时，需要
 
 - Vite 插件：
 
-```ts title="vite.config.ts"
+```ts title="vitePlugin.ts"
 const vitePlugin = {
   name: 'my-plugin',
   config: (config) => {
@@ -50,7 +50,7 @@ const vitePlugin = {
 
 - Rsbuild 插件：
 
-```ts title="rsbuild.config.ts"
+```ts title="rsbuildPlugin.ts"
 const rsbuildPlugin = {
   name: 'my-plugin',
   setup(api) {
@@ -68,3 +68,44 @@ const rsbuildPlugin = {
 :::tip
 查看 [配置迁移](/guide/migration/vite#配置迁移) 了解如何将 Vite 的配置迁移到 Rsbuild。
 :::
+
+## `transformIndexHtml` 钩子
+
+Vite 的 `transformIndexHtml` 钩子对应了 Rsbuild 的两个钩子：
+
+- [modifyHTML](/plugins/dev/hooks#modifyhtml)：用于修改 HTML 内容
+- [modifyHTMLTags](/plugins/dev/hooks#modifyhtmltags)：用于修改 HTML 标签
+
+下面一个是替换 HTML 标题的示例。
+
+- Vite 插件：
+
+```js title="vitePlugin.ts"
+const htmlPlugin = () => {
+  return {
+    name: 'html-plugin',
+    transformIndexHtml(html) {
+      return html.replace(
+        /<title>(.*?)<\/title>/,
+        `<title>Title replaced!</title>`,
+      );
+    },
+  };
+};
+```
+
+- Rsbuild 插件：
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = {
+  name: 'html-plugin',
+  setup(api) {
+    api.modifyHTML((html) => {
+      return html.replace(
+        /<title>(.*?)<\/title>/,
+        `<title>Title replaced!</title>`,
+      );
+    });
+  },
+};
+```


### PR DESCRIPTION
## Summary

This pull request updates the migration guides to provide an example to guide users in migrating the `transformIndexHtml` hook to Rsbuild plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
