### PR TITLE
refactor(dev-middleware): clean up code by removing redundant type casts

### DIFF
--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -60,7 +60,7 @@ export type ResponseData = {
 
 export type NormalizedHeaders =
   | Record<string, string | number>
-  | Array<{ key: string; value: number | string }>;
+  | { key: string; value: number | string }[];
 
 export type Headers<
   RequestInternal extends IncomingMessage = IncomingMessage,
@@ -148,7 +148,6 @@ export async function devMiddleware<
 ): Promise<API<RequestInternal, ResponseInternal>> {
   const context: WithOptional<Context, 'watching' | 'outputFileSystem'> = {
     state: false,
-    // eslint-disable-next-line no-undefined
     stats: undefined,
     callbacks: [],
     options,
@@ -181,7 +180,6 @@ export async function devMiddleware<
       const errorHandler = (error: Error | null | undefined) => {
         if (error) {
           if ((error as any).message?.includes('× Error:')) {
-            // eslint-disable-next-line no-param-reassign
             (error as any).message = (error as any).message
               .replace('× Error:', '')
               .trim();
@@ -197,7 +195,7 @@ export async function devMiddleware<
         );
 
         context.watching = multiCompiler.watch(
-          watchOptions as WatchOptions[],
+          watchOptions,
           errorHandler,
         ) as unknown as MultiWatching;
       } else {
@@ -205,7 +203,7 @@ export async function devMiddleware<
         const watchOptions = singleCompiler.options.watchOptions || {};
 
         context.watching = singleCompiler.watch(
-          watchOptions as WatchOptions,
+          watchOptions,
           errorHandler,
         ) as unknown as Watching;
       }

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -373,7 +373,7 @@ export function wrapper<
       const rangeHeader = getRangeHeader();
 
       if (!res.getHeader('ETag')) {
-        const value = extra.stats!;
+        const value = extra.stats;
         if (value) {
           const hash = getEtag(value);
           res.setHeader('ETag', hash);

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -15,10 +15,9 @@ import { memorize } from './utils/memorize';
 import { parseTokenList } from './utils/parseTokenList';
 import { ready } from './utils/ready';
 
-async function getEtag(stat: FSStats): Promise<string> {
+function getEtag(stat: FSStats): string {
   const mtime = stat.mtime.getTime().toString(16);
   const size = stat.size.toString(16);
-
   return `W/"${size}-${mtime}"`;
 }
 
@@ -124,7 +123,6 @@ export function wrapper<
   return async function middleware(req, res, next) {
     const acceptedMethods = ['GET', 'HEAD'];
 
-    // eslint-disable-next-line no-param-reassign
     (res as any).locals = (res as any).locals || {};
 
     async function goNext() {
@@ -132,10 +130,10 @@ export function wrapper<
         ready(
           context,
           () => {
-            // eslint-disable-next-line no-param-reassign
             // TODO: augment Response type to include `locals`
-            ((res as any).locals as any).webpack = { devMiddleware: context };
-            resolve(next());
+            (res as any).locals.webpack = { devMiddleware: context };
+            next();
+            resolve();
           },
           req,
         );
@@ -173,7 +171,6 @@ export function wrapper<
         }
       }
 
-      // eslint-disable-next-line no-param-reassign
       res.statusCode = status;
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.setHeader('Content-Security-Policy', "default-src 'none'");
@@ -202,7 +199,7 @@ export function wrapper<
         return (
           !etag ||
           (ifMatch !== '*' &&
-            parseTokenList(ifMatch as string).every(
+            parseTokenList(ifMatch).every(
               (match: string) =>
                 match !== etag &&
                 match !== `W/${etag}` &&
@@ -213,7 +210,7 @@ export function wrapper<
 
       const ifUnmodifiedSince = req.headers['if-unmodified-since'];
       if (ifUnmodifiedSince) {
-        const unmodifiedSince = parseHttpDate(ifUnmodifiedSince as string);
+        const unmodifiedSince = parseHttpDate(ifUnmodifiedSince);
         if (!Number.isNaN(unmodifiedSince)) {
           const lastModified = parseHttpDate(
             String(res.getHeader('Last-Modified')),
@@ -235,10 +232,7 @@ export function wrapper<
     function isFresh(resHeaders: import('http').OutgoingHttpHeaders): boolean {
       const cacheControl = req.headers['cache-control'];
 
-      if (
-        cacheControl &&
-        CACHE_CONTROL_NO_CACHE_REGEXP.test(cacheControl as string)
-      ) {
+      if (cacheControl && CACHE_CONTROL_NO_CACHE_REGEXP.test(cacheControl)) {
         return false;
       }
 
@@ -254,7 +248,7 @@ export function wrapper<
           return false;
         }
 
-        const matches = parseTokenList(noneMatch as string);
+        const matches = parseTokenList(noneMatch);
         let etagStale = true;
 
         for (let i = 0; i < matches.length; i++) {
@@ -283,8 +277,7 @@ export function wrapper<
         const modifiedStale =
           !lastModified ||
           !(
-            parseHttpDate(String(lastModified)) <=
-            parseHttpDate(modifiedSince as string)
+            parseHttpDate(String(lastModified)) <= parseHttpDate(modifiedSince)
           );
 
         if (modifiedStale) {
@@ -319,7 +312,7 @@ export function wrapper<
     }
 
     function getRangeHeader(): string | undefined {
-      const rage = req.headers.range as string | undefined;
+      const rage = req.headers.range;
       if (rage && BYTES_RANGE_REGEXP.test(rage)) {
         return rage;
       }
@@ -340,7 +333,7 @@ export function wrapper<
 
     async function processRequest() {
       const extra: import('./utils/getFilenameFromUrl').Extra = {};
-      const filename = getFilenameFromUrl(context, req.url as string, extra);
+      const filename = getFilenameFromUrl(context, req.url!, extra);
 
       if (extra.errorCode) {
         if (extra.errorCode === 403) {
@@ -357,7 +350,7 @@ export function wrapper<
         return;
       }
 
-      const { size } = extra.stats as FSStats;
+      const { size } = extra.stats!;
       let len = size;
       let offset = 0;
 
@@ -373,16 +366,16 @@ export function wrapper<
       }
 
       if (context.options.lastModified && !res.getHeader('Last-Modified')) {
-        const modified = (extra.stats as FSStats).mtime.toUTCString();
+        const modified = extra.stats!.mtime.toUTCString();
         res.setHeader('Last-Modified', modified);
       }
 
       const rangeHeader = getRangeHeader();
 
       if (!res.getHeader('ETag')) {
-        const value = extra.stats as FSStats;
+        const value = extra.stats!;
         if (value) {
-          const hash = await getEtag(value);
+          const hash = getEtag(value);
           res.setHeader('ETag', hash);
         }
       }
@@ -394,7 +387,6 @@ export function wrapper<
         }
 
         if (res.statusCode === 404) {
-          // eslint-disable-next-line no-param-reassign
           res.statusCode = 200;
         }
 
@@ -407,7 +399,6 @@ export function wrapper<
               | undefined,
           })
         ) {
-          // eslint-disable-next-line no-param-reassign
           res.statusCode = 304;
 
           res.removeHeader('Content-Encoding');
@@ -457,20 +448,17 @@ export function wrapper<
         }
 
         if (parsedRanges !== -2 && (parsedRanges as any[]).length === 1) {
-          // eslint-disable-next-line no-param-reassign
           res.statusCode = 206;
           res.setHeader(
             'Content-Range',
             getValueContentRangeHeader(
               'bytes',
               size,
-              (parsedRanges as Ranges)[0] as Range,
+              (parsedRanges as Ranges)[0],
             ),
           );
 
-          [offset, len] = getOffsetAndLenFromRange(
-            (parsedRanges as Ranges)[0] as Range,
-          );
+          [offset, len] = getOffsetAndLenFromRange((parsedRanges as Ranges)[0]);
         }
       }
 
@@ -496,7 +484,6 @@ export function wrapper<
 
       if (req.method === 'HEAD') {
         if (res.statusCode === 404) {
-          // eslint-disable-next-line no-param-reassign
           res.statusCode = 200;
         }
         res.end();
@@ -519,6 +506,7 @@ export function wrapper<
         'error',
         (error: NodeJS.ErrnoException) => {
           cleanup();
+          // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check
           switch (error.code) {
             case 'ENAMETOOLONG':
             case 'ENOENT':

--- a/packages/core/src/dev-middleware/utils/escapeHtml.ts
+++ b/packages/core/src/dev-middleware/utils/escapeHtml.ts
@@ -1,11 +1,10 @@
 const matchHtmlRegExp = /["'&<>]/;
 
 export function escapeHtml(input: string): string {
-  const str = `${input}`;
-  const match = matchHtmlRegExp.exec(str);
+  const match = matchHtmlRegExp.exec(input);
 
   if (!match) {
-    return str;
+    return input;
   }
 
   let htmlEntity: string | undefined;
@@ -13,8 +12,8 @@ export function escapeHtml(input: string): string {
   let index = 0;
   let lastIndex = 0;
 
-  for ({ index } = match as RegExpExecArray; index < str.length; index++) {
-    switch (str.charCodeAt(index)) {
+  for ({ index } = match; index < input.length; index++) {
+    switch (input.charCodeAt(index)) {
       case 34:
         htmlEntity = '&quot' + ';';
         break;
@@ -31,17 +30,16 @@ export function escapeHtml(input: string): string {
         htmlEntity = '&gt' + ';';
         break;
       default:
-        // eslint-disable-next-line no-continue
         continue;
     }
 
     if (lastIndex !== index) {
-      html += str.substring(lastIndex, index);
+      html += input.substring(lastIndex, index);
     }
 
     lastIndex = index + 1;
-    html += htmlEntity as string;
+    html += htmlEntity;
   }
 
-  return lastIndex !== index ? html + str.substring(lastIndex, index) : html;
+  return lastIndex !== index ? html + input.substring(lastIndex, index) : html;
 }

--- a/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
+++ b/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
@@ -15,7 +15,6 @@ export type Extra = {
 // TODO: type the cache options instead of using any for the second parameter
 const memoizedParse = memorize(parse as any, undefined as any, (value: any) => {
   if (value.pathname) {
-    // eslint-disable-next-line no-param-reassign
     value.pathname = decode(value.pathname);
   }
 
@@ -34,10 +33,10 @@ export function getFilenameFromUrl(
   extra: Extra = {},
 ): string | undefined {
   const { options } = context;
-  const paths = getPaths(context) as Array<{
+  const paths = getPaths(context) as {
     publicPath: string | undefined;
     outputPath: string;
-  }>;
+  }[];
 
   let foundFilename: string | undefined;
   let urlObject: URL;

--- a/packages/core/src/dev-middleware/utils/memorize.ts
+++ b/packages/core/src/dev-middleware/utils/memorize.ts
@@ -15,7 +15,7 @@ export function memorize<T>(
     const cacheItem = cache.get(key);
 
     if (cacheItem) {
-      return cacheItem.data as T;
+      return cacheItem.data;
     }
 
     // @ts-ignore preserve runtime behavior

--- a/packages/core/src/dev-middleware/utils/setupHooks.ts
+++ b/packages/core/src/dev-middleware/utils/setupHooks.ts
@@ -5,9 +5,7 @@ export function setupHooks(
   context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
 ): void {
   function invalid() {
-    // eslint-disable-next-line no-param-reassign
     context.state = false;
-    // eslint-disable-next-line no-param-reassign, no-undefined
     context.stats = undefined;
   }
 

--- a/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
+++ b/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
@@ -38,6 +38,5 @@ export async function setupOutputFileSystem(
   }
 
   // @ts-ignore
-  // eslint-disable-next-line no-param-reassign
   (context as any).outputFileSystem = outputFileSystem as OutputFileSystem;
 }

--- a/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
+++ b/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
@@ -50,7 +50,7 @@ export function setupWriteToDisk(
             (mkdirError: NodeJS.ErrnoException | null) => {
               if (mkdirError) {
                 logger.error(
-                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${String(mkdirError)}`,
+                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${mkdirError.message}`,
                 );
 
                 callback(mkdirError);
@@ -63,7 +63,7 @@ export function setupWriteToDisk(
                 (writeFileError: NodeJS.ErrnoException | null) => {
                   if (writeFileError) {
                     logger.error(
-                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${String(writeFileError)}`,
+                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${writeFileError.message}`,
                     );
 
                     callback(writeFileError);

--- a/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
+++ b/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
@@ -50,7 +50,7 @@ export function setupWriteToDisk(
             (mkdirError: NodeJS.ErrnoException | null) => {
               if (mkdirError) {
                 logger.error(
-                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${mkdirError.message}`,
+                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${String(mkdirError)}`,
                 );
 
                 callback(mkdirError);
@@ -63,7 +63,7 @@ export function setupWriteToDisk(
                 (writeFileError: NodeJS.ErrnoException | null) => {
                   if (writeFileError) {
                     logger.error(
-                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${writeFileError.message}`,
+                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${String(writeFileError)}`,
                     );
 
                     callback(writeFileError);

--- a/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
+++ b/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
@@ -35,7 +35,8 @@ export function setupWriteToDisk(
               : true;
 
           if (!allowWrite) {
-            return callback();
+            callback();
+            return;
           }
 
           const dir = path.dirname(targetPath);
@@ -43,35 +44,37 @@ export function setupWriteToDisk(
             ? `Child "${compiler.options.name}": `
             : '';
 
-          return fs.mkdir(
+          fs.mkdir(
             dir,
             { recursive: true },
             (mkdirError: NodeJS.ErrnoException | null) => {
               if (mkdirError) {
                 logger.error(
-                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${mkdirError}`,
+                  `[rsbuild-dev-middleware] ${name}Unable to write "${dir}" directory to disk:\n${mkdirError.message}`,
                 );
 
-                return callback(mkdirError);
+                callback(mkdirError);
+                return;
               }
 
-              return fs.writeFile(
+              fs.writeFile(
                 targetPath,
                 content,
                 (writeFileError: NodeJS.ErrnoException | null) => {
                   if (writeFileError) {
                     logger.error(
-                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${writeFileError}`,
+                      `[rsbuild-dev-middleware] ${name}Unable to write "${targetPath}" asset to disk:\n${writeFileError.message}`,
                     );
 
-                    return callback(writeFileError);
+                    callback(writeFileError);
+                    return;
                   }
 
                   logger.debug(
                     `[rsbuild-dev-middleware] ${name}Asset written to disk: "${targetPath}"`,
                   );
 
-                  return callback();
+                  callback();
                 },
               );
             },

--- a/rslint.json
+++ b/rslint.json
@@ -1,11 +1,7 @@
 [
   {
     "language": "javascript",
-    "ignores": [
-      "**/dist-types/**",
-      "**/compiled/**",
-      "**/src/dev-middleware/**"
-    ],
+    "ignores": ["**/dist/**", "**/dist-types/**", "**/compiled/**"],
     "languageOptions": {
       "parserOptions": {
         "project": [


### PR DESCRIPTION
## Summary

- Simplify type definitions and remove unnecessary type assertions
- Remove redundant `eslint-disable` comments where no longer needed

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6092

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
