### PR TITLE
fix(server): prevent multiple close calls from causing error

### DIFF
--- a/e2e/cases/javascript-api/close-server/index.test.ts
+++ b/e2e/cases/javascript-api/close-server/index.test.ts
@@ -1,0 +1,17 @@
+import { test } from '@e2e/helper';
+
+test('should support calling `close()` multiple times in dev', async ({
+  dev,
+}) => {
+  const result = await dev();
+  await result.close();
+  await result.close();
+});
+
+test('should support calling `close()` multiple times in preview', async ({
+  build,
+}) => {
+  const result = await build();
+  await result.close();
+  await result.close();
+});

--- a/e2e/cases/javascript-api/close-server/src/index.js
+++ b/e2e/cases/javascript-api/close-server/src/index.js
@@ -1,0 +1,1 @@
+console.log('hello');

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -242,12 +242,19 @@ export async function createDevServer<
     ? null
     : setupGracefulShutdown();
 
+  let closingPromise: Promise<void> | null = null;
+
   const closeServer = async () => {
-    // ensure closeServer is only called once
-    removeCleanup(closeServer);
-    cleanupGracefulShutdown?.();
-    await context.hooks.onCloseDevServer.callBatch();
-    await Promise.all([devMiddlewares?.close(), fileWatcher?.close()]);
+    if (!closingPromise) {
+      closingPromise = (async () => {
+        // ensure closeServer is only called once
+        removeCleanup(closeServer);
+        cleanupGracefulShutdown?.();
+        await context.hooks.onCloseDevServer.callBatch();
+        await Promise.all([devMiddlewares?.close(), fileWatcher?.close()]);
+      })();
+    }
+    return closingPromise;
   };
 
   if (!middlewareMode) {


### PR DESCRIPTION
## Summary

- Add promise memoization to server close functions to ensure they're only executed once, even when called multiple times. This prevents potential race conditions and resource cleanup problems.
- Added e2e tests to verify multiple close calls work correctly in both dev and preview modes.

Fix:

<img width="1094" height="238" alt="Screenshot 2025-09-12 at 17 14 14" src="https://github.com/user-attachments/assets/a6be9222-1eba-49d4-8f59-ca0945ce22e0" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
