### PR TITLE
test: add editFile helper for test file modifications

### DIFF
--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -40,7 +40,7 @@ rspackTest(
 
 rspackTest(
   'HMR should work well when `injectStyles` is enabled',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await fs.promises.cp(
       join(fixtures, 'src'),
       join(fixtures, 'test-temp-src'),
@@ -68,11 +68,8 @@ rspackTest(
     const locatorKeep = page.locator('#test-keep');
     const keepNum = await locatorKeep.innerHTML();
 
-    const filePath = join(fixtures, 'test-temp-src/App.module.less');
-
-    await fs.promises.writeFile(
-      filePath,
-      fs.readFileSync(filePath, 'utf-8').replace('20px', '40px'),
+    await editFile('test-temp-src/App.module.less', (code) =>
+      code.replace('20px', '40px'),
     );
 
     // CSS HMR works well

--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -4,7 +4,7 @@ import { expect, rspackTest } from '@e2e/helper';
 
 const cwd = __dirname;
 
-rspackTest('HMR should work by default', async ({ page, dev }) => {
+rspackTest('HMR should work by default', async ({ page, dev, editFile }) => {
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });
@@ -26,11 +26,8 @@ rspackTest('HMR should work by default', async ({ page, dev }) => {
   const locatorKeep = page.locator('#test-keep');
   const keepNum = await locatorKeep.innerHTML();
 
-  const appPath = join(cwd, 'test-temp-src/App.tsx');
-
-  await fs.promises.writeFile(
-    appPath,
-    fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+  await editFile('test-temp-src/App.tsx', (code) =>
+    code.replace('Hello Rsbuild', 'Hello Test'),
   );
 
   await expect(locator).toHaveText('Hello Test!');
@@ -38,11 +35,9 @@ rspackTest('HMR should work by default', async ({ page, dev }) => {
   // #test-keep should remain unchanged when app.tsx HMR
   expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
-  const cssPath = join(cwd, 'test-temp-src/App.css');
-
-  await fs.promises.writeFile(
-    cssPath,
-    `#test {
+  await editFile(
+    'test-temp-src/App.css',
+    () => `#test {
   color: rgb(0, 0, 255);
 }`,
   );

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'HMR should work when setting dev.port and dev.client.host',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -26,14 +26,11 @@ rspackTest(
       },
     });
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
 
     await expect(locator).toHaveText('Hello Test!');

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'HMR should work when dev.client.port is `<port>`',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -26,14 +26,11 @@ rspackTest(
       },
     });
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
 
     await expect(locator).toHaveText('Hello Test!');

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'HMR should work after fixing compilation error',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -24,28 +24,20 @@ rspackTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-
-    await fs.promises.writeFile(
-      appPath,
-      fs
-        .readFileSync(appPath, 'utf-8')
-        .replace(
-          '<div id="test">Hello Rsbuild!</div>',
-          '<div id="test">Hello Rsbuild!</div',
-        ),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace(
+        '<div id="test">Hello Rsbuild!</div>',
+        '<div id="test">Hello Rsbuild!</div',
+      ),
     );
 
     await rsbuild.expectLog('Module build failed');
 
-    await fs.promises.writeFile(
-      appPath,
-      fs
-        .readFileSync(appPath, 'utf-8')
-        .replace(
-          '<div id="test">Hello Rsbuild!</div',
-          '<div id="test">Hello Rsbuild2!</div>',
-        ),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace(
+        '<div id="test">Hello Rsbuild!</div',
+        '<div id="test">Hello Rsbuild2!</div>',
+      ),
     );
 
     await expect(locator).toHaveText('Hello Rsbuild2!');

--- a/e2e/cases/hmr/live-reload/index.test.ts
+++ b/e2e/cases/hmr/live-reload/index.test.ts
@@ -16,24 +16,18 @@ test.afterEach(() => {
 
 rspackTest(
   'should fallback to live-reload when dev.hmr is false',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await dev();
-
     const testEl = page.locator('#test');
     await expect(testEl).toHaveText('Hello Rsbuild!');
-
-    fs.writeFileSync(
-      appFile,
-      appCode.replace('Rsbuild', 'Live Reload'),
-      'utf-8',
-    );
+    await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
     await expect(testEl).toHaveText('Hello Live Reload!');
   },
 );
 
 rspackTest(
   'should not reload page when live-reload is disabled',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await dev({
       rsbuildConfig: {
         dev: {
@@ -44,12 +38,7 @@ rspackTest(
 
     const test = page.locator('#test');
     await expect(test).toHaveText('Hello Rsbuild!');
-
-    fs.writeFileSync(
-      appFile,
-      appCode.replace('Rsbuild', 'Live Reload'),
-      'utf-8',
-    );
+    await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
     await expect(test).toHaveText('Hello Rsbuild!');
   },
 );

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'should allow to create multiple HMR connections',
-  async ({ page: page1, context, devOnly }) => {
+  async ({ page: page1, context, devOnly, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -36,10 +36,8 @@ rspackTest(
     const keepNum1 = await locatorKeep1.innerHTML();
     const keepNum2 = await locatorKeep2.innerHTML();
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
 
     await expect(locator1).toHaveText('Hello Test!');

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -4,35 +4,33 @@ import { expect, rspackTest } from '@e2e/helper';
 
 const cwd = __dirname;
 
-rspackTest('should print changed files in logs', async ({ page, dev }) => {
-  await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-    recursive: true,
-  });
+rspackTest(
+  'should print changed files in logs',
+  async ({ page, dev, editFile }) => {
+    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+      recursive: true,
+    });
 
-  const rsbuild = await dev({
-    rsbuildConfig: {
-      source: {
-        entry: {
-          index: join(cwd, 'test-temp-src/index.ts'),
+    const rsbuild = await dev({
+      rsbuildConfig: {
+        source: {
+          entry: {
+            index: join(cwd, 'test-temp-src/index.ts'),
+          },
         },
       },
-    },
-  });
+    });
 
-  const locator = page.locator('#test');
-  await expect(locator).toHaveText('Hello Rsbuild!');
+    const locator = page.locator('#test');
+    await expect(locator).toHaveText('Hello Rsbuild!');
 
-  const appPath = join(cwd, 'test-temp-src/App.tsx');
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild!', 'Hello Rsbuild2!'),
+    );
 
-  await fs.promises.writeFile(
-    appPath,
-    fs
-      .readFileSync(appPath, 'utf-8')
-      .replace('Hello Rsbuild!', 'Hello Rsbuild2!'),
-  );
-
-  await rsbuild.expectLog(/building test-temp-src[\\/]App\.tsx/);
-});
+    await rsbuild.expectLog(/building test-temp-src[\\/]App\.tsx/);
+  },
+);
 
 rspackTest('should print removed files in logs', async ({ page, dev }) => {
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {

--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'should reconnect Web Socket server as expected',
-  async ({ page, dev, devOnly }) => {
+  async ({ page, dev, devOnly, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -33,10 +33,8 @@ rspackTest(
       },
     });
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
     await expect(locator).toHaveText('Hello Test!');
   },

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -7,7 +7,7 @@ import fse from 'fs-extra';
 // https://github.com/web-infra-dev/rsbuild/issues/5176
 rspackTest(
   'should not re-compile templates when the template is not changed',
-  async ({ dev, page }) => {
+  async ({ dev, page, editFile }) => {
     // Failed to run this case on Windows
     if (process.platform === 'win32') {
       test.skip();
@@ -51,17 +51,17 @@ rspackTest(
     expect(count).toEqual(2);
 
     // Re-compile the template when the template is changed
-    const indexHtmlPath = join(targetDir, 'index.html');
-    const indexHtml = await fs.readFile(indexHtmlPath, 'utf-8');
-    await fs.writeFile(indexHtmlPath, indexHtml.replace('foo', 'foo2'));
+    await editFile('test-temp-src/index.html', (code) =>
+      code.replace('foo', 'foo2'),
+    );
     await expect(page.locator('#root')).toHaveText('foo2');
     // The count will be 4 as the childCompiler in html-rspack-plugin
     // will compile all the templates
     expect(count).toEqual(4);
 
-    const indexJsPath = join(targetDir, 'index.js');
-    const indexJs = await fs.readFile(indexJsPath, 'utf-8');
-    await fs.writeFile(indexJsPath, indexJs.replace('foo', 'foo3'));
+    await editFile('test-temp-src/index.js', (code) =>
+      code.replace('foo', 'foo3'),
+    );
     await expect(page.locator('#content')).toHaveText('foo3');
     // The count should not change if the templates are not changed
     expect(count).toEqual(4);

--- a/e2e/cases/plugin-preact/prefresh-context/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-context/index.test.ts
@@ -4,7 +4,7 @@ import { expect, rspackTest, test } from '@e2e/helper';
 
 rspackTest(
   'HMR should work properly with `createContext`',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     // Prefresh does not work as expected on Windows
     if (process.platform === 'win32') {
       test.skip();
@@ -34,11 +34,7 @@ export default B;
     await expect(b).toHaveText('B: 5');
 
     // simulate a change to component B's source code
-    fs.writeFileSync(
-      compFilePath,
-      compSourceCode.replace('B:', 'Beep:'),
-      'utf-8',
-    );
+    await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
 
     await page.waitForFunction(() => {
       const aText = document.querySelector('#A')?.textContent;

--- a/e2e/cases/plugin-preact/prefresh-disabled/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh-disabled/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev }) => {
+rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
   const root = __dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {
@@ -27,11 +27,7 @@ export default B;
   await expect(b).toHaveText('B: 5');
 
   // simulate a change to component B's source code
-  fs.writeFileSync(
-    compFilePath,
-    compSourceCode.replace('B:', 'Beep:'),
-    'utf-8',
-  );
+  await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
 
   await page.waitForFunction(() => {
     const aText = document.querySelector('#A')?.textContent;

--- a/e2e/cases/plugin-preact/prefresh/index.test.ts
+++ b/e2e/cases/plugin-preact/prefresh/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, rspackTest, test } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev }) => {
+rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
   // Prefresh does not work as expected on Windows
   if (process.platform === 'win32') {
     test.skip();
@@ -32,11 +32,7 @@ export default B;
   await expect(b).toHaveText('B: 5');
 
   // simulate a change to component B's source code
-  fs.writeFileSync(
-    compFilePath,
-    compSourceCode.replace('B:', 'Beep:'),
-    'utf-8',
-  );
+  await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
 
   await page.waitForFunction(() => {
     const aText = document.querySelector('#A')?.textContent;

--- a/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'HMR should work when Fast Refresh is disabled',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -25,10 +25,8 @@ rspackTest(
     await expect(locator).toHaveText('Hello Rsbuild!');
     await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
     await expect(locator).toHaveText('Hello Test!');
   },

--- a/e2e/cases/plugin-solid/hmr/index.test.ts
+++ b/e2e/cases/plugin-solid/hmr/index.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-rspackTest('HMR should work properly', async ({ page, dev }) => {
+rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
   const root = __dirname;
   const compFilePath = path.join(root, 'src/test-temp-B.jsx');
   const compSourceCode = `const B = (props) => {
@@ -27,11 +27,7 @@ export default B;
   await expect(b).toHaveText('B: 5');
 
   // simulate a change to component B's source code
-  fs.writeFileSync(
-    compFilePath,
-    compSourceCode.replace('B:', 'Beep:'),
-    'utf-8',
-  );
+  await editFile(compFilePath, (code) => code.replace('B:', 'Beep:'));
 
   await page.waitForFunction(() => {
     const aText = document.querySelector('#A')?.textContent;

--- a/e2e/cases/plugin-svelte/hmr/index.test.ts
+++ b/e2e/cases/plugin-svelte/hmr/index.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
-rspackTest('HMR should work properly', async ({ page, dev }) => {
+rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
   const cwd = __dirname;
   const bPath = path.join(cwd, 'src/test-temp-B.svelte');
   fs.writeFileSync(
@@ -27,12 +27,12 @@ rspackTest('HMR should work properly', async ({ page, dev }) => {
 
   // simulate a change to component B's source code
   const sourceCodeB = fs.readFileSync(bPath, 'utf-8');
-  fs.writeFileSync(bPath, sourceCodeB.replace('B:', 'Beep:'), 'utf-8');
+  await editFile(bPath, (code) => code.replace('B:', 'Beep:'));
 
   // content of B changed to `Beep: 0` means HMR has taken effect
   await expect(b).toHaveText('Beep: 0');
   // the state (count) of A is not kept because `svelte-loader` does not support HMR for Svelte 5 yet
   await expect(a).toHaveText('A: 0');
 
-  fs.writeFileSync(bPath, sourceCodeB, 'utf-8'); // recover the source code
+  await editFile(bPath, () => sourceCodeB); // recover the source code
 });

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -1,4 +1,3 @@
-import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import {
   expect,
@@ -13,7 +12,7 @@ import { tempConfig } from './rsbuild.config';
 
 rspackTest(
   'should watch tsconfig.json and reload the server when it changes',
-  async ({ page }) => {
+  async ({ page, editFile }) => {
     if (process.platform === 'win32') {
       return;
     }
@@ -37,8 +36,7 @@ rspackTest(
     await gotoPage(page, { port });
     await expect(page.locator('#content')).toHaveText('foo');
 
-    const tsconfigContent = await readFile(tempConfig, 'utf-8');
-    await writeFile(tempConfig, tsconfigContent.replace('foo', 'bar'));
+    await editFile(tempConfig, (code) => code.replace('foo', 'bar'));
     await expect(page.locator('#content')).toHaveText('bar');
 
     close();

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -7,7 +7,7 @@ const cwd = __dirname;
 
 rspackTest(
   'Multiple environments HMR should work correctly',
-  async ({ dev, page, context }) => {
+  async ({ dev, page, context, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -60,22 +60,16 @@ rspackTest(
     const keepNum = await locatorKeep.innerHTML();
 
     // web1 live reload correctly and should not trigger index update
-    const web1JSPath = join(cwd, 'test-temp-src/web1.js');
-
-    await fs.promises.writeFile(
-      web1JSPath,
-      fs.readFileSync(web1JSPath, 'utf-8').replace('(web1)', '(web1-new)'),
+    await editFile('test-temp-src/web1.js', (code) =>
+      code.replace('(web1)', '(web1-new)'),
     );
 
     await expect(locator1).toHaveText('Hello Rsbuild (web1)!');
     expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     // index HMR correctly
-    const appPath = join(cwd, 'test-temp-src/App.tsx');
-
-    await fs.promises.writeFile(
-      appPath,
-      fs.readFileSync(appPath, 'utf-8').replace('Hello Rsbuild', 'Hello Test'),
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
     );
 
     await expect(locator).toHaveText('Hello Test!');

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -4,7 +4,7 @@ import { createLogHelper, expect, test } from '@e2e/helper';
 
 const cwd = __dirname;
 
-test('should show overlay correctly', async ({ page, dev }) => {
+test('should show overlay correctly', async ({ page, dev, editFile }) => {
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });
@@ -30,10 +30,8 @@ test('should show overlay correctly', async ({ page, dev }) => {
   const errorOverlay = page.locator('rsbuild-error-overlay');
   expect(await errorOverlay.locator('.title').count()).toBe(0);
 
-  const appPath = join(cwd, 'test-temp-src/App.tsx');
-  await fs.promises.writeFile(
-    appPath,
-    fs.readFileSync(appPath, 'utf-8').replace('</div>', '</aaaaa>'),
+  await editFile('test-temp-src/App.tsx', (code) =>
+    code.replace('</div>', '</aaaaa>'),
   );
 
   await expectLog('Module build failed');

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -6,7 +6,7 @@ const cwd = __dirname;
 
 rspackTest(
   'should reload page when HTML template changed',
-  async ({ page, dev }) => {
+  async ({ page, dev, editFile }) => {
     // Failed to run this case on Windows
     if (process.platform === 'win32') {
       test.skip();
@@ -20,10 +20,8 @@ rspackTest(
 
     await expect(page).toHaveTitle('Foo');
 
-    const templatePath = join(cwd, 'test-temp-src/index.html');
-    await fs.promises.writeFile(
-      templatePath,
-      fs.readFileSync(templatePath, 'utf-8').replace('Foo', 'Bar'),
+    await editFile('test-temp-src/index.html', (code) =>
+      code.replace('Foo', 'Bar'),
     );
     // expect page title to be 'Bar' after HTML template changed
     await expect(page).toHaveTitle('Bar');

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -51,7 +51,8 @@ type RsbuildFixture = {
 
   /**
    * Edit a file in the test file's cwd.
-   * @param filename The filename relative to the test file's cwd.
+   * @param filename The filename. If it is not absolute, it will be resolved
+   * relative to the test file's cwd.
    * @param replacer The replacer function.
    */
   editFile: EditFile;
@@ -136,7 +137,9 @@ export const test = base.extend<RsbuildFixture>({
 
   editFile: async ({ cwd }, use) => {
     const editFile: EditFile = async (filename, replacer) => {
-      const resolvedFilename = path.resolve(cwd, filename);
+      const resolvedFilename = path.isAbsolute(filename)
+        ? filename
+        : path.resolve(cwd, filename);
       const code = await promises.readFile(resolvedFilename, 'utf-8');
       return promises.writeFile(resolvedFilename, replacer(code));
     };


### PR DESCRIPTION
## Summary

Simplify test file modifications by introducing an `editFile` helper that handles file reading and writing. This improves test readability and reduces boilerplate code across multiple test cases.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
