### PR TITLE
test(e2e): turn shared assets into a package to simplify importing

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,10 +1,12 @@
 # @rsbuild/e2e
 
-This folder contains the e2e test cases of Rsbuild.
+This folder contains the E2E test cases of Rsbuild. The E2E suite is powered by [Playwright](https://github.com/microsoft/playwright).
 
-## Tech stack
+## Directory structure
 
-- [playwright](https://github.com/microsoft/playwright): The e2e test framework.
+- `cases`: Test cases covering different Rsbuild features.
+- `assets`: Common static assets, can be accessed using the `@e2e/assets` package.
+- `scripts`: Shared helpers, can be accessed using the `@e2e/helper` package.
 
 ## Commands
 

--- a/e2e/assets/package.json
+++ b/e2e/assets/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "@e2e/assets",
+  "description": "Common static assets used in E2E test cases.",
+  "private": true,
+  "version": "1.0.0"
+}

--- a/e2e/cases/assets/assets-url/src/App.jsx
+++ b/e2e/cases/assets/assets-url/src/App.jsx
@@ -1,4 +1,4 @@
-import img from '../../../../assets/icon.png?url';
+import img from '@e2e/assets/icon.png?url';
 
 function App() {
   return (

--- a/e2e/cases/assets/custom-dist-path/src/index.js
+++ b/e2e/cases/assets/custom-dist-path/src/index.js
@@ -1,4 +1,4 @@
-import small from '@assets/icon.png?url';
+import small from '@e2e/assets/icon.png?url';
 import './index.css';
 
 import(/* webpackChunkName: "foo" */ './async');

--- a/e2e/cases/assets/emit-assets/src/index.js
+++ b/e2e/cases/assets/emit-assets/src/index.js
@@ -1,4 +1,4 @@
-import small from '../../../../assets/icon.png?url';
+import small from '@e2e/assets/icon.png?url';
 
 const testJson = new URL('./assets/test.json', import.meta.url).href;
 

--- a/e2e/cases/assets/filename-function/src/index.js
+++ b/e2e/cases/assets/filename-function/src/index.js
@@ -1,8 +1,8 @@
 import './index.css';
-import circle from '@assets/circle.svg?url';
-import icon from '@assets/icon.png?url';
-import image from '@assets/image.png?url';
-import mobile from '@assets/mobile.svg?url';
+import circle from '@e2e/assets/circle.svg?url';
+import icon from '@e2e/assets/icon.png?url';
+import image from '@e2e/assets/image.png?url';
+import mobile from '@e2e/assets/mobile.svg?url';
 
 console.log(icon, image, circle, mobile);
 

--- a/e2e/cases/assets/inline-query-auto/src/App.jsx
+++ b/e2e/cases/assets/inline-query-auto/src/App.jsx
@@ -1,4 +1,4 @@
-import img from '@assets/icon.png';
+import img from '@e2e/assets/icon.png';
 
 function App() {
   return (

--- a/e2e/cases/assets/inline-query-false/src/App.jsx
+++ b/e2e/cases/assets/inline-query-false/src/App.jsx
@@ -1,4 +1,4 @@
-import img from '@assets/icon.png?__inline=false';
+import img from '@e2e/assets/icon.png?__inline=false';
 
 function App() {
   return (

--- a/e2e/cases/assets/inline-query/src/App.jsx
+++ b/e2e/cases/assets/inline-query/src/App.jsx
@@ -1,4 +1,4 @@
-import img from '@assets/icon.png?inline';
+import img from '@e2e/assets/icon.png?inline';
 
 function App() {
   return (

--- a/e2e/cases/assets/raw-query/src/index.js
+++ b/e2e/cases/assets/raw-query/src/index.js
@@ -1,5 +1,5 @@
-import normalSvg from '@assets/circle.svg?not-raw';
-import rawSvg from '@assets/circle.svg?raw';
+import normalSvg from '@e2e/assets/circle.svg?not-raw';
+import rawSvg from '@e2e/assets/circle.svg?raw';
 import rawTs4 from './bar.ts?other=value&raw';
 import rawTs1 from './bar.ts?raw';
 import rawTs2 from './bar.ts?raw=1';

--- a/e2e/cases/assets/svg-assets/src/App.css
+++ b/e2e/cases/assets/svg-assets/src/App.css
@@ -1,5 +1,5 @@
 #test-css {
   width: 50px;
   height: 50px;
-  background-image: url('@assets/mobile.svg?url');
+  background-image: url('@e2e/assets/mobile.svg?url');
 }

--- a/e2e/cases/assets/svg-assets/src/index.js
+++ b/e2e/cases/assets/svg-assets/src/index.js
@@ -1,4 +1,4 @@
-import svgImg from '@assets/mobile.svg?url';
+import svgImg from '@e2e/assets/mobile.svg?url';
 import './App.css';
 
 const testEl = document.createElement('div');

--- a/e2e/cases/css/css-assets/src/test/index.module.css
+++ b/e2e/cases/css/css-assets/src/test/index.module.css
@@ -1,3 +1,3 @@
 .header {
-  background: url('@assets/image.jpeg') no-repeat;
+  background: url('@e2e/assets/image.jpeg') no-repeat;
 }

--- a/e2e/cases/css/resolve-alias/src/a.css
+++ b/e2e/cases/css/resolve-alias/src/a.css
@@ -1,4 +1,4 @@
 .the-a-class {
   color: red;
-  background-image: url('@assets/icon.png?url');
+  background-image: url('@e2e/assets/icon.png?url');
 }

--- a/e2e/cases/css/resolve-alias/src/b.scss
+++ b/e2e/cases/css/resolve-alias/src/b.scss
@@ -1,4 +1,4 @@
 .the-b-class {
   color: blue;
-  background-image: url('@assets/icon.png?url');
+  background-image: url('@e2e/assets/icon.png?url');
 }

--- a/e2e/cases/css/resolve-alias/src/c.less
+++ b/e2e/cases/css/resolve-alias/src/c.less
@@ -1,4 +1,4 @@
 .the-c-class {
   color: yellow;
-  background-image: url('@assets/icon.png?url');
+  background-image: url('@e2e/assets/icon.png?url');
 }

--- a/e2e/cases/css/resolve-ts-paths/src/common/b.scss
+++ b/e2e/cases/css/resolve-ts-paths/src/common/b.scss
@@ -1,4 +1,4 @@
 .bar {
   color: blue;
-  background-image: url('@assets/icon.png?url');
+  background-image: url('@e2e/assets/icon.png?url');
 }

--- a/e2e/cases/css/resolve-url-loader/src/common/b.scss
+++ b/e2e/cases/css/resolve-url-loader/src/common/b.scss
@@ -1,4 +1,4 @@
 .bar {
   color: blue;
-  background-image: url('@assets/icon.png?url');
+  background-image: url('@e2e/assets/icon.png?url');
 }

--- a/e2e/cases/output/data-uri-limit/src/App.jsx
+++ b/e2e/cases/output/data-uri-limit/src/App.jsx
@@ -1,4 +1,4 @@
-import img from '@assets/icon.png';
+import img from '@e2e/assets/icon.png';
 
 function App() {
   return (

--- a/e2e/cases/performance/resource-hints-prefetch/src/page1/App.tsx
+++ b/e2e/cases/performance/resource-hints-prefetch/src/page1/App.tsx
@@ -1,4 +1,4 @@
-import png from '@assets/icon.png?url';
+import png from '@e2e/assets/icon.png?url';
 
 const App = () => (
   <>

--- a/e2e/cases/performance/resource-hints-prefetch/src/test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/src/test.ts
@@ -1,4 +1,4 @@
-import png from '@assets/image.png?url';
+import png from '@e2e/assets/image.png?url';
 import './test.css';
 
 export { png };

--- a/e2e/cases/performance/resource-hints-preload/src/page1/App.tsx
+++ b/e2e/cases/performance/resource-hints-preload/src/page1/App.tsx
@@ -1,4 +1,4 @@
-import png from '@assets/icon.png?url';
+import png from '@e2e/assets/icon.png?url';
 
 const App = () => (
   <>

--- a/e2e/cases/performance/resource-hints-preload/src/test.ts
+++ b/e2e/cases/performance/resource-hints-preload/src/test.ts
@@ -1,4 +1,4 @@
-import png from '@assets/image.png?url';
+import png from '@e2e/assets/image.png?url';
 import './test.css';
 
 export { png };

--- a/e2e/cases/plugin-svgr/default-export-component/src/App.jsx
+++ b/e2e/cases/plugin-svgr/default-export-component/src/App.jsx
@@ -1,4 +1,4 @@
-import Logo from '@assets/mobile.svg';
+import Logo from '@e2e/assets/mobile.svg';
 
 function App() {
   return (

--- a/e2e/cases/plugin-svgr/default-export-url/src/App.css
+++ b/e2e/cases/plugin-svgr/default-export-url/src/App.css
@@ -1,11 +1,11 @@
 #test-css-small {
   width: 50px;
   height: 50px;
-  background-image: url('@assets/circle.svg');
+  background-image: url('@e2e/assets/circle.svg');
 }
 
 #test-css-large {
   width: 50px;
   height: 50px;
-  background-image: url('@assets/mobile.svg');
+  background-image: url('@e2e/assets/mobile.svg');
 }

--- a/e2e/cases/plugin-svgr/default-export-url/src/App.jsx
+++ b/e2e/cases/plugin-svgr/default-export-url/src/App.jsx
@@ -1,5 +1,5 @@
-import smallImg from '@assets/circle.svg';
-import largeImg, { ReactComponent as Logo } from '@assets/mobile.svg';
+import smallImg from '@e2e/assets/circle.svg';
+import largeImg, { ReactComponent as Logo } from '@e2e/assets/mobile.svg';
 import './App.css';
 
 function App() {

--- a/e2e/cases/plugin-svgr/disable-emit-asset/src/index.js
+++ b/e2e/cases/plugin-svgr/disable-emit-asset/src/index.js
@@ -1,3 +1,3 @@
-import svgImg from '@assets/mobile.svg?url';
+import svgImg from '@e2e/assets/mobile.svg?url';
 
 console.log(svgImg);

--- a/e2e/cases/plugin-svgr/exclude-importer/src/Bar.jsx
+++ b/e2e/cases/plugin-svgr/exclude-importer/src/Bar.jsx
@@ -1,4 +1,4 @@
-import logo from '@assets/circle.svg';
+import logo from '@e2e/assets/circle.svg';
 
 function Bar() {
   return <img id="bar" src={logo} alt="" />;

--- a/e2e/cases/plugin-svgr/exclude-importer/src/Foo.jsx
+++ b/e2e/cases/plugin-svgr/exclude-importer/src/Foo.jsx
@@ -1,4 +1,4 @@
-import Logo from '@assets/circle.svg';
+import Logo from '@e2e/assets/circle.svg';
 
 function Foo() {
   return <Logo id="foo" />;

--- a/e2e/cases/plugin-svgr/exclude/src/Bar.jsx
+++ b/e2e/cases/plugin-svgr/exclude/src/Bar.jsx
@@ -1,4 +1,4 @@
-import logo from '@assets/circle.svg';
+import logo from '@e2e/assets/circle.svg';
 
 function Bar() {
   return <img id="bar" src={logo} alt="" />;

--- a/e2e/cases/plugin-svgr/exclude/src/Foo.jsx
+++ b/e2e/cases/plugin-svgr/exclude/src/Foo.jsx
@@ -1,4 +1,4 @@
-import Logo from '@assets/mobile.svg';
+import Logo from '@e2e/assets/mobile.svg';
 
 function Foo() {
   return <Logo id="foo" />;

--- a/e2e/cases/plugin-svgr/hash-digest/src/index.js
+++ b/e2e/cases/plugin-svgr/hash-digest/src/index.js
@@ -1,4 +1,4 @@
-import svg1 from '@assets/circle.svg';
-import svg2 from '@assets/circle.svg?url';
+import svg1 from '@e2e/assets/circle.svg';
+import svg2 from '@e2e/assets/circle.svg?url';
 
 console.log(svg1, svg2);

--- a/e2e/cases/plugin-svgr/named-export-component/src/App.jsx
+++ b/e2e/cases/plugin-svgr/named-export-component/src/App.jsx
@@ -1,4 +1,4 @@
-import { ReactComponent as Logo } from '@assets/mobile.svg';
+import { ReactComponent as Logo } from '@e2e/assets/mobile.svg';
 
 function App() {
   return (

--- a/e2e/cases/plugin-svgr/query-custom/src/App.jsx
+++ b/e2e/cases/plugin-svgr/query-custom/src/App.jsx
@@ -1,5 +1,5 @@
-import Component from '@assets/circle.svg?custom';
-import url from '@assets/circle.svg?url';
+import Component from '@e2e/assets/circle.svg?custom';
+import url from '@e2e/assets/circle.svg?url';
 
 function App() {
   return (

--- a/e2e/cases/plugin-svgr/query-react-dynamic-import/src/App.jsx
+++ b/e2e/cases/plugin-svgr/query-react-dynamic-import/src/App.jsx
@@ -1,7 +1,7 @@
 export async function getApp() {
   const name = 'circle';
-  const { default: Component } = await import(`@assets/${name}.svg?react`);
-  const { default: url } = await import(`@assets/${name}.svg?url`);
+  const { default: Component } = await import(`@e2e/assets/${name}.svg?react`);
+  const { default: url } = await import(`@e2e/assets/${name}.svg?url`);
 
   return () => (
     <div>

--- a/e2e/cases/plugin-svgr/query-react/src/App.jsx
+++ b/e2e/cases/plugin-svgr/query-react/src/App.jsx
@@ -1,5 +1,5 @@
-import Component from '@assets/circle.svg?react';
-import url from '@assets/circle.svg?url';
+import Component from '@e2e/assets/circle.svg?react';
+import url from '@e2e/assets/circle.svg?url';
 
 function App() {
   return (

--- a/e2e/cases/plugin-svgr/query-url/src/App.css
+++ b/e2e/cases/plugin-svgr/query-url/src/App.css
@@ -1,5 +1,5 @@
 #test-css {
   width: 50px;
   height: 50px;
-  background-image: url('@assets/mobile.svg?url');
+  background-image: url('@e2e/assets/mobile.svg?url');
 }

--- a/e2e/cases/plugin-svgr/query-url/src/App.jsx
+++ b/e2e/cases/plugin-svgr/query-url/src/App.jsx
@@ -1,5 +1,5 @@
-import Logo from '@assets/mobile.svg';
-import svgImg from '@assets/mobile.svg?url';
+import Logo from '@e2e/assets/mobile.svg';
+import svgImg from '@e2e/assets/mobile.svg?url';
 import './App.css';
 
 function App() {

--- a/e2e/cases/print-file-size/basic/src/App.jsx
+++ b/e2e/cases/print-file-size/basic/src/App.jsx
@@ -1,5 +1,5 @@
 import './App.css';
-import img from '../../../../assets/icon.png?url';
+import img from '@e2e/assets/icon.png?url';
 
 const App = () => (
   <div id="test">

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -55,11 +55,6 @@ const updateConfigForTest = async (
   });
 
   const baseConfig: RsbuildConfig = {
-    resolve: {
-      alias: {
-        '@assets': join(__dirname, '../assets'),
-      },
-    },
     server: {
       // make port random to avoid conflict
       port: await getRandomPort(),

--- a/e2e/helper/package.json
+++ b/e2e/helper/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@e2e/helper",
+  "description": "Common helper functions used in E2E test cases.",
   "private": true,
   "version": "1.0.0",
   "exports": {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -20,6 +20,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
+    "@e2e/assets": "workspace:*",
     "@e2e/helper": "workspace:*",
     "@module-federation/enhanced": "0.19.1",
     "@module-federation/rsbuild-plugin": "0.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
         specifier: ^4.5.1
         version: 4.5.1(vue@3.5.21(typescript@5.9.2))
     devDependencies:
+      '@e2e/assets':
+        specifier: workspace:*
+        version: link:assets
       '@e2e/helper':
         specifier: workspace:*
         version: link:helper
@@ -212,6 +215,8 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+
+  e2e/assets: {}
 
   e2e/cases/browserslist/browserslist-config-mock: {}
 


### PR DESCRIPTION
## Summary

Turn the shared assets into a `@e2e/assets` package to simplify importing.

Before:

```js
import img from '../../../../assets/icon.png?url';
```

After:

```js
import img from '@e2e/assets/icon.png?url';
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
