### PR TITLE
perf: update build configs to target ES2022

### DIFF
--- a/e2e/cases/server/overlay-type-errors/tsconfig.json
+++ b/e2e/cases/server/overlay-type-errors/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "strict": true,
     "skipLibCheck": true,

--- a/examples/node/tsconfig.json
+++ b/examples/node/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"],
+    "target": "ES2022",
+    "lib": ["ES2022"],
     "module": "ESNext",
     "strict": true,
     "skipLibCheck": true,

--- a/examples/react/tsconfig.json
+++ b/examples/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "react-jsx",
     "strict": true,

--- a/examples/vue/tsconfig.json
+++ b/examples/vue/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["DOM", "ES2020"],
+    "target": "ES2022",
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "jsx": "preserve",
     "jsxImportSource": "vue",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
     {
       id: 'esm_index',
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'es2022',
       plugins: [pluginFixDtsTypes],
       dts: {
         build: true,
@@ -100,7 +100,7 @@ export default defineConfig({
     {
       id: 'esm_loaders',
       format: 'esm',
-      syntax: 'es2021',
+      syntax: 'es2022',
       source: {
         entry: {
           ignoreCssLoader: './src/loader/ignoreCssLoader.ts',
@@ -118,7 +118,7 @@ export default defineConfig({
     {
       id: 'cjs_index',
       format: 'cjs',
-      syntax: 'es2021',
+      syntax: 'es2022',
       source: {
         entry: {
           index: './src/index.ts',

--- a/packages/create-rsbuild/rslib.config.ts
+++ b/packages/create-rsbuild/rslib.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from '@rslib/core';
 
 export default defineConfig({
-  lib: [{ format: 'esm', syntax: 'es2021' }],
+  lib: [{ format: 'esm', syntax: 'es2022' }],
 });

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -21,7 +21,7 @@ export const nodeMinifyConfig: Minify = {
 
 export const esmConfig: LibConfig = {
   format: 'esm',
-  syntax: 'es2021',
+  syntax: 'es2022',
   dts: {
     build: true,
   },
@@ -32,7 +32,7 @@ export const esmConfig: LibConfig = {
 
 export const cjsConfig: LibConfig = {
   format: 'cjs',
-  syntax: 'es2021',
+  syntax: 'es2022',
   output: {
     minify: nodeMinifyConfig,
   },

--- a/scripts/config/tsconfig.json
+++ b/scripts/config/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "lib": ["DOM", "ESNext"],
     "jsx": "preserve",
-    "target": "ES2021",
+    "target": "ES2022",
     "types": ["node"],
     "skipLibCheck": true,
     "useDefineForClassFields": true,
 
     /* modules */
-    "module": "ES2020",
+    "module": "ES2022",
     "moduleDetection": "force",
     "moduleResolution": "bundler",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Since Rsbuild v1.5 no longer supports Node 16, we can update build configs to target ES2022 to reduce the output code.

### Before

<img width="500" height="312" alt="image" src="https://github.com/user-attachments/assets/39804878-a6fa-42b6-8081-75c79013a69f" />

### After

<img width="500" height="328" alt="image" src="https://github.com/user-attachments/assets/463ee1c0-793d-470d-bcb5-b35f3e3d367c" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5786

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
