### PR TITLE
docs(config): add security warning about source maps in production

### DIFF
--- a/website/docs/en/config/output/source-map.mdx
+++ b/website/docs/en/config/output/source-map.mdx
@@ -94,6 +94,10 @@ export default {
 };
 ```
 
+:::warning
+Do not deploy source maps (`.map` files) to the public web server or CDN when using values such as `source-map` or `hidden-source-map` in production builds. Public source maps will expose your source code and may bring security risks.
+:::
+
 ## CSS source map
 
 The source map for CSS files is controlled by `sourceMap.css`. Setting it to `true` will enable the source map, while setting it to `false` will disable it.

--- a/website/docs/zh/config/output/source-map.mdx
+++ b/website/docs/zh/config/output/source-map.mdx
@@ -94,6 +94,10 @@ export default {
 };
 ```
 
+:::warning
+在生产构建中使用 `source-map` 或 `hidden-source-map` 等选项时，请勿将 source maps (`.map` 文件) 部署到公开访问的 Web 服务器或 CDN 上。公开 source maps 会暴露你的源代码，并且可能带来安全风险。
+:::
+
 ## CSS source map
 
 CSS 文件的 source map 通过 `sourceMap.css` 来控制，设置为 `true` 为开启，设置为 `false` 为关闭。


### PR DESCRIPTION
## Summary

Add warning about the risks of deploying source maps to public servers in production builds. The warning explains that this could expose source code and create security vulnerabilities.

## Related Links

- https://rspack.rs/config/devtool#production

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
