### PR TITLE
fix(cli): skip greeting when help is requested

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -11,21 +11,12 @@ function initNodeEnv() {
   }
 }
 
-export function runCLI(): void {
-  initNodeEnv();
-
-  // make it easier to identify the process via activity monitor or other tools
-  process.title = 'rsbuild-node';
-
-  // ensure log level is set before any log is printed
-  const logLevelIndex = process.argv.findIndex(
-    (item) => item === '--log-level' || item === '--logLevel',
-  );
-  if (logLevelIndex !== -1) {
-    const level = process.argv[logLevelIndex + 1];
-    if (level && ['warn', 'error', 'silent'].includes(level)) {
-      logger.level = level as LogLevel;
-    }
+function showGreeting() {
+  // Skip greeting when help is requested, as cac's help output already contains
+  // information that would be redundant with the greeting message
+  const { argv } = process;
+  if (argv.includes('--help') || argv.includes('-h')) {
+    return;
   }
 
   // Ensure consistent spacing before the greeting message.
@@ -36,6 +27,28 @@ export function runCLI(): void {
   const isBun = npm_execpath?.includes('.bun');
   const prefix = isNpx || isBun ? '\n' : '';
   logger.greet(`${prefix}  Rsbuild v${RSBUILD_VERSION}\n`);
+}
+
+// ensure log level is set before any log is printed
+function setupLogLevel() {
+  const logLevelIndex = process.argv.findIndex(
+    (item) => item === '--log-level' || item === '--logLevel',
+  );
+  if (logLevelIndex !== -1) {
+    const level = process.argv[logLevelIndex + 1];
+    if (level && ['warn', 'error', 'silent'].includes(level)) {
+      logger.level = level as LogLevel;
+    }
+  }
+}
+
+export function runCLI(): void {
+  // make it easier to identify the process via activity monitor or other tools
+  process.title = 'rsbuild-node';
+
+  initNodeEnv();
+  setupLogLevel();
+  showGreeting();
 
   try {
     setupCommands();

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -2,9 +2,11 @@ import { logger } from '../logger';
 import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
 
+const { argv } = process;
+
 function initNodeEnv() {
   if (!process.env.NODE_ENV) {
-    const command = process.argv[2];
+    const command = argv[2];
     process.env.NODE_ENV = ['build', 'preview'].includes(command)
       ? 'production'
       : 'development';
@@ -14,8 +16,7 @@ function initNodeEnv() {
 function showGreeting() {
   // Skip greeting when help is requested, as cac's help output already contains
   // information that would be redundant with the greeting message
-  const { argv } = process;
-  if (argv.includes('--help') || argv.includes('-h')) {
+  if (argv.some((item) => item === '--help' || item === '-h')) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Skip greeting when help is requested, as cac's help output already contains information that would be redundant with the greeting message.

### Before

<img width="523" height="130" alt="Screenshot 2025-08-08 at 10 00 51" src="https://github.com/user-attachments/assets/22332e49-3e1a-444d-a57a-4e121658fb41" />

### After

<img width="458" height="129" alt="Screenshot 2025-08-08 at 10 08 34" src="https://github.com/user-attachments/assets/30d10678-1698-4872-987f-3d192122383a" />

## Related Links

https://github.com/cacjs/cac/blob/257b140085e8ef7527f3ce9628ae78ed29338ffb/src/Command.ts#L141-L145

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
