### PR TITLE
feat: add experimental ESM output support for node target

### DIFF
--- a/e2e/cases/server/ssr-type-module/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-type-module/rsbuild.config.ts
@@ -55,30 +55,12 @@ export default defineConfig({
     },
     node: {
       output: {
+        module: true,
         target: 'node',
       },
       source: {
         entry: {
           index: './src/index.server',
-        },
-      },
-      tools: {
-        rspack: (config) => {
-          return {
-            ...config,
-            experiments: {
-              ...config.experiments,
-              outputModule: true,
-            },
-            output: {
-              ...config.output,
-              chunkFormat: 'module',
-              chunkLoading: 'import',
-              library: {
-                type: 'module',
-              },
-            },
-          };
         },
       },
     },

--- a/e2e/cases/server/ssr/rsbuild.config.ts
+++ b/e2e/cases/server/ssr/rsbuild.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
     },
     node: {
       output: {
+        module: true,
         target: 'node',
       },
       source: {
@@ -67,19 +68,10 @@ export default defineConfig({
           if (process.env.TEST_ESM_LIBRARY) {
             return {
               ...config,
-              experiments: {
-                ...config.experiments,
-                outputModule: true,
-              },
               output: {
                 ...config.output,
                 filename: '[name].mjs',
                 chunkFilename: '[name].mjs',
-                chunkFormat: 'module',
-                chunkLoading: 'import',
-                library: {
-                  type: 'module',
-                },
               },
             };
           }

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -23,6 +23,7 @@ import { pluginCleanOutput } from './plugins/cleanOutput';
 import { pluginCss } from './plugins/css';
 import { pluginDefine } from './plugins/define';
 import { pluginEntry } from './plugins/entry';
+import { pluginEsm } from './plugins/esm';
 import { pluginExternals } from './plugins/externals';
 import { pluginFileSize } from './plugins/fileSize';
 import { pluginHtml } from './plugins/html';
@@ -94,6 +95,7 @@ function applyDefaultPlugins(
     pluginMinimize(),
     pluginProgress(),
     pluginSwc(),
+    pluginEsm(),
     pluginExternals(),
     pluginSplitChunks(),
     pluginInlineChunk(),

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -173,6 +173,7 @@ const getDefaultOutputConfig = (): NormalizedOutputConfig => ({
   legalComments: 'linked',
   injectStyles: false,
   minify: true,
+  module: false,
   manifest: false,
   sourceMap: {
     js: undefined,

--- a/packages/core/src/plugins/esm.ts
+++ b/packages/core/src/plugins/esm.ts
@@ -1,0 +1,36 @@
+import type { RsbuildPlugin } from '../types';
+
+export const pluginEsm = (): RsbuildPlugin => ({
+  name: 'rsbuild:esm',
+
+  setup(api) {
+    api.modifyBundlerChain((chain, { environment, isServer }) => {
+      const { config } = environment;
+
+      if (!config.output.module) {
+        return;
+      }
+
+      if (!isServer) {
+        throw new Error(
+          '[rsbuild:config] `output.module` config only support node target yet.',
+        );
+      }
+
+      chain.output
+        .module(true)
+        .chunkFormat('module')
+        .chunkLoading('import')
+        .workerChunkLoading('import')
+        .library({
+          ...chain.output.get('library'),
+          type: 'module',
+        });
+
+      chain.experiments({
+        ...chain.get('experiments'),
+        outputModule: true,
+      });
+    });
+  },
+});

--- a/packages/core/src/plugins/esm.ts
+++ b/packages/core/src/plugins/esm.ts
@@ -13,7 +13,7 @@ export const pluginEsm = (): RsbuildPlugin => ({
 
       if (!isServer) {
         throw new Error(
-          '[rsbuild:config] `output.module` config only support node target yet.',
+          '[rsbuild:config] `output.module` is only supported for Node.js targets.',
         );
       }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1231,6 +1231,13 @@ export interface OutputConfig {
    */
   manifest?: ManifestConfig;
   /**
+   * Whether to output JavaScript files in ES modules format. This feature is currently
+   * experimental and only available when `output.target` is `'node'`.
+   * @experimental
+   * @default false
+   */
+  module?: boolean;
+  /**
    * Whether to generate source map files, and which format of source map to generate.
    *
    * @default
@@ -1308,6 +1315,7 @@ export interface NormalizedOutputConfig extends OutputConfig {
   assetPrefix: string;
   dataUriLimit: number | NormalizedDataUriLimit;
   manifest: ManifestConfig;
+  module: boolean;
   minify: Minify;
   inlineScripts: InlineChunkConfig;
   inlineStyles: InlineChunkConfig;

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -72,6 +72,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
     "legalComments": "linked",
     "manifest": false,
     "minify": true,
+    "module": false,
     "polyfill": "off",
     "sourceMap": {
       "css": false,
@@ -217,6 +218,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
     "legalComments": "linked",
     "manifest": false,
     "minify": true,
+    "module": false,
     "polyfill": "off",
     "sourceMap": {
       "css": false,
@@ -362,6 +364,7 @@ exports[`environment config > should print environment config when inspect confi
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -503,6 +506,7 @@ exports[`environment config > should print environment config when inspect confi
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -664,6 +668,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -805,6 +810,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -947,6 +953,7 @@ exports[`environment config > should support modify environment config by api.mo
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -1092,6 +1099,7 @@ exports[`environment config > should support modify single environment config by
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,
@@ -1233,6 +1241,7 @@ exports[`environment config > should support modify single environment config by
       "legalComments": "linked",
       "manifest": false,
       "minify": true,
+      "module": false,
       "polyfill": "off",
       "sourceMap": {
         "css": false,


### PR DESCRIPTION
## Summary

Add `output.module` config to enable experimental ESM output format when target is node. This includes adding a new plugin to handle ESM-specific Rspack configurations and updating related type definitions and test cases.

The feature is marked as experimental and currently only supports node target. This provides a foundation for future ESM support in other targets.

```ts
export default {
  output: {
    module: true,
  }
}
```

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11344
- https://rspack.rs/config/output#outputmodule

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
