### PR TITLE
refactor: eliminate switch exhaustiveness checks

### DIFF
--- a/packages/core/src/helpers/index.ts
+++ b/packages/core/src/helpers/index.ts
@@ -215,6 +215,11 @@ export function getFilename(
 ): Rspack.CssFilename;
 export function getFilename(
   config: NormalizedConfig | NormalizedEnvironmentConfig,
+  type: 'html',
+  isProd?: boolean,
+): string;
+export function getFilename(
+  config: NormalizedConfig | NormalizedEnvironmentConfig,
   type: 'wasm',
   isProd: boolean,
 ): Rspack.WebassemblyModuleFilename;
@@ -227,7 +232,7 @@ export function getFilename(
 export function getFilename(
   config: NormalizedConfig | NormalizedEnvironmentConfig,
   type: keyof FilenameConfig,
-  isProd: boolean,
+  isProd?: boolean,
   isServer?: boolean,
 ) {
   const { filename, filenameHash } = config.output;
@@ -239,25 +244,30 @@ export function getFilename(
     return filenameHash ? '.[contenthash:8]' : '';
   };
 
-  const hash = getHash();
-
   switch (type) {
     case 'js':
-      return filename.js ?? `[name]${isProd && !isServer ? hash : ''}.js`;
+      return filename.js ?? `[name]${isProd && !isServer ? getHash() : ''}.js`;
     case 'css':
-      return filename.css ?? `[name]${isProd ? hash : ''}.css`;
+      return filename.css ?? `[name]${isProd ? getHash() : ''}.css`;
     case 'svg':
-      return filename.svg ?? `[name]${hash}.svg`;
+      return filename.svg ?? `[name]${getHash()}.svg`;
     case 'font':
-      return filename.font ?? `[name]${hash}[ext]`;
+      return filename.font ?? `[name]${getHash()}[ext]`;
     case 'image':
-      return filename.image ?? `[name]${hash}[ext]`;
+      return filename.image ?? `[name]${getHash()}[ext]`;
     case 'media':
-      return filename.media ?? `[name]${hash}[ext]`;
+      return filename.media ?? `[name]${getHash()}[ext]`;
     case 'assets':
-      return filename.assets ?? `[name]${hash}[ext]`;
+      return filename.assets ?? `[name]${getHash()}[ext]`;
     case 'wasm':
       return filename.wasm ?? '[hash].module.wasm';
+    case 'html':
+      if (filename.html) {
+        return filename.html;
+      }
+      return config.html.outputStructure === 'flat'
+        ? '[name].html'
+        : '[name]/index.html';
     default:
       throw new Error(
         `${color.dim('[rsbuild:config]')} unknown key ${color.yellow(

--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -2,7 +2,7 @@ import { join, posix } from 'node:path';
 import type { Compiler } from '@rspack/core';
 import { LOADER_PATH } from './constants';
 import { createPublicContext } from './createContext';
-import { color, removeLeadingSlash } from './helpers';
+import { color, getFilename, removeLeadingSlash } from './helpers';
 import { exitHook } from './helpers/exitHook';
 import type { TransformLoaderOptions } from './loader/transformLoader';
 import { logger } from './logger';
@@ -28,16 +28,7 @@ export function getHTMLPathByEntry(
   entryName: string,
   config: NormalizedEnvironmentConfig,
 ): string {
-  let filename: string;
-
-  if (config.output.filename.html) {
-    filename = config.output.filename.html.replace('[name]', entryName);
-  } else if (config.html.outputStructure === 'flat') {
-    filename = `${entryName}.html`;
-  } else {
-    filename = `${entryName}/index.html`;
-  }
-
+  const filename = getFilename(config, 'html').replace('[name]', entryName);
   const prefix = config.output.distPath.html;
 
   if (prefix.startsWith('/')) {

--- a/packages/core/src/plugins/minimize.ts
+++ b/packages/core/src/plugins/minimize.ts
@@ -29,20 +29,22 @@ export const getSwcMinimizerOptions = (
     };
   }
 
-  switch (config.output.legalComments) {
-    case 'inline':
-      options.minimizerOptions.format.comments = 'some';
-      options.extractComments = false;
-      break;
-    case 'linked':
-      options.extractComments = true;
-      break;
-    case 'none':
-      options.minimizerOptions.format.comments = false;
-      options.extractComments = false;
-      break;
-    default:
-      break;
+  if (config.output.legalComments) {
+    switch (config.output.legalComments) {
+      case 'inline':
+        options.minimizerOptions.format.comments = 'some';
+        options.extractComments = false;
+        break;
+      case 'linked':
+        options.extractComments = true;
+        break;
+      case 'none':
+        options.minimizerOptions.format.comments = false;
+        options.extractComments = false;
+        break;
+      default:
+        break;
+    }
   }
 
   options.minimizerOptions.format.asciiOnly = config.output.charset === 'ascii';

--- a/rslint.json
+++ b/rslint.json
@@ -37,7 +37,6 @@
       "@typescript-eslint/no-misused-promises": "off",
       "@typescript-eslint/no-redundant-type-constituents": "off",
       "@typescript-eslint/no-implied-eval": "off",
-      "@typescript-eslint/switch-exhaustiveness-check": "off",
       "@typescript-eslint/prefer-promise-reject-errors": "off",
       "@typescript-eslint/no-empty-function": "off"
     }


### PR DESCRIPTION
## Summary

- Eliminated switch exhaustiveness checks
- Added support for generating HTML output filenames in the `getFilename` helper
- Enabled the `@typescript-eslint/switch-exhaustiveness-check` rule

## Related Links

- https://typescript-eslint.io/rules/switch-exhaustiveness-check/#allowdefaultcaseforexhaustiveswitch-caveats

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
