### PR TITLE
chore(deps): update stylus to use GitHub source

### DIFF
--- a/e2e/cases/plugin-svelte/package.json
+++ b/e2e/cases/plugin-svelte/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "less": "^4.4.0",
     "sass": "^1.89.2",
-    "stylus": "github:stylus/stylus#0.64.0"
+    "stylus": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz"
   }
 }

--- a/e2e/cases/plugin-svelte/package.json
+++ b/e2e/cases/plugin-svelte/package.json
@@ -8,6 +8,6 @@
   "devDependencies": {
     "less": "^4.4.0",
     "sass": "^1.89.2",
-    "stylus": "0.64.0"
+    "stylus": "github:stylus/stylus#0.64.0"
   }
 }

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "reduce-configs": "^1.1.0",
-    "stylus": "0.64.0",
+    "stylus": "github:stylus/stylus#0.64.0",
     "stylus-loader": "8.1.1"
   },
   "devDependencies": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "reduce-configs": "^1.1.0",
-    "stylus": "github:stylus/stylus#0.64.0",
+    "stylus": "https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz",
     "stylus-loader": "8.1.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^1.89.2
         version: 1.89.2
       stylus:
-        specifier: github:stylus/stylus#0.64.0
-        version: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
+        specifier: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz
+        version: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz
 
   e2e/cases/plugin-vue:
     dependencies:
@@ -998,11 +998,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       stylus:
-        specifier: github:stylus/stylus#0.64.0
-        version: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
+        specifier: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz
+        version: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz
       stylus-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9)(webpack@5.99.9)
+        version: 8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz)(webpack@5.99.9)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -6199,8 +6199,8 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9:
-    resolution: {tarball: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9}
+  stylus@https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz:
+    resolution: {tarball: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz}
     version: 0.64.0
     engines: {node: '>=16'}
     hasBin: true
@@ -12397,11 +12397,11 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9)(webpack@5.99.9):
+  stylus-loader@8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz)(webpack@5.99.9):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
+      stylus: https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz
     optionalDependencies:
       '@rspack/core': 1.4.9(@swc/helpers@0.5.17)
       webpack: 5.99.9
@@ -12417,7 +12417,7 @@ snapshots:
       - supports-color
     optional: true
 
-  stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9:
+  stylus@https://github.com/stylus/stylus/archive/refs/tags/0.64.0.tar.gz:
     dependencies:
       '@adobe/css-tools': 4.3.3
       debug: 4.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -998,11 +998,11 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       stylus:
-        specifier: 0.64.0
-        version: 0.64.0
+        specifier: github:stylus/stylus#0.64.0
+        version: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
       stylus-loader:
         specifier: 8.1.1
-        version: 8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.99.9)
+        version: 8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9)(webpack@5.99.9)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -6182,6 +6182,7 @@ packages:
 
   stylus-loader@8.1.1:
     resolution: {integrity: sha512-Ohe29p3gwJiu1kxq16P80g1qq0FxGtwQevKctLE4su8KUq+Ea06Q6lp7SpcJjaKNrWIuEZQGvESUPt8JpukKVw==}
+    version: 8.1.1
     engines: {node: '>= 18.12.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -6195,6 +6196,12 @@ packages:
 
   stylus@0.64.0:
     resolution: {integrity: sha512-ZIdT8eUv8tegmqy1tTIdJv9We2DumkNZFdCF5mz/Kpq3OcTaxSuCAYZge6HKK2CmNC02G1eJig2RV7XTw5hQrA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9:
+    resolution: {tarball: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9}
+    version: 0.64.0
     engines: {node: '>=16'}
     hasBin: true
 
@@ -12390,16 +12397,26 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.4
 
-  stylus-loader@8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@0.64.0)(webpack@5.99.9):
+  stylus-loader@8.1.1(@rspack/core@1.4.9(@swc/helpers@0.5.17))(stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9)(webpack@5.99.9):
     dependencies:
       fast-glob: 3.3.3
       normalize-path: 3.0.0
-      stylus: 0.64.0
+      stylus: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
     optionalDependencies:
       '@rspack/core': 1.4.9(@swc/helpers@0.5.17)
       webpack: 5.99.9
 
   stylus@0.64.0:
+    dependencies:
+      '@adobe/css-tools': 4.3.3
+      debug: 4.4.1
+      glob: 10.4.5
+      sax: 1.4.1
+      source-map: 0.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9:
     dependencies:
       '@adobe/css-tools': 4.3.3
       debug: 4.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -264,8 +264,8 @@ importers:
         specifier: ^1.89.2
         version: 1.89.2
       stylus:
-        specifier: 0.64.0
-        version: 0.64.0
+        specifier: github:stylus/stylus#0.64.0
+        version: https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9
 
   e2e/cases/plugin-vue:
     dependencies:
@@ -12415,6 +12415,7 @@ snapshots:
       source-map: 0.7.4
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   stylus@https://codeload.github.com/stylus/stylus/tar.gz/1086c6c1fbd7a7fd0ce9ad94f6cf4a62fc79a6e9:
     dependencies:


### PR DESCRIPTION
## Summary

Update stylus to use GitHub source to temporarily fix the problem that stylus cannot be installed via npm.

## Related Links

- https://github.com/stylus/stylus/issues/2938

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
