### PR TITLE
feat: enable lazyCompilation.imports by default

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -16,6 +16,8 @@ permissions:
   contents: write
   # Allow commenting on issues
   issues: write
+  # Allow commenting on PR
+  pull-requests: write
 
 jobs:
   changes:

--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -16,8 +16,6 @@ permissions:
   contents: write
   # Allow commenting on issues
   issues: write
-  # Allow commenting on PR
-  pull-requests: write
 
 jobs:
   changes:

--- a/e2e/cases/nonce/dynamic-chunk/index.test.ts
+++ b/e2e/cases/nonce/dynamic-chunk/index.test.ts
@@ -1,11 +1,25 @@
 import { build, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
+declare global {
+  interface Window {
+    dynamicChunkNonce?: string;
+  }
+}
+
 test('should apply nonce to dynamic chunks in dev build', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
     page,
   });
+
+  await page.waitForFunction(
+    () => window.dynamicChunkNonce !== undefined,
+    undefined,
+    {
+      timeout: 2000,
+    },
+  );
 
   expect(await page.evaluate('window.dynamicChunkNonce')).toEqual(
     'CSP_NONCE_PLACEHOLDER',

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -24,6 +24,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",
@@ -482,6 +486,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
   },
   "infrastructureLogging": {
     "level": "error",

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -29,7 +29,6 @@ function formatURL(fallback?: boolean) {
 }
 
 // Remember some state related to hot module replacement.
-let isFirstCompilation = true;
 let lastCompilationHash: string | undefined;
 let hasCompileErrors = false;
 
@@ -55,22 +54,15 @@ export const registerOverlay = (
 function handleSuccess() {
   clearOutdatedErrors();
 
-  const isHotUpdate = !isFirstCompilation;
-  isFirstCompilation = false;
   hasCompileErrors = false;
 
-  // Attempt to apply hot updates or reload.
-  if (isHotUpdate) {
-    tryApplyUpdates();
-  }
+  tryApplyUpdates();
 }
 
 // Compilation with warnings (e.g. ESLint).
 function handleWarnings({ text }: { text: string[] }) {
   clearOutdatedErrors();
 
-  const isHotUpdate = !isFirstCompilation;
-  isFirstCompilation = false;
   hasCompileErrors = false;
 
   for (let i = 0; i < text.length; i++) {
@@ -83,17 +75,13 @@ function handleWarnings({ text }: { text: string[] }) {
     console.warn(text[i]);
   }
 
-  // Attempt to apply hot updates or reload.
-  if (isHotUpdate) {
-    tryApplyUpdates();
-  }
+  tryApplyUpdates();
 }
 
 // Compilation with errors (e.g. syntax error or missing modules).
 function handleErrors({ text, html }: { text: string[]; html: string }) {
   clearOutdatedErrors();
 
-  isFirstCompilation = false;
   hasCompileErrors = true;
 
   // Also log them to the console.

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -272,6 +272,14 @@ export const withDefaultConfig = async (
     }
   }
 
+  if (merged.dev?.lazyCompilation === undefined) {
+    merged.dev ||= {};
+    merged.dev.lazyCompilation = {
+      imports: true,
+      entries: false,
+    };
+  }
+
   if (!merged.source.tsconfigPath) {
     const tsconfigPath = join(rootPath, TS_CONFIG_FILE);
 

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,6 +11,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,6 +11,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -517,6 +521,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1480,6 +1488,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
+    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -306,6 +306,10 @@ exports[`environment config > should print environment config when inspect confi
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -448,6 +452,10 @@ exports[`environment config > should print environment config when inspect confi
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -610,6 +618,10 @@ exports[`environment config > should support modify environment config by api.mo
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -752,6 +764,10 @@ exports[`environment config > should support modify environment config by api.mo
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -895,6 +911,10 @@ exports[`environment config > should support modify environment config by api.mo
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -1041,6 +1061,10 @@ exports[`environment config > should support modify single environment config by
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -1183,6 +1207,10 @@ exports[`environment config > should support modify single environment config by
         "reconnect": 100,
       },
       "hmr": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "liveReload": true,
       "watchFiles": [],
       "writeToDisk": false,
@@ -1324,6 +1352,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
+      "lazyCompilation": {
+        "entries": false,
+        "imports": true,
+      },
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,


### PR DESCRIPTION
## Summary
- Enable lazyCompilation.imports by default.
We need specify lazyCompilation.entries as false , because rspack will enable lazyCompilation.entries if you pass a object as lazyCompilation. more detail see: [Rspack configuration.lazyCompilation](https://rspack.rs/config/lazy-compilation#lazycompilation-1)

- In lazyCompilation, we will do a hmr compile quickly, so we maybe complete the hmr compile before web socket connect done. It means we need do a hmr action when first web socket message send.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
