### PR TITLE
fix: improve error message for public directory copy failure

### DIFF
--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { isDeno } from '../constants';
 import { normalizePublicDirs } from '../defaultConfig';
-import { dedupeNestedPaths } from '../helpers';
+import { color, dedupeNestedPaths } from '../helpers';
 import { open } from '../server/open';
 import type { OnAfterStartDevServerFn, RsbuildPlugin } from '../types';
 
@@ -79,7 +79,7 @@ export const pluginServer = (): RsbuildPlugin => ({
           );
         } catch (err) {
           if (err instanceof Error) {
-            err.message = `Failed to copy public directory '${normalizedPath}' to output directory:\n${err.message}`;
+            err.message = `Failed to copy public directory '${color.yellow(normalizedPath)}' to output directory. To disable public directory copying, set \`${color.cyan('server.publicDir: false')}\` in your config. \n${err.message}`;
           }
 
           throw err;

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -79,7 +79,7 @@ export const pluginServer = (): RsbuildPlugin => ({
           );
         } catch (err) {
           if (err instanceof Error) {
-            err.message = `Failed to copy public directory '${color.yellow(normalizedPath)}' to output directory. To disable public directory copying, set \`${color.cyan('server.publicDir: false')}\` in your config. \n${err.message}`;
+            err.message = `Failed to copy public directory '${color.yellow(normalizedPath)}' to output directory. To disable public directory copying, set \`${color.cyan('server.publicDir: false')}\` in your config.\n${err.message}`;
           }
 
           throw err;


### PR DESCRIPTION
## Summary

Add color highlighting to the path and suggest disabling public directory copying in config when the copy operation fails.

Preview:

<img width="1015" height="382" alt="Screenshot 2025-09-02 at 12 14 18" src="https://github.com/user-attachments/assets/a21adb1b-6f93-4f6c-ae07-e701bcebaf6f" />

## Related Links

- Related: https://github.com/web-infra-dev/rsbuild/issues/5986

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
