### PR TITLE
chore: write tsBuildInfo files to node_modules cache folder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/packages/compat/plugin-webpack-swc/tsconfig.json
+++ b/packages/compat/plugin-webpack-swc/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -5,6 +5,7 @@
     "rootDir": "src",
     "declarationDir": "./dist-types",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true,
     "types": ["@rspack/core/module"]
   },

--- a/packages/plugin-babel/tsconfig.json
+++ b/packages/plugin-babel/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-less/tsconfig.json
+++ b/packages/plugin-less/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-preact/tsconfig.json
+++ b/packages/plugin-preact/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-react/tsconfig.json
+++ b/packages/plugin-react/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-sass/tsconfig.json
+++ b/packages/plugin-sass/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-solid/tsconfig.json
+++ b/packages/plugin-solid/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-stylus/tsconfig.json
+++ b/packages/plugin-stylus/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-svelte/tsconfig.json
+++ b/packages/plugin-svelte/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-svgr/tsconfig.json
+++ b/packages/plugin-svgr/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [

--- a/packages/plugin-vue/tsconfig.json
+++ b/packages/plugin-vue/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
+    "tsBuildInfoFile": "./node_modules/.cache/.tsbuildinfo",
     "isolatedDeclarations": true
   },
   "references": [


### PR DESCRIPTION
## Summary

Write the tsBuildInfo files to node_modules/.cache to make the working directories cleaner.

## Related Links

- https://www.typescriptlang.org/tsconfig/#tsBuildInfoFile

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
