### PR TITLE
fix(server): adjust indentation in debug log message

### DIFF
--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -61,7 +61,7 @@ export const getRequestLoggerMiddleware: () => Promise<Connect.NextHandleFunctio
 
         // :status :method :url :total-time ms
         logger.debug(
-          `${statusColor(status)} ${method} ${color.dim(url)} ${color.gray(
+          `${statusColor(status)} ${method} ${color.gray(url)} ${color.gray(
             `${totalTime.toFixed(3)} ms`,
           )}`,
         );
@@ -249,8 +249,8 @@ export const getHtmlFallbackMiddleware: (params: {
 
       if (logger.level === 'verbose') {
         logger.debug(
-          `    ${req.method} ${color.dim(
-            `${req.url} ${color.yellow('fallback to')} ${newUrl}`,
+          `    ${req.method} ${color.gray(
+            `${req.url} ${color.yellow('fallback')} to ${newUrl}`,
           )}`,
         );
       }

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -61,7 +61,7 @@ export const getRequestLoggerMiddleware: () => Promise<Connect.NextHandleFunctio
 
         // :status :method :url :total-time ms
         logger.debug(
-          `${statusColor(status)} ${method} ${color.gray(url)} ${color.gray(
+          `${statusColor(status)} ${method} ${color.dim(url)} ${color.gray(
             `${totalTime.toFixed(3)} ms`,
           )}`,
         );
@@ -249,8 +249,8 @@ export const getHtmlFallbackMiddleware: (params: {
 
       if (logger.level === 'verbose') {
         logger.debug(
-          `    ${req.method} ${color.gray(
-            `${req.url} ${color.yellow('fallback')} to ${newUrl}`,
+          `    ${req.method} ${color.dim(
+            `${req.url} ${color.yellow('fallback to')} ${newUrl}`,
           )}`,
         );
       }

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -61,7 +61,7 @@ export const getRequestLoggerMiddleware: () => Promise<Connect.NextHandleFunctio
 
         // :status :method :url :total-time ms
         logger.debug(
-          `${statusColor(status)} ${method} ${color.gray(url)} ${color.gray(
+          `${statusColor(status)} ${method} ${url} ${color.dim(
             `${totalTime.toFixed(3)} ms`,
           )}`,
         );
@@ -249,9 +249,7 @@ export const getHtmlFallbackMiddleware: (params: {
 
       if (logger.level === 'verbose') {
         logger.debug(
-          `    ${req.method} ${color.gray(
-            `${req.url} ${color.yellow('fallback')} to ${newUrl}`,
-          )}`,
+          `    ${req.method} ${req.url} ${color.yellow('fallback to')} ${newUrl}`,
         );
       }
 

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -249,7 +249,7 @@ export const getHtmlFallbackMiddleware: (params: {
 
       if (logger.level === 'verbose') {
         logger.debug(
-          `${req.method} ${color.gray(
+          `    ${req.method} ${color.gray(
             `${req.url} ${color.yellow('fallback')} to ${newUrl}`,
           )}`,
         );


### PR DESCRIPTION
## Summary

- Adjust indentation in debug log message
- Improve color for debug logs

### Before

<img width="739" height="158" alt="Screenshot 2025-08-12 at 18 53 52" src="https://github.com/user-attachments/assets/1f851415-8050-4c07-806a-f5b62e8e7b06" />

### After

<img width="859" height="136" alt="Screenshot 2025-08-12 at 19 06 09" src="https://github.com/user-attachments/assets/a86ae8ab-8fe3-4f0b-84d4-2880e8a9c448" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
