### PR TITLE
test: fix flaky watch files case

### DIFF
--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -25,7 +25,7 @@ rspackOnlyTest(
     await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
 
     const port = await getRandomPort();
-    const childProcess = runCli('dev', {
+    const { childProcess, close } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -41,6 +41,6 @@ rspackOnlyTest(
     await writeFile(tempConfig, tsconfigContent.replace('foo', 'bar'));
     await expect(page.locator('#content')).toHaveText('bar');
 
-    childProcess.kill();
+    close();
   },
 );

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -18,7 +18,7 @@ rspackOnlyTest(
     await remove(distIndexFile);
     await fse.copy(srcDir, tempDir);
 
-    const childProcess = runCli('build --watch', {
+    const { childProcess, close } = runCli('build --watch', {
       cwd: __dirname,
     });
 
@@ -34,6 +34,6 @@ rspackOnlyTest(
     await new Promise((resolve) => setTimeout(resolve, 300));
     expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo2bar1');
 
-    childProcess.kill();
+    close();
   },
 );

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -21,7 +21,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const childProcess = runCli(`build --watch -c ${tempConfigFile}`, {
+  const { childProcess, close } = runCli(`build --watch -c ${tempConfigFile}`, {
     cwd: __dirname,
   });
 
@@ -45,5 +45,5 @@ rspackOnlyTest('should support restart build when config changed', async () => {
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await expectFileWithContent(distIndexFile, 'hello2!');
 
-  childProcess.kill();
+  close();
 });

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -10,7 +10,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const childProcess = runCli('build --watch', {
+  const { childProcess, close } = runCli('build --watch', {
     cwd: __dirname,
   });
 
@@ -20,5 +20,5 @@ rspackOnlyTest('should support watch mode for build command', async () => {
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
   await expectFileWithContent(distIndexFile, 'hello2!');
 
-  childProcess.kill();
+  close();
 });

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -29,7 +29,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const childProcess = runCli('dev', {
+    const { childProcess, close } = runCli('dev', {
       cwd: __dirname,
     });
 
@@ -52,6 +52,6 @@ rspackOnlyTest(
 
     await expectFile(dist2);
 
-    childProcess.kill();
+    close();
   },
 );

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -34,7 +34,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const devProcess = runCli('dev', {
+    const { close } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -47,6 +47,6 @@ rspackOnlyTest(
     fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
     await expectFileWithContent(distIndex, 'rose');
 
-    devProcess.kill();
+    close();
   },
 );

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest(
     await remove(dist);
     fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
 
-    const childProcess = runCli('dev', {
+    const { childProcess, close } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
@@ -34,6 +34,6 @@ rspackOnlyTest(
     await expectFile(dist);
     expect(fs.existsSync(path.join(dist, 'temp.txt')));
 
-    childProcess.kill();
+    close();
   },
 );

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,107 +1,42 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  expectFile,
-  expectFileWithContent,
-  getRandomPort,
-  rspackOnlyTest,
-  runCli,
-} from '@e2e/helper';
-import { test } from '@playwright/test';
+import { getRandomPort, gotoPage, rspackOnlyTest, runCli } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
 import { remove } from 'fs-extra';
 
-const dist = path.join(__dirname, 'dist');
-const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-const tempConfigPath = './test-temp-config.ts';
-const tempOutputFile = path.join(__dirname, 'test-temp-file.txt');
-const extraConfigFile = path.join(__dirname, tempConfigPath);
+const distIndex = path.join(__dirname, 'dist/static/js/index.js');
+const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 
 test.beforeEach(async () => {
-  await remove(dist);
-  await remove(tempOutputFile);
-  await remove(extraConfigFile);
-  fs.writeFileSync(extraConfigFile, 'export default 1;');
+  await remove(distIndex);
+  fs.writeFileSync(tempConfig, 'export default 1;');
 });
 
 rspackOnlyTest(
   'should restart dev server when extra config file changed',
-  async () => {
-    const childProcess = runCli('dev', {
+  async ({ page }) => {
+    const port = await getRandomPort();
+    const { close, clearLogs, expectLog, expectBuildEnd } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,
-        PORT: String(await getRandomPort()),
+        PORT: String(port),
         NODE_ENV: 'development',
-        WATCH_FILES_TYPE: 'reload-server',
       },
     });
 
     // the first build
-    await expectFile(distIndexFile);
-    await expectFileWithContent(tempOutputFile, '1');
+    await expectBuildEnd();
+    await gotoPage(page, { port });
+    await expect(page.locator('#test')).toHaveText('1');
 
-    await remove(tempOutputFile);
-    // temp config changed and trigger rebuild
-    fs.writeFileSync(extraConfigFile, 'export default 2;');
-
-    // rebuild and generate dist files
-    await expectFile(tempOutputFile);
-    await expectFileWithContent(tempOutputFile, '2');
-
-    childProcess.kill();
-  },
-);
-
-rspackOnlyTest(
-  'should not restart dev server if `watchFiles.type` is `reload-page`',
-  async () => {
-    const childProcess = runCli('dev', {
-      cwd: __dirname,
-      env: {
-        ...process.env,
-        PORT: String(await getRandomPort()),
-        NODE_ENV: 'development',
-        WATCH_FILES_TYPE: 'reload-page',
-      },
-    });
-
-    await expectFile(distIndexFile);
-    await expectFileWithContent(tempOutputFile, '1');
-
-    await remove(distIndexFile);
-    // temp config changed
-    fs.writeFileSync(extraConfigFile, 'export default 2;');
-
-    await expectFile(tempOutputFile);
-    await expectFileWithContent(tempOutputFile, '1');
-
-    childProcess.kill();
-  },
-);
-
-rspackOnlyTest(
-  'should not restart dev server if `watchFiles.type` is not set',
-  async () => {
-    const childProcess = runCli('dev', {
-      cwd: __dirname,
-      env: {
-        ...process.env,
-        PORT: String(await getRandomPort()),
-        NODE_ENV: 'development',
-      },
-    });
-
-    // Fix occasional 'directory not empty' error when wait and rm dist.
-    // Sometimes the dist directory exists, but the files in the dist directory have not been completely written.
-    await expectFile(distIndexFile);
-
-    await remove(distIndexFile);
-    // temp config changed
-    fs.writeFileSync(extraConfigFile, 'export default 2;');
-
-    await expectFile(tempOutputFile);
-    await expectFileWithContent(tempOutputFile, '1');
-
-    childProcess.kill();
+    // restart dev server
+    clearLogs();
+    fs.writeFileSync(tempConfig, 'export default 2;');
+    await expectLog('restarting server');
+    await expectBuildEnd();
+    await gotoPage(page, { port });
+    await expect(page.locator('#test')).toHaveText('2');
+    close();
   },
 );

--- a/e2e/cases/cli/watch-files/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files/rsbuild.config.ts
@@ -1,27 +1,16 @@
-import path from 'node:path';
-import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
-import fse from 'fs-extra';
+import { defineConfig } from '@rsbuild/core';
 import content from './test-temp-config';
 
-const testPlugin: RsbuildPlugin = {
-  name: 'test-plugin',
-  setup(api) {
-    api.onBeforeCreateCompiler(() => {
-      fse.outputFileSync(
-        path.join(__dirname, 'test-temp-file.txt'),
-        JSON.stringify(content),
-      );
-    });
-  },
-};
-
 export default defineConfig({
-  plugins: [testPlugin],
   dev: {
-    writeToDisk: true,
     watchFiles: {
-      type: process.env.WATCH_FILES_TYPE as 'reload-page' | 'reload-server',
+      type: 'reload-server',
       paths: ['./test-temp-config.ts'],
+    },
+  },
+  source: {
+    define: {
+      CONTENT: JSON.stringify(content),
     },
   },
   server: {

--- a/e2e/cases/cli/watch-files/src/index.js
+++ b/e2e/cases/cli/watch-files/src/index.js
@@ -1,1 +1,4 @@
-console.log('hello!');
+const el = document.createElement('div');
+el.id = 'test';
+el.innerHTML = CONTENT;
+document.body.appendChild(el);


### PR DESCRIPTION
## Summary

- Fix flaky watch files case
- Replacing manual child process termination with a new `close()` helper
- Enhancing the `runCli` utility to support log assertions

<img width="1008" height="521" alt="Screenshot 2025-08-16 at 16 29 42" src="https://github.com/user-attachments/assets/edb887f9-4604-4f4e-9544-356864446d9e" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
