### PR TITLE
docs: add documentation for resolve.mainFields

### DIFF
--- a/website/docs/en/config/resolve/main-fields.mdx
+++ b/website/docs/en/config/resolve/main-fields.mdx
@@ -1,0 +1,48 @@
+# resolve.mainFields
+
+- **Type:** `string[]`
+- **Version:** `>= 1.5.9`
+
+Controls the priority of fields in a package.json used to locate a package's entry file. It is the ordered list of package.json fields Rspack will try when resolving an npm package's entry point.
+
+:::tip
+`resolve.mainFields` is provided by Rspack, see [Rspack - resolve.mainFields](https://rspack.rs/config/resolve#resolvemainfields) to learn more.
+:::
+
+## Default values
+
+- If [output.target](/config/output/target) is `'web'`, `'web-worker'`, or not specified, the default value is `["browser", "module", "main"]`.
+- If [output.target](/config/output/target) is `'node'`, the default value is `["module", "main"]`.
+
+## Basic example
+
+The value of `resolve.mainFields` overrides the default value of Rsbuild:
+
+```js title="rsbuild.config.ts"
+export default {
+  resolve: {
+    mainFields: ['custom', 'module', 'main'],
+  },
+};
+```
+
+## Multi-environments
+
+Configure different `mainFields` for different [environments](/config/environments):
+
+```js title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      resolve: {
+        mainFields: ['custom', 'browser', 'module', 'main'],
+      },
+    },
+    node: {
+      resolve: {
+        mainFields: ['custom', 'module', 'main'],
+      },
+    },
+  },
+};
+```

--- a/website/docs/en/guide/migration/vite.mdx
+++ b/website/docs/en/guide/migration/vite.mdx
@@ -121,7 +121,7 @@ Here is the corresponding Rsbuild configuration for Vite configuration:
 | resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                         |
 | resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                 |
 | resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)        |
-| resolve.mainFields                    | [tools.rspack.resolve.mainFields](/config/tools/rspack)          |
+| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                |
 | resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)            |
 | html.cspNonce                         | [security.nonce](/config/security/nonce)                         |
 | css.modules                           | [output.cssModules](/config/output/css-modules)                  |

--- a/website/docs/zh/config/resolve/main-fields.mdx
+++ b/website/docs/zh/config/resolve/main-fields.mdx
@@ -1,0 +1,48 @@
+# resolve.mainFields
+
+- **类型：** `string[]`
+- **版本：** `>= 1.5.9`
+
+控制用于定位包入口文件的 package.json 字段优先级。Rspack 在解析 npm 包入口时，会按该列表的顺序依次尝试这些字段。
+
+:::tip
+`resolve.mainFields` 是 Rspack 提供的配置，参考 [Rspack - resolve.mainFields](https://rspack.rs/zh/config/resolve#resolvemainfields) 了解更多。
+:::
+
+## 默认值
+
+- 当 [output.target](/config/output/target) 配置为 `'web'`, `'web-worker'`，或未指定时，默认值为 `["browser", "module", "main"]`。
+- 当 [output.target](/config/output/target) 配置为 `node`，默认值为 `["module", "main"]`。
+
+## 基础示例
+
+`resolve.mainFields` 配置的值会覆盖 Rsbuild 的默认值：
+
+```js title="rsbuild.config.ts"
+export default {
+  resolve: {
+    mainFields: ['custom', 'module', 'main'],
+  },
+};
+```
+
+## 多环境
+
+为不同 [environments](/config/environments) 配置不同的 `mainFields`：
+
+```js title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      resolve: {
+        mainFields: ['custom', 'browser', 'module', 'main'],
+      },
+    },
+    node: {
+      resolve: {
+        mainFields: ['custom', 'module', 'main'],
+      },
+    },
+  },
+};
+```

--- a/website/docs/zh/guide/migration/vite.mdx
+++ b/website/docs/zh/guide/migration/vite.mdx
@@ -121,7 +121,7 @@ Rsbuild 会在构建时自动注入 `<script>` 标签到生成的 HTML 文件中
 | resolve.dedupe                        | [resolve.dedupe](/config/resolve/dedupe)                         |
 | resolve.extensions                    | [resolve.extensions](/config/resolve/extensions)                 |
 | resolve.conditions                    | [resolve.conditionNames](/config/resolve/condition-names)        |
-| resolve.mainFields                    | [tools.rspack.resolve.mainFields](/config/tools/rspack)          |
+| resolve.mainFields                    | [resolve.mainFields](/config/resolve/main-fields)                |
 | resolve.preserveSymlinks              | [tools.rspack.resolve.symlinks](/config/tools/rspack)            |
 | html.cspNonce                         | [security.nonce](/config/security/nonce)                         |
 | css.modules                           | [output.cssModules](/config/output/css-modules)                  |


### PR DESCRIPTION
## Summary

Add documentation for the new `resolve.mainFields` configuration.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6178

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
