### PR TITLE
fix(cli): improve version log when displaying help

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -84,7 +84,10 @@ const applyServerOptions = (command: Command) => {
 export function setupCommands(): void {
   const cli = cac('rsbuild');
 
-  cli.help();
+  cli.help((sections) => {
+    // remove the default version log as we already log it in greeting
+    sections.shift();
+  });
   cli.version(RSBUILD_VERSION);
 
   // Apply common options to all commands

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -14,12 +14,6 @@ function initNodeEnv() {
 }
 
 function showGreeting() {
-  // Skip greeting when help is requested, as cac's help output already contains
-  // information that would be redundant with the greeting message
-  if (argv.some((item) => item === '--help' || item === '-h')) {
-    return;
-  }
-
   // Ensure consistent spacing before the greeting message.
   // Different package managers handle output formatting differently - some automatically
   // add a blank line before command output, while others do not.


### PR DESCRIPTION
## Summary

Remove the built-in version log of cac and use Rsbuild CLI's greeting log instead.

### Before

<img width="597" height="269" alt="Screenshot 2025-09-21 at 16 56 18" src="https://github.com/user-attachments/assets/15eae318-1f51-4a70-b1ce-03dd28138307" />


### After

<img width="572" height="290" alt="Screenshot 2025-09-21 at 16 56 09" src="https://github.com/user-attachments/assets/0d44fab3-f51d-401b-82d6-5fc244398262" />


## Related Links

https://github.com/cacjs/cac?tab=readme-ov-file#clihelpcallback

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
