### PR TITLE
test(e2e): simplify test setup by using built-in fixtures

### DIFF
--- a/e2e/cases/assets/addtional-assets/index.test.ts
+++ b/e2e/cases/assets/addtional-assets/index.test.ts
@@ -1,14 +1,14 @@
 import path from 'node:path';
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
 function isIncludeFile(filenames: string[], includeFilename: string) {
   return filenames.some((filename) => filename.includes(includeFilename));
 }
 
-test('should support configuring additional assets matched by RegExp', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should support configuring additional assets matched by RegExp', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       source: {
         assetsInclude: [/\.json5$/],
@@ -30,9 +30,10 @@ test('should support configuring additional assets matched by RegExp', async () 
   ).toBeFalsy();
 });
 
-test('should support configuring additional assets matched by path', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should support configuring additional assets matched by path', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       source: {
         assetsInclude: path.resolve(__dirname, 'src/assets'),
@@ -54,9 +55,10 @@ test('should support configuring additional assets matched by path', async () =>
   ).toBeFalsy();
 });
 
-test('should support disabling emission for additional assets', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should support disabling emission for additional assets', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       source: {
         assetsInclude: [/\.json5$/],

--- a/e2e/cases/assets/assets-url/index.test.ts
+++ b/e2e/cases/assets/assets-url/index.test.ts
@@ -1,17 +1,11 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should return the asset URL with `?url`', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+test('should return the asset URL with `?url`', async ({ page, build }) => {
+  await build();
 
   await expect(
     page.evaluate(
       `document.getElementById('test-img').src.includes('static/image/icon')`,
     ),
   ).resolves.toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/custom-dist-path/index.test.ts
+++ b/e2e/cases/assets/custom-dist-path/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should support custom dist paths for different file types', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should support custom dist paths for different file types', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);

--- a/e2e/cases/assets/emit-assets/index.test.ts
+++ b/e2e/cases/assets/emit-assets/index.test.ts
@@ -1,14 +1,13 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
 function isIncludeFile(filenames: string[], includeFilename: string) {
   return filenames.some((filename) => filename.includes(includeFilename));
 }
 
-test('should disable asset emission for the node target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should disable asset emission for the node target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);
@@ -20,10 +19,8 @@ test('should disable asset emission for the node target', async () => {
   ).toBeFalsy();
 });
 
-test('should disable asset emission for JSON assets', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should disable asset emission for JSON assets', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);

--- a/e2e/cases/assets/filename-function/index.test.ts
+++ b/e2e/cases/assets/filename-function/index.test.ts
@@ -1,10 +1,7 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should allow to custom filename by function', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should allow to custom filename by function', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);

--- a/e2e/cases/assets/filename-hash/index.test.ts
+++ b/e2e/cases/assets/filename-hash/index.test.ts
@@ -1,26 +1,26 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
-rspackOnlyTest('should set the hash format to fullhash', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+rspackOnlyTest(
+  'should set the hash format to fullhash',
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly();
 
-  const files = rsbuild.getDistFiles();
-  const filenames = Object.keys(files);
+    const files = rsbuild.getDistFiles();
+    const filenames = Object.keys(files);
 
-  let firstHash = '';
+    let firstHash = '';
 
-  for (const filename of filenames) {
-    if (!filename.includes('static')) {
-      continue;
+    for (const filename of filenames) {
+      if (!filename.includes('static')) {
+        continue;
+      }
+
+      const hash = filename.match(/[a-f0-9]{12}\.js/)![0];
+      if (!firstHash) {
+        firstHash = hash;
+      } else {
+        expect(hash).toEqual(firstHash);
+      }
     }
-
-    const hash = filename.match(/[a-f0-9]{12}\.js/)![0];
-    if (!firstHash) {
-      firstHash = hash;
-    } else {
-      expect(hash).toEqual(firstHash);
-    }
-  }
-});
+  },
+);

--- a/e2e/cases/assets/filename-template-path/index.test.ts
+++ b/e2e/cases/assets/filename-template-path/index.test.ts
@@ -1,16 +1,11 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should allow filename.image: "[path]"', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should allow filename.image: "[path]"', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly();
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);
   // Image
   expect(
     filenames.some((filename) => filename.includes('dist/src/assets/icon.png')),
   ).toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/import-json/index.test.ts
+++ b/e2e/cases/assets/import-json/index.test.ts
@@ -1,14 +1,8 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
-rspackOnlyTest('should import JSON correctly', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+rspackOnlyTest('should import JSON correctly', async ({ page, build }) => {
+  await build();
 
   expect(await page.evaluate('window.age')).toBe(1);
   expect(await page.evaluate('window.b')).toBe('{"list":[1,2]}');
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/inline-query-auto/index.test.ts
+++ b/e2e/cases/assets/inline-query-auto/index.test.ts
@@ -1,11 +1,8 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-test('should inline small assets automatically', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
+test('should inline small assets automatically', async ({ page, build }) => {
+  await build({
     plugins: [pluginReact()],
   });
 
@@ -14,6 +11,4 @@ test('should inline small assets automatically', async ({ page }) => {
       `document.getElementById('test-img').src.startsWith('data:image/png')`,
     ),
   ).resolves.toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/inline-query-false/index.test.ts
+++ b/e2e/cases/assets/inline-query-false/index.test.ts
@@ -1,13 +1,11 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should disable asset inlining with `?__inline=false`', async ({
   page,
+  build,
 }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
+  await build({
     plugins: [pluginReact()],
   });
 
@@ -16,6 +14,4 @@ test('should disable asset inlining with `?__inline=false`', async ({
       `document.getElementById('test-img').src.includes('static/image/icon')`,
     ),
   ).resolves.toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/inline-query/index.test.ts
+++ b/e2e/cases/assets/inline-query/index.test.ts
@@ -1,11 +1,8 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-test('should inline assets with `?inline`', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
+test('should inline assets with `?inline`', async ({ page, build }) => {
+  await build({
     plugins: [pluginReact()],
   });
 
@@ -14,6 +11,4 @@ test('should inline assets with `?inline`', async ({ page }) => {
       `document.getElementById('test-img').src.startsWith('data:image/png')`,
     ),
   ).resolves.toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -1,15 +1,14 @@
 import { promises } from 'node:fs';
 import { join } from 'node:path';
-import { build, dev } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { dev, expect, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSvgr } from '@rsbuild/plugin-svgr';
 
-test('should return raw asset content with `?raw` in dev', async ({ page }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+test('should return raw asset content with `?raw` in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev();
 
   expect(await page.evaluate('window.rawSvg')).toEqual(
     await promises.readFile(
@@ -17,17 +16,13 @@ test('should return raw asset content with `?raw` in dev', async ({ page }) => {
       'utf-8',
     ),
   );
-
-  await rsbuild.close();
 });
 
 test('should return raw asset content with `?raw` in build', async ({
   page,
+  build,
 }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+  await build();
 
   expect(await page.evaluate('window.rawSvg')).toEqual(
     await promises.readFile(
@@ -35,16 +30,13 @@ test('should return raw asset content with `?raw` in build', async ({
       'utf-8',
     ),
   );
-
-  await rsbuild.close();
 });
 
 test('should return raw SVG content with `?raw` when using pluginSvgr', async ({
   page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
+  await dev({
     rsbuildConfig: {
       plugins: [pluginSvgr()],
     },
@@ -56,28 +48,18 @@ test('should return raw SVG content with `?raw` when using pluginSvgr', async ({
       'utf-8',
     ),
   );
-
-  await rsbuild.close();
 });
 
-test('should return raw JS content with `?raw`', async ({ page }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+test('should return raw JS content with `?raw`', async ({ page, dev }) => {
+  await dev();
 
   expect(await page.evaluate('window.rawJs')).toEqual(
     await promises.readFile(join(__dirname, 'src/foo.js'), 'utf-8'),
   );
-
-  await rsbuild.close();
 });
 
-test('should return raw TS content with `?raw`', async ({ page }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+test('should return raw TS content with `?raw`', async ({ page, dev }) => {
+  await dev();
 
   const tsContent = await promises.readFile(
     join(__dirname, 'src/bar.ts'),
@@ -87,16 +69,13 @@ test('should return raw TS content with `?raw`', async ({ page }) => {
   expect(await page.evaluate('window.rawTs2')).toEqual(tsContent);
   expect(await page.evaluate('window.rawTs3')).toEqual(tsContent);
   expect(await page.evaluate('window.rawTs4')).toEqual(tsContent);
-
-  await rsbuild.close();
 });
 
 test('should return raw TSX content with `?raw` when using pluginReact', async ({
   page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
+  await dev({
     rsbuildConfig: {
       plugins: [pluginReact()],
     },
@@ -105,34 +84,25 @@ test('should return raw TSX content with `?raw` when using pluginReact', async (
   expect(await page.evaluate('window.rawTsx')).toEqual(
     await promises.readFile(join(__dirname, 'src/baz.tsx'), 'utf-8'),
   );
-
-  await rsbuild.close();
 });
 
 test('should not get raw SVG content with query other than `?raw`', async ({
   page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+  await dev();
 
   expect(
     (await page.evaluate<string>('window.normalSvg')).startsWith(
       'data:image/svg+xml',
     ),
   ).toBe(true);
-
-  await rsbuild.close();
 });
 
 test('should not get raw JS content with query other than `?raw`', async ({
   page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+  await dev();
   expect(await page.evaluate('window.normalJs')).toEqual('foo');
-  await rsbuild.close();
 });

--- a/e2e/cases/assets/script-as-assets/index.test.ts
+++ b/e2e/cases/assets/script-as-assets/index.test.ts
@@ -1,13 +1,9 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to use `new URL` to reference script as assets',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
-    });
+  async ({ page, build }) => {
+    const rsbuild = await build();
 
     const files = rsbuild.getDistFiles();
     const filenames = Object.keys(files);

--- a/e2e/cases/assets/styles-as-assets/index.test.ts
+++ b/e2e/cases/assets/styles-as-assets/index.test.ts
@@ -1,13 +1,9 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to use `new URL` to reference styles as assets',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
-    });
+  async ({ page, build }) => {
+    const rsbuild = await build();
 
     const files = rsbuild.getDistFiles();
     const filenames = Object.keys(files);

--- a/e2e/cases/assets/svg-assets/index.test.ts
+++ b/e2e/cases/assets/svg-assets/index.test.ts
@@ -1,11 +1,7 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should handle SVG assets in JS and CSS', async ({ page }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+test('should handle SVG assets in JS and CSS', async ({ page, build }) => {
+  await build();
 
   // test SVG asset
   await expect(
@@ -20,6 +16,4 @@ test('should handle SVG assets in JS and CSS', async ({ page }) => {
       `getComputedStyle(document.getElementById('test-css')).backgroundImage.includes('static/svg/mobile')`,
     ),
   ).resolves.toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/browserslist/extends-browserslist/index.test.ts
+++ b/e2e/cases/browserslist/extends-browserslist/index.test.ts
@@ -1,13 +1,12 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should extend browserslist and downgrade syntax', async () => {
+test('should extend browserslist and downgrade syntax', async ({
+  buildOnly,
+}) => {
   const originalCwd = process.cwd();
   process.chdir(__dirname);
 
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/browserslist/package-config-array/index.test.ts
+++ b/e2e/cases/browserslist/package-config-array/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should read browserslist array from package.json', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should read browserslist array from package.json', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/browserslist/package-config-object/index.test.ts
+++ b/e2e/cases/browserslist/package-config-object/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should read browserslist string from package.json', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should read browserslist string from package.json', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/browserslist/package-config-string/index.test.ts
+++ b/e2e/cases/browserslist/package-config-string/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should read browserslist string from package.json', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should read browserslist string from package.json', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/cache/build-dependencies/index.test.ts
+++ b/e2e/cases/cache/build-dependencies/index.test.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+
+import { expect, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { remove } from 'fs-extra';
 
-test('should respect `buildCache.buildDependencies`', async () => {
+test('should respect `buildCache.buildDependencies`', async ({ buildOnly }) => {
   const cacheDirectory = path.resolve(
     __dirname,
     './node_modules/.cache/test-cache-build-dependencies',
@@ -38,11 +38,11 @@ test('should respect `buildCache.buildDependencies`', async () => {
   };
 
   // first build without cache
-  let rsbuild = await build(getBuildConfig(''));
+  let rsbuild = await buildOnly(getBuildConfig(''));
 
   expect((await rsbuild.getIndexBundle()).includes('222222')).toBeTruthy();
 
-  rsbuild = await build(getBuildConfig('foo'));
+  rsbuild = await buildOnly(getBuildConfig('foo'));
 
   // extension '.test.js' should work
   expect((await rsbuild.getIndexBundle()).includes('111111')).toBeTruthy();

--- a/e2e/cases/cache/cache-digest/index.test.ts
+++ b/e2e/cases/cache/cache-digest/index.test.ts
@@ -1,10 +1,10 @@
 import path from 'node:path';
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+
+import { expect, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { remove } from 'fs-extra';
 
-test('should respect `buildCache.cacheDigest`', async () => {
+test('should respect `buildCache.cacheDigest`', async ({ buildOnly }) => {
   const cacheDirectory = path.resolve(
     __dirname,
     './node_modules/.cache/test-cache-digest',
@@ -32,11 +32,11 @@ test('should respect `buildCache.cacheDigest`', async () => {
   });
 
   // first build without cache
-  let rsbuild = await build(getBuildConfig(''));
+  let rsbuild = await buildOnly(getBuildConfig(''));
 
   expect((await rsbuild.getIndexBundle()).includes('222222')).toBeTruthy();
 
-  rsbuild = await build(getBuildConfig('foo'));
+  rsbuild = await buildOnly(getBuildConfig('foo'));
 
   // extension '.test.js' should work
   expect((await rsbuild.getIndexBundle()).includes('111111')).toBeTruthy();

--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -1,20 +1,18 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { build, dev } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { dev, expect, test } from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 test('should use `buildCache.cacheDirectory` as expected in dev', async ({
   page,
+  dev,
 }) => {
   const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
   const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
   await remove(defaultDirectory);
   await remove(cacheDirectory);
 
-  const rsbuild = await dev({
-    page,
-    cwd: __dirname,
+  await dev({
     rsbuildConfig: {
       performance: {
         buildCache: {
@@ -26,17 +24,17 @@ test('should use `buildCache.cacheDirectory` as expected in dev', async ({
 
   expect(fs.existsSync(cacheDirectory)).toBeTruthy();
   expect(fs.existsSync(defaultDirectory)).toBeFalsy();
-  await rsbuild.close();
 });
 
-test('should use `buildCache.cacheDirectory` as expected in build', async () => {
+test('should use `buildCache.cacheDirectory` as expected in build', async ({
+  buildOnly,
+}) => {
   const defaultDirectory = path.resolve(__dirname, './node_modules/.cache');
   const cacheDirectory = path.resolve(__dirname, './node_modules/.cache2');
   await remove(defaultDirectory);
   await remove(cacheDirectory);
 
-  await build({
-    cwd: __dirname,
+  await buildOnly({
     rsbuildConfig: {
       performance: {
         buildCache: {

--- a/e2e/cases/cli/base/index.test.ts
+++ b/e2e/cases/cli/base/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest('should run allow to specify base path', async () => {
   runCliSync('build --base /test', {

--- a/e2e/cases/cli/basic/index.test.ts
+++ b/e2e/cases/cli/basic/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest('should run build command correctly', async () => {
   runCliSync('build', {

--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 const nodeVersion = process.version.slice(1).split('.')[0];
 const isNodeVersionCompatible = Number(nodeVersion) >= 22;

--- a/e2e/cases/cli/custom-config/index.test.ts
+++ b/e2e/cases/cli/custom-config/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest(
   'should use custom config when using --config option',

--- a/e2e/cases/cli/custom-env-dir/index.test.ts
+++ b/e2e/cases/cli/custom-env-dir/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 rspackOnlyTest('should support a custom env directory', async () => {
   runCliSync('build --env-dir env', {

--- a/e2e/cases/cli/custom-env-prefix/index.test.ts
+++ b/e2e/cases/cli/custom-env-prefix/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to custom env prefix via loadEnv method',

--- a/e2e/cases/cli/falsy-plugins/index.test.ts
+++ b/e2e/cases/cli/falsy-plugins/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest('should run build command correctly', async () => {
   runCliSync('build', {

--- a/e2e/cases/cli/function-config/index.test.ts
+++ b/e2e/cases/cli/function-config/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 rspackOnlyTest(

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 import { removeSync } from 'fs-extra';
 
 const clean = () => {

--- a/e2e/cases/cli/load-import-meta-env/index.test.ts
+++ b/e2e/cases/cli/load-import-meta-env/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync, test } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 const localFile = path.join(__dirname, '.env.local');

--- a/e2e/cases/cli/load-node-env/index.test.ts
+++ b/e2e/cases/cli/load-node-env/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 // see: https://github.com/web-infra-dev/rsbuild/issues/2904
 rspackOnlyTest(

--- a/e2e/cases/cli/load-process-env/index.test.ts
+++ b/e2e/cases/cli/load-process-env/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync, test } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 const localFile = path.join(__dirname, '.env.local');

--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -1,6 +1,5 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 rspackOnlyTest('should run build command with log level: info', async () => {
   const result = stripAnsi(

--- a/e2e/cases/cli/mode/index.test.ts
+++ b/e2e/cases/cli/mode/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest(
   'should run build command with --mode option correctly',

--- a/e2e/cases/cli/no-env/index.test.ts
+++ b/e2e/cases/cli/no-env/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 rspackOnlyTest('should disable loading env files', async () => {
   runCliSync('build --no-env', {

--- a/e2e/cases/cli/node-env/index.test.ts
+++ b/e2e/cases/cli/node-env/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest(
   'should set NODE_ENV correctly when running build command',

--- a/e2e/cases/cli/public-env-vars/index.test.ts
+++ b/e2e/cases/cli/public-env-vars/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest, runCliSync } from '@e2e/helper';
 
 rspackOnlyTest('should inject public env vars to client', async () => {
   runCliSync('build', {

--- a/e2e/cases/cli/root/index.test.ts
+++ b/e2e/cases/cli/root/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest(
   'should run build command with --root option correctly',

--- a/e2e/cases/cli/specified-environment/index.test.ts
+++ b/e2e/cases/cli/specified-environment/index.test.ts
@@ -1,6 +1,11 @@
 import { join } from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+  test,
+} from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 const distPath = join(__dirname, 'dist');

--- a/e2e/cases/cli/vue/index.test.ts
+++ b/e2e/cases/cli/vue/index.test.ts
@@ -1,6 +1,10 @@
 import path from 'node:path';
-import { readDirContents, rspackOnlyTest, runCliSync } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  readDirContents,
+  rspackOnlyTest,
+  runCliSync,
+} from '@e2e/helper';
 
 rspackOnlyTest('should build Vue SFC correctly', async () => {
   runCliSync('build', {

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getRandomPort, gotoPage, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import {
+  expect,
+  getRandomPort,
+  gotoPage,
+  rspackOnlyTest,
+  runCli,
+} from '@e2e/helper';
 
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,7 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { getRandomPort, gotoPage, rspackOnlyTest, runCli } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import {
+  expect,
+  getRandomPort,
+  gotoPage,
+  rspackOnlyTest,
+  runCli,
+  test,
+} from '@e2e/helper';
 
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 

--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -1,13 +1,11 @@
 import { join } from 'node:path';
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, rspackOnlyTest, test } from '@e2e/helper';
 
 test('should allow to use tools.bundlerChain to set alias config', async ({
   page,
+  build,
 }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
+  await build({
     rsbuildConfig: {
       tools: {
         bundlerChain: (chain) => {
@@ -18,16 +16,13 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
   });
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
-
-  await rsbuild.close();
 });
 
 test('should allow to use async tools.bundlerChain to set alias config', async ({
   page,
+  build,
 }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
+  await build({
     rsbuildConfig: {
       tools: {
         bundlerChain: async (chain) => {
@@ -43,16 +38,12 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
   });
 
   await expect(page.innerHTML('#test')).resolves.toBe('Hello Rsbuild! 1');
-
-  await rsbuild.close();
 });
 
 rspackOnlyTest(
   'should allow to use rspack in tools.bundlerChain',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
+  async ({ page, build }) => {
+    await build({
       rsbuildConfig: {
         tools: {
           bundlerChain: (chain, { rspack }) => {
@@ -70,7 +61,5 @@ rspackOnlyTest(
 
     const testEl = page.locator('#test-define');
     await expect(testEl).toHaveText('aaaaa');
-
-    await rsbuild.close();
   },
 );

--- a/e2e/cases/config/configure-rspack/index.test.ts
+++ b/e2e/cases/config/configure-rspack/index.test.ts
@@ -1,12 +1,9 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to use tools.rspack to configure Rspack',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
+  async ({ page, build }) => {
+    await build({
       rsbuildConfig: {
         tools: {
           rspack: (config, { rspack }) => {
@@ -22,17 +19,13 @@ rspackOnlyTest(
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');
-
-    await rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should allow to use async tools.rspack to configure Rspack',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
+  async ({ page, build }) => {
+    await build({
       rsbuildConfig: {
         tools: {
           rspack: async (config, { rspack }) => {
@@ -53,7 +46,5 @@ rspackOnlyTest(
 
     const testEl = page.locator('#test-el');
     await expect(testEl).toHaveText('aaaaa');
-
-    await rsbuild.close();
   },
 );

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { build, dev } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { dev, expect, test } from '@e2e/helper';
 import { logger } from '@rsbuild/core';
 
 const getRsbuildConfig = (dist: string) =>
@@ -13,14 +12,15 @@ const getBundlerConfig = (dist: string) =>
     `./${dist}/.rsbuild/${process.env.PROVIDE_TYPE || 'rspack'}.config.web.mjs`,
   );
 
-test('should generate config files in debug mode when build', async () => {
+test('should generate config files in debug mode when build', async ({
+  buildOnly,
+}) => {
   const { level } = logger;
   logger.level = 'verbose';
   process.env.DEBUG = 'rsbuild';
 
   const distRoot = 'dist-1';
-  const rsbuild = await build({
-    cwd: __dirname,
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         distPath: {
@@ -38,7 +38,6 @@ test('should generate config files in debug mode when build', async () => {
 
   delete process.env.DEBUG;
   logger.level = level;
-  await rsbuild.close();
 });
 
 test('should generate config files in debug mode when dev', async ({
@@ -69,5 +68,4 @@ test('should generate config files in debug mode when dev', async ({
 
   delete process.env.DEBUG;
   logger.level = level;
-  await rsbuild.close();
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,7 +1,12 @@
 import fs from 'node:fs';
 import path, { join } from 'node:path';
-import { createRsbuild, proxyConsole, rspackOnlyTest } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import {
+  createRsbuild,
+  expect,
+  proxyConsole,
+  rspackOnlyTest,
+  test,
+} from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { remove, removeSync } from 'fs-extra';
 

--- a/e2e/cases/config/rspack-config-validate/index.test.ts
+++ b/e2e/cases/config/rspack-config-validate/index.test.ts
@@ -1,12 +1,58 @@
 import { stripVTControlCharacters as stripAnsi } from 'node:util';
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-rspackOnlyTest('should validate Rspack config by default', async () => {
-  try {
-    const rsbuild = await build({
-      cwd: __dirname,
+rspackOnlyTest(
+  'should validate Rspack config by default',
+  async ({ buildOnly }) => {
+    try {
+      await buildOnly({
+        rsbuildConfig: {
+          tools: {
+            // @ts-expect-error mock invalid config
+            rspack: {
+              entry: 1,
+            },
+          },
+        },
+      });
+    } catch (e) {
+      expect(e).toBeTruthy();
+      expect((e as Error).message).toContain('received object at "entry"');
+    }
+  },
+);
+
+rspackOnlyTest(
+  'should warn when passing unrecognized keys',
+  async ({ buildOnly }) => {
+    const value = process.env.RSPACK_CONFIG_VALIDATE;
+    process.env.RSPACK_CONFIG_VALIDATE = 'loose-unrecognized-keys';
+
+    const rsbuild = await buildOnly({
+      rsbuildConfig: {
+        tools: {
+          rspack: {
+            // @ts-expect-error mock invalid config
+            unrecognized: 1,
+          },
+        },
+      },
+    });
+
+    await rsbuild.expectLog(`Unrecognized key(s) "unrecognized" in object`);
+
+    process.env.RSPACK_CONFIG_VALIDATE = value;
+  },
+);
+
+rspackOnlyTest(
+  'should allow to override Rspack config validate',
+  async ({ buildOnly }) => {
+    const { RSPACK_CONFIG_VALIDATE } = process.env;
+    process.env.RSPACK_CONFIG_VALIDATE = 'loose';
+
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         tools: {
           // @ts-expect-error mock invalid config
@@ -16,65 +62,20 @@ rspackOnlyTest('should validate Rspack config by default', async () => {
         },
       },
     });
-    await rsbuild.close();
-  } catch (e) {
-    expect(e).toBeTruthy();
-    expect((e as Error).message).toContain('received object at "entry"');
-  }
-});
 
-rspackOnlyTest('should warn when passing unrecognized keys', async () => {
-  const value = process.env.RSPACK_CONFIG_VALIDATE;
-  process.env.RSPACK_CONFIG_VALIDATE = 'loose-unrecognized-keys';
+    await rsbuild.expectLog(
+      'Expected array at "entry" or Expected function, received object at "entry"',
+    );
 
-  const rsbuild = await build({
-    cwd: __dirname,
-    rsbuildConfig: {
-      tools: {
-        rspack: {
-          // @ts-expect-error mock invalid config
-          unrecognized: 1,
-        },
-      },
-    },
-  });
-
-  await rsbuild.expectLog(`Unrecognized key(s) "unrecognized" in object`);
-  await rsbuild.close();
-
-  process.env.RSPACK_CONFIG_VALIDATE = value;
-});
-
-rspackOnlyTest('should allow to override Rspack config validate', async () => {
-  const { RSPACK_CONFIG_VALIDATE } = process.env;
-  process.env.RSPACK_CONFIG_VALIDATE = 'loose';
-
-  const rsbuild = await build({
-    cwd: __dirname,
-    rsbuildConfig: {
-      tools: {
-        // @ts-expect-error mock invalid config
-        rspack: {
-          entry: 1,
-        },
-      },
-    },
-  });
-
-  await rsbuild.expectLog(
-    'Expected array at "entry" or Expected function, received object at "entry"',
-  );
-  await rsbuild.close();
-
-  process.env.RSPACK_CONFIG_VALIDATE = RSPACK_CONFIG_VALIDATE;
-});
+    process.env.RSPACK_CONFIG_VALIDATE = RSPACK_CONFIG_VALIDATE;
+  },
+);
 
 rspackOnlyTest(
   'should validate Rspack plugins and recognize Rsbuild plugins',
-  async () => {
+  async ({ buildOnly }) => {
     try {
-      await build({
-        cwd: __dirname,
+      await buildOnly({
         rsbuildConfig: {
           tools: {
             // @ts-expect-error mock invalid config

--- a/e2e/cases/config/stats-module-trace/index.test.ts
+++ b/e2e/cases/config/stats-module-trace/index.test.ts
@@ -1,13 +1,10 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should log error module trace', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should log error module trace', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly({
     catchBuildError: true,
   });
 
   expect(rsbuild.buildError).toBeTruthy();
   await rsbuild.expectLog('@ ./src/index.tsx');
-  await rsbuild.close();
 });

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -1,20 +1,17 @@
-import { build } from '@e2e/helper';
-import { test } from '@playwright/test';
+import { test } from '@e2e/helper';
 
 const WARNING_MSG = 'Using / for division outside of calc() is deprecated';
 
-test('should log warning by default', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should log warning by default', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly();
 
   await rsbuild.expectLog(WARNING_MSG);
-  await rsbuild.close();
 });
 
-test('should not log warning when set stats.warnings false', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should not log warning when set stats.warnings false', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       tools: {
         bundlerChain: (chain) => {
@@ -27,5 +24,4 @@ test('should not log warning when set stats.warnings false', async () => {
   });
 
   rsbuild.expectNoLog(WARNING_MSG);
-  await rsbuild.close();
 });

--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -1,8 +1,7 @@
 import { exec } from 'node:child_process';
 import { access } from 'node:fs/promises';
 import path from 'node:path';
-import { CREATE_RSBUILD_BIN_PATH } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { CREATE_RSBUILD_BIN_PATH, expect } from '@e2e/helper';
 import fse from 'fs-extra';
 
 export const expectPackageJson = (

--- a/e2e/cases/create-rsbuild/jsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/jsTemplates.test.ts
@@ -1,5 +1,4 @@
-import { rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
 rspackOnlyTest('should create react project as expected', async () => {

--- a/e2e/cases/create-rsbuild/tools.test.ts
+++ b/e2e/cases/create-rsbuild/tools.test.ts
@@ -1,7 +1,6 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
 rspackOnlyTest('should create project with eslint as expected', async () => {

--- a/e2e/cases/create-rsbuild/tsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/tsTemplates.test.ts
@@ -1,5 +1,4 @@
-import { rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { createAndValidate } from './helper';
 
 rspackOnlyTest('should create react-ts project as expected', async () => {

--- a/e2e/cases/css/configure-css-extract/index.test.ts
+++ b/e2e/cases/css/configure-css-extract/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should allow to configure options of CSSExtractPlugin', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should allow to configure options of CSSExtractPlugin', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
   const files = rsbuild.getDistFiles();
   const content =
     files[Object.keys(files).find((file) => file.endsWith('my-css.css'))!];

--- a/e2e/cases/css/css-assets/index.test.ts
+++ b/e2e/cases/css/css-assets/index.test.ts
@@ -1,10 +1,7 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should build CSS assets correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should build CSS assets correctly', async ({ buildOnly }) => {
+  const rsbuild = await buildOnly();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);
@@ -14,6 +11,4 @@ test('should build CSS assets correctly', async () => {
       (item) => item.includes('static/image/image') && item.endsWith('.jpeg'),
     ),
   ).toBeTruthy();
-
-  await rsbuild.close();
 });

--- a/e2e/cases/css/css-layers/index.test.ts
+++ b/e2e/cases/css/css-layers/index.test.ts
@@ -1,18 +1,19 @@
-import { build, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
-rspackOnlyTest('should bundle CSS layers as expected in build', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
-  const files = rsbuild.getDistFiles();
+rspackOnlyTest(
+  'should bundle CSS layers as expected in build',
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly();
+    const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 
-  expect(content).toEqual(
-    '@layer a{.a{color:red}}@layer b{.b{color:green}}@layer c{@layer{.c-sub{color:#00f}.c-sub2{color:green}}.c{color:#00f}}',
-  );
-});
+    expect(content).toEqual(
+      '@layer a{.a{color:red}}@layer b{.b{color:green}}@layer c{@layer{.c-sub{color:#00f}.c-sub2{color:green}}.c{color:#00f}}',
+    );
+  },
+);
 
 rspackOnlyTest(
   'should bundle CSS layers as expected in dev',

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -1,26 +1,25 @@
 import path from 'node:path';
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
-rspackOnlyTest('should compile CSS Modules composes correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
-  const files = rsbuild.getDistFiles();
+rspackOnlyTest(
+  'should compile CSS Modules composes correctly',
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly();
+    const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 
-  expect(content).toMatch(
-    /.*\{color:#ff0;background:red\}.*\{background:#00f\}/,
-  );
-});
+    expect(content).toMatch(
+      /.*\{color:#ff0;background:red\}.*\{background:#00f\}/,
+    );
+  },
+);
 
 rspackOnlyTest(
   'should compile CSS Modules composes with external correctly',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         source: {
           entry: { external: path.resolve(__dirname, './src/external.js') },

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,16 +1,13 @@
 import { resolve } from 'node:path';
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
-import { pluginReact } from '@rsbuild/plugin-react';
 
-const fixtures = resolve(__dirname);
+import { expect, test } from '@e2e/helper';
+import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should inject styles and not emit CSS files when output.injectStyles is true', async ({
   page,
+  build,
 }) => {
   const rsbuild = await build({
-    cwd: fixtures,
-    page,
     plugins: [pluginReact()],
     rsbuildConfig: {
       output: {
@@ -32,6 +29,4 @@ test('should inject styles and not emit CSS files when output.injectStyles is tr
   // less worked
   const title = page.locator('#title');
   await expect(title).toHaveCSS('font-size', '20px');
-
-  await rsbuild.close();
 });

--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -1,5 +1,4 @@
-import { type BuildResult, build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { type BuildResult, expect, rspackOnlyTest } from '@e2e/helper';
 
 declare global {
   interface Window {
@@ -18,10 +17,8 @@ const expectCSSContext = async (rsbuild: BuildResult) => {
 
 rspackOnlyTest(
   'should compile CSS Modules with exportLocalsConvention camelCaseOnly',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -39,17 +36,13 @@ rspackOnlyTest(
       'theCamelClass',
       'theUnderscoreClass',
     ]);
-
-    await rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should compile CSS Modules with exportLocalsConvention camelCase',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -69,17 +62,13 @@ rspackOnlyTest(
       'the_underscore_class',
       'theUnderscoreClass',
     ]);
-
-    await rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should compile CSS Modules with exportLocalsConvention dashes',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -98,17 +87,13 @@ rspackOnlyTest(
       'theCamelClass',
       'the_underscore_class',
     ]);
-
-    await rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should compile CSS Modules with exportLocalsConvention dashesOnly',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -126,17 +111,13 @@ rspackOnlyTest(
       'theCamelClass',
       'the_underscore_class',
     ]);
-
-    await rsbuild.close();
   },
 );
 
 rspackOnlyTest(
   'should compile CSS Modules with exportLocalsConvention asIs',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -154,7 +135,5 @@ rspackOnlyTest(
       'theCamelClass',
       'the_underscore_class',
     ]);
-
-    await rsbuild.close();
   },
 );

--- a/e2e/cases/css/css-modules-exports-global/index.test.ts
+++ b/e2e/cases/css/css-modules-exports-global/index.test.ts
@@ -1,4 +1,4 @@
-import { build, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should exports global in CSS Modules correctly in dev build',
@@ -15,19 +15,14 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should exports global in CSS Modules correctly in build',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
-    });
+  async ({ page, build }) => {
+    const rsbuild = await build();
 
     const test1Locator = page.locator('#test1');
     await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
     const test2Locator = page.locator('#test2');
     await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-
-    await rsbuild.close();
 
     const files = rsbuild.getDistFiles();
     const content =

--- a/e2e/cases/css/css-modules-global/index.test.ts
+++ b/e2e/cases/css/css-modules-global/index.test.ts
@@ -1,10 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should compile CSS Modules with :global() correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
+test('should compile CSS Modules with :global() correctly', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly();
   const files = rsbuild.getDistFiles();
 
   const content =

--- a/e2e/cases/css/css-modules-ident-name/index.test.ts
+++ b/e2e/cases/css/css-modules-ident-name/index.test.ts
@@ -1,21 +1,17 @@
-import { build, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 // https://github.com/web-infra-dev/rspack/issues/6470
 test('should generate unique classname for different CSS Modules files in dev build', async ({
   page,
+  build,
 }) => {
-  const rsbuild = await build({
-    cwd: __dirname,
-    page,
-  });
+  await build();
 
   const test1Locator = page.locator('#test1');
   await expect(test1Locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
   const test2Locator = page.locator('#test2');
   await expect(test2Locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-
-  await rsbuild.close();
 });
 
 test('should generate unique classname for different CSS Modules files in build', async ({

--- a/e2e/cases/css/css-modules-mode/index.test.ts
+++ b/e2e/cases/css/css-modules-mode/index.test.ts
@@ -1,9 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should compile CSS Modules global mode correctly', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should compile CSS Modules global mode correctly', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         cssModules: {

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -1,12 +1,9 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should compile CSS Modules with named exports correctly',
-  async ({ page }) => {
+  async ({ page, build }) => {
     const rsbuild = await build({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -28,6 +25,5 @@ rspackOnlyTest(
     const text = await root.innerHTML();
 
     expect(text).toMatch(/classA-\w{6} classB-\w{6} classC-\w{6}/);
-    await rsbuild.close();
   },
 );

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -1,12 +1,9 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should compile CSS Modules with default configuration',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
-    });
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly();
     const files = rsbuild.getDistFiles();
 
     const content =
@@ -20,9 +17,8 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should compile CSS Modules with custom auto configuration',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -46,9 +42,8 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should compile CSS Modules with custom localIdentName pattern',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         output: {
           cssModules: {
@@ -70,9 +65,8 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should compile CSS Modules with custom hash digest format',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         output: {
           cssModules: {

--- a/e2e/cases/css/emit-css/index.test.ts
+++ b/e2e/cases/css/emit-css/index.test.ts
@@ -1,9 +1,9 @@
-import { build } from '@e2e/helper';
-import { expect, test } from '@playwright/test';
+import { expect, test } from '@e2e/helper';
 
-test('should not emit CSS files when build node target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should not emit CSS files when build node target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         target: 'node',
@@ -21,9 +21,10 @@ test('should not emit CSS files when build node target', async () => {
   expect(cssFiles).toHaveLength(0);
 });
 
-test('should allow to emit CSS with output.emitCss when build node target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should allow to emit CSS with output.emitCss when build node target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         target: 'node',
@@ -42,9 +43,10 @@ test('should allow to emit CSS with output.emitCss when build node target', asyn
   expect(cssFiles).toHaveLength(1);
 });
 
-test('should not emit CSS files when build web-worker target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should not emit CSS files when build web-worker target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         target: 'web-worker',
@@ -62,9 +64,10 @@ test('should not emit CSS files when build web-worker target', async () => {
   expect(cssFiles).toHaveLength(0);
 });
 
-test('should allow to emit CSS with output.emitCss when build web-worker target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should allow to emit CSS with output.emitCss when build web-worker target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         target: 'web-worker',
@@ -83,9 +86,10 @@ test('should allow to emit CSS with output.emitCss when build web-worker target'
   expect(cssFiles).toHaveLength(1);
 });
 
-test('should allow to disable CSS emit with output.emitCss when build web target', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
+test('should allow to disable CSS emit with output.emitCss when build web target', async ({
+  buildOnly,
+}) => {
+  const rsbuild = await buildOnly({
     rsbuildConfig: {
       output: {
         target: 'web',

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -1,28 +1,25 @@
-import { build, rspackOnlyTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 const COMPILE_WARNING = 'Compile Warning';
 
-rspackOnlyTest('should allow to enable Rspack experiments.css', async () => {
-  const rsbuild = await build({
-    cwd: __dirname,
-  });
-  const files = rsbuild.getDistFiles();
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('index.css'))!];
+rspackOnlyTest(
+  'should allow to enable Rspack experiments.css',
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly();
+    const files = rsbuild.getDistFiles();
+    const content =
+      files[Object.keys(files).find((file) => file.endsWith('index.css'))!];
 
-  expect(content).toEqual('body{color:red}');
-  // should have no warnings
-  rsbuild.expectNoLog(COMPILE_WARNING);
-
-  await rsbuild.close();
-});
+    expect(content).toEqual('body{color:red}');
+    // should have no warnings
+    rsbuild.expectNoLog(COMPILE_WARNING);
+  },
+);
 
 rspackOnlyTest(
   'should allow to enable Rspack experiments.css with style-loader',
-  async () => {
-    const rsbuild = await build({
-      cwd: __dirname,
+  async ({ buildOnly }) => {
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         output: {
           injectStyles: true,
@@ -37,7 +34,5 @@ rspackOnlyTest(
 
     // should have no warnings
     rsbuild.expectNoLog(COMPILE_WARNING);
-
-    await rsbuild.close();
   },
 );

--- a/e2e/cases/css/export-type-string/index.test.ts
+++ b/e2e/cases/css/export-type-string/index.test.ts
@@ -1,4 +1,4 @@
-import { build, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should allow to configure `cssLoader.exportType` as `string` in development',
@@ -24,11 +24,8 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should allow to configure `cssLoader.exportType` as `string` in production',
-  async ({ page }) => {
-    const rsbuild = await build({
-      cwd: __dirname,
-      page,
-    });
+  async ({ page, build }) => {
+    await build();
 
     expect(await page.evaluate('window.a')).toBe(`.the-a-class {
   color: red;
@@ -42,7 +39,5 @@ rspackOnlyTest(
     expect(
       (await page.evaluate<string>('window.b')).includes('.the-b-class-'),
     ).toBeTruthy();
-
-    await rsbuild.close();
   },
 );


### PR DESCRIPTION
## Summary

This PR continues the work of removing redundant test setups and teardown code by using built-in fixtures.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6131

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
