### PR TITLE
fix(client): prevent duplicate console logs during reconnection

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -205,7 +205,9 @@ function onClose() {
     return;
   }
 
-  console.info('[rsbuild] WebSocket connection lost. Reconnecting...');
+  if (reconnectCount === 0) {
+    console.info('[rsbuild] WebSocket connection lost. Reconnecting...');
+  }
   removeListeners();
   socket = null;
   reconnectCount++;
@@ -225,7 +227,10 @@ function onError() {
 
 // Establishing a WebSocket connection with the server.
 function connect(fallback = false) {
-  console.info('[rsbuild] WebSocket connecting...');
+  if (reconnectCount === 0) {
+    console.info('[rsbuild] WebSocket connecting...');
+  }
+
   const socketUrl = formatURL(fallback);
   socket = new WebSocket(socketUrl);
   socket.addEventListener('open', onOpen);


### PR DESCRIPTION
## Summary

Prevent duplicate console logs during reconnection, only show WebSocket connection messages on the first reconnection attempt to avoid log spam.

### Before

<img width="782" height="403" alt="Screenshot 2025-09-03 at 13 40 27" src="https://github.com/user-attachments/assets/a062afcc-5afb-4353-817b-a294df873143" />

### After

<img width="781" height="186" alt="Screenshot 2025-09-03 at 13 47 30" src="https://github.com/user-attachments/assets/6d390c8d-9669-4d30-a364-0c686ef70fbf" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
