### PR TITLE
fix: adjust when lazy compilation can be applied

### DIFF
--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -4,9 +4,11 @@ import type { RsbuildPlugin } from '../types';
 export const pluginLazyCompilation = (): RsbuildPlugin => ({
   name: 'rsbuild:lazy-compilation',
 
+  apply: 'serve',
+
   setup(api) {
-    api.modifyBundlerChain((chain, { environment, isProd, target }) => {
-      if (isProd || target !== 'web') {
+    api.modifyBundlerChain((chain, { environment, target }) => {
+      if (target !== 'web') {
         return;
       }
 


### PR DESCRIPTION
## Summary

Adjust when the lazy compilation plugin can be applied. Lazy compilation is always available when the dev server is started, not when `mode` is `development`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
