### PR TITLE
feat(plugin-react): improve transpilation scope of ReactRefreshPlugin

### DIFF
--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -65,15 +65,16 @@ export const applyBasicReactSupport = (
       const { ReactRefreshRspackPlugin } = await import(
         '@rspack/plugin-react-refresh'
       );
-      const SCRIPT_REGEX = /\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/;
-      const NODE_MODULES_REGEX = /[\\/]node_modules[\\/]/;
+
+      const jsRule = chain.module.rules.get(CHAIN_ID.RULE.JS);
 
       chain
         .plugin(CHAIN_ID.PLUGIN.REACT_FAST_REFRESH)
         .use(ReactRefreshRspackPlugin, [
           {
-            include: [SCRIPT_REGEX],
-            exclude: [NODE_MODULES_REGEX],
+            test: jsRule.get('test'),
+            include: jsRule.include.values(),
+            exclude: jsRule.exclude.values(),
             resourceQuery: { not: /^\?raw$/ },
             ...options.reactRefreshOptions,
           },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -95,6 +95,33 @@ exports[`plugins/react > should not apply splitChunks rule when strategy is not 
 }
 `;
 
+exports[`plugins/react > should set transpilation scope for react refresh plugin correctly 1`] = `
+ReactRefreshRspackPlugin {
+  "options": {
+    "exclude": [
+      /baz/,
+    ],
+    "forceEnable": false,
+    "include": [
+      {
+        "not": /\\[\\\\\\\\/\\]node_modules\\[\\\\\\\\/\\]/,
+      },
+      /\\\\\\.\\(\\?:ts\\|tsx\\|jsx\\|mts\\|cts\\)\\$/,
+      /\\[\\\\\\\\/\\]@rsbuild\\[\\\\\\\\/\\]core\\[\\\\\\\\/\\]dist\\[\\\\\\\\/\\]/,
+      /foo/,
+      /bar/,
+    ],
+    "injectEntry": true,
+    "injectLoader": true,
+    "overlay": false,
+    "resourceQuery": {
+      "not": /\\^\\\\\\?raw\\$/,
+    },
+    "test": /\\\\\\.\\(\\?:js\\|jsx\\|mjs\\|cjs\\|ts\\|tsx\\|mts\\|cts\\)\\$/,
+  },
+}
+`;
+
 exports[`plugins/react > should work with swc-loader 1`] = `
 [
   {

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -50,7 +50,27 @@ describe('plugins/react', () => {
 
     rsbuild.addPlugins([pluginReact()]);
 
-    expect(await rsbuild.matchBundlerPlugin('ReactRefreshPlugin')).toBeFalsy();
+    expect(
+      await rsbuild.matchBundlerPlugin('ReactRefreshRspackPlugin'),
+    ).toBeFalsy();
+  });
+
+  it('should set transpilation scope for react refresh plugin correctly', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {
+        mode: 'development',
+        source: {
+          include: [/foo/, /bar/],
+          exclude: [/baz/],
+        },
+      },
+    });
+
+    rsbuild.addPlugins([pluginReact()]);
+
+    expect(
+      await rsbuild.matchBundlerPlugin('ReactRefreshRspackPlugin'),
+    ).toMatchSnapshot();
   });
 
   it('should not apply react refresh when target is node', async () => {
@@ -64,7 +84,9 @@ describe('plugins/react', () => {
 
     rsbuild.addPlugins([pluginReact()]);
 
-    expect(await rsbuild.matchBundlerPlugin('ReactRefreshPlugin')).toBeFalsy();
+    expect(
+      await rsbuild.matchBundlerPlugin('ReactRefreshRspackPlugin'),
+    ).toBeFalsy();
   });
 
   it('should not apply react refresh when target is web-worker', async () => {
@@ -78,7 +100,9 @@ describe('plugins/react', () => {
 
     rsbuild.addPlugins([pluginReact()]);
 
-    expect(await rsbuild.matchBundlerPlugin('ReactRefreshPlugin')).toBeFalsy();
+    expect(
+      await rsbuild.matchBundlerPlugin('ReactRefreshRspackPlugin'),
+    ).toBeFalsy();
   });
 
   it('should not apply splitChunks rule when strategy is not split-by-experience', async () => {

--- a/website/docs/en/plugins/list/plugin-react.mdx
+++ b/website/docs/en/plugins/list/plugin-react.mdx
@@ -208,8 +208,10 @@ As Windows does not support the above usage, you can also use [cross-env](https:
 
 ```ts
 type ReactRefreshOptions = {
-  include?: string | RegExp | (string | RegExp)[] | null;
-  exclude?: string | RegExp | (string | RegExp)[] | null;
+  // @link https://rspack.rs/config/module#condition
+  test?: Rspack.RuleSetCondition;
+  include?: Rspack.RuleSetCondition;
+  exclude?: Rspack.RuleSetCondition;
   library?: string;
   forceEnable?: boolean;
 };
@@ -219,8 +221,13 @@ type ReactRefreshOptions = {
 
 ```js
 const defaultOptions = {
-  include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
-  exclude: [/[\\/]node_modules[\\/]/],
+  test: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+  include: [
+    // Same as Rsbuild's `source.include` configuration
+  ],
+  exclude: [
+    // Same as Rsbuild's `source.exclude` configuration
+  ],
   resourceQuery: { not: /^\?raw$/ },
 };
 ```

--- a/website/docs/zh/plugins/list/plugin-react.mdx
+++ b/website/docs/zh/plugins/list/plugin-react.mdx
@@ -210,8 +210,10 @@ pluginReact({
 
 ```ts
 type ReactRefreshOptions = {
-  include?: string | RegExp | (string | RegExp)[] | null;
-  exclude?: string | RegExp | (string | RegExp)[] | null;
+  // @link https://rspack.rs/config/module#condition
+  test?: Rspack.RuleSetCondition;
+  include?: Rspack.RuleSetCondition;
+  exclude?: Rspack.RuleSetCondition;
   library?: string;
   forceEnable?: boolean;
 };
@@ -221,8 +223,13 @@ type ReactRefreshOptions = {
 
 ```js
 const defaultOptions = {
-  include: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
-  exclude: [/[\\/]node_modules[\\/]/],
+  test: [/\.(?:js|jsx|mjs|cjs|ts|tsx|mts|cts)$/],
+  include: [
+    // Same as Rsbuild's `source.include` configuration
+  ],
+  exclude: [
+    // Same as Rsbuild's `source.exclude` configuration
+  ],
   resourceQuery: { not: /^\?raw$/ },
 };
 ```


### PR DESCRIPTION
## Summary

This PR updates the default options of `@rspack/plugin-react-refresh` to keep the plugin's transpilation scope consistent with the `builtin:swc-loader` of Rsbuild.

This is because the `builtin:swc-loader` injects the `$RefreshReg$` related code into the transpiled modules, which then needs to be further processed by the `builtin:react-refresh-loader`.

## Related Links

https://github.com/rspack-contrib/rspack-plugin-react-refresh/pull/45

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
