### PR TITLE
feat: add support for custom HMR client in environments

### DIFF
--- a/e2e/cases/hmr/client-multiple-environment/index.test.ts
+++ b/e2e/cases/hmr/client-multiple-environment/index.test.ts
@@ -1,0 +1,54 @@
+import { join } from 'node:path';
+import { dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+const cwd = __dirname;
+
+rspackOnlyTest(
+  'should allow to set different dev.client for multiple environments',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd,
+      page,
+      rsbuildConfig: {
+        dev: {
+          writeToDisk: true,
+        },
+        environments: {
+          foo: {
+            source: {
+              entry: {
+                foo: join(cwd, 'foo.js'),
+              },
+            },
+            dev: {
+              client: {
+                host: 'http://foo.com',
+              },
+            },
+          },
+          bar: {
+            source: {
+              entry: {
+                bar: join(cwd, 'bar.js'),
+              },
+            },
+            dev: {
+              client: {
+                host: 'http://bar.com',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const files = await rsbuild.getDistFiles();
+    const filenames = Object.keys(files);
+    const fooJs = filenames.find((name) => name.endsWith('foo.js'));
+    const barJs = filenames.find((name) => name.endsWith('bar.js'));
+    expect(files[fooJs!].includes('"host":"http://foo.com"')).toBeTruthy();
+    expect(files[barJs!].includes('"host":"http://bar.com"')).toBeTruthy();
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
+++ b/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});

--- a/e2e/cases/hmr/client-multiple-environment/src/bar.js
+++ b/e2e/cases/hmr/client-multiple-environment/src/bar.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/e2e/cases/hmr/client-multiple-environment/src/foo.js
+++ b/e2e/cases/hmr/client-multiple-environment/src/foo.js
@@ -1,0 +1,1 @@
+console.log('foo');

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -4,7 +4,8 @@ declare global {
   const RSBUILD_VERSION: string;
   const WEBPACK_HASH: string;
   const RSBUILD_CLIENT_CONFIG: NormalizedClientConfig;
-  const RSBUILD_RESOLVED_CLIENT_CONFIG: NormalizedClientConfig;
+  const RSBUILD_SERVER_HOST: string;
+  const RSBUILD_SERVER_PORT: number;
   const RSBUILD_DEV_LIVE_RELOAD: boolean;
   const RSBUILD_WEB_SOCKET_TOKEN: string;
 }

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -26,6 +26,7 @@ import { generateRspackConfig } from './rspackConfig';
 
 const allowedEnvironmentDevKeys: AllowedEnvironmentDevKeys[] = [
   'hmr',
+  'client',
   'liveReload',
   'writeToDisk',
   'assetPrefix',

--- a/packages/core/src/server/cliShortcuts.ts
+++ b/packages/core/src/server/cliShortcuts.ts
@@ -1,10 +1,9 @@
 import { color, isTTY } from '../helpers';
 import { logger } from '../logger';
-import type { CliShortcut, NormalizedDevConfig } from '../types/config';
+import type { CliShortcut, NormalizedConfig } from '../types/config';
 
-export const isCliShortcutsEnabled = (
-  devConfig: NormalizedDevConfig,
-): boolean => devConfig.cliShortcuts && isTTY('stdin');
+export const isCliShortcutsEnabled = (config: NormalizedConfig): boolean =>
+  config.dev.cliShortcuts && isTTY('stdin');
 
 export async function setupCliShortcuts({
   help = true,

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -4,10 +4,9 @@ import { castArray, isMultiCompiler, pick } from '../helpers';
 import { logger } from '../logger';
 import { rspack } from '../rspack';
 import type {
-  DevConfig,
   InternalContext,
+  NormalizedConfig,
   RequestHandler,
-  ServerConfig,
   SetupMiddlewaresContext,
 } from '../types';
 import type { CompilationManager } from './compilationManager';
@@ -26,23 +25,22 @@ import {
 import { createProxyMiddleware } from './proxy';
 
 export type RsbuildDevMiddlewareOptions = {
-  pwd: string;
-  dev: DevConfig;
-  devServerAPI: RsbuildDevServer;
-  server: ServerConfig;
+  config: NormalizedConfig;
   context: InternalContext;
   compilationManager?: CompilationManager;
+  devServerAPI: RsbuildDevServer;
   /**
    * Callbacks returned by the `onBeforeStartDevServer` hook.
    */
   postCallbacks: (() => void)[];
+  pwd: string;
 };
 
 const applySetupMiddlewares = (
-  dev: RsbuildDevMiddlewareOptions['dev'],
+  config: NormalizedConfig,
   devServerAPI: RsbuildDevServer,
 ) => {
-  const setupMiddlewares = dev.setupMiddlewares || [];
+  const setupMiddlewares = config.dev.setupMiddlewares || [];
 
   const serverOptions: SetupMiddlewaresContext = pick(devServerAPI, [
     'sockWrite',
@@ -68,11 +66,11 @@ const applySetupMiddlewares = (
 export type Middlewares = (RequestHandler | [string, RequestHandler])[];
 
 const applyDefaultMiddlewares = async ({
-  devServerAPI,
-  middlewares,
-  server,
+  config,
   compilationManager,
   context,
+  devServerAPI,
+  middlewares,
   pwd,
   postCallbacks,
 }: RsbuildDevMiddlewareOptions & {
@@ -81,6 +79,7 @@ const applyDefaultMiddlewares = async ({
   onUpgrade: UpgradeEvent;
 }> => {
   const upgradeEvents: UpgradeEvent[] = [];
+  const { server } = config;
 
   if (server.cors) {
     const { default: corsMiddleware } = await import(
@@ -270,7 +269,7 @@ export const getDevMiddlewares = async (
 
   // Order: setupMiddlewares.unshift => internal middleware => setupMiddlewares.push
   const { before, after } = applySetupMiddlewares(
-    options.dev,
+    options.config,
     options.devServerAPI,
   );
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -10,7 +10,6 @@ import type {
   EnvironmentAPI,
   InternalContext,
   NormalizedConfig,
-  NormalizedDevConfig,
   Rspack,
 } from '../types';
 import { isCliShortcutsEnabled, setupCliShortcuts } from './cliShortcuts';
@@ -118,14 +117,6 @@ export type RsbuildDevServer = {
   sockWrite: SockWrite;
 };
 
-const formatDevConfig = (config: NormalizedDevConfig, port: number) => {
-  // replace port placeholder
-  if (config.client.port === '<port>') {
-    config.client.port = String(port);
-  }
-  return config;
-};
-
 export async function createDevServer<
   Options extends {
     context: InternalContext;
@@ -147,7 +138,6 @@ export async function createDevServer<
   });
   const { middlewareMode } = config.server;
   const { context } = options;
-  const devConfig = formatDevConfig(config.dev, port);
   const routes = getRoutes(context);
   const root = context.rootPath;
 
@@ -208,13 +198,10 @@ export async function createDevServer<
 
     // create dev middleware instance
     const compilationManager = new CompilationManager({
-      dev: devConfig,
-      server: {
-        ...config.server,
-        port,
-      },
-      publicPaths: publicPaths,
+      config,
       compiler,
+      publicPaths: publicPaths,
+      resolvedPort: port,
       environments: context.environments,
     });
 
@@ -226,7 +213,7 @@ export async function createDevServer<
   const protocol = https ? 'https' : 'http';
   const urls = await getAddressUrls({ protocol, port, host });
 
-  const cliShortcutsEnabled = isCliShortcutsEnabled(devConfig);
+  const cliShortcutsEnabled = isCliShortcutsEnabled(config);
 
   const printUrls = () =>
     printServerURLs({
@@ -273,9 +260,9 @@ export async function createDevServer<
 
     if (cliShortcutsEnabled) {
       const shortcutsOptions =
-        typeof devConfig.cliShortcuts === 'boolean'
+        typeof config.dev.cliShortcuts === 'boolean'
           ? {}
-          : devConfig.cliShortcuts;
+          : config.dev.cliShortcuts;
 
       const cleanup = await setupCliShortcuts({
         openPage,
@@ -465,8 +452,7 @@ export async function createDevServer<
   const compilationManager = runCompile ? await startCompile() : undefined;
 
   fileWatcher = await setupWatchFiles({
-    dev: devConfig,
-    server: config.server,
+    config,
     compilationManager,
     root,
   });
@@ -474,10 +460,9 @@ export async function createDevServer<
   devMiddlewares = await getDevMiddlewares({
     pwd: root,
     compilationManager,
-    dev: devConfig,
+    config,
     devServerAPI,
     context,
-    server: config.server,
     postCallbacks,
   });
 

--- a/packages/core/src/server/hmrFallback.ts
+++ b/packages/core/src/server/hmrFallback.ts
@@ -1,4 +1,3 @@
-import type { DevConfig, ServerConfig } from '../types/config';
 import { isWildcardHost } from './helper';
 
 /**
@@ -22,7 +21,9 @@ export async function getLocalhostResolvedAddress(): Promise<
   return match ? undefined : defaultLookup.address;
 }
 
-async function resolveHostname(host: string | undefined = 'localhost') {
+export async function resolveHostname(
+  host: string | undefined = 'localhost',
+): Promise<string> {
   if (host === 'localhost') {
     const resolvedAddress = await getLocalhostResolvedAddress();
     if (resolvedAddress) {
@@ -32,16 +33,4 @@ async function resolveHostname(host: string | undefined = 'localhost') {
 
   // If possible, set the host name to localhost
   return host === undefined || isWildcardHost(host) ? 'localhost' : host;
-}
-
-export async function getResolvedClientConfig(
-  clientConfig: DevConfig['client'],
-  serverConfig: ServerConfig,
-): Promise<DevConfig['client']> {
-  const resolvedHost = await resolveHostname(serverConfig.host);
-  return {
-    ...clientConfig,
-    host: resolvedHost,
-    port: serverConfig.port,
-  };
 }

--- a/packages/core/src/server/prodServer.ts
+++ b/packages/core/src/server/prodServer.ts
@@ -226,7 +226,7 @@ export async function startProdServer(
 
         const protocol = https ? 'https' : 'http';
         const urls = await getAddressUrls({ protocol, port, host });
-        const cliShortcutsEnabled = isCliShortcutsEnabled(config.dev);
+        const cliShortcutsEnabled = isCliShortcutsEnabled(config);
 
         const cleanupGracefulShutdown = setupGracefulShutdown();
 

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -4,15 +4,15 @@ import { castArray } from '../helpers';
 import type {
   ChokidarOptions,
   DevConfig,
+  NormalizedConfig,
   ServerConfig,
   WatchFiles,
 } from '../types';
 import type { CompilationManager } from './compilationManager';
 
 type WatchFilesOptions = {
-  dev: DevConfig;
-  server: ServerConfig;
   root: string;
+  config: NormalizedConfig;
   compilationManager?: CompilationManager;
 };
 
@@ -23,20 +23,20 @@ export type WatchFilesResult = {
 export async function setupWatchFiles(
   options: WatchFilesOptions,
 ): Promise<WatchFilesResult | undefined> {
-  const { dev, server, root, compilationManager } = options;
+  const { config, root, compilationManager } = options;
 
-  const { hmr, liveReload } = dev;
+  const { hmr, liveReload } = config.dev;
   if ((!hmr && !liveReload) || !compilationManager) {
     return;
   }
 
   const closeDevFilesWatcher = await watchDevFiles(
-    dev,
+    config.dev,
     compilationManager,
     root,
   );
   const serverFilesWatcher = await watchServerFiles(
-    server,
+    config.server,
     compilationManager,
     root,
   );

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1808,6 +1808,7 @@ export type RsbuildConfigMeta = {
  */
 export type AllowedEnvironmentDevKeys =
   | 'hmr'
+  | 'client'
   | 'liveReload'
   | 'assetPrefix'
   | 'progressBar'

--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -12,6 +12,7 @@ interface EnvironmentConfig {
   dev?: Pick<
     DevConfig,
     | 'hmr'
+    | 'client'
     | 'liveReload'
     | 'assetPrefix'
     | 'progressBar'

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -12,6 +12,7 @@ interface EnvironmentConfig {
   dev?: Pick<
     DevConfig,
     | 'hmr'
+    | 'client'
     | 'liveReload'
     | 'assetPrefix'
     | 'progressBar'


### PR DESCRIPTION
## Summary

Add support for custom HMR client via `dev.client` in environments:

```js
export default defineConfig({
  environments: {
    foo: {
      dev: {
        client: {
          // ...
        },
      },
    },
    bar: {
      dev: {
        client: {
          // ...
        },
      },
    },
  },
});
```

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
