### PR TITLE
test(e2e): fix flaky build watch case

### DIFF
--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -10,14 +10,20 @@ rspackOnlyTest('should support watch mode for build command', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const { childProcess, close } = runCli('build --watch', {
-    cwd: __dirname,
-  });
+  const { expectBuildEnd, close, clearLogs, expectLog } = runCli(
+    'build --watch',
+    {
+      cwd: __dirname,
+    },
+  );
 
+  await expectBuildEnd();
   await expectFileWithContent(distIndexFile, 'hello!');
-  await remove(distIndexFile);
+  clearLogs();
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
+  await expectLog('building src/index.js');
+  await expectBuildEnd();
   await expectFileWithContent(distIndexFile, 'hello2!');
 
   close();

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -22,7 +22,7 @@ rspackOnlyTest('should support watch mode for build command', async () => {
   clearLogs();
 
   fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await expectLog('building src/index.js');
+  await expectLog(/building src[\\/]index.js/);
   await expectBuildEnd();
   await expectFileWithContent(distIndexFile, 'hello2!');
 

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -371,7 +371,7 @@ export function runCli(command: string, options?: ExecOptions) {
 
   let logs: string[] = [];
   const onData = (data: Buffer) => {
-    logs.push(data.toString());
+    logs.push(stripAnsi(data.toString()));
   };
 
   childProcess.stdout?.on('data', onData);

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -383,8 +383,12 @@ export function runCli(command: string, options?: ExecOptions) {
     childProcess.kill();
   };
 
-  const expectLog = async (log: string) =>
-    expectPoll(() => logs.some((l) => l.includes(log))).toBeTruthy();
+  const expectLog = async (pattern: string | RegExp) =>
+    expectPoll(() =>
+      logs.some((l) =>
+        typeof pattern === 'string' ? l.includes(pattern) : pattern.test(l),
+      ),
+    ).toBeTruthy();
 
   const expectBuildEnd = async () => expectLog('built in');
 


### PR DESCRIPTION
## Summary

- Fix the flaky build watch case
- Modified the `runCli` function to strip ANSI color codes from CLI output before storing logs

<img width="1003" height="409" alt="Screenshot 2025-08-17 at 09 12 59" src="https://github.com/user-attachments/assets/fd8d96ba-6a21-41e5-80ff-159bba0436d6" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
