### PR TITLE
test(e2e): fix log formatting width calculation

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -23,8 +23,8 @@ import { type ExtendedLogHelper, proxyConsole } from './logs';
 
 function makeBox(title: string) {
   const rawHeader = `╭──────────────  Logs from: "${title}" ──────────────╮`;
-  const visible = stripAnsi(rawHeader);
-  const width = stringWidth(visible);
+  const strippedHeader = stripAnsi(rawHeader);
+  const width = stringWidth(strippedHeader);
   const footer = `╰${'─'.repeat(Math.max(0, width - 2))}╯`;
   return {
     header: color.bold(`\n${rawHeader}\n`),

--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -153,9 +153,7 @@ export const proxyConsole = ({
 
   const printCapturedLogs = () => {
     restore();
-    for (const log of logHelper.originalLogs) {
-      console.log(log);
-    }
+    console.log(logHelper.originalLogs.join('\n'));
   };
 
   return {

--- a/e2e/helper/package.json
+++ b/e2e/helper/package.json
@@ -10,6 +10,7 @@
     }
   },
   "dependencies": {
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "string-width": "^8.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      string-width:
+        specifier: ^8.1.0
+        version: 8.1.0
 
   examples/lit:
     devDependencies:
@@ -4355,6 +4358,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-east-asian-width@1.4.0:
+    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -6210,6 +6217,10 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@8.1.0:
+    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
+    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -10132,6 +10143,8 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-east-asian-width@1.4.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -12375,6 +12388,11 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  string-width@8.1.0:
+    dependencies:
+      get-east-asian-width: 1.4.0
       strip-ansi: 7.1.0
 
   string_decoder@1.3.0:


### PR DESCRIPTION
## Summary

The footer border was calculated with `header.length`, which broke in GitHub Actions because Unicode box-drawing chars are rendered double-width. Switched to using `string-width` so borders align correctly in all environments.

https://github.com/web-infra-dev/rsbuild/actions/runs/17903179910/job/50899610790?pr=6214#step:7:51

<img width="2540" height="422" alt="image" src="https://github.com/user-attachments/assets/8af081ef-904e-4fc0-a1f6-1bfa6bd76b5d" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
