### PR TITLE
docs: improve SSR error logging

### DIFF
--- a/e2e/cases/server/ssr-type-module/rsbuild.config.ts
+++ b/e2e/cases/server/ssr-type-module/rsbuild.config.ts
@@ -33,7 +33,8 @@ export default defineConfig({
           try {
             await serverRenderMiddleware(req, res, next);
           } catch (err) {
-            logger.error('SSR render error, downgrade to CSR...\n', err);
+            logger.error('SSR render error, downgrade to CSR...');
+            logger.error(err);
             next();
           }
         } else {

--- a/e2e/cases/server/ssr/rsbuild.config.ts
+++ b/e2e/cases/server/ssr/rsbuild.config.ts
@@ -33,7 +33,8 @@ export default defineConfig({
           try {
             await serverRenderMiddleware(req, res, next);
           } catch (err) {
-            logger.error('SSR render error, downgrade to CSR...\n', err);
+            logger.error('SSR render error, downgrade to CSR...');
+            logger.error(err);
             next();
           }
         } else {

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -285,7 +285,8 @@ export async function startDevServer() {
     try {
       await serverRenderMiddleware(req, res, next);
     } catch (err) {
-      logger.error('SSR render error, downgrade to CSR...\n', err);
+      logger.error('SSR render error, downgrade to CSR...');
+      logger.error(err);
       next();
     }
   });

--- a/website/docs/en/guide/advanced/ssr.mdx
+++ b/website/docs/en/guide/advanced/ssr.mdx
@@ -111,7 +111,8 @@ async function startDevServer() {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(html);
     } catch (err) {
-      logger.error('SSR failed: ', err);
+      logger.error('SSR failed.');
+      logger.error(err);
       next();
     }
   });

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -285,7 +285,8 @@ export async function startDevServer() {
     try {
       await serverRenderMiddleware(req, res, next);
     } catch (err) {
-      logger.error('SSR render error, downgrade to CSR...\n', err);
+      logger.error('SSR render error, downgrade to CSR...');
+      logger.error(err);
       next();
     }
   });

--- a/website/docs/zh/guide/advanced/ssr.mdx
+++ b/website/docs/zh/guide/advanced/ssr.mdx
@@ -111,7 +111,8 @@ async function startDevServer() {
       res.writeHead(200, { 'Content-Type': 'text/html' });
       res.end(html);
     } catch (err) {
-      logger.error('SSR failed: ', err);
+      logger.error('SSR failed.');
+      logger.error(err);
       next();
     }
   });


### PR DESCRIPTION
## Summary

Improve the SSR error logging example. Improve the SSR error logging example. Rslog only formats the first parameter by default, so we should not pass err as the second parameter of `logger.error`.

### Before

<img width="1009" height="223" alt="Screenshot 2025-08-26 at 13 46 22" src="https://github.com/user-attachments/assets/587f0b2f-c0fc-4617-8207-64641d06f0ad" />

### After

<img width="1013" height="226" alt="Screenshot 2025-08-26 at 13 46 40" src="https://github.com/user-attachments/assets/744f3185-1cb3-49af-ae44-5920bf8b84bf" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
