### PR TITLE
refactor(types): use `LoaderDefinition` to declare loader types

### DIFF
--- a/packages/core/src/loader/ignoreCssLoader.ts
+++ b/packages/core/src/loader/ignoreCssLoader.ts
@@ -1,6 +1,6 @@
-import type { LoaderContext } from '@rspack/core';
+import type { LoaderDefinition } from '@rspack/core';
 
-export default function (this: LoaderContext<unknown>, source: string): string {
+const ignoreCssLoader: LoaderDefinition = function (source) {
   this?.cacheable(true);
 
   // if the source code include '___CSS_LOADER_EXPORT___'
@@ -12,4 +12,6 @@ export default function (this: LoaderContext<unknown>, source: string): string {
 
   // Preserve CSS Modules export for SSR.
   return source;
-}
+};
+
+export default ignoreCssLoader;

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -1,67 +1,66 @@
-import type { LoaderContext } from '@rspack/core';
-import type { EnvironmentContext, Rspack } from '../types';
+import type { LoaderDefinition } from '@rspack/core';
+import type { EnvironmentContext } from '../types';
 
 export type TransformLoaderOptions = {
   id: string;
   getEnvironment: () => EnvironmentContext;
 };
 
-export default async function transform(
-  this: LoaderContext<TransformLoaderOptions>,
-  source: string,
-  map?: string | Rspack.sources.RawSourceMap,
-): Promise<void> {
-  const callback = this.async();
-  const bypass = () => {
-    callback(null, source, map);
-  };
+const transform: LoaderDefinition<TransformLoaderOptions> =
+  async function transform(source, map): Promise<void> {
+    const callback = this.async();
+    const bypass = () => {
+      callback(null, source, map);
+    };
 
-  const { id: transformId, getEnvironment } = this.getOptions();
-  if (!transformId) {
-    bypass();
-    return;
-  }
-
-  const transform = this._compiler?.__rsbuildTransformer?.[transformId];
-  if (!transform) {
-    bypass();
-    return;
-  }
-
-  try {
-    const result = await transform({
-      code: source,
-      context: this.context,
-      resource: this.resource,
-      resourcePath: this.resourcePath,
-      resourceQuery: this.resourceQuery,
-      environment: getEnvironment(),
-      addDependency: this.addDependency.bind(this),
-      addMissingDependency: this.addMissingDependency.bind(this),
-      addContextDependency: this.addContextDependency.bind(this),
-      emitFile: this.emitFile.bind(this),
-      importModule: this.importModule.bind(this),
-      resolve: this.resolve.bind(this),
-    });
-
-    if (result === null || result === undefined) {
+    const { id: transformId, getEnvironment } = this.getOptions();
+    if (!transformId) {
       bypass();
       return;
     }
 
-    if (typeof result === 'string') {
-      callback(null, result, map);
+    const transform = this._compiler?.__rsbuildTransformer?.[transformId];
+    if (!transform) {
+      bypass();
       return;
     }
 
-    const useMap = map !== undefined && map !== null;
-    const finalMap = result.map ?? map;
-    callback(null, result.code, useMap ? finalMap : undefined);
-  } catch (error) {
-    if (error instanceof Error) {
-      callback(error);
-    } else {
-      callback(new Error(String(error)));
+    try {
+      const result = await transform({
+        code: source,
+        context: this.context,
+        resource: this.resource,
+        resourcePath: this.resourcePath,
+        resourceQuery: this.resourceQuery,
+        environment: getEnvironment(),
+        addDependency: this.addDependency.bind(this),
+        addMissingDependency: this.addMissingDependency.bind(this),
+        addContextDependency: this.addContextDependency.bind(this),
+        emitFile: this.emitFile.bind(this),
+        importModule: this.importModule.bind(this),
+        resolve: this.resolve.bind(this),
+      });
+
+      if (result === null || result === undefined) {
+        bypass();
+        return;
+      }
+
+      if (typeof result === 'string') {
+        callback(null, result, map);
+        return;
+      }
+
+      const useMap = map !== undefined && map !== null;
+      const finalMap = result.map ?? map;
+      callback(null, result.code, useMap ? finalMap : undefined);
+    } catch (error) {
+      if (error instanceof Error) {
+        callback(error);
+      } else {
+        callback(new Error(String(error)));
+      }
     }
-  }
-}
+  };
+
+export default transform;

--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -6,7 +6,7 @@ export type TransformLoaderOptions = {
   getEnvironment: () => EnvironmentContext;
 };
 
-const transform: LoaderDefinition<TransformLoaderOptions> =
+const transformLoader: LoaderDefinition<TransformLoaderOptions> =
   async function transform(source, map): Promise<void> {
     const callback = this.async();
     const bypass = () => {
@@ -63,4 +63,4 @@ const transform: LoaderDefinition<TransformLoaderOptions> =
     }
   };
 
-export default transform;
+export default transformLoader;

--- a/packages/plugin-svgr/src/loader.ts
+++ b/packages/plugin-svgr/src/loader.ts
@@ -18,10 +18,7 @@ const transformSvg = callbackify(
     transform(contents, config, state),
 );
 
-function svgrLoader(
-  this: Rspack.LoaderContext<Config>,
-  contents: string,
-): void {
+const svgrLoader: Rspack.LoaderDefinition<Config> = function (contents): void {
   this?.cacheable();
 
   const callback = this.async();
@@ -60,6 +57,6 @@ function svgrLoader(
       });
     });
   }
-}
+};
 
 export default svgrLoader;


### PR DESCRIPTION
## Summary

This pull request refactors several custom loader implementations to use the more generic `LoaderDefinition` type from `@rspack/core`, improving type safety and consistency across the codebase

## Related Links

- https://rspack.rs/api/loader-api/types#write-with-typescript

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
