### PR TITLE
feat: allow control of type safety for import.meta.env

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -1,10 +1,27 @@
 /// <reference types="@rspack/core/module" />
 
 /**
+ * This is a placeholder for extending the type options.
+ * You can augment this interface to enable stricter type checking.
+ * @example
+ * ```ts
+ * interface RsbuildTypeOptions {
+ *   // This will enable strict type checking for `import.meta.env`.
+ *   strictImportMetaEnv: true;
+ * }
+ * ```
+ */
+// biome-ignore lint/suspicious/noEmptyInterface: placeholder
+interface RsbuildTypeOptions {}
+
+/**
  * import.meta
  */
+type ImportMetaEnvFallbackKey =
+  'strictImportMetaEnv' extends keyof RsbuildTypeOptions ? never : string;
+
 interface ImportMetaEnv {
-  [key: string]: any;
+  [key: ImportMetaEnvFallbackKey]: any;
   /**
    * The value of the `mode` configuration.
    * @example

--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -491,6 +491,20 @@ interface ImportMeta {
 }
 ```
 
+By default, Rsbuild's preset types allow you to access any property on `import.meta.env` without causing TypeScript type errors.
+
+For stricter type safety, you can enable the `strictImportMetaEnv` option by extending the `RsbuildTypeOptions` interface. When this option is enabled, only properties predefined by Rsbuild or explicitly declared in your project can be accessed. Accessing any other property will result in a TypeScript type error.
+
+You can add the following code to your `src/env.d.ts` file:
+
+```ts title="src/env.d.ts"
+/// <reference types="@rsbuild/core/types" />
+
+interface RsbuildTypeOptions {
+  strictImportMetaEnv: true;
+}
+```
+
 ### process.env
 
 If the type for `process.env` is missing, please install the dependency [@types/node](https://npmjs.com/package/@types/node):

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -493,6 +493,20 @@ interface ImportMeta {
 }
 ```
 
+默认情况下，Rsbuild 预设的类型允许你访问 `import.meta.env` 上的任何属性，而不会出现 TypeScript 类型错误。
+
+如果希望获得更严格的类型安全，你可以通过扩展 `RsbuildTypeOptions` interface 来开启 `strictImportMetaEnv` 选项。开启后，只有 Rsbuild 预定义或你在项目中明确声明的属性才能被访问，访问其他属性会导致 TypeScript 类型错误。
+
+你可以在 `src/env.d.ts` 文件中添加以下代码：
+
+```ts title="src/env.d.ts"
+/// <reference types="@rsbuild/core/types" />
+
+interface RsbuildTypeOptions {
+  strictImportMetaEnv: true;
+}
+```
+
 ### process.env
 
 如果缺少 `process.env` 的类型，请安装 [@types/node](https://npmjs.com/package/@types/node) 依赖：


### PR DESCRIPTION
## Summary

Added a new `strictImportMetaEnv` type option to allow control of type safety for `import.meta.env`.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/5617

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
