### PR TITLE
fix: ensure inspectConfig properly initializes action before execution

### DIFF
--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -58,6 +58,7 @@ import type {
   CreateDevServer,
   CreateRsbuildOptions,
   Falsy,
+  InspectConfig,
   InternalContext,
   PluginManager,
   PreviewOptions,
@@ -274,11 +275,20 @@ export async function createRsbuild(
     return providerInstance.createDevServer(...args);
   };
 
-  const createCompiler: CreateCompiler = (...args) => {
+  const initAction = () => {
     if (!context.action) {
-      context.action = getNodeEnv() === 'development' ? 'dev' : 'build';
+      context.action = config.mode === 'development' ? 'dev' : 'build';
     }
+  };
+
+  const createCompiler: CreateCompiler = (...args) => {
+    initAction();
     return providerInstance.createCompiler(...args);
+  };
+
+  const inspectConfig: InspectConfig = async (...args) => {
+    initAction();
+    return providerInstance.inspectConfig(...args);
   };
 
   const rsbuild = {
@@ -287,6 +297,7 @@ export async function createRsbuild(
     startDevServer,
     createCompiler,
     createDevServer,
+    inspectConfig,
     ...pick(pluginManager, [
       'addPlugins',
       'getPlugins',
@@ -311,7 +322,7 @@ export async function createRsbuild(
       'getRsbuildConfig',
       'getNormalizedConfig',
     ]),
-    ...pick(providerInstance, ['initConfigs', 'inspectConfig']),
+    ...pick(providerInstance, ['initConfigs']),
   };
 
   if (envs) {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -176,6 +176,10 @@ export type StartDevServer = (
   options?: StartDevServerOptions,
 ) => Promise<StartServerResult>;
 
+export type InspectConfig<B extends 'rspack' | 'webpack' = 'rspack'> = (
+  options?: InspectConfigOptions,
+) => Promise<InspectConfigResult<B>>;
+
 export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = Pick<
   RsbuildInstance,
   'build' | 'createCompiler' | 'createDevServer' | 'startDevServer'
@@ -186,9 +190,7 @@ export type ProviderInstance<B extends 'rspack' | 'webpack' = 'rspack'> = Pick<
     options?: InitConfigsOptions,
   ) => Promise<B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[]>;
 
-  inspectConfig: (
-    options?: InspectConfigOptions,
-  ) => Promise<InspectConfigResult<B>>;
+  inspectConfig: InspectConfig<B>;
 };
 
 export type RsbuildProviderHelpers = typeof providerHelpers;


### PR DESCRIPTION
## Summary

Ensure `inspectConfig` properly initializes `action` before execution. This allows `inspectConfig` to correctly filter based on the plugin's `apply` option and output a more accurate configuration.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
