### PR TITLE
test(e2e): simplify runtime log assertions

### DIFF
--- a/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-error-handle/index.test.ts
@@ -1,15 +1,13 @@
-import { dev, expectPoll, rspackOnlyTest } from '@e2e/helper';
+import { dev, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest('should handle transform error in dev mode', async () => {
   const rsbuild = await dev({
     cwd: __dirname,
   });
 
-  await expectPoll(() =>
-    rsbuild.logs.some(
-      (log) => log.includes('transform error') && log.includes('Build error'),
-    ),
-  ).toBeTruthy();
+  await rsbuild.expectLog(
+    (log) => log.includes('transform error') && log.includes('Build error'),
+  );
 
   await rsbuild.close();
 });

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,12 +1,12 @@
-import { dev, expectPoll } from '@e2e/helper';
+import { createLogMatcher, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
 
 test('should display type errors on overlay correctly', async ({ page }) => {
-  const logs: string[] = [];
+  const { addLog, expectLog } = createLogMatcher();
   page.on('console', (consoleMessage) => {
-    logs.push(consoleMessage.text());
+    addLog(consoleMessage.text());
   });
 
   const rsbuild = await dev({
@@ -14,12 +14,9 @@ test('should display type errors on overlay correctly', async ({ page }) => {
     page,
   });
 
-  await expectPoll(() =>
-    logs.some((log) => log.includes('TS2322:')),
-  ).toBeTruthy();
+  await expectLog('TS2322:');
 
   const errorOverlay = page.locator('rsbuild-error-overlay');
-
   await expect(errorOverlay.locator('.title')).toHaveText('Build failed');
 
   // Get "<span style="color:#888">TS2322: </span>"

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -3,23 +3,23 @@ import type { ConsoleType } from '@rsbuild/core';
 import color from 'picocolors';
 import { BUILD_END_LOG } from './constants';
 
-export type LogPattern = {
-  pattern: string | RegExp;
-  resolve: (value: boolean) => void;
-};
+type LogPattern = string | RegExp | ((log: string) => boolean);
 
-const matchPattern = (log: string, pattern: string | RegExp) => {
+const matchPattern = (log: string, pattern: LogPattern) => {
   if (typeof pattern === 'string') {
     return log.includes(pattern);
   }
-  return pattern.test(log);
+  if (pattern instanceof RegExp) {
+    return pattern.test(log);
+  }
+  return pattern(log);
 };
 
 export const createLogMatcher = () => {
   const logs: string[] = [];
 
   const logPatterns = new Set<{
-    pattern: string | RegExp;
+    pattern: LogPattern;
     resolve: (value: boolean) => void;
   }>();
 
@@ -37,7 +37,7 @@ export const createLogMatcher = () => {
     }
   };
 
-  const expectLog = async (pattern: string | RegExp) => {
+  const expectLog = async (pattern: LogPattern) => {
     if (logs.some((log) => matchPattern(log, pattern))) {
       return true;
     }


### PR DESCRIPTION
## Summary

Replace `expectPoll` with the `expectLog` helper for cleaner test assertions.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
