### PR TITLE
test(e2e): do not rely on building URL to verify lazy  compilation

### DIFF
--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,9 +1,6 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-const BUILD_PAGE1 = 'building src/page1/index.js';
-const BUILD_PAGE2 = 'building src/page2/index.js';
-
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
@@ -26,15 +23,12 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();
@@ -65,15 +59,12 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();

--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -1,5 +1,5 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 rspackOnlyTest(
   'should lazy compile dynamic imported modules',
@@ -14,13 +14,13 @@ rspackOnlyTest(
 
     // the first build
     await rsbuild.expectBuildEnd();
-    rsbuild.expectNoLog('building src/foo.js');
     rsbuild.clearLogs();
 
     // build foo.js
     await gotoPage(page, rsbuild, 'index');
-    await rsbuild.expectLog('building src/foo.js');
     await rsbuild.expectBuildEnd();
+    const value = await page.evaluate(() => window.foo);
+    expect(value).toBe(42);
     await rsbuild.close();
   },
 );

--- a/e2e/cases/lazy-compilation/dynamic-import/src/foo.js
+++ b/e2e/cases/lazy-compilation/dynamic-import/src/foo.js
@@ -1,1 +1,2 @@
 export const foo = 'foo';
+window.__resolveFoo(42);

--- a/e2e/cases/lazy-compilation/dynamic-import/src/index.js
+++ b/e2e/cases/lazy-compilation/dynamic-import/src/index.js
@@ -3,3 +3,7 @@ console.log('entry');
 import('./foo').then(({ foo }) => {
   console.log(foo);
 });
+
+window.foo = new Promise((resolve) => {
+  window.__resolveFoo = resolve;
+});

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,9 +1,6 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-const BUILD_PAGE1 = 'building src/page1/index.js';
-const BUILD_PAGE2 = 'building src/page2/index.js';
-
 rspackOnlyTest(
   'should replace port placeholder with actual port',
   async ({ page }) => {
@@ -21,15 +18,12 @@ rspackOnlyTest(
 
     // build page1
     await gotoPage(page, rsbuild, 'page1');
-    await rsbuild.expectLog(BUILD_PAGE1);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 1');
-    rsbuild.expectNoLog(BUILD_PAGE2);
     rsbuild.clearLogs();
 
     // build page2
     await gotoPage(page, rsbuild, 'page2');
-    await rsbuild.expectLog(BUILD_PAGE2);
     await rsbuild.expectBuildEnd();
     await expect(page.locator('#test')).toHaveText('Page 2');
     await rsbuild.close();


### PR DESCRIPTION
## Summary

Should use runtime to test lazyCompilation instead of terminal logs

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
