### PR TITLE
test(e2e): uncomment and simplify some cases

### DIFF
--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -18,33 +18,33 @@ test.beforeEach(async () => {
   fs.writeFileSync(extraConfigFile, 'export default 1;');
 });
 
-// rspackOnlyTest(
-//   'should restart dev server when extra config file changed',
-//   async () => {
-//     const childProcess = exec('npx rsbuild dev', {
-//       cwd: __dirname,
-//       env: {
-//         ...process.env,
-//         PORT: String(await getRandomPort()),
-//         NODE_ENV: 'development',
-//         WATCH_FILES_TYPE: 'reload-server',
-//       },
-//     });
+rspackOnlyTest(
+  'should restart dev server when extra config file changed',
+  async () => {
+    const childProcess = exec('npx rsbuild dev', {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        PORT: String(await getRandomPort()),
+        NODE_ENV: 'development',
+        WATCH_FILES_TYPE: 'reload-server',
+      },
+    });
 
-//     // the first build
-//     await expectFile(distIndexFile);
+    // the first build
+    await expectFile(distIndexFile);
 
-//     await remove(tempOutputFile);
-//     // temp config changed and trigger rebuild
-//     fs.writeFileSync(extraConfigFile, 'export default 2;');
+    await remove(tempOutputFile);
+    // temp config changed and trigger rebuild
+    fs.writeFileSync(extraConfigFile, 'export default 2;');
 
-//     // rebuild and generate dist files
-//     await expectFile(tempOutputFile);
-//     expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('2');
+    // rebuild and generate dist files
+    await expectFile(tempOutputFile);
+    expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('2');
 
-//     childProcess.kill();
-//   },
-// );
+    childProcess.kill();
+  },
+);
 
 rspackOnlyTest(
   'should not restart dev server if `watchFiles.type` is `reload-page`',
@@ -72,29 +72,29 @@ rspackOnlyTest(
   },
 );
 
-// rspackOnlyTest(
-//   'should not restart dev server if `watchFiles.type` is not set',
-//   async () => {
-//     const childProcess = exec('npx rsbuild dev', {
-//       cwd: __dirname,
-//       env: {
-//         ...process.env,
-//         PORT: String(await getRandomPort()),
-//         NODE_ENV: 'development',
-//       },
-//     });
+rspackOnlyTest(
+  'should not restart dev server if `watchFiles.type` is not set',
+  async () => {
+    const childProcess = exec('npx rsbuild dev', {
+      cwd: __dirname,
+      env: {
+        ...process.env,
+        PORT: String(await getRandomPort()),
+        NODE_ENV: 'development',
+      },
+    });
 
-//     // Fix occasional 'directory not empty' error when wait and rm dist.
-//     // Sometimes the dist directory exists, but the files in the dist directory have not been completely written.
-//     await expectFile(distIndexFile);
+    // Fix occasional 'directory not empty' error when wait and rm dist.
+    // Sometimes the dist directory exists, but the files in the dist directory have not been completely written.
+    await expectFile(distIndexFile);
 
-//     await remove(distIndexFile);
-//     // temp config changed
-//     fs.writeFileSync(extraConfigFile, 'export default 2;');
+    await remove(distIndexFile);
+    // temp config changed
+    fs.writeFileSync(extraConfigFile, 'export default 2;');
 
-//     await expectFile(tempOutputFile);
-//     expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
+    await expectFile(tempOutputFile);
+    expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
 
-//     childProcess.kill();
-//   },
-// );
+    childProcess.kill();
+  },
+);

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -17,7 +17,6 @@ rspackOnlyTest(
       recursive: true,
     });
 
-    const port = await getRandomPort();
     const rsbuild = await dev({
       cwd,
       page,
@@ -27,9 +26,6 @@ rspackOnlyTest(
             index: join(cwd, 'test-temp-src/index.ts'),
           },
         },
-        server: {
-          port,
-        },
         dev: {
           client: {
             host: '',
@@ -37,8 +33,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    expect(rsbuild.port).toBe(port);
 
     const appPath = join(cwd, 'test-temp-src/App.tsx');
 

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -17,7 +17,6 @@ rspackOnlyTest(
       recursive: true,
     });
 
-    const port = await getRandomPort();
     const rsbuild = await dev({
       cwd,
       page,
@@ -27,9 +26,6 @@ rspackOnlyTest(
             index: join(cwd, 'test-temp-src/index.ts'),
           },
         },
-        server: {
-          port,
-        },
         dev: {
           client: {
             port: '<port>',
@@ -37,8 +33,6 @@ rspackOnlyTest(
         },
       },
     });
-
-    expect(rsbuild.port).toBe(port);
 
     const appPath = join(cwd, 'test-temp-src/App.tsx');
 

--- a/e2e/cases/server/assetPrefix/index.test.ts
+++ b/e2e/cases/server/assetPrefix/index.test.ts
@@ -1,10 +1,9 @@
-import { dev, getRandomPort } from '@e2e/helper';
+import { dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 test('should match resource correctly with specify assetPrefix', async ({
   page,
 }) => {
-  const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
     page,
@@ -12,13 +11,8 @@ test('should match resource correctly with specify assetPrefix', async ({
       dev: {
         assetPrefix: '/subpath/',
       },
-      server: {
-        port,
-      },
     },
   });
-
-  expect(rsbuild.port).toBe(port);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');
@@ -29,21 +23,15 @@ test('should match resource correctly with specify assetPrefix', async ({
 test('should match resource correctly with full url assetPrefix', async ({
   page,
 }) => {
-  const port = await getRandomPort();
   const rsbuild = await dev({
     cwd: __dirname,
     page,
     rsbuildConfig: {
       dev: {
-        assetPrefix: `http://localhost:${port}/subpath/`,
-      },
-      server: {
-        port,
+        assetPrefix: `http://localhost:<port>/subpath/`,
       },
     },
   });
-
-  expect(rsbuild.port).toBe(port);
 
   const locator = page.locator('#test');
   await expect(locator).toHaveText('Hello Rsbuild!');


### PR DESCRIPTION
## Summary

- Uncommented and restored two watch-files tests.
- Removed some usage of `getRandomPort` to simplify the cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
