### PR TITLE
fix(server): correct URL message spacing for multiple routes

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -161,7 +161,7 @@ function getURLMessages(
     message += `  ➜  ${label}\n`;
 
     for (const r of routes) {
-      message += `  ${color.dim('-')} ${color.dim(
+      message += `  ${color.dim('-')}  ${color.dim(
         r.entryName.padEnd(maxNameLength + 4),
       )}${color.cyan(normalizeUrl(`${url}${r.pathname}`))}\n`;
     }


### PR DESCRIPTION
## Summary

Corrected the URL message spacing for multiple routes:

<img width="628" height="327" alt="Screenshot 2025-09-05 at 16 59 50" src="https://github.com/user-attachments/assets/b3d38392-7a38-4a60-a851-554e2f4b95a4" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5607

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
