### PR TITLE
fix: temporarily disable const inlining optimization

### DIFF
--- a/e2e/cases/optimization/inline-const/index.test.ts
+++ b/e2e/cases/optimization/inline-const/index.test.ts
@@ -3,15 +3,16 @@ import { expect, rspackTest, test } from '@e2e/helper';
 rspackTest(
   'should inline the constants in build',
   async ({ page, buildPreview }) => {
-    const rsbuild = await buildPreview();
+    await buildPreview();
     await page.waitForFunction(() => window.testDog);
     expect(await page.evaluate(() => window.testFish)).toBe('fish,FISH');
     expect(await page.evaluate(() => window.testCat)).toBe('cat,CAT');
     expect(await page.evaluate(() => window.testDog)).toBe('dog,DOG');
 
-    const indexJs = await rsbuild.getIndexBundle();
-    expect(indexJs).toContain('window.testFish="fish,FISH"');
-    expect(indexJs).toContain('window.testCat="cat,CAT"');
+    // TODO: enable inline const
+    // const indexJs = await rsbuild.getIndexBundle();
+    // expect(indexJs).toContain('window.testFish="fish,FISH"');
+    // expect(indexJs).toContain('window.testCat="cat,CAT"');
   },
 );
 

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -478,7 +478,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     "parser": {
       "javascript": {
         "exportsPresence": "error",
-        "inlineConst": true,
+        "inlineConst": false,
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -920,7 +920,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "parser": {
       "javascript": {
         "exportsPresence": "error",
-        "inlineConst": true,
+        "inlineConst": false,
         "typeReexportsPresence": "tolerant",
       },
     },
@@ -1293,7 +1293,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
       "javascript": {
         "dynamicImportMode": "eager",
         "exportsPresence": "error",
-        "inlineConst": true,
+        "inlineConst": false,
         "typeReexportsPresence": "tolerant",
       },
     },

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -70,7 +70,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
         // Align with the futureDefaults of webpack 6
         chain.module.parser.merge({
           javascript: {
-            inlineConst: isProd,
+            inlineConst: false,
             exportsPresence: 'error',
             typeReexportsPresence: 'tolerant',
           },
@@ -98,7 +98,7 @@ export const pluginBasic = (): RsbuildPlugin => ({
             ...chain.get('experiments'),
             lazyBarrel: true,
             inlineEnum: isProd,
-            inlineConst: isProd,
+            inlineConst: false,
             typeReexportsPresence: true,
             rspackFuture: {
               bundlerInfo: {

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -55,7 +55,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "context": "<ROOT>/packages/core/tests",
   "devtool": false,
   "experiments": {
-    "inlineConst": true,
+    "inlineConst": false,
     "inlineEnum": true,
     "lazyBarrel": true,
     "rspackFuture": {
@@ -73,7 +73,7 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
     "parser": {
       "javascript": {
         "exportsPresence": "error",
-        "inlineConst": true,
+        "inlineConst": false,
         "typeReexportsPresence": "tolerant",
       },
     },

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -527,7 +527,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   },
   "experiments": {
     "asyncWebAssembly": true,
-    "inlineConst": true,
+    "inlineConst": false,
     "inlineEnum": true,
     "lazyBarrel": true,
     "rspackFuture": {
@@ -549,7 +549,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "parser": {
       "javascript": {
         "exportsPresence": "error",
-        "inlineConst": true,
+        "inlineConst": false,
         "typeReexportsPresence": "tolerant",
       },
     },


### PR DESCRIPTION
## Summary

The const inlining optimization was previously enabled in production builds, which could cause issues in some edge cases. (See https://github.com/web-infra-dev/rsbuild/issues/6171).

This PR disables these options to ensure the output code works as expected.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
