### PR TITLE
chore: update @rslib/core to 0.13.3 to use native config loader

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
     "@rsbuild/webpack": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@types/lodash": "^4.17.20",
     "@types/semver": "^7.7.1",
     "typescript": "^5.9.2",

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "ansi-escapes": "4.3.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,8 +46,8 @@
     "types.d.ts"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@jridgewell/remapping": "^2.3.5",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@types/connect": "3.4.38",
     "@types/cors": "^2.8.19",
     "@types/node": "^22.18.3",

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { nodeMinifyConfig } from '@rsbuild/config/rslib.config';
+import { nodeMinifyConfig } from '@rsbuild/config/rslib.config.ts';
 import type { Rspack, rsbuild } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
-import pkgJson from './package.json';
+import pkgJson from './package.json' with { type: 'json' };
 import prebundleConfig from './prebundle.config.mjs';
 
 export const define = {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -23,8 +23,8 @@
     "bin.js"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "start": "node ./dist/index.js",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -39,7 +39,7 @@
     "@rsbuild/plugin-solid": "workspace:*",
     "@rsbuild/plugin-svelte": "workspace:*",
     "@rsbuild/plugin-vue": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@types/node": "^22.18.3",
     "typescript": "^5.9.2"
   },

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -23,8 +23,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "babel-loader": "10.0.0",

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -24,8 +24,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/less": "^3.0.8",
     "less": "4.3.0",

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@types/node": "^22.18.3",
     "preact": "^10.27.2",
     "typescript": "^5.9.2"

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "typescript": "^5.9.2"

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -24,8 +24,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "@types/sass-loader": "^8.0.9",

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "typescript": "^5.9.2"

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "typescript": "^5.9.2"

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "svelte": "^5.38.10",

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -23,8 +23,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "file-loader": "6.2.0",

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch",
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.3",
     "typescript": "^5.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,8 +538,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@types/lodash':
         specifier: ^4.17.20
         version: 4.17.20
@@ -581,8 +581,8 @@ importers:
         specifier: workspace:*
         version: link:../../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../../scripts/test-helper
@@ -624,8 +624,8 @@ importers:
         specifier: ^2.3.5
         version: 2.3.5
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@types/connect':
         specifier: 3.4.38
         version: 3.4.38
@@ -775,8 +775,8 @@ importers:
         specifier: workspace:*
         version: link:../plugin-vue
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@types/node':
         specifier: ^22.18.3
         version: 22.18.3
@@ -815,8 +815,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -846,8 +846,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -886,8 +886,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@types/node':
         specifier: ^22.18.3
         version: 22.18.3
@@ -911,8 +911,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -945,8 +945,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -985,8 +985,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1016,8 +1016,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1041,8 +1041,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1081,8 +1081,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1118,8 +1118,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@scripts/test-helper':
         specifier: workspace:*
         version: link:../../scripts/test-helper
@@ -1139,8 +1139,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/core
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
       '@types/node':
         specifier: ^22.18.3
         version: 22.18.3
@@ -1170,8 +1170,8 @@ importers:
         version: 5.9.2
     devDependencies:
       '@rslib/core':
-        specifier: 0.13.2
-        version: 0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
+        specifier: 0.13.3
+        version: 0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
 
   website:
     devDependencies:
@@ -2373,6 +2373,11 @@ packages:
     engines: {node: '>=18.12.0'}
     hasBin: true
 
+  '@rsbuild/core@1.5.8':
+    resolution: {integrity: sha512-neCNfVxOoE7DsqDB5m1hEwxCwaTRdF6g5Nxq21FaDpSg0TpAdwzYlhHDhaCcriTOP0WhdYBn4l0TRRLP3bPDQQ==}
+    engines: {node: '>=18.12.0'}
+    hasBin: true
+
   '@rsbuild/plugin-babel@1.0.5':
     resolution: {integrity: sha512-g6kZsAREO7c3KEBXRnLbOovIEL/TQDMls2QQFpaGxHx1K7pJB5nNmY1XpTzLCch62xfmBV4crOde0Dow6NAshg==}
     peerDependencies:
@@ -2462,8 +2467,8 @@ packages:
   '@rsdoctor/utils@1.2.3':
     resolution: {integrity: sha512-HawWrcqXeqdhj4dKhdjJg4BXvstcQauYSRx0cnYH78f7z9PW60Smr6vYpByXC87rK3JKpa6CNiZi+qhI5yTAog==}
 
-  '@rslib/core@0.13.2':
-    resolution: {integrity: sha512-Npb27X+kjh4fJoCVMvemfgS1F/gBW4VwHndYlQSmP5pdtqbfOLEj66YNIk0thu/1Z4dh0m2KppM7O3cFiJpqMQ==}
+  '@rslib/core@0.13.3':
+    resolution: {integrity: sha512-W9U3KBC3VZbpJSfceRi6UpHFqbwuNGXjrwCuAErxS1YHi1fM0K15xIjQDNMsYoWsAQg0kazFZ5HHAxYUuEkiyA==}
     engines: {node: '>=18.12.0'}
     hasBin: true
     peerDependencies:
@@ -5064,9 +5069,6 @@ packages:
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
 
-  magic-string@0.30.19:
-    resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
-
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
@@ -5881,8 +5883,8 @@ packages:
       '@rsbuild/core':
         optional: true
 
-  rsbuild-plugin-dts@0.13.2:
-    resolution: {integrity: sha512-Tw88Jl6eqhUcI9JLFXGCaw4Oiqe1IfD7rbLWvV9OPJwsRdV129WJ4ccnI0x7tDpnLDV0xhW/+b/9wGyK28jSgg==}
+  rsbuild-plugin-dts@0.13.3:
+    resolution: {integrity: sha512-clPsUpLq4URqntM0xCF6WMBBx+iTxU0z2mkdJNLnWEx7qPjxAEiHOqFYPQsvaHxNkKRan6Yb75I7XhRMjo0Vrg==}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       '@microsoft/api-extractor': ^7
@@ -8001,6 +8003,14 @@ snapshots:
       core-js: 3.45.1
       jiti: 2.5.1
 
+  '@rsbuild/core@1.5.8':
+    dependencies:
+      '@rspack/core': 1.5.5(@swc/helpers@0.5.17)
+      '@rspack/lite-tapable': 1.0.1
+      '@swc/helpers': 0.5.17
+      core-js: 3.45.1
+      jiti: 2.5.1
+
   '@rsbuild/plugin-babel@1.0.5(@rsbuild/core@packages+core)':
     dependencies:
       '@babel/core': 7.28.4
@@ -8196,11 +8206,10 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rslib/core@0.13.2(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)':
+  '@rslib/core@0.13.3(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)':
     dependencies:
-      '@rsbuild/core': 1.5.4
-      rsbuild-plugin-dts: 0.13.2(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
-      tinyglobby: 0.2.15
+      '@rsbuild/core': 1.5.8
+      rsbuild-plugin-dts: 0.13.3(@rsbuild/core@1.5.8)(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -11002,10 +11011,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magic-string@0.30.19:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
@@ -12150,14 +12155,10 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': link:packages/core
 
-  rsbuild-plugin-dts@0.13.2(@rsbuild/core@1.5.4)(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2):
+  rsbuild-plugin-dts@0.13.3(@rsbuild/core@1.5.8)(@typescript/native-preview@7.0.0-dev.20250914.1)(typescript@5.9.2):
     dependencies:
       '@ast-grep/napi': 0.37.0
-      '@rsbuild/core': 1.5.4
-      magic-string: 0.30.19
-      picocolors: 1.1.1
-      tinyglobby: 0.2.15
-      tsconfig-paths: 4.2.0
+      '@rsbuild/core': 1.5.8
     optionalDependencies:
       '@typescript/native-preview': 7.0.0-dev.20250914.1
       typescript: 5.9.2

--- a/scripts/config/package.json
+++ b/scripts/config/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@rsbuild/config",
   "version": "1.0.1",
+  "type": "module",
   "private": true,
   "devDependencies": {
     "@rsbuild/core": "workspace:*",
-    "@rslib/core": "0.13.2",
+    "@rslib/core": "0.13.3",
     "@types/node": "^22.18.3",
     "@typescript/native-preview": "7.0.0-dev.20250914.1",
     "rsbuild-plugin-arethetypeswrong": "0.1.1",

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -20,8 +20,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build",
-    "dev": "rslib build --watch"
+    "build": "rslib build --config-loader native",
+    "dev": "rslib build -w --config-loader native"
   },
   "dependencies": {
     "@rsbuild/core": "workspace:*",
@@ -30,7 +30,7 @@
     "typescript": "^5.9.2"
   },
   "devDependencies": {
-    "@rslib/core": "0.13.2"
+    "@rslib/core": "0.13.3"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary

- Update @rslib/core dependency across all packages to version 0.13.3
- Modify build scripts to use `--config-loader native` flag, which is faster than `jiti`.

### Before

<img width="879" height="118" alt="Screenshot 2025-09-17 at 17 13 09" src="https://github.com/user-attachments/assets/a5d6cdc6-d87f-4064-a8eb-9ffb9540406c" />

### After

<img width="1000" height="114" alt="Screenshot 2025-09-17 at 17 13 24" src="https://github.com/user-attachments/assets/cfad0571-fc9b-40c3-96d0-e47cce7cd64b" />

## Related Links

https://github.com/web-infra-dev/rslib/releases/tag/v0.13.3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
