### PR TITLE
chore: add JSON schemas for Rspress meta and nav files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,15 @@
   },
   "mdx.validate.validateFileLinks": "ignore",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "json.schemas": [
+    {
+      "fileMatch": ["**/_meta.json"],
+      "url": "./website/node_modules/@rspress/core/meta-json-schema.json"
+    },
+    {
+      "fileMatch": ["**/_nav.json"],
+      "url": "./website/node_modules/@rspress/core/nav-json-schema.json"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Added JSON schema associations for files matching `_meta.json` and `_nav.json`, enabling VS Code to validate these files against the schemas provided by `@rspress/core`

## Related Links

- https://v2.rspress.rs/guide/basic/auto-nav-sidebar#json-schema-type-hint

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
