### PR TITLE
fix: temporarily disable enum inlining optimization

### DIFF
--- a/e2e/cases/typescript/const-enum/index.test.ts
+++ b/e2e/cases/typescript/const-enum/index.test.ts
@@ -13,12 +13,15 @@ rspackOnlyTest(
     expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
     expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
     expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
-    expect(await page.evaluate(() => window.testNumbers)).toBe('0,1,1.0');
+    expect(await page.evaluate(() => window.testNumbers)).toBe(
+      '0,1,1.1,1.0,-1,-1.1',
+    );
 
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('window.testFish="fish,FISH"');
-    expect(indexJs).toContain('window.testCat="cat,CAT"');
-    expect(indexJs).toContain('window.testNumbers="0,1,1.0"');
+    // TODO: enable inline enum optimization
+    // const indexJs = await rsbuild.getIndexBundle();
+    // expect(indexJs).toContain('window.testFish="fish,FISH"');
+    // expect(indexJs).toContain('window.testCat="cat,CAT"');
+    // expect(indexJs).toContain('window.testNumbers="0,1,1.1,1.0,-1,-1.1"');
 
     await rsbuild.close();
   },

--- a/e2e/cases/typescript/const-enum/src/constants.ts
+++ b/e2e/cases/typescript/const-enum/src/constants.ts
@@ -7,4 +7,7 @@ export enum Animals {
 export const enum Numbers {
   Zero = 0,
   One = 1,
+  OnePointOne = 1.1,
+  MinusOne = -1,
+  MinusOnePointOne = -1.1,
 }

--- a/e2e/cases/typescript/const-enum/src/index.ts
+++ b/e2e/cases/typescript/const-enum/src/index.ts
@@ -11,7 +11,7 @@ declare global {
 
 window.testFish = `${Animals.Fish},${Animals.Fish.toUpperCase()}`;
 window.testCat = `${Animals.Cat},${Animals.Cat.toUpperCase()}`;
-window.testNumbers = `${Numbers.Zero},${Numbers.One},${Numbers.One.toFixed(1)}`;
+window.testNumbers = `${Numbers.Zero},${Numbers.One},${Numbers.OnePointOne},${Numbers.One.toFixed(1)},${Numbers.MinusOne},${Numbers.MinusOnePointOne}`;
 
 import('./constants2').then(({ Animals2 }) => {
   window.testDog = `${Animals2.Dog},${Animals2.Dog.toUpperCase()}`;

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -97,7 +97,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           chain.experiments({
             ...chain.get('experiments'),
             lazyBarrel: true,
-            inlineEnum: isProd,
+            inlineEnum: false,
             inlineConst: isProd,
             typeReexportsPresence: true,
             rspackFuture: {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -113,7 +113,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { CHAIN_ID, isDev, isProd, target, environment }) => {
+      handler: (chain, { CHAIN_ID, isDev, target, environment }) => {
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -67,12 +67,10 @@ function getDefaultSwcConfig({
   browserslist,
   cacheRoot,
   config,
-  isProd,
 }: {
   browserslist: string[];
   cacheRoot: string;
   config: NormalizedEnvironmentConfig;
-  isProd: boolean;
 }): SwcLoaderOptions {
   return {
     jsc: {
@@ -100,7 +98,7 @@ function getDefaultSwcConfig({
     rspackExperiments: {
       collectTypeScriptInfo: {
         typeExports: true,
-        exportedEnum: isProd,
+        exportedEnum: false,
       },
     },
   };
@@ -158,7 +156,6 @@ export const pluginSwc = (): RsbuildPlugin => ({
           browserslist,
           cacheRoot,
           config,
-          isProd,
         });
 
         applyTransformImport(swcConfig, config.source.transformImport);

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -56,7 +56,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "devtool": false,
   "experiments": {
     "inlineConst": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -528,7 +528,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": true,
-    "inlineEnum": true,
+    "inlineEnum": false,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -696,7 +696,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },
@@ -754,7 +754,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": true,
+                  "exportedEnum": false,
                   "typeExports": true,
                 },
               },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -475,7 +475,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": true,
+              "exportedEnum": false,
               "typeExports": true,
             },
           },


### PR DESCRIPTION
## Summary

The enum inlining optimization was previously enabled in production builds, which could cause issues in some edge cases. (See the newly added test case).

This PR disables these options to ensure the output code works as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
