### PR TITLE
fix(cache): handle fs operations errors

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -40,8 +40,12 @@ async function validateWebpackCache(
     await fs.promises.rm(cacheDirectory, { force: true, recursive: true });
   }
 
-  await fs.promises.mkdir(cacheDirectory, { recursive: true });
-  await fs.promises.writeFile(configFile, JSON.stringify(buildDependencies));
+  try {
+    await fs.promises.mkdir(cacheDirectory, { recursive: true });
+    await fs.promises.writeFile(configFile, JSON.stringify(buildDependencies));
+  } catch (e) {
+    logger.debug('failed to write the buildDependencies.json', e);
+  }
 }
 
 function getCacheDirectory(

--- a/scripts/test-helper/rstest.setup.ts
+++ b/scripts/test-helper/rstest.setup.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import { beforeAll, expect } from '@rstest/core';
 import { createSnapshotSerializer } from 'path-serializer';
 
 beforeAll((suite) => {


### PR DESCRIPTION
## Summary

Added a `try-catch` block to the `validateWebpackCache` function to handle failures when writing the `buildDependencies.json` file

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
