### PR TITLE
refactor(css-plugins): inherit CSS options from the built-in rule

### DIFF
--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -179,8 +179,6 @@ export const pluginLess = (
 
   setup(api) {
     const { include = /\.less$/, parallel = false } = pluginOptions;
-    const RAW_QUERY_REGEX = /[?&]raw(?:&|=|$)/;
-    const INLINE_QUERY_REGEX = /[?&]inline(?:&|=|$)/;
 
     api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
@@ -188,30 +186,25 @@ export const pluginLess = (
       const lessRule = chain.module
         .rule(findRuleId(chain, CHAIN_ID.RULE.LESS))
         .test(include)
-        // exclude `import './foo.less?raw'` and `import './foo.less?inline'`
-        .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] })
-        .sideEffects(true)
         .resolve.preferRelative(true)
         .end();
 
-      // Rsbuild < 1.3.0 does not have CSS inline rule
-      const supportInline =
-        CHAIN_ID.RULE.CSS_INLINE &&
-        chain.module.rules.has(CHAIN_ID.RULE.CSS_INLINE);
-
-      const inlineRule = supportInline
+      // Rsbuild < 1.3.0 does not have the raw and inline rules
+      const inlineRule = CHAIN_ID.RULE.CSS_INLINE
         ? chain.module
             .rule(findRuleId(chain, CHAIN_ID.RULE.LESS_INLINE))
             .test(include)
-            .resourceQuery(INLINE_QUERY_REGEX)
         : null;
 
       // Support for importing raw Less files
-      chain.module
-        .rule(CHAIN_ID.RULE.LESS_RAW)
-        .test(include)
-        .type('asset/source')
-        .resourceQuery(RAW_QUERY_REGEX);
+      if (CHAIN_ID.RULE.CSS_RAW) {
+        const cssRawRule = chain.module.rules.get(CHAIN_ID.RULE.CSS_RAW);
+        chain.module
+          .rule(CHAIN_ID.RULE.LESS_RAW)
+          .test(include)
+          .type('asset/source')
+          .resourceQuery(cssRawRule.get('resourceQuery'));
+      }
 
       const { sourceMap } = config.output;
       const { excludes, options } = getLessLoaderOptions(
@@ -225,6 +218,7 @@ export const pluginLess = (
         callback: (rule: RspackChain.Rule, type: 'normal' | 'inline') => void,
       ) => {
         callback(lessRule, 'normal');
+
         if (inlineRule) {
           callback(inlineRule, 'inline');
         }
@@ -248,6 +242,8 @@ export const pluginLess = (
           type === 'normal' ? CHAIN_ID.RULE.CSS : CHAIN_ID.RULE.CSS_INLINE,
         );
         rule.dependency(cssRule.get('dependency'));
+        rule.sideEffects(cssRule.get('sideEffects'));
+        rule.resourceQuery(cssRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssRule.uses.entries())) {
           const loader = cssRule.uses.get(id);

--- a/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-less/tests/__snapshots__/index.test.ts.snap
@@ -64,6 +64,7 @@ exports[`plugin-less > should add less-loader 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -174,6 +175,7 @@ exports[`plugin-less > should add less-loader and css-loader when injectStyles 1
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -290,6 +292,7 @@ exports[`plugin-less > should add less-loader with excludes 1`] = `
       /node_modules/,
     ],
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -400,6 +403,7 @@ exports[`plugin-less > should add less-loader with tools.less 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
       {
@@ -517,6 +521,7 @@ exports[`plugin-less > should allow to use Less plugins 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.less\\$/,
     "use": [
       {

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -123,6 +123,8 @@ describe('plugin-less', () => {
               // Mock the behavior of Rsbuild < 1.3.0
               api.modifyBundlerChain((chain, { CHAIN_ID }) => {
                 chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+                // @ts-expect-error
+                delete CHAIN_ID.RULE.CSS_INLINE;
               });
             },
           },

--- a/packages/plugin-sass/src/index.ts
+++ b/packages/plugin-sass/src/index.ts
@@ -99,8 +99,6 @@ export const pluginSass = (
 
   setup(api) {
     const { rewriteUrls = true, include = /\.s(?:a|c)ss$/ } = pluginOptions;
-    const RAW_QUERY_REGEX = /[?&]raw(?:&|=|$)/;
-    const INLINE_QUERY_REGEX = /[?&]inline(?:&|=|$)/;
 
     api.onAfterCreateCompiler(({ compiler }) => {
       patchCompilerGlobalLocation(compiler);
@@ -122,36 +120,32 @@ export const pluginSass = (
       const rule = chain.module
         .rule(findRuleId(chain, CHAIN_ID.RULE.SASS))
         .test(include)
-        // exclude `import './foo.scss?raw'` and `import './foo.scss?inline'`
-        .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] })
-        .sideEffects(true)
         .resolve.preferRelative(true)
         .end();
 
-      // Rsbuild < 1.3.0 does not have CSS inline rule
-      const supportInline =
-        CHAIN_ID.RULE.CSS_INLINE &&
-        chain.module.rules.has(CHAIN_ID.RULE.CSS_INLINE);
-
-      const inlineRule = supportInline
+      // Rsbuild < 1.3.0 does not have the raw and inline rules
+      const inlineRule = CHAIN_ID.RULE.CSS_INLINE
         ? chain.module
             .rule(findRuleId(chain, CHAIN_ID.RULE.SASS_INLINE))
             .test(include)
-            .resourceQuery(INLINE_QUERY_REGEX)
         : null;
 
       // Support for importing raw Sass files
-      chain.module
-        .rule(CHAIN_ID.RULE.SASS_RAW)
-        .test(include)
-        .type('asset/source')
-        .resourceQuery(RAW_QUERY_REGEX);
+      if (CHAIN_ID.RULE.CSS_RAW) {
+        const cssRawRule = chain.module.rules.get(CHAIN_ID.RULE.CSS_RAW);
+        chain.module
+          .rule(CHAIN_ID.RULE.SASS_RAW)
+          .test(include)
+          .type('asset/source')
+          .resourceQuery(cssRawRule.get('resourceQuery'));
+      }
 
       // Update the normal rule and the inline rule
       const updateRules = (
         callback: (rule: RspackChain.Rule, type: 'normal' | 'inline') => void,
       ) => {
         callback(rule, 'normal');
+
         if (inlineRule) {
           callback(inlineRule, 'inline');
         }
@@ -188,6 +182,8 @@ export const pluginSass = (
           type === 'normal' ? CHAIN_ID.RULE.CSS : CHAIN_ID.RULE.CSS_INLINE,
         );
         rule.dependency(cssRule.get('dependency'));
+        rule.sideEffects(cssRule.get('sideEffects'));
+        rule.resourceQuery(cssRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssRule.uses.entries())) {
           const loader = cssRule.uses.get(id);

--- a/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-sass/tests/__snapshots__/index.test.ts.snap
@@ -72,6 +72,7 @@ exports[`plugin-sass > should add sass-loader 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -198,6 +199,7 @@ exports[`plugin-sass > should add sass-loader and css-loader when injectStyles 1
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -330,6 +332,7 @@ exports[`plugin-sass > should add sass-loader with excludes 1`] = `
       /node_modules/,
     ],
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {
@@ -457,6 +460,7 @@ exports[`plugin-sass > should allow to use legacy API and mute deprecation warni
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.s\\(\\?:a\\|c\\)ss\\$/,
     "use": [
       {

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -92,6 +92,8 @@ describe('plugin-sass', () => {
               // Mock the behavior of Rsbuild < 1.3.0
               api.modifyBundlerChain((chain, { CHAIN_ID }) => {
                 chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+                // @ts-expect-error
+                delete CHAIN_ID.RULE.CSS_INLINE;
               });
             },
           },

--- a/packages/plugin-stylus/src/index.ts
+++ b/packages/plugin-stylus/src/index.ts
@@ -72,9 +72,6 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
   name: PLUGIN_STYLUS_NAME,
 
   setup(api) {
-    const RAW_QUERY_REGEX = /[?&]raw(?:&|=|$)/;
-    const INLINE_QUERY_REGEX = /[?&]inline(?:&|=|$)/;
-
     api.modifyBundlerChain((chain, { CHAIN_ID, environment }) => {
       const { config } = environment;
 
@@ -92,36 +89,30 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
       const rule = chain.module
         .rule(CHAIN_ID.RULE.STYLUS)
         .test(test)
-        // exclude `import './foo.styl?raw'` and `import './foo.stylus?inline'`
-        .resourceQuery({ not: [RAW_QUERY_REGEX, INLINE_QUERY_REGEX] })
-        .sideEffects(true)
         .resolve.preferRelative(true)
         .end();
 
-      // Rsbuild < 1.3.0 does not have CSS inline rule
-      const supportInline =
-        CHAIN_ID.RULE.CSS_INLINE &&
-        chain.module.rules.has(CHAIN_ID.RULE.CSS_INLINE);
-
-      const inlineRule = supportInline
-        ? chain.module
-            .rule(CHAIN_ID.RULE.STYLUS_INLINE)
-            .test(test)
-            .resourceQuery(INLINE_QUERY_REGEX)
+      // Rsbuild < 1.3.0 does not have the raw and inline rules
+      const inlineRule = CHAIN_ID.RULE.CSS_INLINE
+        ? chain.module.rule(CHAIN_ID.RULE.STYLUS_INLINE).test(test)
         : null;
 
       // Support for importing raw Stylus files
-      chain.module
-        .rule(CHAIN_ID.RULE.STYLUS_RAW)
-        .test(test)
-        .type('asset/source')
-        .resourceQuery(RAW_QUERY_REGEX);
+      if (CHAIN_ID.RULE.CSS_RAW) {
+        const cssRawRule = chain.module.rules.get(CHAIN_ID.RULE.CSS_RAW);
+        chain.module
+          .rule(CHAIN_ID.RULE.STYLUS_RAW)
+          .test(test)
+          .type('asset/source')
+          .resourceQuery(cssRawRule.get('resourceQuery'));
+      }
 
       // Update the normal rule and the inline rule
       const updateRules = (
         callback: (rule: RspackChain.Rule, type: 'normal' | 'inline') => void,
       ) => {
         callback(rule, 'normal');
+
         if (inlineRule) {
           callback(inlineRule, 'inline');
         }
@@ -133,6 +124,8 @@ export const pluginStylus = (options?: PluginStylusOptions): RsbuildPlugin => ({
           type === 'normal' ? CHAIN_ID.RULE.CSS : CHAIN_ID.RULE.CSS_INLINE,
         );
         rule.dependency(cssRule.get('dependency'));
+        rule.sideEffects(cssRule.get('sideEffects'));
+        rule.resourceQuery(cssRule.get('resourceQuery'));
 
         for (const id of Object.keys(cssRule.uses.entries())) {
           const loader = cssRule.uses.get(id);

--- a/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-stylus/tests/__snapshots__/index.test.ts.snap
@@ -57,6 +57,7 @@ exports[`plugin-stylus > should add stylus loader config correctly 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {
@@ -156,6 +157,7 @@ exports[`plugin-stylus > should allow to configure stylus options 1`] = `
   },
   {
     "resourceQuery": /\\[\\?&\\]inline\\(\\?:&\\|=\\|\\$\\)/,
+    "sideEffects": true,
     "test": /\\\\\\.styl\\(us\\)\\?\\$/,
     "use": [
       {

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -40,6 +40,8 @@ describe('plugin-stylus', () => {
             setup(api: RsbuildPluginAPI) {
               api.modifyBundlerChain((chain, { CHAIN_ID }) => {
                 chain.module.rules.delete(CHAIN_ID.RULE.CSS_INLINE);
+                // @ts-expect-error
+                delete CHAIN_ID.RULE.CSS_INLINE;
               });
             },
           },


### PR DESCRIPTION
## Summary

Remove duplicate regex constants and inherit CSS options from the built-in rule. This reduces our maintenance burden on constants and keeps them from a single source.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
