### PR TITLE
perf: bundle on-finished dependency

### DIFF
--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -20,7 +20,6 @@ export default {
   },
   dependencies: [
     'ws',
-    'on-finished',
     'connect',
     'rspack-manifest-plugin',
     'html-rspack-plugin',

--- a/packages/core/src/dev-middleware/middleware.ts
+++ b/packages/core/src/dev-middleware/middleware.ts
@@ -1,7 +1,7 @@
 import type { Stats as FSStats, ReadStream } from 'node:fs';
+import onFinished from 'on-finished';
 import type { Range, Result as RangeResult, Ranges } from 'range-parser';
 import rangeParser from 'range-parser';
-import onFinishedStream from '../../compiled/on-finished/index.js';
 import { logger } from '../logger';
 import type { RequestHandler } from '../types';
 import type { FilledContext, ServerResponse } from './index';
@@ -498,7 +498,7 @@ export function wrapper(context: FilledContext): RequestHandler {
 
       (bufferOrStream as ReadStream).pipe(res);
 
-      onFinishedStream(res, cleanup);
+      onFinished(res, cleanup);
     }
 
     ready(context, processRequest);

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from 'node:http';
 import path from 'node:path';
+import onFinished from 'on-finished';
 import { addTrailingSlash, color, getAssetsFromStats } from '../helpers';
 import { logger } from '../logger';
 import type {
@@ -39,10 +40,6 @@ const getStatusCodeColor = (status: number) => {
 
 export const getRequestLoggerMiddleware: () => Promise<Connect.NextHandleFunction> =
   async () => {
-    const { default: onFinished } = await import(
-      '../../compiled/on-finished/index.js'
-    );
-
     return (req, res, next) => {
       const _startAt = process.hrtime();
 


### PR DESCRIPTION
## Summary

Remove on-finished from prebundle config and bundle it into the main bundle to reduce require cost.

For small dependencies, it is usually faster to bundle it than to require it, because it avoids the fs overhead.

<img width="1324" height="356" alt="image" src="https://github.com/user-attachments/assets/a8829844-e4f1-4c27-afda-3c67ff7310e1" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
