### PR TITLE
docs: clarify asset prefix behavior and add examples

### DIFF
--- a/website/docs/en/config/server/base.mdx
+++ b/website/docs/en/config/server/base.mdx
@@ -22,7 +22,7 @@ export default {
 
 ## URL prefix of assets
 
-By default, [dev.assetPrefix](/config/dev/asset-prefix) and [output.assetPrefix](/config/output/asset-prefix) will read the value of `server.base` as the default value.
+[dev.assetPrefix](/config/dev/asset-prefix) and [output.assetPrefix](/config/output/asset-prefix) will read the value of `server.base` as the default value.
 
 When `server.base` is `/foo`, the default resource URL loaded in the browser is as follows:
 

--- a/website/docs/en/guide/basic/static-assets.mdx
+++ b/website/docs/en/guide/basic/static-assets.mdx
@@ -198,8 +198,17 @@ The URL returned after importing an asset will automatically include the path pr
 
 - In development, use [dev.assetPrefix](/config/dev/asset-prefix) to set the path prefix.
 - In production, use [output.assetPrefix](/config/output/asset-prefix) to set the path prefix.
+- When either `dev.assetPrefix` or `output.assetPrefix` is not configured, the value of [server.base](/config/server/base) will be automatically used as the default prefix.
 
 For example, you can set `output.assetPrefix` to `https://example.com`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    assetPrefix: 'https://example.com',
+  },
+};
+```
 
 ```js
 import logo from './static/logo.png';

--- a/website/docs/zh/config/server/base.mdx
+++ b/website/docs/zh/config/server/base.mdx
@@ -22,7 +22,7 @@ export default {
 
 ## 静态资源 URL 前缀
 
-默认情况下，[dev.assetPrefix](/config/dev/asset-prefix) 和 [output.assetPrefix](/config/output/asset-prefix) 会读取 `server.base` 的值作为 `assetPrefix` 的默认值。
+[dev.assetPrefix](/config/dev/asset-prefix) 和 [output.assetPrefix](/config/output/asset-prefix) 会读取 `server.base` 的值作为默认值。
 
 当 `server.base` 为 `/foo` 时，默认在浏览器中加载的资源 URL 如下：
 

--- a/website/docs/zh/guide/basic/static-assets.mdx
+++ b/website/docs/zh/guide/basic/static-assets.mdx
@@ -198,8 +198,17 @@ Rsbuild >= 1.3.0 支持 `?raw` 查询参数，>= 1.4.0 支持引用 JS 和 TS �
 
 - 在开发模式下，通过 [dev.assetPrefix](/config/dev/asset-prefix) 设置路径前缀。
 - 在生产模式下，通过 [output.assetPrefix](/config/output/asset-prefix) 设置路径前缀。
+- 当 `dev.assetPrefix` 或 `output.assetPrefix` 未配置时，将自动使用 [server.base](/config/server/base) 的值作为默认前缀。
 
 比如将 `output.assetPrefix` 设置为 `https://example.com`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    assetPrefix: 'https://example.com',
+  },
+};
+```
 
 ```js
 import logo from './static/logo.png';


### PR DESCRIPTION
## Summary

- Update documentation to explicitly state that `server.base` is used as default prefix when `assetPrefix` is not configured.
- Add configuration examples for better clarity.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
