### PR TITLE
feat(create-rsbuild): update typescript to ^5.9.2

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -55,6 +55,6 @@
     "playwright": "1.54.1",
     "polka": "^0.5.2",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/lit/package.json
+++ b/examples/lit/package.json
@@ -10,6 +10,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "lit": "^3.3.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -9,6 +9,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/preact/package.json
+++ b/examples/preact/package.json
@@ -13,6 +13,6 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/plugin-preact": "workspace:*",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,6 +16,6 @@
     "@rsbuild/plugin-react": "workspace:*",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -9,6 +9,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
     "@rsbuild/plugin-webpack-swc": "workspace:*",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nx": "^21.3.7",
     "prettier": "^3.6.2",
     "simple-git-hooks": "^2.13.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "packageManager": "pnpm@10.13.1",
   "engines": {

--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -41,7 +41,7 @@
     "@rslib/core": "0.11.0",
     "@types/lodash": "^4.17.20",
     "@types/semver": "^7.7.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "webpack": "^5.101.0"
   },
   "peerDependencies": {

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -44,7 +44,7 @@
     "ansi-escapes": "4.3.2",
     "cli-truncate": "2.1.0",
     "patch-console": "1.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "^1.3.21"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,7 @@
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",
     "tinyglobby": "^0.2.14",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "webpack": "^5.101.0",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-merge": "6.0.1",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -41,7 +41,7 @@
     "@rsbuild/plugin-vue": "workspace:*",
     "@rslib/core": "0.11.0",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "engines": {
     "node": ">=16.10.0"

--- a/packages/create-rsbuild/template-lit-ts/package.json
+++ b/packages/create-rsbuild/template-lit-ts/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-preact-ts/package.json
+++ b/packages/create-rsbuild/template-preact-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
     "@rsbuild/plugin-preact": "^1.5.1",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-react-ts/package.json
+++ b/packages/create-rsbuild/template-react-ts/package.json
@@ -17,6 +17,6 @@
     "@rsbuild/plugin-react": "^1.3.4",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-react18-ts/package.json
+++ b/packages/create-rsbuild/template-react18-ts/package.json
@@ -17,6 +17,6 @@
     "@rsbuild/plugin-react": "^1.3.4",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-solid-ts/package.json
+++ b/packages/create-rsbuild/template-solid-ts/package.json
@@ -15,6 +15,6 @@
     "@rsbuild/core": "^1.4.11",
     "@rsbuild/plugin-babel": "^1.0.5",
     "@rsbuild/plugin-solid": "^1.0.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-svelte-ts/package.json
+++ b/packages/create-rsbuild/template-svelte-ts/package.json
@@ -16,6 +16,6 @@
     "@rsbuild/core": "^1.4.11",
     "@rsbuild/plugin-svelte": "^1.0.10",
     "svelte-check": "^4.3.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-vanilla-ts/package.json
+++ b/packages/create-rsbuild/template-vanilla-ts/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-vue2-ts/package.json
+++ b/packages/create-rsbuild/template-vue2-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
     "@rsbuild/plugin-vue2": "^1.0.3",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/create-rsbuild/template-vue3-ts/package.json
+++ b/packages/create-rsbuild/template-vue3-ts/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "@rsbuild/core": "^1.4.11",
     "@rsbuild/plugin-vue": "^1.1.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -45,7 +45,7 @@
     "@types/node": "^22.17.0",
     "babel-loader": "10.0.0",
     "prebundle": "1.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -41,7 +41,7 @@
     "less": "4.3.0",
     "less-loader": "^12.3.0",
     "prebundle": "1.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -37,7 +37,7 @@
     "@rslib/core": "0.11.0",
     "@types/node": "^22.17.0",
     "preact": "^10.26.9",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -35,7 +35,7 @@
     "@rslib/core": "0.11.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -45,7 +45,7 @@
     "prebundle": "1.4.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -37,7 +37,7 @@
     "@rslib/core": "0.11.0",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -38,7 +38,7 @@
     "@rslib/core": "0.11.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -36,7 +36,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.17.0",
     "svelte": "^5.37.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "@rsbuild/core": "1.x"

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -44,7 +44,7 @@
     "file-loader": "6.2.0",
     "prebundle": "1.4.0",
     "svgo": "^3.3.2",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "url-loader": "4.1.1"
   },
   "peerDependencies": {

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -36,7 +36,7 @@
     "@rslib/core": "0.11.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "vue": "^3.5.18"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,8 +71,8 @@ importers:
         specifier: ^2.13.0
         version: 2.13.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e:
     dependencies:
@@ -99,20 +99,20 @@ importers:
         version: 1.9.7
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@5.8.3)
+        version: 3.5.18(typescript@5.9.2)
       vue-router:
         specifier: ^4.5.1
-        version: 4.5.1(vue@3.5.18(typescript@5.8.3))
+        version: 4.5.1(vue@3.5.18(typescript@5.9.2))
     devDependencies:
       '@e2e/helper':
         specifier: workspace:*
         version: link:scripts
       '@module-federation/enhanced':
         specifier: 0.17.1
-        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@module-federation/rsbuild-plugin':
         specifier: 0.17.1
-        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@playwright/test':
         specifier: 1.54.1
         version: 1.54.1
@@ -154,7 +154,7 @@ importers:
         version: link:../packages/plugin-svgr
       '@rsbuild/plugin-type-check':
         specifier: ^1.2.3
-        version: 1.2.3(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)
+        version: 1.2.3(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2)
       '@rsbuild/plugin-vue':
         specifier: workspace:*
         version: link:../packages/plugin-vue
@@ -213,8 +213,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   e2e/cases/browserslist/browserslist-config-mock: {}
 
@@ -277,7 +277,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@5.8.3)
+        version: 3.5.18(typescript@5.9.2)
 
   e2e/cases/resolve/pkg-imports: {}
 
@@ -306,8 +306,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/module-federation-v2/host:
     dependencies:
@@ -320,10 +320,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 0.17.1
-        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@module-federation/rsbuild-plugin':
         specifier: 0.17.1
-        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -342,10 +342,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 0.17.1
-        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@module-federation/rsbuild-plugin':
         specifier: 0.17.1
-        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+        version: 0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -394,8 +394,8 @@ importers:
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/preact:
     dependencies:
@@ -410,8 +410,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-preact
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/react:
     dependencies:
@@ -435,8 +435,8 @@ importers:
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/solid:
     dependencies:
@@ -473,14 +473,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   examples/vue:
     dependencies:
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@5.8.3)
+        version: 3.5.18(typescript@5.9.2)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -508,8 +508,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/compat/webpack
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/compat/plugin-webpack-swc:
     dependencies:
@@ -543,7 +543,7 @@ importers:
         version: link:../webpack
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
@@ -551,8 +551,8 @@ importers:
         specifier: ^7.7.0
         version: 7.7.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       webpack:
         specifier: ^5.101.0
         version: 5.101.0
@@ -586,7 +586,7 @@ importers:
         version: link:../../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../../scripts/test-helper
@@ -603,8 +603,8 @@ importers:
         specifier: 1.0.0
         version: 1.0.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/core:
     dependencies:
@@ -626,7 +626,7 @@ importers:
     devDependencies:
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -698,10 +698,10 @@ importers:
         version: 6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0)
       postcss-loader:
         specifier: 8.1.1
-        version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.0)
+        version: 8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0)
       prebundle:
         specifier: 1.4.0
-        version: 1.4.0(typescript@5.8.3)
+        version: 1.4.0(typescript@5.9.2)
       reduce-configs:
         specifier: ^1.1.0
         version: 1.1.0
@@ -727,8 +727,8 @@ importers:
         specifier: ^0.2.14
         version: 0.2.14
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       webpack:
         specifier: ^5.101.0
         version: 5.101.0
@@ -771,13 +771,13 @@ importers:
         version: link:../plugin-vue
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@types/node':
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-babel:
     dependencies:
@@ -811,7 +811,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -823,10 +823,10 @@ importers:
         version: 10.0.0(@babel/core@7.28.0)(webpack@5.101.0)
       prebundle:
         specifier: 1.4.0
-        version: 1.4.0(typescript@5.8.3)
+        version: 1.4.0(typescript@5.9.2)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-less:
     dependencies:
@@ -842,7 +842,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -857,10 +857,10 @@ importers:
         version: 12.3.0(@rspack/core@1.4.11(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.101.0)
       prebundle:
         specifier: 1.4.0
-        version: 1.4.0(typescript@5.8.3)
+        version: 1.4.0(typescript@5.9.2)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-preact:
     dependencies:
@@ -882,7 +882,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@types/node':
         specifier: ^22.17.0
         version: 22.17.0
@@ -890,8 +890,8 @@ importers:
         specifier: ^10.26.9
         version: 10.26.9
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-react:
     dependencies:
@@ -907,7 +907,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -915,8 +915,8 @@ importers:
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-sass:
     dependencies:
@@ -941,7 +941,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -953,7 +953,7 @@ importers:
         version: 8.0.9
       prebundle:
         specifier: 1.4.0
-        version: 1.4.0(typescript@5.8.3)
+        version: 1.4.0(typescript@5.9.2)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -961,8 +961,8 @@ importers:
         specifier: ^16.0.5
         version: 16.0.5(@rspack/core@1.4.11(@swc/helpers@0.5.17))(sass-embedded@1.89.2)(sass@1.89.2)(webpack@5.101.0)
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-solid:
     dependencies:
@@ -981,7 +981,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -989,8 +989,8 @@ importers:
         specifier: ^7.20.5
         version: 7.20.5
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-stylus:
     dependencies:
@@ -1012,7 +1012,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1020,8 +1020,8 @@ importers:
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-svelte:
     dependencies:
@@ -1030,14 +1030,14 @@ importers:
         version: 3.2.4(svelte@5.37.0)
       svelte-preprocess:
         specifier: ^6.0.3
-        version: 6.0.3(@babel/core@7.28.0)(less@4.4.0)(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0))(postcss@8.5.6)(sass@1.89.2)(stylus@0.64.0)(svelte@5.37.0)(typescript@5.8.3)
+        version: 6.0.3(@babel/core@7.28.0)(less@4.4.0)(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0))(postcss@8.5.6)(sass@1.89.2)(stylus@0.64.0)(svelte@5.37.0)(typescript@5.9.2)
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1048,8 +1048,8 @@ importers:
         specifier: ^5.37.0
         version: 5.37.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   packages/plugin-svgr:
     dependencies:
@@ -1058,13 +1058,13 @@ importers:
         version: link:../plugin-react
       '@svgr/core':
         specifier: 8.1.0
-        version: 8.1.0(typescript@5.8.3)
+        version: 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx':
         specifier: 8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
       '@svgr/plugin-svgo':
         specifier: 8.1.0
-        version: 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
+        version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
@@ -1077,7 +1077,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1089,13 +1089,13 @@ importers:
         version: 6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.101.0)
       prebundle:
         specifier: 1.4.0
-        version: 1.4.0(typescript@5.8.3)
+        version: 1.4.0(typescript@5.9.2)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       url-loader:
         specifier: 4.1.1
         version: 4.1.1(patch_hash=4ed67f741914e665ed1dcef907caaa2acc85269026674133f7b987661de3591f)(file-loader@6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.101.0))(webpack@5.101.0)
@@ -1104,7 +1104,7 @@ importers:
     dependencies:
       vue-loader:
         specifier: ^17.4.2
-        version: 17.4.2(vue@3.5.18(typescript@5.8.3))(webpack@5.101.0)
+        version: 17.4.2(vue@3.5.18(typescript@5.9.2))(webpack@5.101.0)
       webpack:
         specifier: ^5.101.0
         version: 5.101.0
@@ -1114,7 +1114,7 @@ importers:
         version: link:../core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1122,11 +1122,11 @@ importers:
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       vue:
         specifier: ^3.5.18
-        version: 3.5.18(typescript@5.8.3)
+        version: 3.5.18(typescript@5.9.2)
 
   scripts/config:
     devDependencies:
@@ -1135,13 +1135,13 @@ importers:
         version: link:../../packages/core
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
       '@types/node':
         specifier: ^22.17.0
         version: 22.17.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
   scripts/test-helper:
     dependencies:
@@ -1155,15 +1155,15 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
       upath:
         specifier: 2.0.1
         version: 2.0.1
     devDependencies:
       '@rslib/core':
         specifier: 0.11.0
-        version: 0.11.0(typescript@5.8.3)
+        version: 0.11.0(typescript@5.9.2)
 
   website:
     devDependencies:
@@ -1228,8 +1228,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
+        specifier: ^5.9.2
+        version: 5.9.2
 
 packages:
 
@@ -6556,8 +6556,8 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -7588,10 +7588,10 @@ snapshots:
       '@types/semver': 7.5.8
       semver: 7.6.3
 
-  '@module-federation/cli@0.17.1(typescript@5.8.3)':
+  '@module-federation/cli@0.17.1(typescript@5.9.2)':
     dependencies:
       '@modern-js/node-bundle-require': 2.68.2
-      '@module-federation/dts-plugin': 0.17.1(typescript@5.8.3)
+      '@module-federation/dts-plugin': 0.17.1(typescript@5.9.2)
       '@module-federation/sdk': 0.17.1
       chalk: 3.0.0
       commander: 11.1.0
@@ -7611,7 +7611,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@module-federation/dts-plugin@0.17.1(typescript@5.8.3)':
+  '@module-federation/dts-plugin@0.17.1(typescript@5.9.2)':
     dependencies:
       '@module-federation/error-codes': 0.17.1
       '@module-federation/managers': 0.17.1
@@ -7628,7 +7628,7 @@ snapshots:
       log4js: 6.9.1
       node-schedule: 2.1.1
       rambda: 9.4.2
-      typescript: 5.8.3
+      typescript: 5.9.2
       ws: 8.18.0
     transitivePeerDependencies:
       - bufferutil
@@ -7636,24 +7636,24 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)':
+  '@module-federation/enhanced@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.17.1
-      '@module-federation/cli': 0.17.1(typescript@5.8.3)
+      '@module-federation/cli': 0.17.1(typescript@5.9.2)
       '@module-federation/data-prefetch': 0.17.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@module-federation/dts-plugin': 0.17.1(typescript@5.8.3)
+      '@module-federation/dts-plugin': 0.17.1(typescript@5.9.2)
       '@module-federation/error-codes': 0.17.1
       '@module-federation/inject-external-runtime-core-plugin': 0.17.1(@module-federation/runtime-tools@0.17.1)
       '@module-federation/managers': 0.17.1
-      '@module-federation/manifest': 0.17.1(typescript@5.8.3)
-      '@module-federation/rspack': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)
+      '@module-federation/manifest': 0.17.1(typescript@5.9.2)
+      '@module-federation/rspack': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2)
       '@module-federation/runtime-tools': 0.17.1
       '@module-federation/sdk': 0.17.1
       btoa: 1.2.1
       schema-utils: 4.3.2
       upath: 2.0.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
       webpack: 5.101.0
     transitivePeerDependencies:
       - '@rspack/core'
@@ -7680,9 +7680,9 @@ snapshots:
       find-pkg: 2.0.0
       fs-extra: 9.1.0
 
-  '@module-federation/manifest@0.17.1(typescript@5.8.3)':
+  '@module-federation/manifest@0.17.1(typescript@5.9.2)':
     dependencies:
-      '@module-federation/dts-plugin': 0.17.1(typescript@5.8.3)
+      '@module-federation/dts-plugin': 0.17.1(typescript@5.9.2)
       '@module-federation/managers': 0.17.1
       '@module-federation/sdk': 0.17.1
       chalk: 3.0.0
@@ -7695,9 +7695,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)':
+  '@module-federation/node@2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)':
     dependencies:
-      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@module-federation/runtime': 0.17.1
       '@module-federation/sdk': 0.17.1
       btoa: 1.2.1
@@ -7716,10 +7716,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)':
+  '@module-federation/rsbuild-plugin@0.17.1(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)':
     dependencies:
-      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
-      '@module-federation/node': 2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.8.3)(webpack@5.101.0)
+      '@module-federation/enhanced': 0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
+      '@module-federation/node': 2.7.10(@rspack/core@1.4.11(@swc/helpers@0.5.17))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(typescript@5.9.2)(webpack@5.101.0)
       '@module-federation/sdk': 0.17.1
       fs-extra: 11.3.0
     optionalDependencies:
@@ -7737,19 +7737,19 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@module-federation/rspack@0.17.1(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.17.1
-      '@module-federation/dts-plugin': 0.17.1(typescript@5.8.3)
+      '@module-federation/dts-plugin': 0.17.1(typescript@5.9.2)
       '@module-federation/inject-external-runtime-core-plugin': 0.17.1(@module-federation/runtime-tools@0.17.1)
       '@module-federation/managers': 0.17.1
-      '@module-federation/manifest': 0.17.1(typescript@5.8.3)
+      '@module-federation/manifest': 0.17.1(typescript@5.9.2)
       '@module-federation/runtime-tools': 0.17.1
       '@module-federation/sdk': 0.17.1
       '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
       btoa: 1.2.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -8105,12 +8105,12 @@ snapshots:
       reduce-configs: 1.1.0
       sass-embedded: 1.89.2
 
-  '@rsbuild/plugin-type-check@1.2.3(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)':
+  '@rsbuild/plugin-type-check@1.2.3(@rsbuild/core@packages+core)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.0
-      ts-checker-rspack-plugin: 1.1.4(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3)
+      ts-checker-rspack-plugin: 1.1.4(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2)
     optionalDependencies:
       '@rsbuild/core': link:packages/core
     transitivePeerDependencies:
@@ -8247,13 +8247,13 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rslib/core@0.11.0(typescript@5.8.3)':
+  '@rslib/core@0.11.0(typescript@5.9.2)':
     dependencies:
       '@rsbuild/core': 1.4.8
-      rsbuild-plugin-dts: 0.11.0(@rsbuild/core@1.4.8)(typescript@5.8.3)
+      rsbuild-plugin-dts: 0.11.0(@rsbuild/core@1.4.8)(typescript@5.9.2)
       tinyglobby: 0.2.14
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   '@rslint/core@0.1.1':
     optionalDependencies:
@@ -8744,12 +8744,12 @@ snapshots:
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.28.0)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.28.0)
 
-  '@svgr/core@8.1.0(typescript@5.8.3)':
+  '@svgr/core@8.1.0(typescript@5.9.2)':
     dependencies:
       '@babel/core': 7.28.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.28.0)
       camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.9.2)
       snake-case: 3.0.4
     transitivePeerDependencies:
       - supports-color
@@ -8760,20 +8760,20 @@ snapshots:
       '@babel/types': 7.27.6
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))':
     dependencies:
       '@babel/core': 7.28.0
       '@svgr/babel-preset': 8.1.0(@babel/core@7.28.0)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/hast-util-to-babel-ast': 8.0.0
       svg-parser: 2.0.4
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.9.2)
+      cosmiconfig: 8.3.6(typescript@5.9.2)
       deepmerge: 4.3.1
       svgo: 3.3.2
     transitivePeerDependencies:
@@ -9235,11 +9235,11 @@ snapshots:
       '@vue/shared': 3.5.18
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.8.3))':
+  '@vue/server-renderer@3.5.18(vue@3.5.18(typescript@5.9.2))':
     dependencies:
       '@vue/compiler-ssr': 3.5.18
       '@vue/shared': 3.5.18
-      vue: 3.5.18(typescript@5.8.3)
+      vue: 3.5.18(typescript@5.9.2)
 
   '@vue/shared@3.5.17': {}
 
@@ -9761,23 +9761,23 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig@8.3.6(typescript@5.8.3):
+  cosmiconfig@8.3.6(typescript@5.9.2):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  cosmiconfig@9.0.0(typescript@5.8.3):
+  cosmiconfig@9.0.0(typescript@5.9.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 4.1.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   create-rstack@1.5.5: {}
 
@@ -11885,9 +11885,9 @@ snapshots:
       postcss: 8.5.6
       yaml: 2.8.0
 
-  postcss-loader@8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.8.3)(webpack@5.101.0):
+  postcss-loader@8.1.1(patch_hash=7f10237e1665e9913e0f735a822545af08363f5cc67eacc2c37408aee7553d47)(@rspack/core@1.4.11(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.8.3)
+      cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
@@ -11933,12 +11933,12 @@ snapshots:
 
   preact@10.26.9: {}
 
-  prebundle@1.4.0(typescript@5.8.3):
+  prebundle@1.4.0(typescript@5.9.2):
     dependencies:
       '@vercel/ncc': 0.38.3
       prettier: 3.6.2
       rollup: 4.45.1
-      rollup-plugin-dts: 6.2.1(rollup@4.45.1)(typescript@5.8.3)
+      rollup-plugin-dts: 6.2.1(rollup@4.45.1)(typescript@5.9.2)
       terser: 5.43.1
     transitivePeerDependencies:
       - typescript
@@ -12204,11 +12204,11 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rollup-plugin-dts@6.2.1(rollup@4.45.1)(typescript@5.8.3):
+  rollup-plugin-dts@6.2.1(rollup@4.45.1)(typescript@5.9.2):
     dependencies:
       magic-string: 0.30.17
       rollup: 4.45.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     optionalDependencies:
       '@babel/code-frame': 7.27.1
 
@@ -12248,7 +12248,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.101.0
 
-  rsbuild-plugin-dts@0.11.0(@rsbuild/core@1.4.8)(typescript@5.8.3):
+  rsbuild-plugin-dts@0.11.0(@rsbuild/core@1.4.8)(typescript@5.9.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
       '@rsbuild/core': 1.4.8
@@ -12257,7 +12257,7 @@ snapshots:
       tinyglobby: 0.2.14
       tsconfig-paths: 4.2.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   rsbuild-plugin-google-analytics@1.0.3(@rsbuild/core@packages+core):
     optionalDependencies:
@@ -12701,7 +12701,7 @@ snapshots:
       svelte-dev-helper: 1.1.9
       svelte-hmr: 0.14.12(svelte@5.37.0)
 
-  svelte-preprocess@6.0.3(@babel/core@7.28.0)(less@4.4.0)(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0))(postcss@8.5.6)(sass@1.89.2)(stylus@0.64.0)(svelte@5.37.0)(typescript@5.8.3):
+  svelte-preprocess@6.0.3(@babel/core@7.28.0)(less@4.4.0)(postcss-load-config@6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0))(postcss@8.5.6)(sass@1.89.2)(stylus@0.64.0)(svelte@5.37.0)(typescript@5.9.2):
     dependencies:
       svelte: 5.37.0
     optionalDependencies:
@@ -12711,7 +12711,7 @@ snapshots:
       postcss-load-config: 6.0.1(jiti@2.5.1)(postcss@8.5.6)(yaml@2.8.0)
       sass: 1.89.2
       stylus: 0.64.0
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   svelte@5.37.0:
     dependencies:
@@ -12835,7 +12835,7 @@ snapshots:
     dependencies:
       matchit: 1.1.0
 
-  ts-checker-rspack-plugin@1.1.4(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.8.3):
+  ts-checker-rspack-plugin@1.1.4(@rspack/core@1.4.11(@swc/helpers@0.5.17))(typescript@5.9.2):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@rspack/lite-tapable': 1.0.1
@@ -12844,7 +12844,7 @@ snapshots:
       memfs: 4.17.2
       minimatch: 9.0.5
       picocolors: 1.1.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     optionalDependencies:
       '@rspack/core': 1.4.11(@swc/helpers@0.5.17)
 
@@ -12874,7 +12874,7 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
   undici-types@6.21.0: {}
 
@@ -12977,29 +12977,29 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vue-loader@17.4.2(vue@3.5.18(typescript@5.8.3))(webpack@5.101.0):
+  vue-loader@17.4.2(vue@3.5.18(typescript@5.9.2))(webpack@5.101.0):
     dependencies:
       chalk: 4.1.2
       hash-sum: 2.0.0
       watchpack: 2.4.4
       webpack: 5.101.0
     optionalDependencies:
-      vue: 3.5.18(typescript@5.8.3)
+      vue: 3.5.18(typescript@5.9.2)
 
-  vue-router@4.5.1(vue@3.5.18(typescript@5.8.3)):
+  vue-router@4.5.1(vue@3.5.18(typescript@5.9.2)):
     dependencies:
       '@vue/devtools-api': 6.6.4
-      vue: 3.5.18(typescript@5.8.3)
+      vue: 3.5.18(typescript@5.9.2)
 
-  vue@3.5.18(typescript@5.8.3):
+  vue@3.5.18(typescript@5.9.2):
     dependencies:
       '@vue/compiler-dom': 3.5.18
       '@vue/compiler-sfc': 3.5.18
       '@vue/runtime-dom': 3.5.18
-      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.8.3))
+      '@vue/server-renderer': 3.5.18(vue@3.5.18(typescript@5.9.2))
       '@vue/shared': 3.5.18
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   watchpack@2.4.4:
     dependencies:

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -6,6 +6,6 @@
     "@rsbuild/core": "workspace:*",
     "@rslib/core": "0.11.0",
     "@types/node": "^22.17.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -28,7 +28,7 @@
     "@rsbuild/core": "workspace:*",
     "@types/node": "^22.17.0",
     "path-serializer": "0.5.0",
-    "typescript": "^5.8.3",
+    "typescript": "^5.9.2",
     "upath": "2.0.1"
   },
   "devDependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -29,6 +29,6 @@
     "rsbuild-plugin-open-graph": "^1.0.2",
     "rspress-plugin-font-open-sans": "^1.0.0",
     "rspress-plugin-sitemap": "^1.2.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.9.2"
   }
 }


### PR DESCRIPTION
## Summary

Update `typescript` to ^5.9.2 for create-rsbuild and other packages.

## Related Links

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
