### PR TITLE
chore(deps): upgrade Rslint to v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
     "@rsbuild/config": "workspace:*",
-    "@rslint/core": "^0.1.0",
+    "@rslint/core": "^0.1.1",
     "@rstest/core": "^0.1.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: workspace:*
         version: link:scripts/config
       '@rslint/core':
-        specifier: ^0.1.0
-        version: 0.1.0
+        specifier: ^0.1.1
+        version: 0.1.1
       '@rstest/core':
         specifier: ^0.1.0
         version: 0.1.0
@@ -2492,37 +2492,37 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.1.0':
-    resolution: {integrity: sha512-B+Zybh0unMFl8JtlPeRbA9rdenE7EHCvliumA/V5HNAj2BHutRTEpUIyBIlpVTv+whCJ+7I+IHuIfuseHulncw==}
+  '@rslint/core@0.1.1':
+    resolution: {integrity: sha512-cElGOzbmfw+pgHvLhaWUc/n7mXkjDw5Ah3q13uSL30BQMQB01GRyakuEbAu38T/8+0/ec9+rKRtrMlRvUfwCIg==}
     hasBin: true
 
-  '@rslint/darwin-arm64@0.1.0':
-    resolution: {integrity: sha512-Os4i54CAtri0CngBDFsakkIiDtnfXHtjjn8dry8+k/rA+5mqIpsH6v1a3YbvrsmR/PfQHTJvCDRq9uelwiOb3w==}
+  '@rslint/darwin-arm64@0.1.1':
+    resolution: {integrity: sha512-Q5sTWseCnOWX7+pAsBT8qpdSSgLdkk04NnW5sbGbLEqxGwDDeju3J5DTqgeEJa5bMPfCQ760KnsKvCnh6TUIdQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/darwin-x64@0.1.0':
-    resolution: {integrity: sha512-891xIpAoTewWZOiZ/xS94//Ck92HWHfx4BunyxklKqnVOQbp3W0PFv+rcnn1CKwMpEEzQ0PuO0v7zVGsZrmb0Q==}
+  '@rslint/darwin-x64@0.1.1':
+    resolution: {integrity: sha512-hDsyfMQiQFbTzEVFjaVKAx8OufXCiU0VWfatC4lfZ3cctODwH50cDafSGpdmHP4aWdIZUPqiYnIxbAVYJxczHA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/linux-arm64@0.1.0':
-    resolution: {integrity: sha512-Ixvu7Wg3XEdzyUVTEF4GmSeA9g2IkWBAu64jgwE8dFnt+u/efB1mBR9jGg1DR8a4zGg+OfLqJ9BtsHAdIEUl0A==}
+  '@rslint/linux-arm64@0.1.1':
+    resolution: {integrity: sha512-rF1t5OeC9Zi0Gp3JuecW4h1p8T/a63/7u9Y57qnCE2NOS/8zhcIls9GZ1JZ2uhIPRRVYHxPhv3IXIh6zkRlyOA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rslint/linux-x64@0.1.0':
-    resolution: {integrity: sha512-M2hL3/3/lI4BeVY/Tu4N/SOKFHVJ1JMVyjcPH0xUVJAsvht8XnTxeC+wZioupRLUolzaSXaVtHsTtGJZ0sqK8Q==}
+  '@rslint/linux-x64@0.1.1':
+    resolution: {integrity: sha512-txLr/jdOl3DRGXN1pymKTBSXuxwIkHcDmi9+QajAuuFOkLQgwEZNWGjJQ7s8QQuXajhzxY6iqFOV0rJVE+vQFg==}
     cpu: [x64]
     os: [linux]
 
-  '@rslint/win32-arm64@0.1.0':
-    resolution: {integrity: sha512-227HHJvY50nylYLebpUvLwJ1a/s8v8tNHWlwgofpWJP68ZeCL8e34MIJqNSCUNgY4kmlrNFk8IMkP3VRrafR/g==}
+  '@rslint/win32-arm64@0.1.1':
+    resolution: {integrity: sha512-YKKJANtEZpGaoGcpAfc4c+D8vR96WXnnIVJeJzIr2c5jwRqAwK54+Ei9C9hk7ElQMntkgBCof9uNYA6tNkBGPw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/win32-x64@0.1.0':
-    resolution: {integrity: sha512-HUJaeyYu6UZ75WkiXMoYefPtyPz63WitvdWnu/B8dOiofqcVfqnh1RMPImujROYy7qfhbfR0PuwxoO4jT6zqoA==}
+  '@rslint/win32-x64@0.1.1':
+    resolution: {integrity: sha512-9ttRF6mzCrEky3H0IkyBhcFkLYxTnfWnkDWOGOJrZ86wk8Nk0K/YdhBZlNGRYsxInUXqXpJL651OfuQWkY9QYA==}
     cpu: [x64]
     os: [win32]
 
@@ -8249,31 +8249,31 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  '@rslint/core@0.1.0':
+  '@rslint/core@0.1.1':
     optionalDependencies:
-      '@rslint/darwin-arm64': 0.1.0
-      '@rslint/darwin-x64': 0.1.0
-      '@rslint/linux-arm64': 0.1.0
-      '@rslint/linux-x64': 0.1.0
-      '@rslint/win32-arm64': 0.1.0
-      '@rslint/win32-x64': 0.1.0
+      '@rslint/darwin-arm64': 0.1.1
+      '@rslint/darwin-x64': 0.1.1
+      '@rslint/linux-arm64': 0.1.1
+      '@rslint/linux-x64': 0.1.1
+      '@rslint/win32-arm64': 0.1.1
+      '@rslint/win32-x64': 0.1.1
 
-  '@rslint/darwin-arm64@0.1.0':
+  '@rslint/darwin-arm64@0.1.1':
     optional: true
 
-  '@rslint/darwin-x64@0.1.0':
+  '@rslint/darwin-x64@0.1.1':
     optional: true
 
-  '@rslint/linux-arm64@0.1.0':
+  '@rslint/linux-arm64@0.1.1':
     optional: true
 
-  '@rslint/linux-x64@0.1.0':
+  '@rslint/linux-x64@0.1.1':
     optional: true
 
-  '@rslint/win32-arm64@0.1.0':
+  '@rslint/win32-arm64@0.1.1':
     optional: true
 
-  '@rslint/win32-x64@0.1.0':
+  '@rslint/win32-x64@0.1.1':
     optional: true
 
   '@rspack/binding-darwin-arm64@1.4.10':


### PR DESCRIPTION
## Summary
upgrad rslint to 0.1.1 to fix unstable lint errors
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
