### PR TITLE
feat(plugin): introduce `order` property for transform hook

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-order/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-order/index.test.ts
@@ -1,0 +1,14 @@
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow plugin to specify the execution order via `order`',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+
+    const indexJs = await rsbuild.getIndexFile();
+    expect(indexJs.content).toContain('with order: pre');
+  },
+);

--- a/e2e/cases/plugin-api/plugin-transform-order/myPlugin.ts
+++ b/e2e/cases/plugin-api/plugin-transform-order/myPlugin.ts
@@ -1,0 +1,14 @@
+import type { RsbuildPlugin } from '@rsbuild/core';
+
+export const myPlugin: RsbuildPlugin = {
+  name: 'my-plugin',
+  setup(api) {
+    api.transform({ test: /\.js$/ }, ({ code }) => {
+      return code.replace('__placeholder__', 'without order');
+    });
+
+    api.transform({ test: /\.js$/, order: 'pre' }, ({ code }) => {
+      return code.replace('__placeholder__', 'with order: pre');
+    });
+  },
+};

--- a/e2e/cases/plugin-api/plugin-transform-order/rsbuild.config.ts
+++ b/e2e/cases/plugin-api/plugin-transform-order/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { myPlugin } from './myPlugin';
+
+export default defineConfig({
+  plugins: [myPlugin],
+});

--- a/e2e/cases/plugin-api/plugin-transform-order/src/index.js
+++ b/e2e/cases/plugin-api/plugin-transform-order/src/index.js
@@ -1,0 +1,1 @@
+console.log('__placeholder__');

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -301,7 +301,10 @@ export function initPluginAPI({
           if (descriptor.mimetype) {
             rule.mimetype(descriptor.mimetype);
           }
-          if (descriptor.enforce) {
+
+          if (descriptor.order && descriptor.order !== 'default') {
+            rule.enforce(descriptor.order);
+          } else if (descriptor.enforce) {
             rule.enforce(descriptor.enforce);
           }
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -393,6 +393,11 @@ export type TransformDescriptor = {
    */
   mimetype?: Rspack.RuleSetCondition;
   /**
+   * An alias for `order` property.
+   * @deprecated Use `order` instead.
+   */
+  enforce?: 'pre' | 'post';
+  /**
    * Specifies the execution order of the transform function.
    * - When specified as 'pre', the transform function will execute before other
    * transform functions (or Rspack loaders).
@@ -400,7 +405,7 @@ export type TransformDescriptor = {
    * transform functions (or Rspack loaders).
    * @see https://rspack.rs/config/module#ruleenforce
    */
-  enforce?: 'pre' | 'post';
+  order?: HookOrder;
 };
 
 export type TransformHook = (

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -283,7 +283,7 @@ type TransformDescriptor = {
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
   mimetype?: RuleSetCondition;
-  enforce?: 'pre' | 'post';
+  order?: 'pre' | 'post' | 'default';
 };
 ```
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -281,7 +281,7 @@ type TransformDescriptor = {
   issuerLayer?: string;
   with?: Record<string, RuleSetCondition>;
   mimetype?: RuleSetCondition;
-  enforce?: 'pre' | 'post';
+  order?: 'pre' | 'post' | 'default';
 };
 ```
 


### PR DESCRIPTION
## Summary

Introduce a new `order` property for the `api.transform()` hook and deprecate the previous `enforce` property.

This change is to ensure that Rsbuild plugins can uniformly use the `order` property to control the execution order of hooks.

## Related Links

- https://rsbuild.rs/plugins/dev/hooks#callback-order

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
