### PR TITLE
fix(dev-middleware): remove unnecessary debug logs

### DIFF
--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -117,17 +117,13 @@ export function wrapper(context: FilledContext): RequestHandler {
 
     async function goNext() {
       return new Promise<void>((resolve) => {
-        ready(
-          context,
-          () => {
-            const extendedRes = res as ServerResponse;
-            extendedRes.locals = extendedRes.locals || {};
-            extendedRes.locals.webpack = { devMiddleware: context };
-            next();
-            resolve();
-          },
-          req,
-        );
+        ready(context, () => {
+          const extendedRes = res as ServerResponse;
+          extendedRes.locals = extendedRes.locals || {};
+          extendedRes.locals.webpack = { devMiddleware: context };
+          next();
+          resolve();
+        });
       });
     }
 
@@ -505,6 +501,6 @@ export function wrapper(context: FilledContext): RequestHandler {
       onFinishedStream(res, cleanup);
     }
 
-    ready(context, processRequest, req);
+    ready(context, processRequest);
   };
 }

--- a/packages/core/src/dev-middleware/utils/ready.ts
+++ b/packages/core/src/dev-middleware/utils/ready.ts
@@ -1,22 +1,12 @@
-import type { IncomingMessage } from 'node:http';
-import { logger } from '../../logger';
 import type { Callback, FilledContext } from '../index';
 
-export function ready<Request extends IncomingMessage>(
+export function ready(
   context: FilledContext,
   callback: (...args: any[]) => any,
-  req?: Request,
 ): void {
   if (context.state) {
     (callback as Callback)(context.stats);
     return;
   }
-
-  const name = req?.url || callback.name;
-
-  logger.debug(
-    `[rsbuild-dev-middleware] wait until bundle finished${name ? `: ${name}` : ''}`,
-  );
-
   context.callbacks.push(callback as Callback);
 }

--- a/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
+++ b/packages/core/src/dev-middleware/utils/setupWriteToDisk.ts
@@ -75,10 +75,6 @@ export function setupWriteToDisk(
                     return;
                   }
 
-                  logger.debug(
-                    `[rsbuild-dev-middleware] ${name}Asset written to disk: "${targetPath}"`,
-                  );
-
                   callback();
                 },
               );


### PR DESCRIPTION
## Summary

Remove unnecessary debug logging statements in dev middleware:

<img width="700" height="496" alt="Screenshot 2025-09-24 at 13 23 19" src="https://github.com/user-attachments/assets/376ac428-9eb9-402f-9382-7697c546e515" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
