### PR TITLE
test(e2e): fix flaky watching file cases

### DIFF
--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
+import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import fse, { remove } from 'fs-extra';
 
@@ -22,14 +22,12 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
-    await expectFile(distIndexFile);
-    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo1bar1');
+    await expectFileWithContent(distIndexFile, 'foo1bar1');
     await remove(distIndexFile);
 
     // should watch foo.js
     fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
-    await expectFile(distIndexFile);
-    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo2bar1');
+    await expectFileWithContent(distIndexFile, 'foo2bar1');
 
     // should not watch bar.js
     fse.outputFileSync(barFile, `export const bar = 'bar2';`);

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,7 +1,5 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 rspackOnlyTest('should support restart build when config changed', async () => {
@@ -27,8 +25,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
     cwd: __dirname,
   });
 
-  await expectFile(distIndexFile);
-  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
+  await expectFileWithContent(distIndexFile, 'hello!');
   await remove(distIndexFile);
 
   fse.outputFileSync(
@@ -42,13 +39,11 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 `,
   );
 
-  await expectFile(distIndexFile);
-  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
+  await expectFileWithContent(distIndexFile, 'hello!');
   await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await expectFile(distIndexFile);
-  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
+  await expectFileWithContent(distIndexFile, 'hello2!');
 
   childProcess.kill();
 });

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,7 +1,5 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 rspackOnlyTest('should support watch mode for build command', async () => {
@@ -16,13 +14,11 @@ rspackOnlyTest('should support watch mode for build command', async () => {
     cwd: __dirname,
   });
 
-  await expectFile(distIndexFile);
-  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello!');
+  await expectFileWithContent(distIndexFile, 'hello!');
   await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await expectFile(distIndexFile);
-  expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('hello2!');
+  await expectFileWithContent(distIndexFile, 'hello2!');
 
   childProcess.kill();
 });

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,7 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expectFileWithContent,
+  getRandomPort,
+  rspackOnlyTest,
+  runCli,
+} from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 rspackOnlyTest(
@@ -38,14 +42,10 @@ rspackOnlyTest(
       },
     });
 
-    await expectFile(distIndex);
-    expect(fs.readFileSync(distIndex, 'utf-8')).toContain('jack');
-
+    await expectFileWithContent(distIndex, 'jack');
     await remove(distIndex);
-
     fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
-    await expectFile(distIndex);
-    expect(fs.readFileSync(distIndex, 'utf-8')).toContain('rose');
+    await expectFileWithContent(distIndex, 'rose');
 
     devProcess.kill();
   },

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,7 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import {
+  expectFile,
+  expectFileWithContent,
+  getRandomPort,
+  rspackOnlyTest,
+  runCli,
+} from '@e2e/helper';
+import { test } from '@playwright/test';
 import { remove } from 'fs-extra';
 
 const dist = path.join(__dirname, 'dist');
@@ -32,6 +38,7 @@ rspackOnlyTest(
 
     // the first build
     await expectFile(distIndexFile);
+    await expectFileWithContent(tempOutputFile, '1');
 
     await remove(tempOutputFile);
     // temp config changed and trigger rebuild
@@ -39,7 +46,7 @@ rspackOnlyTest(
 
     // rebuild and generate dist files
     await expectFile(tempOutputFile);
-    expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('2');
+    await expectFileWithContent(tempOutputFile, '2');
 
     childProcess.kill();
   },
@@ -59,13 +66,14 @@ rspackOnlyTest(
     });
 
     await expectFile(distIndexFile);
+    await expectFileWithContent(tempOutputFile, '1');
 
     await remove(distIndexFile);
     // temp config changed
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
     await expectFile(tempOutputFile);
-    expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
+    await expectFileWithContent(tempOutputFile, '1');
 
     childProcess.kill();
   },
@@ -92,7 +100,7 @@ rspackOnlyTest(
     fs.writeFileSync(extraConfigFile, 'export default 2;');
 
     await expectFile(tempOutputFile);
-    expect(fs.readFileSync(tempOutputFile, 'utf-8')).toEqual('1');
+    await expectFileWithContent(tempOutputFile, '1');
 
     childProcess.kill();
   },

--- a/e2e/scripts/helper.ts
+++ b/e2e/scripts/helper.ts
@@ -73,6 +73,25 @@ export const readDirContents = async (path: string, options?: GlobOptions) => {
 export const expectFile = (dir: string) =>
   expectPoll(() => fs.existsSync(dir)).toBeTruthy();
 
+/**
+ * Expect a file to exist and include specified content
+ */
+export const expectFileWithContent = (
+  filePath: string,
+  expectedContent: string,
+) =>
+  expectPoll(() => {
+    try {
+      if (!fs.existsSync(filePath)) {
+        return false;
+      }
+      const content = fs.readFileSync(filePath, 'utf-8');
+      return content.includes(expectedContent);
+    } catch {
+      return false;
+    }
+  }).toBeTruthy();
+
 export type ProxyConsoleOptions = {
   types?: ConsoleType | ConsoleType[];
   keepAnsi?: boolean;


### PR DESCRIPTION
## Summary

- Add a new helper function `expectFileWithContent`, which asserts that a file exists and contains the expected content.
- Use the new helper to fix flaky watching file cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
