### PR TITLE
chore: fix no-unnecessary-boolean-literal-compare lint issues

### DIFF
--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -296,7 +296,7 @@ export async function initPlugins({
         const result = instance.apply(context.originalConfig, {
           action: context.action,
         });
-        if (result === false) {
+        if (!result) {
           continue;
         }
       } else {

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -34,7 +34,7 @@ const chainStaticAssetRule = ({
     filename,
   };
 
-  if (emit === false) {
+  if (!emit) {
     generatorOptions.emit = false;
   }
 

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -137,8 +137,7 @@ async function loadUserPostcssrc(
 const isPostcssPluginCreator = (
   plugin: AcceptedPlugin,
 ): plugin is PluginCreator<unknown> =>
-  typeof plugin === 'function' &&
-  (plugin as PluginCreator<unknown>).postcss === true;
+  typeof plugin === 'function' && (plugin as PluginCreator<unknown>).postcss;
 
 const getPostcssLoaderOptions = async ({
   config,

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -66,7 +66,7 @@ export const parseMinifyOptions = (
   const { minify } = config.output;
 
   if (typeof minify === 'boolean') {
-    const shouldMinify = minify === true && isProd;
+    const shouldMinify = minify && isProd;
     return {
       minifyJs: shouldMinify,
       minifyCss: shouldMinify,

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -32,7 +32,7 @@ function getPublicPath({
     }
   } else if (typeof dev.assetPrefix === 'string') {
     publicPath = dev.assetPrefix;
-  } else if (dev.assetPrefix === true) {
+  } else if (dev.assetPrefix) {
     const protocol = context.devServer?.https ? 'https' : 'http';
     const hostname = context.devServer?.hostname || DEFAULT_DEV_HOST;
 

--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -26,7 +26,7 @@ export const gzipMiddleware =
     level = zlib.constants.Z_BEST_SPEED,
   }: CompressOptions = {}): RequestHandler =>
   (req, res, next): void => {
-    if (filter && filter(req, res) === false) {
+    if (filter && !filter(req, res)) {
       next();
       return;
     }
@@ -59,9 +59,7 @@ export const gzipMiddleware =
         gzip = zlib.createGzip({ level });
 
         gzip.on('data', (chunk) => {
-          if (
-            (write as (chunk: unknown) => boolean).call(res, chunk) === false
-          ) {
+          if (!(write as (chunk: unknown) => boolean).call(res, chunk)) {
             gzip!.pause();
           }
         });

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -228,7 +228,7 @@ export function printServerURLs({
 
   let message = getURLMessages(urls, routes);
 
-  if (trailingLineBreak === false && message.endsWith('\n')) {
+  if (!trailingLineBreak && message.endsWith('\n')) {
     message = message.slice(0, -1);
   }
 

--- a/rslint.json
+++ b/rslint.json
@@ -33,7 +33,6 @@
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-enum-comparison": "off",
       "@typescript-eslint/no-misused-promises": "off",
-      "@typescript-eslint/no-unnecessary-boolean-literal-compare": "off",
       "@typescript-eslint/unbound-method": "off",
       "@typescript-eslint/no-redundant-type-constituents": "off",
       "@typescript-eslint/no-implied-eval": "off",


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `@typescript-eslint/no-unnecessary-boolean-literal-compare`  rules in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
