### PR TITLE
chore: update externals in Rslib config for postcss-load-config

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -34,8 +34,9 @@ const externals: Rspack.Configuration['externals'] = [
   '@rsbuild/core',
   '@rsbuild/core/client/hmr',
   '@rsbuild/core/client/overlay',
-  // yaml is an optional dependency of `postcss-load-config`
+  // yaml and tsx are optional dependencies of `postcss-load-config`
   'yaml',
+  'tsx/cjs/api',
   // externalize pre-bundled dependencies
   ({ request }, callback) => {
     const entries = Object.entries(regexpMap);


### PR DESCRIPTION
## Summary

Add `tsx` to externals config for `postcss-load-config`, fix the build warning:

<img width="1059" height="418" alt="Screenshot 2025-08-12 at 13 41 17" src="https://github.com/user-attachments/assets/8a129966-131d-498c-8d21-4618eddd3f1a" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5808

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
