### PR TITLE
test(e2e): add exec method to fixture

### DIFF
--- a/e2e/cases/cli/shortcuts/index.test.ts
+++ b/e2e/cases/cli/shortcuts/index.test.ts
@@ -1,84 +1,72 @@
-import { rspackTest, runCommand } from '@e2e/helper';
+import { rspackTest } from '@e2e/helper';
 
-rspackTest('should display shortcuts as expected in dev', async () => {
-  const { childProcess, expectLog, clearLogs, close } = runCommand(
-    'node ./dev.mjs',
-    {
-      cwd: __dirname,
-    },
-  );
+rspackTest(
+  'should display shortcuts as expected in dev',
+  async ({ exec, logHelper }) => {
+    const { childProcess } = exec('node ./dev.mjs');
+    const { expectLog, clearLogs } = logHelper;
 
-  // help
-  await expectLog('press h + enter to show shortcuts');
-  childProcess.stdin?.write('h\n');
-  await expectLog('u + enter  show urls');
+    // help
+    await expectLog('press h + enter to show shortcuts');
+    childProcess.stdin?.write('h\n');
+    await expectLog('u + enter  show urls');
 
-  // print urls
-  clearLogs();
-  childProcess.stdin?.write('u\n');
-  await expectLog('➜  Local:    http://localhost:');
+    // print urls
+    clearLogs();
+    childProcess.stdin?.write('u\n');
+    await expectLog('➜  Local:    http://localhost:');
 
-  // restart server
-  clearLogs();
-  childProcess.stdin?.write('r\n');
-  await expectLog('restarting server');
-  await expectLog('➜  Local:    http://localhost:');
+    // restart server
+    clearLogs();
+    childProcess.stdin?.write('r\n');
+    await expectLog('restarting server');
+    await expectLog('➜  Local:    http://localhost:');
+  },
+);
 
-  close();
-});
+rspackTest(
+  'should display shortcuts as expected in preview',
+  async ({ exec, logHelper }) => {
+    const { childProcess } = exec('node ./preview.mjs');
+    const { expectLog, clearLogs } = logHelper;
 
-rspackTest('should display shortcuts as expected in preview', async () => {
-  const { childProcess, expectLog, clearLogs, close } = runCommand(
-    'node ./preview.mjs',
-    {
-      cwd: __dirname,
-    },
-  );
+    // help
+    await expectLog('press h + enter to show shortcuts');
+    childProcess.stdin?.write('h\n');
+    await expectLog('u + enter  show urls');
 
-  // help
-  await expectLog('press h + enter to show shortcuts');
-  childProcess.stdin?.write('h\n');
-  await expectLog('u + enter  show urls');
+    // print urls
+    clearLogs();
+    childProcess.stdin?.write('u\n');
+    await expectLog('➜  Local:    http://localhost:');
+  },
+);
 
-  // print urls
-  clearLogs();
-  childProcess.stdin?.write('u\n');
-  await expectLog('➜  Local:    http://localhost:');
+rspackTest(
+  'should support custom shortcuts in dev',
+  async ({ exec, logHelper }) => {
+    const { childProcess } = exec('node ./devCustom.mjs');
+    const { expectLog, clearLogs } = logHelper;
 
-  close();
-});
+    await expectLog('press h + enter to show shortcuts');
 
-rspackTest('should support custom shortcuts in dev', async () => {
-  const { childProcess, expectLog, clearLogs, close } = runCommand(
-    'node ./devCustom.mjs',
-    {
-      cwd: __dirname,
-    },
-  );
+    clearLogs();
+    childProcess.stdin?.write('s\n');
+    await expectLog('hello world!');
+  },
+);
 
-  await expectLog('press h + enter to show shortcuts');
+rspackTest(
+  'should support custom shortcuts in preview',
+  async ({ exec, logHelper }) => {
+    const { childProcess } = exec('node ./previewCustom.mjs');
+    const { expectLog, clearLogs } = logHelper;
 
-  clearLogs();
-  childProcess.stdin?.write('s\n');
-  await expectLog('hello world!');
+    // help
+    await expectLog('press h + enter to show shortcuts');
 
-  close();
-});
-
-rspackTest('should support custom shortcuts in preview', async () => {
-  const { childProcess, expectLog, clearLogs, close } = runCommand(
-    'node ./previewCustom.mjs',
-    {
-      cwd: __dirname,
-    },
-  );
-
-  // help
-  await expectLog('press h + enter to show shortcuts');
-
-  clearLogs();
-  childProcess.stdin?.write('s\n');
-  await expectLog('hello world!');
-
-  close();
-});
+    clearLogs();
+    childProcess.stdin?.write('s\n');
+    await expectLog('hello world!');
+  },
+);

--- a/e2e/cases/profiling/rspack-profile/index.test.ts
+++ b/e2e/cases/profiling/rspack-profile/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest, runCli, runCommand, test } from '@e2e/helper';
+import { expect, rspackTest, runCli, test } from '@e2e/helper';
 import { removeSync } from 'fs-extra';
 
 test.afterAll(() => {
@@ -20,20 +20,22 @@ const getProfilePath = (logs: string[]) =>
     ?.split(PROFILE_LOG)[1]
     ?.trim();
 
-rspackTest('should generate rspack profile as expected in dev', async () => {
-  const { logs, close, expectLog } = runCommand('node ./dev.mjs', {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      RSPACK_PROFILE: 'OVERVIEW',
-    },
-  });
+rspackTest(
+  'should generate rspack profile as expected in dev',
+  async ({ exec, logHelper }) => {
+    exec('node ./dev.mjs', {
+      env: {
+        ...process.env,
+        RSPACK_PROFILE: 'OVERVIEW',
+      },
+    });
+    const { logs, expectLog } = logHelper;
 
-  await expectLog(PROFILE_LOG);
-  const profileFile = getProfilePath(logs);
-  expect(fs.existsSync(profileFile!)).toBeTruthy();
-  close();
-});
+    await expectLog(PROFILE_LOG);
+    const profileFile = getProfilePath(logs);
+    expect(fs.existsSync(profileFile!)).toBeTruthy();
+  },
+);
 
 rspackTest('should generate rspack profile as expected in build', async () => {
   const { logs, close, expectLog } = runCli('build', {

--- a/e2e/helper/cli.ts
+++ b/e2e/helper/cli.ts
@@ -17,7 +17,7 @@ export function runCliSync(command: string, options?: ExecSyncOptions) {
   return execSync(`node ${RSBUILD_BIN_PATH} ${command}`, options);
 }
 
-export function runCommand(command: string, options?: ExecOptions) {
+function runCommand(command: string, options?: ExecOptions) {
   const childProcess = exec(command, options);
 
   const logHelper = createLogHelper();


### PR DESCRIPTION
## Summary

- Add a new `exec` method to fixture
- Replace `runCommand` usage with fixture `exec` in test cases

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
