### PR TITLE
docs: standardize terminology for environment variables

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -116,7 +116,7 @@ function applyEnvsToConfig(config: RsbuildConfig, envs: LoadEnvResult | null) {
     return;
   }
 
-  // define the public env variables
+  // define the public environment variables
   config.source ||= {};
   config.source.define = {
     ...envs.publicVars,

--- a/packages/core/src/loadEnv.ts
+++ b/packages/core/src/loadEnv.ts
@@ -81,7 +81,7 @@ export type LoadEnvOptions = {
 
 export type LoadEnvResult = {
   /**
-   * All env variables in the .env file
+   * All environment variables in the .env file
    */
   parsed: Record<string, string>;
   /**
@@ -89,7 +89,7 @@ export type LoadEnvResult = {
    */
   filePaths: string[];
   /**
-   * Env variables that start with prefixes.
+   * Environment variables that start with prefixes.
    *
    * @example
    * ```ts
@@ -100,7 +100,7 @@ export type LoadEnvResult = {
    **/
   rawPublicVars: Record<string, string | undefined>;
   /**
-   * Formatted env variables that start with prefixes.
+   * Formatted environment variables that start with prefixes.
    * The keys contain the prefixes `process.env.*` and `import.meta.env.*`.
    * The values are processed by `JSON.stringify`.
    *
@@ -114,7 +114,7 @@ export type LoadEnvResult = {
    **/
   publicVars: Record<string, string>;
   /**
-   * Clear the env variables mounted on `process.env`
+   * Clear the environment variables mounted on `process.env`
    */
   cleanup: () => void;
 };

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -152,7 +152,7 @@ export type CreateRsbuildOptions = {
    */
   rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
   /**
-   * Whether to call `loadEnv` to load env variables and define them
+   * Whether to call `loadEnv` to load environment variables and define them
    * as global variables via `source.define`.
    * @default false
    */

--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -43,7 +43,7 @@ type CreateRsbuildOptions = {
 - `cwd`: The root path of the current build, defaults to `process.cwd()`.
 - `callerName`: The name of the framework or tool that is currently invoking Rsbuild, defaults to `'rsbuild'`, see [Specify caller name](#specify-caller-name).
 - `environment`: Only build specified [environments](/guide/advanced/environments). If not specified or passing an empty array, all environments will be built.
-- `loadEnv`：Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load env variables and define them as global variables via [source.define](/config/source/define).
+- `loadEnv`：Whether to call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables and define them as global variables via [source.define](/config/source/define).
 - `rsbuildConfig`: Rsbuild configuration object. Refer to [Configuration Overview](/config/) for all available configuration options.
 
 ### Load configuration async
@@ -62,9 +62,9 @@ const rsbuild = await createRsbuild({
 });
 ```
 
-### Load env variables
+### Load environment variables
 
-The `loadEnv` option in `createRsbuild` helps you call the [loadEnv](/api/javascript-api/core#loadenv) method to load env variables:
+The `loadEnv` option in `createRsbuild` helps you call the [loadEnv](/api/javascript-api/core#loadenv) method to load environment variables:
 
 ```ts
 const rsbuild = await createRsbuild({
@@ -74,7 +74,7 @@ const rsbuild = await createRsbuild({
 
 Passing `loadEnv: true` will automatically complete the following steps:
 
-1. Call the `loadEnv` method to load env variables.
+1. Call the `loadEnv` method to load environment variables.
 2. Add [source.define](/config/source/define) configuration, define the `publicVars` returned by `loadEnv` as global variables.
 3. Watch the `.env` file for changes, and restart the dev server when the file changes, and invalidate the build cache.
 4. Automatically call the `cleanup` method returned by `loadEnv` when closing the build or dev server.
@@ -227,12 +227,12 @@ type LoadEnvOptions = {
 };
 
 type LoadEnvResult = {
-  /** All env variables in the .env file */
+  /** All environment variables in the .env file */
   parsed: Record<string, string>;
   /** The absolute paths to all env files */
   filePaths: string[];
   /**
-   * Env variables that start with prefixes.
+   * Environment variables that start with prefixes.
    *
    * @example
    * ```ts
@@ -243,7 +243,7 @@ type LoadEnvResult = {
    **/
   rawPublicVars: Record<string, string | undefined>;
   /**
-   * Formatted env variables that start with prefixes.
+   * Formatted environment variables that start with prefixes.
    * The keys contain the prefixes `process.env.*` and `import.meta.env.*`.
    * The values are processed by `JSON.stringify`.
    *
@@ -256,7 +256,7 @@ type LoadEnvResult = {
    * ```
    **/
   publicVars: Record<string, string>;
-  /** Clear the env variables mounted on `process.env` */
+  /** Clear the environment variables mounted on `process.env` */
   cleanup: () => void;
 };
 

--- a/website/docs/en/config/server/open.mdx
+++ b/website/docs/en/config/server/open.mdx
@@ -155,7 +155,7 @@ For example:
 BROWSER="Google Chrome Canary" npx rsbuild dev
 ```
 
-### Configure env variable
+### Configure environment variable
 
 You can set the `BROWSER` environment variable in the local [.env.local](/guide/advanced/env-vars#env-file) file, so you don't need to manually set the environment variable every time you start the dev server, and it also avoids affecting other developers in the project.
 

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -1,14 +1,14 @@
-# Env variables
+# Environment variables
 
-Rsbuild supports injecting env variables or expressions into the code during build, which is helpful for distinguishing the running environment or replacing constants.
+Rsbuild supports injecting environment variables or expressions into the code during build, which is helpful for distinguishing the running environment or replacing constants.
 
-This chapter introduces how to use env variables in Rsbuild.
+This chapter introduces how to use environment variables in Rsbuild.
 
 ## Default variables
 
-Rsbuild by default injects the some env variables into the code using [source.define](#using-define). These will be replaced with specified values during the build:
+Rsbuild by default injects the some environment variables into the code using [source.define](#using-define). These will be replaced with specified values during the build:
 
-`import.meta.env` contains these env variables:
+`import.meta.env` contains these environment variables:
 
 - [import.meta.env.MODE](#importmetaenvmode)
 - [import.meta.env.DEV](#importmetaenvdev)
@@ -16,7 +16,7 @@ Rsbuild by default injects the some env variables into the code using [source.de
 - [import.meta.env.BASE_URL](#importmetaenvbase_url)
 - [import.meta.env.ASSET_PREFIX](#importmetaenvasset_prefix)
 
-`process.env` contains these env variables:
+`process.env` contains these environment variables:
 
 - [process.env.BASE_URL](#processenvbase_url)
 - [process.env.ASSET_PREFIX](#processenvasset_prefix)
@@ -156,7 +156,7 @@ For example, in the HTML template, you can use `process.env.ASSET_PREFIX` to con
 
 ### process.env.NODE_ENV
 
-By default, Rsbuild will automatically set the `process.env.NODE_ENV` env variable to `'development'` in development mode and `'production'` in production mode.
+By default, Rsbuild will automatically set the `process.env.NODE_ENV` environment variable to `'development'` in development mode and `'production'` in production mode.
 
 You can use `process.env.NODE_ENV` directly in Node.js and in the client code.
 
@@ -198,9 +198,9 @@ export default {
 
 ## `.env` File
 
-When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these env variables and add them to the current Node.js process. The [Public Variables](#public-variables) will be exposed in the client code.
+When a `.env` file exists in the project root directory, Rsbuild CLI will automatically use [dotenv](https://npmjs.com/package/dotenv) to load these environment variables and add them to the current Node.js process. The [Public Variables](#public-variables) will be exposed in the client code.
 
-You can access these env variables through `import.meta.env.[name]` or `process.env.[name]`.
+You can access these environment variables through `import.meta.env.[name]` or `process.env.[name]`.
 
 ### File types
 
@@ -227,7 +227,7 @@ For example, set the env mode as `test`:
 npx rsbuild dev --env-mode test
 ```
 
-Rsbuild will read these files in the following order and merge their contents. If the same env variable is defined in multiple files, values from files loaded later will override those from files loaded earlier:
+Rsbuild will read these files in the following order and merge their contents. If the same environment variable is defined in multiple files, values from files loaded later will override those from files loaded earlier:
 
 - .env
 - .env.local
@@ -262,7 +262,7 @@ FOO=hello
 BAR=1
 ```
 
-Then in the `rsbuild.config.ts` file, you can access the above env variables using `import.meta.env.[name]` or `process.env.[name]`:
+Then in the `rsbuild.config.ts` file, you can access the above environment variables using `import.meta.env.[name]` or `process.env.[name]`:
 
 ```ts title="rsbuild.config.ts"
 console.log(import.meta.env.FOO); // 'hello'
@@ -287,7 +287,7 @@ console.log(process.env.BAR); // '2'
 
 ### Manually load env
 
-If you are not using the Rsbuild CLI and are using the Rsbuild [JavaScript API](/api/start/index) instead, you will need to manually call the [loadEnv](/api/javascript-api/core#loadenv) method to read env variables and inject them into the code via the [source.define](/config/source/define) config.
+If you are not using the Rsbuild CLI and are using the Rsbuild [JavaScript API](/api/start/index) instead, you will need to manually call the [loadEnv](/api/javascript-api/core#loadenv) method to read environment variables and inject them into the code via the [source.define](/config/source/define) config.
 
 ```ts
 import { loadEnv, mergeRsbuildConfig } from '@rsbuild/core';
@@ -313,18 +313,18 @@ You can disable loading `.env` files by using the `--no-env` flag in the CLI.
 npx rsbuild dev --no-env
 ```
 
-When using the `--no-env` flag, Rsbuild CLI will not read any `.env` files, and you can manage env variables using other tools like [dotenvx](https://dotenvx.com/).
+When using the `--no-env` flag, Rsbuild CLI will not read any `.env` files, and you can manage environment variables using other tools like [dotenvx](https://dotenvx.com/).
 
 ## Public variables
 
-All env variables starting with `PUBLIC_` can be accessed in client code. For example, if the following variables are defined:
+All environment variables starting with `PUBLIC_` can be accessed in client code. For example, if the following variables are defined:
 
 ```bash title=".env"
 PUBLIC_NAME=jack
 PASSWORD=123
 ```
 
-In the client code, you can access these env variables through `import.meta.env.PUBLIC_*` or `process.env.PUBLIC_*`. Rsbuild will match the identifiers and replace them with the corresponding values.
+In the client code, you can access these environment variables through `import.meta.env.PUBLIC_*` or `process.env.PUBLIC_*`. Rsbuild will match the identifiers and replace them with the corresponding values.
 
 ```ts title="src/index.ts"
 console.log(import.meta.env.PUBLIC_NAME); // -> 'jack'
@@ -358,9 +358,9 @@ Note that public variables will not replace identifiers in the following files:
 
 ### Custom prefix
 
-Rsbuild provides the [loadEnv](/api/javascript-api/core#loadenv) method, which can inject env variables with any prefix into client code.
+Rsbuild provides the [loadEnv](/api/javascript-api/core#loadenv) method, which can inject environment variables with any prefix into client code.
 
-For example, when migrating a Create React App project to Rsbuild, you can read env variables starting with `REACT_APP_` and inject them through the [source.define](/config/source/define) config as follows:
+For example, when migrating a Create React App project to Rsbuild, you can read environment variables starting with `REACT_APP_` and inject them through the [source.define](/config/source/define) config as follows:
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig, loadEnv } from '@rsbuild/core';
@@ -378,13 +378,13 @@ export default defineConfig({
 
 By using [source.define](/config/source/define), you can replace global identifiers with some expressions or values in compile time.
 
-`define` is similar to the macro definition capabilities provided by other languages. It is often used to inject env variables and other information to the code during build time.
+`define` is similar to the macro definition capabilities provided by other languages. It is often used to inject environment variables and other information to the code during build time.
 
 ### Replace identifiers
 
 The most basic use case for `define` is to replace global identifiers in compile time.
 
-The value of the env variable `NODE_ENV` will change the behavior of many vendor packages. Usually, we need to set it to `production`.
+The value of the environment variable `NODE_ENV` will change the behavior of many vendor packages. Usually, we need to set it to `production`.
 
 ```js
 export default {
@@ -403,7 +403,7 @@ Similarly `{ foo: "bar" }` should be converted to `"{\"foo\":\"bar\"}"`, which i
 For more about `source.define`, just refer to [API References](/config/source/define).
 
 :::tip
-The env variable `NODE_ENV` shown in the example above is already injected by the Rsbuild, and you usually do not need to configure it manually.
+The environment variable `NODE_ENV` shown in the example above is already injected by the Rsbuild, and you usually do not need to configure it manually.
 :::
 
 ### Identifiers matching
@@ -447,16 +447,16 @@ export default {
 
 If the above usage is adopted, the following problems will be caused:
 
-1. Some unused env variables are additionally injected, causing the env variables of the dev server to be leaked into the front-end code.
-2. As each `process.env` code will be replaced by a complete env variable object, the bundle size of the front-end code will increase and the performance will decrease.
+1. Some unused environment variables are additionally injected, causing the environment variables of the dev server to be leaked into the front-end code.
+2. As each `process.env` code will be replaced by a complete environment variable object, the bundle size of the front-end code will increase and the performance will decrease.
 
-Therefore, please inject the env variables on `process.env` according to actual needs and avoid replacing them in its entirety.
+Therefore, please inject the environment variables on `process.env` according to actual needs and avoid replacing them in its entirety.
 
 ## Type declarations
 
 ### Public variables
 
-When you access a public env variable in a TypeScript file, TypeScript may prompt that the variable lacks a type definition, and you need to add the corresponding type declaration.
+When you access a public environment variable in a TypeScript file, TypeScript may prompt that the variable lacks a type definition, and you need to add the corresponding type declaration.
 
 For example, if you reference a `PUBLIC_FOO` variable, the following prompt will appear in the TypeScript file:
 
@@ -478,7 +478,7 @@ Rsbuild provides default TypeScript type definitions for `import.meta.env` throu
 /// <reference types="@rsbuild/core/types" />
 ```
 
-If you have customized env variables starting with `import.meta.env`, you can extend the `ImportMetaEnv` interface:
+If you have customized environment variables starting with `import.meta.env`, you can extend the `ImportMetaEnv` interface:
 
 ```ts title="src/env.d.ts"
 interface ImportMetaEnv {
@@ -538,7 +538,7 @@ const App = () => {
 };
 ```
 
-Specifying the env variable `LANGUAGE=zh` and then running build will eliminate the dead code.
+Specifying the environment variable `LANGUAGE=zh` and then running build will eliminate the dead code.
 
 ```js
 const App = () => {

--- a/website/docs/en/guide/basic/typescript.mdx
+++ b/website/docs/en/guide/basic/typescript.mdx
@@ -52,6 +52,8 @@ You can create a `src/env.d.ts` file to reference it:
 /// <reference types="@rsbuild/core/types" />
 ```
 
+> See [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) for the complete preset type definitions provided by Rsbuild.
+
 ## Type checking
 
 When transpiling TypeScript code using tools like SWC and Babel, type checking is not performed.

--- a/website/docs/en/guide/debug/rsdoctor.mdx
+++ b/website/docs/en/guide/debug/rsdoctor.mdx
@@ -16,7 +16,7 @@ import { PackageManagerTabs } from '@theme';
 
 <PackageManagerTabs command="add @rsdoctor/rspack-plugin -D" />
 
-2. Add `RSDOCTOR=true` env variable before the CLI command:
+2. Add `RSDOCTOR=true` environment variable before the CLI command:
 
 ```json title="package.json"
 {

--- a/website/docs/en/guide/migration/cra.mdx
+++ b/website/docs/en/guide/migration/cra.mdx
@@ -174,7 +174,7 @@ export default {
 };
 ```
 
-## Env variables
+## Environment variables
 
 CRA injects environment variables starting with `REACT_APP_` into the client code by default, while Rsbuild injects environment variables starting with `PUBLIC_` by default (see [public variables](/guide/advanced/env-vars#public-variables)).
 

--- a/website/docs/zh/guide/basic/typescript.mdx
+++ b/website/docs/zh/guide/basic/typescript.mdx
@@ -52,6 +52,8 @@ export type { SomeType } from './types';
 /// <reference types="@rsbuild/core/types" />
 ```
 
+> 参考 [types.d.ts](https://github.com/web-infra-dev/rsbuild/blob/main/packages/core/types.d.ts) 来了解 Rsbuild 提供的完整预设类型定义。
+
 ## 类型检查
 
 在进行 TypeScript 转译时，SWC 和 Babel 等工具不会执行类型检查。


### PR DESCRIPTION
## Summary

- Standardizes the terminology across the codebase and documentation by replacing "env variables" with "environment variables."
- Added a reference to the complete preset type definitions.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
