### PR TITLE
feat: enable error tolerance for type re-exports

### DIFF
--- a/e2e/cases/typescript/type-re-exports/index.test.ts
+++ b/e2e/cases/typescript/type-re-exports/index.test.ts
@@ -1,0 +1,14 @@
+import { build } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should allow to re-export type without the type modifier', async ({
+  page,
+}) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+    catchBuildError: true,
+  });
+  expect(rsbuild.buildError).toBeFalsy();
+  await rsbuild.close();
+});

--- a/e2e/cases/typescript/type-re-exports/index.test.ts
+++ b/e2e/cases/typescript/type-re-exports/index.test.ts
@@ -1,14 +1,15 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
 
-test('should allow to re-export type without the type modifier', async ({
-  page,
-}) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-    catchBuildError: true,
-  });
-  expect(rsbuild.buildError).toBeFalsy();
-  await rsbuild.close();
-});
+rspackOnlyTest(
+  'should allow to re-export type without the type modifier',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      catchBuildError: true,
+    });
+    expect(rsbuild.buildError).toBeFalsy();
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/typescript/type-re-exports/src/bar.ts
+++ b/e2e/cases/typescript/type-re-exports/src/bar.ts
@@ -1,0 +1,1 @@
+export type Bar = string;

--- a/e2e/cases/typescript/type-re-exports/src/foo.ts
+++ b/e2e/cases/typescript/type-re-exports/src/foo.ts
@@ -1,0 +1,3 @@
+import { Bar } from './bar';
+
+export { Bar };

--- a/e2e/cases/typescript/type-re-exports/src/index.ts
+++ b/e2e/cases/typescript/type-re-exports/src/index.ts
@@ -1,0 +1,3 @@
+import { Bar } from './foo';
+
+export { Bar };

--- a/e2e/cases/typescript/type-re-exports/tsconfig.json
+++ b/e2e/cases/typescript/type-re-exports/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "./dist",
+    "verbatimModuleSyntax": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "*.test.ts"]
+}

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -33,6 +33,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -490,6 +491,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -944,6 +946,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -1329,6 +1332,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "javascript": {
         "dynamicImportMode": "eager",
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -71,6 +71,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         chain.module.parser.merge({
           javascript: {
             exportsPresence: 'error',
+            typeReexportsPresence: 'tolerant',
           },
         });
 
@@ -94,6 +95,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         if (api.context.bundlerType === 'rspack') {
           chain.experiments({
             ...chain.get('experiments'),
+            typeReexportsPresence: true,
             rspackFuture: {
               bundlerInfo: {
                 force: false,

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -95,6 +95,11 @@ function getDefaultSwcConfig({
     env: {
       targets: browserslist,
     },
+    rspackExperiments: {
+      collectTypeScriptInfo: {
+        typeExports: true,
+      },
+    },
   };
 }
 

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -98,6 +98,7 @@ function getDefaultSwcConfig({
     rspackExperiments: {
       collectTypeScriptInfo: {
         typeExports: true,
+        exportedEnum: false,
       },
     },
   };

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -10,6 +10,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -19,6 +20,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
   },
@@ -54,6 +56,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -63,6 +66,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
   },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -172,6 +172,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -229,6 +230,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -16,6 +16,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -25,6 +26,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -168,6 +170,11 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
                   "legacyDecorator": false,
                 },
               },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
+                },
+              },
             },
           },
         ],
@@ -218,6 +225,11 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
+                },
+              },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
                 },
               },
             },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -172,6 +172,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -229,6 +230,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -676,6 +678,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -733,6 +736,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1180,6 +1184,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1233,6 +1238,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1643,6 +1649,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1700,6 +1707,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -16,6 +16,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -25,6 +26,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -168,6 +170,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                   "legacyDecorator": false,
                 },
               },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
+                },
+              },
             },
           },
         ],
@@ -218,6 +225,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
+                },
+              },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
                 },
               },
             },
@@ -508,6 +520,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -517,6 +530,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -660,6 +674,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                   "legacyDecorator": false,
                 },
               },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
+                },
+              },
             },
           },
         ],
@@ -710,6 +729,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
+                },
+              },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
                 },
               },
             },
@@ -1028,6 +1052,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1037,6 +1062,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -1152,6 +1178,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                   "legacyDecorator": false,
                 },
               },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
+                },
+              },
             },
           },
         ],
@@ -1198,6 +1229,11 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
+                },
+              },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
                 },
               },
             },
@@ -1443,6 +1479,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
         "force": false,
       },
     },
+    "typeReexportsPresence": true,
   },
   "infrastructureLogging": {
     "level": "error",
@@ -1452,6 +1489,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "parser": {
       "javascript": {
         "exportsPresence": "error",
+        "typeReexportsPresence": "tolerant",
       },
     },
     "rules": [
@@ -1603,6 +1641,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
                   "legacyDecorator": false,
                 },
               },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
+                },
+              },
             },
           },
         ],
@@ -1653,6 +1696,11 @@ exports[`tools.rspack > should match snapshot 1`] = `
                 "transform": {
                   "decoratorVersion": "2022-03",
                   "legacyDecorator": false,
+                },
+              },
+              "rspackExperiments": {
+                "collectTypeScriptInfo": {
+                  "typeExports": true,
                 },
               },
             },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1467,6 +1467,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1524,6 +1525,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1883,6 +1885,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1936,6 +1939,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1311,6 +1311,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "force": false,
         },
       },
+      "typeReexportsPresence": true,
     },
     "infrastructureLogging": {
       "level": "error",
@@ -1320,6 +1321,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "parser": {
         "javascript": {
           "exportsPresence": "error",
+          "typeReexportsPresence": "tolerant",
         },
       },
       "rules": [
@@ -1463,6 +1465,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1513,6 +1520,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1743,6 +1755,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
           "force": false,
         },
       },
+      "typeReexportsPresence": true,
     },
     "infrastructureLogging": {
       "level": "error",
@@ -1752,6 +1765,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "parser": {
         "javascript": {
           "exportsPresence": "error",
+          "typeReexportsPresence": "tolerant",
         },
       },
       "rules": [
@@ -1867,6 +1881,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1913,6 +1932,11 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -55,6 +55,11 @@ exports[`plugin-swc > should add browserslist 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -102,6 +107,11 @@ exports[`plugin-swc > should add browserslist 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -178,6 +188,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   },
                 },
                 "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -237,6 +250,9 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                   },
                 },
                 "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -365,6 +381,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
     ],
@@ -415,6 +436,11 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },
@@ -485,6 +511,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
             },
           },
           "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
             "import": [
               {
                 "libraryName": "foo",
@@ -549,6 +578,9 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
             },
           },
           "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
             "import": [
               {
                 "libraryName": "foo",
@@ -612,6 +644,9 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
             },
           },
           "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
             "import": [
               {
                 "libraryName": "bar",
@@ -667,6 +702,9 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
             },
           },
           "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
             "import": [
               {
                 "libraryName": "bar",
@@ -739,6 +777,9 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                   },
                 },
                 "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -801,6 +842,9 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                   },
                 },
                 "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
                   "import": [
                     {
                       "libraryName": "foo",
@@ -883,6 +927,11 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -933,6 +982,11 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1004,6 +1058,11 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1050,6 +1109,11 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1125,6 +1189,11 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1175,6 +1244,11 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1257,6 +1331,11 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1311,6 +1390,11 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1393,6 +1477,11 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1448,6 +1537,11 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1530,6 +1624,11 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1584,6 +1683,11 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },
@@ -1655,6 +1759,11 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                     "legacyDecorator": false,
                   },
                 },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
+                  },
+                },
               },
             },
           ],
@@ -1701,6 +1810,11 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                   "transform": {
                     "decoratorVersion": "2022-03",
                     "legacyDecorator": false,
+                  },
+                },
+                "rspackExperiments": {
+                  "collectTypeScriptInfo": {
+                    "typeExports": true,
                   },
                 },
               },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -57,6 +57,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -111,6 +112,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -189,6 +191,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -251,6 +254,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -383,6 +387,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -440,6 +445,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -512,6 +518,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -579,6 +586,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -645,6 +653,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -703,6 +712,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -778,6 +788,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -843,6 +854,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -929,6 +941,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -986,6 +999,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1060,6 +1074,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1113,6 +1128,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1191,6 +1207,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1248,6 +1265,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1333,6 +1351,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1394,6 +1413,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1479,6 +1499,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1541,6 +1562,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1626,6 +1648,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1687,6 +1710,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1761,6 +1785,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1814,6 +1839,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -55,6 +55,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -146,6 +147,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -234,6 +236,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -323,6 +326,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -411,6 +415,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
+            "exportedEnum": false,
             "typeExports": true,
           },
         },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -53,6 +53,11 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
             "legacyDecorator": false,
           },
         },
+        "rspackExperiments": {
+          "collectTypeScriptInfo": {
+            "typeExports": true,
+          },
+        },
       },
     },
     {
@@ -139,6 +144,11 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
             "legacyDecorator": false,
           },
         },
+        "rspackExperiments": {
+          "collectTypeScriptInfo": {
+            "typeExports": true,
+          },
+        },
       },
     },
     {
@@ -220,6 +230,11 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
             "decoratorMetadata": true,
             "legacyDecorator": true,
             "useDefineForClassFields": false,
+          },
+        },
+        "rspackExperiments": {
+          "collectTypeScriptInfo": {
+            "typeExports": true,
           },
         },
       },
@@ -306,6 +321,11 @@ exports[`plugins/babel > should set babel-loader 1`] = `
             "legacyDecorator": false,
           },
         },
+        "rspackExperiments": {
+          "collectTypeScriptInfo": {
+            "typeExports": true,
+          },
+        },
       },
     },
     {
@@ -387,6 +407,11 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
           "transform": {
             "decoratorVersion": "2022-03",
             "legacyDecorator": false,
+          },
+        },
+        "rspackExperiments": {
+          "collectTypeScriptInfo": {
+            "typeExports": true,
           },
         },
       },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -64,6 +64,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -158,6 +159,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -62,6 +62,11 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
               },
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
     ],
@@ -149,6 +154,11 @@ exports[`plugins/react > should work with swc-loader 1`] = `
                 "refresh": true,
                 "runtime": "automatic",
               },
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -62,6 +62,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -126,6 +127,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -192,6 +194,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -256,6 +259,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -305,6 +309,7 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -409,6 +414,7 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -469,6 +475,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -533,6 +540,7 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -597,6 +605,7 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -60,6 +60,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
     ],
@@ -117,6 +122,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },
@@ -180,6 +190,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
     ],
@@ -239,6 +254,11 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
     ],
@@ -281,6 +301,11 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },
@@ -382,6 +407,11 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
       {
@@ -435,6 +465,11 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },
@@ -496,6 +531,11 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
               "legacyDecorator": false,
             },
           },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
+            },
+          },
         },
       },
       {
@@ -553,6 +593,11 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
             "transform": {
               "decoratorVersion": "2022-03",
               "legacyDecorator": false,
+            },
+          },
+          "rspackExperiments": {
+            "collectTypeScriptInfo": {
+              "typeExports": true,
             },
           },
         },

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -59,6 +59,11 @@ exports[`svgr > configure SVGR options 1`] = `
                 },
               },
             },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
+              },
+            },
           },
         },
         {
@@ -159,6 +164,11 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 },
               },
             },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
+              },
+            },
           },
         },
         {
@@ -225,6 +235,11 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                   "refresh": false,
                   "runtime": "automatic",
                 },
+              },
+            },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
               },
             },
           },
@@ -326,6 +341,11 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                 },
               },
             },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
+              },
+            },
           },
         },
         {
@@ -392,6 +412,11 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                   "refresh": false,
                   "runtime": "automatic",
                 },
+              },
+            },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
               },
             },
           },
@@ -493,6 +518,11 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                 },
               },
             },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
+              },
+            },
           },
         },
         {
@@ -559,6 +589,11 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                   "refresh": false,
                   "runtime": "automatic",
                 },
+              },
+            },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
               },
             },
           },
@@ -660,6 +695,11 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 },
               },
             },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
+              },
+            },
           },
         },
         {
@@ -726,6 +766,11 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                   "refresh": false,
                   "runtime": "automatic",
                 },
+              },
+            },
+            "rspackExperiments": {
+              "collectTypeScriptInfo": {
+                "typeExports": true,
               },
             },
           },

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -61,6 +61,7 @@ exports[`svgr > configure SVGR options 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -166,6 +167,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -239,6 +241,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -343,6 +346,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -416,6 +420,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -520,6 +525,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -593,6 +599,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -697,6 +704,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -770,6 +778,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },


### PR DESCRIPTION
## Summary

Enable the new `parser.javascript.typeReexportsPresence` feature in Rspack to tolerate errors relating to type re-exports.

This is helpful for some older TypeScript projects that may not have "verbatimModuleSyntax" or "isolatedModules" enabled in their tsconfig.json, or re-export all types using the `type` modifier.

## Related Links

- https://rspack.rs/config/module#moduleparserjavascripttypereexportspresence

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
