### PR TITLE
chore: remove --config-loader native flag from build scripts

### DIFF
--- a/packages/compat/plugin-webpack-swc/package.json
+++ b/packages/compat/plugin-webpack-swc/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,8 +46,8 @@
     "types.d.ts"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -23,8 +23,8 @@
     "bin.js"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "start": "node ./dist/index.js",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -23,8 +23,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -24,8 +24,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/plugin-react/package.json
+++ b/packages/plugin-react/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -24,8 +24,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/plugin-solid/package.json
+++ b/packages/plugin-solid/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -22,8 +22,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -23,8 +23,8 @@
     "compiled"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "prebundle": "prebundle",
     "bump": "pnpx bumpp --no-tag"
   },

--- a/packages/plugin-vue/package.json
+++ b/packages/plugin-vue/package.json
@@ -23,8 +23,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native",
+    "build": "rslib build",
+    "dev": "rslib build -w",
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {

--- a/scripts/test-helper/package.json
+++ b/scripts/test-helper/package.json
@@ -20,8 +20,8 @@
     "dist"
   ],
   "scripts": {
-    "build": "rslib build --config-loader native",
-    "dev": "rslib build -w --config-loader native"
+    "build": "rslib build",
+    "dev": "rslib build -w"
   },
   "dependencies": {
     "@rsbuild/core": "workspace:*",


### PR DESCRIPTION
## Summary

Rslib v0.14 sets `--config-loader auto` by default, so we no longer need to set the `--config-loader native` flag.

## Related Links

- https://github.com/web-infra-dev/rslib/releases/tag/v0.14.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
