### PR TITLE
docs: add native watcher example to build perf guide

### DIFF
--- a/website/docs/en/guide/optimization/build-performance.mdx
+++ b/website/docs/en/guide/optimization/build-performance.mdx
@@ -62,7 +62,23 @@ export default {
 };
 ```
 
-> Please refer to [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
+> Refer to [dev.lazyCompilation](/config/dev/lazy-compilation) for more information.
+
+### Enable native watcher
+
+Enabling Rspack's [native watcher](https://rspack.rs/config/experiments#experimentsnativewatcher) can improve HMR performance in development mode.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
+    },
+  },
+};
+```
 
 ### Source map format
 

--- a/website/docs/zh/guide/optimization/build-performance.mdx
+++ b/website/docs/zh/guide/optimization/build-performance.mdx
@@ -64,6 +64,22 @@ export default {
 
 > 请参考 [dev.lazyCompilation](/config/dev/lazy-compilation) 了解更多。
 
+### 开启 native watcher
+
+启用 Rspack 的 [native watcher](https://rspack.rs/zh/config/experiments#experimentsnativewatcher) 可以提升开发模式下的 HMR 性能。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      experiments: {
+        nativeWatcher: true,
+      },
+    },
+  },
+};
+```
+
 ### Source map 格式
 
 为了提供良好的调试体验，Rsbuild 在开发模式下默认使用 `cheap-module-source-map` 格式 source map，这是一种高质量的 source map 格式，会带来一定的性能开销。


### PR DESCRIPTION
## Summary

Add documentation for enabling Rspack's native watcher feature to improve HMR performance in development mode. 

## Related Links

- https://rspack.rs/config/experiments#experimentsnativewatcher

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
