### PR TITLE
refactor(test): simplify test cases by using build fixture

### DIFF
--- a/e2e/cases/javascript-api/build-and-load-env/index.test.ts
+++ b/e2e/cases/javascript-api/build-and-load-env/index.test.ts
@@ -1,42 +1,27 @@
 import { expect, rspackTest } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
 
-rspackTest('should not load env by default', async () => {
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
+rspackTest('should not load env by default', async ({ build }) => {
+  await build({
     loadEnv: false,
-    rsbuildConfig: {
-      performance: {
-        printFileSize: false,
-      },
-    },
   });
-
-  expect(process.env.PUBLIC_FOO).toBe(undefined);
-  expect(process.env.PUBLIC_BAR).toBe(undefined);
-  const { close } = await rsbuild.build();
-  await close();
-});
-
-rspackTest('should allow to call `build` with `loadEnv` options', async () => {
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-    loadEnv: {
-      mode: 'prod',
-    },
-    rsbuildConfig: {
-      performance: {
-        printFileSize: false,
-      },
-    },
-  });
-
-  expect(process.env.PUBLIC_FOO).toBe('foo');
-  expect(process.env.PUBLIC_BAR).toBe('bar');
-
-  const { close } = await rsbuild.build();
-  await close();
-
   expect(process.env.PUBLIC_FOO).toBe(undefined);
   expect(process.env.PUBLIC_BAR).toBe(undefined);
 });
+
+rspackTest(
+  'should allow to call `build` with `loadEnv` options',
+  async ({ build }) => {
+    const result = await build({
+      loadEnv: {
+        mode: 'prod',
+      },
+    });
+
+    expect(process.env.PUBLIC_FOO).toBe('foo');
+    expect(process.env.PUBLIC_BAR).toBe('bar');
+
+    await result.close();
+    expect(process.env.PUBLIC_FOO).toBe(undefined);
+    expect(process.env.PUBLIC_BAR).toBe(undefined);
+  },
+);

--- a/e2e/cases/javascript-api/build/index.test.ts
+++ b/e2e/cases/javascript-api/build/index.test.ts
@@ -1,17 +1,14 @@
 import { expect, rspackTest } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
 
-rspackTest('should allow to call `build` and get stats object', async () => {
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
+rspackTest(
+  'should allow to call `build` and get stats object',
+  async ({ build }) => {
+    const result = await build();
 
-  const { stats, close } = await rsbuild.build();
+    await result.close();
 
-  await close();
-
-  const result = stats?.toJson({ all: true })!;
-
-  expect(result.name).toBe('web');
-  expect(result.assets?.length).toBeGreaterThan(0);
-});
+    const statsJson = result.stats?.toJson({ all: true })!;
+    expect(statsJson.name).toBe('web');
+    expect(statsJson.assets?.length).toBeGreaterThan(0);
+  },
+);

--- a/e2e/cases/javascript-api/caller-name/index.test.ts
+++ b/e2e/cases/javascript-api/caller-name/index.test.ts
@@ -1,12 +1,10 @@
 import { expect, rspackTest } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
 
 rspackTest(
   'should allow to set caller name and use it in plugins',
-  async () => {
+  async ({ build }) => {
     let callerName = '';
-    const rsbuild = await createRsbuild({
-      cwd: __dirname,
+    await build({
       callerName: 'foo',
       rsbuildConfig: {
         plugins: [
@@ -20,7 +18,6 @@ rspackTest(
       },
     });
 
-    await rsbuild.build();
     expect(callerName).toBe('foo');
   },
 );

--- a/e2e/cases/javascript-api/get-stats/index.test.ts
+++ b/e2e/cases/javascript-api/get-stats/index.test.ts
@@ -1,9 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, proxyConsole, rspackTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
 rspackTest(
   'should allow to call `getStats` to get stats after creating dev server',
   async () => {
+    const { restore } = proxyConsole();
     const rsbuild = await createRsbuild({
       cwd: __dirname,
       rsbuildConfig: {
@@ -25,5 +26,7 @@ rspackTest(
       }),
     ).toBe('object');
     await server.close();
+
+    restore();
   },
 );

--- a/e2e/cases/javascript-api/register-plugin/index.test.ts
+++ b/e2e/cases/javascript-api/register-plugin/index.test.ts
@@ -1,19 +1,15 @@
 import path from 'node:path';
 import { expect, readDirContents, rspackTest } from '@e2e/helper';
-import { createRsbuild } from '@rsbuild/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
 rspackTest(
   'should register plugins correctly when using JavaScript API',
-  async () => {
-    const rsbuild = await createRsbuild({
-      cwd: __dirname,
+  async ({ build }) => {
+    await build({
       rsbuildConfig: {
         plugins: [pluginVue()],
       },
     });
-
-    await rsbuild.build();
 
     const outputs = await readDirContents(path.join(__dirname, 'dist'));
     const outputFiles = Object.keys(outputs);

--- a/e2e/cases/javascript-api/sock-write/index.test.ts
+++ b/e2e/cases/javascript-api/sock-write/index.test.ts
@@ -1,9 +1,11 @@
-import { expectPoll, gotoPage, rspackTest } from '@e2e/helper';
+import { expectPoll, gotoPage, proxyConsole, rspackTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
 rspackTest(
   'should allow to call `sockWrite` after creating dev server',
   async ({ page }) => {
+    const { restore } = proxyConsole();
+
     let count = 0;
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -23,6 +25,8 @@ rspackTest(
     const previousCount = count;
     server.sockWrite('static-changed');
     expectPoll(() => count > previousCount).toBeTruthy();
+
     await server.close();
+    restore();
   },
 );

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -284,6 +284,7 @@ export async function build({
     ...logHelper,
     distPath,
     port,
+    stats: buildResult?.stats,
     close: async () => {
       await buildResult?.close();
       await server.close();


### PR DESCRIPTION
## Summary

- Simplify test cases by using the `build` fixture
- Expose build stats in `build` test helper result

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
