### PR TITLE
feat(plugin-less): support for parallel loader execution

### DIFF
--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -1,20 +1,23 @@
-import { build, dev } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should compile less with `parallel` option in production mode', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+rspackOnlyTest(
+  'should compile less with `parallel` option in production mode',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
 
-  const files = await rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
+    const files = await rsbuild.getDistFiles();
+    const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
-  expect(files[cssFiles]).toEqual(
-    'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
-  );
+    expect(files[cssFiles]).toEqual(
+      'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
+    );
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);
 
 test('should compile less with `parallel` option in development mode', async ({
   page,

--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -19,16 +19,17 @@ rspackOnlyTest(
   },
 );
 
-test('should compile less with `parallel` option in development mode', async ({
-  page,
-}) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest(
+  'should compile less with `parallel` option in development mode',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
 
-  const body = page.locator('body');
-  await expect(body).toHaveCSS('background-color', 'rgb(255, 0, 0)');
-  await expect(body).toHaveCSS('font-size', '16px');
-  await rsbuild.close();
-});
+    const body = page.locator('body');
+    await expect(body).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+    await expect(body).toHaveCSS('font-size', '16px');
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -1,0 +1,31 @@
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should compile less with `parallel` option in production mode', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+  });
+
+  const files = await rsbuild.getDistFiles();
+  const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
+
+  expect(files[cssFiles]).toEqual(
+    'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
+  );
+
+  await rsbuild.close();
+});
+
+test('should compile less with `parallel` option in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+
+  const body = page.locator('body');
+  await expect(body).toHaveCSS('background-color', 'rgb(255, 0, 0)');
+  await expect(body).toHaveCSS('font-size', '16px');
+  await rsbuild.close();
+});

--- a/e2e/cases/plugin-less/parallel/rsbuild.config.ts
+++ b/e2e/cases/plugin-less/parallel/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { pluginLess } from '@rsbuild/plugin-less';
+
+export default {
+  plugins: [
+    pluginLess({
+      parallel: true,
+    }),
+  ],
+};

--- a/e2e/cases/plugin-less/parallel/src/a.less
+++ b/e2e/cases/plugin-less/parallel/src/a.less
@@ -1,0 +1,3 @@
+body {
+  background-color: red;
+}

--- a/e2e/cases/plugin-less/parallel/src/b.less
+++ b/e2e/cases/plugin-less/parallel/src/b.less
@@ -1,0 +1,3 @@
+body {
+  font-size: 16px;
+}

--- a/e2e/cases/plugin-less/parallel/src/c.less
+++ b/e2e/cases/plugin-less/parallel/src/c.less
@@ -1,0 +1,3 @@
+div {
+  font-size: 14px;
+}

--- a/e2e/cases/plugin-less/parallel/src/d.less
+++ b/e2e/cases/plugin-less/parallel/src/d.less
@@ -1,0 +1,3 @@
+h1 {
+  font-size: 18px;
+}

--- a/e2e/cases/plugin-less/parallel/src/e.less
+++ b/e2e/cases/plugin-less/parallel/src/e.less
@@ -1,0 +1,3 @@
+h1 {
+  font-weight: bold;
+}

--- a/e2e/cases/plugin-less/parallel/src/f.less
+++ b/e2e/cases/plugin-less/parallel/src/f.less
@@ -1,0 +1,3 @@
+p {
+  font-size: 15px;
+}

--- a/e2e/cases/plugin-less/parallel/src/index.js
+++ b/e2e/cases/plugin-less/parallel/src/index.js
@@ -1,0 +1,6 @@
+import './a.less';
+import './b.less';
+import './c.less';
+import './d.less';
+import './e.less';
+import './f.less';

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -230,6 +230,11 @@ export const pluginLess = (
         }
       };
 
+      const lessLoaderPath = path.join(
+        __dirname,
+        '../compiled/less-loader/index.js',
+      );
+
       updateRules((rule, type) => {
         for (const item of excludes) {
           rule.exclude.add(item);
@@ -257,23 +262,22 @@ export const pluginLess = (
           rule.use(id).loader(loader.get('loader')).options(clonedOptions);
         }
 
-        const lessLoaderPath = path.join(
-          __dirname,
-          '../compiled/less-loader/index.js',
-        );
-        const lessRule = rule
+        const loader = rule
           .use(CHAIN_ID.USE.LESS)
           .loader(lessLoaderPath)
           .options(options);
 
         if (parallel) {
-          lessRule.parallel(true);
-          chain.experiments({
-            ...chain.get('experiments'),
-            parallelLoader: true,
-          });
+          loader.parallel(true);
         }
       });
+
+      if (parallel) {
+        chain.experiments({
+          ...chain.get('experiments'),
+          parallelLoader: true,
+        });
+      }
     });
   },
 });

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -230,11 +230,6 @@ export const pluginLess = (
         }
       };
 
-      const lessLoaderPath = path.join(
-        __dirname,
-        '../compiled/less-loader/index.js',
-      );
-
       updateRules((rule, type) => {
         for (const item of excludes) {
           rule.exclude.add(item);
@@ -262,6 +257,10 @@ export const pluginLess = (
           rule.use(id).loader(loader.get('loader')).options(clonedOptions);
         }
 
+        const lessLoaderPath = path.join(
+          __dirname,
+          '../compiled/less-loader/index.js',
+        );
         const lessRule = rule
           .use(CHAIN_ID.USE.LESS)
           .loader(lessLoaderPath)

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -120,6 +120,24 @@ pluginLess({
 });
 ```
 
+### parallel
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Version:** Added in v1.4.0
+
+Whether to enable parallel loader execution, running `less-loader` in worker threads. When enabled, this typically improves build performance when processing large numbers of Less modules.
+
+Note that this option is experimental and may not work if your Less options contain functions.
+
+```ts
+pluginLess({
+  parallel: true,
+});
+```
+
+> See [Rspack - Rule.use.parallel](https://rspack.rs/config/module#ruleuseparallel) for more details.
+
 ## Modifying Less version
 
 In some scenarios, if you need to use a specific version of Less instead of the built-in Less v4 in Rsbuild, you can install the desired Less version in your project and set it up using the `implementation` option of the `less-loader`.

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -120,6 +120,24 @@ pluginLess({
 });
 ```
 
+### parallel
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **版本：** 添加于 v1.4.0
+
+是否开启并行 loader 执行，在 worker 线程中运行 `less-loader`。开启后，在处理大量 Less 模块时通常会有构建性能提升。
+
+注意该选项为实验性功能，当 Less 选项中包含函数时将无法正常工作。
+
+```ts
+pluginLess({
+  parallel: true,
+});
+```
+
+> 详见 [Rspack - Rule.use.parallel](https://rspack.rs/config/module#ruleuseparallel)。
+
 ## 修改 Less 版本
 
 在某些场景下，如果你需要使用特定的 Less 版本，而不是使用 Rsbuild 内置的 Less v4，可以在项目中安装需要使用的 Less 版本，并通过 `less-loader` 的 `implementation` 选项设置。


### PR DESCRIPTION
## Summary

Add support for parallel loader execution to `@rsbuild/plugin-less`:

```ts
pluginLess({
  parallel: true,
});
```

This option is experimental and may not work if your Less options contain functions.

## Related Links

See [Rspack - Rule.use.parallel](https://rspack.rs/config/module#ruleuseparallel) for more details.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
