### PR TITLE
fix(hmr): reset reconnect count when connection is established

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -154,6 +154,9 @@ function onOpen() {
   // Notify users that the WebSocket has successfully connected.
   console.info('[rsbuild] WebSocket connected.');
 
+  // Reset reconnect count
+  reconnectCount = 0;
+
   // To prevent WebSocket timeouts caused by proxies (e.g., nginx, docker),
   // send a periodic ping message to keep the connection alive.
   pingIntervalId = setInterval(() => {


### PR DESCRIPTION
## Summary

Introduces a minor improvement to the WebSocket connection logic, the reconnect count is now reset when the WebSocket successfully connects, ensuring accurate tracking of reconnection attempts.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
