### PR TITLE
docs: add exclude option to `printFileSize` type

### DIFF
--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -10,6 +10,7 @@ type PrintFileSizeOptions =
       detail?: boolean;
       compressed?: boolean;
       include?: (asset: PrintFileSizeAsset) => boolean;
+      exclude?: (asset: PrintFileSizeAsset) => boolean;
     };
 ```
 

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -10,6 +10,7 @@ type PrintFileSizeOptions =
       detail?: boolean;
       compressed?: boolean;
       include?: (asset: PrintFileSizeAsset) => boolean;
+      exclude?: (asset: PrintFileSizeAsset) => boolean;
     };
 ```
 


### PR DESCRIPTION
## Summary

Adds the `exclude` option to the `PrintFileSizeOptions` type of `performance.printFileSize` configration.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
