### PR TITLE
test(e2e): add new test case for handling emoji filenames

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -62,5 +62,17 @@
         "noConfusingVoidType": "off"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["e2e/**/🦀.js"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useFilenamingConvention": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/e2e/cases/output/charset-emoji-filename/index.test.ts
+++ b/e2e/cases/output/charset-emoji-filename/index.test.ts
@@ -1,0 +1,33 @@
+import { build, dev } from '@e2e/helper';
+import { expect, test } from '@playwright/test';
+
+const utf8Str = `你好 world! I'm 🦀`;
+
+test('should resolve emoji filename in dev', async ({ page }) => {
+  const rsbuild = await dev({
+    cwd: __dirname,
+    rsbuildConfig: {
+      dev: {
+        writeToDisk: true,
+      },
+    },
+    page,
+  });
+
+  expect(await page.evaluate('window.test')).toBe(utf8Str);
+  await rsbuild.close();
+});
+
+test('should resolve emoji filename in build', async ({ page }) => {
+  const rsbuild = await build({
+    cwd: __dirname,
+    page,
+  });
+
+  expect(await page.evaluate('window.test')).toBe(utf8Str);
+
+  const content = await rsbuild.getIndexBundle();
+  expect(content.includes(utf8Str)).toBeTruthy();
+
+  await rsbuild.close();
+});

--- a/e2e/cases/output/charset-emoji-filename/src/index.js
+++ b/e2e/cases/output/charset-emoji-filename/src/index.js
@@ -1,0 +1,3 @@
+import { name } from './🦀';
+
+window.test = `你好 world! I'm ${name}`;

--- a/e2e/cases/output/charset-emoji-filename/src/🦀.js
+++ b/e2e/cases/output/charset-emoji-filename/src/🦀.js
@@ -1,0 +1,1 @@
+export const name = '🦀';

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -3,6 +3,16 @@ import { expect, test } from '@playwright/test';
 
 const utf8Str = `你好 world! I'm 🦀`;
 const asciiStr = `\\u{4F60}\\u{597D} world! I'm \\u{1F980}`;
+const expectedObject = {
+  Å: 'A',
+  Ð: 'D',
+  Þ: 'o',
+  å: 'a',
+  ð: 'd',
+  þ: 'o',
+  Д: 'A',
+  '𝒩': 'a',
+};
 
 rspackOnlyTest(
   'should set output.charset to ascii in dev',
@@ -20,7 +30,8 @@ rspackOnlyTest(
       },
     });
 
-    expect(await page.evaluate('window.a')).toBe(utf8Str);
+    expect(await page.evaluate('window.testA')).toBe(utf8Str);
+    expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
     const files = await rsbuild.getDistFiles();
     const [, content] = Object.entries(files).find(
@@ -44,7 +55,8 @@ test('should set output.charset to ascii in build', async ({ page }) => {
     },
   });
 
-  expect(await page.evaluate('window.a')).toBe(utf8Str);
+  expect(await page.evaluate('window.testA')).toBe(utf8Str);
+  expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
   const content = await rsbuild.getIndexBundle();
   expect(content.includes(asciiStr)).toBeTruthy();
@@ -52,21 +64,19 @@ test('should set output.charset to ascii in build', async ({ page }) => {
   await rsbuild.close();
 });
 
-test('should set output.charset to utf8 in dev', async ({ page }) => {
+test('should use utf8 charset in dev by default', async ({ page }) => {
   const rsbuild = await dev({
     cwd: __dirname,
     rsbuildConfig: {
       dev: {
         writeToDisk: true,
       },
-      output: {
-        charset: 'utf8',
-      },
     },
     page,
   });
 
-  expect(await page.evaluate('window.a')).toBe(utf8Str);
+  expect(await page.evaluate('window.testA')).toBe(utf8Str);
+  expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
   const files = await rsbuild.getDistFiles();
   const [, content] = Object.entries(files).find(
@@ -78,18 +88,14 @@ test('should set output.charset to utf8 in dev', async ({ page }) => {
   await rsbuild.close();
 });
 
-test('should set output.charset to utf8 in build', async ({ page }) => {
+test('should use utf8 charset in build by default', async ({ page }) => {
   const rsbuild = await build({
     cwd: __dirname,
-    rsbuildConfig: {
-      output: {
-        charset: 'utf8',
-      },
-    },
     page,
   });
 
-  expect(await page.evaluate('window.a')).toBe(utf8Str);
+  expect(await page.evaluate('window.testA')).toBe(utf8Str);
+  expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
   const content = await rsbuild.getIndexBundle();
   expect(content.includes(utf8Str)).toBeTruthy();

--- a/e2e/cases/output/charset/src/index.js
+++ b/e2e/cases/output/charset/src/index.js
@@ -1,6 +1,6 @@
-window.a = `你好 world! I'm 🦀`;
+window.testA = `你好 world! I'm 🦀`;
 
-window.b = {
+window.testB = {
   Д: 'A',
   Å: 'A',
   Ð: 'D',


### PR DESCRIPTION
## Summary

- Added a new test suite to verify that files with emoji filenames are correctly resolved and imported in both dev and build
- Improved the existing `charset` output tests to check both string and object values
- Updated `biome.json` to disable the filename convention rule specifically for emoji-named test files

## Related Links

- https://github.com/web-infra-dev/rspress/issues/2518

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
