### PR TITLE
test(e2e): add HMR reconnect test case

### DIFF
--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -1,0 +1,50 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { dev, rspackOnlyTest } from '@e2e/helper';
+import { expect } from '@playwright/test';
+
+const cwd = __dirname;
+
+rspackOnlyTest(
+  'should reconnect Web Socket server as expected',
+  async ({ page }) => {
+    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+      recursive: true,
+    });
+
+    const entry = {
+      index: join(cwd, 'test-temp-src/index.ts'),
+    };
+
+    const rsbuild = await dev({
+      cwd,
+      page,
+      rsbuildConfig: {
+        source: { entry },
+      },
+    });
+
+    const locator = page.locator('#test');
+    await expect(locator).toHaveText('Hello Rsbuild!');
+
+    const { port } = rsbuild;
+    await rsbuild.close();
+
+    const rsbuild2 = await dev({
+      cwd,
+      rsbuildConfig: {
+        server: { port },
+        source: { entry },
+      },
+    });
+
+    const appPath = join(cwd, 'test-temp-src/App.tsx');
+    await fs.promises.writeFile(
+      appPath,
+      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    );
+    await expect(locator).toHaveText('Hello Test!');
+
+    await rsbuild2.close();
+  },
+);

--- a/e2e/cases/hmr/reconnect/rsbuild.config.ts
+++ b/e2e/cases/hmr/reconnect/rsbuild.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+});

--- a/e2e/cases/hmr/reconnect/src/App.tsx
+++ b/e2e/cases/hmr/reconnect/src/App.tsx
@@ -1,0 +1,2 @@
+const App = () => <div id="test">Hello Rsbuild!</div>;
+export default App;

--- a/e2e/cases/hmr/reconnect/src/index.ts
+++ b/e2e/cases/hmr/reconnect/src/index.ts
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(React.createElement(App));
+}


### PR DESCRIPTION
## Summary

Add a E2E test case to verify the Web Socket server reconnection behavior.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
