### PR TITLE
refactor(dev-middleware): simplify output filesystem setup

### DIFF
--- a/packages/core/src/dev-middleware/index.ts
+++ b/packages/core/src/dev-middleware/index.ts
@@ -110,10 +110,6 @@ export type API<
 
 export type WithOptional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 
-export type WithoutUndefined<T, K extends keyof T> = T & {
-  [P in K]-?: NonNullable<T[P]>;
-};
-
 export async function devMiddleware<
   RequestInternal extends IncomingMessage = IncomingMessage,
   ResponseInternal extends ServerResponse = ServerResponse,
@@ -127,7 +123,7 @@ export async function devMiddleware<
     callbacks: [],
     options,
     compiler,
-  } as WithOptional<Context, 'watching' | 'outputFileSystem'>;
+  };
 
   setupHooks(context);
 


### PR DESCRIPTION
## Summary

- Refactor output filesystem setup to handle single and multi compilers more cleanly
- Remove unused `WithoutUndefined` type and simplify WithOptional usage

## Related Links

close https://github.com/web-infra-dev/rsbuild/pull/6098

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
