### PR TITLE
chore: reorganize global type declarations into namespace

### DIFF
--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -1,11 +1,10 @@
-declare const RSBUILD_VERSION;
+import type { NormalizedClientConfig } from './types';
 
-declare const WEBPACK_HASH: string;
-
-declare const RSBUILD_CLIENT_CONFIG: ClientConfig;
-
-declare const RSBUILD_RESOLVED_CLIENT_CONFIG: ClientConfig;
-
-declare const RSBUILD_DEV_LIVE_RELOAD: boolean;
-
-declare const RSBUILD_WEB_SOCKET_TOKEN: string;
+declare global {
+  const RSBUILD_VERSION: string;
+  const WEBPACK_HASH: string;
+  const RSBUILD_CLIENT_CONFIG: NormalizedClientConfig;
+  const RSBUILD_RESOLVED_CLIENT_CONFIG: NormalizedClientConfig;
+  const RSBUILD_DEV_LIVE_RELOAD: boolean;
+  const RSBUILD_WEB_SOCKET_TOKEN: string;
+}


### PR DESCRIPTION
## Summary

Reorganize global type declarations into namespace and fix some `any` types.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
