### PR TITLE
docs: add section on defining Rsbuild plugins

### DIFF
--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -9,6 +9,34 @@ Before migrating a Vite plugin, it is recommended to check if there is a corresp
 - [Rsbuild official plugins](/plugins/list)
 - [Rsbuild community plugins](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins)
 
+## Define a plugin
+
+Rsbuild plugin is defined in a way similar to Vite, usually a function that accepts plugin options as a parameter and returns a plugin description object.
+
+The main difference is that Vite's hooks are defined directly on the plugin description object, while Rsbuild's hooks are accessed and called through the `api` object.
+
+- Vite plugin:
+
+```ts title="vitePlugin.ts"
+const vitePlugin = (options) => ({
+  name: 'vite-plugin',
+  transform() {
+    // ...
+  },
+});
+```
+
+- Rsbuild plugin:
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = (options) => ({
+  name: 'rsbuild-plugin',
+  setup(api) {
+    api.transform((code, id) => {
+  },
+});
+```
+
 ## Plugin hooks
 
 Rsbuild's plugin API covers most of the Vite and Rollup plugin hooks, for example:

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -9,6 +9,34 @@
 - [Rsbuild 官方插件](/plugins/list)
 - [Rsbuild 社区插件](https://github.com/web-infra-dev/awesome-rspack?tab=readme-ov-file#rsbuild-plugins)
 
+## 定义一个插件
+
+Rsbuild 插件的定义方式与 Vite 相似，通常都是一个接收插件选项作为参数的函数，并返回插件的描述对象。
+
+两者的主要区别在于：Vite 的 hooks 直接定义在插件描述对象上，而 Rsbuild 的 hooks 是通过 `api` 对象来访问和调用。
+
+- Vite 插件：
+
+```ts title="vitePlugin.ts"
+const vitePlugin = (options) => ({
+  name: 'vite-plugin',
+  transform() {
+    // ...
+  },
+});
+```
+
+- Rsbuild 插件：
+
+```ts title="rsbuildPlugin.ts"
+const rsbuildPlugin = (options) => ({
+  name: 'rsbuild-plugin',
+  setup(api) {
+    api.transform((code, id) => {
+  },
+});
+```
+
 ## 插件 hooks
 
 Rsbuild 的插件 API 覆盖了大部分的 Vite 和 Rollup 插件 hooks，例如：


### PR DESCRIPTION
## Summary

Add a new section explaining how to define a plugin in Rsbuild and highlights the differences between Rsbuild and Vite plugin structure.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
