### PR TITLE
docs: configuring output directories for multi-env builds

### DIFF
--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -1,4 +1,4 @@
-# Multi-environment builds
+### Multi-environment builds
 
 Rsbuild supports building outputs for multiple environments at the same time. You can use [environments](/config/environments) to build multiple environments in parallel and set a different Rsbuild config for each environment.
 
@@ -164,6 +164,41 @@ export default {
 ```
 
 If you are a plugin developer, you can view [Developing environment plugins](/plugins/dev/index#environment-plugin) for details.
+
+## Configuring Output Directories
+
+When building for multiple environments, it's recommended to configure different output directories for each environment to prevent dist files with the same name from overwriting each other.
+
+You can use [output.distPath.root](/config/output/dist-path) to set independent output root directories for each environment.
+
+For example, output the web bundles to the default `dist` directory, and the node bundles to `dist/server`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
+    },
+    node: {
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
+      },
+    },
+  },
+};
+```
 
 ## Plugin API
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -1,4 +1,4 @@
-### Multi-environment builds
+# Multi-environment builds
 
 Rsbuild supports building outputs for multiple environments at the same time. You can use [environments](/config/environments) to build multiple environments in parallel and set a different Rsbuild config for each environment.
 

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -165,7 +165,7 @@ export default {
 
 If you are a plugin developer, you can view [Developing environment plugins](/plugins/dev/index#environment-plugin) for details.
 
-## Configuring Output Directories
+## Configuring output directories
 
 When building for multiple environments, it's recommended to configure different output directories for each environment to prevent dist files with the same name from overwriting each other.
 

--- a/website/docs/zh/guide/advanced/environments.mdx
+++ b/website/docs/zh/guide/advanced/environments.mdx
@@ -165,6 +165,41 @@ export default {
 
 如果你是插件开发者，可查看 [开发 Environment 插件](/plugins/dev/index#environment-插件) 了解详情。
 
+## 配置输出目录
+
+在多环境构建时，建议为不同的环境配置不同的输出目录，以避免不同环境的同名构建产物互相覆盖。
+
+你可以通过 [output.distPath.root](/config/output/dist-path) 来为每个环境设置独立的输出根目录。
+
+比如，将 web 产物输出到默认的 `dist`，将 node 产物输出到 `dist/server`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  environments: {
+    web: {
+      source: {
+        entry: {
+          index: './src/index.client.js',
+        },
+      },
+    },
+    node: {
+      source: {
+        entry: {
+          index: './src/index.server.js',
+        },
+      },
+      output: {
+        target: 'node',
+        distPath: {
+          root: 'dist/server',
+        },
+      },
+    },
+  },
+};
+```
+
 ## 插件 API
 
 ### 更新配置


### PR DESCRIPTION
## Summary

Explain how to use `output.distPath.root` to avoid dist files overwriting each other when building for multiple environments.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/6150

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
