### PR TITLE
test(e2e): enable type checking for test files

### DIFF
--- a/e2e/cases/cli/load-import-meta-env/rsbuild.config.ts
+++ b/e2e/cases/cli/load-import-meta-env/rsbuild.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="@rsbuild/core/types" />
 import { defineConfig } from '@rsbuild/core';
 
 export default defineConfig({

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -3,9 +3,10 @@
   "name": "@rsbuild/e2e",
   "version": "1.0.0",
   "scripts": {
-    "e2e": "pnpm e2e:rspack && pnpm e2e:webpack",
+    "e2e": "pnpm e2e:rspack && pnpm e2e:webpack && pnpm type-check",
     "e2e:rspack": "cross-env NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" playwright test",
-    "e2e:webpack": "cross-env PROVIDE_TYPE=webpack playwright test"
+    "e2e:webpack": "cross-env PROVIDE_TYPE=webpack playwright test",
+    "type-check": "tsc"
   },
   "dependencies": {
     "lodash": "^4.17.21",

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,19 +1,13 @@
 {
   "extends": "@rsbuild/config/tsconfig",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "noEmit": true
   },
   "include": [
-    "src",
     "helper",
-    "cases",
     "playwright.config.ts",
     "cases/**/*.test.ts",
-    "cache/cache-basic"
+    "cases/**/*.config.ts"
   ],
   "references": [
     {


### PR DESCRIPTION
## Summary

Enable type checking for test files, ensure that all E2E code is type-checked, simplify the TypeScript configuration, and add type references where needed.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
