### PR TITLE
feat(types): export `Connect` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export type {
   CompressOptions,
   ConfigChain,
   ConfigChainWithContext,
+  Connect,
   ConsoleType,
   CreateCompiler,
   CreateRsbuildOptions,

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import type { IncomingMessage, ServerResponse } from 'node:http';
 import { createRequire } from 'node:module';
 import type { Stats } from '@rspack/core';
 import { HTML_REGEX } from '../constants';
@@ -7,7 +6,6 @@ import { isMultiCompiler } from '../helpers';
 import { getPathnameFromUrl } from '../helpers/path';
 import type {
   EnvironmentContext,
-  NextFunction,
   NormalizedDevConfig,
   NormalizedServerConfig,
   Rspack,
@@ -192,11 +190,7 @@ export class CompilationManager {
         base && base !== '/' ? stripBase(prefix, base) : prefix,
       );
 
-    const wrapper = async (
-      req: IncomingMessage,
-      res: ServerResponse,
-      next: NextFunction,
-    ) => {
+    const wrapper: CompilationMiddleware = async (req, res, next) => {
       const { url } = req;
       const assetPrefix =
         url && assetPrefixes.find((prefix) => url.startsWith(prefix));

--- a/packages/core/src/server/compilationMiddleware.ts
+++ b/packages/core/src/server/compilationMiddleware.ts
@@ -1,10 +1,9 @@
-import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Compiler, MultiCompiler, Stats } from '@rspack/core';
 import { applyToCompiler } from '../helpers';
 import type {
+  Connect,
   DevConfig,
   EnvironmentContext,
-  NextFunction,
   ServerConfig,
 } from '../types';
 import { getResolvedClientConfig } from './hmrFallback';
@@ -100,12 +99,6 @@ function applyHMREntry({
   }
 }
 
-type Middleware = (
-  req: IncomingMessage,
-  res: ServerResponse,
-  next: NextFunction,
-) => Promise<void>;
-
 export type CompilationMiddlewareOptions = {
   /**
    * To ensure HMR works, the devMiddleware need inject the HMR client path into page when HMR enable.
@@ -120,7 +113,7 @@ export type CompilationMiddlewareOptions = {
   environments: Record<string, EnvironmentContext>;
 };
 
-export type CompilationMiddleware = Middleware & {
+export type CompilationMiddleware = Connect.NextHandleFunction & {
   close: (callback: (err: Error | null | undefined) => void) => any;
   watch: () => void;
 };

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -1,10 +1,10 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
-import type Connect from '../../compiled/connect/index.js';
 import { color, getPublicPathFromCompiler, isMultiCompiler } from '../helpers';
 import { logger } from '../logger';
 import { onBeforeRestartServer, restartDevServer } from '../restart';
 import type {
+  Connect,
   CreateCompiler,
   CreateDevServerOptions,
   EnvironmentAPI,

--- a/packages/core/src/server/httpServer.ts
+++ b/packages/core/src/server/httpServer.ts
@@ -1,7 +1,6 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
-import type Connect from '../../compiled/connect/index.js';
-import type { ServerConfig } from '../types';
+import type { Connect, ServerConfig } from '../types';
 
 export const createHttpServer = async ({
   serverConfig,

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,18 +1,18 @@
 import type { IncomingMessage } from 'node:http';
 import path from 'node:path';
-import type Connect from '../../compiled/connect/index.js';
 import { addTrailingSlash, color } from '../helpers';
 import { logger } from '../logger';
 import type {
   EnvironmentAPI,
   HtmlFallback,
-  RequestHandler as Middleware,
+  RequestHandler,
   Rspack,
 } from '../types';
+import type { Connect } from '../types/';
 import type { CompilationManager } from './compilationManager';
 import { joinUrlSegments, stripBase } from './helper';
 
-export const faviconFallbackMiddleware: Middleware = (req, res, next) => {
+export const faviconFallbackMiddleware: RequestHandler = (req, res, next) => {
   if (req.url === '/favicon.ico') {
     res.statusCode = 204;
     res.end();
@@ -73,12 +73,12 @@ export const getRequestLoggerMiddleware: () => Promise<Connect.NextHandleFunctio
     };
   };
 
-export const notFoundMiddleware: Middleware = (_req, res, _next) => {
+export const notFoundMiddleware: RequestHandler = (_req, res, _next) => {
   res.statusCode = 404;
   res.end();
 };
 
-export const optionsFallbackMiddleware: Middleware = (req, res, next) => {
+export const optionsFallbackMiddleware: RequestHandler = (req, res, next) => {
   if (req.method === 'OPTIONS') {
     // Use 204 as no content to send in the response body
     res.statusCode = 204;
@@ -130,7 +130,7 @@ const getUrlPathname = (url: string): string => {
 export const getHtmlCompletionMiddleware: (params: {
   distPath: string;
   compilationManager: CompilationManager;
-}) => Middleware = ({ distPath, compilationManager }) => {
+}) => RequestHandler = ({ distPath, compilationManager }) => {
   return async (req, res, next) => {
     if (!maybeHTMLRequest(req)) {
       return next();
@@ -172,9 +172,9 @@ export const getHtmlCompletionMiddleware: (params: {
 /**
  * handle `server.base`
  */
-export const getBaseMiddleware: (params: { base: string }) => Middleware = ({
-  base,
-}) => {
+export const getBaseMiddleware: (params: {
+  base: string;
+}) => RequestHandler = ({ base }) => {
   return async (req, res, next) => {
     const url = req.url!;
     const pathname = getUrlPathname(url);
@@ -227,7 +227,7 @@ export const getHtmlFallbackMiddleware: (params: {
   distPath: string;
   compilationManager: CompilationManager;
   htmlFallback?: HtmlFallback;
-}) => Middleware = ({ htmlFallback, distPath, compilationManager }) => {
+}) => RequestHandler = ({ htmlFallback, distPath, compilationManager }) => {
   return async (req, res, next) => {
     if (
       !maybeHTMLRequest(req) ||
@@ -264,7 +264,7 @@ export const getHtmlFallbackMiddleware: (params: {
  */
 export const viewingServedFilesMiddleware: (params: {
   environments: EnvironmentAPI;
-}) => Middleware =
+}) => RequestHandler =
   ({ environments }) =>
   async (req, res, next) => {
     const url = req.url!;

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -1,9 +1,9 @@
 import type { Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
-import type Connect from '../../compiled/connect/index.js';
 import { getPathnameFromUrl } from '../helpers/path';
 import { logger } from '../logger';
 import type {
+  Connect,
   InternalContext,
   NormalizedConfig,
   PreviewOptions,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -35,6 +35,7 @@ import type {
 import type { RsbuildEntry, RsbuildMode, RsbuildTarget } from './rsbuild';
 import type { BundlerPluginInstance, Rspack, RspackRule } from './rspack';
 import type {
+  Connect,
   CSSExtractOptions,
   CSSLoaderModulesOptions,
   CSSLoaderOptions,
@@ -1564,13 +1565,7 @@ export type ProgressBarConfig = {
   id?: string;
 };
 
-export type NextFunction = () => void;
-
-export type RequestHandler = (
-  req: IncomingMessage,
-  res: ServerResponse,
-  next: NextFunction,
-) => void;
+export type RequestHandler = Connect.NextHandleFunction;
 
 export type EnvironmentAPI = {
   [name: string]: {

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -4,9 +4,12 @@ import type {
 } from '@rspack/core';
 /** @ts-ignore `webpack` type only exists when `@rsbuild/webpack` is installed */
 import type { Configuration as WebpackConfig } from 'webpack';
+import type Connect from '../../compiled/connect/index.js';
 import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin/index.js';
 import type { AcceptedPlugin, ProcessOptions } from '../../compiled/postcss';
 import type { Rspack } from './rspack';
+
+export type { Connect };
 
 export type { HtmlRspackPlugin };
 


### PR DESCRIPTION
## Summary

- Replaced the custom `Middleware` and `RequestHandler` types with `Connect.NextHandleFunction` in various files, ensuring consistency and simplifying type definitions
- Export the `Connect` type from '@rsbuild/core'.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
