### PR TITLE
docs: mention Rspack's default split chunks strategy

### DIFF
--- a/website/docs/en/guide/optimization/code-splitting.mdx
+++ b/website/docs/en/guide/optimization/code-splitting.mdx
@@ -19,6 +19,10 @@ Rsbuild supports the following chunk splitting strategies:
 - `single-vendor`: bundle all NPM packages into a single chunk.
 - `custom`: custom chunk splitting strategy.
 
+::: tip
+When using strategies other than `all-in-one`, Rspack's default splitting rules will also take effect. For more details, please refer to [Rspack - SplitChunksPlugin](http://rspack.rs/plugins/webpack/split-chunks-plugin#default-behavior).
+:::
+
 ## split-by-experience
 
 ### Behavior
@@ -30,7 +34,7 @@ Rsbuild uses the `split-by-experience` strategy by default, which is an optimiza
 - `lib-react.js`: Provided by [@rsbuild/plugin-react](/plugins/list/plugin-react#splitchunks)
 - `lib-vue.js`: Provided by [@rsbuild/plugin-vue](/plugins/list/plugin-vue#splitchunks)
 
-Grouping commonly used packages in this way and then splitting them into individual chunks helps with browser caching.
+This approach groups commonly used packages and splits them into individual chunks, which helps improve browser caching efficiency.
 
 ### Config
 

--- a/website/docs/zh/guide/optimization/code-splitting.mdx
+++ b/website/docs/zh/guide/optimization/code-splitting.mdx
@@ -19,6 +19,10 @@ Rsbuild 支持设置以下几种拆包策略：
 - `single-vendor`: 将所有 NPM 包的代码打包到一个单独的 chunk 中。
 - `custom`: 自定义拆包配置。
 
+:::tip
+在使用除了 `all-in-one` 之外的其他策略时，Rspack 默认的拆包规则也会生效，详情请参考 [Rspack - SplitChunksPlugin](http://rspack.rs/zh/plugins/webpack/split-chunks-plugin#默认行为)。
+:::
+
 ## split-by-experience
 
 ### 分包策略
@@ -30,7 +34,7 @@ Rsbuild 默认采用 `split-by-experience` 策略，这是基于实践经验制�
 - `lib-react.js`：由 [@rsbuild/plugin-react](/plugins/list/plugin-react#splitchunks) 提供
 - `lib-vue.js`：由 [@rsbuild/plugin-vue](/plugins/list/plugin-vue#splitchunks) 提供
 
-这种方式将常用的包进行分组，然后拆分为单独的 chunk，有助于浏览器缓存。
+这种方式将常用的包进行分组，然后拆分为单独的 chunk，有助于提升浏览器缓存效率。
 
 ### 配置
 


### PR DESCRIPTION
## Summary

Added a tip to explain that Rspack's default chunk splitting rules still apply when using strategies other than `all-in-one`

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
