### PR TITLE
docs: improve code splitting documentation clarity

### DIFF
--- a/website/docs/en/guide/optimization/code-splitting.mdx
+++ b/website/docs/en/guide/optimization/code-splitting.mdx
@@ -23,10 +23,12 @@ Rsbuild supports the following chunk splitting strategies:
 
 ### Behavior
 
-Rsbuild adopts the `split-by-experience` strategy by default, which is a strategy we have developed from experience. Specifically, when the following npm packages are referenced in your project, they will automatically be split into separate chunks:
+Rsbuild uses the `split-by-experience` strategy by default, which is an optimization strategy based on practical experience. When the following npm packages are referenced in the project, they will be automatically split into separate chunks:
 
-- `lib-polyfill.js`: includes `core-js`, `@swc/helpers`, `tslib`.
-- `lib-axios.js`: includes `axios` and related packages.
+- `lib-polyfill.js`: Contains `core-js`, `@swc/helpers`, `tslib`
+- `lib-axios.js`: Contains `axios`
+- `lib-react.js`: Provided by [@rsbuild/plugin-react](/plugins/list/plugin-react#splitchunks)
+- `lib-vue.js`: Provided by [@rsbuild/plugin-vue](/plugins/list/plugin-vue#splitchunks)
 
 Grouping commonly used packages in this way and then splitting them into individual chunks helps with browser caching.
 

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -128,8 +128,8 @@ Most of the time, you should use the plugin's [fastRefresh](#fastrefresh) option
 
 When [chunkSplit.strategy](/config/performance/chunk-split) set to `split-by-experience`, Rsbuild will automatically split `react` and `router` related packages into separate chunks by default:
 
-- `lib-react.js`: includes react, react-dom, and react's sub-dependencies (scheduler).
-- `lib-router.js`: includes react-router, react-router-dom, and react-router's sub-dependencies (history, @remix-run/router).
+- `lib-react.js`: includes `react`, `react-dom`, and their sub-dependencies (`scheduler`).
+- `lib-router.js`: includes `react-router`, `react-router-dom`, and their sub-dependencies (`history`, `@remix-run/router`).
 
 This option is used to control this behavior and determine whether the `react` and `router` related packages need to be split into separate chunks.
 

--- a/website/docs/en/plugins/list/plugin-vue.mdx
+++ b/website/docs/en/plugins/list/plugin-vue.mdx
@@ -68,8 +68,8 @@ pluginVue({
 
 When [chunkSplit.strategy](/config/performance/chunk-split) set to `split-by-experience`, Rsbuild will automatically split `vue` and `router` related packages into separate chunks by default:
 
-- `lib-vue.js`: includes vue, vue-loader, and vue's sub-dependencies (@vue/shared, @vue/reactivity, @vue/runtime-dom, @vue/runtime-core).
-- `lib-router.js`: includes vue-router.
+- `lib-vue.js`: includes `vue`, `vue-loader`, and their sub-dependencies (`@vue/shared`, `@vue/reactivity`, `@vue/runtime-dom`, `@vue/runtime-core`).
+- `lib-router.js`: includes `vue-router`.
 
 This option is used to control this behavior and determine whether the `vue` and `router` related packages need to be split into separate chunks.
 

--- a/website/docs/zh/guide/optimization/code-splitting.mdx
+++ b/website/docs/zh/guide/optimization/code-splitting.mdx
@@ -23,10 +23,12 @@ Rsbuild 支持设置以下几种拆包策略：
 
 ### 分包策略
 
-Rsbuild 默认采用 `split-by-experience` 策略，这是我们根据经验制定的策略。具体来说，当你的项目中引用了以下 npm 包时，它们会自动被拆分为单独的 chunk：
+Rsbuild 默认采用 `split-by-experience` 策略，这是基于实践经验制定的优化策略。当项目中引用以下 npm 包时，它们会自动拆分为独立的 chunk：
 
-- `lib-polyfill.js`：包含 `core-js`，`@swc/helpers`，`tslib`。
-- `lib-axios.js`：包含 `axios` 以及相关的包。
+- `lib-polyfill.js`：包含 `core-js`、`@swc/helpers`、`tslib`
+- `lib-axios.js`：包含 `axios`
+- `lib-react.js`：由 [@rsbuild/plugin-react](/plugins/list/plugin-react#splitchunks) 提供
+- `lib-vue.js`：由 [@rsbuild/plugin-vue](/plugins/list/plugin-vue#splitchunks) 提供
 
 这种方式将常用的包进行分组，然后拆分为单独的 chunk，有助于浏览器缓存。
 

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -130,8 +130,8 @@ pluginReact({
 
 在 [chunkSplit.strategy](/config/performance/chunk-split) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `react` 和 `router` 相关的包拆分为单独的 chunk:
 
-- `lib-react.js`：包含 react，react-dom，以及 react 的子依赖（scheduler）。
-- `lib-router.js`：包含 react-router，react-router-dom，以及 react-router 的子依赖（history，@remix-run/router）。
+- `lib-react.js`：包含 `react`、`react-dom`，以及它们的子依赖（`scheduler`）。
+- `lib-router.js`：包含 `react-router`、`react-router-dom`，以及它们的子依赖（`history`，`@remix-run/router`）。
 
 该选项用于控制这一行为，决定是否需要将 `react` 和 `router` 相关的包拆分为单独的 chunk。
 

--- a/website/docs/zh/plugins/list/plugin-vue.mdx
+++ b/website/docs/zh/plugins/list/plugin-vue.mdx
@@ -68,8 +68,8 @@ pluginVue({
 
 在 [chunkSplit.strategy](/config/performance/chunk-split) 设置为 `split-by-experience` 时，Rsbuild 默认会自动将 `vue` 和 `router` 相关的包拆分为单独的 chunk:
 
-- `lib-vue.js`：包含 vue，vue-loader，以及 vue 的子依赖（@vue/shared，@vue/reactivity，@vue/runtime-dom，@vue/runtime-core）。
-- `lib-router.js`：包含 vue-router。
+- `lib-vue.js`：包含 `vue`、`vue-loader`，以及它们的子依赖（`@vue/shared`，`@vue/reactivity`，`@vue/runtime-dom`，`@vue/runtime-core`）。
+- `lib-router.js`：包含 `vue-router`。
 
 该选项用于控制这一行为，决定是否需要将 `vue` 和 `router` 相关的包拆分为单独的 chunk。
 


### PR DESCRIPTION
## Summary

Clarified the description of the `split-by-experience` strategy code-splitting guides, specifying which npm packages are split into separate chunks and referencing plugin-provided chunks for React and Vue.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
