### PR TITLE
test(e2e): simplify profile test cases by using helpers

### DIFF
--- a/e2e/scripts/shared.ts
+++ b/e2e/scripts/shared.ts
@@ -433,9 +433,12 @@ export function runCommand(command: string, options?: ExecOptions) {
     logs = [];
   };
 
+  const getLogs = () => logs;
+
   return {
     close,
     clearLogs,
+    getLogs,
     expectLog,
     childProcess,
     expectBuildEnd,


### PR DESCRIPTION
## Summary

Replace manual child process handling with `runCommand` and `runCli` helpers in the profile related e2e cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
