### PR TITLE
fix: always output all logs in debug mode

### DIFF
--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -20,3 +20,18 @@ rspackTest(
     expect(stdout).not.toContain('built in');
   },
 );
+
+rspackTest(
+  'should always verbose logs when debug mode is enabled',
+  async ({ execCliSync }) => {
+    const stdout = stripAnsi(
+      execCliSync('build --logLevel error', {
+        env: {
+          ...process.env,
+          DEBUG: 'rsbuild',
+        },
+      }),
+    );
+    expect(stdout).toContain('config inspection completed');
+  },
+);

--- a/e2e/cases/cli/log-level/index.test.ts
+++ b/e2e/cases/cli/log-level/index.test.ts
@@ -22,7 +22,7 @@ rspackTest(
 );
 
 rspackTest(
-  'should always verbose logs when debug mode is enabled',
+  'should always print verbose logs when debug mode is enabled',
   async ({ execCliSync }) => {
     const stdout = stripAnsi(
       execCliSync('build --logLevel error', {

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -1,4 +1,4 @@
-import { logger } from '../logger';
+import { isDebug, logger } from '../logger';
 import type { LogLevel } from '../types';
 import { setupCommands } from './commands';
 
@@ -33,7 +33,7 @@ function setupLogLevel() {
   );
   if (logLevelIndex !== -1) {
     const level = process.argv[logLevelIndex + 1];
-    if (level && ['warn', 'error', 'silent'].includes(level)) {
+    if (level && ['warn', 'error', 'silent'].includes(level) && !isDebug()) {
       logger.level = level as LogLevel;
     }
   }

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -12,7 +12,7 @@ import {
 } from './helpers';
 import { initPluginAPI } from './initPlugins';
 import { type LoadEnvResult, loadEnv } from './loadEnv';
-import { logger } from './logger';
+import { isDebug, logger } from './logger';
 import { createPluginManager } from './pluginManager';
 import { pluginAppIcon } from './plugins/appIcon';
 import { pluginAsset } from './plugins/asset';
@@ -174,7 +174,7 @@ export async function createRsbuild(
 
   if (config.logLevel) {
     // debug mode should always verbose logs
-    logger.level = logger.level === 'verbose' ? 'verbose' : config.logLevel;
+    logger.level = isDebug() ? 'verbose' : config.logLevel;
   }
 
   applyEnvsToConfig(config, envs);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -172,9 +172,9 @@ export async function createRsbuild(
     ? await options.rsbuildConfig()
     : options.rsbuildConfig || {};
 
-  if (config.logLevel) {
-    // debug mode should always verbose logs
-    logger.level = isDebug() ? 'verbose' : config.logLevel;
+  // debug mode should always verbose logs
+  if (config.logLevel && !isDebug()) {
+    logger.level = config.logLevel;
   }
 
   applyEnvsToConfig(config, envs);

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -173,7 +173,8 @@ export async function createRsbuild(
     : options.rsbuildConfig || {};
 
   if (config.logLevel) {
-    logger.level = config.logLevel;
+    // debug mode should always verbose logs
+    logger.level = logger.level === 'verbose' ? 'verbose' : config.logLevel;
   }
 
   applyEnvsToConfig(config, envs);

--- a/website/docs/en/config/log-level.mdx
+++ b/website/docs/en/config/log-level.mdx
@@ -31,6 +31,10 @@ export default {
 - `error`: Output `error` level logs
 - `silent`: Do not output any logs
 
+::: note
+When in [Debug mode](/guide/debug/debug-mode), all logs are always output.
+:::
+
 ## Limitations
 
 Currently, you cannot set different log levels for each Rsbuild instance, because Rsbuild has a global shared [logger](/api/javascript-api/core#logger) instance, and all Rsbuild instances will share this logger instance.

--- a/website/docs/zh/config/log-level.mdx
+++ b/website/docs/zh/config/log-level.mdx
@@ -31,6 +31,10 @@ export default {
 - `error`：输出 `error` 级别的日志
 - `silent`：不输出任何日志
 
+::: note
+当 [开启调试模式](/guide/debug/debug-mode) 时，始终会输出所有日志。
+:::
+
 ## 局限性
 
 目前你无法为每一个 Rsbuild 实例设置不同的日志级别，因为 Rsbuild 内部有一个全局共享的 [logger](/api/javascript-api/core#logger) 实例，所有 Rsbuild 实例都会共享这个 logger 实例。


### PR DESCRIPTION
## Summary

Always output all logs in debug mode.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
