### PR TITLE
perf(deps): update rspack-chain to 1.3.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,7 +89,7 @@
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.3.0",
     "rslog": "^1.2.9",
-    "rspack-chain": "^1.2.6",
+    "rspack-chain": "^1.3.0",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,8 +712,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9
       rspack-chain:
-        specifier: ^1.2.6
-        version: 1.2.6
+        specifier: ^1.3.0
+        version: 1.3.0
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.4.10(@swc/helpers@0.5.17))
@@ -5781,8 +5781,8 @@ packages:
   rslog@1.2.9:
     resolution: {integrity: sha512-KSjM8jJKYYaKgI4jUGZZ4kdTBTM/EIGH1JnoB0ptMkzcyWaHeXW9w6JVLCYs37gh8sFZkLLqAyBb2sT02bqpcQ==}
 
-  rspack-chain@1.2.6:
-    resolution: {integrity: sha512-o2dahcMZt7YdF8LOQCi5Z9zdJNoru/jeYK1RnkFovUVC0a5ermGiybkE45r0M7cSQPfy/DtGmtR9TWJcjKWnnQ==}
+  rspack-chain@1.3.0:
+    resolution: {integrity: sha512-TCiQbcnTOnv/2WCmt0bEGEXlV/KTao2wDbfX1zPIeCCKvzZkhq2iqLo84onSMK42iznrD0Gp4fIxWEMWwbN1GA==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -12004,7 +12004,7 @@ snapshots:
 
   rslog@1.2.9: {}
 
-  rspack-chain@1.2.6:
+  rspack-chain@1.3.0:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Update rspack-chain to 1.3.0 to reduce the bundle size of `@rsbuild/core`.

### Before

<img width="440" height="148" alt="Screenshot 2025-07-27 at 21 50 50" src="https://github.com/user-attachments/assets/d5e373bf-5fb8-459a-b89f-6330f59f2676" />

### After

<img width="449" height="146" alt="Screenshot 2025-07-27 at 21 59 37" src="https://github.com/user-attachments/assets/6809c18a-eb38-4985-b213-62e308f7705a" />

## Related Links

- https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.3.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
