### PR TITLE
ci: remove ecosystem CI workflow trigger from release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,6 @@ on:
         description: 'Release Branch (confirm release branch)'
         required: true
         default: 'main'
-      run_eco_ci:
-        description: 'Run Rsbuild ecosystem CI before release'
-        type: boolean
-        required: false
-        default: true
 
 permissions:
   # Provenance generation in GitHub Actions requires "write" access to the "id-token"
@@ -35,17 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - name: Run Ecosystem CI
-        if: inputs.run_eco_ci == true
-        uses: convictional/trigger-workflow-and-wait@f69fa9eedd3c62a599220f4d5745230e237904be # v1.6.5
-        with:
-          owner: 'rspack-contrib'
-          repo: 'rsbuild-ecosystem-ci'
-          workflow_file_name: 'ecosystem-ci-selected.yml'
-          github_token: ${{ secrets.REPO_RSBUILD_ECO_CI_GITHUB_TOKEN }}
-          ref: 'main'
-          client_payload: '{"ref":"${{ github.event.inputs.branch }}","repo":"web-infra-dev/rsbuild","suite":"-","suiteRefType":"precoded","suiteRef":"precoded"}'
-
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
## Summary

Since we already run ecosystem CI for each commit, running ecosystem CI in releases is no longer necessary, so this PR removes the ecosystem CI workflow trigger from release.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
