### PR TITLE
fix: failed to call `getStats` before the first build is finished

### DIFF
--- a/e2e/cases/javascript-api/get-stats/index.test.ts
+++ b/e2e/cases/javascript-api/get-stats/index.test.ts
@@ -1,0 +1,30 @@
+import { rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import { createRsbuild } from '@rsbuild/core';
+
+rspackOnlyTest(
+  'should allow to call `getStats` to get stats after creating dev server',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+      rsbuildConfig: {
+        environments: {
+          node: {
+            output: {
+              target: 'node',
+            },
+          },
+        },
+      },
+    });
+
+    const server = await rsbuild.createDevServer();
+    const stats = await server.environments.node.getStats();
+    expect(
+      typeof stats.toJson({
+        all: false,
+      }),
+    ).toBe('object');
+    await server.close();
+  },
+);

--- a/e2e/cases/javascript-api/get-stats/src/index.js
+++ b/e2e/cases/javascript-api/get-stats/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -158,9 +158,16 @@ export async function createDevServer<
   let lastStats: Rspack.Stats[];
 
   let waitLastCompileDoneResolve: (() => void) | null = null;
-  let waitLastCompileDone: Promise<void> = Promise.resolve();
+  let waitLastCompileDone = new Promise<void>((resolve) => {
+    waitLastCompileDoneResolve = resolve;
+  });
 
   const resetWaitLastCompileDone = () => {
+    // No need to reset if lastStats is not set
+    if (!lastStats) {
+      return;
+    }
+
     // Resolve the previous promise if it exists
     if (waitLastCompileDoneResolve) {
       waitLastCompileDoneResolve();


### PR DESCRIPTION
## Summary

Fix failed to call `getStats` before the first build is finished, the `waitLastCompileDone` should be a pending Promise by default.

## Related Links

- https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/16360607946/job/46227603075
- https://github.com/web-infra-dev/rsbuild/pull/5615

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
