### PR TITLE
test: add cleanup before each test run

### DIFF
--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,11 +1,13 @@
 import { execSync } from 'node:child_process';
-import path, { join } from 'node:path';
+import { join } from 'node:path';
 import { readDirContents, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { remove } from 'fs-extra';
 
+const distPath = join(__dirname, 'dist');
+
 test.beforeEach(async () => {
-  await remove(join(__dirname, 'dist'));
+  await remove(distPath);
 });
 
 rspackOnlyTest(
@@ -15,7 +17,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await readDirContents(path.join(__dirname, 'dist'));
+    const files = await readDirContents(distPath);
     const outputFiles = Object.keys(files);
 
     expect(
@@ -34,7 +36,7 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    const files = await readDirContents(path.join(__dirname, 'dist'));
+    const files = await readDirContents(distPath);
     const outputFiles = Object.keys(files);
 
     expect(


### PR DESCRIPTION
## Summary

Update the test setup for the specified environment CLI E2E test, improving test isolation by cleaning up the output directory before each test run.

Fix the following error:

<img width="1117" height="431" alt="Screenshot 2025-08-02 at 15 15 51" src="https://github.com/user-attachments/assets/3f0c8feb-3487-484c-80dd-48ba1e756f23" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5719

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).