### PR TITLE
fix(server): handle Deno compatibility in public dir copy

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url';
 
 export const __filename: string = fileURLToPath(import.meta.url);
 export const __dirname: string = dirname(__filename);
+export const isDeno: boolean = typeof Deno !== 'undefined';
 
 // Paths
 // loaders will be emitted to the same folder of the main bundle

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -8,4 +8,5 @@ declare global {
   const RSBUILD_SERVER_PORT: number;
   const RSBUILD_DEV_LIVE_RELOAD: boolean;
   const RSBUILD_WEB_SOCKET_TOKEN: string;
+  const Deno: unknown;
 }


### PR DESCRIPTION
## Summary

Fix the issue where it fails to copy the public directory when running in Deno by first removing the existing directory, if present.

Also improve the clarity of the error message.

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/5804

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
