### PR TITLE
docs: update Node version requirements for loading TS config

### DIFF
--- a/website/docs/en/guide/configuration/rsbuild.mdx
+++ b/website/docs/en/guide/configuration/rsbuild.mdx
@@ -122,11 +122,11 @@ If your JavaScript runtime already natively supports TypeScript, you can use the
 For example, Node.js v22.6.0+ already natively supports TypeScript, you can use the following command to use the Node.js native loader to load the configuration file:
 
 ```bash
-# Node.js v23.6.0+
+# Node.js >= v22.18.0
 # No need to set --experimental-strip-types
 npx rsbuild build --config-loader native
 
-# Node.js v22.6.0 - v23.5.0
+# Node.js v22.6.0 - v22.17.0
 # Need to set --experimental-strip-types
 NODE_OPTIONS="--experimental-strip-types" npx rsbuild build --config-loader native
 ```

--- a/website/docs/zh/guide/configuration/rsbuild.mdx
+++ b/website/docs/zh/guide/configuration/rsbuild.mdx
@@ -122,11 +122,11 @@ rsbuild build -c rsbuild.prod.config.mjs
 例如，Node.js 从 v22.6.0 开始已经原生支持 TypeScript，你可以如下命令来使用 Node.js 原生 loader 来加载配置文件：
 
 ```bash
-# Node.js v23.6.0+
+# Node.js >= v22.18.0
 # 不需要设置 --experimental-strip-types
 npx rsbuild build --config-loader native
 
-# Node.js v22.6.0 - v23.5.0
+# Node.js v22.6.0 - v22.17.0
 # 需要设置 --experimental-strip-types
 NODE_OPTIONS="--experimental-strip-types" npx rsbuild build --config-loader native
 ```


### PR DESCRIPTION
## Summary

This pull request updates the documentation to reflect changes in Node.js version support for TypeScript. The changes clarify the version ranges and requirements for using the Node.js native loader with or without the `--experimental-strip-types` flag.

## Related Links

- https://nodejs.org/en/blog/release/v22.18.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
