### PR TITLE
chore(deps): update Rspress to 2.0.0-beta.22

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1170,18 +1170,21 @@ importers:
       '@rsbuild/plugin-sass':
         specifier: ^1.3.3
         version: 1.3.3(@rsbuild/core@packages+core)
+      '@rspress/core':
+        specifier: 2.0.0-beta.22
+        version: 2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
       '@rspress/plugin-algolia':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@algolia/client-search@5.27.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))(search-insights@2.17.3)
+        specifier: 2.0.0-beta.22
+        version: 2.0.0-beta.22(@algolia/client-search@5.27.0)(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.3)
       '@rspress/plugin-client-redirects':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
+        specifier: 2.0.0-beta.22
+        version: 2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
       '@rspress/plugin-llms':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
+        specifier: 2.0.0-beta.22
+        version: 2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
       '@rspress/plugin-rss':
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
+        specifier: 2.0.0-beta.22
+        version: 2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))
       '@rstack-dev/doc-ui':
         specifier: 1.10.8
         version: 1.10.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1212,9 +1215,6 @@ importers:
       rsbuild-plugin-open-graph:
         specifier: ^1.0.2
         version: 1.0.2(@rsbuild/core@packages+core)
-      rspress:
-        specifier: 2.0.0-beta.21
-        version: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
       rspress-plugin-font-open-sans:
         specifier: ^1.0.0
         version: 1.0.0
@@ -1999,9 +1999,6 @@ packages:
       webpack:
         optional: true
 
-  '@module-federation/error-codes@0.15.0':
-    resolution: {integrity: sha512-CFJSF+XKwTcy0PFZ2l/fSUpR4z247+Uwzp1sXVkdIfJ/ATsnqf0Q01f51qqSEA6MYdQi6FKos9FIcu3dCpQNdg==}
-
   '@module-federation/error-codes@0.16.0':
     resolution: {integrity: sha512-TfmA45b8vvISniGudMg8jjIy1q3tLPon0QN/JdFp5f8AJ8/peICN5b+dkEQnWsAVg2fEusYhk9dO7z3nUeJM8A==}
 
@@ -2055,17 +2052,11 @@ packages:
       vue-tsc:
         optional: true
 
-  '@module-federation/runtime-core@0.15.0':
-    resolution: {integrity: sha512-RYzI61fRDrhyhaEOXH3AgIGlHiot0wPFXu7F43cr+ZnTi+VlSYWLdlZ4NBuT9uV6JSmH54/c+tEZm5SXgKR2sQ==}
-
   '@module-federation/runtime-core@0.16.0':
     resolution: {integrity: sha512-5SECQowG4hlUVBRk/y6bnYLfxbsl5NcMmqn043WPe7NDOhGQWbTuYibJ3Bk+ZBv5U4uYLEmXipBGDc1FKsHklQ==}
 
   '@module-federation/runtime-core@0.17.0':
     resolution: {integrity: sha512-MYwDDevYnBB9gXFfNOmJVIX5XZcbCHd0dral7gT7yVmlwOhbuGOLlm2dh2icwwdCYHA9AFDCfU9l1nJR4ex/ng==}
-
-  '@module-federation/runtime-tools@0.15.0':
-    resolution: {integrity: sha512-kzFn3ObUeBp5vaEtN1WMxhTYBuYEErxugu1RzFUERD21X3BZ+b4cWwdFJuBDlsmVjctIg/QSOoZoPXRKAO0foA==}
 
   '@module-federation/runtime-tools@0.16.0':
     resolution: {integrity: sha512-OzmXNluXBQ2E6znzX4m9CJt1MFHVGmbN8c8MSKcYIDcLzLSKBQAiaz9ZUMhkyWx2YrPgD134glyPEqJrc+fY8A==}
@@ -2073,17 +2064,11 @@ packages:
   '@module-federation/runtime-tools@0.17.0':
     resolution: {integrity: sha512-t4QcKfhmwOHedwByDKUlTQVw4+gPotySYPyNa8GFrBSr1F6wcGdGyOhzP+PdgpiJLIM03cB6V+IKGGHE28SfDQ==}
 
-  '@module-federation/runtime@0.15.0':
-    resolution: {integrity: sha512-dTPsCNum9Bhu3yPOcrPYq0YnM9eCMMMNB1wuiqf1+sFbQlNApF0vfZxooqz3ln0/MpgE0jerVvFsLVGfqvC9Ug==}
-
   '@module-federation/runtime@0.16.0':
     resolution: {integrity: sha512-6o84WI8Qhc9O3HwPLx89kTvOSkyUOHQr73R/zr0I04sYhlMJgw5xTwXeGE7bQAmNgbJclzW9Kh7JTP7+3o3CHg==}
 
   '@module-federation/runtime@0.17.0':
     resolution: {integrity: sha512-eMtrtCSSV6neJpMmQ8WdFpYv93raSgsG5RiAPsKUuSCXfZ5D+yzvleZ+gPcEpFT9HokmloxAn0jep50/1upTQw==}
-
-  '@module-federation/sdk@0.15.0':
-    resolution: {integrity: sha512-PWiYbGcJrKUD6JZiEPihrXhV3bgXdll4bV7rU+opV7tHaun+Z0CdcawjZ82Xnpb8MCPGmqHwa1MPFeUs66zksw==}
 
   '@module-federation/sdk@0.16.0':
     resolution: {integrity: sha512-UXJW1WWuDoDmScX0tpISjl4xIRPzAiN62vg9etuBdAEUM+ja9rz/zwNZaByiUPFS2aqlj2RHenCRvIapE8mYEg==}
@@ -2093,9 +2078,6 @@ packages:
 
   '@module-federation/third-party-dts-extractor@0.17.0':
     resolution: {integrity: sha512-1OkHLDgRZBGNH3h2aQ8f2V8g8p3x8DvLD6qzRb1s7P27/oOrKZW8OGxUSOwQ8M2+/R5cwUgRM0+KYeKUD1xa4g==}
-
-  '@module-federation/webpack-bundler-runtime@0.15.0':
-    resolution: {integrity: sha512-i+3wu2Ljh2TmuUpsnjwZVupOVqV50jP0ndA8PSP4gwMKlgdGeaZ4VH5KkHAXGr2eiYUxYLMrJXz1+eILJqeGDg==}
 
   '@module-federation/webpack-bundler-runtime@0.16.0':
     resolution: {integrity: sha512-yqIDQTelJZP0Rxml0OXv4Er8Kbdxy7NFh6PCzPwDFWI1SkiokJ3uXQJBvtlxZ3lOnCDYOzdHstqa8sJG4JP02Q==}
@@ -2383,11 +2365,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rsbuild/core@1.4.6':
-    resolution: {integrity: sha512-Z5e7ExKGmLv/wvBQEgSE2bPpR9movvq0jnfXjtYzrLzJFGsKFwL/5KShgdr6hUtVGGLoCCCHHHaTBL6BPcNvZA==}
-    engines: {node: '>=16.10.0'}
-    hasBin: true
-
   '@rsbuild/core@1.4.7':
     resolution: {integrity: sha512-mYvMYlCKUQAfz7x7GJnD6lBsVBfUSEAfrZLxkDQ0F3w7If9cQpHWLWZWdRmcFFy3Pzns1Edxn0st1nAmcFhRJQ==}
     engines: {node: '>=16.10.0'}
@@ -2492,11 +2469,6 @@ packages:
       typescript:
         optional: true
 
-  '@rspack/binding-darwin-arm64@1.4.6':
-    resolution: {integrity: sha512-K37H8e58eY7zBHGeMVtT7m0Z5XvlNQX7YDuaxlbiA4hZxqeRoS5BMX/YOcDiGdNbSuqv+iG5GSckJ99YUI67Cw==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rspack/binding-darwin-arm64@1.4.8':
     resolution: {integrity: sha512-PQRNjC3Fc0avpx8Gk+sT5P+HAXxTSzmBA8lU7QLlmbW5GGXO2taVhNstbZ4oxyIX5uDVZpQ2yQ2E0zXirK6/UQ==}
     cpu: [arm64]
@@ -2505,11 +2477,6 @@ packages:
   '@rspack/binding-darwin-arm64@1.4.9':
     resolution: {integrity: sha512-P0O10aXEaLLrwKXK7muSXl64wGJsLGbJEE97zeFe0mFVFo44m3iVC+KVpRpBFBrXhnL1ylCYsu2mS/dTJ+970g==}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rspack/binding-darwin-x64@1.4.6':
-    resolution: {integrity: sha512-3p5u9q/Q9MMVe+5XFJ/WiFrzNrrxUjJFR19kB1k/KMcf8ox982xWjnfJuBkET/k7Hn0EZL7L06ym447uIfAVAg==}
-    cpu: [x64]
     os: [darwin]
 
   '@rspack/binding-darwin-x64@1.4.8':
@@ -2522,11 +2489,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rspack/binding-linux-arm64-gnu@1.4.6':
-    resolution: {integrity: sha512-ZrrCn5b037ImZfZ3MShJrRw4d5M3Tq2rFJupr+SGMg7GTl2T6xEmo3ER/evHlT6e0ETi6tRWPxC9A1125jbSQA==}
-    cpu: [arm64]
-    os: [linux]
-
   '@rspack/binding-linux-arm64-gnu@1.4.8':
     resolution: {integrity: sha512-mJK9diM4Gd8RIGO90AZnl27WwUuAOoRplPQv9G+Vxu2baCt1xE1ccf8PntIJ70/rMgsUdnmkR5qQBaGxhAMJvA==}
     cpu: [arm64]
@@ -2534,11 +2496,6 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@1.4.9':
     resolution: {integrity: sha512-OTsco8WagOax9o6W66i//GjgrjhNFFOXhcS/vl81t7Hx5APEpEXX+pnccirH0e67Gs5sNlm/uLVS1cyA/B77Sg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rspack/binding-linux-arm64-musl@1.4.6':
-    resolution: {integrity: sha512-0a30oR6ZmZrqmsOHQYrbZPCxAgnqAiqlbFozdhHs+Yu2bS7SDiLpdjMg0PHwLZT2+siiMWsLodFZlXRJE54oAQ==}
     cpu: [arm64]
     os: [linux]
 
@@ -2552,11 +2509,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@rspack/binding-linux-x64-gnu@1.4.6':
-    resolution: {integrity: sha512-u6pq1aq7bX+NABVDDTOzH64KMj1KJn8fUWO+FaX7Kr7PBjhmxNRs4OaWZjbXEY6COhMYEJZ04h4DhY+lRzcKjA==}
-    cpu: [x64]
-    os: [linux]
-
   '@rspack/binding-linux-x64-gnu@1.4.8':
     resolution: {integrity: sha512-rEypDlbIfv9B/DcZ2vYVWs56wo5VWE5oj/TvM9JT+xuqwvVWsN/A2TPMiU6QBgOKGXat3EM/MEgx8NhNZUpkXg==}
     cpu: [x64]
@@ -2564,11 +2516,6 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@1.4.9':
     resolution: {integrity: sha512-MitSilaS23e7EPNqYT9PEr2Zomc51GZSaCRCXscNOica5V/oAVBcEMUFbrNoD4ugohDXM68RvK0kVyFmfYuW+Q==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rspack/binding-linux-x64-musl@1.4.6':
-    resolution: {integrity: sha512-rjP/1dWKB828kzd4/QpDYNVasUAKDj0OeRJGh5L/RluSH3pEqhxm5FwvndpmFDv6m3iPekZ4IO26UrpGJmE9fw==}
     cpu: [x64]
     os: [linux]
 
@@ -2582,10 +2529,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@rspack/binding-wasm32-wasi@1.4.6':
-    resolution: {integrity: sha512-5M0g7TaWgCFQJr4NKYW2bTLbQJuAQIgZL7WmiDwotgscBJDQWJVBayFEsnM6PYX1Inmu6RNhQ44BKIYwwoSyYw==}
-    cpu: [wasm32]
-
   '@rspack/binding-wasm32-wasi@1.4.8':
     resolution: {integrity: sha512-hF5gqT0aQ66VUclM2A9MSB6zVdEJqzp++TAXaShBK/eVBI0R4vWrMfJ2TOdzEsSbg4gXgeG4swURpHva3PKbcA==}
     cpu: [wasm32]
@@ -2593,11 +2536,6 @@ packages:
   '@rspack/binding-wasm32-wasi@1.4.9':
     resolution: {integrity: sha512-yWd5llZHBCsA0S5W0UGuXdQQ5zkZC4PQbOQS7XiblBII9RIMZZKJV/3AsYAHUeskTBPnwYMQsm8QCV52BNAE9A==}
     cpu: [wasm32]
-
-  '@rspack/binding-win32-arm64-msvc@1.4.6':
-    resolution: {integrity: sha512-thPCdbh4O+uEAJ8AvXBWZIOW0ZopJAN3CX2zlprso8Cnhi4wDseTtrIxFQh7cTo6pR3xSZAIv/zHd+MMF8TImA==}
-    cpu: [arm64]
-    os: [win32]
 
   '@rspack/binding-win32-arm64-msvc@1.4.8':
     resolution: {integrity: sha512-umD0XzesJq4nnStv9/2/VOmzNUWHfLMIjeHmiHYHpc7iVC0SkXgIdc6Ac7c+g2q7/V3/MFxL66Y60oy7lQE3fg==}
@@ -2607,11 +2545,6 @@ packages:
   '@rspack/binding-win32-arm64-msvc@1.4.9':
     resolution: {integrity: sha512-3+oG19ye2xOmVGGKHao0EXmvPaiGvaFnxJRQ6tc6T7MSxhOvvDhQ1zmx+9X/wXKv/iytAHXMuoLGLHwdGd7GJg==}
     cpu: [arm64]
-    os: [win32]
-
-  '@rspack/binding-win32-ia32-msvc@1.4.6':
-    resolution: {integrity: sha512-KQmm6c/ZfJKQ/TpzbY6J0pDvUB9kwTXzp+xl2FhGq2RXid8uyDS8ZqbeJA6LDxgttsmp4PRVJjMdLVYjZenfLw==}
-    cpu: [ia32]
     os: [win32]
 
   '@rspack/binding-win32-ia32-msvc@1.4.8':
@@ -2624,11 +2557,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@rspack/binding-win32-x64-msvc@1.4.6':
-    resolution: {integrity: sha512-WRRhCsJ+xcOmvzo/r/b2UTejPLnDEbaD/te1yQwHe97sUaFGr3u1Njk6lVYRTV6mEvUopEChb8yAq/S4dvaGLg==}
-    cpu: [x64]
-    os: [win32]
-
   '@rspack/binding-win32-x64-msvc@1.4.8':
     resolution: {integrity: sha512-BVkOfJDZnexHNpGgc/sWENyGrsle1jUQTeUEdSyNYsu4Elsgk/T9gnGK8xyLRd2c6k20M5FN38t0TumCp4DscQ==}
     cpu: [x64]
@@ -2639,23 +2567,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rspack/binding@1.4.6':
-    resolution: {integrity: sha512-rRc6sbKWxhomxxJeqi4QS3S/2T6pKf4JwC/VHXs7KXw7lHXHa3yxPynmn3xHstL0H6VLaM5xQj87Wh7lQYRAPg==}
-
   '@rspack/binding@1.4.8':
     resolution: {integrity: sha512-VKE+2InUdudBUOn3xMZfK9a6KlOwmSifA0Nupjsh7N9/brcBfJtJGSDCnfrIKCq54FF+QAUCgcNAS0DB4/tZmw==}
 
   '@rspack/binding@1.4.9':
     resolution: {integrity: sha512-9EY8OMCNZrwCupQMZccMgrTxWGUQvZGFrLFw/rxfTt+uT4fS4CAbNwHVFxsnROaRd+EE6EXfUpUYu66j6vd4qA==}
-
-  '@rspack/core@1.4.6':
-    resolution: {integrity: sha512-/OpJLv7dPEE7x/qCXGecRm9suNxz5w0Dheq2sh0TjTCUHodtMET3T+FlRWznBAlZeNuHLECDp0DWhchgS8BWuA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@swc/helpers': '>=0.5.1'
-    peerDependenciesMeta:
-      '@swc/helpers':
-        optional: true
 
   '@rspack/core@1.4.8':
     resolution: {integrity: sha512-ARHuZ+gx3P//RIUKSjk/riQUn/D5tCwCWbfgeM5pk/Ti2JsgVnqiP9Sksge8JovVPf7b6Zgw73Cq5FpX4aOXeQ==}
@@ -2694,9 +2610,10 @@ packages:
       webpack-hot-middleware:
         optional: true
 
-  '@rspress/core@2.0.0-beta.21':
-    resolution: {integrity: sha512-dBAvUi2CWw0cyEKE2vafHylzEuZxKcQ+nysLr/cIjrau6s7p3ghajEXYT+nLrpzv2bBeUDURmRYKSuPch+bWzA==}
+  '@rspress/core@2.0.0-beta.22':
+    resolution: {integrity: sha512-rzFNwUuctoS0yvdo/5yJV7QfrFhTTB0o7QkJYkrsNG5L50fvPxOYkxPxn52L83q76anoEdNlVrQGxKOX5f32Bg==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@rspress/mdx-rs-darwin-arm64@0.6.6':
     resolution: {integrity: sha512-fsuhUko2VJin9oZvGDEM8FWIisbhTe+ki8SiiVMqtl6OUtga9wB8F3JmsjVNg615lHp7FiT66Mvfbxweo+jjTQ==}
@@ -2750,39 +2667,39 @@ packages:
     resolution: {integrity: sha512-NpNhTKBIlV3O6ADhoZkgHvBFvXMW2TYlIWmIT1ysJESUBqDpaN9H3Teve5fugjU2pQ2ORBZO6SQGKliMw/8m/Q==}
     engines: {node: '>= 10'}
 
-  '@rspress/plugin-algolia@2.0.0-beta.21':
-    resolution: {integrity: sha512-lHGyJV5DfU/Y6a+2Ss7sl4eDbNpHvkAzo+RfJxvfhGT8ovAPmLkO8rsIMOErhKvTplzlvK31npNYivBoWLTb3Q==}
+  '@rspress/plugin-algolia@2.0.0-beta.22':
+    resolution: {integrity: sha512-FkMlFAZD4oteCWTH6f620TqPkZSDDfR7HzgGeP0GEdZo0BRtBbxv5duP/JdV/YnUa4vn3QyWnYE0bjppjpw7Vw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      rspress: ^2.0.0-beta.21
+      '@rspress/core': ^2.0.0-beta.22
 
-  '@rspress/plugin-client-redirects@2.0.0-beta.21':
-    resolution: {integrity: sha512-LHZZ5MRt/FAQghLp9Ace2wGW6y/dZYnTwzZwkw6XZ0FcutZ0w0NZlCn4/sVmPCp159LMjo4Exm8916USHSHcVg==}
+  '@rspress/plugin-client-redirects@2.0.0-beta.22':
+    resolution: {integrity: sha512-o8en63ntnA9OLD+M2rnOgLK2VrGDl/EFeQSPUuiYfGYw6+XqJEC1yMTOunSN/G2dUVOYOEJ1I8RmL12Mc6ycrw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      rspress: ^2.0.0-beta.21
+      '@rspress/core': ^2.0.0-beta.22
 
-  '@rspress/plugin-llms@2.0.0-beta.21':
-    resolution: {integrity: sha512-Uv8jF7qrV4UIJA4tE1ZN9gEOdE9LUfScC9sUXQHK882++qC12ETYz5/tBM2Jt5klEjlOSR2Bhy9Qq4igs4GsWQ==}
+  '@rspress/plugin-llms@2.0.0-beta.22':
+    resolution: {integrity: sha512-eEMb60CuA1mbu3qUKl+np/Ic8nHFFAchLEfhqOYbeq/8e3GSb2gYBxRNEJ+x4TINI6wgpqP36klf59a+2pxlTw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      rspress: ^2.0.0-beta.21
+      '@rspress/core': ^2.0.0-beta.22
 
-  '@rspress/plugin-rss@2.0.0-beta.21':
-    resolution: {integrity: sha512-RiMmPlEqdbzgsiVmt0qYKgTK6rwtvEJwU8UUEw9a3dIe+STF5dQmSo9cFXGYwYxSJDINAInveLvpd9P5lkHp9Q==}
+  '@rspress/plugin-rss@2.0.0-beta.22':
+    resolution: {integrity: sha512-le8Gyjmz7pZiXMB6rYUze/A2D07o0svEfct6SQIXKY6yrAFPiNbOY4ikQ7Ve8elXd+m5ZPnkHxgr5/Q1E5qcbg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      rspress: ^2.0.0-beta.21
+      '@rspress/core': ^2.0.0-beta.22
 
-  '@rspress/runtime@2.0.0-beta.21':
-    resolution: {integrity: sha512-uYCqzaHTwglSdgoKh1jDAjj73bIup7END/pVDTh+ILrhwkHyEbTXpuRn4km3QwqnPjEN80hVjpuzSzbWx80DjA==}
+  '@rspress/runtime@2.0.0-beta.22':
+    resolution: {integrity: sha512-Z/lharbTJ6vP+ITw1mhuJHk9MMNBU7He3c2C+qe8HcaSIuN0iVUiZJSM9tatSJhCkylyEvY2B6smc1e3I43RBg==}
     engines: {node: '>=18.0.0'}
 
-  '@rspress/shared@2.0.0-beta.21':
-    resolution: {integrity: sha512-Q/yjGH/afdkJY0AJ7FwxnvilD21kFmLhcCsMDzMEnW0U9LGnD+T+J3JoBhHvetTSHfrqg9rKl9YnJ5oreq89vQ==}
+  '@rspress/shared@2.0.0-beta.22':
+    resolution: {integrity: sha512-JLVda5YBoeABoeJukUp3AX6+qNY52sv8HPKZHNytLnmpr/kTpSS1dANp1UODMVK0aluVu3t6VnrcoICSIyOC3g==}
 
-  '@rspress/theme-default@2.0.0-beta.21':
-    resolution: {integrity: sha512-G+yJiAZW0oiAB7FyMFWrEI5B/Lg3z2IdxegbGo3a9q2tYo24bd35YuuXOQOIPuE/0+hWxCtB1vxDYH6WyZwMIQ==}
+  '@rspress/theme-default@2.0.0-beta.22':
+    resolution: {integrity: sha512-hRPITak6Ncoxg3BB/dpSJfKADVgW4E5P00eaZbor30/Qky9E9utekJiv3m+7OEunlGFoz9mfpTCHV8L0/aDBBw==}
     engines: {node: '>=18.0.0'}
 
   '@rstack-dev/doc-ui@1.10.8':
@@ -2804,32 +2721,26 @@ packages:
   '@selderee/plugin-htmlparser2@0.11.0':
     resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
-  '@shikijs/core@3.6.0':
-    resolution: {integrity: sha512-9By7Xb3olEX0o6UeJyPLI1PE1scC4d3wcVepvtv2xbuN9/IThYN4Wcwh24rcFeASzPam11MCq8yQpwwzCgSBRw==}
-
   '@shikijs/core@3.8.1':
     resolution: {integrity: sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang==}
 
-  '@shikijs/engine-javascript@3.6.0':
-    resolution: {integrity: sha512-7YnLhZG/TU05IHMG14QaLvTW/9WiK8SEYafceccHUSXs2Qr5vJibUwsDfXDLmRi0zHdzsxrGKpSX6hnqe0k8nA==}
+  '@shikijs/engine-javascript@3.8.1':
+    resolution: {integrity: sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA==}
 
-  '@shikijs/engine-oniguruma@3.6.0':
-    resolution: {integrity: sha512-nmOhIZ9yT3Grd+2plmW/d8+vZ2pcQmo/UnVwXMUXAKTXdi+LK0S08Ancrz5tQQPkxvjBalpMW2aKvwXfelauvA==}
+  '@shikijs/engine-oniguruma@3.8.1':
+    resolution: {integrity: sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==}
 
-  '@shikijs/langs@3.6.0':
-    resolution: {integrity: sha512-IdZkQJaLBu1LCYCwkr30hNuSDfllOT8RWYVZK1tD2J03DkiagYKRxj/pDSl8Didml3xxuyzUjgtioInwEQM/TA==}
+  '@shikijs/langs@3.8.1':
+    resolution: {integrity: sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==}
 
-  '@shikijs/rehype@3.6.0':
-    resolution: {integrity: sha512-r0Rr2hvXXqLl5DJ1Lx7RImU81XsK2bjThaym/lujl2A0r7SId0u1s+bcWYfFKb+7mCLH7MXF+jdzCtdWGOcYCQ==}
+  '@shikijs/rehype@3.8.1':
+    resolution: {integrity: sha512-ERs9IUaORBY8vu3OQfmB1L0nwGey0qhJi3NVSLwl22H+FPIg3dDyi2bHULY7pcyKC2qo5b1yiu5Vf3jp3ZkPvA==}
 
-  '@shikijs/themes@3.6.0':
-    resolution: {integrity: sha512-Fq2j4nWr1DF4drvmhqKq8x5vVQ27VncF8XZMBuHuQMZvUSS3NBgpqfwz/FoGe36+W6PvniZ1yDlg2d4kmYDU6w==}
+  '@shikijs/themes@3.8.1':
+    resolution: {integrity: sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==}
 
   '@shikijs/transformers@3.8.1':
     resolution: {integrity: sha512-nmTyFfBrhJk6HJi118jes0wuWdfKXeVUq1Nq+hm8h6wbk1KUfvtg+LY/uDfxZD2VDItHO3QoINIs3NtoKBmgxw==}
-
-  '@shikijs/types@3.6.0':
-    resolution: {integrity: sha512-cLWFiToxYu0aAzJqhXTQsFiJRTFDAGl93IrMSBNaGSzs7ixkLfdG6pH11HipuWFGW5vyx4X47W8HDQ7eSrmBUg==}
 
   '@shikijs/types@3.8.1':
     resolution: {integrity: sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==}
@@ -5893,10 +5804,6 @@ packages:
   rspress-plugin-sitemap@1.2.0:
     resolution: {integrity: sha512-fX5i0GLvrxRibKbL9rcBXA8PFDkhoB51bNrFpAuW0mkHg39Ji92SFzzURKvROpuwaGLZ+EP039zJNhx3kYYezA==}
 
-  rspress@2.0.0-beta.21:
-    resolution: {integrity: sha512-dgporOEoGogsxI4y/xAgnmENL8S/YIUi8c8JkJqmyNQET+eyZ9jF83WopP7YaxyDGY1j43cXiFf0bhUMVB8i8w==}
-    hasBin: true
-
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -6121,8 +6028,8 @@ packages:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
 
-  shiki@3.6.0:
-    resolution: {integrity: sha512-tKn/Y0MGBTffQoklaATXmTqDU02zx8NYBGQ+F6gy87/YjKbizcLd+Cybh/0ZtOBX9r1NEnAy/GTRDKtOsc1L9w==}
+  shiki@3.8.1:
+    resolution: {integrity: sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -7633,8 +7540,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/error-codes@0.15.0': {}
-
   '@module-federation/error-codes@0.16.0': {}
 
   '@module-federation/error-codes@0.17.0': {}
@@ -7725,11 +7630,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/runtime-core@0.15.0':
-    dependencies:
-      '@module-federation/error-codes': 0.15.0
-      '@module-federation/sdk': 0.15.0
-
   '@module-federation/runtime-core@0.16.0':
     dependencies:
       '@module-federation/error-codes': 0.16.0
@@ -7740,11 +7640,6 @@ snapshots:
       '@module-federation/error-codes': 0.17.0
       '@module-federation/sdk': 0.17.0
 
-  '@module-federation/runtime-tools@0.15.0':
-    dependencies:
-      '@module-federation/runtime': 0.15.0
-      '@module-federation/webpack-bundler-runtime': 0.15.0
-
   '@module-federation/runtime-tools@0.16.0':
     dependencies:
       '@module-federation/runtime': 0.16.0
@@ -7754,12 +7649,6 @@ snapshots:
     dependencies:
       '@module-federation/runtime': 0.17.0
       '@module-federation/webpack-bundler-runtime': 0.17.0
-
-  '@module-federation/runtime@0.15.0':
-    dependencies:
-      '@module-federation/error-codes': 0.15.0
-      '@module-federation/runtime-core': 0.15.0
-      '@module-federation/sdk': 0.15.0
 
   '@module-federation/runtime@0.16.0':
     dependencies:
@@ -7773,8 +7662,6 @@ snapshots:
       '@module-federation/runtime-core': 0.17.0
       '@module-federation/sdk': 0.17.0
 
-  '@module-federation/sdk@0.15.0': {}
-
   '@module-federation/sdk@0.16.0': {}
 
   '@module-federation/sdk@0.17.0': {}
@@ -7784,11 +7671,6 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
       resolve: 1.22.8
-
-  '@module-federation/webpack-bundler-runtime@0.15.0':
-    dependencies:
-      '@module-federation/runtime': 0.15.0
-      '@module-federation/sdk': 0.15.0
 
   '@module-federation/webpack-bundler-runtime@0.16.0':
     dependencies:
@@ -8002,14 +7884,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.42.0':
     optional: true
 
-  '@rsbuild/core@1.4.6':
-    dependencies:
-      '@rspack/core': 1.4.6(@swc/helpers@0.5.17)
-      '@rspack/lite-tapable': 1.0.1
-      '@swc/helpers': 0.5.17
-      core-js: 3.44.0
-      jiti: 2.4.2
-
   '@rsbuild/core@1.4.7':
     dependencies:
       '@rspack/core': 1.4.8(@swc/helpers@0.5.17)
@@ -8050,9 +7924,9 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.6)':
+  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.8)':
     dependencies:
-      '@rsbuild/core': 1.4.6
+      '@rsbuild/core': 1.4.8
       '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
@@ -8224,16 +8098,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@rspack/binding-darwin-arm64@1.4.6':
-    optional: true
-
   '@rspack/binding-darwin-arm64@1.4.8':
     optional: true
 
   '@rspack/binding-darwin-arm64@1.4.9':
-    optional: true
-
-  '@rspack/binding-darwin-x64@1.4.6':
     optional: true
 
   '@rspack/binding-darwin-x64@1.4.8':
@@ -8242,16 +8110,10 @@ snapshots:
   '@rspack/binding-darwin-x64@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-arm64-gnu@1.4.6':
-    optional: true
-
   '@rspack/binding-linux-arm64-gnu@1.4.8':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.4.9':
-    optional: true
-
-  '@rspack/binding-linux-arm64-musl@1.4.6':
     optional: true
 
   '@rspack/binding-linux-arm64-musl@1.4.8':
@@ -8260,27 +8122,16 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-x64-gnu@1.4.6':
-    optional: true
-
   '@rspack/binding-linux-x64-gnu@1.4.8':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.4.9':
     optional: true
 
-  '@rspack/binding-linux-x64-musl@1.4.6':
-    optional: true
-
   '@rspack/binding-linux-x64-musl@1.4.8':
     optional: true
 
   '@rspack/binding-linux-x64-musl@1.4.9':
-    optional: true
-
-  '@rspack/binding-wasm32-wasi@1.4.6':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.4.8':
@@ -8293,16 +8144,10 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@rspack/binding-win32-arm64-msvc@1.4.6':
-    optional: true
-
   '@rspack/binding-win32-arm64-msvc@1.4.8':
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@1.4.9':
-    optional: true
-
-  '@rspack/binding-win32-ia32-msvc@1.4.6':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.4.8':
@@ -8311,27 +8156,11 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@1.4.9':
     optional: true
 
-  '@rspack/binding-win32-x64-msvc@1.4.6':
-    optional: true
-
   '@rspack/binding-win32-x64-msvc@1.4.8':
     optional: true
 
   '@rspack/binding-win32-x64-msvc@1.4.9':
     optional: true
-
-  '@rspack/binding@1.4.6':
-    optionalDependencies:
-      '@rspack/binding-darwin-arm64': 1.4.6
-      '@rspack/binding-darwin-x64': 1.4.6
-      '@rspack/binding-linux-arm64-gnu': 1.4.6
-      '@rspack/binding-linux-arm64-musl': 1.4.6
-      '@rspack/binding-linux-x64-gnu': 1.4.6
-      '@rspack/binding-linux-x64-musl': 1.4.6
-      '@rspack/binding-wasm32-wasi': 1.4.6
-      '@rspack/binding-win32-arm64-msvc': 1.4.6
-      '@rspack/binding-win32-ia32-msvc': 1.4.6
-      '@rspack/binding-win32-x64-msvc': 1.4.6
 
   '@rspack/binding@1.4.8':
     optionalDependencies:
@@ -8358,14 +8187,6 @@ snapshots:
       '@rspack/binding-win32-arm64-msvc': 1.4.9
       '@rspack/binding-win32-ia32-msvc': 1.4.9
       '@rspack/binding-win32-x64-msvc': 1.4.9
-
-  '@rspack/core@1.4.6(@swc/helpers@0.5.17)':
-    dependencies:
-      '@module-federation/runtime-tools': 0.15.0
-      '@rspack/binding': 1.4.6
-      '@rspack/lite-tapable': 1.0.1
-    optionalDependencies:
-      '@swc/helpers': 0.5.17
 
   '@rspack/core@1.4.8(@swc/helpers@0.5.17)':
     dependencies:
@@ -8396,20 +8217,22 @@ snapshots:
       html-entities: 2.6.0
       react-refresh: 0.17.0
 
-  '@rspress/core@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)':
+  '@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)':
     dependencies:
       '@mdx-js/loader': 3.1.0(acorn@8.15.0)(webpack@5.99.9)
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@mdx-js/react': 3.1.0(@types/react@19.1.8)(react@19.1.0)
-      '@rsbuild/core': 1.4.6
-      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.6)
+      '@rsbuild/core': 1.4.8
+      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.8)
       '@rspress/mdx-rs': 0.6.6
-      '@rspress/runtime': 2.0.0-beta.21
-      '@rspress/shared': 2.0.0-beta.21
-      '@rspress/theme-default': 2.0.0-beta.21
-      '@shikijs/rehype': 3.6.0
+      '@rspress/runtime': 2.0.0-beta.22
+      '@rspress/shared': 2.0.0-beta.22
+      '@rspress/theme-default': 2.0.0-beta.22
+      '@shikijs/rehype': 3.8.1
       '@types/unist': 3.0.3
       '@unhead/react': 2.0.12(react@19.1.0)
+      cac: 6.7.14
+      chokidar: 3.6.0
       enhanced-resolve: 5.18.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -8428,8 +8251,9 @@ snapshots:
       remark: 15.0.1
       remark-gfm: 4.0.1
       rspack-plugin-virtual-module: 1.0.1
-      shiki: 3.6.0
+      shiki: 3.8.1
       tinyglobby: 0.2.14
+      tinypool: 1.1.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
       unist-util-visit-children: 3.0.0
@@ -8475,11 +8299,11 @@ snapshots:
       '@rspress/mdx-rs-win32-arm64-msvc': 0.6.6
       '@rspress/mdx-rs-win32-x64-msvc': 0.6.6
 
-  '@rspress/plugin-algolia@2.0.0-beta.21(@algolia/client-search@5.27.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))(search-insights@2.17.3)':
+  '@rspress/plugin-algolia@2.0.0-beta.22(@algolia/client-search@5.27.0)(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.3)':
     dependencies:
       '@docsearch/css': 3.9.0
       '@docsearch/react': 3.9.0(@algolia/client-search@5.27.0)(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(search-insights@2.17.3)
-      rspress: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
+      '@rspress/core': 2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@types/react'
@@ -8487,48 +8311,48 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@rspress/plugin-client-redirects@2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
+  '@rspress/plugin-client-redirects@2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
     dependencies:
-      rspress: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
+      '@rspress/core': 2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
 
-  '@rspress/plugin-llms@2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
+  '@rspress/plugin-llms@2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
     dependencies:
+      '@rspress/core': 2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
       remark-mdx: 3.1.0
       remark-parse: 11.0.0
       remark-stringify: 11.0.0
-      rspress: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
       unified: 11.0.5
       unist-util-visit: 5.0.0
       unist-util-visit-children: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  '@rspress/plugin-rss@2.0.0-beta.21(rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
+  '@rspress/plugin-rss@2.0.0-beta.22(@rspress/core@2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9))':
     dependencies:
+      '@rspress/core': 2.0.0-beta.22(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
       feed: 4.2.2
-      rspress: 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
 
-  '@rspress/runtime@2.0.0-beta.21':
+  '@rspress/runtime@2.0.0-beta.22':
     dependencies:
-      '@rspress/shared': 2.0.0-beta.21
+      '@rspress/shared': 2.0.0-beta.22
       '@unhead/react': 2.0.12(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       react-router-dom: 6.30.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
-  '@rspress/shared@2.0.0-beta.21':
+  '@rspress/shared@2.0.0-beta.22':
     dependencies:
-      '@rsbuild/core': 1.4.6
-      '@shikijs/rehype': 3.6.0
+      '@rsbuild/core': 1.4.8
+      '@shikijs/rehype': 3.8.1
       gray-matter: 4.0.3
       lodash-es: 4.17.21
       unified: 11.0.5
 
-  '@rspress/theme-default@2.0.0-beta.21':
+  '@rspress/theme-default@2.0.0-beta.22':
     dependencies:
       '@mdx-js/react': 2.3.0(react@19.1.0)
-      '@rspress/runtime': 2.0.0-beta.21
-      '@rspress/shared': 2.0.0-beta.21
+      '@rspress/runtime': 2.0.0-beta.22
+      '@rspress/shared': 2.0.0-beta.22
       '@unhead/react': 2.0.12(react@19.1.0)
       body-scroll-lock: 4.0.0-beta.0
       copy-to-clipboard: 3.3.3
@@ -8539,7 +8363,7 @@ snapshots:
       nprogress: 0.2.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      shiki: 3.6.0
+      shiki: 3.8.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8568,13 +8392,6 @@ snapshots:
       domhandler: 5.0.3
       selderee: 0.11.0
 
-  '@shikijs/core@3.6.0':
-    dependencies:
-      '@shikijs/types': 3.6.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@3.8.1':
     dependencies:
       '@shikijs/types': 3.8.1
@@ -8582,43 +8399,38 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@3.6.0':
+  '@shikijs/engine-javascript@3.8.1':
     dependencies:
-      '@shikijs/types': 3.6.0
+      '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.3
 
-  '@shikijs/engine-oniguruma@3.6.0':
+  '@shikijs/engine-oniguruma@3.8.1':
     dependencies:
-      '@shikijs/types': 3.6.0
+      '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.6.0':
+  '@shikijs/langs@3.8.1':
     dependencies:
-      '@shikijs/types': 3.6.0
+      '@shikijs/types': 3.8.1
 
-  '@shikijs/rehype@3.6.0':
+  '@shikijs/rehype@3.8.1':
     dependencies:
-      '@shikijs/types': 3.6.0
+      '@shikijs/types': 3.8.1
       '@types/hast': 3.0.4
       hast-util-to-string: 3.0.1
-      shiki: 3.6.0
+      shiki: 3.8.1
       unified: 11.0.5
       unist-util-visit: 5.0.0
 
-  '@shikijs/themes@3.6.0':
+  '@shikijs/themes@3.8.1':
     dependencies:
-      '@shikijs/types': 3.6.0
+      '@shikijs/types': 3.8.1
 
   '@shikijs/transformers@3.8.1':
     dependencies:
       '@shikijs/core': 3.8.1
       '@shikijs/types': 3.8.1
-
-  '@shikijs/types@3.6.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   '@shikijs/types@3.8.1':
     dependencies:
@@ -12209,21 +12021,6 @@ snapshots:
 
   rspress-plugin-sitemap@1.2.0: {}
 
-  rspress@2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9):
-    dependencies:
-      '@rsbuild/core': 1.4.6
-      '@rspress/core': 2.0.0-beta.21(@types/react@19.1.8)(acorn@8.15.0)(webpack@5.99.9)
-      '@rspress/shared': 2.0.0-beta.21
-      cac: 6.7.14
-      chokidar: 3.6.0
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - '@types/react'
-      - acorn
-      - supports-color
-      - webpack
-      - webpack-hot-middleware
-
   run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
@@ -12400,14 +12197,14 @@ snapshots:
 
   shell-quote@1.8.3: {}
 
-  shiki@3.6.0:
+  shiki@3.8.1:
     dependencies:
-      '@shikijs/core': 3.6.0
-      '@shikijs/engine-javascript': 3.6.0
-      '@shikijs/engine-oniguruma': 3.6.0
-      '@shikijs/langs': 3.6.0
-      '@shikijs/themes': 3.6.0
-      '@shikijs/types': 3.6.0
+      '@shikijs/core': 3.8.1
+      '@shikijs/engine-javascript': 3.8.1
+      '@shikijs/engine-oniguruma': 3.8.1
+      '@shikijs/langs': 3.8.1
+      '@shikijs/themes': 3.8.1
+      '@shikijs/types': 3.8.1
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 

--- a/website/docs/en/plugins/list/plugin-babel.mdx
+++ b/website/docs/en/plugins/list/plugin-babel.mdx
@@ -1,6 +1,6 @@
 # Babel plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-babel" />
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -1,6 +1,6 @@
 # Less plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less" />
 

--- a/website/docs/en/plugins/list/plugin-preact.mdx
+++ b/website/docs/en/plugins/list/plugin-preact.mdx
@@ -1,6 +1,6 @@
 # Preact plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-preact" />
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -1,6 +1,6 @@
 # React plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-react" />
 

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -1,6 +1,6 @@
 # Sass plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass" />
 

--- a/website/docs/en/plugins/list/plugin-solid.mdx
+++ b/website/docs/en/plugins/list/plugin-solid.mdx
@@ -1,6 +1,6 @@
 # Solid plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-solid" />
 

--- a/website/docs/en/plugins/list/plugin-stylus.mdx
+++ b/website/docs/en/plugins/list/plugin-stylus.mdx
@@ -1,6 +1,6 @@
 # Stylus plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-stylus" />
 

--- a/website/docs/en/plugins/list/plugin-svelte.mdx
+++ b/website/docs/en/plugins/list/plugin-svelte.mdx
@@ -1,6 +1,6 @@
 # Svelte plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-svelte" />
 

--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -1,6 +1,6 @@
 # SVGR plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-svgr" />
 

--- a/website/docs/en/plugins/list/plugin-vue.mdx
+++ b/website/docs/en/plugins/list/plugin-vue.mdx
@@ -1,6 +1,6 @@
 # Vue plugin
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-vue" />
 

--- a/website/docs/zh/plugins/list/plugin-babel.mdx
+++ b/website/docs/zh/plugins/list/plugin-babel.mdx
@@ -1,6 +1,6 @@
 # Babel 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-babel" />
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -1,6 +1,6 @@
 # Less 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less" />
 

--- a/website/docs/zh/plugins/list/plugin-preact.mdx
+++ b/website/docs/zh/plugins/list/plugin-preact.mdx
@@ -1,6 +1,6 @@
 # Preact 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-preact" />
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -1,6 +1,6 @@
 # React 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-react" />
 

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -1,6 +1,6 @@
 # Sass 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass" />
 

--- a/website/docs/zh/plugins/list/plugin-solid.mdx
+++ b/website/docs/zh/plugins/list/plugin-solid.mdx
@@ -1,6 +1,6 @@
 # Solid 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-solid" />
 

--- a/website/docs/zh/plugins/list/plugin-stylus.mdx
+++ b/website/docs/zh/plugins/list/plugin-stylus.mdx
@@ -1,6 +1,6 @@
 # Stylus 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-stylus" />
 

--- a/website/docs/zh/plugins/list/plugin-svelte.mdx
+++ b/website/docs/zh/plugins/list/plugin-svelte.mdx
@@ -1,6 +1,6 @@
 # Svelte 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-svelte" />
 

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -1,6 +1,6 @@
 # SVGR 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-svgr" />
 

--- a/website/docs/zh/plugins/list/plugin-vue.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue.mdx
@@ -1,6 +1,6 @@
 # Vue 插件
 
-import { SourceCode } from 'rspress/theme';
+import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-vue" />
 

--- a/website/package.json
+++ b/website/package.json
@@ -11,9 +11,11 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-sass": "^1.3.3",
-    "@rspress/plugin-client-redirects": "2.0.0-beta.21",
-    "@rspress/plugin-algolia": "2.0.0-beta.21",
-    "@rspress/plugin-rss": "2.0.0-beta.21",
+    "@rspress/core": "2.0.0-beta.22",
+    "@rspress/plugin-algolia": "2.0.0-beta.22",
+    "@rspress/plugin-client-redirects": "2.0.0-beta.22",
+    "@rspress/plugin-llms": "2.0.0-beta.22",
+    "@rspress/plugin-rss": "2.0.0-beta.22",
     "@rstack-dev/doc-ui": "1.10.8",
     "@shikijs/transformers": "^3.8.1",
     "@types/node": "^22.16.5",
@@ -24,10 +26,8 @@
     "react-dom": "^19.1.0",
     "rsbuild-plugin-google-analytics": "^1.0.3",
     "rsbuild-plugin-open-graph": "^1.0.2",
-    "rspress": "2.0.0-beta.21",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.2.0",
-    "@rspress/plugin-llms": "2.0.0-beta.21",
     "typescript": "^5.8.3"
   }
 }

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -1,4 +1,5 @@
 import { pluginSass } from '@rsbuild/plugin-sass';
+import { defineConfig } from '@rspress/core';
 import { pluginAlgolia } from '@rspress/plugin-algolia';
 import { pluginClientRedirects } from '@rspress/plugin-client-redirects';
 import { pluginLlms } from '@rspress/plugin-llms';
@@ -10,7 +11,6 @@ import {
 } from '@shikijs/transformers';
 import { pluginGoogleAnalytics } from 'rsbuild-plugin-google-analytics';
 import { pluginOpenGraph } from 'rsbuild-plugin-open-graph';
-import { defineConfig } from 'rspress/config';
 import { pluginFontOpenSans } from 'rspress-plugin-font-open-sans';
 import pluginSitemap from 'rspress-plugin-sitemap';
 import { rsbuildPluginOverview } from './theme/rsbuildPluginOverview';

--- a/website/theme/components/Benchmark.tsx
+++ b/website/theme/components/Benchmark.tsx
@@ -1,3 +1,4 @@
+import { useI18n } from '@rspress/core/runtime';
 import {
   Benchmark as BaseBenchmark,
   type BenchmarkData,
@@ -9,7 +10,6 @@ import {
   titleAndDescStyle,
   titleStyle,
 } from '@rstack-dev/doc-ui/section-style';
-import { useI18n } from 'rspress/runtime';
 
 // Benchmark data for different cases
 // Unit: second

--- a/website/theme/components/Features.tsx
+++ b/website/theme/components/Features.tsx
@@ -1,9 +1,9 @@
+import { useI18n } from '@rspress/core/runtime';
+import { HomeFeature } from '@rspress/core/theme';
 import {
   containerStyle,
   innerContainerStyle,
 } from '@rstack-dev/doc-ui/section-style';
-import { useI18n } from 'rspress/runtime';
-import { HomeFeature } from 'rspress/theme';
 import './Features.module.scss';
 
 export function Features() {

--- a/website/theme/components/Hero.tsx
+++ b/website/theme/components/Hero.tsx
@@ -1,5 +1,5 @@
+import { useI18n, useNavigate } from '@rspress/core/runtime';
 import { Hero as BaseHero } from '@rstack-dev/doc-ui/hero';
-import { useI18n, useNavigate } from 'rspress/runtime';
 import { useI18nUrl } from './utils';
 import './Hero.module.scss';
 

--- a/website/theme/components/HomeFooter.tsx
+++ b/website/theme/components/HomeFooter.tsx
@@ -1,6 +1,6 @@
+import { useI18n, useLang } from '@rspress/core/runtime';
+import { Link } from '@rspress/core/theme';
 import { memo } from 'react';
-import { useI18n, useLang } from 'rspress/runtime';
-import { Link } from 'rspress/theme';
 import styles from './HomeFooter.module.scss';
 
 function useFooterData() {

--- a/website/theme/components/Overview.tsx
+++ b/website/theme/components/Overview.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'rspress/theme';
+import { Link } from '@rspress/core/theme';
 import styles from './Overview.module.scss';
 import { useI18nUrl } from './utils';
 

--- a/website/theme/components/Step.tsx
+++ b/website/theme/components/Step.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'rspress/theme';
+import { Link } from '@rspress/core/theme';
 import styles from './Step.module.scss';
 import { useI18nUrl } from './utils';
 

--- a/website/theme/components/ToolStack.tsx
+++ b/website/theme/components/ToolStack.tsx
@@ -1,6 +1,6 @@
+import { useLang } from '@rspress/core/runtime';
 import { containerStyle } from '@rstack-dev/doc-ui/section-style';
 import { ToolStack as BaseToolStack } from '@rstack-dev/doc-ui/tool-stack';
-import { useLang } from 'rspress/runtime';
 
 export function ToolStack() {
   const lang = useLang();

--- a/website/theme/components/utils.ts
+++ b/website/theme/components/utils.ts
@@ -1,5 +1,5 @@
+import { useLang, usePageData, withBase } from '@rspress/core/runtime';
 import { useCallback } from 'react';
-import { useLang, usePageData, withBase } from 'rspress/runtime';
 
 export function useI18nUrl() {
   const lang = useLang();

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,13 +1,13 @@
+import { Layout as BaseLayout } from '@rspress/core/theme';
 import { Announcement } from '@rstack-dev/doc-ui/announcement';
 import { NavIcon } from '@rstack-dev/doc-ui/nav-icon';
-import { Layout as BaseLayout } from 'rspress/theme';
 import { HomeLayout } from './pages';
 import './index.scss';
+import { NoSSR, useLang, usePageData } from '@rspress/core/runtime';
 import {
   Search as PluginAlgoliaSearch,
   ZH_LOCALES,
 } from '@rspress/plugin-algolia/runtime';
-import { NoSSR, useLang, usePageData } from 'rspress/runtime';
 
 // Enable announcement when we have something to announce
 const ANNOUNCEMENT_URL = '';
@@ -59,4 +59,4 @@ const Search = () => {
 
 export { Layout, HomeLayout, Search };
 
-export * from 'rspress/theme';
+export * from '@rspress/core/theme';


### PR DESCRIPTION
## Summary

Update Rspress to 2.0.0-beta.22 and use the new package name.

## Related Links

https://github.com/web-infra-dev/rspress/releases

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
