### PR TITLE
test: fix flaky watch-files-array e2e test case

### DIFF
--- a/e2e/cases/cli/watch-files-array/rsbuild.config.ts
+++ b/e2e/cases/cli/watch-files-array/rsbuild.config.ts
@@ -1,23 +1,8 @@
-import path from 'node:path';
-import { defineConfig, type RsbuildPlugin } from '@rsbuild/core';
-import fse from 'fs-extra';
+import { defineConfig } from '@rsbuild/core';
 import content from './test-temp-config';
-
-const testPlugin: RsbuildPlugin = {
-  name: 'test-plugin',
-  setup(api) {
-    api.onBeforeBuild(() => {
-      fse.outputFileSync(
-        path.join(api.context.distPath, 'temp.txt'),
-        JSON.stringify(content),
-      );
-    });
-  },
-};
 
 export default defineConfig({
   dev: {
-    writeToDisk: true,
     watchFiles: [
       {
         type: 'reload-page',
@@ -29,7 +14,11 @@ export default defineConfig({
       },
     ],
   },
-  plugins: [testPlugin],
+  source: {
+    define: {
+      CONTENT: JSON.stringify(content),
+    },
+  },
   server: {
     port: Number(process.env.PORT),
   },

--- a/e2e/cases/cli/watch-files-array/src/index.js
+++ b/e2e/cases/cli/watch-files-array/src/index.js
@@ -1,1 +1,4 @@
-console.log('hello!');
+const el = document.createElement('div');
+el.id = 'test';
+el.innerHTML = CONTENT;
+document.body.appendChild(el);


### PR DESCRIPTION
## Summary

Fix the flaky watch-files-array e2e test case:

<img width="1006" height="142" alt="watch-files-array3" src="https://github.com/user-attachments/assets/0d1de5da-2707-4c9f-abc8-d321b317c2e1" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5860

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
