### PR TITLE
fix: floating promise in rspackProfile plugin

### DIFF
--- a/packages/core/src/plugins/rspackProfile.ts
+++ b/packages/core/src/plugins/rspackProfile.ts
@@ -102,9 +102,9 @@ export const pluginRspackProfile = (): RsbuildPlugin => ({
       );
     };
 
-    api.onBeforeBuild(({ isFirstCompile }) => {
+    api.onBeforeBuild(async ({ isFirstCompile }) => {
       if (isFirstCompile) {
-        onStart();
+        await onStart();
       }
     });
     api.onBeforeStartDevServer(onStart);


### PR DESCRIPTION
## Summary

Ensure proper execution order by awaiting the `onStart` callback during first compilation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
