### PR TITLE
refactor: socket message types

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -1,3 +1,4 @@
+import type { SocketMessage } from '../server/socketServer';
 import type { NormalizedClientConfig } from '../types';
 
 const config: NormalizedClientConfig = RSBUILD_CLIENT_CONFIG;
@@ -28,7 +29,7 @@ function formatURL(config: NormalizedClientConfig) {
 
 // Remember some state related to hot module replacement.
 let isFirstCompilation = true;
-let lastCompilationHash: string | null = null;
+let lastCompilationHash: string | undefined;
 let hasCompileErrors = false;
 
 function clearOutdatedErrors() {
@@ -175,7 +176,7 @@ function onOpen() {
 }
 
 function onMessage(e: MessageEvent<string>) {
-  const message = JSON.parse(e.data);
+  const message: SocketMessage = JSON.parse(e.data);
 
   switch (message.type) {
     case 'hash':

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -40,15 +40,17 @@ import {
 import { createHttpServer } from './httpServer';
 import { notFoundMiddleware, optionsFallbackMiddleware } from './middlewares';
 import { open } from './open';
+import type { SocketMessage } from './socketServer';
 import { setupWatchFiles, type WatchFilesResult } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 
-export type SockWriteType = 'static-changed' | (string & {});
+type ExtractSocketMessageData<T extends SocketMessage['type']> =
+  Extract<SocketMessage, { type: T }> extends { data: infer D } ? D : undefined;
 
-export type SockWrite = (
-  type: SockWriteType,
-  data?: string | boolean | Record<string, any>,
+export type SockWrite = <T extends SocketMessage['type']>(
+  type: T,
+  data?: ExtractSocketMessageData<T>,
 ) => void;
 
 export type RsbuildDevServer = {
@@ -368,7 +370,7 @@ export async function createDevServer<
     compilationManager?.socketServer.sockWrite({
       type,
       data,
-    });
+    } as SocketMessage);
 
   const devServerAPI: RsbuildDevServer = {
     port,


### PR DESCRIPTION
## Summary

This pull request introduces type safety improvements of socket messages. The primary changes include replacing loosely typed structures with a strongly typed `SocketMessage` union, updating related functions to use these types, and simplifying the codebase for better maintainability.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
