### PR TITLE
fix: appendRules helper not work in some cases

### DIFF
--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -124,7 +124,7 @@ export async function generateWebpackConfig({
   let webpackConfig = chain.toConfig() as WebpackConfig;
 
   const configUtils = helpers.getConfigUtils(
-    webpackConfig as Rspack.Configuration,
+    () => webpackConfig as Rspack.Configuration,
     chainUtils as unknown as ModifyRspackConfigUtils,
   ) as unknown as ModifyWebpackConfigUtils;
 

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -74,9 +74,11 @@ export function createEnvironmentAsyncHook<
   const callChain = async ({
     environment,
     args: params,
+    afterEach,
   }: {
     environment?: string;
     args: Parameters<Callback>;
+    afterEach?: (args: Parameters<Callback>) => void;
   }) => {
     const callbacks = [...preGroup, ...defaultGroup, ...postGroup];
 
@@ -94,6 +96,10 @@ export function createEnvironmentAsyncHook<
 
       if (result !== undefined) {
         params[0] = result;
+      }
+
+      if (afterEach) {
+        afterEach(params);
       }
     }
 

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -94,6 +94,10 @@ export type EnvironmentAsyncHook<
      * The parameters to pass to each callback
      */
     args: Parameters<Callback>;
+    /**
+     * The callback function to be executed after each callback
+     */
+    afterEach?: (args: Parameters<Callback>) => void;
   }) => Promise<Parameters<Callback>>;
   /**
    * Executes callbacks in sequence independently and collects all their results into an array.


### PR DESCRIPTION
## Summary

Fix the `appendRules` helper not work in some cases.

In https://github.com/web-infra-dev/rsbuild/pull/4767, we used a proxy to try to get the latest Rspack configuration object in config utils, but this did not work in some cases. This PR changes it to using `getCurrentConfig()` to allow config utils to always get the latest configuration object.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/5764

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
