### PR TITLE
refactor(server): move writeToDisk config resolution to middleware

### DIFF
--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -24,36 +24,6 @@ type Options = {
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
 };
 
-// allow to configure dev.writeToDisk in environments
-const formatDevConfig = (
-  config: NormalizedDevConfig,
-  environments: Record<string, EnvironmentContext>,
-): NormalizedDevConfig => {
-  const writeToDiskValues = Object.values(environments).map(
-    (env) => env.config.dev.writeToDisk,
-  );
-  if (new Set(writeToDiskValues).size === 1) {
-    return {
-      ...config,
-      writeToDisk: writeToDiskValues[0],
-    };
-  }
-
-  return {
-    ...config,
-    writeToDisk(filePath: string, compilationName?: string) {
-      let { writeToDisk } = config;
-      if (compilationName && environments[compilationName]) {
-        writeToDisk =
-          environments[compilationName].config.dev.writeToDisk ?? writeToDisk;
-      }
-      return typeof writeToDisk === 'function'
-        ? writeToDisk(filePath)
-        : writeToDisk!;
-    },
-  };
-};
-
 /**
  * Setup compiler-related logic:
  * 1. setup rsbuild-dev-middleware
@@ -77,7 +47,7 @@ export class CompilationManager {
   public socketServer: SocketServer;
 
   constructor({ dev, server, compiler, publicPaths, environments }: Options) {
-    this.devConfig = formatDevConfig(dev, environments);
+    this.devConfig = dev;
     this.serverConfig = server;
     this.compiler = compiler;
     this.environments = environments;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1678,6 +1678,8 @@ export type CliShortcut = {
   action: () => void | Promise<void>;
 };
 
+export type WriteToDisk = boolean | ((filename: string) => boolean);
+
 export interface DevConfig {
   /**
    * Whether to enable Hot Module Replacement.
@@ -1731,7 +1733,7 @@ export interface DevConfig {
    * Controls whether the build output from development mode is written to disk.
    * @default false
    */
-  writeToDisk?: boolean | ((filename: string) => boolean);
+  writeToDisk?: WriteToDisk;
   /**
    * This option allows you to configure a list of globs/directories/files to watch for
    * file changes.


### PR DESCRIPTION
## Summary

This PR refactors how the `writeToDisk` configuration is handled across multiple environments in the development server setup. I prefer to keep devConfig as its original value and resolve the `writeToDisk` when using it.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
