### PR TITLE
test(e2e): replace direct exec calls with faster helper

### DIFF
--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -1,4 +1,3 @@
-import { exec } from 'node:child_process';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
@@ -6,6 +5,7 @@ import {
   getRandomPort,
   gotoPage,
   rspackOnlyTest,
+  runCli,
 } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse from 'fs-extra';
@@ -25,7 +25,7 @@ rspackOnlyTest(
     await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
 
     const port = await getRandomPort();
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -25,7 +25,7 @@ rspackOnlyTest(
     await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
 
     const port = await getRandomPort();
-    const childProcess = runCli(' dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -18,7 +18,7 @@ rspackOnlyTest(
     await remove(distIndexFile);
     await fse.copy(srcDir, tempDir);
 
-    const childProcess = runCli(' build --watch', {
+    const childProcess = runCli('build --watch', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -19,7 +18,7 @@ rspackOnlyTest(
     await remove(distIndexFile);
     await fse.copy(srcDir, tempDir);
 
-    const childProcess = exec('npx rsbuild build --watch', {
+    const childProcess = runCli(' build --watch', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -24,7 +23,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const childProcess = exec(`npx rsbuild build --watch -c ${tempConfigFile}`, {
+  const childProcess = runCli(`build --watch -c ${tempConfigFile}`, {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -13,7 +12,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const childProcess = exec('npx rsbuild build --watch', {
+  const childProcess = runCli(' build --watch', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -12,7 +12,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const childProcess = runCli(' build --watch', {
+  const childProcess = runCli('build --watch', {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 rspackOnlyTest(
@@ -30,7 +29,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -31,7 +30,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const devProcess = exec('npx rsbuild dev', {
+    const devProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -30,7 +30,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const devProcess = runCli(' dev', {
+    const devProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -17,7 +16,7 @@ rspackOnlyTest(
     await remove(dist);
     fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
 
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest(
     await remove(dist);
     fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
 
-    const childProcess = runCli(' dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -20,7 +20,7 @@ test.beforeEach(async () => {
 rspackOnlyTest(
   'should restart dev server when extra config file changed',
   async () => {
-    const childProcess = runCli(' dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -48,7 +48,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not restart dev server if `watchFiles.type` is `reload-page`',
   async () => {
-    const childProcess = runCli(' dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -74,7 +74,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not restart dev server if `watchFiles.type` is not set',
   async () => {
-    const childProcess = runCli(' dev', {
+    const childProcess = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,7 +1,6 @@
-import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { remove } from 'fs-extra';
 
@@ -21,7 +20,7 @@ test.beforeEach(async () => {
 rspackOnlyTest(
   'should restart dev server when extra config file changed',
   async () => {
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -49,7 +48,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not restart dev server if `watchFiles.type` is `reload-page`',
   async () => {
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -75,7 +74,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not restart dev server if `watchFiles.type` is not set',
   async () => {
-    const childProcess = exec('npx rsbuild dev', {
+    const childProcess = runCli(' dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -1,6 +1,7 @@
 import { exec } from 'node:child_process';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
+import { createRsbuildBinPath } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse from 'fs-extra';
 
@@ -30,7 +31,7 @@ export const createAndValidate = async (
   const dir = path.join(cwd, name);
   await fse.remove(dir);
 
-  let command = `npx create-rsbuild -d ${name} -t ${template}`;
+  let command = `${createRsbuildBinPath} -d ${name} -t ${template}`;
   if (tools.length) {
     const toolsCmd = tools.map((tool) => `--tools ${tool}`).join(' ');
     command += ` ${toolsCmd}`;

--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -31,7 +31,7 @@ export const createAndValidate = async (
   const dir = path.join(cwd, name);
   await fse.remove(dir);
 
-  let command = `${createRsbuildBinPath} -d ${name} -t ${template}`;
+  let command = `node ${createRsbuildBinPath} -d ${name} -t ${template}`;
   if (tools.length) {
     const toolsCmd = tools.map((tool) => `--tools ${tool}`).join(' ');
     command += ` ${toolsCmd}`;

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -2,7 +2,7 @@ import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expectPoll, rspackOnlyTest } from '@e2e/helper';
+import { expectPoll, rsbuildBinPath, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 import { removeSync } from 'fs-extra';
 
@@ -57,7 +57,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should generate rspack profile as expected in build',
   async () => {
-    const buildProcess = spawn('npx', ['rsbuild', 'build'], {
+    const buildProcess = spawn(`${rsbuildBinPath} build`, {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/rspack-profile/index.test.ts
+++ b/e2e/cases/rspack-profile/index.test.ts
@@ -57,7 +57,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should generate rspack profile as expected in build',
   async () => {
-    const buildProcess = spawn(`${rsbuildBinPath} build`, {
+    const buildProcess = spawn('node', [rsbuildBinPath, 'build'], {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/server/ssr-type-module/package.json
+++ b/e2e/cases/server/ssr-type-module/package.json
@@ -1,8 +1,11 @@
 {
-  "private": true,
   "name": "@e2e/custom-server-ssr-type-module",
   "version": "1.0.0",
+  "private": true,
   "scripts": {
-    "dev": "cross-env NODE_OPTIONS=--experimental-vm-modules npx rsbuild dev"
+    "dev": "cross-env NODE_OPTIONS=--experimental-vm-modules rsbuild dev"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "workspace:*"
   }
 }

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -1,5 +1,10 @@
 import assert from 'node:assert';
-import { type ExecSyncOptions, execSync } from 'node:child_process';
+import {
+  type ExecOptions,
+  type ExecSyncOptions,
+  exec,
+  execSync,
+} from 'node:child_process';
 import net from 'node:net';
 import { join } from 'node:path';
 import { URL } from 'node:url';
@@ -342,7 +347,14 @@ export async function build({
   };
 }
 
-const binPath = join(__dirname, '../node_modules/@rsbuild/core/bin/rsbuild.js');
+export const rsbuildBinPath = join(
+  __dirname,
+  '../node_modules/@rsbuild/core/bin/rsbuild.js',
+);
+export const createRsbuildBinPath = join(
+  __dirname,
+  '../node_modules/create-rsbuild/bin.js',
+);
 
 /**
  * Synchronously run the Rsbuild CLI with the given command.
@@ -351,5 +363,9 @@ const binPath = join(__dirname, '../node_modules/@rsbuild/core/bin/rsbuild.js');
  * @returns The result of `execSync`, typically a Buffer containing stdout.
  */
 export function runCliSync(command: string, options?: ExecSyncOptions) {
-  return execSync(`node ${binPath} ${command}`, options);
+  return execSync(`node ${rsbuildBinPath} ${command}`, options);
+}
+
+export function runCli(command: string, options?: ExecOptions) {
+  return exec(`node ${rsbuildBinPath} ${command}`, options);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,11 @@ importers:
         specifier: workspace:*
         version: link:../../../../packages/core
 
-  e2e/cases/server/ssr-type-module: {}
+  e2e/cases/server/ssr-type-module:
+    devDependencies:
+      '@rsbuild/core':
+        specifier: workspace:*
+        version: link:../../../../packages/core
 
   e2e/cases/swc-plugin:
     dependencies:


### PR DESCRIPTION
## Summary

Replace the `exec` and `npx` with a faster `runCliSync` helper in e2e cases:

- Reduce the overhead of `npx`
- Fix the `npx` warning in Node 24

### Before

<img width="1060" height="616" alt="Screenshot 2025-08-07 at 13 12 30" src="https://github.com/user-attachments/assets/ef1634bb-6ae9-4aa3-8129-947866ee264b" />

### After

<img width="1066" height="609" alt="Screenshot 2025-08-07 at 13 14 01" src="https://github.com/user-attachments/assets/0e82db02-3430-49ea-a81f-f646b17e5e33" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5783

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
