### PR TITLE
fix(runner): remove redundant module.instantiate calls

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -335,7 +335,7 @@ export function pick<T, U extends keyof T>(
 }
 
 export const camelCase = (input: string): string =>
-  input.replace(/[-_](\w)/g, (_, c) => c.toUpperCase());
+  input.replace(/[-_](\w)/g, (_, c: string) => c.toUpperCase());
 
 export const prettyTime = (seconds: number): string => {
   const format = (time: string) => color.bold(time);

--- a/packages/core/src/server/runner/asModule.ts
+++ b/packages/core/src/server/runner/asModule.ts
@@ -13,11 +13,11 @@ export const asModule = async (
 
   const exports = [...new Set(['default', ...Object.keys(something)])];
 
-  const module = new SyntheticModule(
+  const syntheticModule = new SyntheticModule(
     exports,
     () => {
       for (const name of exports) {
-        module.setExport(
+        syntheticModule.setExport(
           name,
           name === 'default' ? something : something[name],
         );
@@ -26,9 +26,9 @@ export const asModule = async (
     { context },
   );
 
-  if (unlinked) return module;
+  if (unlinked) return syntheticModule;
 
-  await module.link((() => {}) as unknown as ModuleLinker);
-  await module.evaluate();
-  return module;
+  await syntheticModule.link((() => {}) as unknown as ModuleLinker);
+  await syntheticModule.evaluate();
+  return syntheticModule;
 };

--- a/packages/core/src/server/runner/asModule.ts
+++ b/packages/core/src/server/runner/asModule.ts
@@ -13,24 +13,22 @@ export const asModule = async (
 
   const exports = [...new Set(['default', ...Object.keys(something)])];
 
-  const m = new SyntheticModule(
+  const module = new SyntheticModule(
     exports,
     () => {
       for (const name of exports) {
-        m.setExport(name, name === 'default' ? something : something[name]);
+        module.setExport(
+          name,
+          name === 'default' ? something : something[name],
+        );
       }
     },
-    {
-      context,
-    },
+    { context },
   );
 
-  if (unlinked) return m;
+  if (unlinked) return module;
 
-  await m.link((() => {}) as unknown as ModuleLinker);
-
-  // @ts-expect-error copy from webpack
-  if (m.instantiate) m.instantiate();
-  await m.evaluate();
-  return m;
+  await module.link((() => {}) as unknown as ModuleLinker);
+  await module.evaluate();
+  return module;
 };

--- a/packages/core/src/server/runner/esm.ts
+++ b/packages/core/src/server/runner/esm.ts
@@ -95,7 +95,7 @@ export class EsmRunner extends CommonJsRunner {
             true,
           );
         });
-        if ((esm as any).instantiate) (esm as any).instantiate();
+
         await esm.evaluate();
         if (context.esmMode === EsmMode.Evaluated) {
           return esm;


### PR DESCRIPTION
## Summary

Remove redundant `module.instantiate()` calls in the module runners. `module.instantiate` has been removed since Node.js >= 13.0.0.

## Related Links

- https://github.com/nodejs/node/pull/29776

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
