### PR TITLE
chore: remove unnecessary issues write permission from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ on:
 permissions:
   # Provenance generation in GitHub Actions requires "write" access to the "id-token"
   id-token: write
-  # Allow commenting on issues
-  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Update the workflow permissions in `.github/workflows/release.yml`, removing the write permission for issues. This helps limit the workflow's access to only what is necessary.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
