### PR TITLE
docs: add documentation for `output.module` config

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@examples/node",
   "private": true,
-  "type": "commonjs",
+  "type": "module",
   "scripts": {
     "build": "rsbuild build",
-    "start": "rsbuild build && node ./dist/server/index.js"
+    "start": "rsbuild build && node ./dist/index.js"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/examples/node/rsbuild.config.ts
+++ b/examples/node/rsbuild.config.ts
@@ -3,5 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 export default defineConfig({
   output: {
     target: 'node',
+    module: true,
+    minify: false,
   },
 });

--- a/website/docs/en/config/output/module.mdx
+++ b/website/docs/en/config/output/module.mdx
@@ -1,0 +1,51 @@
+# output.module
+
+- **Type:** `boolean`
+- **Default:** `false`
+- **Version:** Added in v1.5.0
+
+Whether to output JavaScript files in ES modules format.
+
+:::tip
+
+- This feature is currently experimental and only available when [output.target](/config/output/target) is `'node'`.
+- If you need to build JavaScript libraries in ESM format, we recommend using [Rslib](https://rslib.rs), which is an out-of-the-box library development tool built on top of Rsbuild.
+
+:::
+
+## Example
+
+When building Node.js bundles, Rsbuild outputs CommonJS format by default. You can set `output.module` to `true` to output ES modules format:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    module: true,
+  },
+};
+```
+
+## Running ESM bundles
+
+To properly run ESM bundles in Node.js, you can choose either of the following approaches:
+
+1. Set the `type` field in package.json to `'module'`:
+
+```json title="package.json"
+{
+  "type": "module"
+}
+```
+
+2. Change the output JavaScript file extension to `.mjs`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    filename: {
+      js: '[name].mjs',
+    },
+  },
+};
+```

--- a/website/docs/en/config/output/polyfill.mdx
+++ b/website/docs/en/config/output/polyfill.mdx
@@ -11,9 +11,9 @@ Control the injection mode of the polyfills.
 
 ### usage
 
-When `output.polyfill` is configured as `'usage'`, Rsbuild will inject the polyfills based on the APIs used in each file.
+When `output.polyfill` is configured as `'usage'`, Rsbuild will inject the polyfills based on the APIs used in each file. This provides optimal bundle size as only needed polyfills are included.
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'usage',
@@ -23,9 +23,9 @@ export default {
 
 ### entry
 
-When `output.polyfill` is configured as `'entry'`, Rsbuild will inject the polyfills in each entry file.
+When `output.polyfill` is configured as `'entry'`, Rsbuild will inject the polyfills in each entry file. This ensures all polyfills are available but may increase bundle size.
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'entry',
@@ -37,7 +37,7 @@ export default {
 
 When `output.polyfill` is configured as `'off'`, Rsbuild will not inject the polyfills, and developers need to ensure code compatibility themselves.
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'off',

--- a/website/docs/zh/config/output/module.mdx
+++ b/website/docs/zh/config/output/module.mdx
@@ -1,0 +1,51 @@
+# output.module
+
+- **类型：** `boolean`
+- **默认值：** `false`
+- **版本：** 添加于 v1.5.0
+
+是否以 ES 模块格式输出 JavaScript 文件。
+
+:::tip
+
+- 此功能目前为实验性功能，仅在 [output.target](/config/output/target) 为 `'node'` 时可用。
+- 如果你需要构建 ESM 格式的 JavaScript 库，推荐使用 [Rslib](https://rslib.rs)，它是一个开箱即用的库开发工具，基于 Rsbuild 实现。
+
+:::
+
+## 示例
+
+在构建 Node.js bundles 时，Rsbuild 默认输出 CommonJS 格式的产物，你可以将 `output.module` 设置为 `true` 来输出 ES modules 格式：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    target: 'node',
+    module: true,
+  },
+};
+```
+
+## 运行 ESM 产物
+
+为了在 Node.js 中正确运行 ESM 产物，你可以选择以下任一方式：
+
+1. 将 package.json 的 `type` 字段设置为 `'module'`：
+
+```json title="package.json"
+{
+  "type": "module"
+}
+```
+
+2. 将输出的 JavaScript 文件扩展名改为 `.mjs`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    filename: {
+      js: '[name].mjs',
+    },
+  },
+};
+```

--- a/website/docs/zh/config/output/polyfill.mdx
+++ b/website/docs/zh/config/output/polyfill.mdx
@@ -11,9 +11,9 @@
 
 ### usage
 
-当 `output.polyfill` 配置为 `'usage'` 时，Rsbuild 会在每个文件中根据代码中使用的 API 注入 polyfills。
+当 `output.polyfill` 配置为 `'usage'` 时，Rsbuild 会在每个文件中根据代码中使用的 API 注入 polyfills。这提供了最优的包体积，因为只包含所需的 polyfills。
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'usage',
@@ -23,9 +23,9 @@ export default {
 
 ### entry
 
-当 `output.polyfill` 配置为 `'entry'` 时，Rsbuild 会在每个入口文件中注入 polyfills。
+当 `output.polyfill` 配置为 `'entry'` 时，Rsbuild 会在每个入口文件中注入 polyfills。这确保了所有 polyfills 都可用，但可能会增加包体积。
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'entry',
@@ -37,7 +37,7 @@ export default {
 
 当 `output.polyfill` 配置为 `'off'` 时，Rsbuild 不会注入 polyfills，开发者需要自行保证代码的兼容性。
 
-```ts
+```ts title="rsbuild.config.ts"
 export default {
   output: {
     polyfill: 'off',


### PR DESCRIPTION
## Summary

- Added new documentation pages for the `output.module` configuration option
- Changed the Node example's `package.json` to use `"type": "module"` and updated the `start` script to run the correct entry point, enabling ES module support.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5823

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
