### PR TITLE
fix(types): add missing react suffix for svg import

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -279,6 +279,20 @@ declare module '*?raw' {
 }
 
 /**
+ * @requires [@rsbuild/plugin-svgr](https://npmjs.com/package/@rsbuild/plugin-svgr)
+ * Imports svg as a React component.
+ * @note Only works with SVGR and React. Rsbuild will call SVGR to transform the SVG into a React component
+ * @example
+ * import Logo from './logo.svg?react'
+ * 
+ * export const App = () => <Logo />;
+ */
+declare module '*.svg?react' {
+  const content: string;
+  export default content;
+}
+
+/**
  * CSS Modules
  */
 type CSSModuleClasses = {


### PR DESCRIPTION
## Summary
Typescript was complaining about missing type for svg import with react suffix


| Before  | After |
| ------------- | ------------- |
| <img width="1002" height="361" alt="image" src="https://github.com/user-attachments/assets/ec798d94-b47e-4282-9046-65af327b79c6" /> | <img width="797" height="362" alt="image" src="https://github.com/user-attachments/assets/69e39062-4ce0-4406-906b-2cfa2c3f6188" />  |


## Checklist

<!--- Check and mark with an "x" -->

- [ x ] Tests updated (or not required).
- [ x ] Documentation updated (or not required).
