### PR TITLE
chore: ignore output directories in Rslint config

### DIFF
--- a/rslint.json
+++ b/rslint.json
@@ -1,6 +1,7 @@
 [
   {
     "language": "javascript",
+    "ignores": ["**/compiled/**"],
     "languageOptions": {
       "parserOptions": {
         "project": [

--- a/rslint.json
+++ b/rslint.json
@@ -1,7 +1,7 @@
 [
   {
     "language": "javascript",
-    "ignores": ["**/compiled/**"],
+    "ignores": ["**/dist-types/**", "**/compiled/**"],
     "languageOptions": {
       "parserOptions": {
         "project": [


### PR DESCRIPTION
## Summary

Ignore the `compiled` and `dist-types` directory in Rslint config to avoid checking unnecessary files.

## Related Links

- https://github.com/web-infra-dev/rslint

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
