### PR TITLE
feat(plugin): support for the `enforce` property

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -218,11 +218,23 @@ export type RsbuildPlugin = {
    */
   setup: (api: RsbuildPluginAPI) => MaybePromise<void>;
   /**
+   * Specifies the execution order of the plugin.
+   * - `'pre'`: Execute the plugin before other plugins.
+   * - `'post'`: Execute the plugin after other plugins.
+   * - If not specified, the plugin will execute in the order they were registered.
+   *
+   * This affects the order in which hooks are registered, but if a hook specifies
+   * an `order` property, the `order` takes higher precedence.
+   */
+  enforce?: 'pre' | 'post';
+  /**
    * Declare the names of pre-plugins, which will be executed before the current plugin.
+   * This has higher precedence than the `enforce` property.
    */
   pre?: string[];
   /**
    * Declare the names of post-plugins, which will be executed after the current plugin.
+   * This has higher precedence than the `enforce` property.
    */
   post?: string[];
   /**

--- a/packages/core/tests/pluginDependencies.test.ts
+++ b/packages/core/tests/pluginDependencies.test.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPlugin } from '../src';
-import { pluginDagSort } from '../src/pluginManager';
+import { sortPluginsByDependencies } from '../src/pluginManager';
 
-describe('sort plugins', () => {
+describe('sort plugins by dependencies', () => {
   it('should verify each plugin', () => {
     const cases = [
       { name: '1' },
@@ -12,7 +12,7 @@ describe('sort plugins', () => {
       { name: '6', pre: [], post: [] },
     ] as RsbuildPlugin[];
 
-    const result = pluginDagSort(
+    const result = sortPluginsByDependencies(
       cases.map((c) => ({
         instance: c,
         environment: '',
@@ -63,7 +63,7 @@ describe('sort plugins', () => {
       { name: '4' },
     ] as RsbuildPlugin[];
 
-    const result = pluginDagSort(
+    const result = sortPluginsByDependencies(
       cases.map((c) => ({
         instance: c,
         environment: '',
@@ -90,7 +90,7 @@ describe('sort plugins', () => {
       { name: undefined },
     ] as RsbuildPlugin[];
 
-    const result = pluginDagSort(
+    const result = sortPluginsByDependencies(
       cases.map((c) => ({
         instance: c,
         environment: '',
@@ -132,7 +132,7 @@ describe('sort plugins', () => {
     ] as RsbuildPlugin[];
 
     expect(() => {
-      pluginDagSort(
+      sortPluginsByDependencies(
         cases.map((c) => ({
           instance: c,
           environment: '',

--- a/packages/core/tests/pluginEnforce.test.ts
+++ b/packages/core/tests/pluginEnforce.test.ts
@@ -1,0 +1,61 @@
+import type { RsbuildPlugin } from '../src';
+import { sortPluginsByEnforce } from '../src/pluginManager';
+
+describe('sort plugins by enforce', () => {
+  it('should sort plugins with different enforce values', () => {
+    const plugins: RsbuildPlugin[] = [
+      { name: 'normal-1', setup: () => {} },
+      { name: 'post-1', setup: () => {}, enforce: 'post' },
+      { name: 'pre-1', setup: () => {}, enforce: 'pre' },
+      { name: 'normal-2', setup: () => {} },
+      { name: 'pre-2', setup: () => {}, enforce: 'pre' },
+      { name: 'post-2', setup: () => {}, enforce: 'post' },
+    ];
+
+    const result = sortPluginsByEnforce(
+      plugins.map((instance) => ({ instance })),
+    );
+
+    const names = result.map((item) => item.instance.name);
+    expect(names).toEqual([
+      'pre-1',
+      'pre-2',
+      'normal-1',
+      'normal-2',
+      'post-1',
+      'post-2',
+    ]);
+  });
+
+  it('should handle plugins with only pre enforce', () => {
+    const plugins: RsbuildPlugin[] = [
+      { name: 'normal-1', setup: () => {} },
+      { name: 'pre-1', setup: () => {}, enforce: 'pre' },
+      { name: 'normal-2', setup: () => {} },
+      { name: 'pre-2', setup: () => {}, enforce: 'pre' },
+    ];
+
+    const result = sortPluginsByEnforce(
+      plugins.map((instance) => ({ instance })),
+    );
+
+    const names = result.map((item) => item.instance.name);
+    expect(names).toEqual(['pre-1', 'pre-2', 'normal-1', 'normal-2']);
+  });
+
+  it('should handle plugins with only post enforce', () => {
+    const plugins: RsbuildPlugin[] = [
+      { name: 'normal-1', setup: () => {} },
+      { name: 'post-1', setup: () => {}, enforce: 'post' },
+      { name: 'normal-2', setup: () => {} },
+      { name: 'post-2', setup: () => {}, enforce: 'post' },
+    ];
+
+    const result = sortPluginsByEnforce(
+      plugins.map((instance) => ({ instance })),
+    );
+
+    const names = result.map((item) => item.instance.name);
+    expect(names).toEqual(['normal-1', 'normal-2', 'post-1', 'post-2']);
+  });
+});


### PR DESCRIPTION
## Summary

- Added an optional `enforce` property to the Rsbuild plugin to specify execution order.
- Introduced `sortPluginsByEnforce` to sort plugins based on their `enforce` property.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
