### PR TITLE
test(e2e): simplify test setup by removing imports

### DIFF
--- a/e2e/cases/cache/build-dependencies/index.test.ts
+++ b/e2e/cases/cache/build-dependencies/index.test.ts
@@ -18,7 +18,6 @@ test('should respect `buildCache.buildDependencies`', async ({ buildOnly }) => {
   const getBuildConfig = (input: string) => {
     fs.writeFileSync(testDepsPath, input);
     return {
-      cwd: __dirname,
       rsbuildConfig: {
         tools: {
           bundlerChain: (chain) => {

--- a/e2e/cases/cache/cache-digest/index.test.ts
+++ b/e2e/cases/cache/cache-digest/index.test.ts
@@ -13,7 +13,6 @@ test('should respect `buildCache.cacheDigest`', async ({ buildOnly }) => {
   await remove(cacheDirectory);
 
   const getBuildConfig = (input: string) => ({
-    cwd: __dirname,
     rsbuildConfig: {
       tools: {
         bundlerChain: (chain) => {

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import { logger } from '@rsbuild/core';
 
 const getRsbuildConfig = (dist: string) =>
@@ -42,6 +42,7 @@ test('should generate config files in debug mode when build', async ({
 
 test('should generate config files in debug mode when dev', async ({
   page,
+  dev,
 }) => {
   const { level } = logger;
   process.env.DEBUG = 'rsbuild';
@@ -49,7 +50,6 @@ test('should generate config files in debug mode when dev', async ({
 
   const distRoot = 'dist-2';
   const rsbuild = await dev({
-    cwd: __dirname,
     rsbuildConfig: {
       output: {
         distPath: {

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should emit apple-touch-icon to dist path', async ({ buildOnly }) => {
   const rsbuild = await buildOnly({
@@ -275,10 +275,8 @@ test('should allow to customize manifest filename', async ({ buildOnly }) => {
   });
 });
 
-test('should append dev.assetPrefix to icon URL', async ({ page }) => {
+test('should append dev.assetPrefix to icon URL', async ({ dev }) => {
   const rsbuild = await dev({
-    cwd: __dirname,
-    page,
     rsbuildConfig: {
       dev: {
         assetPrefix: 'http://localhost:3000',

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -1,10 +1,9 @@
-import { dev, expect, gotoPage, rspackOnlyTest } from '@e2e/helper';
+import { expect, gotoPage, rspackOnlyTest } from '@e2e/helper';
 
 rspackOnlyTest(
   'should render pages correctly when using lazy compilation',
-  async ({ page }) => {
+  async ({ page, dev }) => {
     const rsbuild = await dev({
-      cwd: __dirname,
       rsbuildConfig: {
         dev: {
           lazyCompilation: true,
@@ -31,9 +30,8 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should allow to configure `tools.rspack.experiments.lazyCompilation`',
-  async ({ page }) => {
+  async ({ page, dev }) => {
     const rsbuild = await dev({
-      cwd: __dirname,
       rsbuildConfig: {
         tools: {
           rspack: {

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, expect, rspackOnlyTest, test } from '@e2e/helper';
+import { expect, rspackOnlyTest, test } from '@e2e/helper';
 
 test('should allow to set development mode when building', async ({
   buildOnly,
@@ -51,10 +51,8 @@ test('should allow to set none mode when building', async ({ buildOnly }) => {
 
 rspackOnlyTest(
   'should allow to set production mode when starting dev server',
-  async ({ page }) => {
+  async ({ dev }) => {
     const rsbuild = await dev({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         mode: 'production',
       },

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -1,12 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import {
-  build,
-  dev,
-  getRandomPort,
-  gotoPage,
-  rspackOnlyTest,
-} from '@e2e/helper';
+import { getRandomPort, gotoPage, rspackOnlyTest } from '@e2e/helper';
 import { expect } from '@playwright/test';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
@@ -26,44 +20,47 @@ export default Button;`,
   );
 };
 
-rspackOnlyTest('should run module federation in dev', async ({ page }) => {
-  writeButtonCode();
+rspackOnlyTest(
+  'should run module federation in dev',
+  async ({ page, devOnly }) => {
+    writeButtonCode();
 
-  const remotePort = await getRandomPort();
+    const remotePort = await getRandomPort();
 
-  process.env.REMOTE_PORT = remotePort.toString();
+    process.env.REMOTE_PORT = remotePort.toString();
 
-  const remoteApp = await dev({
-    cwd: remote,
-  });
-  const hostApp = await dev({
-    cwd: host,
-  });
+    const remoteApp = await devOnly({
+      cwd: remote,
+    });
+    const hostApp = await devOnly({
+      cwd: host,
+    });
 
-  await gotoPage(page, remoteApp);
-  await expect(page.locator('#title')).toHaveText('Remote');
-  await expect(page.locator('#button')).toHaveText('Button from remote');
+    await gotoPage(page, remoteApp);
+    await expect(page.locator('#title')).toHaveText('Remote');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
 
-  await gotoPage(page, hostApp);
-  await expect(page.locator('#title')).toHaveText('Host');
-  await expect(page.locator('#button')).toHaveText('Button from remote');
+    await gotoPage(page, hostApp);
+    await expect(page.locator('#title')).toHaveText('Host');
+    await expect(page.locator('#button')).toHaveText('Button from remote');
 
-  await hostApp.close();
-  await remoteApp.close();
-});
+    await hostApp.close();
+    await remoteApp.close();
+  },
+);
 
 rspackOnlyTest(
   'should allow to set `server.cors` config',
-  async ({ request }) => {
+  async ({ request, devOnly }) => {
     writeButtonCode();
 
     const remotePort = await getRandomPort();
     process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await dev({
+    const remoteApp = await devOnly({
       cwd: remote,
     });
-    const hostApp = await dev({
+    const hostApp = await devOnly({
       cwd: host,
     });
 
@@ -87,14 +84,14 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should run module federation in dev with server.base',
-  async ({ page }) => {
+  async ({ page, devOnly }) => {
     writeButtonCode();
 
     const remotePort = await getRandomPort();
 
     process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await dev({
+    const remoteApp = await devOnly({
       cwd: remote,
       rsbuildConfig: {
         server: {
@@ -102,7 +99,7 @@ rspackOnlyTest(
         },
       },
     });
-    const hostApp = await dev({
+    const hostApp = await devOnly({
       cwd: host,
       rsbuildConfig: {
         server: {
@@ -126,17 +123,17 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should allow remote module to perform HMR',
-  async ({ page }) => {
+  async ({ page, devOnly }) => {
     writeButtonCode();
 
     const remotePort = await getRandomPort();
 
     process.env.REMOTE_PORT = remotePort.toString();
 
-    const remoteApp = await dev({
+    const remoteApp = await devOnly({
       cwd: remote,
     });
-    const hostApp = await dev({
+    const hostApp = await devOnly({
       cwd: host,
     });
 
@@ -160,7 +157,7 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should transform module federation runtime with SWC',
-  async () => {
+  async ({ buildOnly }) => {
     writeButtonCode();
 
     const remotePort = await getRandomPort();
@@ -186,14 +183,14 @@ rspackOnlyTest(
     };
 
     await expect(
-      build({
+      buildOnly({
         cwd: remote,
         rsbuildConfig,
       }),
     ).resolves.toBeTruthy();
 
     await expect(
-      build({
+      buildOnly({
         cwd: host,
         rsbuildConfig,
       }),

--- a/e2e/cases/optimization/css-minify-options/index.test.ts
+++ b/e2e/cases/optimization/css-minify-options/index.test.ts
@@ -3,11 +3,8 @@ import { expect, rspackOnlyTest } from '@e2e/helper';
 rspackOnlyTest(
   'should allow to custom CSS minify options',
   async ({ buildOnly }) => {
-    const rsbuild = await buildOnly({
-      rsbuildConfig: {},
-    });
+    const rsbuild = await buildOnly();
     const files = rsbuild.getDistFiles();
-
     const content =
       files[Object.keys(files).find((file) => file.endsWith('.css'))!];
 

--- a/e2e/cases/output/charset-emoji-filename/index.test.ts
+++ b/e2e/cases/output/charset-emoji-filename/index.test.ts
@@ -1,21 +1,15 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const utf8Str = `你好 world! I'm 🦀`;
 
-test('should resolve emoji filename in dev', async ({ page }) => {
-  await dev({
-    cwd: __dirname,
-    page,
-  });
-
+test('should resolve emoji filename in dev', async ({ page, dev }) => {
+  await dev();
   expect(await page.evaluate('window.test')).toBe(utf8Str);
 });
 
 test('should resolve emoji filename in build', async ({ page, build }) => {
   const rsbuild = await build();
-
-  expect(await page.evaluate('window.test')).toBe(utf8Str);
-
   const content = await rsbuild.getIndexBundle();
+  expect(await page.evaluate('window.test')).toBe(utf8Str);
   expect(content.includes(utf8Str)).toBeTruthy();
 });

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, expect, rspackOnlyTest, test } from '@e2e/helper';
+import { expect, rspackOnlyTest, test } from '@e2e/helper';
 
 const utf8Str = `你好 world! I'm 🦀`;
 const asciiStr = `\\u{4F60}\\u{597D} world! I'm \\u{1F980}`;
@@ -15,10 +15,8 @@ const expectedObject = {
 
 rspackOnlyTest(
   'should set output.charset to ascii in dev',
-  async ({ page }) => {
+  async ({ page, dev }) => {
     const rsbuild = await dev({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         output: {
           charset: 'ascii',
@@ -54,11 +52,8 @@ test('should set output.charset to ascii in build', async ({ page, build }) => {
   expect(content.includes(asciiStr)).toBeTruthy();
 });
 
-test('should use utf8 charset in dev by default', async ({ page }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
+test('should use utf8 charset in dev by default', async ({ page, dev }) => {
+  const rsbuild = await dev();
 
   expect(await page.evaluate('window.testA')).toBe(utf8Str);
   expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 const cwd = __dirname;
@@ -17,11 +17,12 @@ test('should clean dist path by default', async ({ buildOnly }) => {
   expect(fs.existsSync(testDistFile)).toBeFalsy();
 });
 
-test('should not clean dist path in dev when writeToDisk is false', async () => {
+test('should not clean dist path in dev when writeToDisk is false', async ({
+  dev,
+}) => {
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
 
   await dev({
-    cwd,
     rsbuildConfig: {
       dev: {
         writeToDisk: false,
@@ -33,11 +34,12 @@ test('should not clean dist path in dev when writeToDisk is false', async () => 
   await remove(testDistFile);
 });
 
-test('should clean dist path in dev when writeToDisk is true', async () => {
+test('should clean dist path in dev when writeToDisk is true', async ({
+  dev,
+}) => {
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
 
   await dev({
-    cwd,
     rsbuildConfig: {
       dev: {
         writeToDisk: true,

--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -1,7 +1,5 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildPluginAPI } from '@rsbuild/core';
-
-const fixtures = __dirname;
 
 test('should allow to access manifest data in environment context after build', async ({
   buildOnly,
@@ -124,14 +122,13 @@ test('should allow to access manifest data in environment context after dev buil
 });
 
 test('should allow to access manifest data in environment API', async ({
+  dev,
   page,
 }) => {
   let webManifest: Record<string, any> | undefined = {};
   let nodeManifest: Record<string, any> | undefined = {};
 
   const rsbuild = await dev({
-    cwd: fixtures,
-    page,
     rsbuildConfig: {
       output: {
         filenameHash: false,

--- a/e2e/cases/output/manifest-generate/index.test.ts
+++ b/e2e/cases/output/manifest-generate/index.test.ts
@@ -1,7 +1,5 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
-
-const fixtures = __dirname;
 
 const rsbuildConfig: RsbuildConfig = {
   output: {
@@ -48,10 +46,8 @@ test('should generate custom manifest data in production build', async ({
   });
 });
 
-test('should generate custom manifest data in dev', async ({ page }) => {
+test('should generate custom manifest data in dev', async ({ dev }) => {
   const rsbuild = await dev({
-    cwd: fixtures,
-    page,
     rsbuildConfig,
   });
 

--- a/e2e/cases/output/source-map/index.test.ts
+++ b/e2e/cases/output/source-map/index.test.ts
@@ -1,15 +1,9 @@
 import { readFileSync } from 'node:fs';
 import path, { join } from 'node:path';
-import {
-  type Build,
-  dev,
-  expect,
-  mapSourceMapPositions,
-  test,
-} from '@e2e/helper';
+import { type Build, expect, mapSourceMapPositions, test } from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 
-const fixtures = __dirname;
+const cwd = __dirname;
 
 async function testSourceMapType(
   devtool: Rspack.Configuration['devtool'],
@@ -155,12 +149,8 @@ test('should not generate source map if `output.sourceMap` is false', async ({
   expect(cssMapFiles.length).toEqual(0);
 });
 
-test('should generate source map correctly in dev', async ({ page }) => {
-  const rsbuild = await dev({
-    cwd: fixtures,
-    page,
-  });
-
+test('should generate source map correctly in dev', async ({ dev }) => {
+  const rsbuild = await dev();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   const jsMapPath = Object.keys(files).find((files) =>
@@ -172,10 +162,10 @@ test('should generate source map correctly in dev', async ({ page }) => {
   expect(jsMap.sources.length).toBeGreaterThan(1);
   expect(jsMap.file).toEqual('static/js/index.js');
   expect(jsMap.sourcesContent).toContain(
-    readFileSync(join(fixtures, 'src/App.jsx'), 'utf-8'),
+    readFileSync(join(cwd, 'src/App.jsx'), 'utf-8'),
   );
   expect(jsMap.sourcesContent).toContain(
-    readFileSync(join(fixtures, 'src/index.js'), 'utf-8'),
+    readFileSync(join(cwd, 'src/index.js'), 'utf-8'),
   );
   expect(jsMap.mappings).not.toBeUndefined();
 });

--- a/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
@@ -1,4 +1,4 @@
-import { build, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 const createPlugin = () => {
@@ -81,11 +81,10 @@ const createPlugin = () => {
 
 rspackOnlyTest(
   'should run plugin hooks correctly when running build with multiple environments',
-  async () => {
+  async ({ buildOnly }) => {
     process.env.NODE_ENV = 'production';
     const { plugin, names } = createPlugin();
-    const rsbuild = await build({
-      cwd: __dirname,
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         plugins: [plugin],
         environments: {

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -1,12 +1,11 @@
-import { build, expect, recordPluginHooks, rspackOnlyTest } from '@e2e/helper';
+import { expect, recordPluginHooks, rspackOnlyTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
 rspackOnlyTest(
   'should run plugin hooks correctly when running build',
-  async () => {
+  async ({ buildOnly }) => {
     const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await build({
-      cwd: __dirname,
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         plugins: [plugin],
       },
@@ -34,10 +33,9 @@ rspackOnlyTest(
 
 rspackOnlyTest(
   'should run plugin hooks correctly when running build and mode is development',
-  async () => {
+  async ({ buildOnly }) => {
     const { plugin, hooks } = recordPluginHooks();
-    const rsbuild = await build({
-      cwd: __dirname,
+    const rsbuild = await buildOnly({
       rsbuildConfig: {
         mode: 'development',
         plugins: [plugin],

--- a/e2e/cases/plugin-svelte/hmr/index.test.ts
+++ b/e2e/cases/plugin-svelte/hmr/index.test.ts
@@ -1,19 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
-rspackOnlyTest('HMR should work properly', async ({ page }) => {
-  const root = __dirname;
-  const bPath = path.join(root, 'src/test-temp-B.svelte');
+rspackOnlyTest('HMR should work properly', async ({ page, dev }) => {
+  const cwd = __dirname;
+  const bPath = path.join(cwd, 'src/test-temp-B.svelte');
   fs.writeFileSync(
     bPath,
-    fs.readFileSync(path.join(root, 'src/B.svelte'), 'utf-8'),
+    fs.readFileSync(path.join(cwd, 'src/B.svelte'), 'utf-8'),
   );
 
   await dev({
-    cwd: root,
-    page,
     plugins: [pluginSvelte()],
   });
 

--- a/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
@@ -5,12 +5,7 @@ import { expect, test } from '@e2e/helper';
 test('should preserve viewBox after svgo minification', async ({
   buildOnly,
 }) => {
-  const buildOpts = {
-    cwd: __dirname,
-  };
-
-  const rsbuild = await buildOnly(buildOpts);
-
+  const rsbuild = await buildOnly();
   const files = rsbuild.getDistFiles();
   const indexJs = Object.keys(files).find(
     (file) => file.includes('/index.') && file.endsWith('.js'),

--- a/e2e/cases/resolve/exports-presence/index.test.ts
+++ b/e2e/cases/resolve/exports-presence/index.test.ts
@@ -1,4 +1,4 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should detect and report missing named export errors during build', async ({
   buildOnly,
@@ -14,13 +14,9 @@ test('should detect and report missing named export errors during build', async 
 });
 
 test('should detect and report missing named export errors in dev', async ({
-  page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
-
+  const rsbuild = await dev();
   await rsbuild.expectLog(
     `export 'aa' (imported as 'aa') was not found in './test'`,
   );

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -1,20 +1,18 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { dev, expect, rspackOnlyTest } from '@e2e/helper';
+import { expect, rspackOnlyTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const cwd = __dirname;
 
 rspackOnlyTest(
   'Multiple environments HMR should work correctly',
-  async ({ page, context }) => {
+  async ({ dev, page, context }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
 
     const rsbuild = await dev({
-      cwd,
-      page,
       rsbuildConfig: {
         plugins: [pluginReact()],
         environments: {

--- a/e2e/cases/server/environments/index.test.ts
+++ b/e2e/cases/server/environments/index.test.ts
@@ -1,10 +1,7 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
-test('should serve multiple environments correctly', async ({ page }) => {
+test('should serve multiple environments correctly', async ({ dev, page }) => {
   const rsbuild = await dev({
-    cwd,
     rsbuildConfig: {
       environments: {
         web: {},
@@ -42,12 +39,12 @@ test('should serve multiple environments correctly', async ({ page }) => {
 });
 
 test('should expose the environment API in setupMiddlewares', async ({
+  dev,
   page,
 }) => {
   let assertionsCount = 0;
 
   const rsbuild = await dev({
-    cwd,
     rsbuildConfig: {
       dev: {
         setupMiddlewares: (middlewares, { environments }) => {
@@ -94,10 +91,10 @@ test('should expose the environment API in setupMiddlewares', async ({
 
 // TODO: not support serve multiple environments when distPath different
 test.skip('serve multiple environments correctly when distPath different', async ({
+  dev,
   page,
 }) => {
   const rsbuild = await dev({
-    cwd,
     rsbuildConfig: {
       environments: {
         web: {},

--- a/e2e/cases/server/fallback/index.test.ts
+++ b/e2e/cases/server/fallback/index.test.ts
@@ -1,14 +1,9 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should return 204 for OPTIONS requests when no middleware handles them', async ({
-  page,
+  dev,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {},
-  });
-
+  const rsbuild = await dev();
   const response = await fetch(`http://127.0.0.1:${rsbuild.port}`, {
     headers: {
       'content-type': 'application/json',
@@ -19,11 +14,9 @@ test('should return 204 for OPTIONS requests when no middleware handles them', a
 });
 
 test('should return 200 with custom headers for OPTIONS requests handled by middleware', async ({
-  page,
+  dev,
 }) => {
   const rsbuild = await dev({
-    cwd: __dirname,
-    page,
     rsbuildConfig: {
       server: {
         cors: false,

--- a/e2e/cases/server/proxy-sse/index.test.ts
+++ b/e2e/cases/server/proxy-sse/index.test.ts
@@ -1,11 +1,9 @@
-import { dev, expect, getRandomPort, test } from '@e2e/helper';
+import { expect, getRandomPort, test } from '@e2e/helper';
 import polka from 'polka';
 
-test('should proxy SSE request correctly', async ({ page }) => {
+test('should proxy SSE request correctly', async ({ dev, page }) => {
   const ssePort = await getRandomPort();
   const rsbuild = await dev({
-    cwd: __dirname,
-    page,
     rsbuildConfig: {
       server: {
         proxy: {

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -1,10 +1,10 @@
 import { join } from 'node:path';
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const prj1 = join(__dirname, 'project1');
 const prj2 = join(__dirname, 'project2');
 
-test('should apply basic proxy rules correctly', async ({ page }) => {
+test('should apply basic proxy rules correctly', async ({ dev, page }) => {
   const rsbuild1 = await dev({
     cwd: prj1,
     rsbuildConfig: {
@@ -40,7 +40,7 @@ test('should apply basic proxy rules correctly', async ({ page }) => {
   await rsbuild2.close();
 });
 
-test('should handle proxy error correctly', async ({ page }) => {
+test('should handle proxy error correctly', async ({ dev, page }) => {
   const rsbuild = await dev({
     cwd: prj1,
     rsbuildConfig: {

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -1,38 +1,37 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dev, rspackOnlyTest } from '@e2e/helper';
+import { rspackOnlyTest } from '@e2e/helper';
 
-rspackOnlyTest('should work with string and path to file', async ({ page }) => {
-  const file = path.join(__dirname, '/assets/example.txt');
-  await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      dev: {
-        watchFiles: {
-          paths: file,
+rspackOnlyTest(
+  'should work with string and path to file',
+  async ({ dev, page }) => {
+    const file = path.join(__dirname, '/assets/example.txt');
+    await dev({
+      rsbuildConfig: {
+        dev: {
+          watchFiles: {
+            paths: file,
+          },
         },
       },
-    },
-  });
+    });
 
-  await fs.promises.writeFile(file, 'test');
-  // check the page is reloaded
-  await new Promise((resolve) => {
-    page.waitForURL(page.url()).then(resolve);
-  });
+    await fs.promises.writeFile(file, 'test');
+    // check the page is reloaded
+    await new Promise((resolve) => {
+      page.waitForURL(page.url()).then(resolve);
+    });
 
-  // reset file
-  fs.truncateSync(file);
-});
+    // reset file
+    fs.truncateSync(file);
+  },
+);
 
 rspackOnlyTest(
   'should work with string and path to directory',
-  async ({ page }) => {
+  async ({ dev, page }) => {
     const file = path.join(__dirname, '/assets/example.txt');
     await dev({
-      cwd: __dirname,
-      page,
       rsbuildConfig: {
         dev: {
           watchFiles: {
@@ -53,47 +52,46 @@ rspackOnlyTest(
   },
 );
 
-rspackOnlyTest('should work with string array directory', async ({ page }) => {
-  const file = path.join(__dirname, '/assets/example.txt');
-  const other = path.join(__dirname, '/other/other.txt');
-  await dev({
-    cwd: __dirname,
-    page,
-    rsbuildConfig: {
-      dev: {
-        watchFiles: {
-          paths: [
-            path.join(__dirname, '/assets'),
-            path.join(__dirname, '/other'),
-          ],
+rspackOnlyTest(
+  'should work with string array directory',
+  async ({ dev, page }) => {
+    const file = path.join(__dirname, '/assets/example.txt');
+    const other = path.join(__dirname, '/other/other.txt');
+    await dev({
+      rsbuildConfig: {
+        dev: {
+          watchFiles: {
+            paths: [
+              path.join(__dirname, '/assets'),
+              path.join(__dirname, '/other'),
+            ],
+          },
         },
       },
-    },
-  });
+    });
 
-  await fs.promises.writeFile(file, 'test');
-  // check the page is reloaded
-  await new Promise((resolve) => {
-    page.waitForURL(page.url()).then(resolve);
-  });
-  // reset file
-  fs.truncateSync(file);
+    await fs.promises.writeFile(file, 'test');
+    // check the page is reloaded
+    await new Promise((resolve) => {
+      page.waitForURL(page.url()).then(resolve);
+    });
+    // reset file
+    fs.truncateSync(file);
 
-  await fs.promises.writeFile(other, 'test');
-  // check the page is reloaded
-  await new Promise((resolve) => {
-    page.waitForURL(page.url()).then(resolve);
-  });
-  // reset file
-  fs.truncateSync(other);
-});
+    await fs.promises.writeFile(other, 'test');
+    // check the page is reloaded
+    await new Promise((resolve) => {
+      page.waitForURL(page.url()).then(resolve);
+    });
+    // reset file
+    fs.truncateSync(other);
+  },
+);
 
-rspackOnlyTest('should work with string and glob', async ({ page }) => {
+rspackOnlyTest('should work with string and glob', async ({ dev, page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   const watchDir = path.join(__dirname, '/assets');
   await dev({
-    cwd: __dirname,
-    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {
@@ -113,11 +111,9 @@ rspackOnlyTest('should work with string and glob', async ({ page }) => {
   fs.truncateSync(file);
 });
 
-rspackOnlyTest('should work with options', async ({ page }) => {
+rspackOnlyTest('should work with options', async ({ dev, page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   await dev({
-    cwd: __dirname,
-    page,
     rsbuildConfig: {
       dev: {
         watchFiles: {

--- a/e2e/cases/source/define/index.test.ts
+++ b/e2e/cases/source/define/index.test.ts
@@ -1,13 +1,10 @@
-import { dev, expect, gotoPage, test } from '@e2e/helper';
+import { expect, gotoPage, test } from '@e2e/helper';
 
 test('should allow to define global variables in development', async ({
+  dev,
   page,
 }) => {
-  const rsbuild = await dev({
-    cwd: __dirname,
-    page,
-  });
-
+  const rsbuild = await dev();
   await gotoPage(page, rsbuild);
 
   const testEl = page.locator('#test-el');

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -62,13 +62,7 @@ export function shareTest(
   msg: string,
   entry: string,
   transformImport: TransformImport,
-  otherConfigs: {
-    plugins?: any[];
-  } = {},
 ) {
-  const setupConfig = {
-    cwd: __dirname,
-  };
   const config: RsbuildConfig = {
     source: {
       entry: {
@@ -85,9 +79,7 @@ export function shareTest(
 
   test(msg, async ({ buildOnly }) => {
     const rsbuild = await buildOnly({
-      ...setupConfig,
-      ...otherConfigs,
-      rsbuildConfig: { ...config },
+      rsbuildConfig: config,
     });
     const files = rsbuild.getDistFiles({ sourceMaps: true });
     expect(files[findEntry(files)]).toContain('transformImport test succeed');

--- a/e2e/cases/source/pre-entry/index.test.ts
+++ b/e2e/cases/source/pre-entry/index.test.ts
@@ -1,11 +1,10 @@
-import { dev, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
-test('should allow to configure pre-entry in development', async ({ page }) => {
-  await dev({
-    cwd: __dirname,
-    page,
-  });
-
+test('should allow to configure pre-entry in development', async ({
+  dev,
+  page,
+}) => {
+  await dev();
   await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
   await expect(page.evaluate('window.aa')).resolves.toBe(2);
 });
@@ -15,7 +14,6 @@ test('should allow to configure pre-entry in production build', async ({
   build,
 }) => {
   await build();
-
   await expect(page.innerHTML('#test-el')).resolves.toBe('aaaaa');
   await expect(page.evaluate('window.aa')).resolves.toBe(2);
 });

--- a/e2e/helper/index.ts
+++ b/e2e/helper/index.ts
@@ -1,6 +1,12 @@
 export * from './cli';
 export * from './constants';
 export * from './fixture';
-export * from './jsApi';
+export {
+  type Build,
+  type BuildOptions,
+  type BuildResult,
+  createRsbuild,
+  type Dev,
+} from './jsApi';
 export * from './logs';
 export * from './utils';


### PR DESCRIPTION
## Summary

Standardizing the usage of test helpers by removing unnecessary imports and parameters, switching to destructured test context arguments (such as `dev`, `buildOnly`, `devOnly`), and eliminating redundant `cwd` and `page` properties in test invocations. 

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
