### PR TITLE
perf: use `endsWith` instead of regex

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -43,7 +43,6 @@ export const DEFAULT_BROWSERSLIST: Record<string, string[]> = {
 };
 
 // RegExp
-export const HTML_REGEX: RegExp = /\.html$/;
 export const JS_REGEX: RegExp = /\.(?:js|mjs|cjs|jsx)$/;
 export const SCRIPT_REGEX: RegExp = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
 export const CSS_REGEX: RegExp = /\.css$/;

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -6,7 +6,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
-import { CSS_REGEX, HTML_REGEX, JS_REGEX } from '../constants';
+import { JS_REGEX } from '../constants';
 import { color } from '../helpers';
 import { logger } from '../logger';
 import type {
@@ -74,10 +74,10 @@ const coloringAssetName = (assetName: string) => {
   if (JS_REGEX.test(assetName)) {
     return color.cyan(assetName);
   }
-  if (CSS_REGEX.test(assetName)) {
+  if (assetName.endsWith('.css')) {
     return color.yellow(assetName);
   }
-  if (HTML_REGEX.test(assetName)) {
+  if (assetName.endsWith('.html')) {
     return color.green(assetName);
   }
   return color.magenta(assetName);

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import type { Stats } from '@rspack/core';
-import { HTML_REGEX } from '../constants';
 import { isMultiCompiler } from '../helpers';
 import { getPathnameFromUrl } from '../helpers/path';
 import type {
@@ -161,7 +160,7 @@ export class CompilationManager {
     const callbacks: ServerCallbacks = {
       onInvalid: (token: string, fileName?: string | null) => {
         // reload page when HTML template changed
-        if (typeof fileName === 'string' && HTML_REGEX.test(fileName)) {
+        if (typeof fileName === 'string' && fileName.endsWith('.html')) {
           this.socketServer.sockWrite({ type: 'static-changed' }, token);
           return;
         }


### PR DESCRIPTION
## Summary

Simplifies the handling of file type checks by replacing its usage with the `endsWith()` method. 

`endsWith()` performs better in this scenario:

<img width="1373" height="700" alt="Screenshot 2025-07-16 at 22 41 01" src="https://github.com/user-attachments/assets/c7498ebd-b15b-4b48-96fe-af8a3bbf4e1c" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
