### PR TITLE
fix(core): only enable inline enum in production mode

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -97,7 +97,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           chain.experiments({
             ...chain.get('experiments'),
             lazyBarrel: true,
-            inlineEnum: true,
+            inlineEnum: isProd,
             inlineConst: isProd,
             typeReexportsPresence: true,
             rspackFuture: {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -67,10 +67,12 @@ function getDefaultSwcConfig({
   browserslist,
   cacheRoot,
   config,
+  isProd,
 }: {
   browserslist: string[];
   cacheRoot: string;
   config: NormalizedEnvironmentConfig;
+  isProd: boolean;
 }): SwcLoaderOptions {
   return {
     jsc: {
@@ -98,7 +100,7 @@ function getDefaultSwcConfig({
     rspackExperiments: {
       collectTypeScriptInfo: {
         typeExports: true,
-        exportedEnum: true,
+        exportedEnum: isProd,
       },
     },
   };
@@ -113,7 +115,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { CHAIN_ID, isDev, target, environment }) => {
+      handler: (chain, { CHAIN_ID, isDev, isProd, target, environment }) => {
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
@@ -156,6 +158,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           browserslist,
           cacheRoot,
           config,
+          isProd,
         });
 
         applyTransformImport(swcConfig, config.source.transformImport);

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -6,7 +6,7 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "devtool": "cheap-module-source-map",
   "experiments": {
     "inlineConst": false,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -12,7 +12,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -180,7 +180,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -238,7 +238,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -12,7 +12,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -180,7 +180,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -238,7 +238,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1072,7 +1072,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -1208,7 +1208,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1262,7 +1262,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1507,7 +1507,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -1683,7 +1683,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -1741,7 +1741,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1353,7 +1353,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "experiments": {
       "asyncWebAssembly": true,
       "inlineConst": false,
-      "inlineEnum": true,
+      "inlineEnum": false,
       "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
@@ -1521,7 +1521,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1579,7 +1579,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1809,7 +1809,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "experiments": {
       "asyncWebAssembly": true,
       "inlineConst": false,
-      "inlineEnum": true,
+      "inlineEnum": false,
       "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
@@ -1945,7 +1945,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1999,7 +1999,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/core/tests/__snapshots__/swc.test.ts.snap
+++ b/packages/core/tests/__snapshots__/swc.test.ts.snap
@@ -57,7 +57,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -112,7 +112,7 @@ exports[`plugin-swc > should add browserslist 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -191,7 +191,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -254,7 +254,7 @@ exports[`plugin-swc > should add pluginImport 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -387,7 +387,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -445,7 +445,7 @@ exports[`plugin-swc > should allow to use \`tools.swc\` to configure swc-loader 
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -518,7 +518,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -586,7 +586,7 @@ exports[`plugin-swc > should apply environment config correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -653,7 +653,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -712,7 +712,7 @@ exports[`plugin-swc > should apply environment config correctly 2`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
             "import": [
@@ -788,7 +788,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -854,7 +854,7 @@ exports[`plugin-swc > should apply pluginImport correctly when ConfigChain 1`] =
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                   "import": [
@@ -941,7 +941,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -999,7 +999,7 @@ exports[`plugin-swc > should disable pluginImport when return undefined 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1074,7 +1074,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1128,7 +1128,7 @@ exports[`plugin-swc > should disable preset_env in target other than web 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1207,7 +1207,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1265,7 +1265,7 @@ exports[`plugin-swc > should disable preset_env mode 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1351,7 +1351,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1413,7 +1413,7 @@ exports[`plugin-swc > should enable entry mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1499,7 +1499,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1562,7 +1562,7 @@ exports[`plugin-swc > should enable usage mode preset_env 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1648,7 +1648,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1710,7 +1710,7 @@ exports[`plugin-swc > should has correct core-js 1`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1785,7 +1785,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },
@@ -1839,7 +1839,7 @@ exports[`plugin-swc > should has correct core-js 2`] = `
                 },
                 "rspackExperiments": {
                   "collectTypeScriptInfo": {
-                    "exportedEnum": true,
+                    "exportedEnum": false,
                     "typeExports": true,
                   },
                 },

--- a/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-babel/tests/__snapshots__/index.test.ts.snap
@@ -55,7 +55,7 @@ exports[`plugins/babel > babel-loader should works with builtin:swc-loader 1`] =
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -147,7 +147,7 @@ exports[`plugins/babel > should apply environment config correctly 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -236,7 +236,7 @@ exports[`plugins/babel > should apply environment config correctly 2`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -326,7 +326,7 @@ exports[`plugins/babel > should set babel-loader 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },
@@ -415,7 +415,7 @@ exports[`plugins/babel > should set babel-loader when config is add 1`] = `
         },
         "rspackExperiments": {
           "collectTypeScriptInfo": {
-            "exportedEnum": true,
+            "exportedEnum": false,
             "typeExports": true,
           },
         },

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -64,7 +64,7 @@ exports[`plugins/react > should configuring \`tools.swc\` to override react runt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -186,7 +186,7 @@ exports[`plugins/react > should work with swc-loader 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -62,7 +62,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -127,7 +127,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -194,7 +194,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -259,7 +259,7 @@ exports[`plugin-svelte > should add rule for \`.svelte.js\` and \`.svelte.ts\` a
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -309,7 +309,7 @@ exports[`plugin-svelte > should add svelte loader and resolve config properly 1`
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -414,7 +414,7 @@ exports[`plugin-svelte > should override default svelte-loader options throw opt
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -540,7 +540,7 @@ exports[`plugin-svelte > should support pass custom preprocess options 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },
@@ -605,7 +605,7 @@ exports[`plugin-svelte > should turn off HMR by hand correctly 1`] = `
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -61,7 +61,7 @@ exports[`svgr > configure SVGR options 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -167,7 +167,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -241,7 +241,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -346,7 +346,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -420,7 +420,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -525,7 +525,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -599,7 +599,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -704,7 +704,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },
@@ -778,7 +778,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
             },
             "rspackExperiments": {
               "collectTypeScriptInfo": {
-                "exportedEnum": true,
+                "exportedEnum": false,
                 "typeExports": true,
               },
             },


### PR DESCRIPTION
## Summary

This pull request updates the `inlineEnum` related configurations, ensuring that they are only applied in production builds.

## Related Links

The same as https://github.com/web-infra-dev/rsbuild/pull/6062

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
