### PR TITLE
docs(plugin-svgr): add note about default exportType with mixedImport

### DIFF
--- a/website/docs/en/plugins/list/plugin-svgr.mdx
+++ b/website/docs/en/plugins/list/plugin-svgr.mdx
@@ -241,6 +241,10 @@ console.log(logoUrl); // -> string
 console.log(Logo); // -> React component
 ```
 
+:::tip
+When `mixedImport` is enabled, `svgrOptions.exportType` defaults to `'named'` if not explicitly configured.
+:::
+
 #### Limitations
 
 It is recommended to use `?react` to transform SVG to React component instead of using mixed import. Because mixed import has the following limitations:

--- a/website/docs/zh/plugins/list/plugin-svgr.mdx
+++ b/website/docs/zh/plugins/list/plugin-svgr.mdx
@@ -241,6 +241,10 @@ console.log(logoUrl); // -> string
 console.log(Logo); // -> React component
 ```
 
+:::tip
+启用 `mixedImport` 后，如果没有显式设置 `svgrOptions.exportType`，则默认值为 `'named'`。
+:::
+
 #### 局限性
 
 建议优先使用 `?react` 来将 SVG 转换为 React 组件，而不是使用混合导入。因为混合导入有如下局限性：


### PR DESCRIPTION
## Summary

Add documentation tip clarifying the default behavior of `svgrOptions.exportType` when `mixedImport` is enabled.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
