### PR TITLE
test(e2e): add manifest chunks order test case

### DIFF
--- a/e2e/cases/output/manifest-css-order/index.test.ts
+++ b/e2e/cases/output/manifest-css-order/index.test.ts
@@ -8,17 +8,16 @@ test('should generate manifest with initial chunks in correct order', async ({
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
+  const filenames = Object.keys(files);
   const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+    files[filenames.find((file) => file.endsWith('manifest.json'))!];
   const manifest: ManifestData = JSON.parse(manifestContent);
 
-  for (const entryData of Object.values(manifest.entries)) {
-    const htmlFileName = entryData.html![0];
-    const htmlContent =
-      files[Object.keys(files).find((file) => file.endsWith(htmlFileName))!];
-    expect(htmlContent).toBeDefined();
+  for (const entry of Object.values(manifest.entries)) {
+    const htmlFileName = entry.html![0];
+    const html = files[filenames.find((file) => file.endsWith(htmlFileName))!];
 
-    const scriptMatches = htmlContent.match(/<script[^>]*src="([^"]+)"/g) || [];
+    const scriptMatches = html.match(/<script[^>]*src="([^"]+)"/g) || [];
     const htmlScriptOrder = scriptMatches
       .map((match) => {
         const srcMatch = match.match(/src="([^"]+)"/);
@@ -27,7 +26,7 @@ test('should generate manifest with initial chunks in correct order', async ({
       .filter(Boolean);
 
     const linkMatches =
-      htmlContent.match(/<link[^>]*href="([^"]+)"[^>]*rel="stylesheet"/g) || [];
+      html.match(/<link[^>]*href="([^"]+)"[^>]*rel="stylesheet"/g) || [];
     const htmlCssOrder = linkMatches
       .map((match) => {
         const hrefMatch = match.match(/href="([^"]+)"/);
@@ -35,7 +34,7 @@ test('should generate manifest with initial chunks in correct order', async ({
       })
       .filter(Boolean);
 
-    expect(entryData.initial?.js).toEqual(htmlScriptOrder);
-    expect(entryData.initial?.css).toEqual(htmlCssOrder);
+    expect(entry.initial?.js).toEqual(htmlScriptOrder);
+    expect(entry.initial?.css).toEqual(htmlCssOrder);
   }
 });

--- a/e2e/cases/output/manifest-css-order/index.test.ts
+++ b/e2e/cases/output/manifest-css-order/index.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@e2e/helper';
+import type { ManifestData } from '@rsbuild/core';
+
+// https://github.com/web-infra-dev/rsbuild/issues/6187
+test('should generate manifest with initial chunks in correct order', async ({
+  build,
+}) => {
+  const rsbuild = await build();
+
+  const files = rsbuild.getDistFiles();
+  const manifestContent =
+    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifest: ManifestData = JSON.parse(manifestContent);
+
+  for (const entryData of Object.values(manifest.entries)) {
+    const htmlFileName = entryData.html![0];
+    const htmlContent =
+      files[Object.keys(files).find((file) => file.endsWith(htmlFileName))!];
+    expect(htmlContent).toBeDefined();
+
+    const scriptMatches = htmlContent.match(/<script[^>]*src="([^"]+)"/g) || [];
+    const htmlScriptOrder = scriptMatches
+      .map((match) => {
+        const srcMatch = match.match(/src="([^"]+)"/);
+        return srcMatch ? srcMatch[1] : '';
+      })
+      .filter(Boolean);
+
+    const linkMatches =
+      htmlContent.match(/<link[^>]*href="([^"]+)"[^>]*rel="stylesheet"/g) || [];
+    const htmlCssOrder = linkMatches
+      .map((match) => {
+        const hrefMatch = match.match(/href="([^"]+)"/);
+        return hrefMatch ? hrefMatch[1] : '';
+      })
+      .filter(Boolean);
+
+    expect(entryData.initial?.js).toEqual(htmlScriptOrder);
+    expect(entryData.initial?.css).toEqual(htmlCssOrder);
+  }
+});

--- a/e2e/cases/output/manifest-css-order/rsbuild.config.ts
+++ b/e2e/cases/output/manifest-css-order/rsbuild.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  source: {
+    entry: {
+      foo: './src/foo.js',
+      bar: './src/bar.js',
+      bar2: './src/bar.js',
+    },
+  },
+  output: {
+    manifest: true,
+    filenameHash: false,
+  },
+  performance: {
+    chunkSplit: {
+      strategy: 'split-by-module',
+    },
+  },
+});

--- a/e2e/cases/output/manifest-css-order/src/bar.css
+++ b/e2e/cases/output/manifest-css-order/src/bar.css
@@ -1,0 +1,3 @@
+h1 {
+  color: green;
+}

--- a/e2e/cases/output/manifest-css-order/src/bar.js
+++ b/e2e/cases/output/manifest-css-order/src/bar.js
@@ -1,0 +1,2 @@
+import './base.css';
+import './bar.css';

--- a/e2e/cases/output/manifest-css-order/src/base.css
+++ b/e2e/cases/output/manifest-css-order/src/base.css
@@ -1,0 +1,3 @@
+h1 {
+  color: black;
+}

--- a/e2e/cases/output/manifest-css-order/src/env.d.ts
+++ b/e2e/cases/output/manifest-css-order/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="@rsbuild/core/types" />
+
+/**
+ * Imports the SVG file as a React component.
+ * @requires [@rsbuild/plugin-svgr](https://npmjs.com/package/@rsbuild/plugin-svgr)
+ */
+declare module '*.svg?react' {
+  import type React from 'react';
+  const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  export default ReactComponent;
+}

--- a/e2e/cases/output/manifest-css-order/src/foo.js
+++ b/e2e/cases/output/manifest-css-order/src/foo.js
@@ -1,0 +1,2 @@
+import './base.css';
+import './foo.css';

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -9,7 +9,7 @@ import {
   type Dev,
   type DevResult,
 } from './jsApi';
-import { type LogHelper, proxyConsole } from './logs';
+import { type ExtendedLogHelper, proxyConsole } from './logs';
 
 type EditFile = (
   filename: string,
@@ -33,7 +33,7 @@ type RsbuildFixture = {
    * // Clear collected logs
    * logHelper.clearLogs();
    */
-  logHelper: LogHelper;
+  logHelper: ExtendedLogHelper;
 
   /**
    * Build the project. No preview server or page navigation by default.

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -107,7 +107,7 @@ export type ProxyConsoleOptions = {
   types?: ConsoleType | ConsoleType[];
 };
 
-export type ProxyConsoleResult = LogHelper & {
+export type ExtendedLogHelper = LogHelper & {
   /**
    * Restore the original console methods
    */
@@ -123,7 +123,7 @@ export type ProxyConsoleResult = LogHelper & {
  */
 export const proxyConsole = ({
   types = ['log', 'warn', 'info', 'error'],
-}: ProxyConsoleOptions = {}): ProxyConsoleResult => {
+}: ProxyConsoleOptions = {}): ExtendedLogHelper => {
   const restores: Array<() => void> = [];
   const logHelper = createLogHelper();
 


### PR DESCRIPTION
## Summary

Add test case to verify manifest generation with correct initial chunk order.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/6187
- https://github.com/web-infra-dev/rsbuild/pull/6192

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
