### PR TITLE
chore: add open collective funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: rspack


### PR DESCRIPTION
## Summary

Add open collective funding link, the same as the Rspack repo: https://github.com/web-infra-dev/rspack/blob/main/.github/FUNDING.yml

The funding will be mainly used to distribute to upstream projects in the community or create bounty issues.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
