### PR TITLE
fix(types): loosen plugin apply type to support older versions

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -261,7 +261,8 @@ export type RsbuildPlugin = {
 // Rsbuild core without throwing type mismatches. In most cases, Rsbuild core
 // only adds new methods or properties to the API object, which means that lower
 // version plugins will usually work fine.
-type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup'> & {
+type LooseRsbuildPlugin = Omit<RsbuildPlugin, 'setup' | 'apply'> & {
+  apply?: any;
   setup: (api: any) => MaybePromise<void>;
 };
 


### PR DESCRIPTION
## Summary

Make `LooseRsbuildPlugin` more permissive by allowing `apply` to be any type.

Fix the ecosystem CI: https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/16956569824/job/48059896649#step:7:513

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
