### PR TITLE
docs: add react-rstest example link

### DIFF
--- a/website/docs/en/guide/migration/cra.mdx
+++ b/website/docs/en/guide/migration/cra.mdx
@@ -43,7 +43,7 @@ Next, you need to update the npm scripts in package.json to Rsbuild's CLI comman
 ```
 
 :::tip
-Rsbuild does not integrate testing frameworks, so it does not provide a command to replace `react-scripts test`. You can directly use testing frameworks such as [Rstest](https://github.com/web-infra-dev/rstest), Jest or Vitest. You can refer to the [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) example project for configuration.
+Rsbuild does not integrate testing frameworks, so it does not provide a command to replace `react-scripts test`. You can directly use testing frameworks such as [Rstest](https://github.com/web-infra-dev/rstest), Jest or Vitest. You can refer to the [Rsbuild react-rstest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-rstest) or [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) example project for configuration.
 :::
 
 ## Creating configuration file

--- a/website/docs/zh/guide/migration/cra.mdx
+++ b/website/docs/zh/guide/migration/cra.mdx
@@ -43,7 +43,7 @@ import { PackageManagerTabs } from '@theme';
 ```
 
 :::tip
-Rsbuild 未集成测试框架，因此没有提供用于替换 `react-scripts test` 的命令，你可以直接使用 [Rstest](https://github.com/web-infra-dev/rstest)、Jest 或 Vitest 等测试框架。你可以参考 [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) 示例项目进行配置。
+Rsbuild 未集成测试框架，因此没有提供用于替换 `react-scripts test` 的命令，你可以直接使用 [Rstest](https://github.com/web-infra-dev/rstest)、Jest 或 Vitest 等测试框架。你可以参考 [Rsbuild react-rstest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-rstest) 或 [Rsbuild react-jest](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/react-jest) 示例项目进行配置。
 :::
 
 ## 创建配置文件


### PR DESCRIPTION
## Summary

add react-rstest example link.
https://github.com/rspack-contrib/rstack-examples/pull/315

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
