### PR TITLE
chore: fix no-confusing-void-expression lint issues

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -142,8 +142,12 @@ function tryApplyUpdates() {
 
     // https://rspack.rs/api/runtime-api/module-variables#importmetawebpackhot
     import.meta.webpackHot.check(true).then(
-      (updatedModules) => handleApplyUpdates(null, updatedModules),
-      (err) => handleApplyUpdates(err, null),
+      (updatedModules) => {
+        handleApplyUpdates(null, updatedModules);
+      },
+      (err) => {
+        handleApplyUpdates(err, null);
+      },
     );
     return;
   }

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -71,7 +71,9 @@ function clearOverlay() {
   document
     .querySelectorAll<ErrorOverlay>(overlayId)
     // close overlay immediately to avoid multiple overlays at the same time
-    .forEach((n) => n.close(true));
+    .forEach((n) => {
+      n.close(true);
+    });
 }
 
 if (typeof document !== 'undefined') {

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -129,8 +129,9 @@ export function createEnvironmentAsyncHook<
 
   return {
     tapEnvironment,
-    tap: (handler: Callback | HookDescriptor<Callback>) =>
-      tapEnvironment({ handler }),
+    tap: (handler: Callback | HookDescriptor<Callback>) => {
+      tapEnvironment({ handler });
+    },
     callChain,
     callBatch,
   };

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -373,50 +373,59 @@ export function initPluginAPI({
     onAfterStartProdServer: hooks.onAfterStartProdServer.tap,
     onBeforeStartProdServer: hooks.onBeforeStartProdServer.tap,
     modifyRsbuildConfig: hooks.modifyRsbuildConfig.tap,
-    modifyHTML: (handler) =>
+    modifyHTML: (handler) => {
       hooks.modifyHTML.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyHTMLTags: (handler) =>
+      });
+    },
+    modifyHTMLTags: (handler) => {
       hooks.modifyHTMLTags.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyBundlerChain: (handler) =>
+      });
+    },
+    modifyBundlerChain: (handler) => {
       hooks.modifyBundlerChain.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyRspackConfig: (handler) =>
+      });
+    },
+    modifyRspackConfig: (handler) => {
       hooks.modifyRspackConfig.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyWebpackChain: (handler) =>
+      });
+    },
+    modifyWebpackChain: (handler) => {
       hooks.modifyWebpackChain.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyWebpackConfig: (handler) =>
+      });
+    },
+    modifyWebpackConfig: (handler) => {
       hooks.modifyWebpackConfig.tapEnvironment({
         environment,
         handler,
-      }),
-    modifyEnvironmentConfig: (handler) =>
+      });
+    },
+    modifyEnvironmentConfig: (handler) => {
       hooks.modifyEnvironmentConfig.tapEnvironment({
         environment,
         handler,
-      }),
-    onAfterEnvironmentCompile: (handler) =>
+      });
+    },
+    onAfterEnvironmentCompile: (handler) => {
       hooks.onAfterEnvironmentCompile.tapEnvironment({
         environment,
         handler,
-      }),
-    onBeforeEnvironmentCompile: (handler) =>
+      });
+    },
+    onBeforeEnvironmentCompile: (handler) => {
       hooks.onBeforeEnvironmentCompile.tapEnvironment({
         environment,
         handler,
-      }),
+      });
+    },
   });
 }

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -12,16 +12,20 @@ export default async function transform(
   map?: string | Rspack.sources.RawSourceMap,
 ): Promise<void> {
   const callback = this.async();
-  const bypass = () => callback(null, source, map);
+  const bypass = () => {
+    callback(null, source, map);
+  };
 
   const { id: transformId, getEnvironment } = this.getOptions();
   if (!transformId) {
-    return bypass();
+    bypass();
+    return;
   }
 
   const transform = this._compiler?.__rsbuildTransformer?.[transformId];
   if (!transform) {
-    return bypass();
+    bypass();
+    return;
   }
 
   try {
@@ -41,11 +45,13 @@ export default async function transform(
     });
 
     if (result === null || result === undefined) {
-      return bypass();
+      bypass();
+      return;
     }
 
     if (typeof result === 'string') {
-      return callback(null, result, map);
+      callback(null, result, map);
+      return;
     }
 
     const useMap = map !== undefined && map !== null;

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -484,7 +484,9 @@ export function getServerTerminator(
         socket.destroy();
       }
       if (listened) {
-        server.close((err) => (err ? reject(err) : resolve()));
+        server.close((err) => {
+          err ? reject(err) : resolve();
+        });
       } else {
         resolve();
       }

--- a/packages/core/src/server/historyApiFallback.ts
+++ b/packages/core/src/server/historyApiFallback.ts
@@ -18,7 +18,8 @@ export function historyApiFallbackMiddleware(
     const { headers } = req;
 
     if (!req.url) {
-      return next();
+      next();
+      return;
     }
 
     if (req.method !== 'GET' && req.method !== 'HEAD') {
@@ -28,7 +29,8 @@ export function historyApiFallbackMiddleware(
         req.url,
         'because the method is not GET or HEAD.',
       );
-      return next();
+      next();
+      return;
     }
 
     if (!headers || typeof headers.accept !== 'string') {
@@ -38,7 +40,8 @@ export function historyApiFallbackMiddleware(
         req.url,
         'because the client did not send an HTTP accept header.',
       );
-      return next();
+      next();
+      return;
     }
 
     if (headers.accept.indexOf('application/json') === 0) {
@@ -48,7 +51,8 @@ export function historyApiFallbackMiddleware(
         req.url,
         'because the client prefers JSON.',
       );
-      return next();
+      next();
+      return;
     }
 
     const rewrites = options.rewrites || [];
@@ -62,14 +66,16 @@ export function historyApiFallbackMiddleware(
         req.url,
         'because the client does not accept HTML.',
       );
-      return next();
+      next();
+      return;
     }
 
     const parsedUrl = parseReqUrl(req);
 
     // skip invalid request
     if (parsedUrl === null) {
-      return next();
+      next();
+      return;
     }
 
     let rewriteTarget: string;
@@ -98,7 +104,8 @@ export function historyApiFallbackMiddleware(
 
       logger.debug('Rewriting', req.method, req.url, 'to', rewriteTarget);
       req.url = rewriteTarget;
-      return next();
+      next();
+      return;
     }
 
     const { pathname } = parsedUrl;
@@ -113,7 +120,8 @@ export function historyApiFallbackMiddleware(
         req.url,
         'because the path includes a dot (.) character.',
       );
-      return next();
+      next();
+      return;
     }
 
     const index = options.index || '/index.html';

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -133,7 +133,8 @@ export const getHtmlCompletionMiddleware: (params: {
 }) => RequestHandler = ({ distPath, compilationManager }) => {
   return async (req, res, next) => {
     if (!maybeHTMLRequest(req)) {
-      return next();
+      next();
+      return;
     }
 
     const url = req.url!;
@@ -141,9 +142,10 @@ export const getHtmlCompletionMiddleware: (params: {
 
     const rewrite = (newUrl: string) => {
       req.url = newUrl;
-      return compilationManager.middleware(req, res, (...args) => {
+      compilationManager.middleware(req, res, (...args) => {
         next(...args);
       });
+      return;
     };
 
     // '/' => '/index.html'
@@ -152,7 +154,8 @@ export const getHtmlCompletionMiddleware: (params: {
       const filePath = path.join(distPath, newUrl);
 
       if (await isFileExists(filePath, compilationManager.outputFileSystem)) {
-        return rewrite(newUrl);
+        rewrite(newUrl);
+        return;
       }
     }
     // '/main' => '/main.html'
@@ -161,7 +164,8 @@ export const getHtmlCompletionMiddleware: (params: {
       const filePath = path.join(distPath, newUrl);
 
       if (await isFileExists(filePath, compilationManager.outputFileSystem)) {
-        return rewrite(newUrl);
+        rewrite(newUrl);
+        return;
       }
     }
 
@@ -181,7 +185,8 @@ export const getBaseMiddleware: (params: {
 
     if (pathname.startsWith(base)) {
       req.url = stripBase(url, base);
-      return next();
+      next();
+      return;
     }
 
     const redirectPath =
@@ -234,7 +239,8 @@ export const getHtmlFallbackMiddleware: (params: {
       '/favicon.ico' === req.url ||
       htmlFallback !== 'index'
     ) {
-      return next();
+      next();
+      return;
     }
 
     const filePath = path.join(distPath, 'index.html');
@@ -250,9 +256,10 @@ export const getHtmlFallbackMiddleware: (params: {
       }
 
       req.url = newUrl;
-      return compilationManager.middleware(req, res, (...args) =>
-        next(...args),
-      );
+      compilationManager.middleware(req, res, (...args) => {
+        next(...args);
+      });
+      return;
     }
 
     next();

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -324,7 +324,8 @@ export class SocketServer {
     this.initialChunks[token] = newInitialChunks;
 
     if (shouldReload) {
-      return this.sockWrite({ type: 'static-changed' }, token);
+      this.sockWrite({ type: 'static-changed' }, token);
+      return;
     }
 
     const shouldEmit =
@@ -335,7 +336,8 @@ export class SocketServer {
       statsJson.assets.every((asset: any) => !asset.emitted);
 
     if (shouldEmit) {
-      return this.sockWrite({ type: 'ok' }, token);
+      this.sockWrite({ type: 'ok' }, token);
+      return;
     }
 
     this.sockWrite(
@@ -353,7 +355,7 @@ export class SocketServer {
         warnings: [],
       });
 
-      return this.sockWrite(
+      this.sockWrite(
         {
           type: 'errors',
           data: {
@@ -363,6 +365,7 @@ export class SocketServer {
         },
         token,
       );
+      return;
     }
 
     if (statsJson.warningsCount) {
@@ -371,7 +374,7 @@ export class SocketServer {
         warnings,
         errors: [],
       });
-      return this.sockWrite(
+      this.sockWrite(
         {
           type: 'warnings',
           data: {
@@ -380,9 +383,11 @@ export class SocketServer {
         },
         token,
       );
+      return;
     }
 
-    return this.sockWrite({ type: 'ok' }, token);
+    this.sockWrite({ type: 'ok' }, token);
+    return;
   }
 
   // send message to connecting socket

--- a/packages/plugin-babel/src/helper.ts
+++ b/packages/plugin-babel/src/helper.ts
@@ -133,21 +133,29 @@ export const getBabelUtils = (
   const noop = () => {};
 
   return {
-    addPlugins: (plugins: BabelPlugin[]) => addPlugins(plugins, config),
-    addPresets: (presets: BabelPlugin[]) => addPresets(presets, config),
-    removePlugins: (plugins: string | string[]) =>
-      removePlugins(plugins, config),
-    removePresets: (presets: string | string[]) =>
-      removePresets(presets, config),
+    addPlugins: (plugins: BabelPlugin[]) => {
+      addPlugins(plugins, config);
+    },
+    addPresets: (presets: BabelPlugin[]) => {
+      addPresets(presets, config);
+    },
+    removePlugins: (plugins: string | string[]) => {
+      removePlugins(plugins, config);
+    },
+    removePresets: (presets: string | string[]) => {
+      removePresets(presets, config);
+    },
     // `addIncludes` and `addExcludes` are noop functions by default,
     // It can be overridden by `extraBabelUtils`.
     addIncludes: noop,
     addExcludes: noop,
     // Compat `presetEnvOptions` and `presetReactOptions` in Modern.js
-    modifyPresetEnvOptions: (options: PresetEnvOptions) =>
-      modifyPresetOptions('@babel/preset-env', options, config.presets || []),
-    modifyPresetReactOptions: (options: PresetReactOptions) =>
-      modifyPresetOptions('@babel/preset-react', options, config.presets || []),
+    modifyPresetEnvOptions: (options: PresetEnvOptions) => {
+      modifyPresetOptions('@babel/preset-env', options, config.presets || []);
+    },
+    modifyPresetReactOptions: (options: PresetReactOptions) => {
+      modifyPresetOptions('@babel/preset-react', options, config.presets || []);
+    },
   };
 };
 

--- a/rslint.json
+++ b/rslint.json
@@ -24,7 +24,6 @@
       "@typescript-eslint/promise-function-async": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-type-assertion": "off",
-      "@typescript-eslint/no-confusing-void-expression": "off",
       "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `@typescript-eslint/no-confusing-void-expression`  rule in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
