### PR TITLE
chore(deps): update dependency rspack-chain to v1.4.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -89,7 +89,7 @@
     "reduce-configs": "^1.1.1",
     "rsbuild-dev-middleware": "0.3.0",
     "rslog": "^1.2.11",
-    "rspack-chain": "^1.4.0",
+    "rspack-chain": "^1.4.1",
     "rspack-manifest-plugin": "5.0.3",
     "sirv": "^3.0.1",
     "style-loader": "3.3.4",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -63,6 +63,13 @@ export default {
       name: 'rspack-chain',
       copyDts: true,
       dtsOnly: true,
+      // rspack-chain provides ESM types
+      afterBundle(task) {
+        const pkgJsonPath = join(task.distPath, 'package.json');
+        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+        pkgJson.type = 'module';
+        fs.writeFileSync(pkgJsonPath, JSON.stringify(pkgJson));
+      },
     },
     {
       name: 'http-proxy-middleware',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -709,8 +709,8 @@ importers:
         specifier: ^1.2.11
         version: 1.2.11
       rspack-chain:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.4.1
+        version: 1.4.1
       rspack-manifest-plugin:
         specifier: 5.0.3
         version: 5.0.3(@rspack/core@1.5.2(@swc/helpers@0.5.17))
@@ -5919,8 +5919,8 @@ packages:
   rslog@1.2.11:
     resolution: {integrity: sha512-YgMMzQf6lL9q4rD9WS/lpPWxVNJ1ttY9+dOXJ0+7vJrKCAOT4GH0EiRnBi9mKOitcHiOwjqJPV1n/HRqqgZmOQ==}
 
-  rspack-chain@1.4.0:
-    resolution: {integrity: sha512-C7TMioPQzHePujQEspkmPOlnZUnlgldEWQ6qJgoqFit6fnimT1XirIBo8M5pIDSjboGb9kIVumTiMLi1Ifek2Q==}
+  rspack-chain@1.4.1:
+    resolution: {integrity: sha512-cKkRjUXl2fhQzYwQD7aux+Og1WtjuWFG5XjtOZldjYiRanRoz9OrmbRf4s2kCOgxNplPWP946mqG5hAIzY/V0w==}
 
   rspack-manifest-plugin@5.0.3:
     resolution: {integrity: sha512-DCLSu5KE/ReIOhK2JTCQSI0JIgJ40E2i+2noqINtfhu12+UsK29dgMITEHIpYNR0JggcmmgZIDxPxm9dOV/2vQ==}
@@ -12171,7 +12171,7 @@ snapshots:
 
   rslog@1.2.11: {}
 
-  rspack-chain@1.4.0:
+  rspack-chain@1.4.1:
     dependencies:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0


### PR DESCRIPTION
## Summary

Update `rspack-chain` dependency to version 1.4.1 and modify prebundle config to set package type as module for ESM compatibility.

## Related Links

- https://github.com/rspack-contrib/rspack-chain/releases/tag/v1.4.1

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
