### PR TITLE
feat(core): add `action` option to `rsbuild.initConfigs`

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,6 +76,7 @@ export type {
   HtmlTagContext,
   HtmlTagDescriptor,
   HtmlTagHandler,
+  InitConfigsOptions,
   InlineChunkConfig,
   InlineChunkTest,
   InlineChunkTestFunction,

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -50,7 +50,9 @@ export const rspackProvider: RsbuildProvider = async ({
       return build({ context, pluginManager, rsbuildOptions }, options);
     },
 
-    async initConfigs() {
+    async initConfigs(options) {
+      context.action = options?.action;
+
       const { rspackConfigs } = await initConfigs({
         context,
         pluginManager,

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -51,11 +51,21 @@ export const rspackProvider: RsbuildProvider = async ({
     },
 
     async initConfigs(options) {
+      if (
+        context.action &&
+        options?.action &&
+        context.action !== options.action
+      ) {
+        // Calling initConfigs multiple times with different actions
+        throw new Error(
+          `\
+[rsbuild] initConfigs() can only be called with the same action type.
+  - Expected: ${context.action}
+  - Actual: ${options?.action}`,
+        );
+      }
+
       if (options?.action) {
-        if (context.action !== options.action) {
-          // Calling initConfigs multiple times with different actions
-          delete context.normalizedConfig;
-        }
         context.action = options.action;
       }
 

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -51,7 +51,13 @@ export const rspackProvider: RsbuildProvider = async ({
     },
 
     async initConfigs(options) {
-      context.action = options?.action;
+      if (options?.action) {
+        if (context.action !== options.action) {
+          // Calling initConfigs multiple times with different actions
+          delete context.normalizedConfig;
+        }
+        context.action = options.action;
+      }
 
       const { rspackConfigs } = await initConfigs({
         context,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -73,15 +73,7 @@ export type Build = (options?: BuildOptions) => Promise<{
   stats?: Rspack.Stats | Rspack.MultiStats;
 }>;
 
-export type InitConfigsOptions = {
-  /**
-   * The current action type.
-   * - dev: will be set when running `rsbuild dev` or `rsbuild.startDevServer()`
-   * - build: will be set when running `rsbuild build` or `rsbuild.build()`
-   * - preview: will be set when running `rsbuild preview` or `rsbuild.preview()`
-   */
-  action?: RsbuildContext['action'];
-};
+export type InitConfigsOptions = Pick<RsbuildContext, 'action'>;
 
 export type InspectConfigOptions = {
   /**

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -8,7 +8,7 @@ import type {
   NormalizedEnvironmentConfig,
   RsbuildConfig,
 } from './config';
-import type { InternalContext } from './context';
+import type { InternalContext, RsbuildContext } from './context';
 import type { PluginManager, RsbuildPlugin, RsbuildPluginAPI } from './plugin';
 import type { Rspack } from './rspack';
 import type { WebpackConfig } from './thirdParty';
@@ -72,6 +72,16 @@ export type Build = (options?: BuildOptions) => Promise<{
    */
   stats?: Rspack.Stats | Rspack.MultiStats;
 }>;
+
+export type InitConfigsOptions = {
+  /**
+   * The current action type.
+   * - dev: will be set when running `rsbuild dev` or `rsbuild.startDevServer()`
+   * - build: will be set when running `rsbuild build` or `rsbuild.build()`
+   * - preview: will be set when running `rsbuild preview` or `rsbuild.preview()`
+   */
+  action?: RsbuildContext['action'];
+};
 
 export type InspectConfigOptions = {
   /**
@@ -180,9 +190,9 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = Pick<
 > & {
   readonly bundler: Bundler;
 
-  initConfigs: () => Promise<
-    B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[]
-  >;
+  initConfigs: (
+    options?: InitConfigsOptions,
+  ) => Promise<B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[]>;
 
   inspectConfig: (
     options?: InspectConfigOptions,
@@ -266,7 +276,9 @@ export type RsbuildInstance = {
    * since it's automatically invoked by methods like `rsbuild.build` and
    * `rsbuild.startDevServer`.
    */
-  initConfigs: () => Promise<Rspack.Configuration[]>;
+  initConfigs: (
+    options?: InitConfigsOptions,
+  ) => Promise<Rspack.Configuration[]>;
   /**
    * Inspect and debug Rsbuild's internal configurations. It provides access to:
    * - The resolved Rsbuild configuration

--- a/packages/core/tests/pluginApply.test.ts
+++ b/packages/core/tests/pluginApply.test.ts
@@ -34,4 +34,30 @@ describe('pluginApply', () => {
 
     expect(setup).toHaveBeenCalledTimes(1);
   });
+
+  it('should not return the same config when called multiple times', async () => {
+    const setup = rstest.fn();
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        {
+          name: 'plugin-test',
+          apply: 'build',
+          setup,
+        },
+      ],
+    });
+
+    const [config1] = await rsbuild.initConfigs({
+      action: 'dev',
+    });
+
+    expect(setup).not.toBeCalled();
+
+    const [config2] = await rsbuild.initConfigs({
+      action: 'build',
+    });
+
+    expect(setup).toHaveBeenCalledTimes(1);
+    expect(config1).not.toBe(config2);
+  });
 });

--- a/packages/core/tests/pluginApply.test.ts
+++ b/packages/core/tests/pluginApply.test.ts
@@ -1,0 +1,37 @@
+import { createStubRsbuild } from '@scripts/test-helper';
+
+describe('pluginApply', () => {
+  it('should apply plugin correctly', async () => {
+    const setup = rstest.fn();
+
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        {
+          name: 'plugin-test',
+          apply: 'build',
+          setup() {
+            expect.fail('should not apply this plugin');
+          },
+        },
+        {
+          name: 'plugin-test2',
+          apply: 'serve',
+          setup,
+        },
+        {
+          name: 'plugin-test3',
+          apply(_, { action }) {
+            return action === 'preview';
+          },
+          setup,
+        },
+      ],
+    });
+
+    await rsbuild.initConfigs({
+      action: 'dev',
+    });
+
+    expect(setup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/tests/pluginApply.test.ts
+++ b/packages/core/tests/pluginApply.test.ts
@@ -9,6 +9,39 @@ describe('pluginApply', () => {
         {
           name: 'plugin-test',
           apply: 'build',
+          setup,
+        },
+        {
+          name: 'plugin-test2',
+          setup,
+        },
+        {
+          name: 'plugin-test3',
+          apply(config, { action }) {
+            return (
+              config.mode === 'development' ||
+              action === 'build' ||
+              action === 'dev'
+            );
+          },
+          setup,
+        },
+      ],
+    });
+
+    await rsbuild.initConfigs();
+
+    expect(setup).toHaveBeenCalledTimes(3);
+  });
+
+  it('should apply plugin correctly with action', async () => {
+    const setup = rstest.fn();
+
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        {
+          name: 'plugin-test',
+          apply: 'build',
           setup() {
             expect.fail('should not apply this plugin');
           },
@@ -42,6 +75,13 @@ describe('pluginApply', () => {
         {
           name: 'plugin-test',
           apply: 'build',
+          setup() {
+            expect.fail('should not apply this plugin');
+          },
+        },
+        {
+          name: 'plugin-test2',
+          apply: 'serve',
           setup,
         },
       ],
@@ -51,13 +91,42 @@ describe('pluginApply', () => {
       action: 'dev',
     });
 
-    expect(setup).not.toBeCalled();
+    expect(setup).toHaveBeenCalledTimes(1);
 
-    const [config2] = await rsbuild.initConfigs({
-      action: 'build',
-    });
+    const [config2] = await rsbuild.initConfigs();
 
     expect(setup).toHaveBeenCalledTimes(1);
     expect(config1).not.toBe(config2);
+
+    const [config3] = await rsbuild.initConfigs({
+      action: 'dev',
+    });
+
+    expect(setup).toHaveBeenCalledTimes(1);
+    expect(config2).not.toBe(config3);
+  });
+
+  it('should throw error when called with different action type', async () => {
+    const rsbuild = await createStubRsbuild({
+      plugins: [
+        {
+          name: 'plugin-test',
+          apply: 'build',
+          setup() {
+            expect.fail('should not apply this plugin');
+          },
+        },
+      ],
+    });
+
+    await rsbuild.initConfigs({ action: 'dev' });
+
+    await expect(() =>
+      rsbuild.initConfigs({ action: 'build' }),
+    ).rejects.toThrow(
+      `[rsbuild] initConfigs() can only be called with the same action type.
+  - Expected: dev
+  - Actual: build`,
+    );
   });
 });

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -656,7 +656,17 @@ Initialize and return the internal Rspack configurations used by Rsbuild. This m
 - **Type:**
 
 ```ts
-function InitConfigs(): Promise<{
+type InitConfigsOptions = {
+  /**
+   * The current action type.
+   * - dev: will be set when running `rsbuild dev` or `rsbuild.startDevServer()`
+   * - build: will be set when running `rsbuild build` or `rsbuild.build()`
+   * - preview: will be set when running `rsbuild preview` or `rsbuild.preview()`
+   */
+  action?: 'dev' | 'build' | 'preview';
+};
+
+function InitConfigs(options?: InitConfigsOptions): Promise<{
   rspackConfigs: Rspack.Configuration[];
 }>;
 ```
@@ -667,6 +677,12 @@ function InitConfigs(): Promise<{
 const rspackConfigs = await rsbuild.initConfigs();
 
 console.log(rspackConfigs);
+
+const buildConfigs = await rsbuild.initConfigs({
+  action: 'build',
+});
+
+console.log(buildConfigs);
 ```
 
 ## rsbuild.inspectConfig

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -700,6 +700,12 @@ function InitConfigs(options?: InitConfigsOptions): Promise<{
 const rspackConfigs = await rsbuild.initConfigs();
 
 console.log(rspackConfigs);
+
+const buildConfigs = await rsbuild.initConfigs({
+  action: 'build',
+});
+
+console.log(buildConfigs);
 ```
 
 ## rsbuild.inspectConfig

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -679,7 +679,17 @@ rsbuild.isPluginExists(pluginFoo.name, {
 - **类型：**
 
 ```ts
-function InitConfigs(): Promise<{
+type InitConfigsOptions = {
+  /**
+   * 当前的动作类型。
+   * - dev: 当运行 `rsbuild dev` 或 `rsbuild.startDevServer()` 时设置。
+   * - build: 当运行 `rsbuild build` 或 `rsbuild.build()` 时设置。
+   * - preview: 当运行 `rsbuild preview` 或 `rsbuild.preview()` 时设置。
+   */
+  action?: 'dev' | 'build' | 'preview';
+};
+
+function InitConfigs(options?: InitConfigsOptions): Promise<{
   rspackConfigs: Rspack.Configuration[];
 }>;
 ```


### PR DESCRIPTION
## Summary

Add `action` option to `rsbuild.initConfigs` to make it easier for testing Rsbuild plugins.

```js
const rsbuild = await createRsbuild();
const [rspackConfig] = await rsbuild.initConfigs({
  action: 'build'
});
```

## Related Links

<!--- Provide links of related issues or pages -->

We are migrating our plugin to use [`apply`](https://rsbuild.rs/plugins/dev/core#conditional-application) in https://github.com/lynx-family/lynx-stack/pull/1310#discussion_r2224826734. And it seems like it's hard to make unit tests since `rsbuild.initConfigs` would **always** apply a plugin due to there is no `context.action`.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
