### PR TITLE
refactor(dev-middleware): improve output filesystem typing

### DIFF
--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -6,7 +6,7 @@
  * Copyright JS Foundation and other contributors
  * https://github.com/webpack/webpack-dev-middleware/blob/master/LICENSE
  */
-import type { Stats as FSStats, ReadStream } from 'node:fs';
+import type { ReadStream } from 'node:fs';
 import type {
   IncomingMessage,
   ServerResponse as NodeServerResponse,
@@ -19,6 +19,7 @@ import type {
   Stats,
 } from '@rspack/core';
 import { logger } from '../logger';
+import type { Rspack } from '../types';
 import { wrapper as createMiddleware } from './middleware';
 import { type Extra, getFilenameFromUrl } from './utils/getFilenameFromUrl';
 import { ready } from './utils/ready';
@@ -39,17 +40,6 @@ export type WatchOptions = NonNullable<Configuration['watchOptions']>;
 export type Watching = Compiler['watching'];
 
 export type MultiWatching = ReturnType<MultiCompiler['watch']>;
-
-// TODO: refine types to match underlying fs-like implementations
-export type OutputFileSystem = {
-  createReadStream?: (
-    p: string,
-    opts: { start: number; end: number },
-  ) => ReadStream;
-  statSync?: (p: string) => FSStats;
-  lstat?: (p: string) => unknown; // TODO: type
-  readFileSync?: (p: string) => Buffer;
-};
 
 export type Callback = (stats?: Stats | MultiStats) => void;
 
@@ -92,7 +82,7 @@ export type Context = {
   options: Options;
   compiler: Compiler | MultiCompiler;
   watching: Watching | MultiWatching | undefined;
-  outputFileSystem: OutputFileSystem;
+  outputFileSystem: Rspack.OutputFileSystem;
 };
 
 export type FilledContext = Omit<Context, 'watching'> & {

--- a/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
+++ b/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
@@ -86,8 +86,10 @@ export function getFilenameFromUrl(
 
       try {
         extra.stats = (
-          context.outputFileSystem.statSync as (p: string) => Stats
-        )(filename);
+          context.outputFileSystem as unknown as {
+            statSync: (p: string) => Stats;
+          }
+        ).statSync(filename);
       } catch (_ignoreError) {
         continue;
       }
@@ -110,8 +112,10 @@ export function getFilenameFromUrl(
 
         try {
           extra.stats = (
-            context.outputFileSystem.statSync as (p: string) => Stats
-          )(filename);
+            context.outputFileSystem as unknown as {
+              statSync: (p: string) => Stats;
+            }
+          ).statSync(filename);
         } catch (__ignoreError) {
           continue;
         }


### PR DESCRIPTION
## Summary

- Replace custom `OutputFileSystem` type with Rspack's built-in type
- Remove redundant type assertions
- Improve type safety in middleware stream handling

## Related Links


https://github.com/web-infra-dev/rsbuild/pull/6092

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
