### PR TITLE
fix(cli): support `--environment` shorten option

### DIFF
--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -21,3 +21,22 @@ rspackOnlyTest(
     ).toBeTruthy();
   },
 );
+
+rspackOnlyTest(
+  'should build specified environments when using --environment shorten option',
+  async () => {
+    execSync('npx rsbuild build --environment web1,web2', {
+      cwd: __dirname,
+    });
+
+    const files = await readDirContents(path.join(__dirname, 'dist'));
+    const outputFiles = Object.keys(files);
+
+    expect(
+      outputFiles.find((item) => item.includes('web1/index.html')),
+    ).toBeTruthy();
+    expect(
+      outputFiles.find((item) => item.includes('web2/index.html')),
+    ).toBeTruthy();
+  },
+);

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -88,6 +88,11 @@ export async function init({
     commonOpts = cliOptions;
   }
 
+  // Build multiple environments can be shortened to: --environment name1,name2
+  commonOpts.environment = commonOpts.environment?.flatMap((env) =>
+    env.split(','),
+  );
+
   try {
     const cwd = process.cwd();
     const root = commonOpts.root


### PR DESCRIPTION
## Summary

fix(cli): support `--environment` shorten option

Build multiple environments can be shortened to: `rsbuild dev --environment web,node`

## Related Links

https://github.com/web-infra-dev/rsbuild/discussions/5714

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
