### PR TITLE
fix(server): prints correct urls when configuring web and node environments

### DIFF
--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -19,51 +19,6 @@ test('should print server urls correctly by default', async ({ page }) => {
   await rsbuild.close();
 });
 
-test('should print different environment server urls correctly', async ({
-  page,
-}) => {
-  const rsbuild = await dev({
-    cwd,
-    rsbuildConfig: {
-      environments: {
-        web: {
-          output: {
-            distPath: {
-              html: 'html0',
-            },
-          },
-        },
-        web1: {
-          source: {
-            entry: {
-              main: './src/index.js',
-            },
-          },
-          html: {
-            outputStructure: 'nested',
-          },
-          output: {
-            distPath: {
-              html: 'html1',
-            },
-          },
-        },
-      },
-    },
-  });
-
-  await page.goto(`http://localhost:${rsbuild.port}`);
-
-  await rsbuild.expectLog(
-    `-  index    http://localhost:${rsbuild.port}/html0/`,
-  );
-  await rsbuild.expectLog(
-    `-  main     http://localhost:${rsbuild.port}/html1/main`,
-  );
-
-  await rsbuild.close();
-});
-
 test('should not print server urls when printUrls is false', async ({
   page,
 }) => {
@@ -202,7 +157,7 @@ test('should print server urls when HTML is disabled but printUrls is a custom f
   await rsbuild.close();
 });
 
-test('should print server urls for multiple entries as expected', async ({
+test('should print server urls for multiple web environments with custom distPath.root', async ({
   page,
 }) => {
   const rsbuild = await dev({
@@ -243,5 +198,86 @@ test('should print server urls for multiple entries as expected', async ({
     `-  index1    http://localhost:${rsbuild.port}/.dist/web1/index1`,
   );
 
+  await rsbuild.close();
+});
+
+test('should print server urls for multiple web environments with custom distPath.html', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      environments: {
+        web: {
+          output: {
+            distPath: {
+              html: 'html0',
+            },
+          },
+        },
+        web1: {
+          source: {
+            entry: {
+              main: './src/index.js',
+            },
+          },
+          html: {
+            outputStructure: 'nested',
+          },
+          output: {
+            distPath: {
+              html: 'html1',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+
+  await rsbuild.expectLog(
+    `-  index    http://localhost:${rsbuild.port}/html0/`,
+  );
+  await rsbuild.expectLog(
+    `-  main     http://localhost:${rsbuild.port}/html1/main`,
+  );
+
+  await rsbuild.close();
+});
+
+test('should print server urls for web and node environments with custom distPath.root', async ({
+  page,
+}) => {
+  const rsbuild = await dev({
+    cwd,
+    rsbuildConfig: {
+      server: {
+        htmlFallback: false,
+      },
+      environments: {
+        web: {
+          output: {
+            distPath: {
+              root: 'dist/client',
+            },
+          },
+        },
+        node: {
+          output: {
+            target: 'node',
+            distPath: { root: './dist/server' },
+          },
+        },
+      },
+    },
+  });
+
+  await page.goto(`http://localhost:${rsbuild.port}`);
+  expect(await page.evaluate(() => window.test)).toBe(1);
+
+  await rsbuild.expectLog(`➜  Local:    http://localhost:${rsbuild.port}/`, {
+    strict: true,
+  });
   await rsbuild.close();
 });

--- a/e2e/cases/server/print-urls/src/index.js
+++ b/e2e/cases/server/print-urls/src/index.js
@@ -1,1 +1,1 @@
-console.log('1');
+window.test = 1;

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type { Socket } from 'node:net';
 import os from 'node:os';
-import { posix, relative, sep } from 'node:path';
+import { posix, relative } from 'node:path';
 import { DEFAULT_DEV_HOST } from '../constants';
 import {
   addTrailingSlash,
@@ -10,6 +10,7 @@ import {
   getCommonParentPath,
   isFunction,
   removeLeadingSlash,
+  toPosixPath,
 } from '../helpers';
 import { logger } from '../logger';
 import type {
@@ -105,7 +106,10 @@ export const getRoutes = (context: InternalContext): Routes => {
 
   return environmentWithHtml.reduce<Routes>((prev, environmentContext) => {
     const { distPath, config } = environmentContext;
-    const distPrefix = relative(commonDistPath, distPath).split(sep).join('/');
+    const distPrefix = relative(
+      toPosixPath(commonDistPath),
+      toPosixPath(distPath),
+    );
 
     const routes = formatRoutes(
       environmentContext.htmlPaths,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -7,6 +7,7 @@ import { DEFAULT_DEV_HOST } from '../constants';
 import {
   addTrailingSlash,
   color,
+  getCommonParentPath,
   isFunction,
   removeLeadingSlash,
 } from '../helpers';
@@ -91,23 +92,25 @@ export const stripBase = (path: string, base: string): string => {
 };
 
 export const getRoutes = (context: InternalContext): Routes => {
-  return Object.values(context.environments).reduce<Routes>(
-    (prev, environmentContext) => {
-      const { distPath, config } = environmentContext;
-      const distPrefix = relative(context.distPath, distPath)
-        .split(sep)
-        .join('/');
-
-      const routes = formatRoutes(
-        environmentContext.htmlPaths,
-        context.normalizedConfig!.server.base,
-        posix.join(distPrefix, config.output.distPath.html),
-        config.html.outputStructure,
-      );
-      return prev.concat(...routes);
-    },
-    [],
+  const environmentWithHtml = Object.values(context.environments).filter(
+    (item) => Object.keys(item.htmlPaths).length > 0,
   );
+  const commonDistPath = getCommonParentPath(
+    environmentWithHtml.map((item) => item.distPath),
+  );
+
+  return environmentWithHtml.reduce<Routes>((prev, environmentContext) => {
+    const { distPath, config } = environmentContext;
+    const distPrefix = relative(commonDistPath, distPath).split(sep).join('/');
+
+    const routes = formatRoutes(
+      environmentContext.htmlPaths,
+      context.normalizedConfig!.server.base,
+      posix.join(distPrefix, config.output.distPath.html),
+      config.html.outputStructure,
+    );
+    return prev.concat(...routes);
+  }, []);
 };
 
 /*

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage, Server } from 'node:http';
 import type { Http2SecureServer } from 'node:http2';
 import type { Socket } from 'node:net';
 import os from 'node:os';
-import { posix, relative } from 'node:path';
+import { posix, relative, sep } from 'node:path';
 import { DEFAULT_DEV_HOST } from '../constants';
 import {
   addTrailingSlash,
@@ -10,7 +10,6 @@ import {
   getCommonParentPath,
   isFunction,
   removeLeadingSlash,
-  toPosixPath,
 } from '../helpers';
 import { logger } from '../logger';
 import type {
@@ -106,10 +105,7 @@ export const getRoutes = (context: InternalContext): Routes => {
 
   return environmentWithHtml.reduce<Routes>((prev, environmentContext) => {
     const { distPath, config } = environmentContext;
-    const distPrefix = relative(
-      toPosixPath(commonDistPath),
-      toPosixPath(distPath),
-    );
+    const distPrefix = relative(commonDistPath, distPath).split(sep).join('/');
 
     const routes = formatRoutes(
       environmentContext.htmlPaths,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -95,6 +95,10 @@ export const getRoutes = (context: InternalContext): Routes => {
   const environmentWithHtml = Object.values(context.environments).filter(
     (item) => Object.keys(item.htmlPaths).length > 0,
   );
+  if (environmentWithHtml.length === 0) {
+    return [];
+  }
+
   const commonDistPath = getCommonParentPath(
     environmentWithHtml.map((item) => item.distPath),
   );

--- a/packages/core/tests/helpers.test.ts
+++ b/packages/core/tests/helpers.test.ts
@@ -1,4 +1,4 @@
-import { sep } from 'node:path';
+import { join, sep } from 'node:path';
 import {
   ensureAssetPrefix,
   isPlainObject,
@@ -11,9 +11,10 @@ import { getRoutes, normalizeUrl } from '../src/server/helper';
 import type { InternalContext } from '../src/types';
 
 test('should getRoutes correctly', () => {
+  const cwd = __dirname;
   expect(
     getRoutes({
-      distPath: '/project/dist',
+      distPath: join(cwd, 'dist'),
       normalizedConfig: {
         server: {
           base: '/',
@@ -21,7 +22,7 @@ test('should getRoutes correctly', () => {
       },
       environments: {
         web: {
-          distPath: '/project/dist',
+          distPath: join(cwd, 'dist'),
           htmlPaths: {
             index: 'index.html',
           },
@@ -37,7 +38,7 @@ test('should getRoutes correctly', () => {
           },
         },
         web1: {
-          distPath: '/project/dist/web1',
+          distPath: join(cwd, 'dist/web1'),
           htmlPaths: {
             index: 'index.html',
           },
@@ -53,7 +54,7 @@ test('should getRoutes correctly', () => {
           },
         },
         web2: {
-          distPath: '/project/dist/web2',
+          distPath: join(cwd, 'dist/web2'),
           htmlPaths: {
             index: 'index.html',
             main: 'main.html',
@@ -291,7 +292,9 @@ test('should isWebTarget work correctly', () => {
   expect(isWebTarget(['web-worker'])).toBe(true);
   expect(isWebTarget(['web-worker', 'node'])).toBe(true);
 
+  // @ts-expect-error
   expect(isWebTarget('web-worker-special')).toBe(false);
+  // @ts-expect-error
   expect(isWebTarget('something-web-worker-else')).toBe(false);
 });
 


### PR DESCRIPTION
## Summary

- Updated `getRoutes` helper to compute the common parent path across environments with HTML output, ensuring correct relative path calculation for server URLs in multi-environment setups.
- Enhanced the log E2E helper to support a `strict` option for exact line matching, improving the accuracy of log assertions in tests
- Added new tests in `index.test.ts` to verify server URL printing for multiple web environments

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/5381

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
