### PR TITLE
feat(core): simplify config option of createRsbuild

### DIFF
--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -101,7 +101,7 @@ export async function init({
 
     const rsbuild = await createRsbuild({
       cwd: root,
-      rsbuildConfig: () => loadConfig(root),
+      config: () => loadConfig(root),
       environment: commonOpts.environment,
       loadEnv:
         commonOpts.env === false

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -168,9 +168,10 @@ export async function createRsbuild(
       })
     : null;
 
-  const config = isFunction(options.rsbuildConfig)
-    ? await options.rsbuildConfig()
-    : options.rsbuildConfig || {};
+  const configOrFactory = options.config ?? options.rsbuildConfig;
+  const config = isFunction(configOrFactory)
+    ? await configOrFactory()
+    : configOrFactory || {};
 
   // debug mode should always verbose logs
   if (config.logLevel && !isDebug()) {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -151,10 +151,15 @@ export type CreateRsbuildOptions = {
    */
   environment?: string[];
   /**
+   * Alias for `config`.
+   * This option will be deprecated in the future.
+   */
+  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  /**
    * Rsbuild configurations.
    * Passing a function to load the config asynchronously with custom logic.
    */
-  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
   /**
    * Whether to call `loadEnv` to load environment variables and define them
    * as global variables via `source.define`.


### PR DESCRIPTION
## Summary

I originally named the configuration option for `createRsbuild` as `rsbuildConfig` to make it clear that it was specific to Rsbuild (and not Rspack or other tools).

Over time, though, I realized the name is unnecessarily long—especially in e2e tests where I have to type `rsbuildConfig` repeatedly.

This PR shortens it to `config` for simplicity. The old `rsbuildConfig` name will still work for now but is planned for deprecation in the future.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
