### PR TITLE
docs: add example for migrating configEnvironment hook

### DIFF
--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -99,6 +99,42 @@ const rsbuildPlugin = {
 See [Config migration](/guide/migration/vite#config-migration) to learn how to migrate Vite configurations to Rsbuild.
 :::
 
+## `configEnvironment` hook
+
+Rsbuild provides the [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig) hook to modify the configuration of a specific environment.
+
+- Vite plugin:
+
+```ts
+const vitePlugin = {
+  name: 'config-environment',
+  config: (name, config) => {
+    if (name === 'web') {
+      config.resolve.alias = {
+        // ...
+      };
+    }
+  },
+};
+```
+
+- Rsbuild plugin:
+
+```js
+const rsbuildPlugin = {
+  name: 'config-environment',
+  setup(api) {
+    api.modifyEnvironmentConfig((config, { name }) => {
+      if (name === 'web') {
+        config.resolve.alias = {
+          // ...
+        };
+      }
+    });
+  },
+};
+```
+
 ## `configResolved` hook
 
 Rsbuild provides the [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) method to get the resolved configuration. This method serves a similar purpose to Vite's `configResolved` hook.

--- a/website/docs/en/guide/migration/vite-plugin.mdx
+++ b/website/docs/en/guide/migration/vite-plugin.mdx
@@ -108,7 +108,7 @@ Rsbuild provides the [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironm
 ```ts
 const vitePlugin = {
   name: 'config-environment',
-  config: (name, config) => {
+  configEnvironment(name, config) {
     if (name === 'web') {
       config.resolve.alias = {
         // ...

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -99,6 +99,42 @@ const rsbuildPlugin = {
 查看 [配置迁移](/guide/migration/vite#配置迁移) 了解如何将 Vite 的配置迁移到 Rsbuild。
 :::
 
+## `configEnvironment` 钩子
+
+Rsbuild 提供了 [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig) 钩子来修改特定 environment 的配置。
+
+- Vite 插件：
+
+```ts
+const vitePlugin = {
+  name: 'config-environment',
+  config: (name, config) => {
+    if (name === 'web') {
+      config.resolve.alias = {
+        // ...
+      };
+    }
+  },
+};
+```
+
+- Rsbuild 插件：
+
+```js
+const rsbuildPlugin = {
+  name: 'config-environment',
+  setup(api) {
+    api.modifyEnvironmentConfig((config, { name }) => {
+      if (name === 'web') {
+        config.resolve.alias = {
+          // ...
+        };
+      }
+    });
+  },
+};
+```
+
 ## `configResolved` 钩子
 
 Rsbuild 提供了 [api.getNormalizedConfig](/plugins/dev/core#apigetnormalizedconfig) 方法来获取已解析的配置。这个方法与 Vite 的 `configResolved` 钩子的使用场景类似。

--- a/website/docs/zh/guide/migration/vite-plugin.mdx
+++ b/website/docs/zh/guide/migration/vite-plugin.mdx
@@ -108,7 +108,7 @@ Rsbuild 提供了 [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironment
 ```ts
 const vitePlugin = {
   name: 'config-environment',
-  config: (name, config) => {
+  configEnvironment(name, config) {
     if (name === 'web') {
       config.resolve.alias = {
         // ...


### PR DESCRIPTION
## Summary

This pull request updates the migration guides to provide an example to guide users in migrating the `configEnvironment` hook to Rsbuild plugin.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
