### PR TITLE
docs: clarify hash settings in cssModules docs

### DIFF
--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -216,13 +216,13 @@ You can use the following template strings in `localIdentName`:
 
 ### Example
 
-Set `localIdentName` to other value:
+Set `localIdentName` to other value, for example, the shortest 5-character hash value:
 
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
     cssModules: {
-      localIdentName: '[hash:base64:4]',
+      localIdentName: '[hash:base64:5]',
     },
   },
 };

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -216,7 +216,7 @@ You can use the following template strings in `localIdentName`:
 
 ### Example
 
-Set `localIdentName` to other value, for example, the shortest 5-character hash value:
+Set `localIdentName` to other value, for example, the shorter 5-character hash value:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -227,6 +227,10 @@ export default {
   },
 };
 ```
+
+:::tip
+If the hash length is set too short, it may increase the risk of class name conflicts.
+:::
 
 ## cssModules.mode
 

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -212,7 +212,7 @@ You can use the following template strings in `localIdentName`:
 - `[path]` - the relative path.
 - `[file]` - filename and path.
 - `[ext]` - extension with leading dot.
-- `[hash:<hashDigest>:<hashDigestLength>]`: hash with hash settings.
+- `[hash:<hashDigest>:<hashDigestLength>]`: hash with hash settings. `hashDigest` is the [hash encodings](https://rspack.rs/config/output#outputhashdigest), and `hashDigestLength` is the length of the hash value.
 
 ### Example
 

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -216,13 +216,13 @@ console.log(styles.header);
 
 ### 示例
 
-将 `localIdentName` 设置为其他值：
+将 `localIdentName` 设置为其他值，例如最简短的五位哈希值：
 
 ```ts title="rsbuild.config.ts"
 export default {
   output: {
     cssModules: {
-      localIdentName: '[hash:base64:4]',
+      localIdentName: '[hash:base64:5]',
     },
   },
 };

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -216,7 +216,7 @@ console.log(styles.header);
 
 ### 示例
 
-将 `localIdentName` 设置为其他值，例如最简短的五位哈希值：
+将 `localIdentName` 设置为其他值，例如更简短的五位哈希值：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -227,6 +227,10 @@ export default {
   },
 };
 ```
+
+:::tip
+如果 hash 长度设置得较短，可能会增加类名冲突的风险。
+:::
 
 ## cssModules.mode
 

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -212,7 +212,7 @@ console.log(styles.header);
 - `[path]` - 源文件的相对路径。
 - `[file]` - 文件名和路径。
 - `[ext]` - 文件后缀名，包含点号。
-- `[hash:<hashDigest>:<hashDigestLength>]` - 带有哈希设置的哈希。
+- `[hash:<hashDigest>:<hashDigestLength>]` - 带有哈希设置的哈希。其中 `hashDigest` 是[哈希编码](https://rspack.rs/zh/config/output#outputhashdigest)，`hashDigestLength` 是哈希值的长度。
 
 ### 示例
 


### PR DESCRIPTION
## Summary

Add details about `hashDigest` and `hashDigestLength` parameters in documentation to improve clarity for users configuring CSS Modules.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
