### PR TITLE
test(e2e): move Rsbuild CLI execution logic to fixture

### DIFF
--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -1,37 +1,34 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest, runCli } from '@e2e/helper';
+import { expectFileWithContent, rspackTest } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest('should allow to custom watch options for build watch', async () => {
-  const srcDir = path.join(__dirname, 'src');
-  const tempDir = path.join(__dirname, 'test-temp-src');
-  const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  const fooFile = path.join(tempDir, 'foo.js');
-  const barFile = path.join(tempDir, 'bar.js');
+rspackTest(
+  'should allow to custom watch options for build watch',
+  async ({ execCli, logHelper }) => {
+    const srcDir = path.join(__dirname, 'src');
+    const tempDir = path.join(__dirname, 'test-temp-src');
+    const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
+    const fooFile = path.join(tempDir, 'foo.js');
+    const barFile = path.join(tempDir, 'bar.js');
 
-  await fse.copy(srcDir, tempDir);
+    await fse.copy(srcDir, tempDir);
 
-  const { close, expectLog, expectNoLog, expectBuildEnd, clearLogs } = runCli(
-    'build --watch',
-    {
-      cwd: __dirname,
-    },
-  );
+    execCli('build --watch');
+    const { expectLog, expectNoLog, expectBuildEnd, clearLogs } = logHelper;
 
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'foo1bar1');
-  clearLogs();
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'foo1bar1');
+    clearLogs();
 
-  // should watch foo.js
-  fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
-  await expectLog(/building test-temp-src[\\/]foo.js/);
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'foo2bar1');
+    // should watch foo.js
+    fse.outputFileSync(fooFile, `export const foo = 'foo2';`);
+    await expectLog(/building test-temp-src[\\/]foo.js/);
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'foo2bar1');
 
-  // should not watch bar.js
-  fse.outputFileSync(barFile, `export const bar = 'bar2';`);
-  await new Promise((resolve) => setTimeout(resolve, 100));
-  expectNoLog(/building test-temp-src[\\/]bar.js/);
-
-  close();
-});
+    // should not watch bar.js
+    fse.outputFileSync(barFile, `export const bar = 'bar2';`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expectNoLog(/building test-temp-src[\\/]bar.js/);
+  },
+);

--- a/e2e/cases/cli/build-watch-restart/index.test.ts
+++ b/e2e/cases/cli/build-watch-restart/index.test.ts
@@ -1,51 +1,48 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest, runCli } from '@e2e/helper';
+import { expectFileWithContent, rspackTest } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest('should support restart build when config changed', async () => {
-  const indexFile = path.join(__dirname, 'src/index.js');
-  const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-  const tempConfig = path.join(__dirname, 'test-temp-rsbuild.config.mjs');
+rspackTest(
+  'should support restart build when config changed',
+  async ({ execCli, logHelper }) => {
+    const indexFile = path.join(__dirname, 'src/index.js');
+    const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
+    const tempConfig = path.join(__dirname, 'test-temp-rsbuild.config.mjs');
 
-  fse.outputFileSync(indexFile, `console.log('hello!');`);
-  fse.outputFileSync(
-    tempConfig,
-    `export default {
+    fse.outputFileSync(indexFile, `console.log('hello!');`);
+    fse.outputFileSync(
+      tempConfig,
+      `export default {
   output: {
     filenameHash: false,
   },
 };
 `,
-  );
+    );
 
-  const { close, clearLogs, expectLog, expectBuildEnd } = runCli(
-    `build --watch -c ${tempConfig}`,
-    {
-      cwd: __dirname,
-    },
-  );
+    execCli(`build --watch -c ${tempConfig}`);
+    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'hello!');
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'hello!');
 
-  fse.outputFileSync(
-    tempConfig,
-    `export default {
+    fse.outputFileSync(
+      tempConfig,
+      `export default {
   // update
   output: {
     filenameHash: false,
   },
 };
 `,
-  );
+    );
 
-  await expectLog('restarting build');
-  await expectFileWithContent(distIndexFile, 'hello!');
+    await expectLog('restarting build');
+    await expectFileWithContent(distIndexFile, 'hello!');
 
-  clearLogs();
-  fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'hello2!');
-
-  close();
-});
+    clearLogs();
+    fse.outputFileSync(indexFile, `console.log('hello2!');`);
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'hello2!');
+  },
+);

--- a/e2e/cases/cli/build-watch/index.test.ts
+++ b/e2e/cases/cli/build-watch/index.test.ts
@@ -1,28 +1,25 @@
 import path from 'node:path';
-import { expectFileWithContent, rspackTest, runCli } from '@e2e/helper';
+import { expectFileWithContent, rspackTest } from '@e2e/helper';
 import fse from 'fs-extra';
 
-rspackTest('should support watch mode for build command', async () => {
-  const indexFile = path.join(__dirname, 'src/index.js');
-  const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
+rspackTest(
+  'should support watch mode for build command',
+  async ({ execCli, logHelper }) => {
+    const indexFile = path.join(__dirname, 'src/index.js');
+    const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
 
-  fse.outputFileSync(indexFile, `console.log('hello!');`);
+    fse.outputFileSync(indexFile, `console.log('hello!');`);
 
-  const { expectBuildEnd, close, clearLogs, expectLog } = runCli(
-    'build --watch',
-    {
-      cwd: __dirname,
-    },
-  );
+    execCli('build --watch');
+    const { expectBuildEnd, clearLogs, expectLog } = logHelper;
 
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'hello!');
-  clearLogs();
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'hello!');
+    clearLogs();
 
-  fse.outputFileSync(indexFile, `console.log('hello2!');`);
-  await expectLog(/building src[\\/]index.js/);
-  await expectBuildEnd();
-  await expectFileWithContent(distIndexFile, 'hello2!');
-
-  close();
-});
+    fse.outputFileSync(indexFile, `console.log('hello2!');`);
+    await expectLog(/building src[\\/]index.js/);
+    await expectBuildEnd();
+    await expectFileWithContent(distIndexFile, 'hello2!');
+  },
+);

--- a/e2e/cases/cli/reload-config/index.test.ts
+++ b/e2e/cases/cli/reload-config/index.test.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expectFile, getRandomPort, rspackTest, runCli } from '@e2e/helper';
+import { expectFile, getRandomPort, rspackTest } from '@e2e/helper';
 import { remove } from 'fs-extra';
 
 rspackTest(
   'should restart dev server and reload config when config file changed',
-  async () => {
+  async ({ execCli }) => {
     const dist1 = path.join(__dirname, 'dist');
     const dist2 = path.join(__dirname, 'dist-2');
     const configFile = path.join(__dirname, 'rsbuild.config.mjs');
@@ -29,9 +29,7 @@ rspackTest(
     };`,
     );
 
-    const { close } = runCli('dev', {
-      cwd: __dirname,
-    });
+    execCli('dev');
 
     await expectFile(dist1);
 
@@ -51,7 +49,5 @@ rspackTest(
     );
 
     await expectFile(dist2);
-
-    close();
   },
 );

--- a/e2e/cases/cli/reload-env/index.test.ts
+++ b/e2e/cases/cli/reload-env/index.test.ts
@@ -1,22 +1,19 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  expectFileWithContent,
-  getRandomPort,
-  rspackTest,
-  runCli,
-} from '@e2e/helper';
+import { expectFileWithContent, getRandomPort, rspackTest } from '@e2e/helper';
 
-rspackTest('should restart dev server when .env file is changed', async () => {
-  const dist = path.join(__dirname, 'dist');
-  const configFile = path.join(__dirname, 'rsbuild.config.mjs');
-  const envLocalFile = path.join(__dirname, '.env.local');
-  const distIndex = path.join(dist, 'static/js/index.js');
+rspackTest(
+  'should restart dev server when .env file is changed',
+  async ({ execCli, logHelper }) => {
+    const dist = path.join(__dirname, 'dist');
+    const configFile = path.join(__dirname, 'rsbuild.config.mjs');
+    const envLocalFile = path.join(__dirname, '.env.local');
+    const distIndex = path.join(dist, 'static/js/index.js');
 
-  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
-  fs.writeFileSync(
-    configFile,
-    `export default {
+    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=jack');
+    fs.writeFileSync(
+      configFile,
+      `export default {
       dev: {
         writeToDisk: true,
       },
@@ -25,24 +22,18 @@ rspackTest('should restart dev server when .env file is changed', async () => {
       },
       server: { port: ${await getRandomPort()} }
     };`,
-  );
+    );
 
-  const { close, clearLogs, expectLog, expectBuildEnd } = runCli('dev', {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      NODE_ENV: 'development',
-    },
-  });
+    execCli('dev');
+    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
-  await expectBuildEnd();
-  await expectFileWithContent(distIndex, 'jack');
+    await expectBuildEnd();
+    await expectFileWithContent(distIndex, 'jack');
 
-  clearLogs();
-  fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
-  await expectLog('restarting server');
-  await expectBuildEnd();
-  await expectFileWithContent(distIndex, 'rose');
-
-  close();
-});
+    clearLogs();
+    fs.writeFileSync(envLocalFile, 'PUBLIC_NAME=rose');
+    await expectLog('restarting server');
+    await expectBuildEnd();
+    await expectFileWithContent(distIndex, 'rose');
+  },
+);

--- a/e2e/cases/cli/watch-files-array/index.test.ts
+++ b/e2e/cases/cli/watch-files-array/index.test.ts
@@ -1,28 +1,21 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  expect,
-  getRandomPort,
-  gotoPage,
-  rspackTest,
-  runCli,
-} from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, rspackTest } from '@e2e/helper';
 
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 
 rspackTest(
   'should restart dev server when extra config file changed',
-  async ({ page }) => {
+  async ({ page, execCli, logHelper }) => {
     fs.writeFileSync(tempConfig, 'export default 1;');
 
     const port = await getRandomPort();
-    const { close, expectBuildEnd, expectLog, clearLogs } = runCli('dev', {
-      cwd: __dirname,
+    execCli('dev', {
       env: {
-        ...process.env,
         PORT: String(port),
       },
     });
+    const { expectBuildEnd, expectLog, clearLogs } = logHelper;
 
     // the first build
     await expectBuildEnd();
@@ -36,6 +29,5 @@ rspackTest(
     await expectBuildEnd();
     await gotoPage(page, { port });
     await expect(page.locator('#test')).toHaveText('2');
-    close();
   },
 );

--- a/e2e/cases/cli/watch-files/index.test.ts
+++ b/e2e/cases/cli/watch-files/index.test.ts
@@ -1,13 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  expect,
-  getRandomPort,
-  gotoPage,
-  rspackTest,
-  runCli,
-  test,
-} from '@e2e/helper';
+import { expect, getRandomPort, gotoPage, rspackTest, test } from '@e2e/helper';
 
 const tempConfig = path.join(__dirname, 'test-temp-config.ts');
 
@@ -17,16 +10,14 @@ test.beforeEach(async () => {
 
 rspackTest(
   'should restart dev server when extra config file changed',
-  async ({ page }) => {
+  async ({ page, execCli, logHelper }) => {
     const port = await getRandomPort();
-    const { close, clearLogs, expectLog, expectBuildEnd } = runCli('dev', {
-      cwd: __dirname,
+    execCli('dev', {
       env: {
-        ...process.env,
         PORT: String(port),
-        NODE_ENV: 'development',
       },
     });
+    const { clearLogs, expectLog, expectBuildEnd } = logHelper;
 
     // the first build
     await expectBuildEnd();
@@ -40,6 +31,5 @@ rspackTest(
     await expectBuildEnd();
     await gotoPage(page, { port });
     await expect(page.locator('#test')).toHaveText('2');
-    close();
   },
 );

--- a/e2e/cases/profiling/rspack-profile/index.test.ts
+++ b/e2e/cases/profiling/rspack-profile/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest, runCli, test } from '@e2e/helper';
+import { expect, rspackTest, test } from '@e2e/helper';
 import { removeSync } from 'fs-extra';
 
 test.afterAll(() => {
@@ -37,17 +37,18 @@ rspackTest(
   },
 );
 
-rspackTest('should generate rspack profile as expected in build', async () => {
-  const { logs, close, expectLog } = runCli('build', {
-    cwd: __dirname,
-    env: {
-      ...process.env,
-      RSPACK_PROFILE: 'OVERVIEW',
-    },
-  });
+rspackTest(
+  'should generate rspack profile as expected in build',
+  async ({ execCli, logHelper }) => {
+    execCli('build', {
+      env: {
+        RSPACK_PROFILE: 'OVERVIEW',
+      },
+    });
+    const { logs, expectLog } = logHelper;
 
-  await expectLog(PROFILE_LOG);
-  const profileFile = getProfilePath(logs);
-  expect(fs.existsSync(profileFile!)).toBeTruthy();
-  close();
-});
+    await expectLog(PROFILE_LOG);
+    const profileFile = getProfilePath(logs);
+    expect(fs.existsSync(profileFile!)).toBeTruthy();
+  },
+);

--- a/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-reload/index.test.ts
@@ -5,14 +5,13 @@ import {
   getRandomPort,
   gotoPage,
   rspackTest,
-  runCli,
 } from '@e2e/helper';
 import fse from 'fs-extra';
 import { tempConfig } from './rsbuild.config';
 
 rspackTest(
   'should watch tsconfig.json and reload the server when it changes',
-  async ({ page, editFile }) => {
+  async ({ page, editFile, execCli }) => {
     if (process.platform === 'win32') {
       return;
     }
@@ -24,10 +23,8 @@ rspackTest(
     await fse.copy(join(__dirname, 'tsconfig.json'), tempConfig);
 
     const port = await getRandomPort();
-    const { close } = runCli('dev', {
-      cwd: __dirname,
+    execCli('dev', {
       env: {
-        ...process.env,
         PORT: String(port),
       },
     });
@@ -38,7 +35,5 @@ rspackTest(
 
     await editFile(tempConfig, (code) => code.replace('foo', 'bar'));
     await expect(page.locator('#content')).toHaveText('bar');
-
-    close();
   },
 );

--- a/e2e/helper/cli.ts
+++ b/e2e/helper/cli.ts
@@ -1,11 +1,5 @@
-import {
-  type ExecOptions,
-  type ExecSyncOptions,
-  exec,
-  execSync,
-} from 'node:child_process';
+import { type ExecSyncOptions, execSync } from 'node:child_process';
 import { RSBUILD_BIN_PATH } from './constants';
-import { createLogHelper } from './logs';
 
 /**
  * Synchronously run the Rsbuild CLI with the given command.
@@ -15,33 +9,4 @@ import { createLogHelper } from './logs';
  */
 export function runCliSync(command: string, options?: ExecSyncOptions) {
   return execSync(`node ${RSBUILD_BIN_PATH} ${command}`, options);
-}
-
-function runCommand(command: string, options?: ExecOptions) {
-  const childProcess = exec(command, options);
-
-  const logHelper = createLogHelper();
-
-  const onData = (data: Buffer) => {
-    logHelper.addLog(data.toString());
-  };
-
-  childProcess.stdout?.on('data', onData);
-  childProcess.stderr?.on('data', onData);
-
-  const close = () => {
-    childProcess.stdout?.off('data', onData);
-    childProcess.stderr?.off('data', onData);
-    childProcess.kill();
-  };
-
-  return {
-    ...logHelper,
-    close,
-    childProcess,
-  };
-}
-
-export function runCli(command: string, options?: ExecOptions) {
-  return runCommand(`node ${RSBUILD_BIN_PATH} ${command}`, options);
 }


### PR DESCRIPTION
## Summary

Move the CLI execution logic to fixture and simplify test cases by using the new `execCli` helper.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
