### PR TITLE
refactor: fix unbound-method lint issues

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "reduce-configs": "^1.1.0",
     "rsbuild-dev-middleware": "0.3.0",
     "rslog": "^1.2.9",
-    "rspack-chain": "^1.3.0",
+    "rspack-chain": "^1.3.1",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",

--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -173,13 +173,8 @@ export async function outputInspectConfigFiles({
 }
 
 export function stringifyConfig(config: unknown, verbose?: boolean): string {
-  // webpackChain.toString can be used as a common stringify method
-  const stringify = RspackChain.toString as (
-    config: unknown,
-    options: { verbose?: boolean },
-  ) => string;
-
-  return stringify(config, { verbose });
+  // rspackChain.toString can be used as a common stringify method
+  return RspackChain.toString(config, { verbose });
 }
 
 const getInspectOutputPath = (

--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -43,7 +43,10 @@ export const gzipMiddleware =
     let writeHeadStatus: number | undefined;
     let started = false;
 
-    const { end, write, on, writeHead } = res;
+    const on = res.on.bind(res);
+    const end = res.end.bind(res);
+    const write = res.write.bind(res);
+    const writeHead = res.writeHead.bind(res);
     const listeners: Array<[string | symbol, (...args: any[]) => void]> = [];
 
     const start = () => {
@@ -59,15 +62,15 @@ export const gzipMiddleware =
         gzip = zlib.createGzip({ level });
 
         gzip.on('data', (chunk) => {
-          if (!(write as (chunk: unknown) => boolean).call(res, chunk)) {
+          if (!write(chunk)) {
             gzip!.pause();
           }
         });
 
-        on.call(res, 'drain', () => gzip!.resume());
+        on('drain', () => gzip!.resume());
 
         gzip.on('end', () => {
-          (end as () => void).call(res);
+          end();
         });
 
         for (const listener of listeners) {
@@ -79,7 +82,7 @@ export const gzipMiddleware =
         }
       }
 
-      writeHead.call(res, writeHeadStatus ?? res.statusCode);
+      writeHead(writeHeadStatus ?? res.statusCode);
     };
 
     res.writeHead = (status, reason, headers?) => {
@@ -109,7 +112,7 @@ export const gzipMiddleware =
     res.on = (type, listener) => {
       if (started) {
         if (!gzip || type !== 'drain') {
-          on.call(res, type, listener);
+          on(type, listener);
         } else {
           gzip.on(type, listener);
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,8 +712,8 @@ importers:
         specifier: ^1.2.9
         version: 1.2.9
       rspack-chain:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.4.10(@swc/helpers@0.5.17))
@@ -5906,8 +5906,8 @@ packages:
   rslog@1.2.9:
     resolution: {integrity: sha512-KSjM8jJKYYaKgI4jUGZZ4kdTBTM/EIGH1JnoB0ptMkzcyWaHeXW9w6JVLCYs37gh8sFZkLLqAyBb2sT02bqpcQ==}
 
-  rspack-chain@1.3.0:
-    resolution: {integrity: sha512-TCiQbcnTOnv/2WCmt0bEGEXlV/KTao2wDbfX1zPIeCCKvzZkhq2iqLo84onSMK42iznrD0Gp4fIxWEMWwbN1GA==}
+  rspack-chain@1.3.1:
+    resolution: {integrity: sha512-4e/cKohXLrnsTIFDpn5l3CtyQ5HuoVT9ym2Ry3HtOaRMRzlcZc0Rwr8+5nQWYiPi1cElZDLpRGo4WGVbg6M4rQ==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -12251,7 +12251,7 @@ snapshots:
 
   rslog@1.2.9: {}
 
-  rspack-chain@1.3.0:
+  rspack-chain@1.3.1:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0

--- a/rslint.json
+++ b/rslint.json
@@ -33,7 +33,6 @@
       "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unsafe-enum-comparison": "off",
       "@typescript-eslint/no-misused-promises": "off",
-      "@typescript-eslint/unbound-method": "off",
       "@typescript-eslint/no-redundant-type-constituents": "off",
       "@typescript-eslint/no-implied-eval": "off",
       "@typescript-eslint/no-unnecessary-type-assertion": "off",


### PR DESCRIPTION
## Summary

Fix all lint issues found by the `unbound-method`  rules in Rslint.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5699
- https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.3.1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
