### PR TITLE
test(e2e): enable more cases on Windows

### DIFF
--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -1,17 +1,13 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const cwd = __dirname;
 
 rspackOnlyTest(
   'HMR should work after fixing compilation error',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -1,15 +1,11 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const cwd = __dirname;
 
 rspackOnlyTest('should print changed files in logs', async ({ page }) => {
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });
@@ -43,10 +39,6 @@ rspackOnlyTest('should print changed files in logs', async ({ page }) => {
 });
 
 rspackOnlyTest('should print removed files in logs', async ({ page }) => {
-  if (process.platform === 'win32') {
-    test.skip();
-  }
-
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -34,7 +34,7 @@ rspackOnlyTest('should print changed files in logs', async ({ page }) => {
       .replace('Hello Rsbuild!', 'Hello Rsbuild2!'),
   );
 
-  await rsbuild.expectLog('building test-temp-src/App.tsx');
+  await rsbuild.expectLog(/building test-temp-src[\\/]App\.tsx/);
   await rsbuild.close();
 });
 
@@ -62,6 +62,6 @@ rspackOnlyTest('should print removed files in logs', async ({ page }) => {
 
   await fs.promises.unlink(appPath);
 
-  await rsbuild.expectLog('building removed test-temp-src/App.tsx');
+  await rsbuild.expectLog(/building removed test-temp-src[\\/]App\.tsx/);
   await rsbuild.close();
 });

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import fse from 'fs-extra';
 
@@ -9,10 +9,6 @@ import fse from 'fs-extra';
 rspackOnlyTest(
   'should not re-compile templates when the template is not changed',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     let count = 0;
 
     const targetDir = join(__dirname, 'test-temp-src');

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import fse from 'fs-extra';
 
@@ -9,6 +9,11 @@ import fse from 'fs-extra';
 rspackOnlyTest(
   'should not re-compile templates when the template is not changed',
   async ({ page }) => {
+    // Failed to run this case on Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     let count = 0;
 
     const targetDir = join(__dirname, 'test-temp-src');

--- a/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
+++ b/e2e/cases/lazy-compilation/add-initial-chunk/index.test.ts
@@ -1,14 +1,10 @@
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 // https://github.com/web-infra-dev/rspack/issues/6633
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation and add new initial chunk',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
       page,

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,13 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
       rsbuildConfig: {
@@ -38,10 +34,6 @@ rspackOnlyTest(
 rspackOnlyTest(
   'should allow to configure `tools.rspack.experiments.lazyCompilation`',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
       rsbuildConfig: {

--- a/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
+++ b/e2e/cases/lazy-compilation/dynamic-import/index.test.ts
@@ -1,13 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should lazy compile dynamic imported modules',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
     });

--- a/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
+++ b/e2e/cases/lazy-compilation/port-placeholder/index.test.ts
@@ -1,13 +1,9 @@
 import { dev, gotoPage, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 rspackOnlyTest(
   'should replace port placeholder with actual port',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     const rsbuild = await dev({
       cwd: __dirname,
     });

--- a/e2e/cases/module-federation-v2/index.test.ts
+++ b/e2e/cases/module-federation-v2/index.test.ts
@@ -7,7 +7,7 @@ import {
   gotoPage,
   rspackOnlyTest,
 } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
@@ -29,11 +29,6 @@ export default Button;`,
 rspackOnlyTest(
   'should run module federation in development mode',
   async ({ page }) => {
-    // this case often timeout on Windows
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     writeButtonCode();
 
     const remotePort = await getRandomPort();

--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -19,7 +19,7 @@ function extractFileSizeLogs(logs: string[]) {
     if (isFileSizeLog) {
       // replace numbers and contenthash with placeholder
       // remove trailing spaces
-      // replace Windows path seq with slash
+      // replace Windows path sep with slash
       result.push(
         log
           .replace(/\.[a-z0-9]{8}\./g, '.[[hash]].')

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -1,13 +1,18 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const cwd = __dirname;
 
 rspackOnlyTest(
   'should reload page when HTML template changed',
   async ({ page }) => {
+    // Failed to run this case on Windows
+    if (process.platform === 'win32') {
+      test.skip();
+    }
+
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -1,17 +1,13 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 import { dev, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect } from '@playwright/test';
 
 const cwd = __dirname;
 
 rspackOnlyTest(
   'should reload page when HTML template changed',
   async ({ page }) => {
-    if (process.platform === 'win32') {
-      test.skip();
-    }
-
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });


### PR DESCRIPTION
## Summary

Removed redundant checks and calls to `test.skip()` for Windows from multiple test files, allowing tests to run on all platforms unless explicitly broken.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
