### PR TITLE
chore: integrate with `rsbuild-plugin-arethetypeswrong`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -102,7 +102,7 @@
     'style-loader',
     'http-proxy-middleware',
     // Temporary ignore
-    "less",
+    'less',
     '@biomejs/biome',
   ],
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1137,6 +1137,9 @@ importers:
       '@types/node':
         specifier: ^22.17.1
         version: 22.17.1
+      rsbuild-plugin-arethetypeswrong:
+        specifier: 0.1.0
+        version: 0.1.0(@rsbuild/core@packages+core)(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -5727,6 +5730,16 @@ packages:
       webpack: ^5.0.0
     peerDependenciesMeta:
       webpack:
+        optional: true
+
+  rsbuild-plugin-arethetypeswrong@0.1.0:
+    resolution: {integrity: sha512-rbVnrvFjSuZHu0h+bTcChQXCiIUrX8DmY30DnUHzvwrFuMadS4B5mnOqwpynJ6cFNKs6e8bQGdDB77SZuNkXcQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@rsbuild/core': '*'
+      typescript: '*'
+    peerDependenciesMeta:
+      '@rsbuild/core':
         optional: true
 
   rsbuild-plugin-dts@0.11.2:
@@ -11889,6 +11902,12 @@ snapshots:
       rslog: 1.2.11
     optionalDependencies:
       webpack: 5.101.0
+
+  rsbuild-plugin-arethetypeswrong@0.1.0(@rsbuild/core@packages+core)(typescript@5.9.2):
+    dependencies:
+      typescript: 5.9.2
+    optionalDependencies:
+      '@rsbuild/core': link:packages/core
 
   rsbuild-plugin-dts@0.11.2(@rsbuild/core@1.4.14)(typescript@5.9.2):
     dependencies:

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -6,6 +6,7 @@
     "@rsbuild/core": "workspace:*",
     "@rslib/core": "0.11.2",
     "@types/node": "^22.17.1",
+    "rsbuild-plugin-arethetypeswrong": "0.1.0",
     "typescript": "^5.9.2"
   }
 }

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -48,6 +48,7 @@ export const dualPackage = defineConfig({
   },
   plugins: [
     pluginAreTheTypesWrong({
+      enable: Boolean(process.env.CI),
       areTheTypesWrongOptions: {
         ignoreRules: [
           // The dual package always provide the ESM types.

--- a/scripts/config/rslib.config.ts
+++ b/scripts/config/rslib.config.ts
@@ -1,5 +1,6 @@
 import type { Minify } from '@rsbuild/core';
 import { defineConfig, type LibConfig } from '@rslib/core';
+import { pluginAreTheTypesWrong } from 'rsbuild-plugin-arethetypeswrong';
 
 export const commonExternals: Array<string | RegExp> = [
   'webpack',
@@ -45,4 +46,14 @@ export const dualPackage = defineConfig({
       externals: commonExternals,
     },
   },
+  plugins: [
+    pluginAreTheTypesWrong({
+      areTheTypesWrongOptions: {
+        ignoreRules: [
+          // The dual package always provide the ESM types.
+          'false-esm',
+        ],
+      },
+    }),
+  ],
 });

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -15,6 +15,7 @@
       "require": "./dist/index.cjs"
     }
   },
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

Integrate with [`rsbuild-plugin-arethetypeswrong`](https://www.npmjs.com/package/rsbuild-plugin-arethetypeswrong?activeTab=readme). 

## Related Links

<!--- Provide links of related issues or pages -->

This could avoid future regression on issues like https://github.com/web-infra-dev/rsbuild/pull/3695 or https://github.com/web-infra-dev/rsbuild/pull/3089

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
