### PR TITLE
test(e2e): fix flaky CLI shortcuts cases

### DIFF
--- a/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/alias/tsconfig-paths-reload/index.test.ts
@@ -25,7 +25,7 @@ rspackOnlyTest(
     await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
 
     const port = await getRandomPort();
-    const { childProcess, close } = runCli('dev', {
+    const { close } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -18,7 +18,7 @@ rspackOnlyTest(
     await remove(distIndexFile);
     await fse.copy(srcDir, tempDir);
 
-    const { childProcess, close } = runCli('build --watch', {
+    const { close } = runCli('build --watch', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -21,7 +21,7 @@ rspackOnlyTest('should support restart build when config changed', async () => {
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const { childProcess, close } = runCli(`build --watch -c ${tempConfigFile}`, {
+  const { close } = runCli(`build --watch -c ${tempConfigFile}`, {
     cwd: __dirname,
   });
 

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -29,7 +29,7 @@ rspackOnlyTest(
     };`,
     );
 
-    const { childProcess, close } = runCli('dev', {
+    const { close } = runCli('dev', {
       cwd: __dirname,
     });
 

--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -1,126 +1,84 @@
-import { exec } from 'node:child_process';
-import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { expectPoll, rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest, runCommand } from '@e2e/helper';
 
 rspackOnlyTest('should display shortcuts as expected in dev', async () => {
-  const devProcess = exec('node ./dev.mjs', {
-    cwd: __dirname,
-  });
-
-  let logs: string[] = [];
-
-  devProcess.stdout?.on('data', (data) => {
-    const output = data.toString().trim();
-    logs.push(stripAnsi(output));
-  });
+  const { childProcess, expectLog, clearLogs, close } = runCommand(
+    'node ./dev.mjs',
+    {
+      cwd: __dirname,
+    },
+  );
 
   // help
-  await expectPoll(() =>
-    logs.some((log) => log.includes('press h + enter to show shortcuts')),
-  ).toBeTruthy();
-  devProcess.stdin?.write('h\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('u + enter  show urls')),
-  ).toBeTruthy();
+  await expectLog('press h + enter to show shortcuts');
+  childProcess.stdin?.write('h\n');
+  await expectLog('u + enter  show urls');
 
   // print urls
-  logs = [];
-  devProcess.stdin?.write('u\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
-  ).toBeTruthy();
+  clearLogs();
+  childProcess.stdin?.write('u\n');
+  await expectLog('➜  Local:    http://localhost:');
 
   // restart server
-  logs = [];
-  devProcess.stdin?.write('r\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('restarting server')),
-  ).toBeTruthy();
-  await expectPoll(() =>
-    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
-  ).toBeTruthy();
+  clearLogs();
+  childProcess.stdin?.write('r\n');
+  await expectLog('restarting server');
+  await expectLog('➜  Local:    http://localhost:');
 
-  devProcess.kill();
+  close();
 });
 
 rspackOnlyTest('should display shortcuts as expected in preview', async () => {
-  const devProcess = exec('node ./preview.mjs', {
-    cwd: __dirname,
-  });
-
-  let logs: string[] = [];
-
-  devProcess.stdout?.on('data', (data) => {
-    const output = data.toString().trim();
-    logs.push(stripAnsi(output));
-  });
+  const { childProcess, expectLog, clearLogs, close } = runCommand(
+    'node ./preview.mjs',
+    {
+      cwd: __dirname,
+    },
+  );
 
   // help
-  await expectPoll(() =>
-    logs.some((log) => log.includes('press h + enter to show shortcuts')),
-  ).toBeTruthy();
-  devProcess.stdin?.write('h\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('u + enter  show urls')),
-  ).toBeTruthy();
+  await expectLog('press h + enter to show shortcuts');
+  childProcess.stdin?.write('h\n');
+  await expectLog('u + enter  show urls');
 
   // print urls
-  logs = [];
-  devProcess.stdin?.write('u\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('➜  Local:    http://localhost:')),
-  ).toBeTruthy();
+  clearLogs();
+  childProcess.stdin?.write('u\n');
+  await expectLog('➜  Local:    http://localhost:');
 
-  devProcess.kill();
+  close();
 });
 
 rspackOnlyTest('should allow to custom shortcuts in dev', async () => {
-  const devProcess = exec('node ./devCustom.mjs', {
-    cwd: __dirname,
-  });
+  const { childProcess, expectLog, clearLogs, close } = runCommand(
+    'node ./devCustom.mjs',
+    {
+      cwd: __dirname,
+    },
+  );
 
-  let logs: string[] = [];
+  await expectLog('press h + enter to show shortcuts');
 
-  devProcess.stdout?.on('data', (data) => {
-    const output = data.toString().trim();
-    logs.push(stripAnsi(output));
-  });
+  clearLogs();
+  childProcess.stdin?.write('s\n');
+  await expectLog('hello world!');
 
-  await expectPoll(() =>
-    logs.some((log) => log.includes('press h + enter to show shortcuts')),
-  ).toBeTruthy();
-
-  logs = [];
-  devProcess.stdin?.write('s\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('hello world!')),
-  ).toBeTruthy();
-
-  devProcess.kill();
+  close();
 });
 
 rspackOnlyTest('should allow to custom shortcuts in preview', async () => {
-  const devProcess = exec('node ./previewCustom.mjs', {
-    cwd: __dirname,
-  });
-
-  let logs: string[] = [];
-
-  devProcess.stdout?.on('data', (data) => {
-    const output = data.toString().trim();
-    logs.push(stripAnsi(output));
-  });
+  const { childProcess, expectLog, clearLogs, close } = runCommand(
+    'node ./previewCustom.mjs',
+    {
+      cwd: __dirname,
+    },
+  );
 
   // help
-  await expectPoll(() =>
-    logs.some((log) => log.includes('press h + enter to show shortcuts')),
-  ).toBeTruthy();
+  await expectLog('press h + enter to show shortcuts');
 
-  logs = [];
-  devProcess.stdin?.write('s\n');
-  await expectPoll(() =>
-    logs.some((log) => log.includes('hello world!')),
-  ).toBeTruthy();
+  clearLogs();
+  childProcess.stdin?.write('s\n');
+  await expectLog('hello world!');
 
-  devProcess.kill();
+  close();
 });

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -16,7 +16,7 @@ rspackOnlyTest(
     await remove(dist);
     fs.writeFileSync(extraConfigFile, 'export default { foo: 1 };');
 
-    const { childProcess, close } = runCli('dev', {
+    const { close } = runCli('dev', {
       cwd: __dirname,
       env: {
         ...process.env,

--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -17,7 +17,6 @@ import type {
 import { pluginSwc } from '@rsbuild/plugin-webpack-swc';
 import type { Page } from 'playwright';
 import {
-  expectPoll,
   type ProxyConsoleOptions,
   proxyConsole,
   readDirContents,
@@ -373,8 +372,8 @@ export function runCliSync(command: string, options?: ExecSyncOptions) {
   return execSync(`node ${rsbuildBinPath} ${command}`, options);
 }
 
-export function runCli(command: string, options?: ExecOptions) {
-  const childProcess = exec(`node ${rsbuildBinPath} ${command}`, options);
+export function runCommand(command: string, options?: ExecOptions) {
+  const childProcess = exec(command, options);
 
   let logs: string[] = [];
   const logPatterns = new Set<{
@@ -441,4 +440,8 @@ export function runCli(command: string, options?: ExecOptions) {
     childProcess,
     expectBuildEnd,
   };
+}
+
+export function runCli(command: string, options?: ExecOptions) {
+  return runCommand(`node ${rsbuildBinPath} ${command}`, options);
 }


### PR DESCRIPTION
## Summary

- Fixed the flaky CLI shortcuts e2e cases.
- Added the new `runCommand` test helper.

<img width="1009" height="425" alt="cli:shotcuts2" src="https://github.com/user-attachments/assets/55e8444a-7189-4bd3-883f-1bfbda7f06b1" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
