### PR TITLE
test(e2e): add CSS Modules export locals test cases

### DIFF
--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -1,0 +1,160 @@
+import { type BuildResult, build, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+declare global {
+  interface Window {
+    [key: string]: Record<string, string>;
+  }
+}
+
+const expectCSSContext = async (rsbuild: BuildResult) => {
+  const files = await rsbuild.getDistFiles();
+  const content =
+    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  expect(content).toMatch(
+    /\.the-dash-class-\w{6}{color:#00f}\.theCamelClass-\w{6}{color:red}\.the_underscore_class-\w{6}{color:green}/,
+  );
+};
+
+rspackOnlyTest(
+  'should compile CSS Modules with exportLocalsConvention camelCaseOnly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        output: {
+          cssModules: {
+            exportLocalsConvention: 'camelCaseOnly',
+          },
+        },
+      },
+    });
+
+    await expectCSSContext(rsbuild);
+
+    const styles = await page.evaluate(() => window.styles);
+    expect(Object.keys(styles)).toEqual([
+      'theDashClass',
+      'theCamelClass',
+      'theUnderscoreClass',
+    ]);
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should compile CSS Modules with exportLocalsConvention camelCase',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        output: {
+          cssModules: {
+            exportLocalsConvention: 'camelCase',
+          },
+        },
+      },
+    });
+
+    await expectCSSContext(rsbuild);
+
+    const styles = await page.evaluate(() => window.styles);
+    expect(Object.keys(styles)).toEqual([
+      'the-dash-class',
+      'theDashClass',
+      'theCamelClass',
+      'the_underscore_class',
+      'theUnderscoreClass',
+    ]);
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should compile CSS Modules with exportLocalsConvention dashes',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        output: {
+          cssModules: {
+            exportLocalsConvention: 'dashes',
+          },
+        },
+      },
+    });
+
+    await expectCSSContext(rsbuild);
+
+    const styles = await page.evaluate(() => window.styles);
+    expect(Object.keys(styles)).toEqual([
+      'the-dash-class',
+      'theDashClass',
+      'theCamelClass',
+      'the_underscore_class',
+    ]);
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should compile CSS Modules with exportLocalsConvention dashesOnly',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        output: {
+          cssModules: {
+            exportLocalsConvention: 'dashesOnly',
+          },
+        },
+      },
+    });
+
+    await expectCSSContext(rsbuild);
+
+    const styles = await page.evaluate(() => window.styles);
+    expect(Object.keys(styles)).toEqual([
+      'theDashClass',
+      'theCamelClass',
+      'the_underscore_class',
+    ]);
+
+    await rsbuild.close();
+  },
+);
+
+rspackOnlyTest(
+  'should compile CSS Modules with exportLocalsConvention asIs',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+      rsbuildConfig: {
+        output: {
+          cssModules: {
+            exportLocalsConvention: 'asIs',
+          },
+        },
+      },
+    });
+
+    await expectCSSContext(rsbuild);
+
+    const styles = await page.evaluate(() => window.styles);
+    expect(Object.keys(styles)).toEqual([
+      'the-dash-class',
+      'theCamelClass',
+      'the_underscore_class',
+    ]);
+
+    await rsbuild.close();
+  },
+);

--- a/e2e/cases/css/css-modules-export-locals/src/index.js
+++ b/e2e/cases/css/css-modules-export-locals/src/index.js
@@ -1,0 +1,3 @@
+import styles from './style.module.css';
+
+window.styles = styles;

--- a/e2e/cases/css/css-modules-export-locals/src/style.module.css
+++ b/e2e/cases/css/css-modules-export-locals/src/style.module.css
@@ -1,0 +1,11 @@
+.the-dash-class {
+  color: blue;
+}
+
+.theCamelClass {
+  color: red;
+}
+
+.the_underscore_class {
+  color: green;
+}

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -1,22 +1,25 @@
 import { build, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 
-rspackOnlyTest('should compile CSS Modules correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
-  const files = await rsbuild.getDistFiles();
+rspackOnlyTest(
+  'should compile CSS Modules with default configuration',
+  async () => {
+    const rsbuild = await build({
+      cwd: __dirname,
+    });
+    const files = await rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 
-  expect(content).toMatch(
-    /\.the-a-class{color:red}\.the-b-class-\w{6}{color:#00f}\.the-c-class-\w{6}{color:#ff0}\.the-d-class{color:green}/,
-  );
-});
+    expect(content).toMatch(
+      /\.the-a-class{color:red}\.the-b-class-\w{6}{color:#00f}\.the-c-class-\w{6}{color:#ff0}\.the-d-class{color:green}/,
+    );
+  },
+);
 
 rspackOnlyTest(
-  'should compile CSS Modules follow by output.cssModules',
+  'should compile CSS Modules with custom auto configuration',
   async () => {
     const rsbuild = await build({
       cwd: __dirname,
@@ -42,7 +45,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
-  'should compile CSS Modules follow by output.cssModules custom localIdentName',
+  'should compile CSS Modules with custom localIdentName pattern',
   async () => {
     const rsbuild = await build({
       cwd: __dirname,
@@ -66,7 +69,7 @@ rspackOnlyTest(
 );
 
 rspackOnlyTest(
-  'should compile CSS Modules follow by output.cssModules custom localIdentName - hashDigest',
+  'should compile CSS Modules with custom hash digest format',
   async () => {
     const rsbuild = await build({
       cwd: __dirname,

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -250,3 +250,5 @@ export async function build({
     instance: rsbuild,
   };
 }
+
+export type BuildResult = Awaited<ReturnType<typeof build>>;


### PR DESCRIPTION
## Summary

- Add test cases for various CSS Modules exportLocalsConvention options
- Update existing test descriptions to be more specific

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
