### PR TITLE
docs: add version info to onBeforeDevCompile hook

### DIFF
--- a/website/docs/en/shared/onBeforeDevCompile.mdx
+++ b/website/docs/en/shared/onBeforeDevCompile.mdx
@@ -16,3 +16,5 @@ function OnBeforeDevCompile(
   }) => Promise<void> | void,
 ): void;
 ```
+
+- **Version:** Added in v1.5.0

--- a/website/docs/zh/shared/onBeforeDevCompile.mdx
+++ b/website/docs/zh/shared/onBeforeDevCompile.mdx
@@ -16,3 +16,5 @@ function OnBeforeDevCompile(
   }) => Promise<void> | void,
 ): void;
 ```
+
+- **版本：** 新增于 v1.5.0


### PR DESCRIPTION
## Summary

Updates the documentation for the `OnBeforeDevCompile` hook to indicate the version in which it was introduced.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5788

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
