### PR TITLE
chore: set engines to Node.js >=22.18.0 and enable engineStrict

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@10.16.0",
   "engines": {
-    "node": ">=18.12.0",
+    "node": ">=22.18.0",
     "pnpm": ">=10.16.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,3 +19,4 @@ patchedDependencies:
   url-loader: patches/url-loader@4.1.1.patch
 
 strictPeerDependencies: false
+engineStrict: true

--- a/website/docs/zh/config/resolve/main-fields.mdx
+++ b/website/docs/zh/config/resolve/main-fields.mdx
@@ -12,7 +12,7 @@
 ## 默认值
 
 - 当 [output.target](/config/output/target) 配置为 `'web'`, `'web-worker'`，或未指定时，默认值为 `["browser", "module", "main"]`。
-- 当 [output.target](/config/output/target) 配置为 `node`，默认值为 `["module", "main"]`。
+- 当 [output.target](/config/output/target) 配置为 `'node'`，默认值为 `["module", "main"]`。
 
 ## 基础示例
 


### PR DESCRIPTION
## Summary

Set engines to Node.js >=22.18.0 and enable engineStrict.

https://github.com/web-infra-dev/rsbuild/pull/6172 Native config loader Requirements.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
