### PR TITLE
chore(workflow): enable npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     name: Release
     if: github.repository == 'web-infra-dev/rsbuild' && github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    environment: production
+    environment: npm
     steps:
       - name: Run Ecosystem CI
         if: inputs.run_eco_ci == true
@@ -54,7 +54,7 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.event.inputs.branch }}
 
-      - name: Install Pnpm
+      - name: Setup Pnpm
         run: |
           npm install -g corepack@latest --force
           corepack enable
@@ -65,12 +65,15 @@ jobs:
           node-version: 22
           cache: 'pnpm'
 
+      # Update npm to the latest version to enable OIDC
+      - name: Update npm
+        run: |
+          npm install -g npm@latest
+          npm --version
+
       - name: Install Dependencies
         run: pnpm install
 
       - name: Publish to npm
-        env:
-          NPM_TOKEN: ${{ secrets.RSBUILD_NPM_TOKEN }}
         run: |
-          npm config set "//registry.npmjs.org/:_authToken" "${NPM_TOKEN}"
           pnpm -r publish --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}

--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -49,7 +49,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -51,7 +51,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -104,7 +104,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -48,7 +48,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -52,7 +52,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -48,7 +48,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -44,7 +44,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -42,7 +42,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -52,7 +52,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -44,7 +44,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -45,7 +45,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -43,7 +43,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -52,7 +52,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -44,7 +44,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/"
   }
 }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -15,8 +15,6 @@
       "require": "./dist/index.cjs"
     }
   },
-  "main": "./dist/index.cjs",
-  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -36,7 +36,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "provenance": true,
     "registry": "https://registry.npmjs.org/",
     "types": "./dist/index.d.ts"
   }

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -36,7 +36,6 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/",
-    "types": "./dist/index.d.ts"
+    "registry": "https://registry.npmjs.org/"
   }
 }


### PR DESCRIPTION
## Summary

Enable OIDC publishing to make it easier and more secure to publish npm packages from CI.

## Related Links

- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
- https://docs.npmjs.com/trusted-publishers

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
