### PR TITLE
docs(e2e): add debugging instructions

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,6 +25,16 @@ pnpm e2e:webpack css
 pnpm e2e:rspack css
 ```
 
+## Debugging
+
+If a test directory includes an `rsbuild.config.*` file, you can simply run `npx rsbuild dev` or `npx rsbuild build` to start it. This approach provides a simpler and more convenient way to debug.
+
+```bash
+cd cases/assets/emit-assets
+npx rsbuild dev
+npx rsbuild build
+```
+
 ## Add test cases
 
 Test cases added using the `test` method will run in both Rspack and webpack.


### PR DESCRIPTION
## Summary

Add debugging instructions to explain how to debug test cases using rsbuild commands directly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
