### PR TITLE
feat(plugin-react): complete `preserve` React runtime

### DIFF
--- a/packages/plugin-react/src/react.ts
+++ b/packages/plugin-react/src/react.ts
@@ -49,6 +49,16 @@ export const applyBasicReactSupport = (
     return mergeEnvironmentConfig(extraConfig, config);
   });
 
+  if (options.swcReactOptions?.runtime === 'preserve') {
+    api.modifyBundlerChain((chain) => {
+      chain.module.parser.merge({
+        javascript: {
+          jsx: true,
+        },
+      });
+    });
+  }
+
   api.modifyBundlerChain(
     async (chain, { CHAIN_ID, environment, isDev, target }) => {
       const { config } = environment;

--- a/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-react/tests/__snapshots__/index.test.ts.snap
@@ -95,6 +95,15 @@ exports[`plugins/react > should not apply splitChunks rule when strategy is not 
 }
 `;
 
+exports[`plugins/react > should set \`parser.javascript.jsx\` to \`true\` when using \`preserve\` react runtime 1`] = `
+{
+  "exportsPresence": "error",
+  "inlineConst": false,
+  "jsx": true,
+  "typeReexportsPresence": "tolerant",
+}
+`;
+
 exports[`plugins/react > should set transpilation scope for react refresh plugin correctly 1`] = `
 ReactRefreshRspackPlugin {
   "options": {

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -39,6 +39,22 @@ describe('plugins/react', () => {
     expect(matchRules(config, 'a.js')).toMatchSnapshot();
   });
 
+  it('should set `parser.javascript.jsx` to `true` when using `preserve` react runtime', async () => {
+    const rsbuild = await createStubRsbuild({
+      rsbuildConfig: {},
+    });
+
+    rsbuild.addPlugins([
+      pluginReact({
+        swcReactOptions: {
+          runtime: 'preserve',
+        },
+      }),
+    ]);
+    const config = await rsbuild.unwrapConfig();
+    expect(config.module.parser.javascript).toMatchSnapshot();
+  });
+
   it('should not apply react refresh when dev.hmr is false', async () => {
     const rsbuild = await createStubRsbuild({
       rsbuildConfig: {


### PR DESCRIPTION
## Summary

the second step after https://github.com/web-infra-dev/rspack/pull/11664.

the JavaScript parser must be set to support `jsx` or it will panic in paring JSX syntax.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
