### PR TITLE
refactor(dev-middleware): simplify compiler handling

### DIFF
--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -43,7 +43,7 @@ function createReadStreamOrReadFileSync(
 
 async function getContentType(str: string): Promise<false | string> {
   const { lookup } = await import('../../compiled/mrmime/index.js');
-  let mime = lookup(str) as string | false | undefined;
+  let mime = lookup(str);
   if (!mime) {
     return false;
   }

--- a/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
+++ b/packages/core/src/dev-middleware/utils/getFilenameFromUrl.ts
@@ -62,7 +62,7 @@ export function getFilenameFromUrl(
     const { pathname } = urlObject;
     const { pathname: publicPathPathname } = publicPathObject;
 
-    if (pathname && pathname.startsWith(publicPathPathname)) {
+    if (pathname?.startsWith(publicPathPathname)) {
       if (pathname.includes('\u0000')) {
         extra.errorCode = 400;
         return undefined;

--- a/packages/core/src/dev-middleware/utils/getPaths.ts
+++ b/packages/core/src/dev-middleware/utils/getPaths.ts
@@ -1,13 +1,13 @@
-import type { MultiStats as WMultiStats, Stats as WStats } from '@rspack/core';
+import type { MultiStats, Stats } from '@rspack/core';
 import type { FilledContext } from '../index';
 
 type PublicPathInfo = { outputPath: string; publicPath: string | undefined };
 
 export function getPaths(context: FilledContext): PublicPathInfo[] {
   const { stats, options } = context;
-  const childStats: WStats[] = (stats as WMultiStats).stats
-    ? (stats as WMultiStats).stats
-    : [stats as WStats];
+  const childStats: Stats[] = (stats as MultiStats).stats
+    ? (stats as MultiStats).stats
+    : [stats as Stats];
   const publicPaths: PublicPathInfo[] = [];
 
   for (const { compilation } of childStats) {

--- a/packages/core/src/dev-middleware/utils/setupHooks.ts
+++ b/packages/core/src/dev-middleware/utils/setupHooks.ts
@@ -1,15 +1,16 @@
-import type { MultiStats as WMultiStats, Stats as WStats } from '@rspack/core';
+import type { Compiler, MultiCompiler, MultiStats, Stats } from '@rspack/core';
 import type { Context, WithOptional } from '../index';
 
 export function setupHooks(
   context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
+  compiler: Compiler | MultiCompiler,
 ): void {
   function invalid() {
     context.state = false;
     context.stats = undefined;
   }
 
-  function done(stats: WStats | WMultiStats) {
+  function done(stats: Stats | MultiStats) {
     context.state = true;
     context.stats = stats;
 
@@ -23,12 +24,10 @@ export function setupHooks(
       (context as Context).callbacks = [];
 
       callbacks.forEach((callback) => {
-        (callback as (...args: any[]) => WStats | WMultiStats)(stats);
+        (callback as (...args: any[]) => Stats | MultiStats)(stats);
       });
     });
   }
-
-  const compiler = (context as Context).compiler;
 
   compiler.hooks.watchRun.tap('rsbuild-dev-middleware', invalid);
   compiler.hooks.invalid.tap('rsbuild-dev-middleware', invalid);

--- a/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
+++ b/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
@@ -1,31 +1,27 @@
-import type { OutputFileSystem as RspackOutputFileSystem } from '@rspack/core';
-import type { Context, OutputFileSystem, WithOptional } from '../index';
+import type {
+  Compiler,
+  OutputFileSystem as RspackOutputFileSystem,
+} from '@rspack/core';
+import type { Options, OutputFileSystem } from '../index';
 
 export async function setupOutputFileSystem(
-  context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
-): Promise<void> {
+  options: Options,
+  compilers: Compiler[],
+): Promise<OutputFileSystem> {
   let outputFileSystem: unknown;
-  const compilers =
-    'compilers' in context.compiler
-      ? context.compiler.compilers
-      : [context.compiler];
 
-  if (context.options.writeToDisk !== true) {
+  if (options.writeToDisk !== true) {
     const { createFsFromVolume, Volume } = await import(
       '../../../compiled/memfs/index.js'
     );
     outputFileSystem = createFsFromVolume(new Volume());
   } else {
-    if (compilers.length > 1) {
-      ({ outputFileSystem } = compilers[0]);
-    } else {
-      ({ outputFileSystem } = context.compiler);
-    }
+    ({ outputFileSystem } = compilers[0]);
   }
 
   for (const compiler of compilers) {
     compiler.outputFileSystem = outputFileSystem as RspackOutputFileSystem;
   }
 
-  context.outputFileSystem = outputFileSystem as OutputFileSystem;
+  return outputFileSystem as OutputFileSystem;
 }

--- a/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
+++ b/packages/core/src/dev-middleware/utils/setupOutputFileSystem.ts
@@ -8,20 +8,16 @@ export async function setupOutputFileSystem(
   options: Options,
   compilers: Compiler[],
 ): Promise<OutputFileSystem> {
-  let outputFileSystem: unknown;
-
   if (options.writeToDisk !== true) {
     const { createFsFromVolume, Volume } = await import(
       '../../../compiled/memfs/index.js'
     );
-    outputFileSystem = createFsFromVolume(new Volume());
-  } else {
-    ({ outputFileSystem } = compilers[0]);
+    const outputFileSystem = createFsFromVolume(new Volume());
+
+    for (const compiler of compilers) {
+      compiler.outputFileSystem = outputFileSystem as RspackOutputFileSystem;
+    }
   }
 
-  for (const compiler of compilers) {
-    compiler.outputFileSystem = outputFileSystem as RspackOutputFileSystem;
-  }
-
-  return outputFileSystem as OutputFileSystem;
+  return compilers[0].outputFileSystem as OutputFileSystem;
 }

--- a/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
+++ b/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import type { Compilation, Compiler, MultiCompiler } from '@rspack/core';
+import type { Compilation } from '@rspack/core';
 import { logger } from '../../logger';
 import type { Context, WithOptional } from '../index';
 
@@ -13,8 +13,7 @@ declare module '@rspack/core' {
 export function setupWriteToDisk(
   context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
 ): void {
-  const compilers: Compiler[] = (context.compiler as MultiCompiler)
-    .compilers || [context.compiler as Compiler];
+  const { compilers } = context;
 
   for (const compiler of compilers) {
     compiler.hooks.emit.tap('DevMiddleware', () => {


### PR DESCRIPTION
## Summary

This pull request refactors the dev middleware to simplify the setup of hooks, output file systems, and compiler handling logic.

- Remove redundant type assertions and simplify compiler handling logic
- Move output file system setup to return the filesystem directly
- Update setupHooks to accept compiler parameter

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
