### PR TITLE
feat: allow plugin to specify `apply` property

### DIFF
--- a/e2e/cases/plugin-api/plugin-apply/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-apply/index.test.ts
@@ -1,0 +1,34 @@
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should apply plugin as expected when running dev server',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
+
+    const body = page.locator('body');
+    await expect(body).toHaveText('serve-plugin');
+    await expect(body).not.toHaveText('build-plugin');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should apply plugin as expected when running build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+
+    const body = page.locator('body');
+    await expect(body).toHaveText('build-plugin');
+    await expect(body).not.toHaveText('serve-plugin');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/plugin-api/plugin-apply/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-apply/rsbuild.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
+
+const servePlugin: RsbuildPlugin = {
+  name: 'serve-plugin',
+  apply: 'serve',
+  setup(api) {
+    api.modifyHTML((html) => {
+      return html.replace('</div>', 'serve-plugin</div>');
+    });
+  },
+};
+
+const buildPlugin: RsbuildPlugin = {
+  name: 'build-plugin',
+  apply: 'build',
+  setup(api) {
+    api.modifyHTML((html) => {
+      return html.replace('</div>', 'build-plugin</div>');
+    });
+  },
+};
+
+export default defineConfig({
+  plugins: [servePlugin, buildPlugin],
+});

--- a/e2e/cases/plugin-api/plugin-apply/src/index.css
+++ b/e2e/cases/plugin-api/plugin-apply/src/index.css
@@ -1,0 +1,3 @@
+body {
+  color: red;
+}

--- a/e2e/cases/plugin-api/plugin-apply/src/index.js
+++ b/e2e/cases/plugin-api/plugin-apply/src/index.js
@@ -1,0 +1,3 @@
+import './index.css';
+
+console.log('hello');

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -234,7 +234,7 @@ export async function initRsbuildConfig({
   }
 
   await initPlugins({
-    getPluginAPI: context.getPluginAPI!,
+    context,
     pluginManager,
   });
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -194,6 +194,8 @@ export type PluginManager = Pick<
   getAllPluginsWithMeta: () => PluginMeta[];
 };
 
+export type RsbuildPluginApply = 'serve' | 'build';
+
 /**
  * The type of the Rsbuild plugin object.
  */
@@ -202,6 +204,13 @@ export type RsbuildPlugin = {
    * The name of the plugin, a unique identifier.
    */
   name: string;
+  /**
+   * Conditional apply the plugin during serve or build.
+   * - `'serve'`: Apply the plugin when starting the dev server or preview server.
+   * - `'build'`: Apply the plugin during build.
+   * - If not specified, the plugin will be applied during both serve and build.
+   */
+  apply?: RsbuildPluginApply;
   /**
    * The setup function of the plugin, which can be an async function.
    * This function is called once when the plugin is initialized.

--- a/packages/core/tests/pluginStore.test.ts
+++ b/packages/core/tests/pluginStore.test.ts
@@ -1,4 +1,4 @@
-import type { RsbuildPluginAPI } from '../src';
+import type { InternalContext, RsbuildPluginAPI } from '../src';
 import { createPluginManager, initPlugins } from '../src/pluginManager';
 
 describe('initPlugins', () => {
@@ -37,7 +37,9 @@ describe('initPlugins', () => {
 
     await initPlugins({
       pluginManager,
-      getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      context: {
+        getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      } as InternalContext,
     });
 
     expect(result).toEqual([2, 0, 3, 1]);
@@ -71,7 +73,9 @@ describe('initPlugins', () => {
 
     await initPlugins({
       pluginManager,
-      getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      context: {
+        getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      } as InternalContext,
     });
 
     expect(result).toEqual([0, 2]);
@@ -122,7 +126,9 @@ describe('initPlugins', () => {
 
     await initPlugins({
       pluginManager,
-      getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      context: {
+        getPluginAPI: () => ({}) as RsbuildPluginAPI,
+      } as InternalContext,
     });
 
     expect(result).toEqual([0, 2]);


### PR DESCRIPTION
## Summary

Allow plugin to specify the `apply` property:

- `'serve'`: Apply the plugin when starting the dev server or preview server.
- `'build'`: Apply the plugin during build.

If not specified, the plugin will be applied during both serve and build.

```ts
const servePlugin: RsbuildPlugin = {
  name: 'serve-plugin',
  apply: 'serve',
  setup(api) {
    // ...
  },
};
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
