### PR TITLE
fix(plugin-vue): allow CSS Modules with custom inject names

### DIFF
--- a/packages/plugin-vue/src/index.ts
+++ b/packages/plugin-vue/src/index.ts
@@ -63,9 +63,7 @@ export function pluginVue(options: PluginVueOptions = {}): RsbuildPlugin {
             // 1. `/path/to/Foo.vue`
             // 2. `/path/to/Foo.vue.css?query=...`
             if (VUE_REGEXP.test(path) || path.includes('.vue.css')) {
-              return (
-                query.includes('type=style') && query.includes('module=true')
-              );
+              return query.includes('type=style') && query.includes('module=');
             }
             return CSS_MODULES_REGEX.test(path);
           };


### PR DESCRIPTION
## Summary
Currently `plugin-vue` does not recognize style modules with custom inject names:
`<style module` -> `Foo.vue.css?type=style&module=true` ✅
`<style module="bar"` -> `Foo.vue.css?type=style&module=bar` 🚫

This PR fixes that.

## Related Links

https://vuejs.org/api/sfc-css-features#custom-inject-name

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
