### PR TITLE
fix: patch is-wsl to maintaining Node 16.10 compatibility

### DIFF
--- a/patches/wsl-utils@0.1.0.patch
+++ b/patches/wsl-utils@0.1.0.patch
@@ -1,0 +1,12 @@
+diff --git a/index.js b/index.js
+index 8ae51879d98b2aad27b80a77e0a04436ea42ceb6..f91794b0a8c1de8b059b1ef579fa47ef35762556 100644
+--- a/index.js
++++ b/index.js
+@@ -1,5 +1,6 @@
+ import process from 'node:process';
+-import fs, {constants as fsConstants} from 'node:fs/promises';
++import fs from 'node:fs/promises';
++import {constants as fsConstants} from 'fs';
+ import isWsl from 'is-wsl';
+ 
+ export const wslDrivesMountPoint = (() => {

--- a/patches/wsl-utils@0.1.0.patch
+++ b/patches/wsl-utils@0.1.0.patch
@@ -6,7 +6,7 @@ index 8ae51879d98b2aad27b80a77e0a04436ea42ceb6..f91794b0a8c1de8b059b1ef579fa47ef
  import process from 'node:process';
 -import fs, {constants as fsConstants} from 'node:fs/promises';
 +import fs from 'node:fs/promises';
-+import {constants as fsConstants} from 'fs';
++import {constants as fsConstants} from 'node:fs';
  import isWsl from 'is-wsl';
  
  export const wslDrivesMountPoint = (() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ patchedDependencies:
   url-loader:
     hash: 4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f
     path: patches/url-loader@4.1.1.patch
+  wsl-utils@0.1.0:
+    hash: 1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe
+    path: patches/wsl-utils@0.1.0.patch
 
 importers:
 
@@ -11484,7 +11487,7 @@ snapshots:
       default-browser: 5.2.1
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
-      wsl-utils: 0.1.0
+      wsl-utils: 0.1.0(patch_hash=1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe)
 
   open@8.4.2:
     dependencies:
@@ -12832,7 +12835,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  wsl-utils@0.1.0:
+  wsl-utils@0.1.0(patch_hash=1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe):
     dependencies:
       is-wsl: 3.1.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ patchedDependencies:
     hash: 4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f
     path: patches/url-loader@4.1.1.patch
   wsl-utils@0.1.0:
-    hash: 1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe
+    hash: f104c08692fc73e10ddda7868fc2c116e57c9042dd9a721da8242188d3cb8fa6
     path: patches/wsl-utils@0.1.0.patch
 
 importers:
@@ -11487,7 +11487,7 @@ snapshots:
       default-browser: 5.2.1
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
-      wsl-utils: 0.1.0(patch_hash=1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe)
+      wsl-utils: 0.1.0(patch_hash=f104c08692fc73e10ddda7868fc2c116e57c9042dd9a721da8242188d3cb8fa6)
 
   open@8.4.2:
     dependencies:
@@ -12835,7 +12835,7 @@ snapshots:
 
   ws@8.18.3: {}
 
-  wsl-utils@0.1.0(patch_hash=1c69517d3c0eaa676375b19345ddca3fbb36647f7cf2d9709dccc69f8e134bbe):
+  wsl-utils@0.1.0(patch_hash=f104c08692fc73e10ddda7868fc2c116e57c9042dd9a721da8242188d3cb8fa6):
     dependencies:
       is-wsl: 3.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,5 +18,6 @@ patchedDependencies:
   open@10.2.0: patches/open@10.2.0.patch
   postcss-loader@8.1.1: patches/postcss-loader@8.1.1.patch
   url-loader: patches/url-loader@4.1.1.patch
+  wsl-utils@0.1.0: patches/wsl-utils@0.1.0.patch
 
 strictPeerDependencies: false


### PR DESCRIPTION
## Summary

The same as https://github.com/web-infra-dev/rsbuild/pull/5570.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/5655

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
