### PR TITLE
refactor(dev-middleware): clean up unused options

### DIFF
--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -34,8 +34,6 @@ export type ExtendedServerResponse = {
 
 export type ServerResponse = NodeServerResponse & ExtendedServerResponse;
 
-export type WatchOptions = NonNullable<Configuration['watchOptions']>;
-
 export type Watching = Compiler['watching'];
 
 export type MultiWatching = ReturnType<MultiCompiler['watch']>;
@@ -53,34 +51,11 @@ export type OutputFileSystem = {
 
 export type Callback = (stats?: Stats | MultiStats) => void;
 
-export type ResponseData = {
-  data: Buffer | ReadStream;
-  byteLength: number;
-};
-
-export type NormalizedHeaders =
-  | Record<string, string | number>
-  | { key: string; value: number | string }[];
-
-export type Headers<
-  RequestInternal extends IncomingMessage = IncomingMessage,
-  ResponseInternal extends ServerResponse = ServerResponse,
-> =
-  | NormalizedHeaders
-  | ((
-      req: RequestInternal,
-      res: ResponseInternal,
-      context: Context,
-    ) => void | undefined | NormalizedHeaders)
-  | undefined;
-
 export type Options = {
   writeToDisk?:
     | boolean
     | ((targetPath: string, compilationName?: string) => boolean);
   publicPath?: NonNullable<Configuration['output']>['publicPath'];
-  index?: boolean | string;
-  lastModified?: boolean;
 };
 
 export type NextFunction = (err?: unknown) => void;

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -365,11 +365,6 @@ export function wrapper<
         res.setHeader('Accept-Ranges', 'bytes');
       }
 
-      if (context.options.lastModified && !res.getHeader('Last-Modified')) {
-        const modified = extra.stats!.mtime.toUTCString();
-        res.setHeader('Last-Modified', modified);
-      }
-
       const rangeHeader = getRangeHeader();
 
       if (!res.getHeader('ETag')) {

--- a/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
+++ b/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
@@ -12,7 +12,6 @@ export type Extra = {
 };
 
 // TODO: type the cache options instead of using any for the second parameter
-// TODO: type the cache options instead of using any for the second parameter
 const memoizedParse = memorize(parse as any, undefined as any, (value: any) => {
   if (value.pathname) {
     value.pathname = decode(value.pathname);
@@ -32,7 +31,6 @@ export function getFilenameFromUrl(
   url: string,
   extra: Extra = {},
 ): string | undefined {
-  const { options } = context;
   const paths = getPaths(context) as {
     publicPath: string | undefined;
     outputPath: string;
@@ -95,15 +93,8 @@ export function getFilenameFromUrl(
         foundFilename = filename;
         break;
       }
-      if (
-        extra.stats.isDirectory() &&
-        (typeof options.index === 'undefined' || options.index)
-      ) {
-        const indexValue =
-          typeof options.index === 'undefined' ||
-          typeof options.index === 'boolean'
-            ? 'index.html'
-            : options.index;
+      if (extra.stats.isDirectory()) {
+        const indexValue = 'index.html';
 
         filename = path.join(filename, indexValue);
 


### PR DESCRIPTION
## Summary

Some options in dev middleware originated from webpack-dev-middleware and were never used by Rsbuild. This PR removes those options to simplify the code.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
