### PR TITLE
 test: move configurations from inline to dedicated config files

### DIFF
--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -7,11 +7,6 @@ test('should inject styles and not emit CSS files when output.injectStyles is tr
 }) => {
   const rsbuild = await buildPreview({
     plugins: [pluginReact()],
-    rsbuildConfig: {
-      output: {
-        injectStyles: true,
-      },
-    },
   });
 
   // injectStyles worked

--- a/e2e/cases/css/css-modules-dom/rsbuild.config.ts
+++ b/e2e/cases/css/css-modules-dom/rsbuild.config.ts
@@ -1,6 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginSass } from '@rsbuild/plugin-sass';
 
-export default {
+export default defineConfig({
   plugins: [pluginLess(), pluginSass()],
-};
+  output: {
+    injectStyles: true,
+  },
+});

--- a/e2e/cases/css/css-modules-mode/index.test.ts
+++ b/e2e/cases/css/css-modules-mode/index.test.ts
@@ -1,15 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
 test('should compile CSS Modules global mode correctly', async ({ build }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      output: {
-        cssModules: {
-          mode: 'global',
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
   const content =

--- a/e2e/cases/css/css-modules-mode/rsbuild.config.ts
+++ b/e2e/cases/css/css-modules-mode/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    cssModules: {
+      mode: 'global',
+    },
+  },
+});

--- a/e2e/cases/css/css-modules-named-export/index.test.ts
+++ b/e2e/cases/css/css-modules-named-export/index.test.ts
@@ -3,15 +3,7 @@ import { expect, rspackTest } from '@e2e/helper';
 rspackTest(
   'should compile CSS Modules with named exports correctly',
   async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview({
-      rsbuildConfig: {
-        output: {
-          cssModules: {
-            namedExport: true,
-          },
-        },
-      },
-    });
+    const rsbuild = await buildPreview();
     const files = rsbuild.getDistFiles();
 
     const content =

--- a/e2e/cases/css/css-modules-named-export/rsbuild.config.ts
+++ b/e2e/cases/css/css-modules-named-export/rsbuild.config.ts
@@ -1,6 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginSass } from '@rsbuild/plugin-sass';
 
-export default {
+export default defineConfig({
   plugins: [pluginLess(), pluginSass()],
-};
+  output: {
+    cssModules: {
+      namedExport: true,
+    },
+  },
+});

--- a/e2e/cases/css/import-common-css/index.test.ts
+++ b/e2e/cases/css/import-common-css/index.test.ts
@@ -1,15 +1,7 @@
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should compile common CSS import correctly', async ({ build }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      resolve: {
-        alias: {
-          '@': './src',
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
   const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;

--- a/e2e/cases/css/import-common-css/rsbuild.config.ts
+++ b/e2e/cases/css/import-common-css/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': './src',
+    },
+  },
+});

--- a/e2e/cases/css/lightningcss-disabled/index.test.ts
+++ b/e2e/cases/css/lightningcss-disabled/index.test.ts
@@ -3,16 +3,7 @@ import { expect, rspackTest } from '@e2e/helper';
 rspackTest(
   'should allow to disable the built-in lightningcss loader',
   async ({ build }) => {
-    const rsbuild = await build({
-      rsbuildConfig: {
-        tools: {
-          lightningcssLoader: false,
-        },
-        output: {
-          minify: false,
-        },
-      },
-    });
+    const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
     const content =

--- a/e2e/cases/css/lightningcss-disabled/rsbuild.config.ts
+++ b/e2e/cases/css/lightningcss-disabled/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  tools: {
+    lightningcssLoader: false,
+  },
+  output: {
+    minify: false,
+  },
+});

--- a/e2e/cases/css/multi-css/index.test.ts
+++ b/e2e/cases/css/multi-css/index.test.ts
@@ -1,18 +1,7 @@
-import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should emit multiple CSS files correctly', async ({ build }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      source: {
-        entry: {
-          entry1: path.resolve(__dirname, './src/entry1/index.js'),
-          entry2: path.resolve(__dirname, './src/entry2/index.js'),
-          entry3: path.resolve(__dirname, './src/entry3/index.js'),
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
   const entry1CSS = Object.keys(files).find(

--- a/e2e/cases/css/multi-css/rsbuild.config.ts
+++ b/e2e/cases/css/multi-css/rsbuild.config.ts
@@ -1,6 +1,15 @@
+import path from 'node:path';
+import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
 import { pluginSass } from '@rsbuild/plugin-sass';
 
-export default {
+export default defineConfig({
   plugins: [pluginLess(), pluginSass()],
-};
+  source: {
+    entry: {
+      entry1: path.resolve(__dirname, './src/entry1/index.js'),
+      entry2: path.resolve(__dirname, './src/entry2/index.js'),
+      entry3: path.resolve(__dirname, './src/entry3/index.js'),
+    },
+  },
+});

--- a/e2e/cases/environments/disable-hmr/index.test.ts
+++ b/e2e/cases/environments/disable-hmr/index.test.ts
@@ -3,35 +3,7 @@ import { expect, rspackTest } from '@e2e/helper';
 rspackTest(
   'should allow to disable HMR and live reload for a specified environment',
   async ({ dev }) => {
-    const rsbuild = await dev({
-      rsbuildConfig: {
-        performance: {
-          chunkSplit: {
-            strategy: 'all-in-one',
-          },
-        },
-        environments: {
-          foo: {
-            source: {
-              entry: {
-                foo: './src/foo.js',
-              },
-            },
-          },
-          bar: {
-            source: {
-              entry: {
-                bar: './src/bar.js',
-              },
-            },
-            dev: {
-              hmr: false,
-              liveReload: false,
-            },
-          },
-        },
-      },
-    });
+    const rsbuild = await dev();
 
     const files = rsbuild.getDistFiles();
     const filenames = Object.keys(files);

--- a/e2e/cases/environments/disable-hmr/rsbuild.config.ts
+++ b/e2e/cases/environments/disable-hmr/rsbuild.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  performance: {
+    chunkSplit: {
+      strategy: 'all-in-one',
+    },
+  },
+  environments: {
+    foo: {
+      source: {
+        entry: {
+          foo: './src/foo.js',
+        },
+      },
+    },
+    bar: {
+      source: {
+        entry: {
+          bar: './src/bar.js',
+        },
+      },
+      dev: {
+        hmr: false,
+        liveReload: false,
+      },
+    },
+  },
+});

--- a/e2e/cases/environments/outputs/index.test.ts
+++ b/e2e/cases/environments/outputs/index.test.ts
@@ -1,25 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
 test('should apply multiple dist path correctly', async ({ build }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      environments: {
-        web: {
-          output: {
-            filenameHash: false,
-          },
-        },
-        web1: {
-          output: {
-            filenameHash: false,
-            distPath: {
-              root: 'dist/web1',
-            },
-          },
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
   const filenames = Object.keys(files);

--- a/e2e/cases/environments/outputs/rsbuild.config.ts
+++ b/e2e/cases/environments/outputs/rsbuild.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  environments: {
+    web: {
+      output: {
+        filenameHash: false,
+      },
+    },
+    web1: {
+      output: {
+        filenameHash: false,
+        distPath: {
+          root: 'dist/web1',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/environments/plugins/index.test.ts
+++ b/e2e/cases/environments/plugins/index.test.ts
@@ -1,37 +1,10 @@
 import { expect, test } from '@e2e/helper';
 
-import { pluginReact } from '@rsbuild/plugin-react';
-
 test('should add single environment plugin correctly', async ({
   page,
   buildPreview,
 }) => {
-  const rsbuild = await buildPreview({
-    rsbuildConfig: {
-      environments: {
-        web: {
-          output: {
-            filenameHash: false,
-          },
-          plugins: [pluginReact()],
-        },
-        web1: {
-          source: {
-            entry: {
-              main: './src/index1.ts',
-            },
-          },
-          output: {
-            assetPrefix: 'auto',
-            filenameHash: false,
-            distPath: {
-              root: 'dist/web1',
-            },
-          },
-        },
-      },
-    },
-  });
+  const rsbuild = await buildPreview();
 
   const button = page.locator('#test');
   await expect(button).toHaveText('Hello Rsbuild!');

--- a/e2e/cases/environments/plugins/rsbuild.config.ts
+++ b/e2e/cases/environments/plugins/rsbuild.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  environments: {
+    web: {
+      output: {
+        filenameHash: false,
+      },
+      plugins: [pluginReact()],
+    },
+    web1: {
+      source: {
+        entry: {
+          main: './src/index1.ts',
+        },
+      },
+      output: {
+        assetPrefix: 'auto',
+        filenameHash: false,
+        distPath: {
+          root: 'dist/web1',
+        },
+      },
+    },
+  },
+});

--- a/e2e/cases/hmr/client-multiple-environment/index.test.ts
+++ b/e2e/cases/hmr/client-multiple-environment/index.test.ts
@@ -1,41 +1,9 @@
-import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
-
-const cwd = __dirname;
 
 rspackTest(
   'should allow to set different dev.client for multiple environments',
   async ({ dev }) => {
-    const rsbuild = await dev({
-      rsbuildConfig: {
-        environments: {
-          foo: {
-            source: {
-              entry: {
-                foo: join(cwd, 'foo.js'),
-              },
-            },
-            dev: {
-              client: {
-                host: 'http://foo.com',
-              },
-            },
-          },
-          bar: {
-            source: {
-              entry: {
-                bar: join(cwd, 'bar.js'),
-              },
-            },
-            dev: {
-              client: {
-                host: 'http://bar.com',
-              },
-            },
-          },
-        },
-      },
-    });
+    const rsbuild = await dev();
 
     const files = rsbuild.getDistFiles();
     const filenames = Object.keys(files);

--- a/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
+++ b/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
@@ -1,6 +1,33 @@
+import { join } from 'node:path';
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  environments: {
+    foo: {
+      source: {
+        entry: {
+          foo: join(__dirname, 'foo.js'),
+        },
+      },
+      dev: {
+        client: {
+          host: 'http://foo.com',
+        },
+      },
+    },
+    bar: {
+      source: {
+        entry: {
+          bar: join(__dirname, 'bar.js'),
+        },
+      },
+      dev: {
+        client: {
+          host: 'http://bar.com',
+        },
+      },
+    },
+  },
 });

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -3,16 +3,7 @@ import { expect, normalizeNewlines, rspackTest } from '@e2e/helper';
 rspackTest(
   'should not inject charset meta if template already contains it',
   async ({ build }) => {
-    const rsbuild = await build({
-      rsbuildConfig: {
-        html: {
-          template: './src/index.html',
-        },
-        output: {
-          filenameHash: false,
-        },
-      },
-    });
+    const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
     const html =

--- a/e2e/cases/html/meta/rsbuild.config.ts
+++ b/e2e/cases/html/meta/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    template: './src/index.html',
+  },
+  output: {
+    filenameHash: false,
+  },
+});

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -3,19 +3,7 @@ import { expect, rspackTest } from '@e2e/helper';
 rspackTest(
   'should minify template success when inlineScripts & inlineStyles',
   async ({ buildPreview }) => {
-    const rsbuild = await buildPreview({
-      rsbuildConfig: {
-        html: {
-          template: './static/index.html',
-          // avoid Minified React error #200;
-          inject: 'body',
-        },
-        output: {
-          inlineScripts: true,
-          inlineStyles: true,
-        },
-      },
-    });
+    const rsbuild = await buildPreview();
 
     const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/html/minify/rsbuild.config.ts
+++ b/e2e/cases/html/minify/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    template: './static/index.html',
+    // avoid Minified React error #200
+    inject: 'body',
+  },
+  output: {
+    inlineScripts: true,
+    inlineStyles: true,
+  },
+});

--- a/e2e/cases/html/output-structure/index.test.ts
+++ b/e2e/cases/html/output-structure/index.test.ts
@@ -6,13 +6,7 @@ import { expect, test } from '@e2e/helper';
 test('should output nested HTML structure when html.outputStructure is `nested`', async ({
   build,
 }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      html: {
-        outputStructure: 'nested',
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const pagePath = join(rsbuild.distPath, 'index/index.html');
 

--- a/e2e/cases/html/output-structure/rsbuild.config.ts
+++ b/e2e/cases/html/output-structure/rsbuild.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  html: {
+    outputStructure: 'nested',
+  },
+});

--- a/e2e/cases/optimization/css-minify/index.test.ts
+++ b/e2e/cases/optimization/css-minify/index.test.ts
@@ -1,16 +1,7 @@
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow to minify CSS in dev', async ({ dev }) => {
-  const rsbuild = await dev({
-    rsbuildConfig: {
-      output: {
-        minify: {
-          css: 'always',
-        },
-      },
-    },
-  });
-
+  const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
 
   const content =

--- a/e2e/cases/optimization/css-minify/rsbuild.config.ts
+++ b/e2e/cases/optimization/css-minify/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    minify: {
+      css: 'always',
+    },
+  },
+});

--- a/e2e/cases/optimization/js-minify-always/index.test.ts
+++ b/e2e/cases/optimization/js-minify-always/index.test.ts
@@ -1,15 +1,7 @@
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow to minify JS in dev', async ({ dev }) => {
-  const rsbuild = await dev({
-    rsbuildConfig: {
-      output: {
-        minify: {
-          js: 'always',
-        },
-      },
-    },
-  });
+  const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
   const content =
     files[Object.keys(files).find((file) => file.endsWith('.js'))!];

--- a/e2e/cases/optimization/js-minify-always/rsbuild.config.ts
+++ b/e2e/cases/optimization/js-minify-always/rsbuild.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    minify: {
+      js: 'always',
+    },
+  },
+});

--- a/e2e/cases/output/invalid-target/index.test.ts
+++ b/e2e/cases/output/invalid-target/index.test.ts
@@ -5,12 +5,6 @@ test('should throw error when `output.target` is invalid', async ({
 }) => {
   const rsbuild = await build({
     catchBuildError: true,
-    rsbuildConfig: {
-      output: {
-        // @ts-expect-error test invalid target
-        target: 'foo',
-      },
-    },
   });
 
   expect(rsbuild.buildError?.message).toContain(

--- a/e2e/cases/output/invalid-target/rsbuild.config.ts
+++ b/e2e/cases/output/invalid-target/rsbuild.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    // @ts-expect-error intentional invalid target for testing
+    target: 'foo',
+  },
+});

--- a/e2e/cases/output/manifest-async-chunks/index.test.ts
+++ b/e2e/cases/output/manifest-async-chunks/index.test.ts
@@ -3,19 +3,7 @@ import { expect, test } from '@e2e/helper';
 test('should generate manifest for async chunks correctly', async ({
   build,
 }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      output: {
-        manifest: true,
-        filenameHash: false,
-      },
-      performance: {
-        chunkSplit: {
-          strategy: 'all-in-one',
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/output/manifest-async-chunks/rsbuild.config.ts
+++ b/e2e/cases/output/manifest-async-chunks/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    manifest: true,
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'all-in-one',
+    },
+  },
+});

--- a/e2e/cases/performance/external-helpers/index.test.ts
+++ b/e2e/cases/performance/external-helpers/index.test.ts
@@ -1,22 +1,7 @@
-import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should externalHelpers by default', async ({ build }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      source: {
-        entry: { index: path.resolve(__dirname, './src/main.ts') },
-        decorators: {
-          version: '2022-03',
-        },
-      },
-      output: {
-        sourceMap: {
-          js: 'source-map',
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
   const content =

--- a/e2e/cases/performance/external-helpers/rsbuild.config.ts
+++ b/e2e/cases/performance/external-helpers/rsbuild.config.ts
@@ -1,0 +1,16 @@
+import path from 'node:path';
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: { index: path.resolve(__dirname, './src/main.ts') },
+    decorators: {
+      version: '2022-03',
+    },
+  },
+  output: {
+    sourceMap: {
+      js: 'source-map',
+    },
+  },
+});

--- a/e2e/cases/performance/split-chunk-by-module/index.test.ts
+++ b/e2e/cases/performance/split-chunk-by-module/index.test.ts
@@ -8,16 +8,6 @@ test('should generate module chunks when chunkSplit is "split-by-module"', async
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
-      output: {
-        filenameHash: false,
-      },
-      performance: {
-        chunkSplit: {
-          strategy: 'split-by-module',
-        },
-      },
-    },
   });
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/performance/split-chunk-by-module/rsbuild.config.ts
+++ b/e2e/cases/performance/split-chunk-by-module/rsbuild.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'split-by-module',
+    },
+  },
+});

--- a/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
+++ b/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
@@ -1,24 +1,10 @@
 import { basename } from 'node:path';
-
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({
   build,
 }) => {
-  const rsbuild = await build({
-    plugins: [pluginReact()],
-    rsbuildConfig: {
-      output: {
-        filenameHash: false,
-      },
-      performance: {
-        chunkSplit: {
-          strategy: 'single-vendor',
-        },
-      },
-    },
-  });
+  const rsbuild = await build({});
 
   const files = rsbuild.getDistFiles();
 

--- a/e2e/cases/performance/split-chunk-single-vendor/rsbuild.config.ts
+++ b/e2e/cases/performance/split-chunk-single-vendor/rsbuild.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@rsbuild/core';
+import { pluginReact } from '@rsbuild/plugin-react';
+
+export default defineConfig({
+  plugins: [pluginReact()],
+  output: {
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'single-vendor',
+    },
+  },
+});

--- a/e2e/cases/server/proxy-error/index.test.ts
+++ b/e2e/cases/server/proxy-error/index.test.ts
@@ -1,21 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
 test('should handle proxy error', async ({ dev, page }) => {
-  const rsbuild = await dev({
-    rsbuildConfig: {
-      server: {
-        cors: true,
-        proxy: [
-          {
-            context: ['/api'],
-            target: 'http://somepagewhichdoesnotexist.com:9000',
-            changeOrigin: true,
-            secure: false,
-          },
-        ],
-      },
-    },
-  });
+  const rsbuild = await dev();
 
   const res = await page.goto(`http://localhost:${rsbuild.port}/api`);
   expect(res?.status()).toBe(504);

--- a/e2e/cases/server/proxy-error/rsbuild.config.ts
+++ b/e2e/cases/server/proxy-error/rsbuild.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  server: {
+    cors: true,
+    proxy: [
+      {
+        context: ['/api'],
+        target: 'http://somepagewhichdoesnotexist.com:9000',
+        changeOrigin: true,
+        secure: false,
+      },
+    ],
+  },
+});

--- a/e2e/cases/source/source-exclude/index.test.ts
+++ b/e2e/cases/source/source-exclude/index.test.ts
@@ -1,21 +1,10 @@
-import path from 'node:path';
 import { expect, test, toPosixPath } from '@e2e/helper';
-import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 
 test('should not compile specified file when source.exclude', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginCheckSyntax()],
     catchBuildError: true,
-    rsbuildConfig: {
-      source: {
-        exclude: [path.resolve(__dirname, './src/test.js')],
-      },
-      output: {
-        overrideBrowserslist: ['android >= 4.4'],
-      },
-    },
   });
 
   expect(rsbuild.buildError).toBeTruthy();

--- a/e2e/cases/source/source-exclude/rsbuild.config.ts
+++ b/e2e/cases/source/source-exclude/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import path from 'node:path';
+import { defineConfig } from '@rsbuild/core';
+import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
+
+export default defineConfig({
+  plugins: [pluginCheckSyntax()],
+  source: {
+    exclude: [path.resolve(__dirname, './src/test.js')],
+  },
+  output: {
+    overrideBrowserslist: ['android >= 4.4'],
+  },
+});

--- a/e2e/cases/source/transform-lodash/index.test.ts
+++ b/e2e/cases/source/transform-lodash/index.test.ts
@@ -3,23 +3,7 @@ import { expect, test } from '@e2e/helper';
 test('should support using transformImport to reduce lodash bundle size', async ({
   build,
 }) => {
-  const rsbuild = await build({
-    rsbuildConfig: {
-      source: {
-        transformImport: [
-          {
-            libraryName: 'lodash',
-            customName: 'lodash/{{ member }}',
-          },
-        ],
-      },
-      performance: {
-        chunkSplit: {
-          strategy: 'all-in-one',
-        },
-      },
-    },
-  });
+  const rsbuild = await build();
 
   const content = await rsbuild.getIndexBundle();
   const size = content.length / 1024;

--- a/e2e/cases/source/transform-lodash/rsbuild.config.ts
+++ b/e2e/cases/source/transform-lodash/rsbuild.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    transformImport: [
+      {
+        libraryName: 'lodash',
+        customName: 'lodash/{{ member }}',
+      },
+    ],
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'all-in-one',
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Move `rsbuildConfig` configurations from inline to dedicated config files. This allows these e2e use cases to be debugged via `npx rsbuild build` or `npx rsbuild dev.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
