### PR TITLE
chore: update source map type imports

### DIFF
--- a/packages/core/src/loader/transformLoader.ts
+++ b/packages/core/src/loader/transformLoader.ts
@@ -1,4 +1,4 @@
-import type { LoaderDefinition, sources } from '@rspack/core';
+import type { LoaderDefinition, RawSourceMap } from '@rspack/core';
 import type { EnvironmentContext } from '../types';
 
 export type TransformLoaderOptions = {
@@ -7,9 +7,9 @@ export type TransformLoaderOptions = {
 };
 
 const mergeSourceMap = async (
-  originalSourceMap?: sources.RawSourceMap | string,
-  generatedSourceMap?: sources.RawSourceMap | string | null,
-): Promise<sources.RawSourceMap | string | undefined> => {
+  originalSourceMap?: RawSourceMap | string,
+  generatedSourceMap?: RawSourceMap | string | null,
+): Promise<RawSourceMap | string | undefined> => {
   if (!originalSourceMap || !generatedSourceMap) {
     return generatedSourceMap ?? originalSourceMap;
   }
@@ -65,10 +65,7 @@ const transformLoader: LoaderDefinition<TransformLoaderOptions> =
         return;
       }
 
-      const mergedMap = await mergeSourceMap(
-        map as sources.RawSourceMap,
-        result.map,
-      );
+      const mergedMap = await mergeSourceMap(map as RawSourceMap, result.map);
       callback(null, result.code, mergedMap);
     } catch (error) {
       if (error instanceof Error) {

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -301,7 +301,7 @@ type TransformResult =
   | string
   | {
       code: string;
-      map?: string | Rspack.sources.RawSourceMap | null;
+      map?: string | Rspack.RawSourceMap | null;
     };
 
 export type TransformContext = {


### PR DESCRIPTION
## Summary

Simplify type imports by using `RawSourceMap` directly from Rspack core instead of through the sources namespace. This makes the code more consistent and reduces unnecessary nesting in type references.

## Related Links

- https://github.com/web-infra-dev/rspack/releases/tag/v1.5.3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
