### PR TITLE
feat: add support for `resolve.conditionNames` configuration

### DIFF
--- a/e2e/cases/resolve/condition-names/index.test.ts
+++ b/e2e/cases/resolve/condition-names/index.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from '@e2e/helper';
+import { copy } from 'fs-extra';
+import { join } from 'path';
+
+declare global {
+  interface Window {
+    test: string;
+  }
+}
+
+copy(
+  join(__dirname, 'package-foo'),
+  join(__dirname, 'node_modules/@e2e/resolve-condition-names-package-foo'),
+);
+
+test('should apply resolve.conditionNames as expected in dev', async ({
+  page,
+  dev,
+}) => {
+  await dev({
+    rsbuildConfig: {
+      resolve: {
+        conditionNames: ['custom', 'import', 'require'],
+      },
+    },
+  });
+  expect(await page.evaluate(() => window.test)).toBe('custom');
+
+  await dev({
+    rsbuildConfig: {
+      resolve: {
+        conditionNames: ['require', 'import'],
+      },
+    },
+  });
+  expect(await page.evaluate(() => window.test)).toBe('import');
+});
+
+test('should apply resolve.conditionNames as expected in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview({
+    rsbuildConfig: {
+      resolve: {
+        conditionNames: ['custom', 'import', 'require'],
+      },
+    },
+  });
+  expect(await page.evaluate(() => window.test)).toBe('custom');
+
+  await buildPreview({
+    rsbuildConfig: {
+      resolve: {
+        conditionNames: ['require', 'import'],
+      },
+    },
+  });
+
+  // The key order in the `exports` object determines priority
+  expect(await page.evaluate(() => window.test)).toBe('import');
+});

--- a/e2e/cases/resolve/condition-names/package-foo/custom.js
+++ b/e2e/cases/resolve/condition-names/package-foo/custom.js
@@ -1,0 +1,1 @@
+export const value = 'custom';

--- a/e2e/cases/resolve/condition-names/package-foo/import.js
+++ b/e2e/cases/resolve/condition-names/package-foo/import.js
@@ -1,0 +1,1 @@
+export const value = 'import';

--- a/e2e/cases/resolve/condition-names/package-foo/package.json
+++ b/e2e/cases/resolve/condition-names/package-foo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@e2e/resolve-condition-names-package-foo",
+  "exports": {
+    ".": {
+      "custom": "./custom.js",
+      "import": "./import.js",
+      "require": "./require.js"
+    }
+  }
+}

--- a/e2e/cases/resolve/condition-names/package-foo/require.js
+++ b/e2e/cases/resolve/condition-names/package-foo/require.js
@@ -1,0 +1,1 @@
+export const value = 'require';

--- a/e2e/cases/resolve/condition-names/src/index.js
+++ b/e2e/cases/resolve/condition-names/src/index.js
@@ -1,0 +1,3 @@
+import { value } from '@e2e/resolve-condition-names-package-foo';
+
+window.test = value;

--- a/e2e/cases/resolve/extensions/index.test.ts
+++ b/e2e/cases/resolve/extensions/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@e2e/helper';
 
-test('should apply resolve.extensions as expected', async ({
+test('should apply resolve.conditionNames as expected', async ({
   page,
   buildPreview,
 }) => {

--- a/e2e/cases/resolve/extensions/index.test.ts
+++ b/e2e/cases/resolve/extensions/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@e2e/helper';
 
-test('should apply resolve.conditionNames as expected', async ({
+test('should apply resolve.extensions as expected', async ({
   page,
   buildPreview,
 }) => {

--- a/e2e/cases/resolve/extensions/tsconfig.json
+++ b/e2e/cases/resolve/extensions/tsconfig.json
@@ -1,11 +1,4 @@
 {
   "extends": "@rsbuild/config/tsconfig",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "outDir": "./dist",
-    "paths": {
-      "@/*": ["./src/*"]
-    }
-  },
   "include": ["src", "*.test.ts"]
 }

--- a/packages/core/src/mergeConfig.ts
+++ b/packages/core/src/mergeConfig.ts
@@ -10,6 +10,7 @@ const OVERRIDE_PATHS = [
   'server.open',
   'server.printUrls',
   'resolve.extensions',
+  'resolve.conditionNames',
   'provider',
 ];
 

--- a/packages/core/src/plugins/resolve.ts
+++ b/packages/core/src/plugins/resolve.ts
@@ -124,8 +124,13 @@ export const pluginResolve = (): RsbuildPlugin => ({
       order: 'pre',
       handler: (chain, { environment, CHAIN_ID }) => {
         const { config, tsconfigPath } = environment;
+        const { extensions, conditionNames } = config.resolve;
 
-        chain.resolve.extensions.merge([...config.resolve.extensions]);
+        chain.resolve.extensions.merge([...extensions]);
+
+        if (conditionNames?.length) {
+          chain.resolve.conditionNames.merge([...conditionNames]);
+        }
 
         const isTsProject =
           tsconfigPath && !tsconfigPath.endsWith('jsconfig.json');

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1830,7 +1830,7 @@ export interface ResolveConfig {
   /**
    * Specifies the condition names used to match entry points in the exports field
    * of a package.
-   * @default Inherit from Rspack. See https://rspack.rs/config/resolve#resolveconditionnames
+   * @default Inherits from Rspack. See https://rspack.rs/config/resolve#resolveconditionnames
    */
   conditionNames?: string[];
 }

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1827,6 +1827,12 @@ export interface ResolveConfig {
    * @default ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json']
    */
   extensions?: string[];
+  /**
+   * Specifies the condition names used to match entry points in the exports field
+   * of a package.
+   * @default Inherit from Rspack. See https://rspack.rs/config/resolve#resolveconditionnames
+   */
+  conditionNames?: string[];
 }
 
 export type NormalizedResolveConfig = ResolveConfig &


### PR DESCRIPTION
## Summary

This pull request adds support for the `resolve.conditionNames` option in the configuration, allowing users to customize the order of condition names used when resolving package exports.

The newly added `resolve.conditionNames` is basically the same as `tools.rspack.resolve.conditionNames`. The differences are:

- `resolve.conditionNames` is shorter and more intuitive.
- `resolve.conditionNames` overrides the existing configuration instead of merging with it.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/6097
- https://github.com/web-infra-dev/rsbuild/issues/3864

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
