### PR TITLE
fix(types): update `ImportMetaEnv` interface to use Record

### DIFF
--- a/packages/core/types.d.ts
+++ b/packages/core/types.d.ts
@@ -20,8 +20,7 @@ interface RsbuildTypeOptions {}
 type ImportMetaEnvFallbackKey =
   'strictImportMetaEnv' extends keyof RsbuildTypeOptions ? never : string;
 
-interface ImportMetaEnv {
-  [key: ImportMetaEnvFallbackKey]: any;
+interface ImportMetaEnv extends Record<ImportMetaEnvFallbackKey, any> {
   /**
    * The value of the `mode` configuration.
    * @example


### PR DESCRIPTION
## Summary

Update `ImportMetaEnv` interface to use Record to fix the type error when `skipLibCheck` is `false`:

<img width="1023" height="439" alt="Screenshot 2025-09-18 at 11 31 20" src="https://github.com/user-attachments/assets/5885a79d-4859-47ea-8301-87f2bfc937bd" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
