### PR TITLE
refactor: fork connect-history-api-fallback dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,7 +70,6 @@
     "cac": "^6.7.14",
     "chokidar": "^4.0.3",
     "connect": "3.7.0",
-    "connect-history-api-fallback": "^2.0.0",
     "cors": "^2.8.5",
     "css-loader": "7.1.2",
     "deepmerge": "^4.3.1",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -60,10 +60,6 @@ export default {
       ignoreDts: true,
     },
     {
-      name: 'connect-history-api-fallback',
-      ignoreDts: true,
-    },
-    {
       name: 'rspack-chain',
       copyDts: true,
       dtsOnly: true,

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -14,6 +14,7 @@ import type { CompilationManager } from './compilationManager';
 import type { RsbuildDevServer } from './devServer';
 import { gzipMiddleware } from './gzipMiddleware';
 import type { UpgradeEvent } from './helper';
+import { historyApiFallbackMiddleware } from './historyApiFallback';
 import {
   faviconFallbackMiddleware,
   getBaseMiddleware,
@@ -228,14 +229,11 @@ const applyDefaultMiddlewares = async ({
   }
 
   if (server.historyApiFallback) {
-    const { default: connectHistoryApiFallback } = await import(
-      '../../compiled/connect-history-api-fallback/index.js'
+    middlewares.push(
+      historyApiFallbackMiddleware(
+        server.historyApiFallback === true ? {} : server.historyApiFallback,
+      ),
     );
-    const historyApiFallbackMiddleware = connectHistoryApiFallback(
-      server.historyApiFallback === true ? {} : server.historyApiFallback,
-    ) as RequestHandler;
-
-    middlewares.push(historyApiFallbackMiddleware);
 
     // ensure fallback request can be handled by compilation middleware
     if (compilationManager?.middleware) {

--- a/packages/core/src/server/historyApiFallback.ts
+++ b/packages/core/src/server/historyApiFallback.ts
@@ -1,0 +1,144 @@
+/**
+ * This module is modified based on source found in
+ * https://github.com/bripkens/connect-history-api-fallback
+ *
+ * MIT Licensed
+ * Copyright (c) 2022 Ben Blackmore and contributors
+ * https://github.com/bripkens/connect-history-api-fallback/blob/master/LICENSE
+ */
+import type { IncomingMessage } from 'node:http';
+import url from 'node:url';
+import { logger } from '../logger';
+import type {
+  HistoryApiFallbackOptions,
+  HistoryApiFallbackTo,
+  RequestHandler,
+} from '../types';
+
+export function historyApiFallbackMiddleware(
+  options: HistoryApiFallbackOptions = {},
+): RequestHandler {
+  return (req, _res, next) => {
+    const { headers } = req;
+
+    if (!req.url) {
+      return next();
+    }
+
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      logger.debug(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the method is not GET or HEAD.',
+      );
+      return next();
+    }
+
+    if (!headers || typeof headers.accept !== 'string') {
+      logger.debug(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the client did not send an HTTP accept header.',
+      );
+      return next();
+    }
+
+    if (headers.accept.indexOf('application/json') === 0) {
+      logger.debug(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the client prefers JSON.',
+      );
+      return next();
+    }
+
+    if (!acceptsHtml(headers.accept, options)) {
+      logger.debug(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the client does not accept HTML.',
+      );
+      return next();
+    }
+
+    const parsedUrl = url.parse(req.url);
+    let rewriteTarget: string;
+
+    options.rewrites = options.rewrites || [];
+
+    for (const rewrite of options.rewrites) {
+      const match = parsedUrl.pathname?.match(rewrite.from);
+      if (match) {
+        rewriteTarget = evaluateRewriteRule(parsedUrl, match, rewrite.to, req);
+
+        if (rewriteTarget.charAt(0) !== '/') {
+          logger.debug(
+            'We recommend using an absolute path for the rewrite target.',
+            'Received a non-absolute rewrite target',
+            rewriteTarget,
+            'for URL',
+            req.url,
+          );
+        }
+
+        logger.debug('Rewriting', req.method, req.url, 'to', rewriteTarget);
+        req.url = rewriteTarget;
+        return next();
+      }
+    }
+
+    const { pathname } = parsedUrl;
+    if (
+      pathname &&
+      pathname.lastIndexOf('.') > pathname.lastIndexOf('/') &&
+      options.disableDotRule !== true
+    ) {
+      logger.debug(
+        'Not rewriting',
+        req.method,
+        req.url,
+        'because the path includes a dot (.) character.',
+      );
+      return next();
+    }
+
+    rewriteTarget = options.index || '/index.html';
+    logger.debug('Rewriting', req.method, req.url, 'to', rewriteTarget);
+    req.url = rewriteTarget;
+    next();
+  };
+}
+
+function evaluateRewriteRule(
+  parsedUrl: import('node:url').Url,
+  match: RegExpMatchArray,
+  rule: HistoryApiFallbackTo,
+  req: IncomingMessage,
+) {
+  if (typeof rule === 'string') {
+    return rule;
+  }
+  if (typeof rule !== 'function') {
+    throw new Error('Rewrite rule can only be of type string or function.');
+  }
+
+  return rule({
+    parsedUrl: parsedUrl,
+    match: match,
+    request: req,
+  });
+}
+
+function acceptsHtml(header: string, options: HistoryApiFallbackOptions) {
+  options.htmlAcceptHeaders = options.htmlAcceptHeaders || ['text/html', '*/*'];
+  for (const item of options.htmlAcceptHeaders) {
+    if (header.indexOf(item) !== -1) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -7,7 +7,6 @@ import type {
   InternalContext,
   NormalizedConfig,
   PreviewOptions,
-  RequestHandler,
   ServerConfig,
 } from '../types';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
@@ -25,6 +24,7 @@ import {
   printServerURLs,
   type StartServerResult,
 } from './helper';
+import { historyApiFallbackMiddleware } from './historyApiFallback';
 import { createHttpServer } from './httpServer';
 import {
   faviconFallbackMiddleware,
@@ -122,14 +122,11 @@ export class RsbuildProdServer {
     await this.applyStaticAssetMiddleware();
 
     if (historyApiFallback) {
-      const { default: connectHistoryApiFallback } = await import(
-        '../../compiled/connect-history-api-fallback/index.js'
+      this.middlewares.use(
+        historyApiFallbackMiddleware(
+          historyApiFallback === true ? {} : historyApiFallback,
+        ),
       );
-      const historyApiFallbackMiddleware = connectHistoryApiFallback(
-        historyApiFallback === true ? {} : historyApiFallback,
-      ) as RequestHandler;
-
-      this.middlewares.use(historyApiFallbackMiddleware);
 
       // ensure fallback request can be handled by sirv
       await this.applyStaticAssetMiddleware();

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -369,18 +369,21 @@ export type ProxyConfig =
 export type HistoryApiFallbackContext = {
   match: RegExpMatchArray;
   parsedUrl: import('node:url').Url;
-  request: Request;
+  request: IncomingMessage;
 };
+
+export type HistoryApiFallbackTo =
+  | string
+  | RegExp
+  | ((context: HistoryApiFallbackContext) => string);
 
 export type HistoryApiFallbackOptions = {
   index?: string;
-  verbose?: boolean;
-  logger?: typeof console.log;
   htmlAcceptHeaders?: string[];
   disableDotRule?: true;
   rewrites?: Array<{
     from: RegExp;
-    to: string | RegExp | ((context: HistoryApiFallbackContext) => string);
+    to: HistoryApiFallbackTo;
   }>;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -654,9 +654,6 @@ importers:
       connect:
         specifier: 3.7.0
         version: 3.7.0
-      connect-history-api-fallback:
-        specifier: ^2.0.0
-        version: 2.0.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -3721,10 +3718,6 @@ packages:
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
-
-  connect-history-api-fallback@2.0.0:
-    resolution: {integrity: sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==}
-    engines: {node: '>=0.8'}
 
   connect@3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
@@ -9606,8 +9599,6 @@ snapshots:
   commander@7.2.0: {}
 
   commander@8.3.0: {}
-
-  connect-history-api-fallback@2.0.0: {}
 
   connect@3.7.0:
     dependencies:

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -6,6 +6,7 @@ applescript
 atrules
 attributify
 biomejs
+blackmore
 brotli
 browserslistrc
 bundleless


### PR DESCRIPTION
## Summary

The connect-history-api-fallback dependency is no longer actively maintained and contains only ~100 lines of code, so I decided to fork it to better maintain the code.

This PR also removes the `logger` and `verbose` options, because we can use `logger.debug()` instead, which will not have any impact on the functionality of this middleware.

## Related Links

- https://github.com/bripkens/connect-history-api-fallback

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
