### PR TITLE
docs: add `distPath.favicon` option

### DIFF
--- a/website/docs/en/config/html/favicon.mdx
+++ b/website/docs/en/config/html/favicon.mdx
@@ -57,6 +57,26 @@ After recompiling, the following tags are automatically generated in the HTML:
 <link rel="icon" href="/favicon.ico" />
 ```
 
+## Output Path
+
+By default, favicons are output to the root path of the output directory, for example:
+
+- `./src/assets/icon.png` will be output to `./dist/icon.png`.
+- `./src/assets/favicon.ico` will be output to `./dist/favicon.ico`.
+
+You can customize the output path for favicons using the [output.distPath.favicon](/config/output/dist-path) option:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    distPath: {
+      // Output favicon to "./dist/static/favicon/" directory
+      favicon: 'static/favicon',
+    },
+  },
+};
+```
+
 ## Function usage
 
 - **Type:**

--- a/website/docs/en/config/output/dist-path.mdx
+++ b/website/docs/en/config/output/dist-path.mdx
@@ -6,6 +6,7 @@
 type DistPathConfig = {
   root?: string;
   html?: string;
+  favicon?: string;
   js?: string;
   jsAsync?: string;
   css?: string;
@@ -25,6 +26,7 @@ type DistPathConfig = {
 const defaultDistPath = {
   root: 'dist',
   html: './',
+  favicon: './',
   js: output.target === 'node' ? '' : 'static/js',
   jsAsync: output.target === 'node' ? '' : 'static/js/async',
   css: 'static/css',
@@ -50,6 +52,7 @@ Here are the details of each `output.distPath` option:
 
 - `root`: The root directory of all output files.
 - `html`: The output directory of HTML files.
+- `favicon`: The output directory of favicon files.
 - `js`: The output directory of JavaScript files.
 - `jsAsync`: The output directory of async JavaScript files, which by default will be output to the `async` subdirectory of `distPath.js`.
 - `css`: The output directory of CSS style files.

--- a/website/docs/zh/config/html/favicon.mdx
+++ b/website/docs/zh/config/html/favicon.mdx
@@ -57,6 +57,26 @@ export default {
 <link rel="icon" href="/favicon.ico" />
 ```
 
+## 输出路径
+
+默认情况下，favicon 文件会输出到构建产物目录的根路径下，比如：
+
+- `./src/assets/icon.png` 会输出到 `./dist/icon.png`。
+- `./src/assets/favicon.ico` 会输出到 `./dist/favicon.ico`。
+
+你可以通过 [output.distPath.favicon](/config/output/dist-path) 选项来自定义 favicon 的输出路径：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    distPath: {
+      // 将 favicon 输出到 "./dist/static/favicon/" 目录
+      favicon: 'static/favicon',
+    },
+  },
+};
+```
+
 ## 函数用法
 
 - **类型：**

--- a/website/docs/zh/config/output/dist-path.mdx
+++ b/website/docs/zh/config/output/dist-path.mdx
@@ -6,6 +6,7 @@
 type DistPathConfig = {
   root?: string;
   html?: string;
+  favicon?: string;
   js?: string;
   jsAsync?: string;
   css?: string;
@@ -25,6 +26,7 @@ type DistPathConfig = {
 const defaultDistPath = {
   root: 'dist',
   html: './',
+  favicon: './',
   js: output.target === 'node' ? '' : 'static/js',
   jsAsync: output.target === 'node' ? '' : 'static/js/async',
   css: 'static/css',
@@ -50,6 +52,7 @@ const defaultDistPath = {
 
 - `root`: 所有构建产物输出的根目录。
 - `html`：HTML 文件的输出目录。
+- `favicon`：favicon 文件的输出目录。
 - `js`：JavaScript 文件的输出目录。
 - `jsAsync`：异步 JavaScript 文件的输出目录，默认会输出到 `distPath.js` 的 `async` 子目录。
 - `css`：CSS 文件的输出目录。


### PR DESCRIPTION
## Summary

Added a section to explain the default output path for favicon files and how to customize it using the `output.distPath.favicon` option.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5746

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
