### PR TITLE
test(e2e): replace execSync and npx with a faster helper

### DIFF
--- a/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
+++ b/e2e/cases/alias/tsconfig-paths-reload/tsconfig.json
@@ -4,7 +4,7 @@
     "jsx": "react-jsx",
     "outDir": "./dist",
     "paths": {
-      "@/content": ["src/foo/test.ts"]
+      "@/content": ["./src/foo/test.ts"]
     }
   },
   "include": ["src"]

--- a/e2e/cases/cli/base/index.test.ts
+++ b/e2e/cases/cli/base/index.test.ts
@@ -1,10 +1,9 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run allow to specify base path', async () => {
-  execSync('npx rsbuild build --base /test', {
+  runCliSync('build --base /test', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/basic/index.test.ts
+++ b/e2e/cases/cli/basic/index.test.ts
@@ -1,10 +1,9 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command correctly', async () => {
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,6 +1,5 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 const nodeVersion = process.version.slice(1).split('.')[0];
@@ -11,7 +10,7 @@ const conditionalTest = isNodeVersionCompatible
   : rspackOnlyTest.skip;
 
 conditionalTest('should use Node.js native loader to load config', async () => {
-  execSync('npx rsbuild build --config-loader native', {
+  runCliSync('build --config-loader native', {
     cwd: __dirname,
     env: {
       ...process.env,

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,12 +1,11 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should use custom config when using --config option',
   async () => {
-    execSync('npx rsbuild build --config ./custom.config.mjs', {
+    runCliSync('build --config ./custom.config.mjs', {
       cwd: __dirname,
     });
 
@@ -21,7 +20,7 @@ rspackOnlyTest(
   'should support custom config to find absolute path',
   async () => {
     const absPath = path.join(__dirname, 'custom.config.mjs');
-    execSync(`npx rsbuild build --config ${absPath}`, {
+    runCliSync(`build --config ${absPath}`, {
       cwd: __dirname,
     });
     const outputs = await readDirContents(path.join(__dirname, 'dist-custom'));

--- a/e2e/cases/cli/custom-env-dir/index.test.ts
+++ b/e2e/cases/cli/custom-env-dir/index.test.ts
@@ -1,11 +1,10 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should allow to custom env directory', async () => {
-  execSync('npx rsbuild build --env-dir env', {
+  runCliSync('build --env-dir env', {
     cwd: __dirname,
   });
   const content = fs.readFileSync(

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -1,13 +1,12 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should allow to custom env prefix via loadEnv method',
   async () => {
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     const content = fs.readFileSync(

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,10 +1,9 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command correctly', async () => {
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,6 +1,5 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -10,7 +9,7 @@ rspackOnlyTest('should allow to export function in config file', async () => {
   await remove(targetDir);
 
   delete process.env.NODE_ENV;
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,6 +1,5 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { removeSync } from 'fs-extra';
 
@@ -12,7 +11,7 @@ const clean = () => {
 rspackOnlyTest('should run inspect command correctly', async () => {
   clean();
 
-  execSync('npx rsbuild inspect', {
+  runCliSync('inspect', {
     cwd: __dirname,
   });
 
@@ -39,7 +38,7 @@ rspackOnlyTest(
   async () => {
     clean();
 
-    execSync('npx rsbuild inspect --mode production', {
+    runCliSync('inspect --mode production', {
       cwd: __dirname,
     });
 
@@ -64,7 +63,7 @@ rspackOnlyTest(
   async () => {
     clean();
 
-    execSync('npx rsbuild inspect --output foo', {
+    runCliSync('inspect --output foo', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -1,7 +1,6 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -16,7 +15,7 @@ test.beforeEach(async () => {
 rspackOnlyTest(
   'should load .env config and allow rsbuild.config.ts to read env vars',
   async () => {
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     expect(fs.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
@@ -26,7 +25,7 @@ rspackOnlyTest(
 rspackOnlyTest('should load .env.local with higher priority', async () => {
   fse.outputFileSync(localFile, 'FOO=2');
 
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
   expect(fs.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
@@ -38,7 +37,7 @@ rspackOnlyTest(
     fse.outputFileSync(localFile, 'FOO=2');
     fse.outputFileSync(prodLocalFile, 'FOO=3');
 
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     expect(fs.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
@@ -46,7 +45,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest('should allow to specify env mode via --env-mode', async () => {
-  execSync('npx rsbuild build --env-mode test', {
+  runCliSync('build --env-mode test', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -1,14 +1,13 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 // see: https://github.com/web-infra-dev/rsbuild/issues/2904
 rspackOnlyTest(
   'should load .env config and set NODE_ENV as expected',
   async () => {
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     expect(

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -1,7 +1,6 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -16,7 +15,7 @@ test.beforeEach(async () => {
 rspackOnlyTest(
   'should load .env config and allow rsbuild.config.ts to read env vars',
   async () => {
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     expect(fs.existsSync(path.join(__dirname, 'dist/1'))).toBeTruthy();
@@ -26,7 +25,7 @@ rspackOnlyTest(
 rspackOnlyTest('should load .env.local with higher priority', async () => {
   fse.outputFileSync(localFile, 'FOO=2');
 
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
   expect(fs.existsSync(path.join(__dirname, 'dist/2'))).toBeTruthy();
@@ -38,7 +37,7 @@ rspackOnlyTest(
     fse.outputFileSync(localFile, 'FOO=2');
     fse.outputFileSync(prodLocalFile, 'FOO=3');
 
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
     expect(fs.existsSync(path.join(__dirname, 'dist/3'))).toBeTruthy();
@@ -46,7 +45,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest('should allow to specify env mode via --env-mode', async () => {
-  execSync('npx rsbuild build --env-mode test', {
+  runCliSync('build --env-mode test', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,11 +1,10 @@
-import { execSync } from 'node:child_process';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should run build command with log level: info', async () => {
   const result = stripAnsi(
-    execSync('npx rsbuild build --logLevel info', {
+    runCliSync('build --logLevel info', {
       cwd: __dirname,
     }).toString(),
   );
@@ -17,7 +16,7 @@ rspackOnlyTest('should run build command with log level: info', async () => {
 
 rspackOnlyTest('should run build command with log level: warn', async () => {
   const result = stripAnsi(
-    execSync('npx rsbuild build --logLevel warn', {
+    runCliSync('build --logLevel warn', {
       cwd: __dirname,
     }).toString(),
   );

--- a/e2e/cases/cli/mode/index.test.ts
+++ b/e2e/cases/cli/mode/index.test.ts
@@ -1,12 +1,11 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should run build command with --mode option correctly',
   async () => {
-    execSync('npx rsbuild build --mode development', {
+    runCliSync('build --mode development', {
       cwd: __dirname,
     });
 
@@ -26,7 +25,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should run build command with -m option correctly',
   async () => {
-    execSync('npx rsbuild build -m development', {
+    runCliSync('build -m development', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/no-env/index.test.ts
+++ b/e2e/cases/cli/no-env/index.test.ts
@@ -1,11 +1,10 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should allow to disable loading env files', async () => {
-  execSync('npx rsbuild build --no-env', {
+  runCliSync('build --no-env', {
     cwd: __dirname,
   });
   const content = fs.readFileSync(

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,13 +1,12 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should set NODE_ENV correctly when running build command',
   async () => {
     delete process.env.NODE_ENV;
-    execSync('npx rsbuild build', {
+    runCliSync('build', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -1,11 +1,10 @@
-import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should inject public env vars to client', async () => {
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
     env: {
       ...process.env,

--- a/e2e/cases/cli/root/index.test.ts
+++ b/e2e/cases/cli/root/index.test.ts
@@ -1,12 +1,11 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should run build command with --root option correctly',
   async () => {
-    execSync('npx rsbuild build --root test', {
+    runCliSync('build --root test', {
       cwd: __dirname,
     });
 
@@ -22,7 +21,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should run build command with -r option correctly',
   async () => {
-    execSync('npx rsbuild build -r test', {
+    runCliSync('build -r test', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,6 +1,5 @@
-import { execSync } from 'node:child_process';
 import { join } from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -13,7 +12,7 @@ test.beforeEach(async () => {
 rspackOnlyTest(
   'should only build specified environment when using --environment option',
   async () => {
-    execSync('npx rsbuild build --environment web2', {
+    runCliSync('build --environment web2', {
       cwd: __dirname,
     });
 
@@ -32,7 +31,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should build specified environments when using --environment shorten option',
   async () => {
-    execSync('npx rsbuild build --environment web1,web2', {
+    runCliSync('build --environment web1,web2', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,10 +1,9 @@
-import { execSync } from 'node:child_process';
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest } from '@e2e/helper';
+import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
 rspackOnlyTest('should build Vue SFC correctly', async () => {
-  execSync('npx rsbuild build', {
+  runCliSync('build', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/server/ssr/package.json
+++ b/e2e/cases/server/ssr/package.json
@@ -1,9 +1,12 @@
 {
-  "private": true,
   "name": "@e2e/custom-server-ssr",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
-    "dev": "npx rsbuild dev",
-    "dev:esm": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" TEST_ESM_LIBRARY=true npx rsbuild dev"
+    "dev": "rsbuild dev",
+    "dev:esm": "cross-env NODE_OPTIONS=\"--experimental-vm-modules\" TEST_ESM_LIBRARY=true rsbuild dev"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "workspace:*"
   }
 }

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -344,6 +344,12 @@ export async function build({
 
 const binPath = join(__dirname, '../node_modules/@rsbuild/core/bin/rsbuild.js');
 
+/**
+ * Synchronously run the Rsbuild CLI with the given command.
+ * @param command - The CLI command string to run (e.g., "build --config ./rsbuild.config.ts").
+ * @param options - Optional options to pass to `execSync`.
+ * @returns The result of `execSync`, typically a Buffer containing stdout.
+ */
 export function runCliSync(command: string, options?: ExecSyncOptions) {
   return execSync(`${binPath} ${command}`, options);
 }

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -351,5 +351,5 @@ const binPath = join(__dirname, '../node_modules/@rsbuild/core/bin/rsbuild.js');
  * @returns The result of `execSync`, typically a Buffer containing stdout.
  */
 export function runCliSync(command: string, options?: ExecSyncOptions) {
-  return execSync(`${binPath} ${command}`, options);
+  return execSync(`node ${binPath} ${command}`, options);
 }

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import { type ExecSyncOptions, execSync } from 'node:child_process';
 import net from 'node:net';
 import { join } from 'node:path';
 import { URL } from 'node:url';
@@ -339,4 +340,10 @@ export async function build({
     getIndexFile,
     instance: rsbuild,
   };
+}
+
+const binPath = join(__dirname, '../node_modules/@rsbuild/core/bin/rsbuild.js');
+
+export function runCliSync(command: string, options?: ExecSyncOptions) {
+  return execSync(`${binPath} ${command}`, options);
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=18.0.0",
     "pnpm": ">=10.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,7 +281,11 @@ importers:
 
   e2e/cases/server/custom-server: {}
 
-  e2e/cases/server/ssr: {}
+  e2e/cases/server/ssr:
+    devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
 
   e2e/cases/server/ssr-type-module: {}
 


### PR DESCRIPTION
## Summary

Replace the `execSync` and `npx` with a faster `runCliSync` helper in e2e cases:

- Reduce the overhead of `npx`
- Fix the `npx` warning in Node 24

### Before

<img width="250" height="66" alt="Screenshot 2025-08-07 at 13 04 09" src="https://github.com/user-attachments/assets/0f8531ac-e122-493b-9204-d5622398a0a3" />

<img width="1064" height="441" alt="Screenshot 2025-08-07 at 12 53 52" src="https://github.com/user-attachments/assets/8d75389f-ae5d-42c0-97eb-1db97a9e4db6" />


### After

<img width="258" height="61" alt="Screenshot 2025-08-07 at 13 03 23" src="https://github.com/user-attachments/assets/b365817f-62ea-479b-8b4f-30e721bd9af0" />

<img width="1052" height="330" alt="Screenshot 2025-08-07 at 12 54 04" src="https://github.com/user-attachments/assets/77f4174b-499b-4bba-ab56-8d2240f7a342" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
