### PR TITLE
ci: add pull-requests write permission to ecosystem workflow

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -16,6 +16,8 @@ permissions:
   contents: write
   # Allow commenting on issues
   issues: write
+  # Allow commenting on PR
+  pull-requests: write
 
 jobs:
   changes:


### PR DESCRIPTION
## Summary

Enables commenting on pull requests by adding the `pull-requests: write` permission to the `ecosystem-ci.yml` workflow.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5824#discussion_r2269443858
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
