### PR TITLE
chore: update pnpm workspace exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,8 @@ packages:
   - packages/**
   - examples/**
   - '!**/compiled/**'
-  - '!**/dist-types/**'
+  - '!**/dist/**'
+  - '!**/dist-*/**'
   - '!**/create-rsbuild/template-*/**'
   - '!**/test-temp-*/**'
 


### PR DESCRIPTION
## Summary

Update workspace exclusion patterns to include 'dist' and 'dist-*' directories. 

Fix: https://github.com/web-infra-dev/rsbuild/pull/6192/files#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bb

<img width="2310" height="964" alt="image" src="https://github.com/user-attachments/assets/6d181bdd-b3e2-47cd-9960-f262825a7cda" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
