### PR TITLE
test(e2e): improve inline const test case

### DIFF
--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -8,12 +8,14 @@ rspackOnlyTest(
       cwd: __dirname,
       page,
     });
-    expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
-    expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
+    await page.waitForFunction(() => window.test3);
+    expect(await page.evaluate(() => window.test1)).toBe('fish,cat');
+    expect(await page.evaluate(() => window.test2)).toBe('FISH,CAT');
+    expect(await page.evaluate(() => window.test3)).toBe('dog,DOG');
 
     const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('window.test1="Fish fish, Cat cat"');
-    expect(indexJs).toContain('window.test2="Fish FISH, Cat CAT"');
+    expect(indexJs).toContain('window.test1="fish,cat"');
+    expect(indexJs).toContain('window.test2="FISH,CAT"');
 
     await rsbuild.close();
   },
@@ -26,7 +28,9 @@ test('should import the constants as expected in development mode', async ({
     cwd: __dirname,
     page,
   });
-  expect(await page.evaluate(() => window.test1)).toBe('Fish fish, Cat cat');
-  expect(await page.evaluate(() => window.test2)).toBe('Fish FISH, Cat CAT');
+  await page.waitForFunction(() => window.test3);
+  expect(await page.evaluate(() => window.test1)).toBe('fish,cat');
+  expect(await page.evaluate(() => window.test2)).toBe('FISH,CAT');
+  expect(await page.evaluate(() => window.test3)).toBe('dog,DOG');
   await rsbuild.close();
 });

--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -9,13 +9,13 @@ rspackOnlyTest(
       page,
     });
     await page.waitForFunction(() => window.test3);
-    expect(await page.evaluate(() => window.test1)).toBe('fish,cat');
-    expect(await page.evaluate(() => window.test2)).toBe('FISH,CAT');
+    expect(await page.evaluate(() => window.test1)).toBe('fish,FISH');
+    expect(await page.evaluate(() => window.test2)).toBe('cat,CAT');
     expect(await page.evaluate(() => window.test3)).toBe('dog,DOG');
 
     const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('window.test1="fish,cat"');
-    expect(indexJs).toContain('window.test2="FISH,CAT"');
+    expect(indexJs).toContain('window.test1="fish,FISH"');
+    expect(indexJs).toContain('window.test2="cat,CAT"');
 
     await rsbuild.close();
   },
@@ -29,8 +29,8 @@ test('should import the constants as expected in development mode', async ({
     page,
   });
   await page.waitForFunction(() => window.test3);
-  expect(await page.evaluate(() => window.test1)).toBe('fish,cat');
-  expect(await page.evaluate(() => window.test2)).toBe('FISH,CAT');
+  expect(await page.evaluate(() => window.test1)).toBe('fish,FISH');
+  expect(await page.evaluate(() => window.test2)).toBe('cat,CAT');
   expect(await page.evaluate(() => window.test3)).toBe('dog,DOG');
   await rsbuild.close();
 });

--- a/e2e/cases/optimization/inline-const/src/constants2.ts
+++ b/e2e/cases/optimization/inline-const/src/constants2.ts
@@ -1,0 +1,1 @@
+export const DOG = 'dog';

--- a/e2e/cases/optimization/inline-const/src/index.ts
+++ b/e2e/cases/optimization/inline-const/src/index.ts
@@ -8,8 +8,8 @@ declare global {
   }
 }
 
-window.test1 = `${FISH},${CAT}`;
-window.test2 = `${FISH.toUpperCase()},${CAT.toUpperCase()}`;
+window.test1 = `${FISH},${FISH.toUpperCase()}`;
+window.test2 = `${CAT},${CAT.toUpperCase()}`;
 
 import('./constants2').then(({ DOG }) => {
   window.test3 = `${DOG},${DOG.toUpperCase()}`;

--- a/e2e/cases/optimization/inline-const/src/index.ts
+++ b/e2e/cases/optimization/inline-const/src/index.ts
@@ -4,8 +4,13 @@ declare global {
   interface Window {
     test1: string;
     test2: string;
+    test3: string;
   }
 }
 
-window.test1 = `Fish ${FISH}, Cat ${CAT}`;
-window.test2 = `Fish ${FISH.toUpperCase()}, Cat ${CAT.toUpperCase()}`;
+window.test1 = `${FISH},${CAT}`;
+window.test2 = `${FISH.toUpperCase()},${CAT.toUpperCase()}`;
+
+import('./constants2').then(({ DOG }) => {
+  window.test3 = `${DOG},${DOG.toUpperCase()}`;
+});


### PR DESCRIPTION
## Summary

This pull request updates the inline constants optimization test case by introducing a new constant that is dynamically imported.

## Related Links

- https://github.com/web-infra-dev/rspack/issues/11589

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
