### PR TITLE
perf: enable Rspack's barrel file optimization by default

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -95,6 +95,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         if (api.context.bundlerType === 'rspack') {
           chain.experiments({
             ...chain.get('experiments'),
+            lazyBarrel: true,
             typeReexportsPresence: true,
             rspackFuture: {
               bundlerInfo: {

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -5,6 +5,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
   "experiments": {
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -51,6 +52,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
   "experiments": {
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,6 +11,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,6 +11,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -521,6 +522,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1059,6 +1061,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1488,6 +1491,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
+    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1352,6 +1352,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
+      "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,
@@ -1802,6 +1803,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
+      "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,


### PR DESCRIPTION
## Summary

Enable Rspack's experimental barrel file optimization by default.

When building applications with barrel files, this optimization should make builds significantly faster.

<img width="1058" height="294" alt="Screenshot 2025-08-14 at 11 35 40" src="https://github.com/user-attachments/assets/f980ead5-6742-4632-bb65-61c06efaddb6" />

## Related Links

- https://rspack.rs/config/experiments#experimentslazybarrel

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
