### PR TITLE
perf: remove pre-bundling of postcss-load-config

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -171,27 +171,5 @@ export type SourceMapGenerator = unknown;
       },
       ignoreDts: true,
     },
-    {
-      name: 'postcss-load-config',
-      externals: {
-        yaml: 'yaml',
-        jiti: 'jiti',
-      },
-      ignoreDts: true,
-      // this is a trick to avoid ncc compiling the dynamic import syntax
-      // https://github.com/vercel/ncc/issues/935
-      beforeBundle(task) {
-        replaceFileContent(join(task.depPath, 'src/req.js'), (content) =>
-          content.replaceAll('await import', 'await __import'),
-        );
-      },
-      afterBundle(task) {
-        replaceFileContent(
-          join(task.distPath, 'index.js'),
-          (content) =>
-            `${content.replaceAll('await __import', 'await import')}`,
-        );
-      },
-    },
   ],
 };

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -34,6 +34,8 @@ const externals: Rspack.Configuration['externals'] = [
   '@rsbuild/core',
   '@rsbuild/core/client/hmr',
   '@rsbuild/core/client/overlay',
+  // yaml is an optional dependency of `postcss-load-config`
+  'yaml',
   // externalize pre-bundled dependencies
   ({ request }, callback) => {
     const entries = Object.entries(regexpMap);

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -98,6 +98,12 @@ export default defineConfig({
       output: {
         minify: nodeMinifyConfig,
       },
+      shims: {
+        esm: {
+          // For `postcss-load-config`
+          __filename: true,
+        },
+      },
     },
     {
       id: 'esm_loaders',

--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -1,5 +1,6 @@
 import path, { posix } from 'node:path';
 import deepmerge from 'deepmerge';
+import postcssrc from 'postcss-load-config';
 import { reduceConfigs, reduceConfigsWithContext } from 'reduce-configs';
 import type { AcceptedPlugin, PluginCreator } from '../../compiled/postcss';
 import {
@@ -114,13 +115,9 @@ async function loadUserPostcssrc(
     return clonePostCSSConfig(await cached);
   }
 
-  const { default: postcssrc } = await import(
-    '../../compiled/postcss-load-config/index.js'
-  );
-
-  const promise = postcssrc({}, root).catch((err: Error) => {
+  const promise = postcssrc({}, root).catch((err: unknown) => {
     // ignore the config not found error
-    if (err.message?.includes('No PostCSS Config found')) {
+    if ((err as Error).message?.includes('No PostCSS Config found')) {
       return {};
     }
     throw err;


### PR DESCRIPTION
## Summary

Since `postcss-load-config` is required to be executed by default, we don't need to pre-bundle it. Using Rslib to bundle it directly into the main bundle can reduce the overhead of Node.js import.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
