### PR TITLE
test(plugin-vue): add e2e test case for custom css modules inject name

### DIFF
--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/index.test.ts
@@ -1,0 +1,42 @@
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+rspackOnlyTest(
+  'should allow to custom CSS Modules inject name in dev build',
+  async ({ page }) => {
+    const rsbuild = await dev({
+      cwd: __dirname,
+      page,
+    });
+
+    const test1 = page.locator('#test1');
+    const test2 = page.locator('#test2');
+    const test3 = page.locator('#test3');
+
+    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should allow to custom CSS Modules inject name in prod build',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+
+    const test1 = page.locator('#test1');
+    const test2 = page.locator('#test2');
+    const test3 = page.locator('#test3');
+
+    await expect(test1).toHaveCSS('color', 'rgb(255, 0, 0)');
+    await expect(test2).toHaveCSS('color', 'rgb(0, 0, 255)');
+    await expect(test3).toHaveCSS('color', 'rgb(0, 128, 0)');
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/rsbuild.config.ts
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginVue } from '@rsbuild/plugin-vue';
+
+export default defineConfig({
+  plugins: [pluginVue()],
+});

--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/src/App.vue
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/src/App.vue
@@ -1,0 +1,27 @@
+<template>
+  <p id="test1" :class="{ [classes.red]: isRed }">Red</p>
+  <p id="test2" :class="[classes.red, classes.blue]">Blue</p>
+  <p id="test3" :class="style.green">Green</p>
+</template>
+
+<script>
+import style from './style.module.css';
+
+export default {
+  setup() {
+    return {
+      style,
+      isRed: true,
+    };
+  },
+};
+</script>
+
+<style module="classes">
+.red {
+  color: red;
+}
+.blue {
+  color: blue;
+}
+</style>

--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/src/index.js
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/src/index.js
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#root');

--- a/e2e/cases/plugin-vue/sfc-css-modules-custom/src/style.module.css
+++ b/e2e/cases/plugin-vue/sfc-css-modules-custom/src/style.module.css
@@ -1,0 +1,3 @@
+.green {
+  color: green;
+}


### PR DESCRIPTION
## Summary

Add test case to verify custom CSS Modules inject name works in both dev and prod builds.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5931

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
