### PR TITLE
perf: reduce getStatus cost when previewing static assets

### DIFF
--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -34,6 +34,23 @@ export const getAllStatsErrors = (
   return statsData.errors;
 };
 
+export const getAssetsFromStats = (
+  stats: Rspack.Stats,
+): Rspack.StatsAsset[] => {
+  const statsJson = stats.toJson({
+    all: false,
+    assets: true,
+    cachedAssets: true,
+    groupAssetsByInfo: false,
+    groupAssetsByPath: false,
+    groupAssetsByChunk: false,
+    groupAssetsByExtension: false,
+    groupAssetsByEmitStatus: false,
+  });
+
+  return statsJson.assets || [];
+};
+
 export const getAllStatsWarnings = (
   statsData: StatsCompilation,
 ): Rspack.StatsError[] | undefined => {

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -7,7 +7,7 @@ import path from 'node:path';
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
 import { JS_REGEX } from '../constants';
-import { color } from '../helpers';
+import { color, getAssetsFromStats } from '../helpers';
 import { logger } from '../logger';
 import type {
   PrintFileSizeAsset,
@@ -136,18 +136,7 @@ async function printFileSizes(
       return [];
     }
 
-    const origin = stats.toJson({
-      all: false,
-      assets: true,
-      cachedAssets: true,
-      groupAssetsByInfo: false,
-      groupAssetsByPath: false,
-      groupAssetsByChunk: false,
-      groupAssetsByExtension: false,
-      groupAssetsByEmitStatus: false,
-    });
-
-    const filteredAssets = (origin.assets || []).filter((asset) => {
+    const filteredAssets = getAssetsFromStats(stats).filter((asset) => {
       const assetInfo: PrintFileSizeAsset = {
         name: asset.name,
         size: asset.size,

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import path from 'node:path';
-import { addTrailingSlash, color } from '../helpers';
+import { addTrailingSlash, color, getAssetsFromStats } from '../helpers';
 import { logger } from '../logger';
 import type {
   Connect,
@@ -329,12 +329,7 @@ export const viewingServedFilesMiddleware: (params: {
         const list = [];
         const environment = environments[key];
         const stats = await environment.getStats();
-        const statsJson = stats.toJson({
-          all: false,
-          assets: true,
-          cachedAssets: true,
-        });
-        const { assets = [] } = statsJson;
+        const assets = getAssetsFromStats(stats);
 
         res.write('<ul>');
 

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -270,10 +270,14 @@ export const viewingServedFilesMiddleware: (params: {
     const url = req.url!;
     const pathname = getUrlPathname(url);
 
-    if (pathname === '/rsbuild-dev-server') {
-      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
-      res.write(
-        `<!DOCTYPE html>
+    if (pathname !== '/rsbuild-dev-server') {
+      next();
+      return;
+    }
+
+    res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.write(
+      `<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8"/>
@@ -316,31 +320,37 @@ export const viewingServedFilesMiddleware: (params: {
     <h1>Assets Report</h1>
   </body>
 </html>`,
-      );
-      try {
-        for (const key in environments) {
-          const list = [];
-          res.write(`<h2>Environment: ${key}</h2>`);
-          const environment = environments[key];
-          const stats = await environment.getStats();
-          const statsForPrint = stats.toJson();
-          const { assets = [] } = statsForPrint;
-          res.write('<ul>');
-          for (const asset of assets) {
-            list.push(
-              `<li><a target="_blank" href="${asset?.name}">${asset?.name}</a></li>`,
-            );
-          }
-          res.write(list?.join(''));
-          res.write('</ul>');
+    );
+
+    try {
+      for (const key in environments) {
+        res.write(`<h2>Environment: ${key}</h2>`);
+
+        const list = [];
+        const environment = environments[key];
+        const stats = await environment.getStats();
+        const statsJson = stats.toJson({
+          all: false,
+          assets: true,
+          cachedAssets: true,
+        });
+        const { assets = [] } = statsJson;
+
+        res.write('<ul>');
+
+        for (const asset of assets) {
+          list.push(
+            `<li><a target="_blank" href="${asset?.name}">${asset?.name}</a></li>`,
+          );
         }
-        res.end('</body></html>');
-      } catch (err) {
-        logger.error(err);
-        res.writeHead(500);
-        res.end('Failed to list the files');
+
+        res.write(list?.join(''));
+        res.write('</ul>');
       }
-    } else {
-      next();
+      res.end('</body></html>');
+    } catch (err) {
+      logger.error(err);
+      res.writeHead(500);
+      res.end('Failed to list the files');
     }
   };


### PR DESCRIPTION
## Summary

Passing fine-grained stats options to `stats.getJson()` to reduce the cost when previewing static assets.

### Before

<img width="330" height="97" alt="Screenshot 2025-07-26 at 18 45 50" src="https://github.com/user-attachments/assets/71b23782-e802-4e75-877d-01a63ba0ca6e" />

### After

<img width="332" height="86" alt="Screenshot 2025-07-26 at 18 49 09" src="https://github.com/user-attachments/assets/3e3ae4f3-974b-4d2f-9ae6-eba979bedc1e" />

## Related Links

- https://rspack.rs/api/javascript-api/stats#tojson

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
