### PR TITLE
docs: add examples for CSS Modules exportLocalsConvention

### DIFF
--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -97,7 +97,7 @@ export default {
 
 Suppose you have the following CSS file:
 
-```css title="src/style.css"
+```css title="src/style.module.css"
 .dash-class {
   color: blue;
 }

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -97,7 +97,7 @@ export default {
 
 假设你有以下 CSS 文件：
 
-```css title="src/style.css"
+```css title="src/style.module.css"
 .dash-class {
   color: blue;
 }


### PR DESCRIPTION
## Summary

Adds example sections to the documentation for the `exportLocalsConvention` option. These examples illustrate how different configuration values affect the exported class names.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
