### PR TITLE
chore: replace npx with pnpx in bump scripts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
-        run: pnpm install && cd ./e2e && npx playwright install chromium
+        run: pnpm install && cd ./e2e && pnpx playwright install chromium
 
       - name: E2E Test - 1
         if: steps.changes.outputs.changed == 'true'

--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@modern-js/swc-plugins": "0.6.11",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "copy-webpack-plugin": "11.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,7 +49,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "prebundle",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@rspack/core": "1.4.11",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -26,7 +26,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "start": "node ./dist/index.js",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "create-rstack": "1.5.6"

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -26,7 +26,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "prebundle",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@babel/core": "^7.28.0",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -27,7 +27,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "prebundle",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@prefresh/core": "^1.5.5",

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@rspack/plugin-react-refresh": "~1.4.3",

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -27,7 +27,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "prebundle",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@rsbuild/plugin-babel": "workspace:*",

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "deepmerge": "^4.3.1",

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "svelte-loader": "3.2.4",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -26,7 +26,7 @@
     "build": "rslib build",
     "dev": "rslib build --watch",
     "prebundle": "prebundle",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "@rsbuild/plugin-react": "workspace:^1.1.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "rslib build",
     "dev": "rslib build --watch",
-    "bump": "npx bumpp --no-tag"
+    "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
     "vue-loader": "^17.4.2",


### PR DESCRIPTION
## Summary

This PR standardizes the usage of the `pnpx` command instead of `npx` for running scripts. This maintains consistency with the current repo package manager.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
