### PR TITLE
docs: update historyApiFallback documentation

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -484,8 +484,9 @@ export interface ServerConfig {
    */
   htmlFallback?: HtmlFallback;
   /**
-   * Provide alternative pages for some 404 responses or other requests.
-   * see https://github.com/bripkens/connect-history-api-fallback
+   * Used to support routing based on the history API.
+   * When a user visits a path that does not exist, it will automatically
+   * return a specified HTML file to avoid a 404 error.
    */
   historyApiFallback?: boolean | HistoryApiFallbackOptions;
   /**

--- a/website/docs/en/config/server/history-api-fallback.mdx
+++ b/website/docs/en/config/server/history-api-fallback.mdx
@@ -1,13 +1,15 @@
 # server.historyApiFallback
 
-- **Type:** `boolean | ConnectHistoryApiFallbackOptions`
+- **Type:** `boolean | HistoryApiFallbackOptions`
 - **Default:** `false`
+
+`historyApiFallback` is used to support routing based on the [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API). When a user visits a path that does not exist, it will automatically return a specified HTML file to avoid a 404 error.
 
 When Rsbuild's default [page routing](/guide/basic/server#page-routing) behavior cannot meet your needs, for example, if you want to be able to access `main.html` when accessing `/`, you can achieve this through the `server.historyApiFallback` configuration.
 
 ## Example
 
-`server.historyApiFallback` is implemented based on [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback), and setting `server.historyApiFallback` to `true` is equivalent to using the default options of `connect-history-api-fallback`.
+When `server.historyApiFallback` is set to `true`, all HTML GET requests that do not match an actual resource will return `index.html`. This ensures that routing in single-page applications works correctly.
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -17,13 +19,16 @@ export default {
 };
 ```
 
-By default, `connect-history-api-fallback` will redirect all HTML GET requests to `index.html`.
+Rsbuild will change the requested location to the [index](#index) you specify whenever there is a request which fulfills the following criteria:
+
+- The request is a `GET` or `HEAD` request
+- The request accepts `text/html`
+- The requested path does not contain a `.` (dot), meaning it is not a direct file request
+- The requested path does not match any pattern defined in [rewrites](#rewrites)
 
 ## Options
 
-`server.historyApiFallback` also supports passing an object to configure the behavior of `connect-history-api-fallback`.
-
-Here are some commonly used options, and more options and detailed information can be found in the [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) documentation.
+`server.historyApiFallback` also supports passing an object to customize its behavior.
 
 ### index
 
@@ -55,7 +60,7 @@ export default {
 ```ts
 type Rewrites = Array<{
   from: RegExp;
-  to: string | RegExp | ((context: HistoryApiFallbackContext) => string);
+  to: string | ((context: HistoryApiFallbackContext) => string);
 }>;
 ```
 
@@ -72,6 +77,42 @@ export default {
         { from: /^\/subpage/, to: '/views/subpage.html' },
         { from: /./, to: '/views/404.html' },
       ],
+    },
+  },
+};
+```
+
+### htmlAcceptHeaders
+
+- **Type:** `string[]`
+- **Default:** `['text/html', '*/*']`
+
+Override the default `Accepts:` headers that are queried when matching HTML content requests.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    historyApiFallback: {
+      htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
+    },
+  },
+};
+```
+
+### disableDotRule
+
+- **Type:** `boolean`
+- **Default:** `false`
+
+By default, requests containing a dot (`.`) in the path are treated as direct file requests and are not redirected.
+
+Setting `disableDotRule` to `true` will disable this behavior and allow such requests to be redirected as well.
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    historyApiFallback: {
+      disableDotRule: true,
     },
   },
 };

--- a/website/docs/zh/config/server/history-api-fallback.mdx
+++ b/website/docs/zh/config/server/history-api-fallback.mdx
@@ -1,13 +1,15 @@
 # server.historyApiFallback
 
-- **类型：** `boolean | ConnectHistoryApiFallbackOptions`
+- **类型：** `boolean | HistoryApiFallbackOptions`
 - **默认值：** `false`
+
+`historyApiFallback` 用于支持基于 [history API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) 的路由，当用户访问不存在的路径时，自动返回指定的 HTML 文件，避免出现 404 错误。
 
 当 Rsbuild 默认的 [页面路由](/guide/basic/server#page-routing) 行为无法满足你的需求时，例如，希望在访问 `/` 时可以访问 `main.html` ，你可以通过 `server.historyApiFallback` 配置项来实现这个功能。
 
 ## 示例
 
-`server.historyApiFallback` 基于 [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) 实现，将 `server.historyApiFallback` 设置为 `true` 时，等价于使用 `connect-history-api-fallback` 的默认选项。
+将 `server.historyApiFallback` 设置为 `true` 时，所有未匹配到实际资源的 HTML GET 请求都会返回 `index.html`，从而保证单页应用的路由能够正常工作。
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -17,13 +19,16 @@ export default {
 };
 ```
 
-默认情况下，`connect-history-api-fallback` 会将所有的 HTML GET 请求重定向到 `index.html`。
+当满足以下条件时，Rsbuild 会将请求的路径重定向到你指定的 [index](#index) 文件：
+
+- 请求方式为 `GET` 或 `HEAD`
+- 请求头包含 `text/html`
+- 请求路径中不包含 `.`，即不是直接的文件请求
+- 请求路径未匹配到 [rewrites](#rewrites) 中定义的任何模式
 
 ## 选项
 
-`server.historyApiFallback` 也支持传入一个对象来配置 `connect-history-api-fallback` 的行为。
-
-下面是一些常用的选项，更多选项和详细信息可参考 [connect-history-api-fallback](https://github.com/bripkens/connect-history-api-fallback) 文档。
+`server.historyApiFallback` 也支持传入一个对象来自定义行为。
 
 ### index
 
@@ -55,7 +60,7 @@ export default {
 ```ts
 type Rewrites = Array<{
   from: RegExp;
-  to: string | RegExp | ((context: HistoryApiFallbackContext) => string);
+  to: string | ((context: HistoryApiFallbackContext) => string);
 }>;
 ```
 
@@ -72,6 +77,42 @@ export default {
         { from: /^\/subpage/, to: '/views/subpage.html' },
         { from: /./, to: '/views/404.html' },
       ],
+    },
+  },
+};
+```
+
+### htmlAcceptHeaders
+
+- **类型：** `string[]`
+- **默认值：** `['text/html', '*/*']`
+
+用于覆盖匹配 HTML 内容请求时默认查询的 `Accepts:` 请求头。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    historyApiFallback: {
+      htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
+    },
+  },
+};
+```
+
+### disableDotRule
+
+- **类型：** `boolean`
+- **默认值：** `false`
+
+默认情况下，路径中包含点（`.`）的请求会被视为直接的文件请求，不会被重定向。
+
+将 `disableDotRule` 设置为 `true` 后，这一行为会被关闭，此类请求也会被重定向。
+
+```ts title="rsbuild.config.ts"
+export default {
+  server: {
+    historyApiFallback: {
+      disableDotRule: true,
     },
   },
 };


### PR DESCRIPTION
## Summary

Update `server.historyApiFallback` documentation,  replacing references to `connect-history-api-fallback` , describe the current functionality and all configuration options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
