### PR TITLE
docs(config): clarify HTTP/2 behavior

### DIFF
--- a/website/docs/en/config/server/https.mdx
+++ b/website/docs/en/config/server/https.mdx
@@ -28,7 +28,7 @@ HTTPS:
 ```
 
 :::tip
-Rsbuild enables HTTP/2 server by default. However, when you use [server.proxy](/config/server/proxy), the server will downgrade to HTTP/1, because the underlying [http-proxy](https://www.npmjs.com/package/http-proxy) does not support HTTP/2.
+When HTTPS is enabled, Rsbuild uses an HTTP/2 server by default. However, if you enable [server.proxy](/config/server/proxy), the dev server falls back to HTTP/1 because its underlying dependency, [http-proxy](https://www.npmjs.com/package/http-proxy), does not support HTTP/2.
 :::
 
 ## Set certificate

--- a/website/docs/zh/config/server/https.mdx
+++ b/website/docs/zh/config/server/https.mdx
@@ -28,7 +28,7 @@ type Https = ServerOptions | SecureServerSessionOptions;
 ```
 
 :::tip
-Rsbuild 默认会启用 HTTP/2 server。但当你使用 [server.proxy](/config/server/proxy) 时，server 会降级到 HTTP/1，这是因为底层使用的 [http-proxy](https://www.npmjs.com/package/http-proxy) 不支持 HTTP/2。
+当启用 HTTPS 时，Rsbuild 默认会启用 HTTP/2；但如果你使用 [server.proxy](/config/server/proxy)，由于其底层依赖的 [http-proxy](https://www.npmjs.com/package/http-proxy) 不支持 HTTP/2，开发服务器会降级到 HTTP/1。
 :::
 
 ## 设置证书


### PR DESCRIPTION
## Summary

Improve documentation to clearly state that HTTP/2 is default with HTTPS but falls back to HTTP/1 when proxy is enabled due to http-proxy limitation

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
