### PR TITLE
docs: add  `resolve.conditionNames` configuration

### DIFF
--- a/website/docs/en/config/resolve/condition-names.mdx
+++ b/website/docs/en/config/resolve/condition-names.mdx
@@ -1,0 +1,41 @@
+# resolve.conditionNames
+
+- **Type:** `string[]`
+- **Default:** Same as Rspack's [resolve.conditionNames](https://rspack.rs/config/resolve#resolveconditionnames)
+- **Version:** `>= 1.5.7`
+
+Specifies the condition names used to match entry points in the [`exports` field](https://nodejs.org/api/packages.html#packages_exports) of a package.
+
+## Example
+
+The value of `resolve.conditionNames` overrides the default value of Rsbuild:
+
+```js title="rsbuild.config.ts"
+export default {
+  resolve: {
+    conditionNames: ['require', 'node'],
+  },
+};
+```
+
+## Rspack config
+
+`resolve.conditionNames` is provided by Rspack, see [Rspack - resolve.conditionNames](https://rspack.rs/config/resolve#resolveconditionnames).
+
+You can also configure it using [tools.rspack](/config/tools/rspack):
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      resolve: {
+        conditionNames: ['custom'],
+      },
+    },
+  },
+};
+```
+
+The difference between them is how the configuration is merged.
+
+`tools.rspack` merges the configuration arrays based on [webpack-merge](https://github.com/survivejs/webpack-merge), which means `tools.rspack.resolve.conditionNames` will merge with the default value of Rsbuild, rather than overriding it.

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -120,7 +120,7 @@ Here is the corresponding Rsbuild configuration for Vite configuration:
 | resolve.alias                         | [resolve.alias](/config/resolve/alias)                           |
 | resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                         |
 | resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                 |
-| resolve.conditions                    | [tools.rspack.resolve.conditionNames](/config/tools/rspack)      |
+| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)        |
 | resolve.mainFields                    | [tools.rspack.resolve.mainFields](/config/tools/rspack)          |
 | resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)            |
 | html.cspNonce                         | [security.nonce](/config/security/nonce)                         |

--- a/website/docs/zh/config/resolve/condition-names.mdx
+++ b/website/docs/zh/config/resolve/condition-names.mdx
@@ -1,0 +1,41 @@
+# resolve.conditionNames
+
+- **类型：** `string[]`
+- **默认值：** 与 Rspack 的 [resolve.conditionNames](https://rspack.rs/config/resolve#resolveconditionnames) 一致
+- **版本：** `>= 1.5.7`
+
+指定用于匹配包 [`exports` 字段](https://nodejs.org/api/packages.html#packages_exports) 入口点的 condition names（条件名称）。
+
+## 示例
+
+`resolve.conditionNames` 配置的值会覆盖 Rsbuild 的默认值：
+
+```js title="rsbuild.config.ts"
+export default {
+  resolve: {
+    conditionNames: ['require', 'node'],
+  },
+};
+```
+
+## Rspack 配置
+
+`resolve.conditionNames` 是 Rspack 提供的配置，参考 [Rspack - resolve.conditionNames](https://rspack.rs/zh/config/resolve#resolveconditionnames)。
+
+事实上，你也可以使用 [tools.rspack](/config/tools/rspack) 来配置它：
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: {
+      resolve: {
+        conditionNames: ['custom'],
+      },
+    },
+  },
+};
+```
+
+这两种用法的区别在于配置合并的方式。
+
+`tools.rspack` 基于 [webpack-merge](https://github.com/survivejs/webpack-merge) 来合并配置中的数组，这意味着 `tools.rspack.resolve.conditionNames` 会与 Rsbuild 的默认值合并，而不是覆盖它。

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -120,7 +120,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | resolve.alias                         | [resolve.alias](/config/resolve/alias)                           |
 | resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                         |
 | resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                 |
-| resolve.conditions                    | [tools.rspack.resolve.conditionNames](/config/tools/rspack)      |
+| resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)        |
 | resolve.mainFields                    | [tools.rspack.resolve.mainFields](/config/tools/rspack)          |
 | resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)            |
 | html.cspNonce                         | [security.nonce](/config/security/nonce)                         |


### PR DESCRIPTION
## Summary

Added a new English documentation page for `resolve.conditionNames`, explaining its usage, default value, version, and how it differs from configuring via `tools.rspack`.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
