### PR TITLE
refactor(e2e): ensure all logs can be captured

### DIFF
--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -1,12 +1,6 @@
 import fs from 'node:fs';
 import path, { join } from 'node:path';
-import {
-  createRsbuild,
-  expect,
-  proxyConsole,
-  rspackTest,
-  test,
-} from '@e2e/helper';
+import { createRsbuild, expect, rspackTest, test } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 import { remove, removeSync } from 'fs-extra';
 
@@ -41,8 +35,8 @@ const INSPECT_LOG = 'config inspection completed';
 
 rspackTest(
   'should generate config files when writeToDisk is true',
-  async () => {
-    const { expectLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectLog } = logHelper;
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -57,15 +51,13 @@ rspackTest(
 
     await remove(rsbuildConfig);
     await remove(bundlerConfig);
-
-    restore();
   },
 );
 
 rspackTest(
   'should generate config files correctly when output is specified',
-  async () => {
-    const { expectLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectLog } = logHelper;
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -91,15 +83,13 @@ rspackTest(
 
     await remove(rsbuildConfig);
     await remove(bundlerConfig);
-
-    restore();
   },
 );
 
 rspackTest(
   'should generate bundler config for node when target contains node',
-  async () => {
-    const { expectLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectLog } = logHelper;
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -131,14 +121,12 @@ rspackTest(
     await remove(rsbuildNodeConfig);
     await remove(bundlerConfig);
     await remove(bundlerNodeConfig);
-
-    restore();
   },
 );
 
 rspackTest(
   'should not generate config files when writeToDisk is false',
-  async () => {
+  async ({ logHelper }) => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
     });
@@ -151,32 +139,33 @@ rspackTest(
   },
 );
 
-rspackTest('should allow to specify absolute output path', async () => {
-  const { expectLog, restore } = proxyConsole();
+rspackTest(
+  'should allow to specify absolute output path',
+  async ({ logHelper }) => {
+    const { expectLog } = logHelper;
 
-  const rsbuild = await createRsbuild({
-    cwd: __dirname,
-  });
-  const outputPath = path.join(__dirname, 'test-temp-output');
+    const rsbuild = await createRsbuild({
+      cwd: __dirname,
+    });
+    const outputPath = path.join(__dirname, 'test-temp-output');
 
-  await rsbuild.inspectConfig({
-    writeToDisk: true,
-    outputPath,
-  });
+    await rsbuild.inspectConfig({
+      writeToDisk: true,
+      outputPath,
+    });
 
-  await expectLog(INSPECT_LOG);
+    await expectLog(INSPECT_LOG);
 
-  expect(
-    fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
-  ).toBeTruthy();
+    expect(
+      fs.existsSync(path.join(outputPath, 'rspack.config.web.mjs')),
+    ).toBeTruthy();
 
-  await remove(rsbuildConfig);
+    await remove(rsbuildConfig);
+  },
+);
 
-  restore();
-});
-
-rspackTest('should generate extra config files', async () => {
-  const { expectLog, restore } = proxyConsole();
+rspackTest('should generate extra config files', async ({ logHelper }) => {
+  const { expectLog } = logHelper;
 
   const rsbuild = await createRsbuild({
     cwd: __dirname,
@@ -198,13 +187,9 @@ rspackTest('should generate extra config files', async () => {
   expect(fs.existsSync(rstestConfig)).toBeTruthy();
   await expectLog('Rstest Config:');
   await remove(rstestConfig);
-
-  restore();
 });
 
 rspackTest('should apply plugin correctly', async () => {
-  const { restore } = proxyConsole();
-
   let servePluginApplied = false;
   let buildPluginApplied = false;
 
@@ -249,6 +234,4 @@ rspackTest('should apply plugin correctly', async () => {
 
   expect(servePluginApplied).toBe(false);
   expect(buildPluginApplied).toBe(true);
-
-  restore();
 });

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -126,7 +126,7 @@ rspackTest(
 
 rspackTest(
   'should not generate config files when writeToDisk is false',
-  async ({ logHelper }) => {
+  async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
     });

--- a/e2e/cases/javascript-api/get-stats/index.test.ts
+++ b/e2e/cases/javascript-api/get-stats/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, proxyConsole, rspackTest } from '@e2e/helper';
+import { expect, rspackTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
 rspackTest(
   'should allow to call `getStats` to get stats after creating dev server',
   async () => {
-    const { restore } = proxyConsole();
     const rsbuild = await createRsbuild({
       cwd: __dirname,
       rsbuildConfig: {
@@ -26,7 +25,5 @@ rspackTest(
       }),
     ).toBe('object');
     await server.close();
-
-    restore();
   },
 );

--- a/e2e/cases/javascript-api/sock-write/index.test.ts
+++ b/e2e/cases/javascript-api/sock-write/index.test.ts
@@ -1,11 +1,9 @@
-import { expectPoll, gotoPage, proxyConsole, rspackTest } from '@e2e/helper';
+import { expectPoll, gotoPage, rspackTest } from '@e2e/helper';
 import { createRsbuild } from '@rsbuild/core';
 
 rspackTest(
   'should allow to call `sockWrite` after creating dev server',
   async ({ page }) => {
-    const { restore } = proxyConsole();
-
     let count = 0;
     const rsbuild = await createRsbuild({
       cwd: __dirname,
@@ -27,6 +25,5 @@ rspackTest(
     expectPoll(() => count > previousCount).toBeTruthy();
 
     await server.close();
-    restore();
   },
 );

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 

--- a/e2e/cases/module-federation/v2-basic/index.test.ts
+++ b/e2e/cases/module-federation/v2-basic/index.test.ts
@@ -1,7 +1,6 @@
 import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
-import { expect } from '@playwright/test';
+import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 import { pluginCheckSyntax } from '@rsbuild/plugin-check-syntax';
 

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -113,9 +113,6 @@ rspackTest(
       cwd: __dirname,
       rsbuildConfig: {
         plugins: [plugin],
-        server: {
-          printUrls: false,
-        },
       },
     });
 

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, proxyConsole, rspackTest } from '@e2e/helper';
+import { expect, rspackTest } from '@e2e/helper';
 import { createRsbuild, type Rspack } from '@rsbuild/core';
 import { RsdoctorRspackPlugin } from '@rsdoctor/rspack-plugin';
 import { matchPlugin } from '@scripts/test-helper';
@@ -7,8 +7,8 @@ const RSDOCTOR_LOG = '@rsdoctor/rspack-plugin enabled';
 
 rspackTest(
   'should register Rsdoctor plugin when process.env.RSDOCTOR is true',
-  async () => {
-    const { expectLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectLog } = logHelper;
     process.env.RSDOCTOR = 'true';
 
     const rsbuild = await createRsbuild({
@@ -26,15 +26,14 @@ rspackTest(
       ),
     ).toBeTruthy();
 
-    restore();
     process.env.RSDOCTOR = '';
   },
 );
 
 rspackTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is false',
-  async () => {
-    const { expectNoLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectNoLog } = logHelper;
     process.env.RSDOCTOR = 'false';
 
     const rsbuild = await createRsbuild({
@@ -53,14 +52,13 @@ rspackTest(
     ).toBeFalsy();
 
     process.env.RSDOCTOR = '';
-    restore();
   },
 );
 
 rspackTest(
   'should not register Rsdoctor plugin when process.env.RSDOCTOR is true and the plugin has been registered',
-  async () => {
-    const { expectNoLog, restore } = proxyConsole();
+  async ({ logHelper }) => {
+    const { expectNoLog } = logHelper;
 
     process.env.RSDOCTOR = 'true';
 
@@ -91,6 +89,5 @@ rspackTest(
     expectNoLog(RSDOCTOR_LOG);
 
     process.env.RSDOCTOR = '';
-    restore();
   },
 );

--- a/e2e/cases/server/custom-server/scripts/pureServer.mjs
+++ b/e2e/cases/server/custom-server/scripts/pureServer.mjs
@@ -11,7 +11,6 @@ export async function startDevServerPure(fixtures) {
         middlewareMode: true,
       },
       dev: {
-        printUrls: false,
         setupMiddlewares: (middlewares) => {
           middlewares.unshift((req, res, next) => {
             if (req.url === '/test') {

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -9,9 +9,6 @@ export async function startDevServer(fixtures) {
         htmlFallback: false,
         middlewareMode: true,
       },
-      dev: {
-        printUrls: false,
-      },
     },
   });
 

--- a/e2e/cases/server/multi-server/index.test.ts
+++ b/e2e/cases/server/multi-server/index.test.ts
@@ -22,7 +22,6 @@ test.skip('multiple rsbuild dev servers should work correctly', async ({
         assetPrefix: '/app1',
       },
       server: {
-        printUrls: false,
         middlewareMode: true,
       },
     },
@@ -42,7 +41,6 @@ test.skip('multiple rsbuild dev servers should work correctly', async ({
         },
       },
       server: {
-        printUrls: false,
         middlewareMode: true,
       },
       dev: {

--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,10 +1,11 @@
-import { createLogHelper, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 test('should display type errors on overlay correctly', async ({
   page,
   dev,
+  logHelper,
 }) => {
-  const { addLog, expectLog } = createLogHelper();
+  const { addLog, expectLog } = logHelper;
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());
   });

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,15 +1,20 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { createLogHelper, expect, test } from '@e2e/helper';
+import { expect, test } from '@e2e/helper';
 
 const cwd = __dirname;
 
-test('should show overlay correctly', async ({ page, dev, editFile }) => {
+test('should show overlay correctly', async ({
+  page,
+  dev,
+  editFile,
+  logHelper,
+}) => {
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });
 
-  const { expectLog, addLog } = createLogHelper();
+  const { expectLog, addLog } = logHelper;
 
   page.on('console', (consoleMessage) => {
     addLog(consoleMessage.text());

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -8,6 +8,7 @@ import {
   type Dev,
   type DevResult,
 } from './jsApi';
+import { type LogHelper, proxyConsole } from './logs';
 
 type EditFile = (
   filename: string,
@@ -19,6 +20,8 @@ type RsbuildFixture = {
    * Absolute working directory of the current test file.
    */
   cwd: string;
+
+  logHelper: LogHelper;
 
   /**
    * Build the project. No preview server or page navigation by default.
@@ -67,10 +70,20 @@ export const test = base.extend<RsbuildFixture>({
     await use(cwd);
   },
 
-  build: async ({ cwd }, use) => {
+  logHelper: [
+    // biome-ignore lint/correctness/noEmptyPattern: required by playwright
+    async ({}, use) => {
+      const logHelper = proxyConsole();
+      await use(logHelper);
+      logHelper.restore();
+    },
+    { auto: true },
+  ],
+
+  build: async ({ cwd, logHelper }, use) => {
     const closes: Close[] = [];
     const build: typeof baseBuild = async (options) => {
-      const result = await baseBuild({ cwd, ...options });
+      const result = await baseBuild({ cwd, logHelper, ...options });
       closes.push(result.close);
       return result;
     };
@@ -84,10 +97,10 @@ export const test = base.extend<RsbuildFixture>({
     }
   },
 
-  buildPreview: async ({ cwd, page }, use) => {
+  buildPreview: async ({ cwd, page, logHelper }, use) => {
     const closes: Close[] = [];
     const build: typeof baseBuild = async (options) => {
-      const result = await baseBuild({ cwd, page, ...options });
+      const result = await baseBuild({ cwd, page, logHelper, ...options });
       closes.push(result.close);
       return result;
     };
@@ -101,10 +114,10 @@ export const test = base.extend<RsbuildFixture>({
     }
   },
 
-  dev: async ({ cwd, page }, use) => {
+  dev: async ({ cwd, page, logHelper }, use) => {
     const closes: Close[] = [];
     const dev: typeof baseDev = async (options) => {
-      const result = await baseDev({ cwd, page, ...options });
+      const result = await baseDev({ cwd, page, logHelper, ...options });
       closes.push(result.close);
       return result;
     };
@@ -118,10 +131,10 @@ export const test = base.extend<RsbuildFixture>({
     }
   },
 
-  devOnly: async ({ cwd }, use) => {
+  devOnly: async ({ cwd, logHelper }, use) => {
     const closes: Close[] = [];
     const dev: typeof baseDev = async (options) => {
-      const result = await baseDev({ cwd, ...options });
+      const result = await baseDev({ cwd, logHelper, ...options });
       closes.push(result.close);
       return result;
     };

--- a/e2e/helper/index.ts
+++ b/e2e/helper/index.ts
@@ -8,5 +8,4 @@ export {
   createRsbuild,
   type Dev,
 } from './jsApi';
-export * from './logs';
 export * from './utils';


### PR DESCRIPTION
## Summary

This PR integrates `logHelper` into the default Playwright fixtures, so that logs are automatically captured during tests and using `logHelper` becomes easier.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
