### PR TITLE
feat: add support for disabling live reload in environments

### DIFF
--- a/e2e/cases/environments/disable-hmr/index.test.ts
+++ b/e2e/cases/environments/disable-hmr/index.test.ts
@@ -1,0 +1,59 @@
+import { dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to disable HMR and live reload for a specified environment',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      page,
+      cwd: __dirname,
+      rsbuildConfig: {
+        dev: {
+          writeToDisk: true,
+        },
+        performance: {
+          chunkSplit: {
+            strategy: 'all-in-one',
+          },
+        },
+        environments: {
+          foo: {
+            source: {
+              entry: {
+                foo: './src/foo.js',
+              },
+            },
+          },
+          bar: {
+            source: {
+              entry: {
+                bar: './src/bar.js',
+              },
+            },
+            dev: {
+              hmr: false,
+              liveReload: false,
+            },
+          },
+        },
+      },
+    });
+
+    const files = await rsbuild.getDistFiles();
+    const filenames = Object.keys(files);
+
+    const fooJs = filenames.find((filename) =>
+      filename.includes('dist/static/js/foo.js'),
+    );
+    const barJs = filenames.find((filename) =>
+      filename.includes('dist/static/js/bar.js'),
+    );
+    const fooContent = files[fooJs!];
+    const barContent = files[barJs!];
+
+    expect(fooContent.includes('dist/client/hmr.js')).toBeTruthy();
+    expect(barContent.includes('dist/client/hmr.js')).toBeFalsy();
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/environments/disable-hmr/src/bar.js
+++ b/e2e/cases/environments/disable-hmr/src/bar.js
@@ -1,1 +1,1 @@
-console.log('foo!');
+console.log('bar!');

--- a/e2e/cases/environments/disable-hmr/src/bar.js
+++ b/e2e/cases/environments/disable-hmr/src/bar.js
@@ -1,0 +1,1 @@
+console.log('foo!');

--- a/e2e/cases/environments/disable-hmr/src/foo.js
+++ b/e2e/cases/environments/disable-hmr/src/foo.js
@@ -1,1 +1,1 @@
-console.log('bar!');
+console.log('foo!');

--- a/e2e/cases/environments/disable-hmr/src/foo.js
+++ b/e2e/cases/environments/disable-hmr/src/foo.js
@@ -1,0 +1,1 @@
+console.log('bar!');

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -10,6 +10,7 @@ import { isDebug, logger } from '../logger';
 import { mergeRsbuildConfig } from '../mergeConfig';
 import { initPlugins } from '../pluginManager';
 import type {
+  AllowedEnvironmentDevKeys,
   InspectConfigOptions,
   InternalContext,
   MergedEnvironmentConfig,
@@ -22,6 +23,15 @@ import type {
   Rspack,
 } from '../types';
 import { generateRspackConfig } from './rspackConfig';
+
+const allowedEnvironmentDevKeys: AllowedEnvironmentDevKeys[] = [
+  'hmr',
+  'liveReload',
+  'writeToDisk',
+  'assetPrefix',
+  'progressBar',
+  'lazyCompilation',
+];
 
 async function modifyRsbuildConfig(context: InternalContext) {
   logger.debug('modify Rsbuild config');
@@ -122,13 +132,7 @@ const initEnvironmentConfigs = (
             ...(mergeRsbuildConfig(
               {
                 ...rsbuildSharedConfig,
-                dev: pick(dev, [
-                  'writeToDisk',
-                  'hmr',
-                  'assetPrefix',
-                  'progressBar',
-                  'lazyCompilation',
-                ]),
+                dev: pick(dev, allowedEnvironmentDevKeys),
               } as MergedEnvironmentConfig,
               config as unknown as MergedEnvironmentConfig,
             ) as MergedEnvironmentConfig),
@@ -161,13 +165,7 @@ const initEnvironmentConfigs = (
   return {
     [defaultEnvironmentName]: applyEnvironmentDefaultConfig({
       ...rsbuildSharedConfig,
-      dev: pick(dev, [
-        'hmr',
-        'assetPrefix',
-        'progressBar',
-        'lazyCompilation',
-        'writeToDisk',
-      ]),
+      dev: pick(dev, allowedEnvironmentDevKeys),
     } as MergedEnvironmentConfig),
   };
 };
@@ -249,18 +247,6 @@ export async function initRsbuildConfig({
     context.specifiedEnvironments,
   );
 
-  const {
-    dev: {
-      hmr: _hmr,
-      assetPrefix: _assetPrefix,
-      progressBar: _progressBar,
-      lazyCompilation: _lazyCompilation,
-      writeToDisk: _writeToDisk,
-      ...rsbuildSharedDev
-    },
-    server,
-  } = normalizedBaseConfig;
-
   const tsconfigPaths = new Set<string>();
 
   for (const [name, config] of Object.entries(mergedEnvironments)) {
@@ -273,10 +259,10 @@ export async function initRsbuildConfig({
     const normalizedEnvironmentConfig = {
       ...environmentConfig,
       dev: {
+        ...normalizedBaseConfig.dev,
         ...environmentConfig.dev,
-        ...rsbuildSharedDev,
       },
-      server,
+      server: normalizedBaseConfig.server,
     };
 
     const { tsconfigPath } = normalizedEnvironmentConfig.source;

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
 import type { Stats } from '@rspack/core';
 import { isMultiCompiler } from '../helpers';
 import { getPathnameFromUrl } from '../helpers/path';
@@ -16,8 +15,6 @@ import {
 } from './compilationMiddleware';
 import { stripBase } from './helper';
 import { SocketServer } from './socketServer';
-
-const require = createRequire(import.meta.url);
 
 type Options = {
   publicPaths: string[];
@@ -56,22 +53,6 @@ const formatDevConfig = (
     },
   };
 };
-
-function getClientPaths(devConfig: NormalizedDevConfig) {
-  const clientPaths: string[] = [];
-
-  if (!devConfig.hmr && !devConfig.liveReload) {
-    return clientPaths;
-  }
-
-  clientPaths.push(require.resolve('@rsbuild/core/client/hmr'));
-
-  if (devConfig.client?.overlay) {
-    clientPaths.push(require.resolve('@rsbuild/core/client/overlay'));
-  }
-
-  return clientPaths;
-}
 
 /**
  * Setup compiler-related logic:
@@ -172,11 +153,8 @@ export class CompilationManager {
       },
     };
 
-    const clientPaths = getClientPaths(devConfig);
-
     const middleware = await getCompilationMiddleware(this.compiler, {
       callbacks,
-      clientPaths,
       devConfig,
       serverConfig,
       environments,

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1799,16 +1799,24 @@ export type RsbuildConfigMeta = {
 };
 
 /**
+ * Only some dev options can be defined in the environment config
+ */
+export type AllowedEnvironmentDevKeys =
+  | 'hmr'
+  | 'liveReload'
+  | 'assetPrefix'
+  | 'progressBar'
+  | 'lazyCompilation'
+  | 'writeToDisk';
+
+/**
  * The Rsbuild config to run in the specified environment.
  * */
 export interface EnvironmentConfig {
   /**
    * Options for local development.
    */
-  dev?: Pick<
-    DevConfig,
-    'hmr' | 'assetPrefix' | 'progressBar' | 'lazyCompilation' | 'writeToDisk'
-  >;
+  dev?: Pick<DevConfig, AllowedEnvironmentDevKeys>;
   /**
    * Options for HTML generation.
    */
@@ -1899,10 +1907,7 @@ export interface RsbuildConfig extends EnvironmentConfig {
 export type MergedEnvironmentConfig = {
   mode: RsbuildMode;
   root: string;
-  dev: Pick<
-    NormalizedDevConfig,
-    'hmr' | 'assetPrefix' | 'progressBar' | 'lazyCompilation' | 'writeToDisk'
-  >;
+  dev: Pick<NormalizedDevConfig, AllowedEnvironmentDevKeys>;
   html: NormalizedHtmlConfig;
   tools: NormalizedToolsConfig;
   resolve: NormalizedResolveConfig;

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -11,7 +11,12 @@ interface EnvironmentConfig {
   plugins?: RsbuildPlugins;
   dev?: Pick<
     DevConfig,
-    'hmr' | 'assetPrefix' | 'progressBar' | 'lazyCompilation' | 'writeToDisk'
+    | 'hmr'
+    | 'liveReload'
+    | 'assetPrefix'
+    | 'progressBar'
+    | 'lazyCompilation'
+    | 'writeToDisk'
   >;
   html?: HtmlConfig;
   tools?: ToolsConfig;

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -11,7 +11,12 @@ interface EnvironmentConfig {
   plugins?: RsbuildPlugins;
   dev?: Pick<
     DevConfig,
-    'hmr' | 'assetPrefix' | 'progressBar' | 'lazyCompilation' | 'writeToDisk'
+    | 'hmr'
+    | 'liveReload'
+    | 'assetPrefix'
+    | 'progressBar'
+    | 'lazyCompilation'
+    | 'writeToDisk'
   >;
   html?: HtmlConfig;
   tools?: ToolsConfig;


### PR DESCRIPTION
## Summary

Add support for disabling live reload in a specified environment:

```js
export default defineConfig({
  environments: {
    foo: {
      source: {
        entry: {
          foo: './src/foo.js',
        },
      },
    },
    bar: {
      source: {
        entry: {
          bar: './src/bar.js',
        },
      },
      dev: {
        hmr: false,
        liveReload: false,
      },
    },
  },
});
```

## Related Links

- https://github.com/web-infra-dev/rsbuild/discussions/5728

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
