### PR TITLE
perf: lazy loading memfs dependency

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -25,6 +25,7 @@ export default {
     'rspack-manifest-plugin',
     'html-rspack-plugin',
     'mrmime',
+    'memfs',
     'tinyglobby',
     'chokidar',
     'cors',

--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -139,13 +139,13 @@ export type WithoutUndefined<T, K extends keyof T> = T & {
   [P in K]-?: NonNullable<T[P]>;
 };
 
-export function devMiddleware<
+export async function devMiddleware<
   RequestInternal extends IncomingMessage = IncomingMessage,
   ResponseInternal extends ServerResponse = ServerResponse,
 >(
   compiler: Compiler | MultiCompiler,
   options: Options = {},
-): API<RequestInternal, ResponseInternal> {
+): Promise<API<RequestInternal, ResponseInternal>> {
   const context: WithOptional<Context, 'watching' | 'outputFileSystem'> = {
     state: false,
     // eslint-disable-next-line no-undefined
@@ -161,7 +161,7 @@ export function devMiddleware<
     setupWriteToDisk(context);
   }
 
-  setupOutputFileSystem(context);
+  await setupOutputFileSystem(context);
 
   const filledContext = context as unknown as FilledContext;
 

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -2,7 +2,6 @@ import type { Stats as FSStats, ReadStream } from 'node:fs';
 import type { IncomingMessage } from 'node:http';
 import type { Range, Result as RangeResult, Ranges } from 'range-parser';
 import rangeParser from 'range-parser';
-import mrmime from '../../compiled/mrmime/index.js';
 import onFinishedStream from '../../compiled/on-finished/index.js';
 import { logger } from '../logger';
 import type {
@@ -43,8 +42,9 @@ function createReadStreamOrReadFileSync(
   return { bufferOrStream, byteLength };
 }
 
-function getContentType(str: string): false | string {
-  let mime = mrmime.lookup(str) as string | false | undefined;
+async function getContentType(str: string): Promise<false | string> {
+  const { lookup } = await import('../../compiled/mrmime/index.js');
+  let mime = lookup(str) as string | false | undefined;
   if (!mime) {
     return false;
   }
@@ -362,7 +362,7 @@ export function wrapper<
       let offset = 0;
 
       if (!res.getHeader('Content-Type')) {
-        const contentType = getContentType(filename);
+        const contentType = await getContentType(filename);
         if (contentType) {
           res.setHeader('Content-Type', contentType);
         }

--- a/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
+++ b/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
@@ -1,14 +1,16 @@
 import type { MultiCompiler } from '@rspack/core';
-import { createFsFromVolume, Volume } from 'memfs';
 import type { Context, OutputFileSystem, WithOptional } from '../index';
 
-export function setupOutputFileSystem(
+export async function setupOutputFileSystem(
   context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
-): void {
+): Promise<void> {
   // TODO: refine concrete fs type returned by memfs to match OutputFileSystem
   let outputFileSystem: OutputFileSystem | any;
 
   if (context.options.writeToDisk !== true) {
+    const { createFsFromVolume, Volume } = await import(
+      '../../../compiled/memfs/index.js'
+    );
     outputFileSystem = createFsFromVolume(new Volume());
   } else {
     const isMultiCompiler = (context.compiler as MultiCompiler).compilers;

--- a/packages/core/src/server/compilationMiddleware.ts
+++ b/packages/core/src/server/compilationMiddleware.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module';
 import type { Compiler, MultiCompiler, Stats } from '@rspack/core';
+import { devMiddleware } from '../dev-middleware';
 import { applyToCompiler } from '../helpers';
 import type {
   Connect,
@@ -193,7 +194,6 @@ export const getCompilationMiddleware = async ({
   environments: Record<string, EnvironmentContext>;
   resolvedPort: number;
 }): Promise<CompilationMiddleware> => {
-  const { devMiddleware } = await import('../dev-middleware');
   const resolvedHost = await resolveHostname(config.server.host);
 
   const setupCompiler = (compiler: Compiler, index: number) => {
@@ -227,7 +227,7 @@ export const getCompilationMiddleware = async ({
 
   applyToCompiler(compiler, setupCompiler);
 
-  return devMiddleware(compiler, {
+  return await devMiddleware(compiler, {
     publicPath: '/',
     writeToDisk: resolveWriteToDiskConfig(config.dev, environments),
   });

--- a/packages/core/src/server/compilationMiddleware.ts
+++ b/packages/core/src/server/compilationMiddleware.ts
@@ -227,7 +227,7 @@ export const getCompilationMiddleware = async ({
 
   applyToCompiler(compiler, setupCompiler);
 
-  return await devMiddleware(compiler, {
+  return devMiddleware(compiler, {
     publicPath: '/',
     writeToDisk: resolveWriteToDiskConfig(config.dev, environments),
   });


### PR DESCRIPTION
## Summary

Lazy loading the `memfs` dependency to reduce the main bundle size and make the dev server faster.

### Before

<img width="537" height="166" alt="Screenshot 2025-09-08 at 22 38 38" src="https://github.com/user-attachments/assets/c7ffb7c9-0307-458a-9f65-b68a2678d383" />

### After

<img width="515" height="171" alt="Screenshot 2025-09-08 at 22 42 46" src="https://github.com/user-attachments/assets/2016023f-1c16-4fb7-96a5-6d6f11560158" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6092

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
