### PR TITLE
test(e2e): print captured logs for failed tests

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -1,6 +1,7 @@
 import { promises } from 'node:fs';
 import path from 'node:path';
 import base, { expect } from '@playwright/test';
+import color from 'picocolors';
 import {
   type Build,
   build as baseBuild,
@@ -87,10 +88,23 @@ export const test = base.extend<RsbuildFixture>({
 
   logHelper: [
     // biome-ignore lint/correctness/noEmptyPattern: required by playwright
-    async ({}, use) => {
+    async ({}, use, testInfo) => {
       const logHelper = proxyConsole();
       await use(logHelper);
       logHelper.restore();
+
+      // If the test failed, log the console output for debugging
+      if (testInfo.status !== testInfo.expectedStatus) {
+        // header log
+        const header = `╭──────────────  Logs from: "${testInfo.title}" ──────────────╮`;
+        console.log(color.bold(`\n${header}\n`));
+
+        // body logs
+        logHelper.printCapturedLogs();
+
+        // footer log
+        console.log(color.bold(`╰${'─'.repeat(header.length - 2)}╯\n`));
+      }
     },
     { auto: true },
   ],

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -25,6 +25,7 @@ const matchPattern = (
 
 export const createLogHelper = () => {
   const logs: string[] = [];
+  const originalLogs: string[] = [];
 
   const logPatterns = new Set<{
     pattern: LogPattern;
@@ -39,6 +40,8 @@ export const createLogHelper = () => {
   const addLog = (input: string) => {
     const log = stripAnsi(input);
     logs.push(log);
+    originalLogs.push(input);
+
     for (const { pattern, resolve, options } of logPatterns) {
       if (matchPattern(log, pattern, options)) {
         resolve(true);
@@ -87,10 +90,17 @@ export const createLogHelper = () => {
 
   const expectBuildEnd = async () => expectLog(BUILD_END_LOG);
 
+  const printCapturedLogs = () => {
+    for (const log of originalLogs) {
+      console.log(log);
+    }
+  };
+
   return {
     logs,
     addLog,
     clearLogs,
+    printCapturedLogs,
     expectLog,
     expectNoLog,
     expectBuildEnd,


### PR DESCRIPTION
## Summary

Print the captured logs for failed E2E tests to make debugging easier:

<img width="1093" height="690" alt="Screenshot 2025-09-19 at 11 31 08" src="https://github.com/user-attachments/assets/3b731c38-fd8f-4763-8d43-51728be86d19" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
