### PR TITLE
test(e2e): improve lazy compilation cases

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,6 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
+const BUILD_PAGE1 = 'building src/page1/index.js';
+const BUILD_PAGE2 = 'building src/page2/index.js';
+
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
@@ -23,15 +26,15 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog('building src/page2/index.js');
+    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();
@@ -62,15 +65,15 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog('building src/page2/index.js');
+    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -17,15 +17,23 @@ rspackOnlyTest(
       },
     });
 
+    // the first build
+    await rsbuild.expectBuildEnd();
+    rsbuild.clearLogs();
+
+    // build page1
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectBuildEnd();
     rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.clearLogs();
 
+    // build page2
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
-
+    await rsbuild.expectBuildEnd();
     await rsbuild.close();
   },
 );
@@ -48,15 +56,23 @@ rspackOnlyTest(
       },
     });
 
+    // the first build
+    await rsbuild.expectBuildEnd();
+    rsbuild.clearLogs();
+
+    // build page1
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectBuildEnd();
     rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.clearLogs();
 
+    // build page2
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
-
+    await rsbuild.expectBuildEnd();
     await rsbuild.close();
   },
 );

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -23,17 +23,17 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 1');
     rsbuild.expectNoLog('building src/page2/index.js');
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();
   },
 );
@@ -62,17 +62,17 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 1');
     rsbuild.expectNoLog('building src/page2/index.js');
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();
   },
 );

--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -12,11 +12,15 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
+    // the first build
     await rsbuild.expectBuildEnd();
     rsbuild.expectNoLog('building src/foo.js');
+    rsbuild.clearLogs();
 
+    // build foo.js
     await gotoPage(page, rsbuild, 'index');
     await rsbuild.expectLog('building src/foo.js');
+    await rsbuild.expectBuildEnd();
     await rsbuild.close();
   },
 );

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,6 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
+const BUILD_PAGE1 = 'building src/page1/index.js';
+const BUILD_PAGE2 = 'building src/page2/index.js';
+
 rspackOnlyTest(
   'should replace port placeholder with actual port',
   async ({ page }) => {
@@ -18,15 +21,15 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog('building src/page2/index.js');
+    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -12,14 +12,23 @@ rspackOnlyTest(
       cwd: __dirname,
     });
 
+    // the first build
+    await rsbuild.expectBuildEnd();
+    rsbuild.clearLogs();
+
+    // build page1
     await gotoPage(page, rsbuild, 'page1');
     await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
+    await rsbuild.expectBuildEnd();
     rsbuild.expectNoLog('building src/page2/index.js');
+    rsbuild.clearLogs();
 
+    // build page2
     await gotoPage(page, rsbuild, 'page2');
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
+    await rsbuild.expectBuildEnd();
     await rsbuild.close();
   },
 );

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -18,17 +18,17 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await expect(page.locator('#test')).toHaveText('Page 1');
     await rsbuild.expectLog('building src/page1/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 1');
     rsbuild.expectNoLog('building src/page2/index.js');
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.expectLog('building src/page2/index.js');
     await rsbuild.expectBuildEnd();
+    await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();
   },
 );


### PR DESCRIPTION
## Summary

Improves the reliability and clarity of several lazy compilation e2e tests by ensuring that build completion is explicitly awaited after navigation events, and by clearing build logs between test steps.

This should reduce the chance of panic in lazy compilation cases. I guess we need to wait for the last build to finish before closing the compiler, otherwise the worker process may exit incorrectly.

<img width="1016" height="117" alt="lazy-compilation2" src="https://github.com/user-attachments/assets/6c2f213c-670a-424f-b290-e2bbe4d1d0c8" />

<img width="1003" height="119" alt="lazy-compilation7" src="https://github.com/user-attachments/assets/eb8f45e7-d4e6-4d0f-a548-bbc34d5d046c" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
