### PR TITLE
chore: fix return-await lint issues

### DIFF
--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -388,7 +388,7 @@ export const registerBuildHook = ({
   }, []);
 
   const beforeCompile = async () =>
-    await context.hooks.onBeforeBuild.callBatch({
+    context.hooks.onBeforeBuild.callBatch({
       bundlerConfigs,
       environments: context.environments,
       isWatch,
@@ -396,7 +396,7 @@ export const registerBuildHook = ({
     });
 
   const beforeEnvironmentCompiler = async (buildIndex: number) =>
-    await context.hooks.onBeforeEnvironmentCompile.callBatch({
+    context.hooks.onBeforeEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {
@@ -469,7 +469,7 @@ export const registerDevHook = ({
   }, []);
 
   const beforeEnvironmentCompiler = async (buildIndex: number) =>
-    await context.hooks.onBeforeEnvironmentCompile.callBatch({
+    context.hooks.onBeforeEnvironmentCompile.callBatch({
       environment: environmentList[buildIndex].name,
       args: [
         {

--- a/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
+++ b/packages/core/src/rspack-plugins/RsbuildHtmlPlugin.ts
@@ -279,7 +279,7 @@ export class RsbuildHtmlPlugin {
         ? favicon
         : path.join(compilation.compiler.context, favicon);
 
-      let buffer: Buffer<ArrayBufferLike> | undefined;
+      let buffer: Buffer | undefined;
 
       try {
         buffer = await promisify(compilation.inputFileSystem.readFile)(

--- a/rslint.json
+++ b/rslint.json
@@ -37,15 +37,12 @@
       "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
       "@typescript-eslint/unbound-method": "off",
       "@typescript-eslint/no-redundant-type-constituents": "off",
-      "@typescript-eslint/return-await": "off",
       "@typescript-eslint/no-implied-eval": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/switch-exhaustiveness-check": "off",
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
-      "@typescript-eslint/no-unnecessary-type-arguments": "off",
       "@typescript-eslint/non-nullable-type-assertion-style": "off",
-      "@typescript-eslint/prefer-promise-reject-errors": "off",
-      "@typescript-eslint/no-misused-spread": "off"
+      "@typescript-eslint/prefer-promise-reject-errors": "off"
     }
   }
 ]


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `@typescript-eslint/return-await` and `@typescript-eslint/no-unnecessary-type-arguments`  rules in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
