### PR TITLE
fix: move lazyCompilation config to root level to fix deprecation warning

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -24,13 +24,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "development",
   "module": {
@@ -486,13 +486,13 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "production",
   "module": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "reduce-configs": "^1.1.1",
     "rsbuild-dev-middleware": "0.3.0",
     "rslog": "^1.2.11",
-    "rspack-chain": "^1.3.2",
+    "rspack-chain": "^1.4.0",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",

--- a/packages/core/src/plugins/lazyCompilation.ts
+++ b/packages/core/src/plugins/lazyCompilation.ts
@@ -25,12 +25,9 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         // If there is only one entry, do not enable lazy compilation for entries
         // this can reduce the rebuild time
         if (Object.keys(entries).length <= 1) {
-          chain.experiments({
-            ...chain.get('experiments'),
-            lazyCompilation: {
-              entries: false,
-              imports: true,
-            },
+          chain.lazyCompilation({
+            entries: false,
+            imports: true,
           });
           return;
         }
@@ -42,23 +39,17 @@ export const pluginLazyCompilation = (): RsbuildPlugin => ({
         typeof options.serverUrl === 'string' &&
         api.context.devServer
       ) {
-        chain.experiments({
-          ...chain.get('experiments'),
-          lazyCompilation: {
-            ...options,
-            serverUrl: replacePortPlaceholder(
-              options.serverUrl,
-              api.context.devServer.port,
-            ),
-          },
+        chain.lazyCompilation({
+          ...options,
+          serverUrl: replacePortPlaceholder(
+            options.serverUrl,
+            api.context.devServer.port,
+          ),
         });
         return;
       }
 
-      chain.experiments({
-        ...chain.get('experiments'),
-        lazyCompilation: options,
-      });
+      chain.lazyCompilation(options);
     });
   },
 });

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,10 +11,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -24,6 +20,10 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "development",
   "module": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,10 +11,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -24,6 +20,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "development",
   "module": {
@@ -521,10 +521,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -534,6 +530,10 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "production",
   "module": {
@@ -1488,10 +1488,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "lazyCompilation": {
-      "entries": false,
-      "imports": true,
-    },
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1501,6 +1497,10 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "infrastructureLogging": {
     "level": "error",
+  },
+  "lazyCompilation": {
+    "entries": false,
+    "imports": true,
   },
   "mode": "development",
   "module": {

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1352,10 +1352,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
-      "lazyCompilation": {
-        "entries": false,
-        "imports": true,
-      },
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,
@@ -1365,6 +1361,10 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     },
     "infrastructureLogging": {
       "level": "error",
+    },
+    "lazyCompilation": {
+      "entries": false,
+      "imports": true,
     },
     "mode": "development",
     "module": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -710,8 +710,8 @@ importers:
         specifier: ^1.2.11
         version: 1.2.11
       rspack-chain:
-        specifier: ^1.3.2
-        version: 1.3.2
+        specifier: ^1.4.0
+        version: 1.4.0
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.5.0-beta.0(@swc/helpers@0.5.17))
@@ -5835,8 +5835,8 @@ packages:
   rslog@1.2.11:
     resolution: {integrity: sha512-YgMMzQf6lL9q4rD9WS/lpPWxVNJ1ttY9+dOXJ0+7vJrKCAOT4GH0EiRnBi9mKOitcHiOwjqJPV1n/HRqqgZmOQ==}
 
-  rspack-chain@1.3.2:
-    resolution: {integrity: sha512-vokGFR82CtdSShFkxzUv9y+PvlxNYqvhcVoy99hkDUMYZQPWHWDHJG5O8fOb76ZUXQkNoSgywMsbQGUt2iUq7w==}
+  rspack-chain@1.4.0:
+    resolution: {integrity: sha512-C7TMioPQzHePujQEspkmPOlnZUnlgldEWQ6qJgoqFit6fnimT1XirIBo8M5pIDSjboGb9kIVumTiMLi1Ifek2Q==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -12044,7 +12044,7 @@ snapshots:
 
   rslog@1.2.11: {}
 
-  rspack-chain@1.3.2:
+  rspack-chain@1.4.0:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

- Update rspack-chain to v1.4.0: https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.4.0
- Update lazy compilation config to be set at the root level instead of under experiments.
- Fix the deprecation warning:

<img width="1063" height="274" alt="Screenshot 2025-08-13 at 13 55 26" src="https://github.com/user-attachments/assets/089d3e6a-41b0-496c-a591-50816c3859cb" />

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11337

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
