### PR TITLE
perf: require rspack to improve startup performance

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,7 @@
  */
 
 import type * as Rspack from '@rspack/core';
-import { rspack } from '@rspack/core';
+import { rspack } from './rspack';
 
 export { runCLI } from './cli';
 export { createRsbuild } from './createRsbuild';

--- a/packages/core/src/pluginHelper.ts
+++ b/packages/core/src/pluginHelper.ts
@@ -2,7 +2,7 @@
  * This file is used to get/set the global instance for html-plugin and css-extract plugin.
  */
 import { createRequire } from 'node:module';
-import { rspack } from '@rspack/core';
+import { rspack } from './rspack';
 import type { HtmlRspackPlugin } from './types';
 
 const require = createRequire(import.meta.url);

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -2,7 +2,6 @@ import type {
   LightningCssMinimizerRspackPluginOptions,
   SwcJsMinimizerRspackPluginOptions,
 } from '@rspack/core';
-import { rspack } from '@rspack/core';
 import deepmerge from 'deepmerge';
 import { isPlainObject, pick } from '../helpers';
 import type { NormalizedEnvironmentConfig, RsbuildPlugin } from '../types';
@@ -88,7 +87,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
   setup(api) {
     const isRspack = api.context.bundlerType === 'rspack';
 
-    api.modifyBundlerChain(async (chain, { environment, CHAIN_ID }) => {
+    api.modifyBundlerChain(async (chain, { environment, CHAIN_ID, rspack }) => {
       const { config } = environment;
       const { minifyJs, minifyCss, jsOptions, cssOptions } =
         parseMinifyOptions(config);

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -1,6 +1,6 @@
 import { isRegExp } from 'node:util/types';
 import type { RspackPluginInstance } from '@rspack/core';
-import { rspack } from '@rspack/core';
+import { rspack } from '../rspack';
 import type { RsbuildPlugin, Rspack } from '../types';
 
 /**

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -1,5 +1,4 @@
 import { posix } from 'node:path';
-import { rspack } from '@rspack/core';
 import {
   DEFAULT_ASSET_PREFIX,
   DEFAULT_DEV_HOST,
@@ -78,7 +77,10 @@ export const pluginOutput = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      async (chain, { CHAIN_ID, isDev, isProd, isServer, environment }) => {
+      async (
+        chain,
+        { CHAIN_ID, isDev, isProd, isServer, environment, rspack },
+      ) => {
         const { distPath, config } = environment;
 
         const publicPath = getPublicPath({

--- a/packages/core/src/plugins/progress.ts
+++ b/packages/core/src/plugins/progress.ts
@@ -1,4 +1,3 @@
-import { rspack } from '@rspack/core';
 import type { RsbuildPlugin } from '../types';
 
 export const pluginProgress = (): RsbuildPlugin => ({
@@ -10,7 +9,7 @@ export const pluginProgress = (): RsbuildPlugin => ({
       return;
     }
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment, rspack }) => {
       const { config } = environment;
       const options = config.dev.progressBar;
 

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -1,8 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspack } from '@rspack/core';
 import { color } from '../helpers';
 import { logger } from '../logger';
+import { rspack } from '../rspack';
 import type { RsbuildPlugin } from '../types';
 
 enum TracePreset {

--- a/packages/core/src/plugins/sri.ts
+++ b/packages/core/src/plugins/sri.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import { rspack } from '@rspack/core';
 import { COMPILED_PATH } from '../constants';
 import type { RsbuildPlugin } from '../types';
 
@@ -7,7 +6,7 @@ export const pluginSri = (): RsbuildPlugin => ({
   name: 'rsbuild:sri',
 
   setup(api) {
-    api.modifyBundlerChain((chain, { environment, CHAIN_ID }) => {
+    api.modifyBundlerChain((chain, { environment, CHAIN_ID, rspack }) => {
       if (api.context.bundlerType === 'webpack') {
         return;
       }

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -1,6 +1,6 @@
-import { rspack } from '@rspack/core';
 import { registerBuildHook } from '../hooks';
 import { logger } from '../logger';
+import { rspack } from '../rspack';
 import type { Build, BuildOptions, Rspack } from '../types';
 import { createCompiler } from './createCompiler';
 import type { InitConfigsOptions } from './initConfigs';

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -1,6 +1,5 @@
 import { sep } from 'node:path';
 import type { StatsCompilation } from '@rspack/core';
-import { rspack } from '@rspack/core';
 import {
   color,
   formatStats,
@@ -11,6 +10,7 @@ import {
 } from '../helpers';
 import { registerDevHook } from '../hooks';
 import { logger } from '../logger';
+import { rspack } from '../rspack';
 import type { InternalContext, Rspack } from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -1,4 +1,3 @@
-import { rspack } from '@rspack/core';
 import {
   type ConfigChainAsyncWithContext,
   reduceConfigsAsyncWithContext,
@@ -8,6 +7,7 @@ import { CHAIN_ID, modifyBundlerChain } from '../configChain';
 import { castArray, color, getNodeEnv } from '../helpers';
 import { logger } from '../logger';
 import { getHTMLPlugin } from '../pluginHelper';
+import { rspack } from '../rspack';
 import type {
   EnvironmentContext,
   InternalContext,

--- a/packages/core/src/rspack.ts
+++ b/packages/core/src/rspack.ts
@@ -1,0 +1,13 @@
+import { createRequire } from 'node:module';
+
+/**
+ * Currently, Rspack only provides a CJS bundle, so we use require to load it
+ * for better startup performance. If we use `import { rspack } from '@rspack/core'`,
+ * Node.js will use `cjs-module-lexer` to parse it, which slows down startup by ~30ms.
+ * We can remove this module once `@rspack/core` provides an ESM bundle in the future.
+ */
+const require = createRequire(import.meta.url);
+const rspack =
+  require('@rspack/core') as (typeof import('@rspack/core'))['rspack'];
+
+export { rspack };

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -1,8 +1,8 @@
 import { isAbsolute, join } from 'node:path';
-import { rspack } from '@rspack/core';
 import { normalizePublicDirs } from '../defaultConfig';
 import { castArray, isMultiCompiler, pick } from '../helpers';
 import { logger } from '../logger';
+import { rspack } from '../rspack';
 import type {
   DevConfig,
   InternalContext,


### PR DESCRIPTION
## Summary

Currently, Rspack only provides a CJS bundle, so we use require to load it for better startup performance. If we use `import { rspack } from '@rspack/core'`, Node.js will use `cjs-module-lexer` to parse it, which slows down startup by 25-30ms.

<img width="750" src="https://github.com/user-attachments/assets/b46ebdba-e926-4af6-a799-b5bebe869346" />

We can remove this module once `@rspack/core` provides an ESM bundle in the future.

### Before

<img width="610" src="https://github.com/user-attachments/assets/b13459d5-81c3-41e8-be25-abc5dc1fe62f" />

### After

<img width="600" src="https://github.com/user-attachments/assets/1cd1fd87-5279-41d3-8b6f-143ceaaa451f" />

## Related Links

- https://github.com/nodejs/cjs-module-lexer

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
