### PR TITLE
docs: add example for migrating configureServer hook

### DIFF
--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -109,3 +109,35 @@ const rsbuildPlugin = {
   },
 };
 ```
+
+## `configureServer` hook
+
+Rsbuild provides the `onBeforeStartDevServer` hook to replace Vite's `configureServer` hook, which allows you to get the dev server instance and add custom middleware.
+
+- Vite plugin:
+
+```ts title="vitePlugin.ts"
+const vitePlugin = () => ({
+  name: 'setup-middleware',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      // custom handle request...
+    });
+  },
+});
+```
+
+- Rsbuild plugin:
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = {
+  name: 'setup-middleware',
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      server.middlewares.use((req, res, next) => {
+        // custom handle request...
+      });
+    });
+  },
+};
+```

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -109,3 +109,35 @@ const rsbuildPlugin = {
   },
 };
 ```
+
+## `configureServer` 钩子
+
+Rsbuild 提供了 `onBeforeStartDevServer` 钩子来替代 Vite 的 `configureServer` 钩子，它允许你获取 dev server 实例和添加自定义的中间件。
+
+- Vite 插件：
+
+```ts title="vitePlugin.ts"
+const vitePlugin = () => ({
+  name: 'setup-middleware',
+  configureServer(server) {
+    server.middlewares.use((req, res, next) => {
+      // custom handle request...
+    });
+  },
+});
+```
+
+- Rsbuild 插件：
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = {
+  name: 'setup-middleware',
+  setup(api) {
+    api.onBeforeStartDevServer(({ server }) => {
+      server.middlewares.use((req, res, next) => {
+        // custom handle request...
+      });
+    });
+  },
+};
+```


### PR DESCRIPTION
## Summary

This pull request updates the migration guides to provide an example to guide users in migrating the `configureServer` hook to Rsbuild plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
