### PR TITLE
docs: add rslint to the list of Rstack tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Rstack is a unified JavaScript toolchain built around Rspack, with high performa
 | [Rspress](https://github.com/web-infra-dev/rspress)   | Static site generator    |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | Build analyzer           |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                   |
 
 ## 🔗 Links
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -81,6 +81,7 @@ Rstack é uma cadeia de ferramentas JavaScript unificada construída em torno do
 | [Rspress](https://github.com/web-infra-dev/rspress)   | Gerador de site estático                       |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | Analisador de build                            |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Framework de testes                            |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                                         |
 
 ## 🔗 Links
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,6 +81,7 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 | [Rspress](https://github.com/web-infra-dev/rspress)   | 静态站点生成器 |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | 构建分析工具   |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码分析工具   |
 
 ## 🔗 链接
 

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -102,6 +102,7 @@ rsbuild
 rsdoctor
 rsfamily
 rslib
+rslint
 rslog
 rspack
 rspeedy

--- a/website/docs/en/guide/start/index.mdx
+++ b/website/docs/en/guide/start/index.mdx
@@ -72,6 +72,7 @@ Rstack includes the following tools:
 | [Rspress](https://github.com/web-infra-dev/rspress)   | Static site generator    |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | Build analyzer           |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | Testing framework        |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | Linter                   |
 
 ## 🔗 Links
 

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -72,6 +72,7 @@ Rstack 包含以下工具：
 | [Rspress](https://github.com/web-infra-dev/rspress)   | 静态站点生成器 |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | 构建分析工具   |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码分析工具   |
 
 ## 🔗 链接
 


### PR DESCRIPTION
## Summary

Add Rslint to the list of Rstack tools.

## Related links

https://github.com/web-infra-dev/rslint

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
