### PR TITLE
docs: add higher precision CPU profiling example

### DIFF
--- a/website/docs/en/guide/debug/build-profiling.mdx
+++ b/website/docs/en/guide/debug/build-profiling.mdx
@@ -22,6 +22,9 @@ node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js dev
 
 # build
 node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js build
+
+# Set higher precision sampling interval
+node --cpu-prof --cpu-prof-interval=100 ./node_modules/@rsbuild/core/bin/rsbuild.js build
 ```
 
 The above commands will generate a `*.cpuprofile` file. We can use [speedscope](https://github.com/jlfwong/speedscope) to visualize this file:

--- a/website/docs/zh/guide/debug/build-profiling.mdx
+++ b/website/docs/zh/guide/debug/build-profiling.mdx
@@ -22,6 +22,9 @@ node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js dev
 
 # build
 node --cpu-prof ./node_modules/@rsbuild/core/bin/rsbuild.js build
+
+# 设置更高精度的采样间隔
+node --cpu-prof --cpu-prof-interval=100 ./node_modules/@rsbuild/core/bin/rsbuild.js build
 ```
 
 以上命令执行后会生成一个 `*.cpuprofile` 文件，我们可以使用 [speedscope](https://github.com/jlfwong/speedscope) 来可视化查看该文件：


### PR DESCRIPTION
## Summary

Added an example command using the `--cpu-prof-interval=100` flag to increase the sampling interval precision for CPU profiling. This helps with minor performance optimizations.

## Related Links

- https://nodejs.org/download/release/v12.22.4/docs/api/cli.html#cli_cpu_prof_interval

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
