### PR TITLE
feat(core): expose modifyEnvironmentConfig method in instance

### DIFF
--- a/e2e/cases/javascript-api/instance-api/index.test.ts
+++ b/e2e/cases/javascript-api/instance-api/index.test.ts
@@ -16,3 +16,22 @@ rspackOnlyTest(
     expect(result.origin.rsbuildConfig.mode).toBe('none');
   },
 );
+
+rspackOnlyTest(
+  'should allow to call `modifyEnvironmentConfig` via Rsbuild instance',
+  async () => {
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+    rsbuild.modifyRsbuildConfig((config) => {
+      config.mode = 'development';
+    });
+    rsbuild.modifyEnvironmentConfig((config) => {
+      config.mode = 'none';
+    });
+
+    const result = await rsbuild.inspectConfig();
+    expect(result.origin.rsbuildConfig.mode).toBe('development');
+    expect(result.origin.environmentConfigs.web.mode).toBe('none');
+  },
+);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -308,6 +308,7 @@ export async function createRsbuild(
       'context',
       'getRsbuildConfig',
       'getNormalizedConfig',
+      'modifyEnvironmentConfig',
       'modifyRsbuildConfig',
       'onCloseBuild',
       'onBeforeBuild',

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -318,6 +318,7 @@ export type RsbuildInstance = {
   | 'getNormalizedConfig'
   | 'getRsbuildConfig'
   | 'isPluginExists'
+  | 'modifyEnvironmentConfig'
   | 'modifyRsbuildConfig'
   | 'onAfterBuild'
   | 'onAfterCreateCompiler'

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -1043,3 +1043,19 @@ rsbuild.modifyRsbuildConfig((config) => {
   config.html.title = 'My Default Title';
 });
 ```
+
+## rsbuild.modifyEnvironmentConfig
+
+> Provides the same functionality as the [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig) plugin API.
+
+- **Version：** Added in v1.5.0
+- **Example：**
+
+```ts
+rsbuild.modifyEnvironmentConfig((config, { name }) => {
+  if (name !== 'web') {
+    return config;
+  }
+  config.html.title = 'My Default Title';
+});
+```

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -1065,3 +1065,19 @@ rsbuild.modifyRsbuildConfig((config) => {
   config.html.title = 'My Default Title';
 });
 ```
+
+## rsbuild.modifyEnvironmentConfig
+
+> 功能与 [modifyEnvironmentConfig](/plugins/dev/hooks#modifyenvironmentconfig) 插件 API 一致。
+
+- **版本：** 添加于 v1.5.0
+- **示例：**
+
+```ts
+rsbuild.modifyEnvironmentConfig((config, { name }) => {
+  if (name !== 'web') {
+    return config;
+  }
+  config.html.title = 'My Default Title';
+});
+```


### PR DESCRIPTION
## Summary

Expose the `modifyEnvironmentConfig` plugin API in the Rsbuild instance.

This allows upper-level tools like Rslib or Rstest to more easily add some configuration merging logic.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
