### PR TITLE
test: use the shared tsconfig

### DIFF
--- a/rstest.config.ts
+++ b/rstest.config.ts
@@ -10,8 +10,7 @@ export default defineConfig({
         require('./packages/core/package.json').version,
       ),
     },
-    // TODO: try to find closest tsconfig.json
-    tsconfigPath: 'packages/core/tsconfig.json',
+    tsconfigPath: './scripts/config/tsconfig.json',
   },
   output: {
     externals: ['@rsbuild/core'],


### PR DESCRIPTION
## Summary

Updates the tsconfig.json path in the `rstest.config.ts` file to use the shared config file.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
