### PR TITLE
docs: add onAfterDevCompile, mark onDevCompileDone as deprecated

### DIFF
--- a/website/docs/en/api/javascript-api/environment-api.mdx
+++ b/website/docs/en/api/javascript-api/environment-api.mdx
@@ -176,7 +176,7 @@ api.onAfterBuild(({ environments }) => {
   console.log(environments.web.manifest);
 });
 
-api.onDevCompileDone(({ environments }) => {
+api.onAfterDevCompile(({ environments }) => {
   console.log(environments.web.manifest);
 });
 
@@ -191,7 +191,7 @@ The manifest data is only available after the build has completed, you can acces
 - [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
 - [onCloseBuild](/plugins/dev/hooks#onclosebuild)
 - [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
-- [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
+- [onAfterDevCompile](/plugins/dev/hooks#onafterdevcompile)
 - [onExit](/plugins/dev/hooks#onexit)
 
 ### webSocketToken

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -960,18 +960,18 @@ rsbuild.onBeforeDevCompile(({ bundlerConfigs }) => {
 });
 ```
 
-## rsbuild.onDevCompileDone
+## rsbuild.onAfterDevCompile
 
-> Provides the same functionality as the [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone) plugin hook.
+> Provides the same functionality as the [onAfterDevCompile](/plugins/dev/hooks#onafterdevcompile) plugin hook.
 
-import OnDevCompileDone from '@en/shared/onDevCompileDone.mdx';
+import OnAfterDevCompile from '@en/shared/onAfterDevCompile.mdx';
 
-<OnDevCompileDone />
+<OnAfterDevCompile />
 
 - **Example:**
 
 ```ts
-rsbuild.onDevCompileDone(({ isFirstCompile }) => {
+rsbuild.onAfterDevCompile(({ isFirstCompile }) => {
   if (isFirstCompile) {
     console.log('first compile!');
   } else {
@@ -979,6 +979,10 @@ rsbuild.onDevCompileDone(({ isFirstCompile }) => {
   }
 });
 ```
+
+## rsbuild.onDevCompileDone
+
+Deprecated. This hook has the same functionality as [onAfterDevCompile](#onafterdevcompile). Please consider using `onAfterDevCompile` instead (added in v1.5.0).
 
 ## rsbuild.onExit
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -226,12 +226,12 @@ const myPlugin = () => ({
 });
 ```
 
-For some global plugin hooks (such as [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver), etc.), Rsbuild supports obtaining the context of all environments through the `environments` parameter.
+For some global plugin hooks (such as [onAfterDevCompile](/plugins/dev/hooks#onafterdevcompile), [onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver), etc.), Rsbuild supports obtaining the context of all environments through the `environments` parameter.
 
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onDevCompileDone(({ environments }) => {
+    api.onAfterDevCompile(({ environments }) => {
       environments.forEach((environment) => {
         console.log('environment', environment);
       });

--- a/website/docs/en/plugins/dev/hooks.mdx
+++ b/website/docs/en/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@ Called only when running the `rsbuild dev` command or the `rsbuild.startDevServe
 - [onBeforeStartDevServer](#onbeforestartdevserver): Called before starting the dev server.
 - [onAfterStartDevServer](#onafterstartdevserver): Called after starting the dev server.
 - [onBeforeDevCompile](#onbeforedevcompile): Called before each build in development mode.
-- [onDevCompileDone](#ondevcompiledone): Called after each build in development mode.
+- [onAfterDevCompile](#onafterdevcompile): Called after each build in development mode.
 
 Called only when Rsbuild is restarted or when the [close()](/api/javascript-api/instance#close-server) method of `rsbuild.startDevServer()` is executed.
 
@@ -68,7 +68,7 @@ When the `rsbuild dev` command or `rsbuild.startDevServer()` method is executed,
 - [modifyHTMLTags](#modifyhtmltags)
 - [modifyHTML](#modifyhtml)
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 - [onCloseDevServer](#onclosedevserver)
 - [onExit](#onexit)
 
@@ -79,7 +79,7 @@ When rebuilding, the following hooks will be triggered again:
 - [modifyHTMLTags](#modifyhtmltags)
 - [modifyHTML](#modifyhtml)
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 
 ### Build hooks
 
@@ -136,7 +136,7 @@ Correspondingly, there are some plugin hooks that are related to the current env
 - [onAfterCreateCompiler](#onaftercreatecompiler)
 - [onAfterStartDevServer](#onafterstartdevserver)
 - [onBeforeDevCompile](#onbeforedevcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 - [onCloseDevServer](#onclosedevserver)
 - [onBeforeBuild](#onbeforebuild)
 - [onAfterBuild](#onafterbuild)
@@ -891,18 +891,19 @@ const myPlugin = () => ({
 });
 ```
 
-### onDevCompileDone
+### onAfterDevCompile
 
-import OnDevCompileDone from '@en/shared/onDevCompileDone.mdx';
+import OnAfterDevCompile from '@en/shared/onAfterDevCompile.mdx';
 
-<OnDevCompileDone />
+<OnAfterDevCompile />
 
+- **Version:** Added in v1.5.0
 - **Example:**
 
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onDevCompileDone(({ isFirstCompile }) => {
+    api.onAfterDevCompile(({ isFirstCompile }) => {
       if (isFirstCompile) {
         console.log('first compile!');
       } else {
@@ -912,6 +913,10 @@ const myPlugin = () => ({
   },
 });
 ```
+
+### onDevCompileDone
+
+Deprecated. This hook has the same functionality as [onAfterDevCompile](#onafterdevcompile). Please consider using `onAfterDevCompile` instead (added in v1.5.0).
 
 ### onCloseDevServer
 

--- a/website/docs/en/shared/onAfterDevCompile.mdx
+++ b/website/docs/en/shared/onAfterDevCompile.mdx
@@ -3,7 +3,7 @@ Called after each development mode build, you can use `isFirstCompile` to determ
 - **Type:**
 
 ```ts
-function OnDevCompileDone(
+function OnAfterDevCompile(
   callback: (params: {
     isFirstCompile: boolean;
     stats: Stats | MultiStats;

--- a/website/docs/zh/api/javascript-api/environment-api.mdx
+++ b/website/docs/zh/api/javascript-api/environment-api.mdx
@@ -177,7 +177,7 @@ api.onAfterBuild(({ environments }) => {
   console.log(environments.web.manifest);
 });
 
-api.onDevCompileDone(({ environments }) => {
+api.onAfterDevCompile(({ environments }) => {
   console.log(environments.web.manifest);
 });
 
@@ -192,7 +192,7 @@ manifest 数据仅在构建完成后才能被访问，你可以在以下 hooks �
 - [onAfterEnvironmentCompile](/plugins/dev/hooks#onafterenvironmentcompile)
 - [onCloseBuild](/plugins/dev/hooks#onclosebuild)
 - [onCloseDevServer](/plugins/dev/hooks#onclosedevserver)
-- [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)
+- [onAfterDevCompile](/plugins/dev/hooks#onafterdevcompile)
 - [onExit](/plugins/dev/hooks#onexit)
 
 ### webSocketToken

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -982,18 +982,19 @@ rsbuild.onBeforeDevCompile(({ bundlerConfigs }) => {
 });
 ```
 
-## rsbuild.onDevCompileDone
+## rsbuild.onAfterDevCompile
 
-> 功能与 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone) 插件 hook 一致。
+> 功能与 [onAfterDevCompile](/plugins/dev/hooks#onafterdevcompile) 插件 hook 一致。
 
-import OnDevCompileDone from '@zh/shared/onDevCompileDone.mdx';
+import OnAfterDevCompile from '@zh/shared/onAfterDevCompile.mdx';
 
-<OnDevCompileDone />
+<OnAfterDevCompile />
 
+- **版本：** 新增于 v1.5.0
 - **示例：**
 
 ```ts
-rsbuild.onDevCompileDone(({ isFirstCompile }) => {
+rsbuild.onAfterDevCompile(({ isFirstCompile }) => {
   if (isFirstCompile) {
     console.log('first compile!');
   } else {
@@ -1001,6 +1002,10 @@ rsbuild.onDevCompileDone(({ isFirstCompile }) => {
   }
 });
 ```
+
+## rsbuild.onDevCompileDone
+
+已废弃。与 [onAfterDevCompile](#onafterdevcompile) 功能完全一致，请优先考虑使用 `onAfterDevCompile` 代替（在 v1.5.0 中添加）。
 
 ## rsbuild.onExit
 

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -226,12 +226,12 @@ const myPlugin = () => ({
 });
 ```
 
-对于一些全局的 plugin hooks（如 [onDevCompileDone](/plugins/dev/hooks#ondevcompiledone)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等）， Rsbuild 支持通过 `environments` 参数获取所有环境的上下文。
+对于一些全局的 plugin hooks（如 [onAfterDevCompile](/plugins/dev/hooks#onafterdevCompile)、[onBeforeStartDevServer](/plugins/dev/hooks#onbeforestartdevserver) 等）， Rsbuild 支持通过 `environments` 参数获取所有环境的上下文。
 
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onDevCompileDone(({ environments }) => {
+    api.onAfterDevCompile(({ environments }) => {
       environments.forEach((environment) => {
         console.log('environment', environment);
       });

--- a/website/docs/zh/plugins/dev/hooks.mdx
+++ b/website/docs/zh/plugins/dev/hooks.mdx
@@ -25,7 +25,7 @@
 - [onBeforeStartDevServer](#onbeforestartdevserver)：在启动开发服务器前调用。
 - [onAfterStartDevServer](#onafterstartdevserver)：在启动开发服务器后调用。
 - [onBeforeDevCompile](#onbeforedevcompile)：在每次执行开发环境构建前调用。
-- [onDevCompileDone](#ondevcompiledone)：在每次开发模式构建结束后调用。
+- [onAfterDevCompile](#onafterdevcompile)：在每次开发模式构建结束后调用。
 
 仅在 Rsbuild restart 时，或是执行 `rsbuild.startDevServer()` 的 [close()](/api/javascript-api/instance#关闭-server) 方法时调用。
 
@@ -68,7 +68,7 @@
 - [modifyHTMLTags](#modifyhtmltags)
 - [modifyHTML](#modifyhtml)
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 - [onCloseDevServer](#onclosedevserver)
 - [onExit](#onexit)
 
@@ -79,7 +79,7 @@
 - [modifyHTMLTags](#modifyhtmltags)
 - [modifyHTML](#modifyhtml)
 - [onAfterEnvironmentCompile](#onafterenvironmentcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 
 ### Build hooks
 
@@ -136,7 +136,7 @@
 - [onAfterCreateCompiler](#onaftercreatecompiler)
 - [onAfterStartDevServer](#onafterstartdevserver)
 - [onBeforeDevCompile](#onbeforedevcompile)
-- [onDevCompileDone](#ondevcompiledone)
+- [onAfterDevCompile](#onafterdevcompile)
 - [onCloseDevServer](#onclosedevserver)
 - [onBeforeBuild](#onbeforebuild)
 - [onAfterBuild](#onafterbuild)
@@ -887,18 +887,19 @@ const myPlugin = () => ({
 });
 ```
 
-### onDevCompileDone
+### onAfterDevCompile
 
-import OnDevCompileDone from '@zh/shared/onDevCompileDone.mdx';
+import OnAfterDevCompile from '@zh/shared/onAfterDevCompile.mdx';
 
-<OnDevCompileDone />
+<OnAfterDevCompile />
 
+- **版本：** 新增于 v1.5.0
 - **示例：**
 
 ```ts
 const myPlugin = () => ({
   setup(api) {
-    api.onDevCompileDone(({ isFirstCompile }) => {
+    api.onAfterDevCompile(({ isFirstCompile }) => {
       if (isFirstCompile) {
         console.log('first compile!');
       } else {
@@ -908,6 +909,10 @@ const myPlugin = () => ({
   },
 });
 ```
+
+### onDevCompileDone
+
+已废弃。与 [onAfterDevCompile](#onafterdevcompile) 功能完全一致，请优先考虑使用 `onAfterDevCompile` 代替（在 v1.5.0 中添加）。
 
 ### onCloseDevServer
 

--- a/website/docs/zh/shared/onAfterDevCompile.mdx
+++ b/website/docs/zh/shared/onAfterDevCompile.mdx
@@ -3,7 +3,7 @@
 - **类型：**
 
 ```ts
-function OnDevCompileDone(
+function OnAfterDevCompile(
   callback: (params: {
     isFirstCompile: boolean;
     stats: Stats | MultiStats;


### PR DESCRIPTION
## Summary

- replace all `onDevCompileDone` with `onAfterDevCompile`
- mark `onDevCompileDone` as deprecated.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
