### PR TITLE
docs(config): add links to chunk splitting strategies

### DIFF
--- a/website/docs/en/config/performance/chunk-split.mdx
+++ b/website/docs/en/config/performance/chunk-split.mdx
@@ -13,12 +13,12 @@ Please refer to the [Code Splitting](/guide/optimization/code-splitting) for the
 
 Rsbuild supports the following chunk splitting strategies:
 
-- `split-by-experience`: an empirical splitting strategy, automatically splits some commonly used npm packages into chunks of moderate size.
-- `split-by-module`: split by NPM package granularity, each NPM package corresponds to a chunk.
-- `split-by-size`: automatically split according to module size.
-- `all-in-one`: bundle all codes into one chunk.
-- `single-vendor`: bundle all NPM packages into a single chunk.
-- `custom`: custom chunk splitting strategy.
+- [split-by-experience](/guide/optimization/code-splitting#split-by-experience): an empirical splitting strategy, automatically splits some commonly used npm packages into chunks of moderate size.
+- [split-by-module](/guide/optimization/code-splitting#split-by-module): split by NPM package granularity, each NPM package corresponds to a chunk.
+- [split-by-size](/guide/optimization/code-splitting#split-by-size): automatically split according to module size.
+- [all-in-one](/guide/optimization/code-splitting#all-in-one): bundle all codes into one chunk.
+- [single-vendor](/guide/optimization/code-splitting#single-vendor): bundle all NPM packages into a single chunk.
+- [custom](/guide/optimization/code-splitting#custom-splitting-strategy): custom chunk splitting strategy.
 
 ## Type definition
 

--- a/website/docs/zh/config/performance/chunk-split.mdx
+++ b/website/docs/zh/config/performance/chunk-split.mdx
@@ -13,12 +13,12 @@
 
 Rsbuild 支持设置以下几种拆包策略：
 
-- `split-by-experience`: 根据经验制定的拆分策略，自动将一些常用的 npm 包拆分为体积适中的 chunk。
-- `split-by-module`: 按 NPM 包的粒度拆分，每个 NPM 包对应一个 chunk。
-- `split-by-size`：根据模块大小自动进行拆分。
-- `all-in-one`: 将所有代码全部打包到一个 chunk 中。
-- `single-vendor`: 将所有 NPM 包的代码打包到一个单独的 chunk 中。
-- `custom`: 自定义拆包配置。
+- [split-by-experience](/guide/optimization/code-splitting#split-by-experience): 根据经验制定的拆分策略，自动将一些常用的 npm 包拆分为体积适中的 chunk。
+- [split-by-module](/guide/optimization/code-splitting#split-by-module): 按 NPM 包的粒度拆分，每个 NPM 包对应一个 chunk。
+- [split-by-size](/guide/optimization/code-splitting#split-by-size)：根据模块大小自动进行拆分。
+- [all-in-one](/guide/optimization/code-splitting#all-in-one)：将所有代码全部打包到一个 chunk 中。
+- [single-vendor](/guide/optimization/code-splitting#single-vendor)：将所有 NPM 包的代码打包到一个单独的 chunk 中。
+- [custom](/guide/optimization/code-splitting#自定义拆包): 自定义拆包配置。
 
 ## 类型定义
 


### PR DESCRIPTION
## Summary

Add links to each chunk splitting strategy to improve navigation and provide direct access to detailed explanations.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
