### PR TITLE
fix(dev-middleware): remove unused cacheStore in memorize util

### DIFF
--- a/packages/core/src/dev-middleware/utils/memorize.ts
+++ b/packages/core/src/dev-middleware/utils/memorize.ts
@@ -1,8 +1,3 @@
-const cacheStore: WeakMap<
-  (...args: any[]) => void,
-  Map<string, { data: unknown }>
-> = new WeakMap();
-
 export function memorize<T>(
   fn: (...args: any[]) => T,
   {
@@ -30,8 +25,6 @@ export function memorize<T>(
 
     return result;
   };
-
-  cacheStore.set(memoized, cache as Map<string, { data: unknown }>);
 
   return memoized;
 }


### PR DESCRIPTION
## Summary

The `cacheStore` WeakMap was not being utilized in the memorize function, so it has been removed to simplify the code.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
