### PR TITLE
fix: add `OnDevCompileDoneFn` type for backward compatibility

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -135,6 +135,7 @@ export type {
   OnBeforeStartProdServerFn,
   OnCloseBuildFn,
   OnCloseDevServerFn,
+  OnDevCompileDoneFn,
   OnExitFn,
   OutputConfig,
   OutputStructure,

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -68,6 +68,11 @@ export type OnAfterDevCompileFn = (params: {
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
+/**
+ * @deprecated Use `OnAfterDevCompileFn` instead.
+ */
+export type OnDevCompileDoneFn = OnAfterDevCompileFn;
+
 export type OnBeforeStartDevServerFn = (params: {
   /**
    * The dev server instance, the same as the return value of `createDevServer`.

--- a/website/docs/zh/api/javascript-api/types.mdx
+++ b/website/docs/zh/api/javascript-api/types.mdx
@@ -140,7 +140,7 @@ import type { InspectConfigOptions } from '@rsbuild/core';
 
 ## Rspack
 
-包含 `@rspack/core` 导出的所有类型，比如 `Rspack.Configuration`
+包含 `@rspack/core` 导出的所有类型，比如 `Rspack.Configuration`。
 
 ```ts
 import type { Rspack } from '@rsbuild/core';


### PR DESCRIPTION
## Summary

Add the deprecated `OnDevCompileDoneFn` type alias to maintain backward compatibility.

Fix the ecosystem CI: https://github.com/rspack-contrib/rsbuild-ecosystem-ci/actions/runs/17115980695/job/48546866958#step:7:10790

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5882

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
