### PR TITLE
fix(core): ensure inlined assets are deleted if devtool disabled

### DIFF
--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -257,7 +257,7 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
         for (const name of inlinedAssets) {
           // If the source map reference is removed,
           // we do not need to preserve the source map of inlined files
-          if (devtool === 'hidden-source-map') {
+          if (devtool === 'hidden-source-map' || devtool === false) {
             compilation.deleteAsset(name);
           } else {
             // use delete instead of compilation.deleteAsset


### PR DESCRIPTION
## Summary

When source maps are disabled (`devtool` is set to `false`), the inline chunk plugin will now also delete the asset via `deleteAsset()` to correctly remove the asset from compilation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
