### PR TITLE
fix: remove default `javascript/auto` type for JavaScript modules

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -119,7 +119,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -576,7 +575,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -1032,7 +1030,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
@@ -1418,7 +1415,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
       },
       {
         "resourceQuery": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -120,7 +120,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
         const rule = chain.module
           .rule(CHAIN_ID.RULE.JS)
           .test(SCRIPT_REGEX)
-          .type('javascript/auto')
           // When using `new URL('./path/to/foo.js', import.meta.url)`,
           // the module should be treated as an asset module rather than a JS module.
           .dependency({ not: 'url' })

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -142,7 +142,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "builtin:swc-loader",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -142,7 +142,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "builtin:swc-loader",
@@ -654,7 +653,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "builtin:swc-loader",
@@ -1166,7 +1164,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "builtin:swc-loader",
@@ -1633,7 +1630,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
           "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
         },
         "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-        "type": "javascript/auto",
         "use": [
           {
             "loader": "builtin:swc-loader",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1483,7 +1483,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1907,7 +1906,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -24,7 +24,6 @@ exports[`plugin-swc > should add browserslist 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -155,7 +154,6 @@ exports[`plugin-swc > should add pluginImport 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -294,7 +292,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to be function type 1`] 
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -351,7 +348,6 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -480,7 +476,6 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -621,7 +616,6 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -752,7 +746,6 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -905,7 +898,6 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1042,7 +1034,6 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1171,7 +1162,6 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1314,7 +1304,6 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1461,7 +1450,6 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1611,7 +1599,6 @@ exports[`plugin-swc > should has correct core-js 1`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",
@@ -1753,7 +1740,6 @@ exports[`plugin-swc > should has correct core-js 2`] = `
             "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
           },
           "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-          "type": "javascript/auto",
           "use": [
             {
               "loader": "builtin:swc-loader",

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -19,7 +19,6 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
     "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-  "type": "javascript/auto",
   "use": [
     {
       "loader": "builtin:swc-loader",
@@ -111,7 +110,6 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
     "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-  "type": "javascript/auto",
   "use": [
     {
       "loader": "builtin:swc-loader",
@@ -203,7 +201,6 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
     "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-  "type": "javascript/auto",
   "use": [
     {
       "loader": "builtin:swc-loader",
@@ -290,7 +287,6 @@ exports[`plugins/babel > should set babel-loader 1`] = `
     "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-  "type": "javascript/auto",
   "use": [
     {
       "loader": "builtin:swc-loader",
@@ -379,7 +375,6 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
     "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
   },
   "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-  "type": "javascript/auto",
   "use": [
     {
       "loader": "builtin:swc-loader",

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -23,7 +23,6 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -118,7 +117,6 @@ exports[`plugins/react > should work with swc-loader 1`] = `
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -26,7 +26,6 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",
@@ -158,7 +157,6 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
       "not": /\\[\\?&\\]raw\\(\\?:&\\|=\\|\\$\\)/,
     },
     "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
-    "type": "javascript/auto",
     "use": [
       {
         "loader": "builtin:swc-loader",


### PR DESCRIPTION
## Summary

This PR removes the `type: 'javascript/auto'` from the rule for JavaScript modules.

When Rspack encounters modules with `type: "module"` in package.json or modules with `.mjs` and `.mts` extensions, Rspack will configure these modules with `javascript/esm` by default.

If Rsbuild sets `javascript/auto` for ES modules, this change will break the ESM/CJS interop. For example, when a user writes an `.mjs` file and imports a CJS module, interop runtime should be added. However, with `javascript/auto`, the interop won't be added.

## Related Links

- https://rspack.rs/config/module#ruletype
- https://github.com/fi3ework-reproduction/wrong-external-module-after-multiple-pack

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
