### PR TITLE
feat: add type module to package.json files across examples

### DIFF
--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/lit",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/module-federation-v2/host/package.json
+++ b/examples/module-federation-v2/host/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/module-federation-v2-host",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build"

--- a/examples/module-federation-v2/remote/package.json
+++ b/examples/module-federation-v2/remote/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/module-federation-v2-remote",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build"

--- a/examples/module-federation/host/package.json
+++ b/examples/module-federation/host/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/module-federation-host",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build"

--- a/examples/module-federation/remote/package.json
+++ b/examples/module-federation/remote/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/module-federation-remote",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev",
     "build": "rsbuild build"

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/preact",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,9 +1,10 @@
 {
   "name": "@examples/react",
   "private": true,
+  "type": "module",
   "scripts": {
-    "dev": "rsbuild dev --open",
     "build": "rsbuild build",
+    "dev": "rsbuild dev --open",
     "preview": "rsbuild preview"
   },
   "dependencies": {

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/solid",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/svelte",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/vanilla",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@examples/vue",
   "private": true,
-  "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@examples/webpack",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "rsbuild dev --open",
     "build": "rsbuild build",


### PR DESCRIPTION
## Summary

Add type module to package.json files across examples. This makes Node >= 24  and "rsbuild build --config-loader=native" work correctly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
