### PR TITLE
fix: temporarily disable inline enum optimization

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -96,7 +96,8 @@ export const pluginBasic = (): RsbuildPlugin => ({
           chain.experiments({
             ...chain.get('experiments'),
             lazyBarrel: true,
-            inlineEnum: true,
+            // TODO: enable
+            inlineEnum: false,
             typeReexportsPresence: true,
             rspackFuture: {
               bundlerInfo: {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -98,7 +98,8 @@ function getDefaultSwcConfig({
     rspackExperiments: {
       collectTypeScriptInfo: {
         typeExports: true,
-        exportedEnum: true,
+        // TODO: enable
+        exportedEnum: false,
       },
     },
   };

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -5,7 +5,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
   "experiments": {
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -53,7 +53,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
   "experiments": {
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -11,7 +11,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -178,7 +178,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -236,7 +236,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -11,7 +11,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -178,7 +178,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -236,7 +236,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -523,7 +523,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -690,7 +690,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -748,7 +748,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1063,7 +1063,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -1198,7 +1198,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1252,7 +1252,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1494,7 +1494,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -1669,7 +1669,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1727,7 +1727,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1352,7 +1352,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval-source-map",
     "experiments": {
       "asyncWebAssembly": true,
-      "inlineEnum": true,
+      "inlineEnum": false,
       "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
@@ -1519,7 +1519,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1577,7 +1577,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1804,7 +1804,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "devtool": "eval",
     "experiments": {
       "asyncWebAssembly": true,
-      "inlineEnum": true,
+      "inlineEnum": false,
       "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
@@ -1939,7 +1939,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1993,7 +1993,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -57,7 +57,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -112,7 +112,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -191,7 +191,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -254,7 +254,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -387,7 +387,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -445,7 +445,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -518,7 +518,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -586,7 +586,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -653,7 +653,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -712,7 +712,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -788,7 +788,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -854,7 +854,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -941,7 +941,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -999,7 +999,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1074,7 +1074,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1128,7 +1128,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1207,7 +1207,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1265,7 +1265,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1351,7 +1351,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1413,7 +1413,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1499,7 +1499,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1562,7 +1562,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1648,7 +1648,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1710,7 +1710,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1785,7 +1785,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1839,7 +1839,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -55,7 +55,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -147,7 +147,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -236,7 +236,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -326,7 +326,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -415,7 +415,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -64,7 +64,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -159,7 +159,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -62,7 +62,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -127,7 +127,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -194,7 +194,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -259,7 +259,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -309,7 +309,7 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -414,7 +414,7 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -475,7 +475,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -540,7 +540,7 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -605,7 +605,7 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -61,7 +61,7 @@ exports[`svgr > configure SVGR options 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -167,7 +167,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -241,7 +241,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -346,7 +346,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -420,7 +420,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -525,7 +525,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -599,7 +599,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -704,7 +704,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -778,7 +778,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },


### PR DESCRIPTION
## Summary

Due to some edge case issues with inline enum, it has been temporarily disabled.

When Rspack releases a new hotfix, we will re-enable this optimization.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/5959
- https://github.com/web-infra-dev/rspack/pull/11508

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
