### PR TITLE
test(e2e): simplify box rendering

### DIFF
--- a/e2e/cases/cli/dev/index.test.ts
+++ b/e2e/cases/cli/dev/index.test.ts
@@ -7,7 +7,7 @@ rspackTest(
     execCli(`dev --port ${port}`);
     await logHelper.expectBuildEnd();
     await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hel22o');
+    await expect(page.locator('#test')).toHaveText('hello');
   },
 );
 
@@ -18,6 +18,6 @@ rspackTest(
     execCli(`--port ${port}`);
     await logHelper.expectBuildEnd();
     await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hel22lo');
+    await expect(page.locator('#test')).toHaveText('hello');
   },
 );

--- a/e2e/cases/cli/dev/index.test.ts
+++ b/e2e/cases/cli/dev/index.test.ts
@@ -7,7 +7,7 @@ rspackTest(
     execCli(`dev --port ${port}`);
     await logHelper.expectBuildEnd();
     await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hello');
+    await expect(page.locator('#test')).toHaveText('hel22o');
   },
 );
 
@@ -18,6 +18,6 @@ rspackTest(
     execCli(`--port ${port}`);
     await logHelper.expectBuildEnd();
     await gotoPage(page, { port });
-    await expect(page.locator('#test')).toHaveText('hello');
+    await expect(page.locator('#test')).toHaveText('hel22lo');
   },
 );

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -23,8 +23,11 @@ import { type ExtendedLogHelper, proxyConsole } from './logs';
 
 function makeBox(title: string) {
   const rawHeader = `╭──────────────  Logs from: "${title}" ──────────────╮`;
-  const strippedHeader = stripAnsi(rawHeader);
-  const width = stringWidth(strippedHeader);
+  const width = stringWidth(stripAnsi(rawHeader), {
+    // Treat ambiguous-width characters (like box drawing chars) as wide (2 columns),
+    // so that string width matches how GitHub Actions renders them.
+    ambiguousIsNarrow: false,
+  });
   const footer = `╰${'─'.repeat(Math.max(0, width - 2))}╯`;
   return {
     header: color.bold(`\n${rawHeader}\n`),

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -7,10 +7,7 @@ import {
 } from 'node:child_process';
 import { promises } from 'node:fs';
 import path from 'node:path';
-import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import base, { expect } from '@playwright/test';
-import color from 'picocolors';
-import stringWidth from 'string-width';
 import { RSBUILD_BIN_PATH } from './constants';
 import {
   type Build,
@@ -22,16 +19,11 @@ import {
 import { type ExtendedLogHelper, proxyConsole } from './logs';
 
 function makeBox(title: string) {
-  const rawHeader = `╭──────────────  Logs from: "${title}" ──────────────╮`;
-  const width = stringWidth(stripAnsi(rawHeader), {
-    // Treat ambiguous-width characters (like box drawing chars) as wide (2 columns),
-    // so that string width matches how GitHub Actions renders them.
-    ambiguousIsNarrow: false,
-  });
-  const footer = `╰${'─'.repeat(Math.max(0, width - 2))}╯`;
+  const header = `╭──────────────  Logs from: "${title}" ──────────────╮`;
+  const footer = `╰──────────────  Logs from: "${title}" ──────────────╯`;
   return {
-    header: color.bold(`\n${rawHeader}\n`),
-    footer: color.bold(`${footer}\n`),
+    header: `\n${header}\n`,
+    footer: `${footer}\n`,
   };
 }
 

--- a/e2e/helper/package.json
+++ b/e2e/helper/package.json
@@ -10,7 +10,6 @@
     }
   },
   "dependencies": {
-    "picocolors": "^1.1.1",
-    "string-width": "^8.1.0"
+    "picocolors": "^1.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,9 +306,6 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
-      string-width:
-        specifier: ^8.1.0
-        version: 8.1.0
 
   examples/lit:
     devDependencies:
@@ -4358,10 +4355,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.4.0:
-    resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
-    engines: {node: '>=18'}
-
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -6217,10 +6210,6 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
-
-  string-width@8.1.0:
-    resolution: {integrity: sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==}
-    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -10143,8 +10132,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.4.0: {}
-
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -12388,11 +12375,6 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
-  string-width@8.1.0:
-    dependencies:
-      get-east-asian-width: 1.4.0
       strip-ansi: 7.1.0
 
   string_decoder@1.3.0:


### PR DESCRIPTION
## Summary

The `string-width` package was removed as it's no longer needed for calculating box width. Simplified the box rendering logic by using fixed-width formatting instead of dynamic width calculation.

## Links

- https://www.npmjs.com/package/string-width#options

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
