### PR TITLE
test(config-loader): simplify test by removing node version check

### DIFF
--- a/e2e/cases/cli/config-loader/index.test.ts
+++ b/e2e/cases/cli/config-loader/index.test.ts
@@ -1,12 +1,11 @@
 import path from 'node:path';
 import { expect, readDirContents, rspackTest, runCliSync } from '@e2e/helper';
 
-const nodeVersion = process.version.slice(1).split('.')[0];
-const isNodeVersionCompatible = Number(nodeVersion) >= 22;
+rspackTest('should use Node.js native loader to load config', async () => {
+  if (!process.features.typescript) {
+    return;
+  }
 
-const conditionalTest = isNodeVersionCompatible ? rspackTest : rspackTest.skip;
-
-conditionalTest('should use Node.js native loader to load config', async () => {
   runCliSync('build --config-loader native', {
     cwd: __dirname,
     env: {

--- a/website/docs/en/guide/basic/cli.mdx
+++ b/website/docs/en/guide/basic/cli.mdx
@@ -27,19 +27,19 @@ Commands:
 
 The Rsbuild CLI includes several common flags that work with all commands:
 
-| Flag                       | Description                                                                                                                       |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| `--base <base>`            | Set the base path of the server, see [server.base](/config/server/base)                                                           |
-| `-c, --config <config>`    | Set the configuration file (relative or absolute path), see [Set config file](/guide/configuration/rsbuild#specify-config-file)   |
-| `--config-loader <loader>` | Set the config file loader (`jiti` \| `native`), see [Set config loader](/guide/configuration/rsbuild#specify-config-loader)      |
-| `--env-mode <mode>`        | Set the env mode to load the `.env.[mode]` file, see [Env mode](/guide/advanced/env-vars#env-mode)                                |
-| `--env-dir <dir>`          | Set the directory for loading `.env` files, see [Env directory](/guide/advanced/env-vars#env-directory)                           |
-| `--environment <name>`     | Set the environment name(s) to build, see [Build specified environment](/guide/advanced/environments#build-specified-environment) |
-| `-h, --help`               | Display help for command                                                                                                          |
-| `--log-level <level>`      | Set the log level (`info` \| `warn` \| `error` \| `silent`), see [logLevel](/config/log-level)                                    |
-| `-m, --mode <mode>`        | Set the build mode (`development` \| `production` \| `none`), see [mode](/config/mode)                                            |
-| `--no-env`                 | Disable loading of `.env` files                                                                                                   |
-| `-r, --root <root>`        | Set the project root directory (absolute path or relative to [cwd](https://nodejs.org/api/process.html#processcwd))               |
+| Flag                       | Description                                                                                                                         |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--base <base>`            | Set the base path of the server, see [server.base](/config/server/base)                                                             |
+| `-c, --config <config>`    | Set the configuration file (relative or absolute path), see [Specify config file](/guide/configuration/rsbuild#specify-config-file) |
+| `--config-loader <loader>` | Set the config file loader (`jiti` \| `native`), see [Specify config loader](/guide/configuration/rsbuild#specify-config-loader)    |
+| `--env-mode <mode>`        | Set the env mode to load the `.env.[mode]` file, see [Env mode](/guide/advanced/env-vars#env-mode)                                  |
+| `--env-dir <dir>`          | Set the directory for loading `.env` files, see [Env directory](/guide/advanced/env-vars#env-directory)                             |
+| `--environment <name>`     | Set the environment name(s) to build, see [Build specified environment](/guide/advanced/environments#build-specified-environment)   |
+| `-h, --help`               | Display help for command                                                                                                            |
+| `--log-level <level>`      | Set the log level (`info` \| `warn` \| `error` \| `silent`), see [logLevel](/config/log-level)                                      |
+| `-m, --mode <mode>`        | Set the build mode (`development` \| `production` \| `none`), see [mode](/config/mode)                                              |
+| `--no-env`                 | Disable loading of `.env` files                                                                                                     |
+| `-r, --root <root>`        | Set the project root directory (absolute path or relative to [cwd](https://nodejs.org/api/process.html#processcwd))                 |
 
 ## rsbuild dev
 


### PR DESCRIPTION
## Summary

Use the `process.features.typescript` flag instead of checking Node.js version to simplify test code.

## Related Links

https://nodejs.org/api/process.html#processfeaturestypescript

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
