### PR TITLE
fix: should apply lazyCompilationMiddleware when using top-level configuration 

### DIFF
--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -135,6 +135,7 @@ const applyDefaultMiddlewares = async ({
     // Rsbuild users can enable lazy compilation in two ways:
     // 1. Use Rsbuild's `dev.lazyCompilation` option
     // 2. Use Rspack's `experiments.lazyCompilation` option
+    // 3. Use Rspack's configuration top-level `lazyCompilation` option
     const isLazyCompilationEnabled = () => {
       if (isMultiCompiler(compiler)) {
         return compiler.compilers.some(

--- a/packages/core/src/server/devMiddlewares.ts
+++ b/packages/core/src/server/devMiddlewares.ts
@@ -138,10 +138,15 @@ const applyDefaultMiddlewares = async ({
     const isLazyCompilationEnabled = () => {
       if (isMultiCompiler(compiler)) {
         return compiler.compilers.some(
-          (childCompiler) => childCompiler.options.experiments?.lazyCompilation,
+          (childCompiler) =>
+            childCompiler.options.experiments?.lazyCompilation ||
+            childCompiler.options.lazyCompilation,
         );
       }
-      return compiler.options.experiments?.lazyCompilation;
+      return (
+        compiler.options.experiments?.lazyCompilation ||
+        compiler.options.lazyCompilation
+      );
     };
 
     if (isLazyCompilationEnabled()) {


### PR DESCRIPTION
## Summary

See title

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11337

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
