### PR TITLE
fix: failed to create multiple HMR connections

### DIFF
--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -92,7 +92,7 @@ rspackOnlyTest(
     await expect(title).toHaveCSS('font-size', '40px');
 
     // #test-keep should unchanged when CSS HMR
-    await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
+    expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     await rsbuild.close();
   },

--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -44,7 +44,7 @@ rspackOnlyTest('HMR should work by default', async ({ page }) => {
   await expect(locator).toHaveText('Hello Test!');
 
   // #test-keep should remain unchanged when app.tsx HMR
-  await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
+  expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
   const cssPath = join(cwd, 'test-temp-src/App.css');
 

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -53,8 +53,8 @@ rspackOnlyTest(
     await expect(locator2).toHaveText('Hello Test!');
 
     // #test-keep should remain unchanged when app.tsx HMR
-    await expect(locatorKeep1.innerHTML()).resolves.toBe(keepNum1);
-    await expect(locatorKeep2.innerHTML()).resolves.toBe(keepNum2);
+    expect(await locatorKeep1.innerHTML()).toBe(keepNum1);
+    expect(await locatorKeep2.innerHTML()).toBe(keepNum2);
 
     await rsbuild.close();
   },

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+const cwd = __dirname;
+
+rspackOnlyTest(
+  'should allow to create multiple HMR connections',
+  async ({ page: page1, context }) => {
+    // HMR cases will fail on Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
+    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+      recursive: true,
+    });
+
+    const rsbuild = await dev({
+      cwd,
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: join(cwd, 'test-temp-src/index.ts'),
+          },
+        },
+      },
+    });
+
+    const page2 = await context.newPage();
+    await gotoPage(page1, rsbuild);
+    await gotoPage(page2, rsbuild);
+
+    const locator1 = page1.locator('#test');
+    const locator2 = page2.locator('#test');
+
+    await expect(locator1).toHaveText('Hello Rsbuild!');
+    await expect(locator2).toHaveText('Hello Rsbuild!');
+
+    const locatorKeep1 = page1.locator('#test-keep');
+    const locatorKeep2 = page2.locator('#test-keep');
+    const keepNum1 = await locatorKeep1.innerHTML();
+    const keepNum2 = await locatorKeep2.innerHTML();
+
+    const appPath = join(cwd, 'test-temp-src/App.tsx');
+    await fs.promises.writeFile(
+      appPath,
+      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    );
+
+    await expect(locator1).toHaveText('Hello Test!');
+    await expect(locator2).toHaveText('Hello Test!');
+
+    // #test-keep should remain unchanged when app.tsx HMR
+    await expect(locatorKeep1.innerHTML()).resolves.toBe(keepNum1);
+    await expect(locatorKeep2.innerHTML()).resolves.toBe(keepNum2);
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/hmr/multiple-connection/rsbuild.config.ts
+++ b/e2e/cases/hmr/multiple-connection/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});

--- a/e2e/cases/hmr/multiple-connection/src/App.tsx
+++ b/e2e/cases/hmr/multiple-connection/src/App.tsx
@@ -1,0 +1,2 @@
+const App = () => <div id="test">Hello Rsbuild!</div>;
+export default App;

--- a/e2e/cases/hmr/multiple-connection/src/index.ts
+++ b/e2e/cases/hmr/multiple-connection/src/index.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const num = Math.ceil(Math.random() * 100);
+const testEl = document.createElement('div');
+testEl.id = 'test-keep';
+
+testEl.innerHTML = String(num);
+
+document.body.appendChild(testEl);
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -76,8 +76,7 @@ rspackOnlyTest(
     );
 
     await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
-
-    await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
+    expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     // index HMR correctly
     const appPath = join(cwd, 'test-temp-src/App.tsx');
@@ -90,7 +89,7 @@ rspackOnlyTest(
     await expect(locator).toHaveText('Hello Test!');
 
     // #test-keep should remain unchanged when app.tsx HMR
-    await expect(locatorKeep.innerHTML()).resolves.toBe(keepNum);
+    expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     await rsbuild.close();
   },

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -249,9 +249,12 @@ export class SocketServer {
       connection.isAlive = true;
     });
 
-    const sockets = this.socketsMap.get(token) ?? new Set();
+    let sockets = this.socketsMap.get(token);
+    if (!sockets) {
+      sockets = new Set();
+      this.socketsMap.set(token, sockets);
+    }
     sockets.add(connection);
-    this.socketsMap.set(token, sockets);
 
     connection.on('close', () => {
       const sockets = this.socketsMap.get(token);

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -59,7 +59,7 @@ const parseQueryString = (req: IncomingMessage) => {
 export class SocketServer {
   private wsServer!: Ws.Server;
 
-  private readonly sockets: Map<string, Ws> = new Map();
+  private readonly socketsMap: Map<string, Set<Ws>> = new Map();
 
   private readonly options: DevConfig;
 
@@ -170,7 +170,7 @@ export class SocketServer {
   public updateStats(stats: Rspack.Stats, token: string): void {
     this.stats[token] = stats;
 
-    if (!this.sockets.size) {
+    if (!this.socketsMap.size) {
       return;
     }
 
@@ -187,14 +187,21 @@ export class SocketServer {
    */
   public sockWrite(message: SocketMessage, token?: string): void {
     const messageStr = JSON.stringify(message);
-    if (token) {
-      const socket = this.sockets.get(token);
-      if (socket) {
+
+    const sendToSockets = (sockets: Set<Ws>) => {
+      for (const socket of sockets) {
         this.send(socket, messageStr);
       }
+    };
+
+    if (token) {
+      const sockets = this.socketsMap.get(token);
+      if (sockets) {
+        sendToSockets(sockets);
+      }
     } else {
-      for (const socket of this.sockets.values()) {
-        this.send(socket, messageStr);
+      for (const sockets of this.socketsMap.values()) {
+        sendToSockets(sockets);
       }
     }
   }
@@ -210,14 +217,16 @@ export class SocketServer {
       socket.terminate();
     }
     // Close all tracked sockets
-    for (const socket of this.sockets.values()) {
-      socket.close();
+    for (const sockets of this.socketsMap.values()) {
+      sockets.forEach((socket) => {
+        socket.close();
+      });
     }
 
     // Reset all properties
     this.stats = {};
     this.initialChunks = {};
-    this.sockets.clear();
+    this.socketsMap.clear();
 
     return new Promise<void>((resolve, reject) => {
       this.wsServer.close((err) => {
@@ -240,10 +249,20 @@ export class SocketServer {
       connection.isAlive = true;
     });
 
-    this.sockets.set(token, connection);
+    const sockets = this.socketsMap.get(token) ?? new Set();
+    sockets.add(connection);
+    this.socketsMap.set(token, sockets);
 
     connection.on('close', () => {
-      this.sockets.delete(token);
+      const sockets = this.socketsMap.get(token);
+      if (!sockets) {
+        return;
+      }
+
+      sockets.delete(connection);
+      if (sockets.size === 0) {
+        this.socketsMap.delete(token);
+      }
     });
 
     // send first stats to active client sock if stats exist


### PR DESCRIPTION
## Summary

- Fixed HMR failure when opening multiple browser tabs at the same time. We should use a Set to store all Web Socket connections instead of letting the new connection overwrite the previous one.
- Added a new e2e test that verifies multiple browser pages can establish independent HMR connections and receive updates simultaneously.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5531

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
