### PR TITLE
test(e2e): add helper to assert no logs

### DIFF
--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect } from '@playwright/test';
 import fse from 'fs-extra';
 
 rspackOnlyTest(
@@ -14,7 +13,7 @@ rspackOnlyTest(
 
     await fse.copy(srcDir, tempDir);
 
-    const { logs, close, expectLog, expectBuildEnd, clearLogs } = runCli(
+    const { close, expectLog, expectNoLog, expectBuildEnd, clearLogs } = runCli(
       'build --watch',
       {
         cwd: __dirname,
@@ -34,9 +33,7 @@ rspackOnlyTest(
     // should not watch bar.js
     fse.outputFileSync(barFile, `export const bar = 'bar2';`);
     await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(
-      logs.some((log) => /building test-temp-src[\\/]bar.js/.test(log)),
-    ).toBeFalsy();
+    expectNoLog(/building test-temp-src[\\/]bar.js/);
 
     close();
   },

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,12 +1,10 @@
 import path from 'node:path';
 import { expectFileWithContent, rspackOnlyTest, runCli } from '@e2e/helper';
-import fse, { remove } from 'fs-extra';
+import fse from 'fs-extra';
 
 rspackOnlyTest('should support watch mode for build command', async () => {
   const indexFile = path.join(__dirname, 'src/index.js');
   const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  await remove(indexFile);
-  await remove(distIndexFile);
 
   fse.outputFileSync(indexFile, `console.log('hello!');`);
 

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -2,15 +2,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getRandomPort, gotoPage, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect } from '@playwright/test';
-import { remove } from 'fs-extra';
 
-const distIndex = path.join(__dirname, 'dist/static/js/index.js');
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 
 rspackOnlyTest(
   'should restart dev server when extra config file changed',
   async ({ page }) => {
-    await remove(distIndex);
     fs.writeFileSync(tempConfig, 'export default 1;');
 
     const port = await getRandomPort();

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -2,13 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getRandomPort, gotoPage, rspackOnlyTest, runCli } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
-import { remove } from 'fs-extra';
 
-const distIndex = path.join(__dirname, 'dist/static/js/index.js');
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 
 test.beforeEach(async () => {
-  await remove(distIndex);
   fs.writeFileSync(tempConfig, 'export default 1;');
 });
 

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -19,7 +19,7 @@ test('should generate config files in debug mode when build', async () => {
   process.env.DEBUG = 'rsbuild';
 
   const distRoot = 'dist-1';
-  const { logs, close } = await build({
+  const rsbuild = await build({
     cwd: __dirname,
     rsbuildConfig: {
       output: {
@@ -33,15 +33,12 @@ test('should generate config files in debug mode when build', async () => {
   expect(fs.existsSync(getRsbuildConfig(distRoot))).toBeTruthy();
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
-  expect(
-    logs.some((log) => log.includes('config inspection completed')),
-  ).toBeTruthy();
-
-  expect(logs.some((log) => log.includes('create compiler'))).toBeTruthy();
+  await rsbuild.expectLog('config inspection completed');
+  await rsbuild.expectLog('create compiler');
 
   delete process.env.DEBUG;
   logger.level = level;
-  await close();
+  await rsbuild.close();
 });
 
 test('should generate config files in debug mode when dev', async ({

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -32,10 +32,12 @@ const bundlerNodeConfig = path.resolve(
   `./dist/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.node.mjs`,
 );
 
+const INSPECT_LOG = 'config inspection completed';
+
 rspackOnlyTest(
   'should generate config files when writeToDisk is true',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectLog, restore } = proxyConsole();
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -46,10 +48,7 @@ rspackOnlyTest(
 
     expect(fs.existsSync(bundlerConfig)).toBeTruthy();
     expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
-
-    expect(
-      logs.some((log) => log.includes('config inspection completed')),
-    ).toBeTruthy();
+    await expectLog(INSPECT_LOG);
 
     await remove(rsbuildConfig);
     await remove(bundlerConfig);
@@ -61,7 +60,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should generate config files correctly when output is specified',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectLog, restore } = proxyConsole();
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -83,10 +82,7 @@ rspackOnlyTest(
 
     expect(fs.existsSync(bundlerConfig)).toBeTruthy();
     expect(fs.existsSync(rsbuildConfig)).toBeTruthy();
-
-    expect(
-      logs.some((log) => log.includes('config inspection completed')),
-    ).toBeTruthy();
+    await expectLog(INSPECT_LOG);
 
     await remove(rsbuildConfig);
     await remove(bundlerConfig);
@@ -98,7 +94,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should generate bundler config for node when target contains node',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectLog, restore } = proxyConsole();
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -124,10 +120,7 @@ rspackOnlyTest(
     expect(fs.existsSync(rsbuildNodeConfig)).toBeTruthy();
     expect(fs.existsSync(bundlerConfig)).toBeTruthy();
     expect(fs.existsSync(bundlerNodeConfig)).toBeTruthy();
-
-    expect(
-      logs.some((log) => log.includes('config inspection completed')),
-    ).toBeTruthy();
+    await expectLog(INSPECT_LOG);
 
     await remove(rsbuildConfig);
     await remove(rsbuildNodeConfig);
@@ -154,7 +147,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest('should allow to specify absolute output path', async () => {
-  const { logs, restore } = proxyConsole();
+  const { expectLog, restore } = proxyConsole();
 
   const rsbuild = await createRsbuild({
     cwd: __dirname,
@@ -166,9 +159,7 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
     outputPath,
   });
 
-  expect(
-    logs.some((log) => log.includes('config inspection completed')),
-  ).toBeTruthy();
+  await expectLog(INSPECT_LOG);
 
   expect(
     fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
@@ -180,7 +171,7 @@ rspackOnlyTest('should allow to specify absolute output path', async () => {
 });
 
 rspackOnlyTest('should generate extra config files', async () => {
-  const { logs, restore } = proxyConsole();
+  const { expectLog, restore } = proxyConsole();
 
   const rsbuild = await createRsbuild({
     cwd: __dirname,
@@ -200,9 +191,7 @@ rspackOnlyTest('should generate extra config files', async () => {
   );
 
   expect(fs.existsSync(rstestConfig)).toBeTruthy();
-
-  expect(logs.some((log) => log.includes('Rstest Config:'))).toBeTruthy();
-
+  await expectLog('Rstest Config:');
   await remove(rstestConfig);
 
   restore();

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -1,14 +1,14 @@
 import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
+
+const WARNING_MSG = 'Using / for division outside of calc() is deprecated';
 
 test('should log warning by default', async () => {
   const rsbuild = await build({
     cwd: __dirname,
   });
 
-  await rsbuild.expectLog(
-    'Using / for division outside of calc() is deprecated',
-  );
+  await rsbuild.expectLog(WARNING_MSG);
   await rsbuild.close();
 });
 
@@ -26,11 +26,6 @@ test('should not log warning when set stats.warnings false', async () => {
     },
   });
 
-  expect(
-    rsbuild.logs.some((log) =>
-      log.includes('Using / for division outside of calc() is deprecated'),
-    ),
-  ).toBeFalsy();
-
+  rsbuild.expectNoLog(WARNING_MSG);
   await rsbuild.close();
 });

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -1,6 +1,8 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
+const COMPILE_WARNING = 'Compile Warning';
+
 rspackOnlyTest('should allow to enable Rspack experiments.css', async () => {
   const rsbuild = await build({
     cwd: __dirname,
@@ -11,9 +13,7 @@ rspackOnlyTest('should allow to enable Rspack experiments.css', async () => {
 
   expect(content).toEqual('body{color:red}');
   // should have no warnings
-  expect(
-    rsbuild.logs.some((log) => log.includes('Compile Warning')),
-  ).toBeFalsy();
+  rsbuild.expectNoLog(COMPILE_WARNING);
 
   await rsbuild.close();
 });
@@ -36,9 +36,7 @@ rspackOnlyTest(
     expect(content).toContain('color:red');
 
     // should have no warnings
-    expect(
-      rsbuild.logs.some((log) => log.includes('Compile Warning')),
-    ).toBeFalsy();
+    rsbuild.expectNoLog(COMPILE_WARNING);
 
     await rsbuild.close();
   },

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -16,13 +16,6 @@ rspackOnlyTest('should compile common CSS import correctly', async () => {
   const files = await rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
 
-  // there will be a deprecation log for `~`.
-  expect(
-    rsbuild.logs.some((log) =>
-      log.includes(`a request starts with '~' is deprecated`),
-    ),
-  );
-
   expect(files[cssFiles]).toEqual(
     'html{min-height:100%}#a{color:red}#b{color:#00f}',
   );

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -20,9 +20,7 @@ rspackOnlyTest(
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
-    expect(
-      rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
-    ).toBeFalsy();
+    rsbuild.expectNoLog('building src/page2/index.js');
 
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');
@@ -53,9 +51,7 @@ rspackOnlyTest(
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
-    expect(
-      rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
-    ).toBeFalsy();
+    rsbuild.expectNoLog('building src/page2/index.js');
 
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');

--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -1,5 +1,5 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { test } from '@playwright/test';
 
 rspackOnlyTest(
   'should lazy compile dynamic imported modules',
@@ -13,9 +13,7 @@ rspackOnlyTest(
     });
 
     await rsbuild.expectBuildEnd();
-    expect(
-      rsbuild.logs.some((log) => log.includes('building src/foo.js')),
-    ).toBeFalsy();
+    rsbuild.expectNoLog('building src/foo.js');
 
     await gotoPage(page, rsbuild, 'index');
     await rsbuild.expectLog('building src/foo.js');

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -15,9 +15,7 @@ rspackOnlyTest(
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
-    expect(
-      rsbuild.logs.some((log) => log.includes('building src/page2/index.js')),
-    ).toBeFalsy();
+    rsbuild.expectNoLog('building src/page2/index.js');
 
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');

--- a/e2e/cases/print-file-size/with-error/index.test.ts
+++ b/e2e/cases/print-file-size/with-error/index.test.ts
@@ -15,7 +15,7 @@ test('should not print file size if has errors', async () => {
   });
 
   expect(rsbuild.buildError).toBeTruthy();
-  expect(rsbuild.logs.some((log) => log.includes('Total:'))).toBeFalsy();
+  rsbuild.expectNoLog('Total:');
 
   await rsbuild.close();
 });

--- a/e2e/cases/rsdoctor/index.test.ts
+++ b/e2e/cases/rsdoctor/index.test.ts
@@ -4,10 +4,12 @@ import { createRsbuild, type Rspack } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { matchPlugin } from '@scripts/test-helper';
 
+const RSDOCTOR_LOG = '@rsdoctor/rspack-plugin enabled';
+
 rspackOnlyTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectLog, restore } = proxyConsole();
     process.env.RSDOCTOR = 'true';
 
     const rsbuild = await createRsbuild({
@@ -16,9 +18,7 @@ rspackOnlyTest(
 
     const compiler = await rsbuild.createCompiler();
 
-    expect(
-      logs.some((log) => log.includes('@rsdoctor') && log.includes('enabled')),
-    ).toBe(true);
+    await expectLog(RSDOCTOR_LOG);
 
     expect(
       matchPlugin(
@@ -35,7 +35,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectNoLog, restore } = proxyConsole();
     process.env.RSDOCTOR = 'false';
 
     const rsbuild = await createRsbuild({
@@ -44,9 +44,7 @@ rspackOnlyTest(
 
     const compiler = await rsbuild.createCompiler();
 
-    expect(
-      logs.some((log) => log.includes('@rsdoctor') && log.includes('enabled')),
-    ).toBe(false);
+    expectNoLog(RSDOCTOR_LOG);
 
     expect(
       matchPlugin(
@@ -63,7 +61,7 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered',
   async () => {
-    const { logs, restore } = proxyConsole();
+    const { expectNoLog, restore } = proxyConsole();
 
     process.env.RSDOCTOR = 'true';
 
@@ -91,9 +89,7 @@ rspackOnlyTest(
       ),
     ).toBeTruthy();
 
-    expect(
-      logs.some((log) => log.includes('@rsdoctor') && log.includes('enabled')),
-    ).toBe(false);
+    expectNoLog(RSDOCTOR_LOG);
 
     process.env.RSDOCTOR = '';
     restore();

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,10 +1,10 @@
-import { createLogMatcher, dev } from '@e2e/helper';
+import { createLogHelper, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
 
 test('should display type errors on overlay correctly', async ({ page }) => {
-  const { addLog, expectLog } = createLogMatcher();
+  const { addLog, expectLog } = createLogHelper();
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());
   });

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { createLogMatcher, dev } from '@e2e/helper';
+import { createLogHelper, dev } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
@@ -15,7 +15,7 @@ test('should show overlay correctly', async ({ page }) => {
     recursive: true,
   });
 
-  const { expectLog, addLog } = createLogMatcher();
+  const { expectLog, addLog } = createLogHelper();
 
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());

--- a/e2e/helper/cli.ts
+++ b/e2e/helper/cli.ts
@@ -5,7 +5,7 @@ import {
   execSync,
 } from 'node:child_process';
 import { RSBUILD_BIN_PATH } from './constants';
-import { createLogMatcher } from './logs';
+import { createLogHelper } from './logs';
 
 /**
  * Synchronously run the Rsbuild CLI with the given command.
@@ -20,11 +20,10 @@ export function runCliSync(command: string, options?: ExecSyncOptions) {
 export function runCommand(command: string, options?: ExecOptions) {
   const childProcess = exec(command, options);
 
-  const { addLog, clearLogs, expectLog, expectBuildEnd, logs } =
-    createLogMatcher();
+  const logHelper = createLogHelper();
 
   const onData = (data: Buffer) => {
-    addLog(data.toString());
+    logHelper.addLog(data.toString());
   };
 
   childProcess.stdout?.on('data', onData);
@@ -37,12 +36,9 @@ export function runCommand(command: string, options?: ExecOptions) {
   };
 
   return {
-    logs,
+    ...logHelper,
     close,
-    clearLogs,
-    expectLog,
     childProcess,
-    expectBuildEnd,
   };
 }
 

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -106,7 +106,7 @@ export async function dev({
 }) {
   process.env.NODE_ENV = 'development';
 
-  const logHelpers = proxyConsole();
+  const logHelper = proxyConsole();
 
   options.rsbuildConfig = await updateConfigForTest(
     options.rsbuildConfig || {},
@@ -136,13 +136,13 @@ export async function dev({
 
   return {
     ...result,
-    ...logHelpers,
+    ...logHelper,
     instance: rsbuild,
     getDistFiles: (ignoreMap?: boolean) =>
       getDistFiles(rsbuild.context.distPath, ignoreMap),
     close: async () => {
       await result.server.close();
-      logHelpers.restore();
+      logHelper.restore();
     },
   };
 }
@@ -181,7 +181,7 @@ export async function build({
 }) {
   process.env.NODE_ENV = 'production';
 
-  const logHelpers = proxyConsole();
+  const logHelper = proxyConsole();
 
   options.rsbuildConfig = await updateConfigForTest(
     options.rsbuildConfig || {},
@@ -236,13 +236,13 @@ export async function build({
   }
 
   return {
-    ...logHelpers,
+    ...logHelper,
     distPath,
     port,
     close: async () => {
       await closeBuild?.();
       await server.close();
-      logHelpers.restore();
+      logHelper.restore();
     },
     buildError,
     getDistFiles: (ignoreMap?: boolean) => getDistFiles(distPath, ignoreMap),


### PR DESCRIPTION
## Summary

- Replace manual log checks with `expectLog` and `expectNoLog` helper methods
- Clean up test setup code by removing unnecessary file deletions
- Rename `createLogMatcher` to `createLogHelper` for clarity

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
