### PR TITLE
fix(cli): ensure consistent spacing for npx of node 20+

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -28,18 +28,14 @@ export function runCLI(): void {
     }
   }
 
-  // Print a blank line to keep the greet log nice.
-  // Some package managers automatically output a blank line, some do not.
-  const { npm_execpath } = process.env;
-  if (
-    !npm_execpath ||
-    npm_execpath.includes('npx-cli.js') ||
-    npm_execpath.includes('.bun')
-  ) {
-    logger.log();
-  }
-
-  logger.greet(`  Rsbuild v${RSBUILD_VERSION}\n`);
+  // Ensure consistent spacing before the greeting message.
+  // Different package managers handle output formatting differently - some automatically
+  // add a blank line before command output, while others do not.
+  const { npm_execpath, npm_lifecycle_event } = process.env;
+  const isNpx = npm_lifecycle_event === 'npx';
+  const isBun = npm_execpath?.includes('.bun');
+  const prefix = isNpx || isBun ? '\n' : '';
+  logger.greet(`${prefix}  Rsbuild v${RSBUILD_VERSION}\n`);
 
   try {
     setupCommands();


### PR DESCRIPTION
## Summary

In Node.js >= 20, we can no longer use `npm_execpath.includes('npx-cli.js')` to identify npx.

This PR uses `process.env.npm_lifecycle_event === 'npx'` instead.

### Before

<img width="465" height="131" alt="Screenshot 2025-08-07 at 20 56 42" src="https://github.com/user-attachments/assets/9a5712d2-7a4d-4360-a9ff-6d46d1e221b1" />

### After

<img width="481" height="160" alt="Screenshot 2025-08-07 at 20 55 53" src="https://github.com/user-attachments/assets/2ae8d17d-02d6-42e9-8d57-b762c7b88acf" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
