### PR TITLE
fix: watch options not work in build watch mode

### DIFF
--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,0 +1,42 @@
+import { exec } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { expectFile, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+import fse, { remove } from 'fs-extra';
+
+rspackOnlyTest(
+  'should allow to custom watch options for build watch',
+  async () => {
+    const srcDir = path.join(__dirname, 'src');
+    const tempDir = path.join(__dirname, 'test-temp-src');
+    const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
+    const fooFile = path.join(tempDir, 'foo.js');
+    const barFile = path.join(tempDir, 'bar.js');
+
+    // clean up
+    await remove(tempDir);
+    await remove(distIndexFile);
+    await fse.copy(srcDir, tempDir);
+
+    const childProcess = exec('npx rsbuild build --watch', {
+      cwd: __dirname,
+    });
+
+    await expectFile(distIndexFile);
+    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo1bar1');
+    await remove(distIndexFile);
+
+    // should watch foo.js
+    fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
+    await expectFile(distIndexFile);
+    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo2bar1');
+
+    // should not watch bar.js
+    fse.outputFileSync(barFile, `export const bar = 'bar2';`);
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo2bar1');
+
+    childProcess.kill();
+  },
+);

--- a/e2e/cases/cli/build-watch-options/rsbuild.config.mjs
+++ b/e2e/cases/cli/build-watch-options/rsbuild.config.mjs
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      index: './test-temp-src/index.js',
+    },
+  },
+  output: {
+    filenameHash: false,
+  },
+  tools: {
+    rspack: {
+      watchOptions: {
+        ignored: /bar/,
+      },
+    },
+  },
+});

--- a/e2e/cases/cli/build-watch-options/src/bar.js
+++ b/e2e/cases/cli/build-watch-options/src/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar1';

--- a/e2e/cases/cli/build-watch-options/src/foo.js
+++ b/e2e/cases/cli/build-watch-options/src/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo1';

--- a/e2e/cases/cli/build-watch-options/src/index.js
+++ b/e2e/cases/cli/build-watch-options/src/index.js
@@ -1,0 +1,4 @@
+import { bar } from './bar';
+import { foo } from './foo';
+
+console.log(foo + bar);

--- a/e2e/cases/cli/build-watch-options/tsconfig.json
+++ b/e2e/cases/cli/build-watch-options/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "@rsbuild/config/tsconfig",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist"
-  },
-  "include": ["src", "*.test.ts"]
-}

--- a/e2e/cases/cli/build-watch-options/tsconfig.json
+++ b/e2e/cases/cli/build-watch-options/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "./dist"
+  },
+  "include": ["src", "*.test.ts"]
+}

--- a/e2e/cases/cli/build-watch/tsconfig.json
+++ b/e2e/cases/cli/build-watch/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "@rsbuild/config/tsconfig",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist"
-  },
-  "include": ["src", "*.test.ts"]
-}

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -1,3 +1,4 @@
+import type { WatchOptions } from '@rspack/core';
 import { registerBuildHook } from '../hooks';
 import { logger } from '../logger';
 import { rspack } from '../rspack';
@@ -33,11 +34,20 @@ export const build = async (
   });
 
   if (watch) {
-    compiler.watch({}, (err) => {
-      if (err) {
-        logger.error(err);
-      }
-    });
+    const watchOptions: WatchOptions[] = bundlerConfigs
+      ? bundlerConfigs.map((options) => options.watchOptions || {})
+      : [];
+
+    compiler.watch(
+      // @ts-expect-error
+      // TODO: https://github.com/web-infra-dev/rspack/pull/11174
+      watchOptions.length > 1 ? watchOptions : watchOptions[0] || {},
+      (err) => {
+        if (err) {
+          logger.error(err);
+        }
+      },
+    );
 
     return {
       close: () =>


### PR DESCRIPTION
## Summary

This PR fixes support for custom watch options in the build watch mode and adds E2E tests to validate this functionality.

When calling the `compiler.watch()` method, we should pass `watchOptions` to ensure that Rspack can read it correctly.

## Related Links

- https://rspack.rs/api/javascript-api/compiler#watch-1

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
