### PR TITLE
feat: re-enable enum inlining optimization in production

### DIFF
--- a/e2e/cases/syntax-ts/const-enum/index.test.ts
+++ b/e2e/cases/syntax-ts/const-enum/index.test.ts
@@ -3,7 +3,7 @@ import { expect, rspackTest, test } from '@e2e/helper';
 rspackTest(
   'should inline the enum values in build',
   async ({ page, buildPreview }) => {
-    await buildPreview();
+    const result = await buildPreview();
 
     await page.waitForFunction(() => window.testDog);
     expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
@@ -13,11 +13,11 @@ rspackTest(
       '0,1,10,1.1,1.0,-1,-1.1',
     );
 
-    // TODO: enable inline enum optimization
-    // const indexJs = await rsbuild.getIndexBundle();
-    // expect(indexJs).toContain('window.testFish="fish,FISH"');
-    // expect(indexJs).toContain('window.testCat="cat,CAT"');
-    // expect(indexJs).toContain('window.testNumbers="0,1,10,1.1,1.0,-1,-1.1"');
+    const indexJs = await result.getIndexBundle();
+    expect(indexJs).toContain('window.testFish="fish,FISH"');
+    expect(indexJs).toContain('window.testCat="cat,CAT"');
+    // minus values cannot be inlined
+    expect(indexJs).toContain('window.testNumbers=`0,1,10,1.1,1.0');
   },
 );
 

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -97,7 +97,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
           chain.experiments({
             ...chain.get('experiments'),
             lazyBarrel: true,
-            inlineEnum: false,
+            inlineEnum: isProd,
             inlineConst: isProd,
             typeReexportsPresence: true,
             rspackFuture: {

--- a/packages/core/src/plugins/swc.ts
+++ b/packages/core/src/plugins/swc.ts
@@ -67,10 +67,12 @@ function getDefaultSwcConfig({
   browserslist,
   cacheRoot,
   config,
+  isProd,
 }: {
   browserslist: string[];
   cacheRoot: string;
   config: NormalizedEnvironmentConfig;
+  isProd: boolean;
 }): SwcLoaderOptions {
   return {
     jsc: {
@@ -98,7 +100,7 @@ function getDefaultSwcConfig({
     rspackExperiments: {
       collectTypeScriptInfo: {
         typeExports: true,
-        exportedEnum: false,
+        exportedEnum: isProd,
       },
     },
   };
@@ -113,7 +115,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
   setup(api) {
     api.modifyBundlerChain({
       order: 'pre',
-      handler: (chain, { CHAIN_ID, isDev, target, environment }) => {
+      handler: (chain, { CHAIN_ID, isDev, isProd, target, environment }) => {
         const { config, browserslist } = environment;
         const cacheRoot = path.join(api.context.cachePath, '.swc');
 
@@ -156,6 +158,7 @@ export const pluginSwc = (): RsbuildPlugin => ({
           browserslist,
           cacheRoot,
           config,
+          isProd,
         });
 
         applyTransformImport(swcConfig, config.source.transformImport);

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -56,7 +56,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "devtool": false,
   "experiments": {
     "inlineConst": true,
-    "inlineEnum": false,
+    "inlineEnum": true,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -528,7 +528,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": true,
-    "inlineEnum": false,
+    "inlineEnum": true,
     "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
@@ -696,7 +696,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": false,
+                  "exportedEnum": true,
                   "typeExports": true,
                 },
               },
@@ -754,7 +754,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
               },
               "rspackExperiments": {
                 "collectTypeScriptInfo": {
-                  "exportedEnum": false,
+                  "exportedEnum": true,
                   "typeExports": true,
                 },
               },

--- a/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svelte/tests/__snapshots__/index.test.ts.snap
@@ -475,7 +475,7 @@ exports[`plugin-svelte > should set dev and hotReload to false in production mod
           },
           "rspackExperiments": {
             "collectTypeScriptInfo": {
-              "exportedEnum": false,
+              "exportedEnum": true,
               "typeExports": true,
             },
           },


### PR DESCRIPTION
## Summary

This PR reverts https://github.com/web-infra-dev/rsbuild/pull/6114.

Since Rspack v1.5.4 has fixed all known enum inlining bugs, we can re-enable this optimization in production.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11629

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
