### PR TITLE
docs: update JavaScript runtime installation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ own GitHub account and then [clone](https://help.github.com/articles/cloning-a-r
 
 ### Install Node.js
 
-We recommend using Node.js LTS version. See [Install Node.js](https://nodejs.org/en/download).
+Use the latest Node.js LTS version. For installation instructions, see [Install Node.js](https://nodejs.org/en/download).
 
 ### Install dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,22 +18,7 @@ own GitHub account and then [clone](https://help.github.com/articles/cloning-a-r
 
 ### Install Node.js
 
-We recommend using Node.js LTS version. You can check your current Node.js version using the following command:
-
-```bash
-node -v
-```
-
-If you do not have Node.js installed in your current environment, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install it.
-
-Here is an example of how to install the Node.js LTS version via nvm:
-
-```bash
-# Install Node.js LTS
-nvm install --lts
-# Switch to Node.js LTS
-nvm use --lts
-```
+We recommend using Node.js LTS version. See [Install Node.js](https://nodejs.org/en/download).
 
 ### Install dependencies
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -19,8 +19,8 @@ You can refer to the following installation guides and choose one runtime:
 
 :::tip Version requirements
 
-- Rsbuild version 1.5 and above requires Node.js at least 18.12.0.
-- Rsbuild versions below 1.5 support Node.js 16.10.0 as the minimum.
+- Rsbuild >= v1.5.0 requires Node.js 18.12.0 or higher.
+- Rsbuild < 1.5.0 requires Node.js 16.10.0 or higher.
 
 :::
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -7,33 +7,21 @@ We provide online examples based on Rsbuild. The examples give an intuitive feel
 - [StackBlitz example](https://stackblitz.com/~/github.com/rspack-contrib/rsbuild-stackblitz-example)
 - [CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
 
-## Setup environment
+## Environment preparation
 
-Rsbuild supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the runtime.
+Rsbuild supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
 
-### Node.js
+You can refer to the following installation guides and choose one runtime:
 
-For Node.js, you will need to install Node.js >= version 16, it is recommended to use the Node.js LTS version.
+- [Install Node.js](https://nodejs.org/en/download)
+- [Install Bun](https://bun.com/docs/installation)
+- [Install Deno](https://docs.deno.com/runtime/getting_started/installation/)
 
-Check the current Node.js version with the following command:
+:::tip Version requirements
 
-```bash
-node -v
-```
+- Rsbuild version 1.5 and above requires Node.js at least 18.12.0.
+- Rsbuild versions below 1.5 support Node.js 16.10.0 as the minimum.
 
-If you do not have Node.js installed in current environment, or the installed version is too low, you can use [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to install.
-
-Here is an example of how to install via nvm:
-
-```bash
-# Install Node.js LTS
-nvm install --lts
-# Switch to Node.js LTS
-nvm use --lts
-```
-
-:::tip
-Node.js 16 will no longer be supported by Rsbuild ≥ 1.5.
 :::
 
 ## Create an Rsbuild application

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -9,31 +9,19 @@
 
 ## 环境准备
 
-Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为运行时。
+Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 或 [Bun](https://bun.sh/) 作为 JavaScript 运行时。
 
-### Node.js
+你可以参考以下安装指南，选择其中一种运行时：
 
-对于 Node.js，请安装 Node.js >= 16 版本，推荐使用 Node.js LTS 版本。
+- [安装 Node.js](https://nodejs.org/en/download)
+- [安装 Bun](https://bun.com/docs/installation)
+- [安装 Deno](https://docs.deno.com/runtime/getting_started/installation/)
 
-通过以下命令检查当前使用的 Node.js 版本：
+:::tip 版本要求
 
-```bash
-node -v
-```
+- Rsbuild 1.5 及以上版本要求 Node.js 至少为 18.12.0。
+- Rsbuild 1.5 以下版本最低支持 Node.js 16.10.0。
 
-如果你的环境中尚未安装 Node.js，或是版本过低，可以通过 [nvm](https://github.com/nvm-sh/nvm) 或 [fnm](https://github.com/Schniz/fnm) 安装。
-
-下面是通过 nvm 安装的例子：
-
-```bash
-# 安装 Node.js LTS
-nvm install --lts
-# 切换到 Node.js LTS
-nvm use --lts
-```
-
-:::tip
-Rsbuild >= 1.5 将不再支持 Node.js 16。
 :::
 
 ## 创建 Rsbuild 应用

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -19,8 +19,8 @@ Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 
 
 :::tip 版本要求
 
-- Rsbuild 1.5 及以上版本要求 Node.js 至少为 18.12.0。
-- Rsbuild 1.5 以下版本最低支持 Node.js 16.10.0。
+- Rsbuild >= 1.5 要求 Node.js 18.12.0 或更高版本。
+- Rsbuild < 1.5 要求 Node.js 16.10.0 或更高版本。
 
 :::
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -13,7 +13,7 @@ Rsbuild 支持使用 [Node.js](https://nodejs.org/)、[Deno](https://deno.com/) 
 
 你可以参考以下安装指南，选择其中一种运行时：
 
-- [安装 Node.js](https://nodejs.org/en/download)
+- [安装 Node.js](https://nodejs.org/zh-cn/download)
 - [安装 Bun](https://bun.com/docs/installation)
 - [安装 Deno](https://docs.deno.com/runtime/getting_started/installation/)
 


### PR DESCRIPTION
## Summary

As Rsbuild ≥ 1.5.0 no longer supports Node 16, the quick start guide should be updated to reflect this.

This PR also adds links to the installation guides for other JavaScript runtimes, such as Bun and Deno.

**I removed the previous detailed Node.js installation guide because the Node.js website now provides better instructions: https://nodejs.org/en/download.**

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5786

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
