### PR TITLE
feat: add more params for `performance.printFileSize.total`

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -190,6 +190,11 @@ async function printFileSizes(
   const getCustomTotal = () => {
     if (typeof options.total === 'function') {
       return options.total({
+        environmentName,
+        distFolder: path.relative(
+          rootPath,
+          stats.compilation.outputOptions.path || '',
+        ),
         assets: assets.map((asset) => ({
           name: asset.name,
           size: asset.size,

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -191,7 +191,7 @@ async function printFileSizes(
     if (typeof options.total === 'function') {
       return options.total({
         environmentName,
-        distFolder: path.relative(
+        distPath: path.relative(
           rootPath,
           stats.compilation.outputOptions.path || '',
         ),

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -622,7 +622,7 @@ export type PrintFileSizeOptions = {
     | boolean
     | ((params: {
         environmentName: string;
-        distFolder: string;
+        distPath: string;
         assets: PrintFileSizeAsset[];
         totalSize: number;
         totalGzipSize: number;

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -621,6 +621,8 @@ export type PrintFileSizeOptions = {
   total?:
     | boolean
     | ((params: {
+        environmentName: string;
+        distFolder: string;
         assets: PrintFileSizeAsset[];
         totalSize: number;
         totalGzipSize: number;

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -57,7 +57,7 @@ type Total =
   | boolean
   | ((params: {
       environmentName: string;
-      distFolder: string;
+      distPath: string;
       assets: PrintFileSizeAsset[];
       totalSize: number;
       totalGzipSize: number;
@@ -90,8 +90,8 @@ When set to a function, you can customize the total size output format:
 export default {
   performance: {
     printFileSize: {
-      total: ({ distFolder, assets, totalSize }) => {
-        return `Generated ${assets.length} files in ${distFolder}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
+      total: ({ distPath, assets, totalSize }) => {
+        return `Generated ${assets.length} files in ${distPath}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
       },
     },
   },
@@ -101,7 +101,7 @@ export default {
 Function parameters:
 
 - `environmentName`: The unique name of the current environment, used to distinguish and locate the environment
-- `distFolder`: The output directory relative to the project root
+- `distPath`: The output directory relative to the project root
 - `assets`: Array of static assets, each containing `name` and `size` properties
 - `totalSize`: Total size of all static assets in bytes
 - `totalGzipSize`: Total gzip-compressed size of all static assets in bytes

--- a/website/docs/en/config/performance/print-file-size.mdx
+++ b/website/docs/en/config/performance/print-file-size.mdx
@@ -56,6 +56,8 @@ You can customize the output format through the options.
 type Total =
   | boolean
   | ((params: {
+      environmentName: string;
+      distFolder: string;
       assets: PrintFileSizeAsset[];
       totalSize: number;
       totalGzipSize: number;
@@ -88,8 +90,8 @@ When set to a function, you can customize the total size output format:
 export default {
   performance: {
     printFileSize: {
-      total: ({ assets, totalSize }) => {
-        return `Generated ${assets.length} files, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
+      total: ({ distFolder, assets, totalSize }) => {
+        return `Generated ${assets.length} files in ${distFolder}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
       },
     },
   },
@@ -98,6 +100,8 @@ export default {
 
 Function parameters:
 
+- `environmentName`: The unique name of the current environment, used to distinguish and locate the environment
+- `distFolder`: The output directory relative to the project root
 - `assets`: Array of static assets, each containing `name` and `size` properties
 - `totalSize`: Total size of all static assets in bytes
 - `totalGzipSize`: Total gzip-compressed size of all static assets in bytes

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -57,7 +57,7 @@ type Total =
   | boolean
   | ((params: {
       environmentName: string;
-      distFolder: string;
+      distPath: string;
       assets: PrintFileSizeAsset[];
       totalSize: number;
       totalGzipSize: number;
@@ -90,8 +90,8 @@ export default {
 export default {
   performance: {
     printFileSize: {
-      total: ({ distFolder, assets, totalSize }) => {
-        return `Generated ${assets.length} files in ${distFolder}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
+      total: ({ distPath, assets, totalSize }) => {
+        return `Generated ${assets.length} files in ${distPath}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
       },
     },
   },
@@ -101,7 +101,7 @@ export default {
 函数参数说明：
 
 - `environmentName`: 当前环境的唯一名称，用于区分和定位该环境
-- `distFolder`: 输出目录相对于项目根目录的路径
+- `distPath`: 输出目录相对于项目根目录的路径
 - `assets`: 静态资源列表，每个资源包含 `name` 和 `size` 属性
 - `totalSize`: 所有静态资源的体积
 - `totalGzipSize`: 所有静态资源 gzip 压缩后的体积

--- a/website/docs/zh/config/performance/print-file-size.mdx
+++ b/website/docs/zh/config/performance/print-file-size.mdx
@@ -56,6 +56,8 @@ export default {
 type Total =
   | boolean
   | ((params: {
+      environmentName: string;
+      distFolder: string;
       assets: PrintFileSizeAsset[];
       totalSize: number;
       totalGzipSize: number;
@@ -88,8 +90,8 @@ export default {
 export default {
   performance: {
     printFileSize: {
-      total: ({ assets, totalSize }) => {
-        return `Generated ${assets.length} files, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
+      total: ({ distFolder, assets, totalSize }) => {
+        return `Generated ${assets.length} files in ${distFolder}, the total size is ${(totalSize / 1000).toFixed(1)} kB.`;
       },
     },
   },
@@ -98,6 +100,8 @@ export default {
 
 函数参数说明：
 
+- `environmentName`: 当前环境的唯一名称，用于区分和定位该环境
+- `distFolder`: 输出目录相对于项目根目录的路径
 - `assets`: 静态资源列表，每个资源包含 `name` 和 `size` 属性
 - `totalSize`: 所有静态资源的体积
 - `totalGzipSize`: 所有静态资源 gzip 压缩后的体积


### PR DESCRIPTION
## Summary

Add more params for `performance.printFileSize.total`

- `environmentName`: The unique name of the current environment, used to distinguish and locate the environment
- `distPath`: The output directory relative to the project root

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
