### PR TITLE
docs: add code examples for html tags config options

### DIFF
--- a/website/docs/en/config/html/tags.mdx
+++ b/website/docs/en/config/html/tags.mdx
@@ -207,6 +207,20 @@ Controls whether to insert the tag after existing tags.
 - `true`: Insert after existing tags
 - `false`: Insert before existing tags
 
+```ts title="rsbuild.config.ts"
+export default {
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: { src: 'https://example.com/script.js' },
+        append: false,
+      },
+    ],
+  },
+};
+```
+
 See [Injection position](#injection-position) for more details.
 
 ### head
@@ -218,6 +232,20 @@ Specifies whether to inject the tag into the HTML `<head>` element.
 
 - `true`: Inject into `<head>`
 - `false`: Inject into `<body>`
+
+```ts title="rsbuild.config.ts"
+export default {
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: { src: 'https://example.com/script.js' },
+        head: false,
+      },
+    ],
+  },
+};
+```
 
 For elements allowed in the `<head>`, the default is `true`; for other elements, the default is `false`.
 

--- a/website/docs/zh/config/html/tags.mdx
+++ b/website/docs/zh/config/html/tags.mdx
@@ -207,6 +207,20 @@ export default {
 - `true`：在现有标签之后插入
 - `false`：在现有标签之前插入
 
+```ts title="rsbuild.config.ts"
+export default {
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: { src: 'https://example.com/script.js' },
+        append: false,
+      },
+    ],
+  },
+};
+```
+
 查看 [插入位置](#插入位置) 了解更多。
 
 ### head
@@ -218,6 +232,20 @@ export default {
 
 - `true`：注入到 `<head>` 中
 - `false`：注入到 `<body>` 中
+
+```ts title="rsbuild.config.ts"
+export default {
+  html: {
+    tags: [
+      {
+        tag: 'script',
+        attrs: { src: 'https://example.com/script.js' },
+        head: false,
+      },
+    ],
+  },
+};
+```
 
 对于允许包含在 `<head>` 中的元素，默认值为 `true`；其他元素默认值为 `false`。
 


### PR DESCRIPTION
## Summary

Add usage examples for the `append` and `head` options in the HTML tags configuration documentation to improve clarity.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
