### PR TITLE
refactor: remove unnecessary async and update type definitions

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -81,7 +81,7 @@ Rstack 是一个围绕 Rspack 打造的 JavaScript 统一工具链，具有优�
 | [Rspress](https://github.com/web-infra-dev/rspress)   | 静态站点生成器 | <a href="https://npmjs.com/package/@rspress/core"><img src="https://img.shields.io/npm/v/@rspress/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>   |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | 构建分析工具   | <a href="https://npmjs.com/package/@rsdoctor/core"><img src="https://img.shields.io/npm/v/@rsdoctor/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a> |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
-| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码分析工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
 ## 🔗 链接
 

--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -123,10 +123,10 @@ export async function generateWebpackConfig({
 
   let webpackConfig = chain.toConfig() as WebpackConfig;
 
-  const configUtils = (await helpers.getConfigUtils(
+  const configUtils = helpers.getConfigUtils(
     webpackConfig as Rspack.Configuration,
     chainUtils as unknown as ModifyRspackConfigUtils,
-  )) as unknown as ModifyWebpackConfigUtils;
+  ) as unknown as ModifyWebpackConfigUtils;
 
   webpackConfig = await modifyWebpackConfig(
     context,

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -11,7 +11,7 @@ function initNodeEnv() {
   }
 }
 
-export async function runCLI(): Promise<void> {
+export function runCLI(): void {
   initNodeEnv();
 
   // make it easier to identify the process via activity monitor or other tools

--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -29,7 +29,7 @@ function getAbsoluteDistPath(
 // using cache to avoid multiple calls to loadConfig
 const browsersListCache = new Map<string, string[]>();
 
-export async function getBrowserslist(path: string): Promise<string[] | null> {
+export function getBrowserslist(path: string): string[] | null {
   const env = process.env.NODE_ENV;
   const cacheKey = path + env;
 
@@ -47,10 +47,10 @@ export async function getBrowserslist(path: string): Promise<string[] | null> {
   return null;
 }
 
-export async function getBrowserslistByEnvironment(
+export function getBrowserslistByEnvironment(
   path: string,
   config: NormalizedEnvironmentConfig,
-): Promise<string[]> {
+): string[] {
   const { target, overrideBrowserslist } = config.output;
 
   if (Array.isArray(overrideBrowserslist)) {
@@ -59,7 +59,7 @@ export async function getBrowserslistByEnvironment(
 
   // Read project browserslist config when target is `web-like`
   if (target === 'web' || target === 'web-worker') {
-    const browserslistrc = await getBrowserslist(path);
+    const browserslistrc = getBrowserslist(path);
     if (browserslistrc) {
       return browserslistrc;
     }
@@ -99,10 +99,7 @@ export async function updateEnvironmentContext(
   context.environments ||= {};
 
   for (const [index, [name, config]] of Object.entries(configs).entries()) {
-    const browserslist = await getBrowserslistByEnvironment(
-      context.rootPath,
-      config,
-    );
+    const browserslist = getBrowserslistByEnvironment(context.rootPath, config);
 
     const { entry = {}, tsconfigPath } = config.source;
     const htmlPaths = getEnvironmentHTMLPaths(entry, config);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -69,7 +69,7 @@ import type {
   StartDevServer,
 } from './types';
 
-async function applyDefaultPlugins(
+function applyDefaultPlugins(
   pluginManager: PluginManager,
   context: InternalContext,
 ) {
@@ -191,7 +191,7 @@ export async function createRsbuild(
   const globalPluginAPI = getPluginAPI();
 
   logger.debug('add default plugins');
-  await applyDefaultPlugins(pluginManager, context);
+  applyDefaultPlugins(pluginManager, context);
   logger.debug('add default plugins done');
 
   const provider = (config.provider as RsbuildProvider) || rspackProvider;

--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -83,9 +83,7 @@ const compareSemver = (version1: string, version2: string) => {
  * we should check that the Rspack version is greater than the minimum
  * supported version.
  */
-export const isSatisfyRspackVersion = async (
-  originalVersion: string,
-): Promise<boolean> => {
+export const isSatisfyRspackVersion = (originalVersion: string): boolean => {
   let version = originalVersion;
 
   // The nightly version of Rspack is to append `-canary-abc` to the current version
@@ -124,7 +122,7 @@ export const getPublicPathFromChain = (
   chain: RspackChain,
   withSlash = true,
 ): string => {
-  const publicPath = chain.output.get('publicPath');
+  const publicPath: Rspack.PublicPath = chain.output.get('publicPath');
 
   if (typeof publicPath === 'string') {
     return formatPublicPath(publicPath, withSlash);

--- a/packages/core/src/plugins/entry.ts
+++ b/packages/core/src/plugins/entry.ts
@@ -5,7 +5,7 @@ export const pluginEntry = (): RsbuildPlugin => ({
   name: 'rsbuild:entry',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { environment, isServer }) => {
+    api.modifyBundlerChain((chain, { environment, isServer }) => {
       const { config, entry } = environment;
       const { preEntry } = config.source;
 

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -87,7 +87,7 @@ export const pluginMinimize = (): RsbuildPlugin => ({
   setup(api) {
     const isRspack = api.context.bundlerType === 'rspack';
 
-    api.modifyBundlerChain(async (chain, { environment, CHAIN_ID, rspack }) => {
+    api.modifyBundlerChain((chain, { environment, CHAIN_ID, rspack }) => {
       const { config } = environment;
       const { minifyJs, minifyCss, jsOptions, cssOptions } =
         parseMinifyOptions(config);

--- a/packages/core/src/plugins/moduleFederation.ts
+++ b/packages/core/src/plugins/moduleFederation.ts
@@ -163,34 +163,32 @@ export function pluginModuleFederation(): RsbuildPlugin {
         ];
       });
 
-      api.modifyBundlerChain(
-        async (chain, { CHAIN_ID, target, environment }) => {
-          const { config } = environment;
+      api.modifyBundlerChain((chain, { CHAIN_ID, target, environment }) => {
+        const { config } = environment;
 
-          if (!config.moduleFederation?.options || target !== 'web') {
-            return;
+        if (!config.moduleFederation?.options || target !== 'web') {
+          return;
+        }
+
+        const { options } = config.moduleFederation;
+
+        chain
+          .plugin(CHAIN_ID.PLUGIN.MODULE_FEDERATION)
+          .use(rspack.container.ModuleFederationPlugin, [options]);
+
+        if (options.name) {
+          if (options.exposes) {
+            chain
+              .plugin('mf-patch-split-chunks')
+              .use(PatchSplitChunksPlugin, [options.name]);
           }
 
-          const { options } = config.moduleFederation;
-
-          chain
-            .plugin(CHAIN_ID.PLUGIN.MODULE_FEDERATION)
-            .use(rspack.container.ModuleFederationPlugin, [options]);
-
-          if (options.name) {
-            if (options.exposes) {
-              chain
-                .plugin('mf-patch-split-chunks')
-                .use(PatchSplitChunksPlugin, [options.name]);
-            }
-
-            // `uniqueName` is required for react refresh to work
-            if (!chain.output.get('uniqueName')) {
-              chain.output.set('uniqueName', options.name);
-            }
+          // `uniqueName` is required for react refresh to work
+          if (!chain.output.get('uniqueName')) {
+            chain.output.set('uniqueName', options.name);
           }
-        },
-      );
+        }
+      });
     },
   };
 }

--- a/packages/core/src/plugins/moment.ts
+++ b/packages/core/src/plugins/moment.ts
@@ -4,7 +4,7 @@ export const pluginMoment = (): RsbuildPlugin => ({
   name: 'rsbuild:moment',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { environment, bundler }) => {
+    api.modifyBundlerChain((chain, { environment, bundler }) => {
       const { config } = environment;
 
       if (config.performance.removeMomentLocale) {

--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -77,10 +77,7 @@ export const pluginOutput = (): RsbuildPlugin => ({
 
   setup(api) {
     api.modifyBundlerChain(
-      async (
-        chain,
-        { CHAIN_ID, isDev, isProd, isServer, environment, rspack },
-      ) => {
+      (chain, { CHAIN_ID, isDev, isProd, isServer, environment, rspack }) => {
         const { distPath, config } = environment;
 
         const publicPath = getPublicPath({

--- a/packages/core/src/plugins/progress.ts
+++ b/packages/core/src/plugins/progress.ts
@@ -9,7 +9,7 @@ export const pluginProgress = (): RsbuildPlugin => ({
       return;
     }
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment, rspack }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment, rspack }) => {
       const { config } = environment;
       const options = config.dev.progressBar;
 

--- a/packages/core/src/plugins/resourceHints.ts
+++ b/packages/core/src/plugins/resourceHints.ts
@@ -61,7 +61,7 @@ export const pluginResourceHints = (): RsbuildPlugin => ({
       return { headTags, bodyTags };
     });
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config, htmlPaths } = environment;
 
       if (Object.keys(htmlPaths).length === 0) {

--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -81,7 +81,7 @@ async function applyProfile(
 export const pluginRspackProfile = (): RsbuildPlugin => ({
   name: 'rsbuild:rspack-profile',
 
-  async setup(api) {
+  setup(api) {
     if (api.context.bundlerType === 'webpack') {
       return;
     }

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -10,7 +10,7 @@ export const pluginServer = (): RsbuildPlugin => ({
   name: 'rsbuild:server',
 
   setup(api) {
-    const onStartServer: OnAfterStartDevServerFn = async ({ port, routes }) => {
+    const onStartServer: OnAfterStartDevServerFn = ({ port, routes }) => {
       const config = api.getNormalizedConfig();
       if (config.server.open) {
         open({

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -113,7 +113,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: async (chain, { CHAIN_ID, isDev, target, environment }) => {
+      handler: (chain, { CHAIN_ID, isDev, target, environment }) => {
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
@@ -170,7 +170,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           } else {
             swcConfig.env!.mode = polyfillMode;
 
-            const coreJsDir = await applyCoreJs(swcConfig, polyfillMode);
+            const coreJsDir = applyCoreJs(swcConfig, polyfillMode);
             for (const item of [rule, dataUriRule]) {
               item.resolve.alias.set('core-js', coreJsDir);
             }
@@ -219,10 +219,7 @@ const getCoreJsVersion = (corejsPkgPath: string) => {
   }
 };
 
-async function applyCoreJs(
-  swcConfig: SwcLoaderOptions,
-  polyfillMode: Polyfill,
-) {
+function applyCoreJs(swcConfig: SwcLoaderOptions, polyfillMode: Polyfill) {
   const coreJsPath = require.resolve('core-js/package.json');
   const version = getCoreJsVersion(coreJsPath);
   const coreJsDir = path.dirname(coreJsPath);

--- a/packages/core/src/plugins/target.ts
+++ b/packages/core/src/plugins/target.ts
@@ -7,7 +7,7 @@ export const pluginTarget = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: async (chain, { target, environment }) => {
+      handler: (chain, { target, environment }) => {
         if (target === 'node') {
           chain.target('node');
           return;

--- a/packages/core/src/plugins/wasm.ts
+++ b/packages/core/src/plugins/wasm.ts
@@ -6,7 +6,7 @@ export const pluginWasm = (): RsbuildPlugin => ({
   name: 'rsbuild:wasm',
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment, isProd }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment, isProd }) => {
       const { config } = environment;
       const distPath = config.output.distPath.wasm;
       const filename = posix.join(

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -87,7 +87,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     environments: context.environments,
   });
 
-  if (!(await isSatisfyRspackVersion(rspack.rspackVersion))) {
+  if (!isSatisfyRspackVersion(rspack.rspackVersion)) {
     throw new Error(
       `${color.dim('[rsbuild]')} The current Rspack version does not meet the requirements, the minimum supported version of Rspack is ${color.green(
         rspackMinVersion,

--- a/packages/core/src/provider/provider.ts
+++ b/packages/core/src/provider/provider.ts
@@ -5,7 +5,7 @@ import { build } from './build';
 import { createCompiler as baseCreateCompiler } from './createCompiler';
 import { initConfigs, initRsbuildConfig } from './initConfigs';
 
-export const rspackProvider: RsbuildProvider = async ({
+export const rspackProvider: RsbuildProvider = ({
   context,
   pluginManager,
   rsbuildOptions,

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -41,7 +41,7 @@ async function modifyRspackConfig(
     },
   );
 
-  const utils = await getConfigUtils(proxiedConfig, chainUtils);
+  const utils = getConfigUtils(proxiedConfig, chainUtils);
 
   [currentConfig] = await context.hooks.modifyRspackConfig.callChain({
     environment: utils.environment.name,
@@ -71,10 +71,10 @@ async function modifyRspackConfig(
   return currentConfig;
 }
 
-export async function getConfigUtils(
+export function getConfigUtils(
   config: Rspack.Configuration,
   chainUtils: ModifyChainUtils,
-): Promise<ModifyRspackConfigUtils> {
+): ModifyRspackConfigUtils {
   return {
     ...chainUtils,
 

--- a/packages/core/src/restart.ts
+++ b/packages/core/src/restart.ts
@@ -6,7 +6,7 @@ import { logger } from './logger';
 import { createChokidar } from './server/watchFiles.js';
 import type { RsbuildInstance } from './types';
 
-type Cleaner = () => Promise<unknown> | unknown;
+type Cleaner = () => unknown;
 
 let cleaners: Cleaner[] = [];
 

--- a/packages/core/src/server/compilationManager.ts
+++ b/packages/core/src/server/compilationManager.ts
@@ -137,7 +137,7 @@ export class CompilationManager {
         base && base !== '/' ? stripBase(prefix, base) : prefix,
       );
 
-    const wrapper: CompilationMiddleware = async (req, res, next) => {
+    const wrapper: CompilationMiddleware = (req, res, next) => {
       const { url } = req;
       const assetPrefix =
         url && assetPrefixes.find((prefix) => url.startsWith(prefix));

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -73,10 +73,10 @@ export const loadBundle = async <T>(
   return res;
 };
 
-export const getTransformedHtml = async (
+export const getTransformedHtml = (
   entryName: string,
   utils: ServerUtils,
-): Promise<string> => {
+): string => {
   const { htmlPaths, distPath } = utils.environment;
   const htmlPath = htmlPaths[entryName];
 
@@ -100,7 +100,7 @@ export const createCacheableFunction = <T>(
     stats: Rspack.Stats,
     entryName: string,
     utils: ServerUtils,
-  ) => Promise<T>,
+  ) => Promise<T> | T,
 ) => {
   const cache = new WeakMap<
     Rspack.Stats,

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -179,7 +179,7 @@ export const getHtmlCompletionMiddleware: (params: {
 export const getBaseMiddleware: (params: {
   base: string;
 }) => RequestHandler = ({ base }) => {
-  return async (req, res, next) => {
+  return (req, res, next) => {
     const url = req.url!;
     const pathname = getUrlPathname(url);
 

--- a/packages/core/src/server/runner/index.ts
+++ b/packages/core/src/server/runner/index.ts
@@ -41,7 +41,7 @@ export const run = async <T>({
 }): Promise<T> => {
   const runnerFactory = new BasicRunnerFactory(bundlePath);
   const runner = runnerFactory.create(runnerFactoryOptions);
-  const mod = runner.run(bundlePath);
+  const mod = await runner.run(bundlePath);
 
   return mod as T;
 };

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -199,7 +199,7 @@ export type RsbuildProvider<B extends 'rspack' | 'webpack' = 'rspack'> =
     pluginManager: PluginManager;
     rsbuildOptions: ResolvedCreateRsbuildOptions;
     helpers: RsbuildProviderHelpers;
-  }) => Promise<ProviderInstance<B>>;
+  }) => Promise<ProviderInstance<B>> | ProviderInstance<B>;
 
 export type AddPluginsOptions = {
   /**

--- a/packages/core/tests/rspackVersion.test.ts
+++ b/packages/core/tests/rspackVersion.test.ts
@@ -1,19 +1,19 @@
 import { isSatisfyRspackVersion, rspackMinVersion } from '../src/helpers';
 
 describe('rspack version', () => {
-  it('isSatisfyRspackVersion', async () => {
-    expect(await isSatisfyRspackVersion('0.1.0')).toBeFalsy();
+  it('isSatisfyRspackVersion', () => {
+    expect(isSatisfyRspackVersion('0.1.0')).toBeFalsy();
 
-    expect(await isSatisfyRspackVersion(rspackMinVersion)).toBeTruthy();
+    expect(isSatisfyRspackVersion(rspackMinVersion)).toBeTruthy();
 
-    expect(await isSatisfyRspackVersion('10.0.0')).toBeTruthy();
+    expect(isSatisfyRspackVersion('10.0.0')).toBeTruthy();
 
     expect(
-      await isSatisfyRspackVersion('0.2.7-canary-efa0dc6-20230817005622'),
+      isSatisfyRspackVersion('0.2.7-canary-efa0dc6-20230817005622'),
     ).toBeFalsy();
 
     expect(
-      await isSatisfyRspackVersion(
+      isSatisfyRspackVersion(
         `${rspackMinVersion}-canary-efa0dc6-20230817005622`,
       ),
     ).toBeTruthy();

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -175,7 +175,7 @@ export const pluginLess = (
     const RAW_QUERY_REGEX: RegExp = /^\?raw$/;
     const INLINE_QUERY_REGEX: RegExp = /^\?inline$/;
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
       const lessRule = chain.module

--- a/packages/plugin-sass/src/helpers.ts
+++ b/packages/plugin-sass/src/helpers.ts
@@ -50,9 +50,7 @@ export function patchCompilerGlobalLocation(compiler: {
  *
  * reference: https://github.com/bholloway/resolve-url-loader/blob/e2695cde68f325f617825e168173df92236efb93/packages/resolve-url-loader/docs/advanced-features.md
  */
-export const getResolveUrlJoinFn = async (): Promise<
-  (...args: unknown[]) => void
-> => {
+export const getResolveUrlJoinFn = (): ((...args: unknown[]) => void) => {
   const {
     createJoinFunction,
     asGenerator,

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -106,7 +106,7 @@ export const pluginSass = (
       patchCompilerGlobalLocation(compiler);
     });
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
       const { sourceMap } = config.output;
       const isUseSourceMap =
@@ -168,7 +168,7 @@ export const pluginSass = (
       );
 
       const resolveUrlLoaderOptions = {
-        join: await getResolveUrlJoinFn(),
+        join: getResolveUrlJoinFn(),
         // 'resolve-url-loader' relies on 'adjust-sourcemap-loader',
         // it has performance regression issues in some scenarios,
         // so we need to disable the sourceMap option.

--- a/packages/plugin-solid/src/index.ts
+++ b/packages/plugin-solid/src/index.ts
@@ -21,7 +21,7 @@ export function pluginSolid(options: PluginSolidOptions = {}): RsbuildPlugin {
 
     setup(api) {
       api.modifyBundlerChain(
-        async (chain, { CHAIN_ID, environment, isProd, target }) => {
+        (chain, { CHAIN_ID, environment, isProd, target }) => {
           const environmentConfig = environment.config;
 
           modifyBabelLoaderOptions({

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -75,7 +75,7 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
     const RAW_QUERY_REGEX: RegExp = /^\?raw$/;
     const INLINE_QUERY_REGEX: RegExp = /^\?inline$/;
 
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
       const { sourceMap } = config.output;

--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -141,7 +141,7 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
   pre: [PLUGIN_REACT_NAME],
 
   setup(api) {
-    api.modifyBundlerChain(async (chain, { CHAIN_ID, environment }) => {
+    api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
       const { dataUriLimit } = config.output;
       const maxSize =

--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -74,7 +74,7 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
         return merged;
       });
 
-      api.modifyBundlerChain(async (chain, { CHAIN_ID }) => {
+      api.modifyBundlerChain((chain, { CHAIN_ID }) => {
         chain.resolve.extensions.add('.vue');
 
         const userLoaderOptions = options.vueLoaderOptions ?? {};

--- a/rslint.json
+++ b/rslint.json
@@ -27,7 +27,6 @@
       "@typescript-eslint/promise-function-async": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-type-assertion": "off",
-      "@typescript-eslint/require-await": "off",
       "@typescript-eslint/no-unsafe-call": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/restrict-template-expressions": "off",

--- a/website/docs/zh/guide/start/index.mdx
+++ b/website/docs/zh/guide/start/index.mdx
@@ -72,7 +72,7 @@ Rstack 包含以下工具：
 | [Rspress](https://github.com/web-infra-dev/rspress)   | 静态站点生成器 | <a href="https://npmjs.com/package/@rspress/core"><img src="https://img.shields.io/npm/v/@rspress/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>   |
 | [Rsdoctor](https://github.com/web-infra-dev/rsdoctor) | 构建分析工具   | <a href="https://npmjs.com/package/@rsdoctor/core"><img src="https://img.shields.io/npm/v/@rsdoctor/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a> |
 | [Rstest](https://github.com/web-infra-dev/rstest)     | 测试框架       | <a href="https://npmjs.com/package/@rstest/core"><img src="https://img.shields.io/npm/v/@rstest/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
-| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码分析工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
+| [Rslint](https://github.com/web-infra-dev/rslint)     | 代码检查工具   | <a href="https://npmjs.com/package/@rslint/core"><img src="https://img.shields.io/npm/v/@rslint/core?style=flat-square&colorA=564341&colorB=EDED91" alt="npm version" /></a>     |
 
 ## 🔗 链接
 


### PR DESCRIPTION
## Summary

- Remove unnecessary async and update type definitions
- Enable the `@typescript-eslint/require-await` rule of Rslint.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
