### PR TITLE
chore: fix non-nullable-type-assertion-style lint issues

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -145,7 +145,7 @@ function tryApplyUpdates() {
       (updatedModules) => {
         handleApplyUpdates(null, updatedModules);
       },
-      (err) => {
+      (err: unknown) => {
         handleApplyUpdates(err, null);
       },
     );

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -21,7 +21,7 @@ export { color, RspackChain };
 // `SubresourceIntegrityPlugin` added in Rspack v1.2.4
 export const rspackMinVersion = '1.2.4';
 
-export const getNodeEnv = () => process.env.NODE_ENV as string;
+export const getNodeEnv = (): string => process.env.NODE_ENV || '';
 export const setNodeEnv = (env: string): void => {
   process.env.NODE_ENV = env;
 };

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -401,7 +401,7 @@ export const registerBuildHook = ({
       environment: environmentList[buildIndex].name,
       args: [
         {
-          bundlerConfig: bundlerConfigs?.[buildIndex] as Rspack.Configuration,
+          bundlerConfig: bundlerConfigs?.[buildIndex]!,
           environment: environmentList[buildIndex],
           isWatch,
           isFirstCompile,
@@ -474,7 +474,7 @@ export const registerDevHook = ({
       environment: environmentList[buildIndex].name,
       args: [
         {
-          bundlerConfig: bundlerConfigs?.[buildIndex] as Rspack.Configuration,
+          bundlerConfig: bundlerConfigs?.[buildIndex]!,
           environment: environmentList[buildIndex],
           isWatch: true,
           isFirstCompile,

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -311,9 +311,9 @@ export const pluginFileSize = (): RsbuildPlugin => ({
 
           logs.push(...statsLogs);
         }),
-      ).catch((err) => {
+      ).catch((err: unknown) => {
         logger.warn('Failed to print file size.');
-        logger.warn(err as Error);
+        logger.warn(err);
       });
 
       logger.log(logs.join('\n'));

--- a/rslint.json
+++ b/rslint.json
@@ -38,8 +38,6 @@
       "@typescript-eslint/no-implied-eval": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off",
       "@typescript-eslint/switch-exhaustiveness-check": "off",
-      "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
-      "@typescript-eslint/non-nullable-type-assertion-style": "off",
       "@typescript-eslint/prefer-promise-reject-errors": "off"
     }
   }


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `@typescript-eslint/use-unknown-in-catch-callback-variable` and `@typescript-eslint/non-nullable-type-assertion-style` rules in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
