### PR TITLE
fix(server): remove unused socket messages

### DIFF
--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -145,8 +145,6 @@ export class CompilationManager {
           this.socketServer.sockWrite({ type: 'static-changed' }, token);
           return;
         }
-
-        this.socketServer.sockWrite({ type: 'invalid' }, token);
       },
       onDone: (token: string, stats: Stats) => {
         this.socketServer.updateStats(stats, token);

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -34,14 +34,6 @@ export type SocketMessageOk = {
   type: 'ok';
 };
 
-export type SocketMessageInvalid = {
-  type: 'invalid';
-};
-
-export type SocketMessageHot = {
-  type: 'hot';
-};
-
 export type SocketMessageWarnings = {
   type: 'warnings';
   data: { text: string[] };
@@ -54,8 +46,6 @@ export type SocketMessageErrors = {
 
 export type SocketMessage =
   | SocketMessageOk
-  | SocketMessageHot
-  | SocketMessageInvalid
   | SocketMessageStaticChanged
   | SocketMessageHash
   | SocketMessageWarnings
@@ -209,10 +199,6 @@ export class SocketServer {
     }
   }
 
-  private singleWrite(socket: Ws, message: SocketMessage) {
-    this.send(socket, JSON.stringify(message));
-  }
-
   public async close(): Promise<void> {
     this.clearHeartbeatTimer();
 
@@ -259,12 +245,6 @@ export class SocketServer {
     connection.on('close', () => {
       this.sockets.delete(token);
     });
-
-    if (this.options.hmr || this.options.liveReload) {
-      this.singleWrite(connection, {
-        type: 'hot',
-      });
-    }
 
     // send first stats to active client sock if stats exist
     if (this.stats) {


### PR DESCRIPTION
## Summary

This pull request simplifies the Socket server by removing unused message types and redundant methods. The `hot` and `invalid` messages are no longer used by the HMR client, so we don't need to send these messages.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
