### PR TITLE
test(e2e): add new cases to verify enum with property access

### DIFF
--- a/e2e/cases/typescript/const-enum/index.test.ts
+++ b/e2e/cases/typescript/const-enum/index.test.ts
@@ -6,6 +6,10 @@ test('should compile const enum correctly', async ({ page }) => {
     cwd: __dirname,
     page,
   });
-  expect(await page.evaluate(() => window.test)).toBe('Fish 0, Cat 1');
+  expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
   expect(await page.evaluate(() => window.test2)).toBe('Fish 0, Cat 1');
+
+  // https://github.com/web-infra-dev/rsbuild/issues/5959
+  expect(await page.evaluate(() => window.test3)).toBe('Fish FISH, Cat CAT');
+  expect(await page.evaluate(() => window.test4)).toBe('Fish 0, Cat 1');
 });

--- a/e2e/cases/typescript/const-enum/src/foo.ts
+++ b/e2e/cases/typescript/const-enum/src/foo.ts
@@ -1,6 +1,6 @@
 export enum Animals {
-  Fish = 0,
-  Cat = 1,
+  Fish = 'fish',
+  Cat = 'cat',
 }
 
 // biome-ignore lint/suspicious/noConstEnum: for testing

--- a/e2e/cases/typescript/const-enum/src/index.ts
+++ b/e2e/cases/typescript/const-enum/src/index.ts
@@ -2,10 +2,14 @@ import { Animals, Animals2 } from './foo';
 
 declare global {
   interface Window {
-    test: string;
+    test1: string;
     test2: string;
+    test3: string;
+    test4: string;
   }
 }
 
-window.test = `Fish ${Animals.Fish}, Cat ${Animals.Cat}`;
+window.test1 = `Fish ${Animals.Fish}, Cat ${Animals.Cat}`;
 window.test2 = `Fish ${Animals2.Fish}, Cat ${Animals2.Cat}`;
+window.test3 = `Fish ${Animals.Fish.toUpperCase()}, Cat ${Animals.Cat.toUpperCase()}`;
+window.test4 = `Fish ${Animals2.Fish.toString()}, Cat ${Animals2.Cat.toString()}`;


### PR DESCRIPTION
## Summary

This PR adds new cases to verify enum with property access. This is to avoid the regression in https://github.com/web-infra-dev/rsbuild/issues/5959 from happening again.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
