### PR TITLE
refactor: improve debug log messages for better clarity

### DIFF
--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -34,7 +34,7 @@ test('should generate config files in debug mode when build', async () => {
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   await rsbuild.expectLog('config inspection completed');
-  await rsbuild.expectLog('create compiler');
+  await rsbuild.expectLog('creating compiler');
 
   delete process.env.DEBUG;
   logger.level = level;
@@ -65,7 +65,7 @@ test('should generate config files in debug mode when dev', async ({
   expect(fs.existsSync(getBundlerConfig(distRoot))).toBeTruthy();
 
   await rsbuild.expectLog('config inspection completed');
-  await rsbuild.expectLog('create compiler');
+  await rsbuild.expectLog('creating compiler');
 
   delete process.env.DEBUG;
   logger.level = level;

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -3,7 +3,7 @@ import WebpackMultiStats from 'webpack/lib/MultiStats.js';
 import { type InitConfigsOptions, initConfigs } from './initConfigs.js';
 
 export async function createCompiler(options: InitConfigsOptions) {
-  logger.debug('create compiler');
+  logger.debug('creating compiler');
   const { helpers, context } = options;
   const { webpackConfigs } = await initConfigs(options);
 
@@ -58,7 +58,7 @@ export async function createCompiler(options: InitConfigsOptions) {
     compiler,
     environments: context.environments,
   });
-  logger.debug('create compiler done');
+  logger.debug('compiler created');
 
   return {
     compiler,

--- a/packages/core/src/configChain.ts
+++ b/packages/core/src/configChain.ts
@@ -6,7 +6,7 @@ export async function modifyBundlerChain(
   context: InternalContext,
   utils: ModifyBundlerChainUtils,
 ): Promise<RspackChain> {
-  logger.debug('modify bundler chain');
+  logger.debug('applying modifyBundlerChain hook');
 
   const bundlerChain = new RspackChain();
 
@@ -22,7 +22,7 @@ export async function modifyBundlerChain(
     }
   }
 
-  logger.debug('modify bundler chain done');
+  logger.debug('applied modifyBundlerChain hook');
 
   return modifiedBundlerChain;
 }

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -193,9 +193,9 @@ export async function createRsbuild(
   context.getPluginAPI = getPluginAPI;
   const globalPluginAPI = getPluginAPI();
 
-  logger.debug('add default plugins');
+  logger.debug('registering default plugins');
   applyDefaultPlugins(pluginManager, context);
-  logger.debug('add default plugins done');
+  logger.debug('default plugins registered');
 
   const provider = (config.provider as RsbuildProvider) || rspackProvider;
 

--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -209,7 +209,7 @@ export async function loadConfig({
     );
   }
 
-  logger.debug('loaded config file:', configFilePath);
+  logger.debug('configuration loaded from:', configFilePath);
 
   return {
     content: applyMetaInfo(configExport),

--- a/packages/core/src/pluginManager.ts
+++ b/packages/core/src/pluginManager.ts
@@ -255,7 +255,7 @@ export async function initPlugins({
   context: InternalContext;
   pluginManager: PluginManager;
 }): Promise<void> {
-  logger.debug('init plugins');
+  logger.debug('initializing plugins');
 
   let plugins = pluginManager.getAllPluginsWithMeta();
   plugins = sortPluginsByEnforce(plugins);
@@ -316,5 +316,5 @@ export async function initPlugins({
     await setup(context.getPluginAPI!(environment));
   }
 
-  logger.debug('init plugins done');
+  logger.debug('plugins initialized');
 }

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -78,7 +78,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
   compiler: Rspack.Compiler | Rspack.MultiCompiler;
   rspackConfigs: Rspack.Configuration[];
 }> {
-  logger.debug('create compiler');
+  logger.debug('creating compiler');
   const { context } = options;
   const { rspackConfigs } = await initConfigs(options);
 
@@ -105,7 +105,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
   const logRspackVersion = () => {
     if (!isVersionLogged) {
-      logger.debug(`use Rspack v${rspack.rspackVersion}`);
+      logger.debug(`using Rspack v${rspack.rspackVersion}`);
       isVersionLogged = true;
     }
   };
@@ -196,7 +196,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     compiler,
     environments: context.environments,
   });
-  logger.debug('create compiler done');
+  logger.debug('compiler created');
 
   return {
     compiler,

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -35,7 +35,7 @@ const allowedEnvironmentDevKeys: AllowedEnvironmentDevKeys[] = [
 ];
 
 async function modifyRsbuildConfig(context: InternalContext) {
-  logger.debug('modify Rsbuild config');
+  logger.debug('applying modifyRsbuildConfig hook');
 
   const pluginsCount = context.config.plugins?.length ?? 0;
   const [modified] = await context.hooks.modifyRsbuildConfig.callChain(
@@ -53,7 +53,7 @@ async function modifyRsbuildConfig(context: InternalContext) {
     );
   }
 
-  logger.debug('modify Rsbuild config done');
+  logger.debug('applied modifyRsbuildConfig hook');
 }
 
 async function modifyEnvironmentConfig(
@@ -61,7 +61,7 @@ async function modifyEnvironmentConfig(
   config: MergedEnvironmentConfig,
   name: string,
 ) {
-  logger.debug(`modify Rsbuild environment(${name}) config`);
+  logger.debug(`applying modifyEnvironmentConfig hook (${name})`);
 
   const [modified] = await context.hooks.modifyEnvironmentConfig.callChain({
     environment: name,
@@ -75,7 +75,7 @@ async function modifyEnvironmentConfig(
     ],
   });
 
-  logger.debug(`modify Rsbuild environment(${name}) config done`);
+  logger.debug(`applied modifyEnvironmentConfig hook (${name})`);
 
   return modified;
 }

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -56,7 +56,7 @@ async function modifyRspackConfig(
     });
   }
 
-  logger.debug('applied `modifyRspackConfig` hook');
+  logger.debug('applied modifyRspackConfig hook');
   return currentConfig;
 }
 

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -23,7 +23,7 @@ async function modifyRspackConfig(
   rspackConfig: Rspack.Configuration,
   chainUtils: ModifyChainUtils,
 ) {
-  logger.debug('modify Rspack config');
+  logger.debug('applying modifyRspackConfig hook');
 
   let currentConfig = rspackConfig;
 
@@ -56,7 +56,7 @@ async function modifyRspackConfig(
     });
   }
 
-  logger.debug('modify Rspack config done');
+  logger.debug('applied `modifyRspackConfig` hook');
   return currentConfig;
 }
 

--- a/website/docs/en/guide/debug/debug-mode.mdx
+++ b/website/docs/en/guide/debug/debug-mode.mdx
@@ -20,9 +20,9 @@ In debug mode, you will see some logs in the terminal starting with `rsbuild`, i
 $ DEBUG=rsbuild pnpm dev
 
   ...
-  rsbuild init plugins
-  rsbuild init plugins done
-  rsbuild use Rspack v1.0.0
+  rsbuild 10:00:00 configuration loaded from: /path/to/...
+  rsbuild 10:00:00 registering default plugins
+  rsbuild 10:00:00 default plugins registered
   ...
 ```
 

--- a/website/docs/en/guide/faq/features.mdx
+++ b/website/docs/en/guide/faq/features.mdx
@@ -58,9 +58,9 @@ You can enable the debug mode of Rsbuild by adding the `DEBUG=rsbuild` environme
 ➜ DEBUG=rsbuild pnpm dev
 
   ...
-  rsbuild init plugins
-  rsbuild init plugins done
-  rsbuild use Rspack v1.0.0
+  rsbuild 10:00:00 configuration loaded from: /path/to/...
+  rsbuild 10:00:00 registering default plugins
+  rsbuild 10:00:00 default plugins registered
   ...
 
 config inspection completed, generated files:

--- a/website/docs/zh/guide/debug/debug-mode.mdx
+++ b/website/docs/zh/guide/debug/debug-mode.mdx
@@ -20,9 +20,9 @@ DEBUG=rsbuild pnpm build
 $ DEBUG=rsbuild pnpm dev
 
   ...
-  rsbuild init plugins
-  rsbuild init plugins done
-  rsbuild use Rspack v1.0.0
+  rsbuild 10:00:00 configuration loaded from: /path/to/...
+  rsbuild 10:00:00 registering default plugins
+  rsbuild 10:00:00 default plugins registered
   ...
 ```
 

--- a/website/docs/zh/guide/faq/features.mdx
+++ b/website/docs/zh/guide/faq/features.mdx
@@ -58,9 +58,9 @@ Rsbuild 默认提供了移除 console 的配置项，请查看 [performance.remo
 ➜ DEBUG=rsbuild pnpm dev
 
   ...
-  rsbuild init plugins
-  rsbuild init plugins done
-  rsbuild use Rspack v1.0.0
+  rsbuild 10:00:00 configuration loaded from: /path/to/...
+  rsbuild 10:00:00 registering default plugins
+  rsbuild 10:00:00 default plugins registered
   ...
 
 config inspection completed, generated files:


### PR DESCRIPTION
## Summary

- update debug log messages across core modules to be more descriptive and consistent
- update documentation examples to reflect new debug log format

```bash
➜  DEBUG=rsbuild pnpm dev

  rsbuild 10:49:23 configuration loaded from: /path/to/rsbuild.config.ts
  rsbuild 10:49:23 registering default plugins
  rsbuild 10:49:23 default plugins registered
  rsbuild 10:49:23 initializing plugins
  rsbuild 10:49:23 plugins initialized
  rsbuild 10:49:23 applying modifyRsbuildConfig hook
  rsbuild 10:49:23 applied modifyRsbuildConfig hook
  rsbuild 10:49:23 applying modifyEnvironmentConfig hook (web)
  rsbuild 10:49:23 applied modifyEnvironmentConfig hook (web)
  rsbuild 10:49:23 create dev server
  rsbuild 10:49:23 creating compiler
  rsbuild 10:49:23 applying modifyBundlerChain hook
  rsbuild 10:49:23 applied modifyBundlerChain hook
  rsbuild 10:49:23 applying modifyRspackConfig hook
  rsbuild 10:49:23 applied modifyRspackConfig hook
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
