### PR TITLE
feat(app-icon): add support for purpose field in web app manifest

### DIFF
--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -195,6 +195,56 @@ test('should allow to specify target for each icon', async () => {
   });
 });
 
+test('should allow to specify purpose for each icon', async () => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    rsbuildConfig: {
+      html: {
+        appIcon: {
+          name: 'My Website',
+          icons: [
+            {
+              src: '../../../assets/circle.svg',
+              size: 192,
+              target: 'web-app-manifest',
+              purpose: 'monochrome',
+            },
+            {
+              src: '../../../assets/image.png',
+              size: 512,
+              target: 'web-app-manifest',
+              purpose: 'maskable',
+            },
+          ],
+        },
+      },
+    },
+  });
+  const files = await rsbuild.getDistFiles();
+  const manifestPath = Object.keys(files).find((file) =>
+    file.endsWith('manifest.webmanifest'),
+  );
+  expect(manifestPath).toBeTruthy();
+
+  expect(JSON.parse(files[manifestPath!])).toEqual({
+    name: 'My Website',
+    icons: [
+      {
+        src: '/static/image/circle.svg',
+        sizes: '192x192',
+        type: 'image/svg+xml',
+        purpose: 'monochrome',
+      },
+      {
+        src: '/static/image/image.png',
+        sizes: '512x512',
+        type: 'image/png',
+        purpose: 'maskable',
+      },
+    ],
+  });
+});
+
 test('should allow to customize manifest filename', async () => {
   const rsbuild = await build({
     cwd: __dirname,

--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -180,6 +180,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
               const result = {
                 src: icon.src,
                 sizes: icon.sizes,
+                purpose: icon.purpose,
               };
               if (icon.mimeType) {
                 return { ...result, type: icon.mimeType };

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1484,6 +1484,21 @@ export type AppIconItem = {
    * - `web-app-manifest` for web application manifest.
    */
   target?: 'apple-touch-icon' | 'web-app-manifest';
+  /**
+   * A case-sensitive keyword string that specifies one or more contexts in
+   * which the icon can be used by the browser or operating system.
+   * This field is only effective when the `target` is `'web-app-manifest'`.
+   *
+   * The possible properties include:
+   * - `'monochrome'`: Indicates that the icon is intended to be used as a
+   * monochrome icon with a solid fill.
+   * - `'maskable'`: Indicates that the icon is designed with icon masks and
+   * safe zone in mind.
+   * - `'any'`: Indicates that the icon can be used in any context. This is
+   * the default value.
+   * @see https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons#purpose
+   */
+  purpose?: string;
 };
 
 export type AppIcon = {

--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -7,6 +7,7 @@ type AppIconItem = {
   src: string;
   size: number;
   target?: 'apple-touch-icon' | 'web-app-manifest';
+  purpose?: string;
 };
 
 type AppIcon = {
@@ -106,6 +107,7 @@ The list of icons:
 - `src` is the path of the icon, which can be a URL, an absolute file path, or a relative path to the project [root](/config/root).
 - `size` is the size of the icon in pixels.
 - `target` refers to the intended target for the icon, which can be either `apple-touch-icon` or `web-app-manifest`. If `target` is not set, by default, the manifest file will include all icons, while the `apple-touch-icon` tags will only include icons smaller than `200x200`.
+- `purpose` is a case-sensitive keyword string that specifies one or more contexts in which the icon can be used by the browser or operating system. This field is only effective when the `target` is `'web-app-manifest'`. See [MDN - purpose](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons#purpose) for more details.
 
 ### Example
 
@@ -172,3 +174,9 @@ export default {
   },
 };
 ```
+
+## Version history
+
+| Version | Changes                            |
+| ------- | ---------------------------------- |
+| v1.5.5  | Added support for `purpose` option |

--- a/website/docs/zh/config/html/app-icon.mdx
+++ b/website/docs/zh/config/html/app-icon.mdx
@@ -7,6 +7,7 @@ type AppIconItem = {
   src: string;
   size: number;
   target?: 'apple-touch-icon' | 'web-app-manifest';
+  purpose?: string;
 };
 
 type AppIcon = {
@@ -106,6 +107,7 @@ export default {
 - `src` 是图标的路径，可以是 URL 地址、文件的绝对路径，或是相对于项目 [root](/config/root) 的相对路径。
 - `size` 是图标的大小，以像素为单位。
 - `target` 是图标的目标，可以是 `apple-touch-icon` 或 `web-app-manifest`。如果未设置 `target`，默认情况下，manifest 文件会包含所有的图标，而 `apple-touch-icon` 标签只会包含小于 `200x200` 的图标。
+- `purpose` 是一个区分大小写的字符串，用于指定浏览器或操作系统在何种场景下可以使用该图标。该字段仅在 `target` 为 `'web-app-manifest'` 时生效。更多信息请参考 [MDN - purpose](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons#purpose)。
 
 ### 示例
 
@@ -172,3 +174,9 @@ export default {
   },
 };
 ```
+
+## 版本历史
+
+| 版本   | 变更内容                    |
+| ------ | --------------------------- |
+| v1.5.5 | 新增对 `purpose` 选项的支持 |


### PR DESCRIPTION
## Summary

Add `purpose` field to app icon configuration to specify usage contexts like 'monochrome' and 'maskable'. Update documentation and add test cases to verify the functionality.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/6088

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
