### PR TITLE
feat(types): export `BuildResult` type

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export type {
   AppIconItem,
   Build,
   BuildOptions,
+  BuildResult,
   BundlerPluginInstance,
   Charset,
   CleanDistPath,

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -61,7 +61,9 @@ export type BuildOptions = {
   compiler?: Compiler | MultiCompiler;
 };
 
-export type Build = (options?: BuildOptions) => Promise<{
+export type Build = (options?: BuildOptions) => Promise<BuildResult>;
+
+export type BuildResult = {
   /**
    * Close the build and call the `onCloseBuild` hook.
    * In watch mode, this method will stop watching.
@@ -71,7 +73,7 @@ export type Build = (options?: BuildOptions) => Promise<{
    * Rspack's [stats](https://rspack.rs/api/javascript-api/stats) object.
    */
   stats?: Rspack.Stats | Rspack.MultiStats;
-}>;
+};
 
 export type InitConfigsOptions = Pick<RsbuildContext, 'action'>;
 


### PR DESCRIPTION
## Summary

Exports the `BuildResult` type, which is now used as the return type for the `rsbuild.build()` function. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
