### PR TITLE
fix: remove the deprecated `url.parse` from historyApiFallback

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -155,7 +155,7 @@ export const urlJoin = (base: string, path: string) => {
   return `${urlProtocol}://${posix.join(baseUrl, path)}`;
 };
 
-// Can be replaced with URL.canParse when we drop support for Node.js 16
+// TODO: Can be replaced with URL.canParse when we drop support for Node.js 16
 export const canParse = (url: string): boolean => {
   try {
     new URL(url);

--- a/packages/core/src/server/historyApiFallback.ts
+++ b/packages/core/src/server/historyApiFallback.ts
@@ -55,13 +55,11 @@ export function historyApiFallbackMiddleware(
       return next();
     }
 
-    options.rewrites = options.rewrites || [];
-    options.htmlAcceptHeaders = options.htmlAcceptHeaders || [
-      'text/html',
-      '*/*',
-    ];
+    const rewrites = options.rewrites || [];
+    const htmlAcceptHeaders = options.htmlAcceptHeaders || ['text/html', '*/*'];
+    const { accept } = headers;
 
-    if (!acceptsHtml(headers.accept, options.htmlAcceptHeaders)) {
+    if (!htmlAcceptHeaders.some((item) => accept.includes(item))) {
       logger.debug(
         'Not rewriting',
         req.method,
@@ -82,7 +80,7 @@ export function historyApiFallbackMiddleware(
 
     let rewriteTarget: string;
 
-    for (const rewrite of options.rewrites) {
+    for (const rewrite of rewrites) {
       const match = parsedUrl.pathname?.match(rewrite.from);
       if (match) {
         rewriteTarget = evaluateRewriteRule(parsedUrl, match, rewrite.to, req);
@@ -142,8 +140,4 @@ function evaluateRewriteRule(
     match: match,
     request: req,
   });
-}
-
-function acceptsHtml(header: string, htmlAcceptHeaders: string[]) {
-  return htmlAcceptHeaders.some((item) => header.includes(item));
 }

--- a/packages/core/src/server/historyApiFallback.ts
+++ b/packages/core/src/server/historyApiFallback.ts
@@ -9,11 +9,7 @@
 import type { IncomingMessage } from 'node:http';
 import { URL } from 'node:url';
 import { logger } from '../logger';
-import type {
-  HistoryApiFallbackOptions,
-  HistoryApiFallbackTo,
-  RequestHandler,
-} from '../types';
+import type { HistoryApiFallbackOptions, RequestHandler } from '../types';
 
 export function historyApiFallbackMiddleware(
   options: HistoryApiFallbackOptions = {},

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { SecureServerSessionOptions } from 'node:http2';
 import type { ServerOptions as HttpsServerOptions } from 'node:https';
+import type { URL } from 'node:url';
 import type {
   Configuration,
   CopyRspackPluginOptions,
@@ -368,7 +369,7 @@ export type ProxyConfig =
 
 export type HistoryApiFallbackContext = {
   match: RegExpMatchArray;
-  parsedUrl: import('node:url').Url;
+  parsedUrl: URL;
   request: IncomingMessage;
 };
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -375,7 +375,6 @@ export type HistoryApiFallbackContext = {
 
 export type HistoryApiFallbackTo =
   | string
-  | RegExp
   | ((context: HistoryApiFallbackContext) => string);
 
 export type HistoryApiFallbackOptions = {


### PR DESCRIPTION
## Summary

`url.parse` has been deprecated since Node 24, and we should use `new URL` instead.

<img width="1051" height="120" alt="Screenshot 2025-07-28 at 21 46 34" src="https://github.com/user-attachments/assets/371fe5ec-2436-48a1-b734-bb91ee719f9f" />

## Related Links

- https://nodejs.org/en/blog/release/v24.0.0#deprecations-and-removals
- https://github.com/nodejs/node/pull/55017
- https://github.com/web-infra-dev/rsbuild/pull/5694

## TODO

We still have three dependencies that use `url.parse`:

<img width="600" height="670" alt="image" src="https://github.com/user-attachments/assets/59014d3b-edff-49fe-8a14-b8ced45fcf65" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
