### PR TITLE
chore: update array type syntax to use parentheses consistently

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -153,7 +153,7 @@ export function updateContextByNormalizedConfig(
 export function createPublicContext(
   context: RsbuildContext,
 ): Readonly<RsbuildContext> {
-  const exposedKeys: Array<keyof RsbuildContext> = [
+  const exposedKeys: (keyof RsbuildContext)[] = [
     'action',
     'version',
     'rootPath',

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -324,7 +324,7 @@ export async function createRsbuild(
       );
     } while (plugins.some((v) => isPromise(v)));
 
-    return plugins as Array<RsbuildPlugin | Falsy>;
+    return plugins as (RsbuildPlugin | Falsy)[];
   };
 
   if (config.plugins) {

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -321,7 +321,7 @@ export const isMultiCompiler = (
 
 export function pick<T, U extends keyof T>(
   obj: T,
-  keys: ReadonlyArray<U>,
+  keys: readonly U[],
 ): Pick<T, U> {
   return keys.reduce(
     (ret, key) => {

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -144,7 +144,7 @@ export function initPluginAPI({
     );
   }) as GetRsbuildConfig;
 
-  const exposed: Array<{ id: string | symbol; api: any }> = [];
+  const exposed: { id: string | symbol; api: any }[] = [];
 
   const expose = (id: string | symbol, api: any) => {
     exposed.push({ id, api });
@@ -158,16 +158,16 @@ export function initPluginAPI({
 
   let transformId = 0;
   const transformer: Record<string, TransformHandler> = {};
-  const processAssetsFns: Array<{
+  const processAssetsFns: {
     environment?: string;
     descriptor: ProcessAssetsDescriptor;
     handler: ProcessAssetsHandler;
-  }> = [];
+  }[] = [];
 
-  const resolveFns: Array<{
+  const resolveFns: {
     environment?: string;
     handler: ResolveHandler;
-  }> = [];
+  }[] = [];
 
   hooks.modifyBundlerChain.tap((chain, { target, environment }) => {
     const pluginName = 'RsbuildCorePlugin';

--- a/packages/core/src/inspectConfig.ts
+++ b/packages/core/src/inspectConfig.ts
@@ -42,10 +42,10 @@ export const getRsbuildInspectConfig = ({
 }): {
   rawRsbuildConfig: string;
   rsbuildConfig: InspectConfigResult['origin']['rsbuildConfig'];
-  rawEnvironmentConfigs: Array<{
+  rawEnvironmentConfigs: {
     name: string;
     content: string;
-  }>;
+  }[];
   environmentConfigs: InspectConfigResult['origin']['environmentConfigs'];
 } => {
   const { environments, ...rsbuildConfig } = normalizedConfig;
@@ -58,10 +58,10 @@ export const getRsbuildInspectConfig = ({
   const rawRsbuildConfig = stringifyConfig(debugConfig, inspectOptions.verbose);
   const environmentConfigs: Record<string, NormalizedEnvironmentConfig> = {};
 
-  const rawEnvironmentConfigs: Array<{
+  const rawEnvironmentConfigs: {
     name: string;
     content: string;
-  }> = [];
+  }[] = [];
 
   for (const [name, config] of Object.entries(environments)) {
     const debugConfig = {

--- a/packages/core/src/plugins/html.ts
+++ b/packages/core/src/plugins/html.ts
@@ -171,7 +171,7 @@ function getTemplateParameters(
 
 function getChunks(
   entryName: string,
-  entryValue: Array<string | string[] | EntryDescription>,
+  entryValue: (string | string[] | EntryDescription)[],
 ): string[] {
   const chunks = [entryName];
 

--- a/packages/core/src/rspack-plugins/resource-hints/doesChunkBelongToHtml.ts
+++ b/packages/core/src/rspack-plugins/resource-hints/doesChunkBelongToHtml.ts
@@ -29,7 +29,7 @@ interface DoesChunkBelongToHtmlOptions {
 function recursiveChunkGroup(
   chunkGroup: ChunkGroup,
   visited = new Set<ChunkGroup>(),
-): Array<string | undefined> {
+): (string | undefined)[] {
   // check if the chunkGroup has been visited to prevent circular reference
   if (visited.has(chunkGroup)) {
     return [];

--- a/packages/core/src/rspack-plugins/resource-hints/extractChunks.ts
+++ b/packages/core/src/rspack-plugins/resource-hints/extractChunks.ts
@@ -34,10 +34,10 @@ export function extractChunks(
   includeType?: ResourceHintsIncludeType,
 ):
   | Chunk[]
-  | Array<{
+  | {
       files: string[];
       auxiliaryFiles?: string[];
-    }> {
+    }[] {
   const chunks = [...compilation.chunks];
 
   // 'asyncChunks' are chunks intended for lazy/async loading usually generated as

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -65,7 +65,7 @@ const applySetupMiddlewares = (
   return { before, after };
 };
 
-export type Middlewares = Array<RequestHandler | [string, RequestHandler]>;
+export type Middlewares = (RequestHandler | [string, RequestHandler])[];
 
 const applyDefaultMiddlewares = async ({
   devServerAPI,

--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -47,7 +47,7 @@ export const gzipMiddleware =
     const end = res.end.bind(res);
     const write = res.write.bind(res);
     const writeHead = res.writeHead.bind(res);
-    const listeners: Array<[string | symbol, (...args: any[]) => void]> = [];
+    const listeners: [string | symbol, (...args: any[]) => void][] = [];
 
     const start = () => {
       if (started) {

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -138,7 +138,7 @@ export const formatRoutes = (
 };
 
 function getURLMessages(
-  urls: Array<{ url: string; label: string }>,
+  urls: { url: string; label: string }[],
   routes: Routes,
 ) {
   if (routes.length <= 1) {
@@ -178,7 +178,7 @@ export function printServerURLs({
   printUrls,
   trailingLineBreak = true,
 }: {
-  urls: Array<{ url: string; label: string }>;
+  urls: { url: string; label: string }[];
   port: number;
   routes: Routes;
   protocol: string;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -302,9 +302,7 @@ export interface SourceConfig {
   /**
    * Used to import the code and style of the component library on demand.
    */
-  transformImport?:
-    | TransformImportFn
-    | Array<TransformImport | TransformImportFn>;
+  transformImport?: TransformImportFn | (TransformImport | TransformImportFn)[];
   /**
    * Configure a custom tsconfig.json file path to use, can be a relative or absolute path.
    * @default 'tsconfig.json'
@@ -381,10 +379,10 @@ export type HistoryApiFallbackOptions = {
   index?: string;
   htmlAcceptHeaders?: string[];
   disableDotRule?: true;
-  rewrites?: Array<{
+  rewrites?: {
     from: RegExp;
     to: HistoryApiFallbackTo;
-  }>;
+  }[];
 };
 
 export type PrintUrls =
@@ -595,7 +593,7 @@ export type BuildCacheOptions = {
    * when any value in the array changes.
    * @default undefined
    */
-  cacheDigest?: Array<string | undefined>;
+  cacheDigest?: (string | undefined)[];
   /**
    * An array of files containing build dependencies.
    * Rspack will use the hash of each of these files to invalidate the persistent cache.
@@ -658,7 +656,7 @@ export interface PreconnectOption {
   crossorigin?: boolean;
 }
 
-export type Preconnect = Array<string | PreconnectOption>;
+export type Preconnect = (string | PreconnectOption)[];
 
 export type DnsPrefetch = string[];
 

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -72,10 +72,10 @@ export type OnBeforeStartDevServerFn = (params: {
 
 export type OnBeforeStartProdServerFn = () => MaybePromise<void>;
 
-export type Routes = Array<{
+export type Routes = {
   entryName: string;
   pathname: string;
-}>;
+}[];
 
 export type OnAfterStartDevServerFn = (params: {
   port: number;
@@ -154,7 +154,7 @@ export type ModifyRsbuildConfigUtils = {
   mergeRsbuildConfig: (...configs: RsbuildConfig[]) => RsbuildConfig;
 };
 
-type ArrayAtLeastOne<A, B> = [A, ...Array<A | B>] | [...Array<A | B>, A];
+type ArrayAtLeastOne<A, B> = [A, ...(A | B)[]] | [...(A | B)[], A];
 
 export type ModifyEnvironmentConfigUtils = {
   /** environment name. */

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -215,7 +215,7 @@ export type AddPluginsOptions = {
 };
 
 export type AddPlugins = (
-  plugins: Array<RsbuildPlugin | Falsy>,
+  plugins: (RsbuildPlugin | Falsy)[],
   options?: AddPluginsOptions,
 ) => void;
 

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -82,7 +82,7 @@ export type PluginLessOptions = {
        * @deprecated
        * use `exclude` option instead.
        */
-      addExcludes: (items: string | RegExp | Array<string | RegExp>) => void;
+      addExcludes: (items: string | RegExp | (string | RegExp)[]) => void;
     }
   >;
 
@@ -106,7 +106,7 @@ const getLessLoaderOptions = (
 ) => {
   const excludes: (RegExp | string)[] = [];
 
-  const addExcludes = (items: string | RegExp | Array<string | RegExp>) => {
+  const addExcludes = (items: string | RegExp | (string | RegExp)[]) => {
     excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -23,7 +23,7 @@ const getSassLoaderOptions = (
 } => {
   const excludes: (RegExp | string)[] = [];
 
-  const addExcludes = (items: string | RegExp | Array<string | RegExp>) => {
+  const addExcludes = (items: string | RegExp | (string | RegExp)[]) => {
     excludes.push(...(Array.isArray(items) ? items : [items]));
   };
 

--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -41,7 +41,7 @@ export type PluginSassOptions = {
        * @deprecated
        * use `exclude` option instead.
        */
-      addExcludes: (items: string | RegExp | Array<string | RegExp>) => void;
+      addExcludes: (items: string | RegExp | (string | RegExp)[]) => void;
     }
   >;
 

--- a/rslint.json
+++ b/rslint.json
@@ -21,7 +21,6 @@
     },
     "plugins": ["@typescript-eslint"],
     "rules": {
-      "@typescript-eslint/array-type": "off",
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/promise-function-async": "off",


### PR DESCRIPTION
## Summary

This pull request standardizes the way array types are defined throughout the codebase by replacing the `Array<T>` syntax with the simpler and more modern `T[]` syntax.

This change improves code readability and consistency, and aligns with common TypeScript best practices.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
