### PR TITLE
chore: fix no-unnecessary-template-expression lint issues

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -39,7 +39,7 @@ export async function runCLI(): Promise<void> {
     logger.log();
   }
 
-  logger.greet(`  ${`Rsbuild v${RSBUILD_VERSION}`}\n`);
+  logger.greet(`  Rsbuild v${RSBUILD_VERSION}\n`);
 
   try {
     setupCommands();

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -43,7 +43,7 @@ logger.override({
     if (logger.level !== 'verbose') {
       return;
     }
-    const time = color.gray(`${getTime()}`);
+    const time = color.gray(getTime());
     console.log(`  ${color.magenta('rsbuild')} ${time} ${message}`, ...args);
   },
 });

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -67,7 +67,7 @@ function getClientPaths(devConfig: NormalizedDevConfig) {
   clientPaths.push(require.resolve('@rsbuild/core/client/hmr'));
 
   if (devConfig.client?.overlay) {
-    clientPaths.push(`${require.resolve('@rsbuild/core/client/overlay')}`);
+    clientPaths.push(require.resolve('@rsbuild/core/client/overlay'));
   }
 
   return clientPaths;

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -158,7 +158,7 @@ function getURLMessages(
     if (index > 0) {
       message += '\n';
     }
-    message += `  ${`➜  ${label}`}\n`;
+    message += `  ➜  ${label}\n`;
 
     for (const r of routes) {
       message += `  ${color.dim('-')} ${color.dim(

--- a/rslint.json
+++ b/rslint.json
@@ -29,7 +29,6 @@
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/restrict-template-expressions": "off",
-      "@typescript-eslint/no-unnecessary-template-expression": "off",
       "@typescript-eslint/no-floating-promises": "off",
       "@typescript-eslint/no-unsafe-member-access": "off",
       "@typescript-eslint/no-unsafe-return": "off",


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `@typescript-eslint/no-unnecessary-template-expression`  rule in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
