### PR TITLE
fix: wait until the last build is finished before calling `stats.toJson`

### DIFF
--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -161,6 +161,11 @@ export async function createDevServer<
   let waitLastCompileDone: Promise<void> = Promise.resolve();
 
   const resetWaitLastCompileDone = () => {
+    // Resolve the previous promise if it exists
+    if (waitLastCompileDoneResolve) {
+      waitLastCompileDoneResolve();
+      waitLastCompileDoneResolve = null;
+    }
     waitLastCompileDone = new Promise<void>((resolve) => {
       waitLastCompileDoneResolve = resolve;
     });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -189,10 +189,6 @@ export async function createDevServer<
       );
     }
 
-    compiler?.hooks.run.tap('rsbuild:run', () => {
-      resetWaitLastCompileDone();
-    });
-
     compiler?.hooks.watchRun.tap('rsbuild:watchRun', () => {
       resetWaitLastCompileDone();
     });

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -157,19 +157,17 @@ export async function createDevServer<
 
   let lastStats: Rspack.Stats[];
 
-  // should register onDevCompileDone hook before startCompile
-  const waitFirstCompileDone = runCompile
-    ? new Promise<void>((resolve) => {
-        context.hooks.onDevCompileDone.tap(({ stats, isFirstCompile }) => {
-          lastStats = 'stats' in stats ? stats.stats : [stats];
+  let waitLastCompileDoneResolve: (() => void) | null = null;
+  let waitLastCompileDone: Promise<void> = Promise.resolve();
 
-          if (!isFirstCompile) {
-            return;
-          }
-          resolve();
-        });
-      })
-    : Promise.resolve();
+  // should register onDevCompileDone hook before startCompile
+  context.hooks.onDevCompileDone.tap(({ stats }) => {
+    lastStats = 'stats' in stats ? stats.stats : [stats];
+    if (waitLastCompileDoneResolve) {
+      waitLastCompileDoneResolve();
+      waitLastCompileDoneResolve = null;
+    }
+  });
 
   const startCompile: () => Promise<CompilationManager> = async () => {
     const compiler = customCompiler || (await createCompiler());
@@ -179,6 +177,13 @@ export async function createDevServer<
         `${color.dim('[rsbuild:server]')} Failed to get compiler instance.`,
       );
     }
+
+    compiler.hooks.beforeCompile.tap('rsbuild:before', () => {
+      // reset waitLastCompileDone
+      waitLastCompileDone = new Promise<void>((resolve) => {
+        waitLastCompileDoneResolve = resolve;
+      });
+    });
 
     const publicPaths = isMultiCompiler(compiler)
       ? compiler.compilers.map(getPublicPathFromCompiler)
@@ -289,7 +294,7 @@ export async function createDevServer<
                   `${color.yellow('runCompile')} is false`,
               );
             }
-            await waitFirstCompileDone;
+            await waitLastCompileDone;
             return lastStats[environment.index];
           },
           context: environment,
@@ -301,7 +306,7 @@ export async function createDevServer<
                   `${color.yellow('runCompile')} is false`,
               );
             }
-            await waitFirstCompileDone;
+            await waitLastCompileDone;
             return cacheableLoadBundle(
               lastStats[environment.index],
               entryName,
@@ -319,7 +324,7 @@ export async function createDevServer<
                   `${color.yellow('runCompile')} is false`,
               );
             }
-            await waitFirstCompileDone;
+            await waitLastCompileDone;
             return cacheableTransformedHtml(
               lastStats[environment.index],
               entryName,

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -178,7 +178,7 @@ export async function createDevServer<
       );
     }
 
-    compiler.hooks.beforeCompile.tap('rsbuild:before', () => {
+    compiler.hooks.beforeCompile.tap('rsbuild:beforeCompile', () => {
       // reset waitLastCompileDone
       waitLastCompileDone = new Promise<void>((resolve) => {
         waitLastCompileDoneResolve = resolve;


### PR DESCRIPTION
## Summary

fix rspack panic when call `stats.toJson()`  during rebuild,  rsbuild should wait the last compile done when `loadBundle`. Because, in the next compilation rspack will clean up the old compilation, but `stats.toJson` read from the old compilation, so the panic happens.


## Related Links

https://github.com/web-infra-dev/rspack/issues/11005

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
