### PR TITLE
fix: move rspack configuration `experiments.lazyCompilation` to top-level

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -48,9 +48,7 @@ rspackOnlyTest(
       rsbuildConfig: {
         tools: {
           rspack: {
-            experiments: {
-              lazyCompilation: true,
-            },
+            lazyCompilation: true,
           },
         },
       },


### PR DESCRIPTION
## Summary

Rsbuild will set rspack configuration top-level `lazyCompilation` as `{ imports: true, entries: false }`.
If user set rspack `experiments.lazyCompilation` as true, the finally config that pass to rspack will become:
```js
{
  experiments: {
    // ...
    lazyCompilation: true
  },
  lazyCompilation: {
    imports: true,
    entries: false
  },
}
```
In Rspack, the top-level lazyCompilation will take precedence over experiments.lazyCompilation.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
