### PR TITLE
feat!: update minimum Node.js version to 18.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">= 18.12.0",
+    "node": ">=18.12.0",
     "pnpm": ">=10.14.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@10.14.0",
   "engines": {
-    "node": ">=18.0.0",
+    "node": ">= 18.12.0",
     "pnpm": ">=10.14.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
     "ws": "^8.18.3"
   },
   "engines": {
-    "node": ">=16.10.0"
+    "node": ">= 18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -100,7 +100,7 @@
     "ws": "^8.18.3"
   },
   "engines": {
-    "node": ">= 18.12.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">= 18.12.0"
+    "node": ">=18.12.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -44,7 +44,7 @@
     "typescript": "^5.9.2"
   },
   "engines": {
-    "node": ">=16.10.0"
+    "node": ">= 18.12.0"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

Rspack and Rsbuild v1.5 will no longer support Node 16, as Node.js reached end-of-life on September 11th, 2023, and many npm packages in the ecosystem have also dropped support for Node 16.

This PR marks the first step toward this goal by updating the engines field in package.json to require Node.js >= 18.12.0.

## Related Links

- https://github.com/web-infra-dev/rspack/discussions/10867

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
