### PR TITLE
test(e2e): fix flaky plugin hooks watch test

### DIFF
--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -105,7 +105,7 @@ rspackOnlyTest(
     await fs.promises.writeFile(filePath, "console.log('2');");
     await expectFile(distPath);
 
-    expect(names).toEqual([
+    expect(names.slice(0, 13)).toEqual([
       'ModifyRsbuildConfig',
       'ModifyBundlerChain',
       'ModifyBundlerConfig',


### PR DESCRIPTION
## Summary

Fix the flaky plugin hooks watch test. Since the watch may fire multiple times, we need to limit the scope of the assertion.

<img width="1055" height="435" alt="Screenshot 2025-07-28 at 21 23 05" src="https://github.com/user-attachments/assets/5263ce96-55e9-42bc-ad0d-1bcd917c4670" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
