### PR TITLE
docs: add Rstest to callerName section

### DIFF
--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -101,6 +101,7 @@ Here are some tools based on Rsbuild that have already set the `callerName` valu
 | Name                                                | callerName  |
 | --------------------------------------------------- | ----------- |
 | [Rslib](https://github.com/web-infra-dev/rslib)     | `'rslib'`   |
+| [Rstest](https://github.com/web-infra-dev/rstest)   | `'rstest'`  |
 | [Rspress](https://github.com/web-infra-dev/rspress) | `'rspress'` |
 | [Rspeedy](https://lynxjs.org/rspeedy)               | `'rspeedy'` |
 

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -101,6 +101,7 @@ export const myPlugin = {
 | 名称                                                | callerName  |
 | --------------------------------------------------- | ----------- |
 | [Rslib](https://github.com/web-infra-dev/rslib)     | `'rslib'`   |
+| [Rstest](https://github.com/web-infra-dev/rstest)   | `'rstest'`  |
 | [Rspress](https://github.com/web-infra-dev/rspress) | `'rspress'` |
 | [Rspeedy](https://lynxjs.org/rspeedy)               | `'rspeedy'` |
 


### PR DESCRIPTION
## Summary

Updates the documentation by adding Rstest to the list of tools that already set the `callerName` value.

## Related Links

- https://github.com/web-infra-dev/rstest/pull/407

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
