### PR TITLE
chore(workflow): integrate Rslint for type-aware linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "e2e:webpack": "cd ./e2e && pnpm e2e:webpack",
     "format": "prettier --write . && heading-case --write",
     "lint": "biome check && pnpm run check-spell",
+    "lint:type": "rslint --config rslint.json",
     "prebundle": "nx run-many -t prebundle",
     "prepare": "simple-git-hooks && pnpm run build",
     "sort-package-json": "pnpx sort-package-json \"./package.json\" \"packages/*/package.json\" \"packages/compat/*/package.json\"",
@@ -35,6 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
     "@rsbuild/config": "workspace:*",
+    "@rslint/core": "^0.0.15",
     "@rstest/core": "0.0.10",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@rsbuild/config':
         specifier: workspace:*
         version: link:scripts/config
+      '@rslint/core':
+        specifier: ^0.0.15
+        version: 0.0.15
       '@rstest/core':
         specifier: 0.0.10
         version: 0.0.10
@@ -2480,6 +2483,40 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  '@rslint/core@0.0.15':
+    resolution: {integrity: sha512-U6NBznW5Ycy8Q9zzzdj+DZW+gXiZ7BLtYwzzYybgchn5xIV7JcKC/wVHmE64mXAq5AdcN9NYcLBK6mkb8bXHCQ==}
+    hasBin: true
+
+  '@rslint/darwin-arm64@0.0.15':
+    resolution: {integrity: sha512-eBn9Fi52YHYyaTGwxN+CS+vX4K5CzoMRFeXCz/xplV67/k9s1QPtlWPJh9hK9Zu3/ijqMC7c5oE0/mhJn965ig==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rslint/darwin-x64@0.0.15':
+    resolution: {integrity: sha512-PxRu09Q3b3iyTLa47bMsixp5ms3KGRzRfjezeCx/LgWWBYXoNCJmUcDRpuDzAhVf3huxe1f2haVuYkkLYsTm/Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rslint/linux-arm64@0.0.15':
+    resolution: {integrity: sha512-GiEaFJInBvm6KPDZaXBmYbQ9qkbW6Yrwj8/5lMus77Rav1uHvrF/aCK6DV6vOW3aoLyyNPutGgHy9dwKsNJmjQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rslint/linux-x64@0.0.15':
+    resolution: {integrity: sha512-NuSrJpyXkT/n+tL/jBcfvAgr3NmasGkLQfky2eECP9f6xPbMiyEbrJuKzecX8XaRpY1R/prW1sx1YXUMx6OKlg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rslint/win32-arm64@0.0.15':
+    resolution: {integrity: sha512-N63m6/R0Auaqkf0HUtNmIFL37eEi/PtAP7JqXjTGOJv/2/ChRcYvh+L5T2bzhnh8swBnFD5gNV9GtfbnADPw2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rslint/win32-x64@0.0.15':
+    resolution: {integrity: sha512-+gvPNDo6UgcMyP6R0+S7HhDdrSIVyUH4UgVGhqzgsJHJ9W9ubLHFupo77IpuF0Ke79Ak8MMOXKyk+0Mx6ambsQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@rspack/binding-darwin-arm64@1.4.10':
     resolution: {integrity: sha512-PraYGuVSzvEwdoYC8T70qI/8j1QeUe2sysiWmjSdxUpxJsDfw35hK9TfxULeAJULlAUAiiXs03hdZk29DBc3ow==}
@@ -8189,6 +8226,33 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       typescript: 5.8.3
+
+  '@rslint/core@0.0.15':
+    optionalDependencies:
+      '@rslint/darwin-arm64': 0.0.15
+      '@rslint/darwin-x64': 0.0.15
+      '@rslint/linux-arm64': 0.0.15
+      '@rslint/linux-x64': 0.0.15
+      '@rslint/win32-arm64': 0.0.15
+      '@rslint/win32-x64': 0.0.15
+
+  '@rslint/darwin-arm64@0.0.15':
+    optional: true
+
+  '@rslint/darwin-x64@0.0.15':
+    optional: true
+
+  '@rslint/linux-arm64@0.0.15':
+    optional: true
+
+  '@rslint/linux-x64@0.0.15':
+    optional: true
+
+  '@rslint/win32-arm64@0.0.15':
+    optional: true
+
+  '@rslint/win32-x64@0.0.15':
+    optional: true
 
   '@rspack/binding-darwin-arm64@1.4.10':
     optional: true

--- a/rslint.json
+++ b/rslint.json
@@ -1,0 +1,11 @@
+[
+  {
+    "language": "javascript",
+    "languageOptions": {
+      "parserOptions": {
+        "project": ["./packages/core/tsconfig.json"]
+      }
+    },
+    "plugins": ["@typescript-eslint"]
+  }
+]


### PR DESCRIPTION
## What is Rslint

Rslint is a linter currently under development for Rstack, and the repository is still private. We plan to make it public soon.

## Summary

This PR introduces Rslint to enable type-aware linting rules. This improves the TypeScript code quality in Rsbuild and it also helps to validate Rslint’s capabilities.

<img width="1137" height="708" alt="Screenshot 2025-07-29 at 10 36 34" src="https://github.com/user-attachments/assets/8b59ebf2-0504-45e4-b377-3ef3fd175f52" />

## TODO

- Fix issues found by Rslint
- Enable Rslint in CI
- Add more subdirectories to `project` options

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
