### PR TITLE
refactor(dev-middleware): remove unnecessary type assertions

### DIFF
--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -127,7 +127,7 @@ export async function devMiddleware<
     callbacks: [],
     options,
     compiler,
-  } as unknown as WithOptional<Context, 'watching' | 'outputFileSystem'>;
+  } as WithOptional<Context, 'watching' | 'outputFileSystem'>;
 
   setupHooks(context);
 
@@ -137,10 +137,10 @@ export async function devMiddleware<
 
   await setupOutputFileSystem(context);
 
-  const filledContext = context as unknown as FilledContext;
+  const filledContext = context as FilledContext;
 
   const instance = (
-    createMiddleware as unknown as (
+    createMiddleware as (
       ctx: FilledContext,
     ) => API<RequestInternal, ResponseInternal>
   )(filledContext);
@@ -148,16 +148,14 @@ export async function devMiddleware<
   // API
   instance.watch = () => {
     if ((context.compiler as Compiler).watching) {
-      context.watching = (context.compiler as Compiler).watching as unknown as
+      context.watching = (context.compiler as Compiler).watching as
         | Watching
         | MultiWatching;
     } else {
       const errorHandler = (error: Error | null | undefined) => {
         if (error) {
-          if ((error as any).message?.includes('× Error:')) {
-            (error as any).message = (error as any).message
-              .replace('× Error:', '')
-              .trim();
+          if (error.message?.includes('× Error:')) {
+            error.message = error.message.replace('× Error:', '').trim();
           }
           logger.error(error);
         }
@@ -172,7 +170,7 @@ export async function devMiddleware<
         context.watching = multiCompiler.watch(
           watchOptions,
           errorHandler,
-        ) as unknown as MultiWatching;
+        ) as MultiWatching;
       } else {
         const singleCompiler = context.compiler as Compiler;
         const watchOptions = singleCompiler.options.watchOptions || {};
@@ -180,14 +178,14 @@ export async function devMiddleware<
         context.watching = singleCompiler.watch(
           watchOptions,
           errorHandler,
-        ) as unknown as Watching;
+        ) as Watching;
       }
     }
   };
 
   instance.getFilenameFromUrl = (url, extra) =>
     (
-      getFilenameFromUrl as unknown as (
+      getFilenameFromUrl as (
         ctx: FilledContext,
         url: string,
         extra?: Extra,
@@ -207,8 +205,7 @@ export async function devMiddleware<
     filledContext.watching?.close(callback);
   };
 
-  // TODO: extend the middleware function type to include `context` without casting
-  (instance as any).context = filledContext;
+  instance.context = filledContext;
 
   return instance;
 }

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -78,22 +78,21 @@ function parseHttpDate(date: string): number {
 const CACHE_CONTROL_NO_CACHE_REGEXP = /(?:^|,)\s*?no-cache\s*?(?:,|$)/;
 
 function destroyStream(stream: ReadStream, suppress: boolean): void {
-  if (typeof (stream as any).destroy === 'function') {
-    (stream as any).destroy();
+  if (typeof stream.destroy === 'function') {
+    stream.destroy();
   }
 
-  if (typeof (stream as any).close === 'function') {
-    stream.on('open', function onOpenClose(this: ReadStream) {
-      // @ts-ignore
-      if (typeof (this as any).fd === 'number') {
+  if (typeof stream.close === 'function') {
+    stream.on('open', function onOpenClose(this: ReadStream, fd) {
+      if (typeof fd === 'number') {
         this.close();
       }
     });
   }
 
-  if (typeof (stream as any).addListener === 'function' && suppress) {
-    (stream as any).removeAllListeners('error');
-    (stream as any).addListener('error', () => {});
+  if (typeof stream.addListener === 'function' && suppress) {
+    stream.removeAllListeners('error');
+    stream.addListener('error', () => {});
   }
 }
 
@@ -123,15 +122,13 @@ export function wrapper<
   return async function middleware(req, res, next) {
     const acceptedMethods = ['GET', 'HEAD'];
 
-    (res as any).locals = (res as any).locals || {};
-
     async function goNext() {
       return new Promise<void>((resolve) => {
         ready(
           context,
           () => {
-            // TODO: augment Response type to include `locals`
-            (res as any).locals.webpack = { devMiddleware: context };
+            res.locals = res.locals || {};
+            res.locals.webpack = { devMiddleware: context };
             next();
             resolve();
           },
@@ -166,7 +163,7 @@ export function wrapper<
           const key = keys[i];
           const value = options.headers[key];
           if (typeof value !== 'undefined') {
-            res.setHeader(key, value as any);
+            res.setHeader(key, value);
           }
         }
       }
@@ -368,9 +365,8 @@ export function wrapper<
       const rangeHeader = getRangeHeader();
 
       if (!res.getHeader('ETag')) {
-        const value = extra.stats;
-        if (value) {
-          const hash = getEtag(value);
+        if (extra.stats) {
+          const hash = getEtag(extra.stats);
           res.setHeader('ETag', hash);
         }
       }
@@ -427,7 +423,7 @@ export function wrapper<
 
           sendError(416, {
             headers: {
-              'Content-Range': res.getHeader('Content-Range') as any,
+              'Content-Range': res.getHeader('Content-Range'),
             },
           });
           return;
@@ -436,13 +432,13 @@ export function wrapper<
           logger.error(
             "[rsbuild-dev-middleware] A malformed 'Range' header was provided. A regular response will be sent for this request.",
           );
-        } else if ((parsedRanges as any[]).length > 1) {
+        } else if (parsedRanges.length > 1) {
           logger.error(
             "[rsbuild-dev-middleware] A 'Range' header with multiple ranges was provided. Multiple ranges are not supported, so a regular response will be sent for this request.",
           );
         }
 
-        if (parsedRanges !== -2 && (parsedRanges as any[]).length === 1) {
+        if (parsedRanges !== -2 && parsedRanges.length === 1) {
           res.statusCode = 206;
           res.setHeader(
             'Content-Range',
@@ -474,7 +470,6 @@ export function wrapper<
         return;
       }
 
-      // @ts-ignore
       res.setHeader('Content-Length', byteLength);
 
       if (req.method === 'HEAD') {
@@ -515,7 +510,7 @@ export function wrapper<
         },
       );
 
-      (bufferOrStream as ReadStream).pipe(res as any);
+      (bufferOrStream as ReadStream).pipe(res);
 
       onFinishedStream(res, cleanup);
     }

--- a/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
+++ b/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
@@ -12,7 +12,7 @@ export type Extra = {
 };
 
 // TODO: type the cache options instead of using any for the second parameter
-const memoizedParse = memorize(parse as any, undefined as any, (value: any) => {
+const memoizedParse = memorize(parse, undefined, (value: any) => {
   if (value.pathname) {
     value.pathname = decode(value.pathname);
   }
@@ -40,7 +40,7 @@ export function getFilenameFromUrl(
   let urlObject: URL;
 
   try {
-    urlObject = memoizedParse(url, false, true) as unknown as URL;
+    urlObject = memoizedParse(url, false, true) as URL;
   } catch (_ignoreError) {
     return undefined;
   }
@@ -54,13 +54,13 @@ export function getFilenameFromUrl(
         publicPath !== 'auto' && publicPath ? publicPath : '/',
         false,
         true,
-      ) as unknown as URL;
+      ) as URL;
     } catch (_ignoreError) {
       continue;
     }
 
-    const { pathname } = urlObject as any;
-    const { pathname: publicPathPathname } = publicPathObject as any;
+    const { pathname } = urlObject;
+    const { pathname: publicPathPathname } = publicPathObject;
 
     if (
       pathname &&

--- a/packages/core/src/dev-middleware/utils/getPaths.ts
+++ b/packages/core/src/dev-middleware/utils/getPaths.ts
@@ -6,18 +6,18 @@ type PublicPathInfo = { outputPath: string; publicPath: string | undefined };
 export function getPaths(context: FilledContext): PublicPathInfo[] {
   const { stats, options } = context;
   const childStats: WStats[] = (stats as WMultiStats).stats
-    ? ((stats as WMultiStats).stats as unknown as WStats[])
+    ? ((stats as WMultiStats).stats as WStats[])
     : [stats as WStats];
   const publicPaths: PublicPathInfo[] = [];
 
-  for (const { compilation } of childStats as any) {
+  for (const { compilation } of childStats) {
     const outputPath = compilation.getPath(
       compilation.outputOptions.path || '',
     );
     const publicPath = options.publicPath
-      ? compilation.getPath(options.publicPath)
+      ? compilation.getPath(options.publicPath as string)
       : compilation.outputOptions.publicPath
-        ? compilation.getPath(compilation.outputOptions.publicPath)
+        ? compilation.getPath(compilation.outputOptions.publicPath as string)
         : '';
 
     publicPaths.push({ outputPath, publicPath });

--- a/packages/core/src/dev-middleware/utils/memorize.ts
+++ b/packages/core/src/dev-middleware/utils/memorize.ts
@@ -18,7 +18,6 @@ export function memorize<T>(
       return cacheItem.data;
     }
 
-    // @ts-ignore preserve runtime behavior
     let result: T = fn.apply(undefined, arguments_);
 
     if (callback) {
@@ -32,7 +31,7 @@ export function memorize<T>(
     return result;
   };
 
-  cacheStore.set(memoized, cache as unknown as Map<string, { data: unknown }>);
+  cacheStore.set(memoized, cache as Map<string, { data: unknown }>);
 
   return memoized;
 }

--- a/packages/core/src/dev-middleware/utils/ready.ts
+++ b/packages/core/src/dev-middleware/utils/ready.ts
@@ -12,11 +12,11 @@ export function ready<Request extends IncomingMessage>(
     return;
   }
 
-  const name = (req && (req as any).url) || callback.name;
+  const name = req?.url || callback.name;
 
   logger.debug(
     `[rsbuild-dev-middleware] wait until bundle finished${name ? `: ${name}` : ''}`,
   );
 
-  context.callbacks.push(callback as unknown as Callback);
+  context.callbacks.push(callback as Callback);
 }

--- a/packages/core/src/dev-middleware/utils/setupHooks.ts
+++ b/packages/core/src/dev-middleware/utils/setupHooks.ts
@@ -28,7 +28,7 @@ export function setupHooks(
     });
   }
 
-  const compiler = (context as unknown as Context).compiler as any;
+  const compiler = (context as Context).compiler;
 
   compiler.hooks.watchRun.tap('rsbuild-dev-middleware', invalid);
   compiler.hooks.invalid.tap('rsbuild-dev-middleware', invalid);

--- a/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
+++ b/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
@@ -21,10 +21,9 @@ export async function setupOutputFileSystem(
       );
 
       ({ outputFileSystem } =
-        compiler[0] ||
-        ((context.compiler as MultiCompiler).compilers[0] as any));
+        compiler[0] || (context.compiler as MultiCompiler).compilers[0]);
     } else {
-      ({ outputFileSystem } = context.compiler as any);
+      ({ outputFileSystem } = context.compiler);
     }
   }
 
@@ -32,11 +31,9 @@ export async function setupOutputFileSystem(
     context.compiler,
   ];
 
-  for (const compiler of compilers as any[]) {
-    // @ts-ignore
+  for (const compiler of compilers) {
     compiler.outputFileSystem = outputFileSystem;
   }
 
-  // @ts-ignore
-  (context as any).outputFileSystem = outputFileSystem as OutputFileSystem;
+  context.outputFileSystem = outputFileSystem as OutputFileSystem;
 }


### PR DESCRIPTION
## Summary

This PR continues to clean up the dev middleware and removes unnecessary type assertions.

- Replace unsafe type assertions with proper type casting
- Remove redundant ts-ignore comments

## Related Links

- https://github.com/web-infra-dev/rsbuild/commits/main/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
