### PR TITLE
fix(types): correct ProxyConfig type definition

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -361,8 +361,7 @@ export type ProxyOptions = HttpProxyOptions & {
 };
 
 export type ProxyConfig =
-  | Record<string, string>
-  | Record<string, ProxyOptions>
+  | Record<string, string | ProxyOptions>
   | ProxyOptions[]
   | ProxyOptions;
 

--- a/website/docs/en/config/server/proxy.mdx
+++ b/website/docs/en/config/server/proxy.mdx
@@ -1,6 +1,14 @@
 # server.proxy
 
-- **Type:** `Record<string, string> | Record<string, ProxyOptions> | ProxyOptions[] | ProxyOptions`
+- **Type:**
+
+```ts
+type ProxyConfig =
+  | Record<string, string | ProxyOptions>
+  | ProxyOptions[]
+  | ProxyOptions;
+```
+
 - **Default:** `undefined`
 
 Configure proxy rules for the dev server or preview server to proxy requests to the specified service.
@@ -21,7 +29,7 @@ export default {
 };
 ```
 
-A request to `/api/users` will now proxy the request to http://localhost:3000/api/users.
+A request to `/api/users` will now proxy the request to `http://localhost:3000/api/users`.
 
 You can also proxy to an online domain name, such as:
 

--- a/website/docs/zh/config/server/proxy.mdx
+++ b/website/docs/zh/config/server/proxy.mdx
@@ -1,6 +1,14 @@
 # server.proxy
 
-- **类型：** `Record<string, string> | Record<string, ProxyOptions> | ProxyOptions[] | ProxyOptions`
+- **类型：**
+
+```ts
+type ProxyConfig =
+  | Record<string, string | ProxyOptions>
+  | ProxyOptions[]
+  | ProxyOptions;
+```
+
 - **默认值：** `undefined`
 
 为开发服务器或预览服务器配置代理规则，将请求代理到指定的服务上。
@@ -21,7 +29,7 @@ export default {
 };
 ```
 
-此时，`/api/users` 请求将会代理到 http://localhost:3000/api/users。
+此时，`/api/users` 请求将会代理到 `http://localhost:3000/api/users`。
 
 你也可以代理到线上域名，比如:
 


### PR DESCRIPTION
## Summary

- Update `ProxyConfig` type to combine string and `ProxyOptions` records into a single union type
- Update documentation to reflect the type changes

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/6163

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
