### PR TITLE
feat(cli): improve help output formatting

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -1,4 +1,5 @@
 import cac, { type CAC, type Command } from 'cac';
+import { color } from '../helpers';
 import type { ConfigLoader } from '../loadConfig';
 import { logger } from '../logger';
 import { RSPACK_BUILD_ERROR } from '../provider/build';
@@ -84,17 +85,13 @@ const applyServerOptions = (command: Command) => {
 export function setupCommands(): void {
   const cli = cac('rsbuild');
 
-  cli.help((sections) => {
-    // remove the default version log as we already log it in greeting
-    sections.shift();
-  });
   cli.version(RSBUILD_VERSION);
 
   // Apply common options to all commands
   applyCommonOptions(cli);
 
-  // Allow to run `rsbuild` without any sub-command to trigger dev
-  const devCommand = cli.command('', 'Start the dev server').alias('dev');
+  const devDescription = `Start the dev server ${color.dim('(default if no command is given)')}`;
+  const devCommand = cli.command('', devDescription).alias('dev');
   const buildCommand = cli.command('build', 'Build the app for production');
   const previewCommand = cli.command(
     'preview',
@@ -181,6 +178,29 @@ export function setupCommands(): void {
         process.exit(1);
       }
     });
+
+  cli.help((sections) => {
+    // remove the default version log as we already log it in greeting
+    sections.shift();
+
+    for (const section of sections) {
+      // Fix the dev command name
+      if (section.title === 'Commands') {
+        section.body = section.body.replace(
+          `         ${devDescription}`,
+          `dev      ${devDescription}`,
+        );
+      }
+
+      // Simplify the help output for sub-commands
+      if (section.title?.startsWith('For more info')) {
+        section.title = color.dim('  For details on a sub-command, run');
+        section.body = color.dim('  $ rsbuild <command> -h');
+      } else {
+        section.title = color.cyan(section.title);
+      }
+    }
+  });
 
   cli.parse();
 }

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -23,7 +23,7 @@ function showGreeting() {
   const isBun = npm_execpath?.includes('.bun');
   const isNodeRun = Boolean(NODE_RUN_SCRIPT_NAME);
   const prefix = isNpx || isBun || isNodeRun ? '\n' : '';
-  logger.greet(`${prefix}  Rsbuild v${RSBUILD_VERSION}\n`);
+  logger.greet(`${prefix}Rsbuild v${RSBUILD_VERSION}\n`);
 }
 
 // ensure log level is set before any log is printed


### PR DESCRIPTION
## Summary

Improve help output formatting:

- Add color for better visual distinction in help output
- Fix dev command name display in help section
- Simplify sub-command help instructions

## Before

<img width="2000" height="1290" alt="image" src="https://github.com/user-attachments/assets/cd7366ba-6154-4fbf-95eb-2f7a2e1900fa" />

## After

<img width="2010" height="1290" alt="image" src="https://github.com/user-attachments/assets/89b064c2-aa89-4b7b-95d4-2088b6a5c54e" />


## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
