### PR TITLE
chore: fix type issues in rslib.config.ts

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,11 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { nodeMinifyConfig } from '@rsbuild/config/rslib.config';
+import type { Rspack, rsbuild } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
-import type { Configuration } from '@rspack/core';
 import pkgJson from './package.json';
 import prebundleConfig from './prebundle.config.mjs';
-import type { RsbuildPlugin } from './src';
 
 const define = {
   RSBUILD_VERSION: JSON.stringify(pkgJson.version),
@@ -18,7 +17,7 @@ for (const item of prebundleConfig.dependencies) {
   regexpMap[depName] = new RegExp(`compiled[\\/]${depName}(?:[\\/]|$)`);
 }
 
-const externals: Configuration['externals'] = [
+const externals: Rspack.Configuration['externals'] = [
   'webpack',
   '@rspack/core',
   '@rsbuild/core',
@@ -42,7 +41,7 @@ const externals: Configuration['externals'] = [
   },
 ];
 
-const pluginFixDtsTypes: RsbuildPlugin = {
+const pluginFixDtsTypes: rsbuild.RsbuildPlugin = {
   name: 'fix-dts-types',
   setup(api) {
     api.onAfterBuild(() => {


### PR DESCRIPTION
## Summary

Updated type imports to use `Rspack` and `rsbuild` from `@rslib/core` to fix type issues in rslib.config.ts.

<img width="1978" height="1052" alt="image" src="https://github.com/user-attachments/assets/71c6ada1-ff70-4814-a012-b3bde0041840" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
