### PR TITLE
test(e2e): add test case for constant inlining optimization

### DIFF
--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -1,20 +1,23 @@
-import { build, dev } from '@e2e/helper';
+import { build, dev, rspackOnlyTest } from '@e2e/helper';
 import { expect, test } from '@playwright/test';
 
-test('should inline the constants in production mode', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
-  expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
-  expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
+rspackOnlyTest(
+  'should inline the constants in production mode',
+  async ({ page }) => {
+    const rsbuild = await build({
+      cwd: __dirname,
+      page,
+    });
+    expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
+    expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
 
-  const indexJs = await rsbuild.getIndexBundle();
-  expect(indexJs).toContain('window.test1="Fish fish, Cat cat"');
-  expect(indexJs).toContain('window.test2="Fish FISH, Cat CAT"');
+    const indexJs = await rsbuild.getIndexBundle();
+    expect(indexJs).toContain('window.test1="Fish fish, Cat cat"');
+    expect(indexJs).toContain('window.test2="Fish FISH, Cat CAT"');
 
-  await rsbuild.close();
-});
+    await rsbuild.close();
+  },
+);
 
 test('should import the constants as expected in development mode', async ({
   page,

--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -1,0 +1,29 @@
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+test('should inline the constants in production mode', async ({ page }) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+  expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
+  expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
+
+  const indexJs = await rsbuild.getIndexBundle();
+  expect(indexJs).toContain('window.test1="Fish fish, Cat cat"');
+  expect(indexJs).toContain('window.test2="Fish FISH, Cat CAT"');
+
+  await rsbuild.close();
+});
+
+test('should import the constants as expected in development mode', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    page,
+  });
+  expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
+  expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
+  await rsbuild.close();
+});

--- a/e2e/cases/optimization/inline-const/src/constants.ts
+++ b/e2e/cases/optimization/inline-const/src/constants.ts
@@ -1,0 +1,2 @@
+export const FISH = 'fish';
+export const CAT = 'cat';

--- a/e2e/cases/optimization/inline-const/src/index.ts
+++ b/e2e/cases/optimization/inline-const/src/index.ts
@@ -1,0 +1,11 @@
+import { CAT, FISH } from './constants';
+
+declare global {
+  interface Window {
+    test1: string;
+    test2: string;
+  }
+}
+
+window.test1 = `Fish ${FISH}, Cat ${CAT}`;
+window.test2 = `Fish ${FISH.toUpperCase()}, Cat ${CAT.toUpperCase()}`;

--- a/e2e/cases/optimization/inline-const/tsconfig.json
+++ b/e2e/cases/optimization/inline-const/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@rsbuild/config/tsconfig",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": ["src", "*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Add E2E test case to verify constant inlining behavior in both production and development modes. The test checks if constants are properly inlined in production and imported as expected in development.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6043

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
