### PR TITLE
refactor: simplify plugin environment handling

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,5 +1,4 @@
 import { isFunction, isMultiCompiler } from './helpers';
-import { isEnvironmentMatch } from './pluginManager';
 import type {
   AsyncHook,
   EnvironmentAsyncHook,
@@ -84,9 +83,9 @@ export function createEnvironmentAsyncHook<
     for (const callback of callbacks) {
       // If this callback is not a global callback, the environment info should match
       if (
-        callback.environment &&
         environment &&
-        !isEnvironmentMatch(callback.environment, environment)
+        callback.environment &&
+        callback.environment !== environment
       ) {
         continue;
       }
@@ -114,9 +113,9 @@ export function createEnvironmentAsyncHook<
     for (const callback of callbacks) {
       // If this callback is not a global callback, the environment info should match
       if (
-        callback.environment &&
         environment &&
-        !isEnvironmentMatch(callback.environment, environment)
+        callback.environment &&
+        callback.environment !== environment
       ) {
         continue;
       }

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,5 +1,5 @@
 import { isFunction, isMultiCompiler } from './helpers';
-import { isPluginMatchEnvironment } from './pluginManager';
+import { isEnvironmentMatch } from './pluginManager';
 import type {
   AsyncHook,
   EnvironmentAsyncHook,
@@ -86,7 +86,7 @@ export function createEnvironmentAsyncHook<
       if (
         callback.environment &&
         environment &&
-        !isPluginMatchEnvironment(callback.environment, environment)
+        !isEnvironmentMatch(callback.environment, environment)
       ) {
         continue;
       }
@@ -116,7 +116,7 @@ export function createEnvironmentAsyncHook<
       if (
         callback.environment &&
         environment &&
-        !isPluginMatchEnvironment(callback.environment, environment)
+        !isEnvironmentMatch(callback.environment, environment)
       ) {
         continue;
       }

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -6,7 +6,7 @@ import { color, removeLeadingSlash } from './helpers';
 import { exitHook } from './helpers/exitHook';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import { logger } from './logger';
-import { isPluginMatchEnvironment } from './pluginManager';
+import { isEnvironmentMatch } from './pluginManager';
 import type {
   GetRsbuildConfig,
   InternalContext,
@@ -184,7 +184,7 @@ export function initPluginAPI({
         for (const { handler, environment: pluginEnvironment } of resolveFns) {
           if (
             pluginEnvironment &&
-            !isPluginMatchEnvironment(pluginEnvironment, environment.name)
+            !isEnvironmentMatch(pluginEnvironment, environment.name)
           ) {
             continue;
           }
@@ -229,7 +229,7 @@ export function initPluginAPI({
                 !descriptor.environments.includes(environment.name)) ||
               // the plugin is registered in a specific environment config
               (pluginEnvironment &&
-                !isPluginMatchEnvironment(pluginEnvironment, environment.name))
+                !isEnvironmentMatch(pluginEnvironment, environment.name))
             ) {
               continue;
             }

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -56,10 +56,17 @@ function validatePlugin(plugin: unknown) {
   );
 }
 
+/**
+ * Determines whether the two environments match.
+ * If the value is undefined, it means it can match any environment.
+ */
 export const isEnvironmentMatch = (
   environmentA?: string,
   environmentB?: string,
-): boolean => environmentA === environmentB && environmentA !== undefined;
+): boolean =>
+  environmentA === environmentB ||
+  environmentA === undefined ||
+  environmentB === undefined;
 
 export function createPluginManager(): PluginManager {
   let plugins: PluginMeta[] = [];
@@ -126,8 +133,10 @@ export function createPluginManager(): PluginManager {
 
   const getPlugins = (options: { environment?: string } = {}) => {
     return plugins
-      .filter((p) => isEnvironmentMatch(p.environment, options.environment))
-      .map((p) => p.instance);
+      .filter((plugin) =>
+        isEnvironmentMatch(plugin.environment, options.environment),
+      )
+      .map(({ instance }) => instance);
   };
 
   return {

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -1,8 +1,8 @@
 import { color, isFunction } from './helpers';
 import { logger } from './logger';
 import type {
+  AddPlugins,
   BundlerPluginInstance,
-  Falsy,
   PluginManager,
   PluginMeta,
   RsbuildPlugin,
@@ -64,10 +64,7 @@ export const isEnvironmentMatch = (
 export function createPluginManager(): PluginManager {
   let plugins: PluginMeta[] = [];
 
-  const addPlugins = (
-    newPlugins: Array<RsbuildPlugin | Falsy>,
-    options?: { before?: string; environment?: string },
-  ) => {
+  const addPlugins: AddPlugins = (newPlugins, options) => {
     const { before, environment } = options || {};
 
     for (const newPlugin of newPlugins) {

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -123,12 +123,10 @@ export function createPluginManager(): PluginManager {
     pluginName: string,
     options: { environment?: string } = {},
   ) =>
-    Boolean(
-      plugins.find(
-        (plugin) =>
-          plugin.instance.name === pluginName &&
-          isEnvironmentMatch(plugin.environment, options.environment),
-      ),
+    plugins.some(
+      (plugin) =>
+        plugin.instance.name === pluginName &&
+        isEnvironmentMatch(plugin.environment, options.environment),
     );
 
   const getPlugins = (options: { environment?: string } = {}) => {
@@ -242,9 +240,13 @@ export async function initPlugins({
     }
     if (environment) {
       removedEnvPlugins[environment] ??= new Set();
-      instance.remove.forEach(removedEnvPlugins[environment].add);
+      for (const item of instance.remove) {
+        removedEnvPlugins[environment].add(item);
+      }
     } else {
-      instance.remove.forEach(removedPlugins.add);
+      for (const item of instance.remove) {
+        removedPlugins.add(item);
+      }
     }
   }
 

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -242,9 +242,9 @@ export async function initPlugins({
     }
     if (environment) {
       removedEnvPlugins[environment] ??= new Set();
-      removedEnvPlugins[environment].add(instance.name);
+      instance.remove.forEach(removedEnvPlugins[environment].add);
     } else {
-      removedPlugins.add(instance.name);
+      instance.remove.forEach(removedPlugins.add);
     }
   }
 

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -247,14 +247,12 @@ export async function initPlugins({
 
   for (const { instance, environment } of plugins) {
     const { name, setup } = instance;
-
-    if (removedPlugins.has(name)) {
+    if (
+      removedPlugins.has(name) ||
+      (environment && removedEnvPlugins[environment]?.has(name))
+    ) {
       continue;
     }
-    if (environment && removedEnvPlugins[environment]?.has(name)) {
-      continue;
-    }
-
     await setup(getPluginAPI(environment));
   }
 

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -57,16 +57,14 @@ function validatePlugin(plugin: unknown) {
 }
 
 /**
- * Determines whether the two environments match.
- * If the value is undefined, it means it can match any environment.
+ * Determines whether the plugin is registered in the specified environment.
+ * If the pluginEnvironment is undefined, it means it can match any environment.
  */
 export const isEnvironmentMatch = (
-  environmentA?: string,
-  environmentB?: string,
+  pluginEnvironment?: string,
+  specifiedEnvironment?: string,
 ): boolean =>
-  environmentA === environmentB ||
-  environmentA === undefined ||
-  environmentB === undefined;
+  pluginEnvironment === specifiedEnvironment || pluginEnvironment === undefined;
 
 export function createPluginManager(): PluginManager {
   let plugins: PluginMeta[] = [];

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -56,11 +56,10 @@ function validatePlugin(plugin: unknown) {
   );
 }
 
-export const isPluginMatchEnvironment = (
-  pluginEnvironment: string | undefined,
-  currentEnvironment: string | undefined,
-): boolean =>
-  pluginEnvironment === currentEnvironment || pluginEnvironment === undefined;
+export const isEnvironmentMatch = (
+  environmentA?: string,
+  environmentB?: string,
+): boolean => environmentA === environmentB && environmentA !== undefined;
 
 export function createPluginManager(): PluginManager {
   let plugins: PluginMeta[] = [];
@@ -124,15 +123,13 @@ export function createPluginManager(): PluginManager {
       plugins.find(
         (plugin) =>
           plugin.instance.name === pluginName &&
-          isPluginMatchEnvironment(plugin.environment, options.environment),
+          isEnvironmentMatch(plugin.environment, options.environment),
       ),
     );
 
   const getPlugins = (options: { environment?: string } = {}) => {
     return plugins
-      .filter((p) =>
-        isPluginMatchEnvironment(p.environment, options.environment),
-      )
+      .filter((p) => isEnvironmentMatch(p.environment, options.environment))
       .map((p) => p.instance);
   };
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -39,7 +39,11 @@ import type {
   OnDevCompileDoneFn,
   OnExitFn,
 } from './hooks';
-import type { RsbuildInstance, RsbuildTarget } from './rsbuild';
+import type {
+  AddPluginsOptions,
+  RsbuildInstance,
+  RsbuildTarget,
+} from './rsbuild';
 import type { Rspack } from './rspack';
 import type { HtmlRspackPlugin } from './thirdParty';
 import type { Falsy, MaybePromise } from './utils';
@@ -178,11 +182,7 @@ export type ModifyWebpackConfigFn = (
 ) => Promise<WebpackConfig | void> | WebpackConfig | void;
 
 export type PluginMeta = {
-  /**
-   * Specify the environment that the plugin will be applied to.
-   * If not specified, the plugin will be applied to all environments.
-   */
-  environment?: string;
+  environment?: AddPluginsOptions['environment'];
   instance: RsbuildPlugin;
 };
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -178,7 +178,11 @@ export type ModifyWebpackConfigFn = (
 ) => Promise<WebpackConfig | void> | WebpackConfig | void;
 
 export type PluginMeta = {
-  environment: string;
+  /**
+   * Specify the environment that the plugin will be applied to.
+   * If not specified, the plugin will be applied to all environments.
+   */
+  environment?: string;
   instance: RsbuildPlugin;
 };
 

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -199,26 +199,31 @@ export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
     helpers: RsbuildProviderHelpers;
   }) => Promise<ProviderInstance<B>>;
 
+export type AddPluginsOptions = {
+  /**
+   * Insert before the specified plugin.
+   */
+  before?: string;
+  /**
+   * Specify the environment that the plugin will be applied to.
+   * If not specified, the plugin will be be registered as a global plugin and
+   * applied to all environments.
+   */
+  environment?: string;
+};
+
+export type AddPlugins = (
+  plugins: Array<RsbuildPlugin | Falsy>,
+  options?: AddPluginsOptions,
+) => void;
+
 export type RsbuildInstance = {
   /**
    * Register one or more Rsbuild plugins, which can be called multiple times.
    * This method needs to be called before compiling. If it is called after
    * compiling, it will not affect the compilation result.
    */
-  addPlugins: (
-    plugins: Array<RsbuildPlugin | Falsy>,
-    options?: {
-      /**
-       * Insert before the specified plugin.
-       */
-      before?: string;
-      /**
-       * Add a plugin for the specified environment.
-       * If environment is not specified, it will be registered as a global plugin (effective in all environments)
-       */
-      environment?: string;
-    },
-  ) => void;
+  addPlugins: AddPlugins;
   /**
    * Get all the Rsbuild plugins registered in the current Rsbuild instance.
    */


### PR DESCRIPTION
## Summary

Improve code readability and simplify plugin environment handling by removing the `RSBUILD_ALL_ENVIRONMENT_SYMBOL` variable.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
