### PR TITLE
test(e2e): add test case for utf-8 charset in dev mode

### DIFF
--- a/e2e/cases/output/charset/src/index.js
+++ b/e2e/cases/output/charset/src/index.js
@@ -1,4 +1,4 @@
-window.a = '你好 world!';
+window.a = `你好 world! I'm 🦀`;
 
 window.b = {
   Д: 'A',


### PR DESCRIPTION
## Summary

Added new test cases to explicitly verify `output.charset` behavior for both `'ascii'` and `'utf8'` settings in development mode.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
