### PR TITLE
chore(workflow): remove experimental typescript setting

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "biomejs.biome",
     "esbenp.prettier-vscode",
-    "unifiedjs.vscode-mdx",
-    "TypeScriptTeam.native-preview"
+    "unifiedjs.vscode-mdx"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,5 @@
       "fileMatch": ["**/_nav.json"],
       "url": "./website/node_modules/@rspress/core/nav-json-schema.json"
     }
-  ],
-  "typescript.experimental.useTsgo": true
+  ]
 }


### PR DESCRIPTION
## Summary

Since the `TypeScriptTeam.native-preview` extension has not been published to the Open VSX registry, we removed the experimental typescript setting to avoid breaking the editors forked from VS Code.

## Related Links

- https://open-vsx.org/?search=typescript%20native&sortBy=relevance&sortOrder=desc
- https://github.com/web-infra-dev/rsbuild/pull/6087

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
