### PR TITLE
fix: failed to escape undefined template params

### DIFF
--- a/e2e/cases/html/template-escape/index.test.ts
+++ b/e2e/cases/html/template-escape/index.test.ts
@@ -4,6 +4,13 @@ import { expect, test } from '@playwright/test';
 test('should escape template parameters correctly', async () => {
   const rsbuild = await build({
     cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        templateParameters: {
+          text: '<div>escape me</div>',
+        },
+      },
+    },
   });
   const files = await rsbuild.getDistFiles();
 
@@ -14,4 +21,30 @@ test('should escape template parameters correctly', async () => {
   const barHtml =
     files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
   expect(barHtml).toContain('<div>escape me</div>');
+});
+
+test('should allow to passing undefined to template parameters', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        templateParameters: {
+          text: undefined,
+        },
+      },
+    },
+  });
+
+  const files = await rsbuild.getDistFiles();
+
+  const fooHtml =
+    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  expect(fooHtml).toContain('<div id="test"></div>');
+
+  const barHtml =
+    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  expect(barHtml).toContain('<div id="test"></div>');
+
+  expect(rsbuild.buildError).toBeFalsy();
+  await rsbuild.close();
 });

--- a/e2e/cases/html/template-escape/rsbuild.config.ts
+++ b/e2e/cases/html/template-escape/rsbuild.config.ts
@@ -12,8 +12,5 @@ export default defineConfig({
     template({ entryName }) {
       return `./static/${entryName}.html`;
     },
-    templateParameters: {
-      text: '<div>escape me</div>',
-    },
   },
 });

--- a/e2e/cases/html/template-escape/static/bar.html
+++ b/e2e/cases/html/template-escape/static/bar.html
@@ -4,6 +4,6 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <%= text %>
+    <div id="test"><%= text %></div>
   </body>
 </html>

--- a/e2e/cases/html/template-escape/static/foo.html
+++ b/e2e/cases/html/template-escape/static/foo.html
@@ -4,6 +4,6 @@
     <meta charset="utf-8" />
   </head>
   <body>
-    <%- text %>
+    <div id="test"><%- text %></div>
   </body>
 </html>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,7 +74,7 @@
     "css-loader": "7.1.2",
     "deepmerge": "^4.3.1",
     "dotenv-expand": "12.0.2",
-    "html-rspack-plugin": "6.1.2",
+    "html-rspack-plugin": "6.1.3",
     "http-proxy-middleware": "^2.0.9",
     "launch-editor-middleware": "^2.11.1",
     "mrmime": "^2.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -665,8 +665,8 @@ importers:
         specifier: 12.0.2
         version: 12.0.2
       html-rspack-plugin:
-        specifier: 6.1.2
-        version: 6.1.2(@rspack/core@1.5.1(@swc/helpers@0.5.17))
+        specifier: 6.1.3
+        version: 6.1.3(@rspack/core@1.5.1(@swc/helpers@0.5.17))
       http-proxy-middleware:
         specifier: ^2.0.9
         version: 2.0.9
@@ -4630,8 +4630,8 @@ packages:
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
 
-  html-rspack-plugin@6.1.2:
-    resolution: {integrity: sha512-30xlM6snYGpHJQnrE83miP0MaZEDAsmqEJj0I2IOPbzUSxU5Cct9D+6cM1bOZfc+C9XQZ9syB/ATKimyz2hWcw==}
+  html-rspack-plugin@6.1.3:
+    resolution: {integrity: sha512-PrhsMQfAyK4V8kWMNf3agA7iqKwFFlQy94SHDRWsCq7RAfhxWNXmMkdQP2pnGDUF4h3W65SaWj8wygcnR7dJtQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
@@ -10667,7 +10667,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.43.1
 
-  html-rspack-plugin@6.1.2(@rspack/core@1.5.1(@swc/helpers@0.5.17)):
+  html-rspack-plugin@6.1.3(@rspack/core@1.5.1(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.0.1
     optionalDependencies:


### PR DESCRIPTION
## Summary

- Update `html-rspack-plugin` to v6.1.3 to resolve the issue of failed template parameter escaping.
- Add a new test to verify that passing `undefined` to `templateParameters` results within the HTML templates, and ensures no build errors occur.

## Related Links

- https://github.com/rspack-contrib/html-rspack-plugin/releases/tag/v6.1.3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
