### PR TITLE
fix: should detect JavaScript runtime when enable `--config-loader auto`

### DIFF
--- a/packages/core/src/loadConfig.ts
+++ b/packages/core/src/loadConfig.ts
@@ -140,7 +140,12 @@ export async function loadConfig({
   let configExport: RsbuildConfigExport;
 
   // Determine the loading strategy based on the config loader type
-  const useNative = loader === 'native' || loader === 'auto';
+  const useNative =
+    loader === 'native' ||
+    (loader === 'auto' &&
+      (process.features.typescript ||
+        process.versions.bun ||
+        process.versions.deno));
 
   if (useNative || /\.(?:js|mjs|cjs)$/.test(configFilePath)) {
     try {


### PR DESCRIPTION
## Summary

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
