### PR TITLE
fix(cli): ensure consistent spacing for node run script

### DIFF
--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -23,10 +23,12 @@ function showGreeting() {
   // Ensure consistent spacing before the greeting message.
   // Different package managers handle output formatting differently - some automatically
   // add a blank line before command output, while others do not.
-  const { npm_execpath, npm_lifecycle_event } = process.env;
+  const { npm_execpath, npm_lifecycle_event, NODE_RUN_SCRIPT_NAME } =
+    process.env;
   const isNpx = npm_lifecycle_event === 'npx';
   const isBun = npm_execpath?.includes('.bun');
-  const prefix = isNpx || isBun ? '\n' : '';
+  const isNodeRun = Boolean(NODE_RUN_SCRIPT_NAME);
+  const prefix = isNpx || isBun || isNodeRun ? '\n' : '';
   logger.greet(`${prefix}  Rsbuild v${RSBUILD_VERSION}\n`);
 }
 


### PR DESCRIPTION
## Summary

Ensure consistent spacing for `node --run` script.

### Before

<img width="618" height="307" alt="Screenshot 2025-08-11 at 16 01 43" src="https://github.com/user-attachments/assets/788912f1-6afb-4fee-bd7d-7f4903e4d775" />

### After

<img width="652" height="326" alt="Screenshot 2025-08-11 at 16 01 34" src="https://github.com/user-attachments/assets/9bdbc067-6dbe-4721-91a0-70b9610f77a3" />

## Related Links

- https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line#environment-variables

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
