### PR TITLE
test(cli): fix flaky build watch options test

### DIFF
--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,8 +1,7 @@
-import fs from 'node:fs';
 import path from 'node:path';
 import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import fse, { remove } from 'fs-extra';
+import fse from 'fs-extra';
 
 rspackOnlyTest(
   'should allow to custom watch options for build watch',
@@ -13,26 +12,31 @@ rspackOnlyTest(
     const fooFile = path.join(tempDir, 'foo.js');
     const barFile = path.join(tempDir, 'bar.js');
 
-    // clean up
-    await remove(tempDir);
-    await remove(distIndexFile);
     await fse.copy(srcDir, tempDir);
 
-    const { close } = runCli('build --watch', {
-      cwd: __dirname,
-    });
+    const { logs, close, expectLog, expectBuildEnd, clearLogs } = runCli(
+      'build --watch',
+      {
+        cwd: __dirname,
+      },
+    );
 
+    await expectBuildEnd();
     await expectFileWithContent(distIndexFile, 'foo1bar1');
-    await remove(distIndexFile);
+    clearLogs();
 
     // should watch foo.js
     fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
+    await expectLog(/building test-temp-src[\\/]foo.js/);
+    await expectBuildEnd();
     await expectFileWithContent(distIndexFile, 'foo2bar1');
 
     // should not watch bar.js
     fse.outputFileSync(barFile, `export const bar = 'bar2';`);
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    expect(fs.readFileSync(distIndexFile, 'utf-8')).toContain('foo2bar1');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(
+      logs.some((log) => /building test-temp-src[\\/]bar.js/.test(log)),
+    ).toBeFalsy();
 
     close();
   },


### PR DESCRIPTION
## Summary

Fix the flaky build watch options test:

<img width="1006" height="418" alt="cli:build-watch-options" src="https://github.com/user-attachments/assets/ed28797e-d44f-454f-94c7-241272089adc" />

![cli:build-watch-options3](https://github.com/user-attachments/assets/3476a8b2-c622-454f-aadc-abc9f65e7634)


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
