### PR TITLE
chore: exclude additional directories from biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,12 @@
       "**/e2e/**",
       "**/scripts/**",
       "**/website/**",
+      "!**/node_modules/**",
+      "!**/.nx/**",
+      "!**/dist/**",
+      "!**/dist-*/**",
+      "!**/doc_build/**",
+      "!**/compiled/**",
       "!**/*.vue",
       "!**/*.svelte",
       "!**/template-lit-*/src/my-element.*"


### PR DESCRIPTION
## Summary

It seems that Biome's `"useIgnoreFile": true` option does not work as expected. We can manually skip some directories to improve Biome's performance.

Try to fix: https://github.com/biomejs/biome/issues/7020

<img width="397" height="78" alt="Screenshot 2025-08-08 at 10 48 51" src="https://github.com/user-attachments/assets/1887bc1d-35a4-48da-871a-88f64ee637cf" />

### Before

<img width="490" height="140" alt="Screenshot 2025-08-08 at 11 27 03" src="https://github.com/user-attachments/assets/b7fb60b7-cac1-4ca5-8d04-08aae2ee1f5c" />

### After

<img width="514" height="137" alt="Screenshot 2025-08-08 at 11 30 55" src="https://github.com/user-attachments/assets/0bef3018-f9bc-4227-9890-0e278d87efa8" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
