### PR TITLE
test: rename rsbuildConfig to config in test files

### DIFF
--- a/e2e/cases/assets/addtional-assets/index.test.ts
+++ b/e2e/cases/assets/addtional-assets/index.test.ts
@@ -9,7 +9,7 @@ test('should support configuring additional assets matched by RegExp', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         assetsInclude: [/\.json5$/],
       },
@@ -34,7 +34,7 @@ test('should support configuring additional assets matched by path', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         assetsInclude: path.resolve(__dirname, 'src/assets'),
       },
@@ -59,7 +59,7 @@ test('should support disabling emission for additional assets', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         assetsInclude: [/\.json5$/],
       },

--- a/e2e/cases/assets/asset-prefix/index.test.ts
+++ b/e2e/cases/assets/asset-prefix/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should allow dev.assetPrefix to be `auto`', async ({ page, dev }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: 'auto',
       },
@@ -18,7 +18,7 @@ test('should allow dev.assetPrefix to be `auto`', async ({ page, dev }) => {
 
 test('should allow dev.assetPrefix to be true', async ({ page, dev }) => {
   const result = await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: true,
       },
@@ -34,7 +34,7 @@ test('should allow dev.assetPrefix to have <port> placeholder', async ({
   dev,
 }) => {
   const result = await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: 'http://localhost:<port>/',
       },
@@ -53,7 +53,7 @@ test('should allow output.assetPrefix to be `auto`', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       output: {
         assetPrefix: 'auto',
       },
@@ -69,7 +69,7 @@ test('should inject assetPrefix to env var and template correctly', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       html: {
         template: './src/template.html',
       },
@@ -86,7 +86,7 @@ test('should inject assetPrefix to env var and template correctly', async ({
 
 test('should use output.assetPrefix in none mode', async ({ build }) => {
   const result = await build({
-    rsbuildConfig: {
+    config: {
       mode: 'none',
       dev: {
         assetPrefix: 'http://dev.com',

--- a/e2e/cases/assets/raw-query/index.test.ts
+++ b/e2e/cases/assets/raw-query/index.test.ts
@@ -37,7 +37,7 @@ test('should return raw SVG content with `?raw` when using pluginSvgr', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       plugins: [pluginSvgr()],
     },
   });
@@ -76,7 +76,7 @@ test('should return raw TSX content with `?raw` when using pluginReact', async (
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       plugins: [pluginReact()],
     },
   });

--- a/e2e/cases/cache/build-dependencies/index.test.ts
+++ b/e2e/cases/cache/build-dependencies/index.test.ts
@@ -18,7 +18,7 @@ test('should respect `buildCache.buildDependencies`', async ({ build }) => {
   const getBuildConfig = (input: string) => {
     fs.writeFileSync(testDepsPath, input);
     return {
-      rsbuildConfig: {
+      config: {
         tools: {
           bundlerChain: (chain) => {
             if (input === 'foo') {

--- a/e2e/cases/cache/cache-digest/index.test.ts
+++ b/e2e/cases/cache/cache-digest/index.test.ts
@@ -13,7 +13,7 @@ test('should respect `buildCache.cacheDigest`', async ({ build }) => {
   await remove(cacheDirectory);
 
   const getBuildConfig = (input: string) => ({
-    rsbuildConfig: {
+    config: {
       tools: {
         bundlerChain: (chain) => {
           if (input === 'foo') {

--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -12,7 +12,7 @@ test('should use `buildCache.cacheDirectory` as expected in dev', async ({
   await remove(cacheDirectory);
 
   await dev({
-    rsbuildConfig: {
+    config: {
       performance: {
         buildCache: {
           cacheDirectory,
@@ -34,7 +34,7 @@ test('should use `buildCache.cacheDirectory` as expected in build', async ({
   await remove(cacheDirectory);
 
   await build({
-    rsbuildConfig: {
+    config: {
       performance: {
         buildCache: {
           cacheDirectory,

--- a/e2e/cases/cli/inspect/index.test.ts
+++ b/e2e/cases/cli/inspect/index.test.ts
@@ -14,13 +14,11 @@ rspackTest('should run inspect command correctly', async ({ execCliSync }) => {
   const files = await readDirContents(path.join(__dirname, 'dist/.rsbuild'));
   const fileNames = Object.keys(files);
 
-  const rsbuildConfig = fileNames.find((item) =>
-    item.includes('rsbuild.config.mjs'),
-  );
-  expect(rsbuildConfig).toBeTruthy();
-  expect(files[rsbuildConfig!]).toContain("'rsbuild:basic'");
-  expect(files[rsbuildConfig!]).toContain('hmr: true');
-  expect(files[rsbuildConfig!]).toContain('plugins:');
+  const config = fileNames.find((item) => item.includes('rsbuild.config.mjs'));
+  expect(config).toBeTruthy();
+  expect(files[config!]).toContain("'rsbuild:basic'");
+  expect(files[config!]).toContain('hmr: true');
+  expect(files[config!]).toContain('plugins:');
 
   const rspackConfig = fileNames.find((item) =>
     item.includes('rspack.config.web.mjs'),
@@ -39,10 +37,10 @@ rspackTest(
     const files = await readDirContents(path.join(__dirname, 'dist/.rsbuild'));
     const fileNames = Object.keys(files);
 
-    const rsbuildConfig = fileNames.find((item) =>
+    const config = fileNames.find((item) =>
       item.includes('rsbuild.config.mjs'),
     );
-    expect(rsbuildConfig).toBeTruthy();
+    expect(config).toBeTruthy();
 
     const rspackConfig = fileNames.find((item) =>
       item.includes('rspack.config.web.mjs'),

--- a/e2e/cases/cli/shortcuts/dev.mjs
+++ b/e2e/cases/cli/shortcuts/dev.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       dev: {
         cliShortcuts: true,
       },

--- a/e2e/cases/cli/shortcuts/devCustom.mjs
+++ b/e2e/cases/cli/shortcuts/devCustom.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       dev: {
         cliShortcuts: {
           custom: (shortcuts) => {

--- a/e2e/cases/cli/shortcuts/preview.mjs
+++ b/e2e/cases/cli/shortcuts/preview.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       dev: {
         cliShortcuts: true,
       },

--- a/e2e/cases/cli/shortcuts/previewCustom.mjs
+++ b/e2e/cases/cli/shortcuts/previewCustom.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       dev: {
         cliShortcuts: {
           custom: (shortcuts) => {

--- a/e2e/cases/config/bundler-chain/index.test.ts
+++ b/e2e/cases/config/bundler-chain/index.test.ts
@@ -6,7 +6,7 @@ test('should allow to use tools.bundlerChain to set alias config', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       tools: {
         bundlerChain: (chain) => {
           chain.resolve.alias.set('@common', join(__dirname, 'src/common'));
@@ -23,7 +23,7 @@ test('should allow to use async tools.bundlerChain to set alias config', async (
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       tools: {
         bundlerChain: async (chain) => {
           return new Promise((resolve) => {
@@ -44,7 +44,7 @@ rspackTest(
   'should allow to use rspack in tools.bundlerChain',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         tools: {
           bundlerChain: (chain, { rspack }) => {
             chain.resolve.alias.set('@common', join(__dirname, 'src/common'));

--- a/e2e/cases/config/configure-rspack/index.test.ts
+++ b/e2e/cases/config/configure-rspack/index.test.ts
@@ -4,7 +4,7 @@ rspackTest(
   'should allow to use tools.rspack to configure Rspack',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: (config, { rspack }) => {
             config.plugins.push(
@@ -26,7 +26,7 @@ rspackTest(
   'should allow to use async tools.rspack to configure Rspack',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: async (config, { rspack }) => {
             return new Promise<void>((resolve) => {

--- a/e2e/cases/config/debug-mode/index.test.ts
+++ b/e2e/cases/config/debug-mode/index.test.ts
@@ -21,7 +21,7 @@ test('should generate config files in debug mode when build', async ({
 
   const distRoot = 'dist-1';
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: distRoot,
@@ -50,7 +50,7 @@ test('should generate config files in debug mode when dev', async ({
 
   const distRoot = 'dist-2';
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: distRoot,

--- a/e2e/cases/config/inspect-config/index.test.ts
+++ b/e2e/cases/config/inspect-config/index.test.ts
@@ -94,7 +94,7 @@ rspackTest(
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             output: {
@@ -212,7 +212,7 @@ rspackTest('should apply plugin correctly', async () => {
 
   const rsbuild1 = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       mode: 'development',
       plugins: [servePlugin, buildPlugin],
     },
@@ -226,7 +226,7 @@ rspackTest('should apply plugin correctly', async () => {
 
   const rsbuild2 = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       mode: 'production',
       plugins: [servePlugin, buildPlugin],
     },

--- a/e2e/cases/config/rspack-config-validate/index.test.ts
+++ b/e2e/cases/config/rspack-config-validate/index.test.ts
@@ -5,7 +5,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 rspackTest('should validate Rspack config by default', async ({ build }) => {
   try {
     await build({
-      rsbuildConfig: {
+      config: {
         tools: {
           // @ts-expect-error mock invalid config
           rspack: {
@@ -25,7 +25,7 @@ rspackTest('should warn when passing unrecognized keys', async ({ build }) => {
   process.env.RSPACK_CONFIG_VALIDATE = 'loose-unrecognized-keys';
 
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       tools: {
         rspack: {
           // @ts-expect-error mock invalid config
@@ -47,7 +47,7 @@ rspackTest(
     process.env.RSPACK_CONFIG_VALIDATE = 'loose';
 
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         tools: {
           // @ts-expect-error mock invalid config
           rspack: {
@@ -70,7 +70,7 @@ rspackTest(
   async ({ build }) => {
     try {
       await build({
-        rsbuildConfig: {
+        config: {
           tools: {
             // @ts-expect-error mock invalid config
             rspack: {

--- a/e2e/cases/config/stats-options/index.test.ts
+++ b/e2e/cases/config/stats-options/index.test.ts
@@ -12,7 +12,7 @@ test('should not log warning when set stats.warnings false', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       tools: {
         bundlerChain: (chain) => {
           chain.stats({

--- a/e2e/cases/css/css-modules-composes/index.test.ts
+++ b/e2e/cases/css/css-modules-composes/index.test.ts
@@ -20,7 +20,7 @@ rspackTest(
   'should compile CSS Modules composes with external correctly',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: { external: path.resolve(__dirname, './src/external.js') },
         },

--- a/e2e/cases/css/css-modules-export-locals/index.test.ts
+++ b/e2e/cases/css/css-modules-export-locals/index.test.ts
@@ -19,7 +19,7 @@ rspackTest(
   'should compile CSS Modules with exportLocalsConvention camelCaseOnly',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             exportLocalsConvention: 'camelCaseOnly',
@@ -43,7 +43,7 @@ rspackTest(
   'should compile CSS Modules with exportLocalsConvention camelCase',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             exportLocalsConvention: 'camelCase',
@@ -69,7 +69,7 @@ rspackTest(
   'should compile CSS Modules with exportLocalsConvention dashes',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             exportLocalsConvention: 'dashes',
@@ -94,7 +94,7 @@ rspackTest(
   'should compile CSS Modules with exportLocalsConvention dashesOnly',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             exportLocalsConvention: 'dashesOnly',
@@ -118,7 +118,7 @@ rspackTest(
   'should compile CSS Modules with exportLocalsConvention asIs',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             exportLocalsConvention: 'asIs',

--- a/e2e/cases/css/css-modules/index.test.ts
+++ b/e2e/cases/css/css-modules/index.test.ts
@@ -19,7 +19,7 @@ rspackTest(
   'should compile CSS Modules with custom auto configuration',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             auto: (resource) => {
@@ -44,7 +44,7 @@ rspackTest(
   'should compile CSS Modules with custom localIdentName pattern',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             localIdentName: '[hash:base64:8]',
@@ -67,7 +67,7 @@ rspackTest(
   'should compile CSS Modules with custom hash digest format',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             localIdentName: '[hash:hex:4]',

--- a/e2e/cases/css/emit-css/index.test.ts
+++ b/e2e/cases/css/emit-css/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should not emit CSS files when build node target', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'node',
       },
@@ -23,7 +23,7 @@ test('should allow to emit CSS with output.emitCss when build node target', asyn
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'node',
         emitCss: true,
@@ -45,7 +45,7 @@ test('should not emit CSS files when build web-worker target', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web-worker',
       },
@@ -66,7 +66,7 @@ test('should allow to emit CSS with output.emitCss when build web-worker target'
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web-worker',
         emitCss: true,
@@ -88,7 +88,7 @@ test('should allow to disable CSS emit with output.emitCss when build web target
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web',
         emitCss: false,

--- a/e2e/cases/css/enable-experiments-css/index.test.ts
+++ b/e2e/cases/css/enable-experiments-css/index.test.ts
@@ -20,7 +20,7 @@ rspackTest(
   'should allow to enable Rspack experiments.css with style-loader',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           injectStyles: true,
         },

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -48,7 +48,7 @@ rspackTest(
     );
 
     await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(fixtures, 'test-temp-src/index.ts'),
@@ -84,7 +84,7 @@ rspackTest(
   'should allow to disable CSS minification when `injectStyles` is enabled',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           minify: false,
         },

--- a/e2e/cases/environments/basic/index.test.ts
+++ b/e2e/cases/environments/basic/index.test.ts
@@ -5,7 +5,7 @@ test('should build successfully with multiple environments', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {
           output: {
@@ -30,7 +30,7 @@ test('should serve successfully in dev with multiple environments', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {
           output: {

--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -10,7 +10,7 @@ rspackTest('HMR should work by default', async ({ page, dev, editFile }) => {
   });
 
   await dev({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/live-reload/index.test.ts
+++ b/e2e/cases/hmr/live-reload/index.test.ts
@@ -29,7 +29,7 @@ rspackTest(
   'should not reload page when live-reload is disabled',
   async ({ page, dev, editFile }) => {
     await dev({
-      rsbuildConfig: {
+      config: {
         dev: {
           liveReload: false,
         },

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     const rsbuild = await devOnly({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),
@@ -38,7 +38,7 @@ rspackTest('should print removed files in logs', async ({ page, dev }) => {
   });
 
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -16,7 +16,7 @@ rspackTest(
     };
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         source: { entry },
       },
     });
@@ -27,7 +27,7 @@ rspackTest(
     const { port } = rsbuild;
 
     await devOnly({
-      rsbuildConfig: {
+      config: {
         server: { port },
         source: { entry },
       },

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should emit apple-touch-icon to dist path', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           icons: [{ src: '../../../assets/icon.png', size: 180 }],
@@ -26,7 +26,7 @@ test('should emit apple-touch-icon to dist path', async ({ build }) => {
 
 test('should emit manifest.webmanifest to dist path', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           name: 'My Website',
@@ -75,7 +75,7 @@ test('should emit manifest.webmanifest to dist path', async ({ build }) => {
 
 test('should allow to specify URL as icon', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           name: 'My Website',
@@ -120,7 +120,7 @@ test('should allow to specify URL as icon', async ({ build }) => {
 
 test('should allow to specify target for each icon', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           name: 'My Website',
@@ -192,7 +192,7 @@ test('should allow to specify target for each icon', async ({ build }) => {
 
 test('should allow to specify purpose for each icon', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           name: 'My Website',
@@ -241,7 +241,7 @@ test('should allow to specify purpose for each icon', async ({ build }) => {
 
 test('should allow to customize manifest filename', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           filename: 'manifest.json',
@@ -277,7 +277,7 @@ test('should allow to customize manifest filename', async ({ build }) => {
 
 test('should append dev.assetPrefix to icon URL', async ({ dev }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: 'http://localhost:3000',
       },
@@ -336,7 +336,7 @@ test('should append dev.assetPrefix to icon URL', async ({ dev }) => {
 
 test('should append output.assetPrefix to icon URL', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         assetPrefix: 'https://example.com',
       },
@@ -394,7 +394,7 @@ test('should append output.assetPrefix to icon URL', async ({ build }) => {
 
 test('should apply asset prefix to apple-touch-icon URL', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         appIcon: {
           icons: [{ src: '../../../assets/icon.png', size: 180 }],

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should not apply crossOrigin by default', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         scriptLoading: 'blocking',
       },
@@ -19,7 +19,7 @@ test('should apply crossOrigin when crossorigin is "anonymous" and not same orig
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         scriptLoading: 'blocking',
         crossorigin: 'anonymous',

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should emit local favicon to dist path', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: '../../../assets/icon.png',
       },
@@ -26,7 +26,7 @@ test('should allow `html.favicon` to be an absolute path', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: path.resolve(__dirname, '../../../assets/icon.png'),
       },
@@ -46,7 +46,7 @@ test('should allow `html.favicon` to be an absolute path', async ({
 
 test('should add type attribute for SVG favicon', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: '../../../assets/mobile.svg',
       },
@@ -68,7 +68,7 @@ test('should add type attribute for SVG favicon', async ({ build }) => {
 
 test('should apply asset prefix to favicon URL', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: '../../../assets/icon.png',
       },
@@ -89,7 +89,7 @@ test('should apply asset prefix to favicon URL', async ({ build }) => {
 
 test('should allow favicon to be a CDN URL', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: 'https://foo.com/icon.png',
       },
@@ -105,7 +105,7 @@ test('should allow favicon to be a CDN URL', async ({ build }) => {
 
 test('should generate favicon via function correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
@@ -142,7 +142,7 @@ test('should allow to custom favicon dist path with a relative path', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: '../../../assets/icon.png',
       },
@@ -171,7 +171,7 @@ test('should allow to custom favicon dist path with a relative path starting wit
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         favicon: '../../../assets/icon.png',
       },

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -4,7 +4,7 @@ test('should allow to generate HTML with filename hash using filename.html', asy
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         filename: {
           html: '[name].[contenthash:8].html',
@@ -25,7 +25,7 @@ test('should allow to generate HTML with filename hash using tools.htmlPlugin', 
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       tools: {
         htmlPlugin(config, { entryName }) {
           config.filename = `${entryName}.[contenthash:8].html`;

--- a/e2e/cases/html/html-plugin/index.test.ts
+++ b/e2e/cases/html/html-plugin/index.test.ts
@@ -7,7 +7,7 @@ test('should allow to use tools.htmlPlugin to modify HTML plugin options', async
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       tools: {
         htmlPlugin(config, { entryName }) {
           if (entryName === 'index') {
@@ -32,7 +32,7 @@ test('should allow to use tools.htmlPlugin to return a new config object', async
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         crossorigin: true,
         tags: [

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -11,7 +11,7 @@ test('should preserve the expected script injection order', async ({
         inlineRuntime: false,
       }),
     ],
-    rsbuildConfig: {
+    config: {
       html: {
         inject: false,
         template: './static/index.html',
@@ -34,7 +34,7 @@ test('should preserve the expected script injection order', async ({
 
 rspackTest('should set inject via function correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: path.resolve(__dirname, './src/index.js'),

--- a/e2e/cases/html/mount-id/index.test.ts
+++ b/e2e/cases/html/mount-id/index.test.ts
@@ -9,7 +9,7 @@ test.describe('should render mountId correctly', () => {
   }) => {
     const rsbuild = await build({
       runServer: true,
-      rsbuildConfig: {
+      config: {
         html: {
           mountId: 'app',
         },
@@ -29,7 +29,7 @@ test.describe('should render mountId correctly', () => {
 
   test('should inject scripts into <head> by default', async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         html: {
           mountId: 'app',
         },

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -13,7 +13,7 @@ test('should remove defer when scriptLoading is "blocking"', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         scriptLoading: 'blocking',
       },
@@ -28,7 +28,7 @@ test('should remove defer when scriptLoading is "blocking"', async ({
 
 test('should allow to set scriptLoading to "module"', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         scriptLoading: 'module',
       },

--- a/e2e/cases/html/template-cache/index.test.ts
+++ b/e2e/cases/html/template-cache/index.test.ts
@@ -22,7 +22,7 @@ rspackTest(
     });
 
     await dev({
-      rsbuildConfig: {
+      config: {
         root: targetDir,
         source: {
           entry: {

--- a/e2e/cases/html/template-escape/index.test.ts
+++ b/e2e/cases/html/template-escape/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should escape template parameters correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         templateParameters: {
           text: '<div>escape me</div>',
@@ -25,7 +25,7 @@ test('should allow to passing undefined to template parameters', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       html: {
         templateParameters: {
           text: undefined,

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should set template via function correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: path.resolve(__dirname, './src/index.js'),
@@ -40,7 +40,7 @@ test('should allow to access templateParameters', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       html: {
         template: './static/index.html',
         templateParameters: {
@@ -63,7 +63,7 @@ test('should set template via tools.htmlPlugin correctly', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: path.resolve(__dirname, './src/index.js'),

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should generate default title correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
@@ -21,7 +21,7 @@ test('should allow setting empty title to unset the default title', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
@@ -39,7 +39,7 @@ test('should allow setting empty title to unset the default title', async ({
 
 test('should generate title correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
@@ -59,7 +59,7 @@ test('should generate title correctly when using custom HTML template', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
@@ -80,7 +80,7 @@ test('should generate title correctly when using htmlPlugin.options.title', asyn
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },
@@ -99,7 +99,7 @@ test('should generate title correctly when using htmlPlugin.options.title', asyn
 
 test('should generate title via function correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           foo: path.resolve(__dirname, './src/foo.js'),
@@ -128,7 +128,7 @@ test('should not inject title if template already contains a title', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { foo: path.resolve(__dirname, './src/foo.js') },
       },

--- a/e2e/cases/javascript-api/caller-name/index.test.ts
+++ b/e2e/cases/javascript-api/caller-name/index.test.ts
@@ -6,7 +6,7 @@ rspackTest(
     let callerName = '';
     await build({
       callerName: 'foo',
-      rsbuildConfig: {
+      config: {
         plugins: [
           {
             name: 'foo',

--- a/e2e/cases/javascript-api/get-stats/index.test.ts
+++ b/e2e/cases/javascript-api/get-stats/index.test.ts
@@ -6,7 +6,7 @@ rspackTest(
   async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         environments: {
           node: {
             output: {

--- a/e2e/cases/javascript-api/register-plugin/index.test.ts
+++ b/e2e/cases/javascript-api/register-plugin/index.test.ts
@@ -6,7 +6,7 @@ rspackTest(
   'should register plugins correctly when using JavaScript API',
   async ({ build }) => {
     await build({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginVue()],
       },
     });

--- a/e2e/cases/lazy-compilation/basic/index.test.ts
+++ b/e2e/cases/lazy-compilation/basic/index.test.ts
@@ -7,7 +7,7 @@ rspackTest(
   'should render pages correctly when using lazy compilation',
   async ({ page, dev }) => {
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         dev: {
           lazyCompilation: true,
         },
@@ -38,7 +38,7 @@ rspackTest(
   'should allow to configure `tools.rspack.experiments.lazyCompilation`',
   async ({ page, dev }) => {
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: {
             lazyCompilation: true,

--- a/e2e/cases/mode/basic/index.test.ts
+++ b/e2e/cases/mode/basic/index.test.ts
@@ -4,7 +4,7 @@ test('should allow to set development mode when building', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       mode: 'development',
     },
   });
@@ -31,7 +31,7 @@ test('should allow to set development mode when building', async ({
 
 test('should allow to set none mode when building', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       mode: 'none',
     },
   });
@@ -53,7 +53,7 @@ rspackTest(
   'should allow to set production mode when starting dev server',
   async ({ dev }) => {
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         mode: 'production',
       },
     });

--- a/e2e/cases/mode/define/index.test.ts
+++ b/e2e/cases/mode/define/index.test.ts
@@ -11,7 +11,7 @@ test('should define vars in build correctly', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       mode: 'production',
     },
   });
@@ -58,7 +58,7 @@ test('should define vars in build correctly', async ({
 
 test('should define vars in dev', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       mode: 'development',
     },
   });
@@ -102,7 +102,7 @@ test('should define vars in none mode correctly', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       mode: 'none',
     },
   });
@@ -149,7 +149,7 @@ test('should define vars in none mode correctly', async ({
 
 rspackTest('should allow to disable NODE_ENV injection', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       mode: 'production',
       tools: {
         rspack: {

--- a/e2e/cases/module-federation/v1-basic/index.test.ts
+++ b/e2e/cases/module-federation/v1-basic/index.test.ts
@@ -83,7 +83,7 @@ rspackTest(
 
     const remoteApp = await devOnly({
       cwd: remote,
-      rsbuildConfig: {
+      config: {
         server: {
           base: '/remote',
         },
@@ -91,7 +91,7 @@ rspackTest(
     });
     const hostApp = await devOnly({
       cwd: host,
-      rsbuildConfig: {
+      config: {
         server: {
           base: '/host',
         },
@@ -148,7 +148,7 @@ rspackTest(
 
     process.env.REMOTE_PORT = remotePort.toString();
 
-    const rsbuildConfig: RsbuildConfig = {
+    const config: RsbuildConfig = {
       output: {
         sourceMap: true,
         overrideBrowserslist: ['Chrome >= 51'],
@@ -169,14 +169,14 @@ rspackTest(
     await expect(
       build({
         cwd: remote,
-        rsbuildConfig,
+        config,
       }),
     ).resolves.toBeTruthy();
 
     await expect(
       build({
         cwd: host,
-        rsbuildConfig,
+        config,
       }),
     ).resolves.toBeTruthy();
   },

--- a/e2e/cases/module-federation/v2-basic/index.test.ts
+++ b/e2e/cases/module-federation/v2-basic/index.test.ts
@@ -81,7 +81,7 @@ rspackTest('should downgrade syntax as expected', async ({ build }) => {
 
   process.env.REMOTE_PORT = remotePort.toString();
 
-  const rsbuildConfig: RsbuildConfig = {
+  const config: RsbuildConfig = {
     output: {
       sourceMap: true,
       overrideBrowserslist: ['Chrome >= 51'],
@@ -102,14 +102,14 @@ rspackTest('should downgrade syntax as expected', async ({ build }) => {
   await expect(
     build({
       cwd: remote,
-      rsbuildConfig,
+      config,
     }),
   ).resolves.toBeTruthy();
 
   await expect(
     build({
       cwd: host,
-      rsbuildConfig,
+      config,
     }),
   ).resolves.toBeTruthy();
 });

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -46,7 +46,7 @@ test('should compile Node addons in the node_modules correctly', async ({
   );
 
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: './src/other.js',

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -17,7 +17,7 @@ rspackTest(
   'should set output.charset to ascii in dev',
   async ({ page, dev }) => {
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         output: {
           charset: 'ascii',
         },
@@ -41,7 +41,7 @@ test('should set output.charset to ascii in build', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       output: {
         charset: 'ascii',
       },

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -23,7 +23,7 @@ test('should not clean dist path in dev when writeToDisk is false', async ({
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
 
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         writeToDisk: false,
       },
@@ -40,7 +40,7 @@ test('should clean dist path in dev when writeToDisk is true', async ({
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
 
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         writeToDisk: true,
       },
@@ -56,7 +56,7 @@ test('should not clean dist path if it is outside root', async ({ build }) => {
 
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: '../node_modules',
@@ -81,7 +81,7 @@ test('should allow to disable cleanDistPath', async ({ build }) => {
 
   await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       output: {
         cleanDistPath: false,
       },
@@ -101,7 +101,7 @@ test('should allow to use `cleanDistPath.keep` to keep some files', async ({
 
   await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       output: {
         cleanDistPath: {
           keep: [/dist\/test.json/, /dist\/foo\/bar\/test.json/],

--- a/e2e/cases/output/copy/index.test.ts
+++ b/e2e/cases/output/copy/index.test.ts
@@ -6,7 +6,7 @@ import type { RsbuildPlugin } from '@rsbuild/core';
 
 test('should copy asset to dist folder correctly', async ({ build }) => {
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-1',
@@ -23,7 +23,7 @@ test('should copy asset from src to dist folder correctly', async ({
   build,
 }) => {
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         copy: [
           { from: '**/*.txt', to: 'assets', context: join(__dirname, 'src') },
@@ -37,7 +37,7 @@ test('should copy asset from src to dist folder correctly', async ({
 
 test('should copy asset to dist sub-folder correctly', async ({ build }) => {
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-1',
@@ -88,7 +88,7 @@ test('should merge copy config correctly', async ({ build }) => {
   });
 
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-4',

--- a/e2e/cases/output/data-uri-limit/assets.test.ts
+++ b/e2e/cases/output/data-uri-limit/assets.test.ts
@@ -42,7 +42,7 @@ for (const item of cases) {
   test(item.name, async ({ page, buildPreview }) => {
     await buildPreview({
       plugins: [pluginReact()],
-      rsbuildConfig: item.config || {},
+      config: item.config || {},
     });
 
     if (item.expected === 'url') {

--- a/e2e/cases/output/externals/index.test.ts
+++ b/e2e/cases/output/externals/index.test.ts
@@ -7,7 +7,7 @@ test('should treat specified modules as externals', async ({
 }) => {
   await buildPreview({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       output: {
         externals: {
           './aaa': 'aa',
@@ -35,7 +35,7 @@ test('should not externalize dependencies when target is web worker', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web-worker',
         externals: {

--- a/e2e/cases/output/inline-chunk/index.test.ts
+++ b/e2e/cases/output/inline-chunk/index.test.ts
@@ -21,7 +21,7 @@ test('should inline all scripts and emit all source maps', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: path.resolve(__dirname, './src/index.js'),
@@ -56,7 +56,7 @@ test('should inline all scripts and emit all source maps', async ({
 
 test('should inline scripts when matching a RegExp', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineScripts: /\/index\.\w+\.js$/,
       },
@@ -81,7 +81,7 @@ test('should inline scripts when matching a RegExp', async ({ build }) => {
 
 test('should inline scripts based on filename and size', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineScripts({ size, name }) {
           return name.includes('index') && size < 10000;
@@ -108,7 +108,7 @@ test('should inline scripts based on filename and size', async ({ build }) => {
 
 test('should inline styles when matching a RegExp', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineStyles: /\/index\.\w+\.css$/,
       },
@@ -127,7 +127,7 @@ test('should inline styles when matching a RegExp', async ({ build }) => {
 
 test('should inline styles based on filename and size', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineStyles({ size, name }) {
           return name.includes('index') && size < 1000;
@@ -148,7 +148,7 @@ test('should inline styles based on filename and size', async ({ build }) => {
 
 test('should not inline styles by default in dev', async ({ page, dev }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       tools: toolsConfig,
     },
   });
@@ -166,7 +166,7 @@ test('should inline styles in dev when matching a RegExp', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineStyles: {
           enable: true,
@@ -190,7 +190,7 @@ test('should inline styles in dev based on filename and size', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineStyles: {
           enable: true,
@@ -213,7 +213,7 @@ test('should inline styles in dev based on filename and size', async ({
 
 test('should not inline scripts when disabled', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineScripts: {
           enable: false,
@@ -241,7 +241,7 @@ test('should not inline scripts when disabled', async ({ build }) => {
 
 test('should not inline styles when disabled', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineStyles: {
           enable: false,
@@ -263,7 +263,7 @@ test('should not inline styles when disabled', async ({ build }) => {
 
 test('should inline assets in build when enable is auto', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineScripts: {
           enable: 'auto',
@@ -305,7 +305,7 @@ test('should not inline assets in dev when enable is auto', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         inlineScripts: {
           enable: 'auto',
@@ -340,7 +340,7 @@ test('should not inline scripts or styles in dev by default when enable is unset
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       tools: toolsConfig,
       output: {
         inlineStyles: true,
@@ -367,7 +367,7 @@ test('should not inline scripts or styles in dev by default when enable is unset
 test('should update source mapping URL in build', async ({ build }) => {
   const assetPrefix = 'https://example.com/base/';
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         filenameHash: false,
         inlineScripts: true,

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -4,7 +4,7 @@ import { pluginReact } from '@rsbuild/plugin-react';
 rspackTest('legalComments linked (default)', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -45,7 +45,7 @@ test('should omit legal comments when legalComments is set to "none"', async ({
 }) => {
   const rsbuild = await buildPreview({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -83,7 +83,7 @@ test('should inline legal comments when legalComments is set to "inline"', async
 }) => {
   const rsbuild = await buildPreview({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',

--- a/e2e/cases/output/manifest-environment/index.test.ts
+++ b/e2e/cases/output/manifest-environment/index.test.ts
@@ -8,7 +8,7 @@ test('should allow to access manifest data in environment context after build', 
   let nodeManifest: Record<string, any> = {};
 
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         filenameHash: false,
       },
@@ -68,7 +68,7 @@ test('should allow to access manifest data in environment context after dev buil
   let nodeManifest: Record<string, any> = {};
 
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         filenameHash: false,
       },
@@ -129,7 +129,7 @@ test('should allow to access manifest data in environment API', async ({
   let nodeManifest: Record<string, any> | undefined = {};
 
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         filenameHash: false,
       },

--- a/e2e/cases/output/manifest-generate/index.test.ts
+++ b/e2e/cases/output/manifest-generate/index.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 
-const rsbuildConfig: RsbuildConfig = {
+const config: RsbuildConfig = {
   output: {
     manifest: {
       filename: 'my-manifest.json',
@@ -24,7 +24,7 @@ const rsbuildConfig: RsbuildConfig = {
 
 test('should generate custom manifest data in build', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig,
+    config,
   });
 
   const files = rsbuild.getDistFiles();
@@ -46,7 +46,7 @@ test('should generate custom manifest data in build', async ({ build }) => {
 
 test('should generate custom manifest data in dev', async ({ dev }) => {
   const rsbuild = await dev({
-    rsbuildConfig,
+    config,
   });
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -4,7 +4,7 @@ import { expect, rspackTest, test } from '@e2e/helper';
 
 test('should generate manifest file in output', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         manifest: true,
         filenameHash: false,
@@ -39,7 +39,7 @@ test('should generate manifest file in output', async ({ build }) => {
 
 test('should generate manifest file at specified path', async ({ build }) => {
   await build({
-    rsbuildConfig: {
+    config: {
       output: {
         manifest: './custom/my-manifest.json',
         filenameHash: false,
@@ -64,7 +64,7 @@ test('should generate manifest file at specified path', async ({ build }) => {
 
 test('should generate manifest file when target is node', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-1',
@@ -97,7 +97,7 @@ test('should generate manifest file when target is node', async ({ build }) => {
 
 test('should always write manifest to disk when in dev', async ({ dev }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-dev',
@@ -123,7 +123,7 @@ test('should always write manifest to disk when in dev', async ({ dev }) => {
 
 test('should allow to filter files in manifest', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         manifest: {
           filter: (file) => file.name.endsWith('.js'),
@@ -158,7 +158,7 @@ rspackTest(
   'should allow to include license files in manifest',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           manifest: {
             filter: () => true,

--- a/e2e/cases/output/source-map/index.test.ts
+++ b/e2e/cases/output/source-map/index.test.ts
@@ -10,7 +10,7 @@ async function testSourceMapType(
   build: Build,
 ) {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: {
           js: devtool,
@@ -107,7 +107,7 @@ test('should generate source map if `output.sourceMap` is true', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: true,
       },
@@ -130,7 +130,7 @@ test('should not generate source map if `output.sourceMap` is false', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: false,
       },
@@ -172,7 +172,7 @@ test('should generate source map correctly in dev', async ({ dev }) => {
 
 test('should generate source maps only for CSS files', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: {
           js: false,

--- a/e2e/cases/performance/moment-locale/index.test.ts
+++ b/e2e/cases/performance/moment-locale/index.test.ts
@@ -4,7 +4,7 @@ test('should retain Moment locales when removeMomentLocale is false (default)', 
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: {
           js: 'source-map',
@@ -43,7 +43,7 @@ test('should remove Moment locales when removeMomentLocale is true', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         sourceMap: {
           js: 'source-map',

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -21,7 +21,7 @@ const expectConsoleType = async (
 test('should remove specified console correctly', async ({ build }) => {
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       performance: {
         removeConsole: ['log', 'warn'],
       },
@@ -39,7 +39,7 @@ test('should remove specified console correctly', async ({ build }) => {
 test('should remove all console correctly', async ({ build }) => {
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       performance: {
         removeConsole: true,
       },

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -9,7 +9,7 @@ test('should generate prefetch link when prefetch is defined', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -51,7 +51,7 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -88,7 +88,7 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
 test('should generate prefetch link with include', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -126,7 +126,7 @@ test('should generate prefetch link with include', async ({ build }) => {
 test('should generate prefetch link with include array', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -164,7 +164,7 @@ test('should generate prefetch link with include array', async ({ build }) => {
 test('should generate prefetch link with exclude array', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -204,7 +204,7 @@ test('should generate prefetch link by config (distinguish html)', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           page1: join(fixtures, 'src/page1/index.ts'),
@@ -253,7 +253,7 @@ rspackTest(
   async ({ build }) => {
     const rsbuild = await build({
       plugins: [pluginReact()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),
@@ -284,7 +284,7 @@ rspackTest(
   async ({ build }) => {
     const rsbuild = await build({
       plugins: [pluginReact()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -9,7 +9,7 @@ test('should generate preload link when preload is defined', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -46,7 +46,7 @@ test('should generate preload link when preload is defined', async ({
 test('should generate preload link with duplicate', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -85,7 +85,7 @@ test('should generate preload link with duplicate', async ({ build }) => {
 test('should generate preload link with crossOrigin', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -130,7 +130,7 @@ test('should generate preload link without crossOrigin when same origin', async 
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -170,7 +170,7 @@ test('should generate preload link without crossOrigin when same origin', async 
 test('should generate preload link with include', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -208,7 +208,7 @@ test('should generate preload link with include', async ({ build }) => {
 test('should generate preload link with include array', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -248,7 +248,7 @@ rspackTest(
   async ({ build }) => {
     const rsbuild = await build({
       plugins: [pluginReact()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),
@@ -279,7 +279,7 @@ rspackTest(
   async ({ build }) => {
     const rsbuild = await build({
       plugins: [pluginReact()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),

--- a/e2e/cases/plugin-api/logger/index.test.ts
+++ b/e2e/cases/plugin-api/logger/index.test.ts
@@ -12,7 +12,7 @@ test('should allow plugin to custom resolver', async ({ build }) => {
   };
 
   await build({
-    rsbuildConfig: {
+    config: {
       plugins: [loggerPlugin],
     },
   });

--- a/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-after-build-hook/index.test.ts
@@ -37,7 +37,7 @@ rspackTest(
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
         environments: {
           web: {

--- a/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-before-start-dev-server-hook/index.test.ts
@@ -31,7 +31,7 @@ test('should run onBeforeStartDevServer hooks and add custom middleware', async 
   };
 
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       plugins: [plugin],
     },
   });

--- a/e2e/cases/plugin-api/plugin-expose/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-expose/index.test.ts
@@ -29,7 +29,7 @@ rspackTest('should allow plugin to expose and consume API', async () => {
 
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       plugins: [pluginParent, pluginChild],
     },
   });

--- a/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/index.test.ts
@@ -85,7 +85,7 @@ rspackTest(
     process.env.NODE_ENV = 'production';
     const { plugin, names } = createPlugin();
     await build({
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
         environments: {
           web: {},
@@ -142,7 +142,7 @@ rspackTest(
 
     const { plugin, names } = createPlugin();
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
         environments: {
           web: {},

--- a/e2e/cases/plugin-api/plugin-hooks-environment/rebuild.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-environment/rebuild.test.ts
@@ -31,7 +31,7 @@ rspackTest(
     const { plugin, names } = createPlugin();
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
         environments: {
           web: {},

--- a/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks-watch/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     const { plugin, hooks } = recordPluginHooks();
     const rsbuild = await build({
       watch: true,
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
       },
     });

--- a/e2e/cases/plugin-api/plugin-hooks/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-hooks/index.test.ts
@@ -6,7 +6,7 @@ rspackTest(
   async ({ build }) => {
     const { plugin, hooks } = recordPluginHooks();
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
       },
     });
@@ -36,7 +36,7 @@ rspackTest(
   async ({ build }) => {
     const { plugin, hooks } = recordPluginHooks();
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         mode: 'development',
         plugins: [plugin],
       },
@@ -69,7 +69,7 @@ rspackTest(
 
     const { plugin, hooks } = recordPluginHooks();
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
       },
     });
@@ -111,7 +111,7 @@ rspackTest(
     const { plugin, hooks } = recordPluginHooks();
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [plugin],
       },
     });

--- a/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
@@ -18,7 +18,7 @@ rspackTest('should allow plugin to modify HTML content', async ({ build }) => {
   };
 
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       plugins: [myPlugin],
     },
   });
@@ -54,7 +54,7 @@ rspackTest(
     };
 
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         plugins: [myPlugin],
       },
     });

--- a/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
+++ b/e2e/cases/plugin-api/plugin-on-exit-hook/run.mjs
@@ -29,7 +29,7 @@ const plugin = {
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       plugins: [plugin],
     },
   });

--- a/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
@@ -2,7 +2,7 @@ import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest('should process assets when target is web', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web',
       },
@@ -20,7 +20,7 @@ rspackTest(
   'should not process assets when target is not web',
   async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web-worker',
         },

--- a/e2e/cases/plugin-babel/basic/index.test.ts
+++ b/e2e/cases/plugin-babel/basic/index.test.ts
@@ -22,7 +22,7 @@ rspackTest(
   'should allow to exclude file from babel transformation',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         source: {
           exclude: [/aa/],
         },

--- a/e2e/cases/plugin-babel/decorator/index.test.ts
+++ b/e2e/cases/plugin-babel/decorator/index.test.ts
@@ -19,7 +19,7 @@ rspackTest(
   async ({ page, buildPreview }) => {
     await buildPreview({
       plugins: [pluginBabel()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: './src/jsIndex.js',

--- a/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
@@ -12,7 +12,7 @@ rspackTest(
     });
 
     await dev({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: join(cwd, 'test-temp-src/index.ts'),

--- a/e2e/cases/plugin-react/split-chunk/index.test.ts
+++ b/e2e/cases/plugin-react/split-chunk/index.test.ts
@@ -17,7 +17,7 @@ test('should not split react chunks when strategy is `all-in-one`', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -35,7 +35,7 @@ test('should not split react chunks when strategy is `all-in-one`', async ({
 test('should not override user defined cache groups', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginReact()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           override: {

--- a/e2e/cases/plugin-sass/exclude/index.test.ts
+++ b/e2e/cases/plugin-sass/exclude/index.test.ts
@@ -4,7 +4,7 @@ test('should exclude specified Sass files using the exclude option', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       tools: {
         bundlerChain(chain) {
           chain.module

--- a/e2e/cases/plugin-vue/split-chunks/index.test.ts
+++ b/e2e/cases/plugin-vue/split-chunks/index.test.ts
@@ -17,7 +17,7 @@ test('should not split vue chunks when strategy is `all-in-one`', async ({
 }) => {
   const rsbuild = await build({
     plugins: [pluginVue()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -35,7 +35,7 @@ test('should not split vue chunks when strategy is `all-in-one`', async ({
 test('should not override user defined cache groups', async ({ build }) => {
   const rsbuild = await build({
     plugins: [pluginVue()],
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           override: {

--- a/e2e/cases/polyfill/core-js-basic/index.test.ts
+++ b/e2e/cases/polyfill/core-js-basic/index.test.ts
@@ -14,7 +14,7 @@ test('should add polyfill when set polyfill entry (default)', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       output: {
         polyfill: 'entry',
         sourceMap: {
@@ -40,7 +40,7 @@ rspackTest(
   'should add polyfill when set polyfill usage',
   async ({ page, buildPreview }) => {
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         output: {
           polyfill: 'usage',
           sourceMap: {

--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -59,7 +59,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
   }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         output: {
           filenameHash: false,
         },
@@ -100,7 +100,7 @@ dist/static/js/lib-react.js   X.X kB   X.X kB
   }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: false,
         },
@@ -115,7 +115,7 @@ dist/static/js/lib-react.js   X.X kB   X.X kB
   }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             detail: false,
@@ -131,7 +131,7 @@ Total size (web): X.X kB (X.X kB gzipped)`);
   test('printFileSize.total: false should work', async ({ build }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             total: false,
@@ -154,7 +154,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
   }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             root: '../test-temp-folder/dist',
@@ -176,7 +176,7 @@ File (web)                                                 Size       Gzip
   test('should allow to disable gzip-compressed size', async ({ build }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             compressed: false,
@@ -198,7 +198,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB
   test('should allow to filter assets by name', async ({ build }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             include: (asset) => asset.name.endsWith('.js'),
@@ -217,7 +217,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
   test('should allow to filter assets by size', async ({ build }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             include: (asset) => asset.size > 10 * 1000,
@@ -234,7 +234,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
   test('should allow to custom exclude function', async ({ build }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             exclude: (asset) =>
@@ -276,7 +276,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
   }) => {
     const rsbuild = await build({
       cwd,
-      rsbuildConfig: {
+      config: {
         performance: {
           printFileSize: {
             total: ({ assets }) => {

--- a/e2e/cases/profiling/enable-rsdoctor/index.test.ts
+++ b/e2e/cases/profiling/enable-rsdoctor/index.test.ts
@@ -64,7 +64,7 @@ rspackTest(
 
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: {
             plugins: [

--- a/e2e/cases/profiling/rspack-profile/dev.mjs
+++ b/e2e/cases/profiling/rspack-profile/dev.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 async function main() {
   const rsbuild = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       dev: {
         cliShortcuts: true,
       },

--- a/e2e/cases/resolve/condition-names/index.test.ts
+++ b/e2e/cases/resolve/condition-names/index.test.ts
@@ -18,7 +18,7 @@ test('should apply resolve.conditionNames as expected in dev', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       resolve: {
         conditionNames: ['custom', 'import', 'require'],
       },
@@ -27,7 +27,7 @@ test('should apply resolve.conditionNames as expected in dev', async ({
   expect(await page.evaluate(() => window.test)).toBe('custom');
 
   await dev({
-    rsbuildConfig: {
+    config: {
       resolve: {
         conditionNames: ['require', 'import'],
       },
@@ -41,7 +41,7 @@ test('should apply resolve.conditionNames as expected in build', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         conditionNames: ['custom', 'import', 'require'],
       },
@@ -50,7 +50,7 @@ test('should apply resolve.conditionNames as expected in build', async ({
   expect(await page.evaluate(() => window.test)).toBe('custom');
 
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         conditionNames: ['require', 'import'],
       },

--- a/e2e/cases/resolve/extension-alias-js/index.test.ts
+++ b/e2e/cases/resolve/extension-alias-js/index.test.ts
@@ -30,7 +30,7 @@ test('should resolve the .js file first if both .js and .ts exist', async ({
   );
 
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: join(__dirname, 'test-temp-src/index.ts'),

--- a/e2e/cases/resolve/extensions/index.test.ts
+++ b/e2e/cases/resolve/extensions/index.test.ts
@@ -5,7 +5,7 @@ test('should apply resolve.extensions as expected', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         extensions: ['.ts', '.js'],
       },
@@ -15,7 +15,7 @@ test('should apply resolve.extensions as expected', async ({
   expect(await page.evaluate(() => window.test)).toBe('ts');
 
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         extensions: ['.js', '.ts'],
       },

--- a/e2e/cases/resolve/jsconfig-paths/index.test.ts
+++ b/e2e/cases/resolve/jsconfig-paths/index.test.ts
@@ -4,7 +4,7 @@ rspackTest(
   'tsconfig paths should work and override the alias config',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common2',
@@ -25,7 +25,7 @@ rspackTest(
   'tsconfig paths should not work when aliasStrategy is "prefer-alias"',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@/common': './src/common2',

--- a/e2e/cases/resolve/main-fields/index.test.ts
+++ b/e2e/cases/resolve/main-fields/index.test.ts
@@ -18,7 +18,7 @@ test('should apply resolve.mainFields as expected in dev', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       resolve: {
         mainFields: ['custom', 'module', 'main'],
       },
@@ -27,7 +27,7 @@ test('should apply resolve.mainFields as expected in dev', async ({
   expect(await page.evaluate(() => window.test)).toBe('custom');
 
   await dev({
-    rsbuildConfig: {
+    config: {
       resolve: {
         mainFields: ['main', 'module'],
       },
@@ -41,7 +41,7 @@ test('should apply resolve.conditionNames as expected in build', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         mainFields: ['custom', 'module', 'main'],
       },
@@ -50,7 +50,7 @@ test('should apply resolve.conditionNames as expected in build', async ({
   expect(await page.evaluate(() => window.test)).toBe('custom');
 
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         mainFields: ['main', 'module'],
       },

--- a/e2e/cases/resolve/tsconfig-paths-references/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths-references/index.test.ts
@@ -4,7 +4,7 @@ rspackTest(
   'tsconfig paths should work with references',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common2',

--- a/e2e/cases/resolve/tsconfig-paths/index.test.ts
+++ b/e2e/cases/resolve/tsconfig-paths/index.test.ts
@@ -5,7 +5,7 @@ test('should respect tsconfig paths and override resolve.alias', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         alias: {
           '@common': './src/common2',
@@ -23,7 +23,7 @@ test('should ignore tsconfig paths when aliasStrategy is "prefer-alias"', async 
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       resolve: {
         alias: {
           '@/common': './src/common2',

--- a/e2e/cases/root/index.test.ts
+++ b/e2e/cases/root/index.test.ts
@@ -4,7 +4,7 @@ import fse from 'fs-extra';
 
 test('should support setting a relative root path', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       root: './test',
     },
   });
@@ -16,7 +16,7 @@ test('should support setting a relative root path', async ({ build }) => {
 
 test('should support setting an absolute root path', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       root: join(__dirname, './test'),
     },
   });
@@ -36,7 +36,7 @@ test('should serve publicDir correctly when setting root', async ({
   );
 
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       root: './test',
     },
   });

--- a/e2e/cases/security/nonce-basic/index.test.ts
+++ b/e2e/cases/security/nonce-basic/index.test.ts
@@ -11,7 +11,7 @@ rspackTest('should apply nonce to script and style tags', async ({ build }) => {
 
 rspackTest('should apply environment nonce', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {
           security: {

--- a/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
+++ b/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
@@ -37,7 +37,7 @@ test('should apply nonce to dynamic chunks in build', async ({
 
 test('should apply nonce to preload script tags', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       performance: {
         preload: true,
       },

--- a/e2e/cases/server/assetPrefix/index.test.ts
+++ b/e2e/cases/server/assetPrefix/index.test.ts
@@ -5,7 +5,7 @@ test('should match resource correctly with specify assetPrefix', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: '/subpath/',
       },
@@ -21,7 +21,7 @@ test('should match resource correctly with full url assetPrefix', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: `http://localhost:<port>/subpath/`,
       },

--- a/e2e/cases/server/base-url-env-var/index.test.ts
+++ b/e2e/cases/server/base-url-env-var/index.test.ts
@@ -4,7 +4,7 @@ rspackTest(
   'should define BASE_URL env var correctly in dev',
   async ({ page, dev }) => {
     await dev({
-      rsbuildConfig: {
+      config: {
         html: {
           template: './src/index.html',
         },
@@ -26,7 +26,7 @@ rspackTest(
   'should define BASE_URL env var correctly in build',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      rsbuildConfig: {
+      config: {
         html: {
           template: './src/index.html',
         },

--- a/e2e/cases/server/base-url/index.test.ts
+++ b/e2e/cases/server/base-url/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should apply server.base in dev', async ({ page, dev }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         base: '/base',
       },
@@ -45,7 +45,7 @@ test('should respect server.base when dev.assetPrefix is true', async ({
   dev,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         base: '/base',
       },
@@ -66,7 +66,7 @@ test('should respect server.base when dev.assetPrefix is true', async ({
 
 test('should apply server.base in preview', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         base: '/base',
       },
@@ -109,7 +109,7 @@ test('should serve resource correctly when assetPrefix is a subPath of server.ba
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: '/base/aaa',
       },

--- a/e2e/cases/server/cors/index.test.ts
+++ b/e2e/cases/server/cors/index.test.ts
@@ -10,7 +10,7 @@ test('should include CORS headers for dev server if `cors` is `true`', async ({
   dev,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: true,
       },
@@ -26,7 +26,7 @@ test('should include CORS headers for preview server if `cors` is `true`', async
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: true,
       },
@@ -39,7 +39,7 @@ test('should include CORS headers for preview server if `cors` is `true`', async
 
 rspackTest('should include CORS headers for MF', async ({ request, dev }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       moduleFederation: {
         options: {
           name: 'foo',
@@ -58,7 +58,7 @@ test('should not include CORS headers for dev server if `cors` is `false`', asyn
   dev,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: false,
       },
@@ -83,7 +83,7 @@ test('should not include CORS headers for preview server if `cors` is `false`', 
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: false,
       },
@@ -96,7 +96,7 @@ test('should not include CORS headers for preview server if `cors` is `false`', 
 
 test('should allow to configure CORS', async ({ request, buildPreview }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: {
           origin: 'https://example.com',
@@ -116,7 +116,7 @@ test('should override `server.cors` for dev server when `server.headers` is set'
   dev,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: true,
         headers: {
@@ -137,7 +137,7 @@ test('should override `server.cors` for preview server when `server.headers` is 
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: true,
         headers: {

--- a/e2e/cases/server/custom-server/scripts/pureServer.mjs
+++ b/e2e/cases/server/custom-server/scripts/pureServer.mjs
@@ -5,7 +5,7 @@ import polka from 'polka';
 export async function startDevServerPure(fixtures) {
   const rsbuild = await createRsbuild({
     cwd: fixtures,
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
         middlewareMode: true,

--- a/e2e/cases/server/custom-server/scripts/server.mjs
+++ b/e2e/cases/server/custom-server/scripts/server.mjs
@@ -4,7 +4,7 @@ import polka from 'polka';
 export async function startDevServer(fixtures) {
   const rsbuild = await createRsbuild({
     cwd: fixtures,
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
         middlewareMode: true,

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -13,7 +13,7 @@ rspackTest(
     });
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginReact()],
         environments: {
           web: {

--- a/e2e/cases/server/environments/index.test.ts
+++ b/e2e/cases/server/environments/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should serve multiple environments correctly', async ({ dev, page }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {},
         web1: {
@@ -45,7 +45,7 @@ test('should expose the environment API in setupMiddlewares', async ({
   let assertionsCount = 0;
 
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         setupMiddlewares: (middlewares, { environments }) => {
           middlewares.unshift(async (req, _res, next) => {
@@ -95,7 +95,7 @@ test.skip('serve multiple environments correctly when distPath different', async
   page,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {},
         web1: {

--- a/e2e/cases/server/fallback/index.test.ts
+++ b/e2e/cases/server/fallback/index.test.ts
@@ -17,7 +17,7 @@ test('should return 200 with custom headers for OPTIONS requests handled by midd
   dev,
 }) => {
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         cors: false,
       },

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -9,7 +9,7 @@ rspackTest(
   async ({ page, devOnly }) => {
     const rsbuild = await devOnly({
       plugins: [pluginReact()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: join(cwd, 'src/index.jsx'),
@@ -42,7 +42,7 @@ test('should provide history api fallback for preview server correctly', async (
     cwd,
     plugins: [pluginReact()],
 
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.jsx'),

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -31,7 +31,7 @@ test('should access / success and htmlFallback success by default', async ({
 
 test('should return 404 when htmlFallback false', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
       },
@@ -50,7 +50,7 @@ test('should access /main with query or hash success', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -80,7 +80,7 @@ test('should access /main.html success when entry is main', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -102,7 +102,7 @@ test('should access /main success when entry is main', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -126,7 +126,7 @@ test('should access /main success when entry is main and use memoryFs', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -148,7 +148,7 @@ test('should access /main success when entry is main and set assetPrefix', async
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -173,7 +173,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -195,7 +195,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
 
 test('should return 404 when page is not found', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -216,7 +216,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -251,7 +251,7 @@ test('should access /main success when modify publicPath in compiler', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),
@@ -289,7 +289,7 @@ test('should access /main success when distPath is absolute', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(cwd, 'src/index.js'),

--- a/e2e/cases/server/multi-server/index.test.ts
+++ b/e2e/cases/server/multi-server/index.test.ts
@@ -8,7 +8,7 @@ test.skip('multiple rsbuild dev servers should work correctly', async ({
 }) => {
   const rsbuild1 = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: './src/index1',
@@ -30,7 +30,7 @@ test.skip('multiple rsbuild dev servers should work correctly', async ({
 
   const rsbuild2 = await createRsbuild({
     cwd: __dirname,
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: './src/index2',

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -21,7 +21,7 @@ test('should show overlay correctly', async ({
   });
 
   await dev({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           index: join(cwd, 'test-temp-src/index.tsx'),

--- a/e2e/cases/server/port/index.test.ts
+++ b/e2e/cases/server/port/index.test.ts
@@ -6,7 +6,7 @@ test('should set the port via server.port', async ({ page, dev }) => {
 
   const port = await getRandomPort();
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         port,
       },

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -10,7 +10,7 @@ test('should print server urls correctly by default', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
       },
@@ -32,7 +32,7 @@ test('should not print server urls when printUrls is false', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         printUrls: false,
       },
@@ -47,7 +47,7 @@ test('should not print server urls when printUrls is false', async ({
 
 test('should allow to custom urls', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         printUrls: ({ urls, protocol, port }) => {
           expect(typeof port).toEqual('number');
@@ -69,7 +69,7 @@ test('should allow to modify and return new urls', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         printUrls: ({ urls }) => urls.map((url) => `${url}/test`),
       },
@@ -88,7 +88,7 @@ test('should allow to modify and return new urls', async ({
 
 test('should listen only on localhost in dev', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         host: 'localhost',
         htmlFallback: false,
@@ -111,7 +111,7 @@ test('should listen only on localhost in preview', async ({
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       server: {
         host: 'localhost',
         htmlFallback: false,
@@ -133,7 +133,7 @@ test('should not print server urls when HTML is disabled', async ({
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       tools: {
         htmlPlugin: false,
       },
@@ -150,7 +150,7 @@ test('should print server urls when HTML is disabled but printUrls is a custom f
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       tools: {
         htmlPlugin: false,
       },
@@ -168,7 +168,7 @@ test('should print server urls for multiple web environments with custom distPat
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         printUrls: ({ urls, routes }) => {
           expect(routes[0].pathname).toBe('/dist/');
@@ -210,7 +210,7 @@ test('should print server urls for multiple web environments with custom distPat
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
       },
@@ -259,7 +259,7 @@ test('should print server urls for web and node environments with custom distPat
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
       },

--- a/e2e/cases/server/prod-server/index.test.ts
+++ b/e2e/cases/server/prod-server/index.test.ts
@@ -8,7 +8,7 @@ test('should access / and htmlFallback success by default', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-0',
@@ -36,7 +36,7 @@ test('should return 404 when htmlFallback false', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         htmlFallback: false,
       },
@@ -60,7 +60,7 @@ test('should access /main.html success when entry is main', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -87,7 +87,7 @@ test('should access /main success when entry is main', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -116,7 +116,7 @@ test('should access /main success when entry is main and set assetPrefix', async
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -144,7 +144,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -174,7 +174,7 @@ test('should return 404 when page is not found', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -200,7 +200,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: {
           main: join(fixtures, 'src/index.ts'),
@@ -238,7 +238,7 @@ test('should match resource correctly with specify assetPrefix', async ({
   const port = await getRandomPort();
 
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         port,
       },
@@ -266,7 +266,7 @@ test('should match resource correctly with full url assetPrefix', async ({
   const port = await getRandomPort();
 
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       server: {
         port,
       },

--- a/e2e/cases/server/proxy-mixed-rules/index.test.ts
+++ b/e2e/cases/server/proxy-mixed-rules/index.test.ts
@@ -7,7 +7,7 @@ const cwd2 = join(__dirname, 'project2');
 test('should apply mixed proxy rules', async ({ dev, page }) => {
   const rsbuild1 = await dev({
     cwd: cwd1,
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: true,
       },
@@ -16,7 +16,7 @@ test('should apply mixed proxy rules', async ({ dev, page }) => {
 
   const rsbuild2 = await dev({
     cwd: cwd2,
-    rsbuildConfig: {
+    config: {
       server: {
         proxy: {
           '/foo': `http://127.0.0.1:${rsbuild1.port}/`,

--- a/e2e/cases/server/proxy-sse/index.test.ts
+++ b/e2e/cases/server/proxy-sse/index.test.ts
@@ -4,7 +4,7 @@ import polka from 'polka';
 test('should proxy SSE request', async ({ dev, page }) => {
   const ssePort = await getRandomPort();
   const rsbuild = await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         proxy: {
           '/api': {

--- a/e2e/cases/server/proxy/index.test.ts
+++ b/e2e/cases/server/proxy/index.test.ts
@@ -7,7 +7,7 @@ const cwd2 = join(__dirname, 'project2');
 test('should apply basic proxy rules', async ({ dev, page }) => {
   const rsbuild1 = await dev({
     cwd: cwd1,
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: true,
       },
@@ -16,7 +16,7 @@ test('should apply basic proxy rules', async ({ dev, page }) => {
 
   const rsbuild2 = await dev({
     cwd: cwd2,
-    rsbuildConfig: {
+    config: {
       server: {
         proxy: {
           // https://stackoverflow.com/a/76727711/6219457

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -11,7 +11,7 @@ test('should serve publicDir for dev server correctly', async ({
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-dev-1',
@@ -34,7 +34,7 @@ test('should serve publicDir with assetPrefix for dev server correctly', async (
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: '/dev/',
       },
@@ -62,7 +62,7 @@ test('should serve multiple publicDir for dev server correctly', async ({
   await fse.outputFile(join(__dirname, 'test-temp-dir2', 'b.txt'), 'b');
 
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: [{ name: 'test-temp-dir1' }, { name: 'test-temp-dir2' }],
       },
@@ -91,7 +91,7 @@ test('should serve custom publicDir for dev server correctly', async ({
   );
 
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: {
           name: 'public1',
@@ -117,7 +117,7 @@ test('should not serve publicDir when publicDir is false', async ({
   devOnly,
 }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: false,
         htmlFallback: false,
@@ -146,7 +146,7 @@ test('should serve publicDir for preview server correctly', async ({
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-build-1',
@@ -169,7 +169,7 @@ test('should copy publicDir to the environment distDir when multiple environment
 
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       environments: {
         web1: {
           output: {
@@ -223,7 +223,7 @@ test('should copy publicDir to the node distDir when copyOnBuild is specified as
 
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: {
           copyOnBuild: true,
@@ -259,7 +259,7 @@ test('should copy publicDir to root dist when environment dist path has a parent
 
   const rsbuild = await build({
     cwd,
-    rsbuildConfig: {
+    config: {
       environments: {
         web1: {
           output: {
@@ -302,7 +302,7 @@ test('should serve publicDir for preview server with assetPrefix correctly', asy
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       dev: {
         assetPrefix: '/dev/',
       },
@@ -332,7 +332,7 @@ test('should serve multiple publicDir for preview server correctly', async ({
   const rsbuild = await buildPreview({
     cwd,
 
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: [{ name: 'test-temp-dir1' }, { name: 'test-temp-dir2' }],
       },
@@ -356,7 +356,7 @@ test('should reload page when publicDir file changes', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: {
           watch: true,
@@ -382,7 +382,7 @@ test('should reload page when custom publicDir file changes', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       server: {
         publicDir: {
           name: 'public1',

--- a/e2e/cases/server/setup-middlewares/index.test.ts
+++ b/e2e/cases/server/setup-middlewares/index.test.ts
@@ -8,7 +8,7 @@ test('should apply custom middleware via `setupMiddlewares`', async ({
 
   // Only tested to see if it works, not all configurations.
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         setupMiddlewares: (middlewares) => {
           middlewares.unshift((_req, _res, next) => {
@@ -33,7 +33,7 @@ test('should apply to trigger page reload via the `static-changed` type of sockW
 
   // Only tested to see if it works, not all configurations.
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         setupMiddlewares: (middlewares, { sockWrite }) => {
           middlewares.unshift((_req, _res, next) => {

--- a/e2e/cases/server/ssr/index.test.ts
+++ b/e2e/cases/server/ssr/index.test.ts
@@ -17,7 +17,7 @@ rspackTest('support SSR', async ({ page, devOnly }) => {
 
 rspackTest('support SSR with external', async ({ page, devOnly }) => {
   const rsbuild = await devOnly({
-    rsbuildConfig: {
+    config: {
       output: {
         externals: {
           react: 'react',
@@ -59,7 +59,7 @@ rspackTest(
     process.env.TEST_ESM_LIBRARY = '1';
 
     const rsbuild = await devOnly({
-      rsbuildConfig: {
+      config: {
         output: {
           externals: {
             react: 'react',

--- a/e2e/cases/server/viewing-served-files/index.test.ts
+++ b/e2e/cases/server/viewing-served-files/index.test.ts
@@ -34,7 +34,7 @@ rspackTest(
   'should show assets on /rsbuild-dev-server path with server.base and assetPrefix',
   async ({ page, dev }) => {
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         dev: {
           assetPrefix: '/testing/assets/',
         },
@@ -76,7 +76,7 @@ rspackTest(
     const entry2 = './src2/index.tsx';
 
     const rsbuild = await dev({
-      rsbuildConfig: {
+      config: {
         environments: {
           test1: {
             source: {

--- a/e2e/cases/server/watch-files/index.test.ts
+++ b/e2e/cases/server/watch-files/index.test.ts
@@ -7,7 +7,7 @@ rspackTest(
   async ({ dev, page }) => {
     const file = path.join(__dirname, '/assets/example.txt');
     await dev({
-      rsbuildConfig: {
+      config: {
         dev: {
           watchFiles: {
             paths: file,
@@ -32,7 +32,7 @@ rspackTest(
   async ({ dev, page }) => {
     const file = path.join(__dirname, '/assets/example.txt');
     await dev({
-      rsbuildConfig: {
+      config: {
         dev: {
           watchFiles: {
             paths: path.join(__dirname, '/assets'),
@@ -56,7 +56,7 @@ rspackTest('should work with string array directory', async ({ dev, page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   const other = path.join(__dirname, '/other/other.txt');
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         watchFiles: {
           paths: [
@@ -89,7 +89,7 @@ rspackTest('should work with string and glob', async ({ dev, page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   const watchDir = path.join(__dirname, '/assets');
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         watchFiles: {
           paths: `${watchDir}/**/*`,
@@ -111,7 +111,7 @@ rspackTest('should work with string and glob', async ({ dev, page }) => {
 rspackTest('should work with options', async ({ dev, page }) => {
   const file = path.join(__dirname, '/assets/example.txt');
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         watchFiles: {
           paths: file,

--- a/e2e/cases/server/write-to-disk-environments/index.test.ts
+++ b/e2e/cases/server/write-to-disk-environments/index.test.ts
@@ -18,7 +18,7 @@ test('should handle writeToDisk correctly across multiple environments', async (
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         writeToDisk: true,
       },
@@ -67,7 +67,7 @@ test('should writeToDisk correctly when environment writeToDisk configuration sa
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       dev: {
         writeToDisk: false,
       },

--- a/e2e/cases/server/write-to-disk/index.test.ts
+++ b/e2e/cases/server/write-to-disk/index.test.ts
@@ -5,7 +5,7 @@ test('should work with the default writeToDisk configuration', async ({
   dev,
 }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-write-to-disk-default',
@@ -20,7 +20,7 @@ test('should work with the default writeToDisk configuration', async ({
 
 test('should work when writeToDisk is set to false', async ({ page, dev }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-write-to-disk-false',
@@ -38,7 +38,7 @@ test('should work when writeToDisk is set to false', async ({ page, dev }) => {
 
 test('should work when writeToDisk is set to true', async ({ page, dev }) => {
   await dev({
-    rsbuildConfig: {
+    config: {
       output: {
         distPath: {
           root: 'dist-write-to-disk',

--- a/e2e/cases/source/define/index.test.ts
+++ b/e2e/cases/source/define/index.test.ts
@@ -25,7 +25,7 @@ test('should allow to define global variables in build', async ({
 
 test('should warn when define `process.env`', async ({ buildPreview }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         define: {
           'process.env': process.env,
@@ -41,7 +41,7 @@ test('should warn when define stringified `process.env`', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         define: {
           'process.env': JSON.stringify(process.env),

--- a/e2e/cases/source/plugin-import/helper.ts
+++ b/e2e/cases/source/plugin-import/helper.ts
@@ -79,7 +79,7 @@ export function shareTest(
 
   test(msg, async ({ build }) => {
     const rsbuild = await build({
-      rsbuildConfig: config,
+      config,
     });
     const files = rsbuild.getDistFiles({ sourceMaps: true });
     expect(files[findEntry(files)]).toContain('transformImport test succeed');

--- a/e2e/cases/source/plugin-import/index.test.ts
+++ b/e2e/cases/source/plugin-import/index.test.ts
@@ -5,7 +5,7 @@ test('should import with template config', async ({ build }) => {
   copyPkgToNodeModules();
 
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         transformImport: [
           {
@@ -30,7 +30,7 @@ test('should not transformImport by default', async ({ build }) => {
   copyPkgToNodeModules();
 
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',

--- a/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
@@ -30,7 +30,7 @@ test.fail(
   async ({ page, buildPreview }) => {
     // SyntaxError: Decorators must be placed *after* the 'export' keyword
     const rsbuild = await buildPreview({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: './src/decoratorBeforeExport.js',

--- a/e2e/cases/syntax-es/decorator-config/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-config/index.test.ts
@@ -17,7 +17,7 @@ test('should allow to use stage 3 decorators', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    rsbuildConfig: {
+    config: {
       source: {
         decorators: {
           version: '2022-03',
@@ -49,7 +49,7 @@ rspackTest(
   async ({ page, buildPreview }) => {
     await buildPreview({
       plugins: [pluginBabel()],
-      rsbuildConfig: {
+      config: {
         source: {
           decorators: {
             version: '2022-03',

--- a/e2e/cases/workers/web-worker-target/index.test.ts
+++ b/e2e/cases/workers/web-worker-target/index.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@e2e/helper';
 
 test('should build web-worker target correctly', async ({ build }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       output: {
         target: 'web-worker',
       },
@@ -21,7 +21,7 @@ test('should build web-worker target with dynamicImport correctly', async ({
   build,
 }) => {
   const rsbuild = await build({
-    rsbuildConfig: {
+    config: {
       source: {
         entry: { index: path.resolve(__dirname, './src/index2.js') },
       },

--- a/e2e/helper/jsApi.ts
+++ b/e2e/helper/jsApi.ts
@@ -14,14 +14,14 @@ import type { LogHelper } from './logs';
 import { getRandomPort, gotoPage, noop, toPosixPath } from './utils';
 
 const createRsbuild = async (
-  rsbuildOptions: CreateRsbuildOptions & { rsbuildConfig?: RsbuildConfig },
+  rsbuildOptions: CreateRsbuildOptions & { config?: RsbuildConfig },
   plugins: RsbuildPlugins = [],
 ) => {
   const { createRsbuild } = await import('@rsbuild/core');
 
-  rsbuildOptions.rsbuildConfig ||= {};
-  rsbuildOptions.rsbuildConfig.plugins = [
-    ...(rsbuildOptions.rsbuildConfig.plugins || []),
+  rsbuildOptions.config ||= {};
+  rsbuildOptions.config.plugins = [
+    ...(rsbuildOptions.config.plugins || []),
     ...(plugins || []),
   ];
 
@@ -33,7 +33,7 @@ const createRsbuild = async (
 
   const { webpackProvider } = await import('@rsbuild/webpack');
 
-  rsbuildOptions.rsbuildConfig.provider = webpackProvider;
+  rsbuildOptions.config.provider = webpackProvider;
 
   const rsbuild = await createRsbuild(rsbuildOptions);
 
@@ -121,7 +121,7 @@ const collectOutputFiles = (rsbuild: RsbuildInstance) => {
 export type DevOptions = CreateRsbuildOptions & {
   logHelper?: LogHelper;
   plugins?: RsbuildPlugins;
-  rsbuildConfig?: RsbuildConfig;
+  config?: RsbuildConfig;
   /**
    * Playwright Page instance.
    * This method will automatically goto the page.
@@ -147,10 +147,7 @@ export async function dev({
 }: DevOptions = {}) {
   process.env.NODE_ENV = 'development';
 
-  options.rsbuildConfig = await updateConfigForTest(
-    options.rsbuildConfig || {},
-    options.cwd,
-  );
+  options.config = await updateConfigForTest(options.config || {}, options.cwd);
 
   const rsbuild = await createRsbuild(options, plugins);
   const getOutputFiles = collectOutputFiles(rsbuild);
@@ -192,7 +189,7 @@ export async function dev({
 export type BuildOptions = CreateRsbuildOptions & {
   logHelper?: LogHelper;
   plugins?: RsbuildPlugins;
-  rsbuildConfig?: RsbuildConfig;
+  config?: RsbuildConfig;
   /**
    * Whether to catch the build error.
    * @default false
@@ -228,10 +225,7 @@ export async function build({
 }: BuildOptions = {}) {
   process.env.NODE_ENV = 'production';
 
-  options.rsbuildConfig = await updateConfigForTest(
-    options.rsbuildConfig || {},
-    options.cwd,
-  );
+  options.config = await updateConfigForTest(options.config || {}, options.cwd);
 
   const rsbuild = await createRsbuild(options, plugins);
   const getOutputFiles = collectOutputFiles(rsbuild);

--- a/packages/compat/plugin-webpack-swc/tests/plugin.test.ts
+++ b/packages/compat/plugin-webpack-swc/tests/plugin.test.ts
@@ -20,7 +20,7 @@ describe('plugin-webpack-swc', () => {
   it('should set swc-loader', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -32,7 +32,7 @@ describe('plugin-webpack-swc', () => {
   it('should apply multiple environment configs correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         environments: {
           web: {
@@ -67,7 +67,7 @@ describe('plugin-webpack-swc', () => {
     process.env.NODE_ENV = 'production';
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -82,7 +82,7 @@ describe('plugin-webpack-swc', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         output: {
           legalComments: 'none',
         },
@@ -102,7 +102,7 @@ describe('plugin-webpack-swc', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         output: {
           charset: 'utf8',
         },
@@ -121,7 +121,7 @@ describe('plugin-webpack-swc', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         output: {
           legalComments: 'inline',
         },
@@ -147,7 +147,7 @@ describe('plugin-webpack-swc', () => {
           },
         }),
       ],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -170,7 +170,7 @@ describe('plugin-webpack-swc', () => {
           },
         }),
       ],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -189,7 +189,7 @@ describe('plugin-webpack-swc', () => {
           cssMinify: false,
         }),
       ],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -211,7 +211,7 @@ describe('plugin-webpack-swc', () => {
           minify: true,
         }),
       ],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -225,7 +225,7 @@ describe('plugin-webpack-swc', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         source: {
           include: [/foo/],
@@ -242,7 +242,7 @@ describe('plugin-webpack-swc', () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         dev: {
           hmr: false,
@@ -260,7 +260,7 @@ describe('plugin-webpack-swc', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         environments: {
           node: {
@@ -416,7 +416,7 @@ describe('plugin-webpack-swc', () => {
           },
         }),
       ],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
       },
     });
@@ -444,7 +444,7 @@ describe('plugin-webpack-swc', () => {
     process.env.NODE_ENV = 'production';
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         environments: {
           web: {
@@ -474,7 +474,7 @@ describe('plugin-webpack-swc', () => {
     process.env.NODE_ENV = 'production';
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSwc()],
-      rsbuildConfig: {
+      config: {
         provider: webpackProvider,
         environments: {
           web: {

--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -17,11 +17,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   },
   "context": "<ROOT>/packages/compat/webpack/tests",
   "devtool": "cheap-module-source-map",
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
   },
@@ -318,64 +313,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
       "name": "RsbuildCorePlugin",
     },
     HotModuleReplacementPlugin {},
-    HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": "auto",
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "userOptions": {
-        "chunks": [
-          "index",
-        ],
-        "entryName": "index",
-        "filename": "index.html",
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "scriptLoading": "defer",
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        Symbol(entryName): "index",
-      },
-      "version": 5,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
-    },
     DefinePlugin {
       "definitions": {
         "import.meta.env": {
@@ -462,11 +399,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   },
   "context": "<ROOT>/packages/compat/webpack/tests",
   "devtool": false,
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
   },
@@ -760,64 +692,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
     {
       "name": "RsbuildCorePlugin",
     },
-    HtmlWebpackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "minify": "auto",
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "userOptions": {
-        "chunks": [
-          "index",
-        ],
-        "entryName": "index",
-        "filename": "index.html",
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "scriptLoading": "defer",
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        Symbol(entryName): "index",
-      },
-      "version": 5,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
-    },
     DefinePlugin {
       "definitions": {
         "import.meta.env": {
@@ -904,11 +778,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "context": "<ROOT>/packages/compat/webpack/tests",
   "devtool": false,
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
   },
@@ -1276,11 +1145,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   },
   "context": "<ROOT>/packages/compat/webpack/tests",
   "devtool": false,
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
   },

--- a/packages/compat/webpack/tests/default.test.ts
+++ b/packages/compat/webpack/tests/default.test.ts
@@ -6,7 +6,7 @@ describe('applyDefaultPlugins', () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'development';
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         _privateMeta: {
           configFilePath: '/path/to/rsbuild.config.ts',
         },
@@ -36,7 +36,7 @@ describe('applyDefaultPlugins', () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'production';
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web-worker',
         },
@@ -54,7 +54,7 @@ describe('applyDefaultPlugins', () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'production';
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
         },

--- a/packages/compat/webpack/tests/environment.test.ts
+++ b/packages/compat/webpack/tests/environment.test.ts
@@ -4,7 +4,7 @@ describe('environment config', () => {
   it('tools.webpack / bundlerChain can be used in environment config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [],
-      rsbuildConfig: {
+      config: {
         tools: {
           webpack(config) {
             return {

--- a/packages/compat/webpack/tests/helper.ts
+++ b/packages/compat/webpack/tests/helper.ts
@@ -3,15 +3,15 @@ import { createStubRsbuild as createBaseRsbuild } from '@scripts/test-helper';
 import { webpackProvider } from '../src/provider';
 
 export async function createStubRsbuild({
-  rsbuildConfig = {},
+  config = {},
   plugins,
   ...options
 }: CreateRsbuildOptions & {
   plugins?: RsbuildPlugins;
 }) {
-  rsbuildConfig.provider = webpackProvider;
+  config.provider = webpackProvider;
   return createBaseRsbuild({
-    rsbuildConfig,
+    config,
     plugins,
     ...options,
   });

--- a/packages/compat/webpack/tests/initConfigs.test.ts
+++ b/packages/compat/webpack/tests/initConfigs.test.ts
@@ -32,7 +32,7 @@ describe('modifyRsbuildConfig', () => {
 
   it('should modify config by utils', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: 'src/index.ts',

--- a/packages/core/src/cli/init.ts
+++ b/packages/core/src/cli/init.ts
@@ -101,7 +101,7 @@ export async function init({
 
     const rsbuild = await createRsbuild({
       cwd: root,
-      rsbuildConfig: () => loadConfig(root),
+      config: () => loadConfig(root),
       environment: commonOpts.environment,
       loadEnv:
         commonOpts.env === false

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -168,9 +168,10 @@ export async function createRsbuild(
       })
     : null;
 
-  const config = isFunction(options.rsbuildConfig)
-    ? await options.rsbuildConfig()
-    : options.rsbuildConfig || {};
+  const configOrFactory = options.config ?? options.rsbuildConfig;
+  const config = isFunction(configOrFactory)
+    ? await configOrFactory()
+    : configOrFactory || {};
 
   // debug mode should always verbose logs
   if (config.logLevel && !isDebug()) {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -151,10 +151,15 @@ export type CreateRsbuildOptions = {
    */
   environment?: string[];
   /**
+   * Alias for `config`.
+   * This option will be deprecated in the future.
+   */
+  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  /**
    * Rsbuild configurations.
    * Passing a function to load the config asynchronously with custom logic.
    */
-  rsbuildConfig?: RsbuildConfig | (() => Promise<RsbuildConfig>);
+  config?: RsbuildConfig | (() => Promise<RsbuildConfig>);
   /**
    * Whether to call `loadEnv` to load environment variables and define them
    * as global variables via `source.define`.

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1064,11 +1064,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
@@ -1499,11 +1494,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
 {
   "context": "<ROOT>/packages/core/tests",
   "devtool": "cheap-module-source-map",
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "experiments": {
     "asyncWebAssembly": true,
     "inlineConst": false,
@@ -1932,43 +1922,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
     HotModuleReplacementPlugin {
       "affectedHooks": undefined,
       "name": "HotModuleReplacementPlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
     DefinePlugin {
       "_args": [

--- a/packages/core/tests/__snapshots__/html.test.ts.snap
+++ b/packages/core/tests/__snapshots__/html.test.ts.snap
@@ -90,43 +90,9 @@ exports[`plugin-html > should allow to configure html.tags 1`] = `
 
 exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin 1`] = `
 {
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": "all",
-        "chunksSortMode": "auto",
-        "compile": true,
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": true,
-        "meta": {},
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "auto",
-        "templateContent": false,
-        "templateParameters": [Function],
-        "title": "Rspack App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
   ],
 }
@@ -134,51 +100,9 @@ exports[`plugin-html > should allow to modify plugin options by tools.htmlPlugin
 
 exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = `
 {
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "head",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
   ],
 }
@@ -186,51 +110,9 @@ exports[`plugin-html > should allow to set favicon by html.favicon option 1`] = 
 
 exports[`plugin-html > should allow to set inject by html.inject option 1`] = `
 {
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": "body",
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
   ],
 }
@@ -342,51 +224,9 @@ exports[`plugin-html > should register html plugin correctly 1`] = `
 
 exports[`plugin-html > should stop injecting <script> if inject is () => false 1`] = `
 {
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": false,
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
   ],
 }
@@ -394,51 +234,9 @@ exports[`plugin-html > should stop injecting <script> if inject is () => false 1
 
 exports[`plugin-html > should stop injecting <script> if inject is false 1`] = `
 {
-  "entry": {
-    "index": [
-      "./src/index.js",
-    ],
-  },
   "plugins": [
     {
       "name": "RsbuildCorePlugin",
-    },
-    HtmlRspackPlugin {
-      "options": {
-        "base": false,
-        "cache": true,
-        "chunks": [
-          "index",
-        ],
-        "chunksSortMode": "auto",
-        "compile": true,
-        "entryName": "index",
-        "excludeChunks": [],
-        "favicon": false,
-        "filename": "index.html",
-        "hash": false,
-        "inject": false,
-        "meta": {
-          "charset": {
-            "charset": "UTF-8",
-          },
-          "viewport": "width=device-width, initial-scale=1.0",
-        },
-        "publicPath": "auto",
-        "scriptLoading": "defer",
-        "showErrors": true,
-        "template": "",
-        "templateContent": "<!doctype html><html><head></head><body><div id=\\"root\\"></div></body></html>",
-        "templateParameters": [Function],
-        "title": "Rsbuild App",
-        "xhtml": false,
-        Symbol(entryName): "index",
-      },
-      "version": 6,
-    },
-    RsbuildHtmlPlugin {
-      "getExtraData": [Function],
-      "name": "RsbuildHtmlPlugin",
     },
   ],
 }

--- a/packages/core/tests/asset.test.ts
+++ b/packages/core/tests/asset.test.ts
@@ -25,7 +25,7 @@ describe('plugin-asset', () => {
   test('should allow to use distPath.image to modify dist path', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginAsset()],
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             image: 'foo',
@@ -41,7 +41,7 @@ describe('plugin-asset', () => {
   test('should add image rules correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginAsset()],
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             image: '',
@@ -57,7 +57,7 @@ describe('plugin-asset', () => {
   test('should allow to use filename.image to modify filename', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginAsset()],
-      rsbuildConfig: {
+      config: {
         output: {
           filename: {
             image: 'foo[ext]',

--- a/packages/core/tests/basic.test.ts
+++ b/packages/core/tests/basic.test.ts
@@ -35,7 +35,7 @@ describe('plugin-basic', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBasic()],
-      rsbuildConfig: {
+      config: {
         output: {
           minify: false,
         },

--- a/packages/core/tests/builder.test.ts
+++ b/packages/core/tests/builder.test.ts
@@ -5,7 +5,7 @@ describe('should use Rspack as the default bundler', () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: './src/index.js',
@@ -40,7 +40,7 @@ describe('plugins', () => {
     }
 
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             index: './src/index.js',

--- a/packages/core/tests/bundleAnalyzer.test.ts
+++ b/packages/core/tests/bundleAnalyzer.test.ts
@@ -6,7 +6,7 @@ describe('plugin-bundle-analyze', () => {
   it('should add bundle analyze plugin', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBundleAnalyzer()],
-      rsbuildConfig: {
+      config: {
         performance: {
           bundleAnalyze: {
             reportFilename: 'index$$.html',
@@ -23,7 +23,7 @@ describe('plugin-bundle-analyze', () => {
   it('should add bundle analyze plugin when bundle analyze is enabled in environments', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginBundleAnalyzer()],
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             performance: {
@@ -44,7 +44,7 @@ describe('plugin-bundle-analyze', () => {
   it('should enable bundle analyze plugin when performance.profile is enable', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginPerformance(), pluginBundleAnalyzer()],
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             performance: {

--- a/packages/core/tests/cache.test.ts
+++ b/packages/core/tests/cache.test.ts
@@ -14,7 +14,7 @@ describe('plugin-cache', () => {
     },
     {
       name: 'should custom cache directory by user',
-      rsbuildConfig: {
+      config: {
         performance: {
           buildCache: {
             cacheDirectory: './node_modules/.cache/tmp',
@@ -24,7 +24,7 @@ describe('plugin-cache', () => {
     },
     {
       name: 'should apply cacheDigest',
-      rsbuildConfig: {
+      config: {
         performance: {
           buildCache: {
             cacheDigest: ['a', 'b', 'c'],
@@ -34,7 +34,7 @@ describe('plugin-cache', () => {
     },
     {
       name: 'should not apply cacheDigest',
-      rsbuildConfig: {
+      config: {
         performance: {
           buildCache: {
             cacheDigest: [],
@@ -44,7 +44,7 @@ describe('plugin-cache', () => {
     },
     {
       name: 'should disable cache',
-      rsbuildConfig: {
+      config: {
         performance: {
           buildCache: false,
         },
@@ -55,7 +55,7 @@ describe('plugin-cache', () => {
   it.each(cases)('$name', async (item) => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCache()],
-      rsbuildConfig: item.rsbuildConfig || {
+      config: item.config || {
         performance: {
           buildCache: true,
         },

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -33,7 +33,7 @@ describe('stringifyConfig', () => {
   });
 
   it('should stringify Rsbuild config correctly', async () => {
-    const rsbuildConfig = {
+    const config = {
       tools: {
         bundlerChain(chain: any) {
           chain.devtool('eval');
@@ -41,6 +41,6 @@ describe('stringifyConfig', () => {
       },
     };
 
-    expect(stringifyConfig(rsbuildConfig)).toMatchSnapshot();
+    expect(stringifyConfig(config)).toMatchSnapshot();
   });
 });

--- a/packages/core/tests/configureRspack.test.ts
+++ b/packages/core/tests/configureRspack.test.ts
@@ -10,7 +10,7 @@ import {
 describe('configure Rspack', () => {
   it('should allow tools.rspack to return config', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(config) {
             return {
@@ -28,7 +28,7 @@ describe('configure Rspack', () => {
 
   it('should allow tools.rspack to modify config object', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(config) {
             config.devtool = 'eval-cheap-source-map';
@@ -43,7 +43,7 @@ describe('configure Rspack', () => {
 
   it('should allow tools.rspack to be an object', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: {
             devtool: 'eval',
@@ -58,7 +58,7 @@ describe('configure Rspack', () => {
 
   it('should allow tools.rspack to be an array', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: [
             {
@@ -78,7 +78,7 @@ describe('configure Rspack', () => {
 
   it('should provide mergeConfig util in tools.rspack function', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: (config, { mergeConfig }) => {
             return mergeConfig(config, {
@@ -95,7 +95,7 @@ describe('configure Rspack', () => {
 
   it('should allow to use tools.bundlerChain to modify config', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           bundlerChain(chain) {
             chain.devtool('eval');
@@ -110,7 +110,7 @@ describe('configure Rspack', () => {
 
   it('should allow tools.bundlerChain to be an array', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           bundlerChain: [
             (chain) => {
@@ -130,7 +130,7 @@ describe('configure Rspack', () => {
 
   it('should expose HtmlWebpackPlugin instance via params', async () => {
     await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(_config, utils) {
             expect(utils.HtmlPlugin.version).toEqual(5);
@@ -142,7 +142,7 @@ describe('configure Rspack', () => {
 
   it('should allow to append and prepend plugins', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(_config, utils) {
             utils.appendPlugins([new utils.rspack.DefinePlugin({ foo: '1' })]);
@@ -165,7 +165,7 @@ describe('configure Rspack', () => {
 
   it('should allow to remove plugins', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(_config, utils) {
             utils.appendPlugins([new utils.rspack.DefinePlugin({ foo: '1' })]);
@@ -187,7 +187,7 @@ describe('configure Rspack', () => {
     };
 
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(_config, utils) {
             utils.addRules(newRule);
@@ -228,7 +228,7 @@ describe('configure Rspack', () => {
     const mergedConfig = mergeRsbuildConfig(config1, config2, config3);
 
     const rsbuildInstance = await createRsbuild({
-      rsbuildConfig: mergedConfig,
+      config: mergedConfig,
     });
     const config = await rsbuildInstance.initConfigs();
     const plugins = config[0].plugins || [];
@@ -294,7 +294,7 @@ describe('configure Rspack', () => {
     const mergedConfig = mergeRsbuildConfig(config1, config2, config3);
 
     const rsbuildInstance = await createRsbuild({
-      rsbuildConfig: mergedConfig,
+      config: mergedConfig,
     });
     const config = await rsbuildInstance.initConfigs();
     const rules = config[0].module?.rules || [];

--- a/packages/core/tests/css.test.ts
+++ b/packages/core/tests/css.test.ts
@@ -39,7 +39,7 @@ describe('plugin-css', () => {
   it('should enable source map when output.sourceMap.css is true', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           sourceMap: {
             css: true,
@@ -56,7 +56,7 @@ describe('plugin-css', () => {
   it('should disable source map when output.sourceMap.css is false', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           sourceMap: {
             css: false,
@@ -88,7 +88,7 @@ describe('plugin-css', () => {
   it('should allow to custom cssModules.localIdentName', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             localIdentName: '[hash]',
@@ -107,7 +107,7 @@ describe('plugin-css', () => {
   it('should use custom cssModules rule when using output.cssModules config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           cssModules: {
             auto: (resourcePath) => resourcePath.includes('.module.'),
@@ -124,7 +124,7 @@ describe('plugin-css injectStyles', () => {
   it('should use css-loader + style-loader when injectStyles is true', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           injectStyles: true,
         },
@@ -139,7 +139,7 @@ describe('plugin-css injectStyles', () => {
   it('should apply ignoreCssLoader when injectStyles is true and target is node', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginCss()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
           injectStyles: true,
@@ -156,7 +156,7 @@ describe('plugin-css injectStyles', () => {
 it('should ensure isolation of PostCSS config objects between different builds', async () => {
   const rsbuild = await createStubRsbuild({
     plugins: [pluginCss()],
-    rsbuildConfig: {
+    config: {
       environments: {
         web: {
           tools: {

--- a/packages/core/tests/default.test.ts
+++ b/packages/core/tests/default.test.ts
@@ -29,7 +29,7 @@ describe('applyDefaultPlugins', () => {
     const { NODE_ENV } = process.env;
     process.env.NODE_ENV = 'test';
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         mode: 'development',
         output: {
           target: 'node',
@@ -56,7 +56,7 @@ describe('tools.rspack', () => {
     }
 
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack: (_config, { addRules, prependPlugins, appendRules }) => {
             addRules({
@@ -211,7 +211,7 @@ describe('bundlerApi', () => {
 describe('default value', () => {
   it('should apply server.base as assetPrefix default value', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         server: {
           base: '/base',
         },
@@ -227,7 +227,7 @@ describe('default value', () => {
 
   it('should apply dev / output assetPrefix value correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         server: {
           base: '/base',
         },

--- a/packages/core/tests/define.test.ts
+++ b/packages/core/tests/define.test.ts
@@ -5,7 +5,7 @@ describe('plugin-define', () => {
   test('should register define plugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginDefine()],
-      rsbuildConfig: {
+      config: {
         source: {
           define: {
             NAME: JSON.stringify('Jack'),

--- a/packages/core/tests/entry.test.ts
+++ b/packages/core/tests/entry.test.ts
@@ -42,7 +42,7 @@ describe('plugin-entry', () => {
   it.each(cases)('$name', async (item) => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry()],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: item.entry as unknown as Record<string, string | string[]>,
           preEntry: item.preEntry,
@@ -58,7 +58,7 @@ describe('plugin-entry', () => {
   it('should apply environments entry config correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry()],
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             source: {
@@ -85,7 +85,7 @@ describe('plugin-entry', () => {
   it('should apply different environments entry config correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry()],
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             source: {

--- a/packages/core/tests/environments.test.ts
+++ b/packages/core/tests/environments.test.ts
@@ -8,7 +8,7 @@ describe('environment config', () => {
     const cwd = process.cwd();
     const rsbuild = await createRsbuild({
       cwd,
-      rsbuildConfig: {
+      config: {
         environments: {
           ssr: {
             output: {
@@ -37,7 +37,7 @@ describe('environment config', () => {
   it('should support modify environment config by api.modifyRsbuildConfig', async () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common',
@@ -100,7 +100,7 @@ describe('environment config', () => {
   it('should support modify single environment config by api.modifyEnvironmentConfig', async () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common',
@@ -174,7 +174,7 @@ describe('environment config', () => {
       },
     });
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             plugins: [plugin('web')],
@@ -215,7 +215,7 @@ describe('environment config', () => {
     });
 
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             plugins: [plugin('web')],
@@ -241,7 +241,7 @@ describe('environment config', () => {
   it('should normalize environment config correctly', async () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common',
@@ -296,7 +296,7 @@ describe('environment config', () => {
   it('should print environment config when inspect config', async () => {
     process.env.NODE_ENV = 'development';
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             '@common': './src/common',
@@ -330,7 +330,7 @@ describe('environment config', () => {
 
   it('tools.rspack / bundlerChain can be configured in environment config', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           rspack(config) {
             return {
@@ -370,7 +370,7 @@ describe('environment config', () => {
 
   it('dev.hmr can be configured in environment config', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             dev: {

--- a/packages/core/tests/html.test.ts
+++ b/packages/core/tests/html.test.ts
@@ -19,7 +19,7 @@ describe('plugin-html', () => {
   it('should not register html plugin when target is node', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
         },
@@ -31,7 +31,7 @@ describe('plugin-html', () => {
   it('should not register html plugin when target is web-worker', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web-worker',
         },
@@ -43,7 +43,7 @@ describe('plugin-html', () => {
   it('should allow to set favicon by html.favicon option', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         html: {
           favicon: './src/favicon.ico',
         },
@@ -57,7 +57,7 @@ describe('plugin-html', () => {
   it('should allow to set inject by html.inject option', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         html: {
           inject: 'body',
         },
@@ -85,7 +85,7 @@ describe('plugin-html', () => {
   it('should allow to modify plugin options by tools.htmlPlugin', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         tools: {
           htmlPlugin(_config, utils) {
             expect(utils.entryName).toEqual('index');
@@ -104,7 +104,7 @@ describe('plugin-html', () => {
   it('should allow to disable html plugin', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         tools: {
           htmlPlugin: false,
         },
@@ -117,7 +117,7 @@ describe('plugin-html', () => {
   it('should support multi entry', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: './src/main.ts',
@@ -139,7 +139,7 @@ describe('plugin-html', () => {
   it('should allow to configure html.tags', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         source: {
           entry: {
             main: './src/main.ts',
@@ -158,7 +158,7 @@ describe('plugin-html', () => {
   it('should support environment html config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginEntry(), pluginHtml(stubContext)],
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             source: {
@@ -203,7 +203,7 @@ describe('plugin-html', () => {
     async ({ value }) => {
       const rsbuild = await createStubRsbuild({
         plugins: [pluginEntry(), pluginHtml(stubContext)],
-        rsbuildConfig: { html: { inject: value } },
+        config: { html: { inject: value } },
       });
       const config = await rsbuild.unwrapConfig();
       expect(config).toMatchSnapshot();

--- a/packages/core/tests/minimize.test.ts
+++ b/packages/core/tests/minimize.test.ts
@@ -71,7 +71,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         output: {
           minify: {
             js: false,
@@ -95,7 +95,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         output: {
           minify: {
             css: false,
@@ -117,7 +117,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         output: {
           minify: {
             css: false,
@@ -141,7 +141,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         output: {
           minify: {
             jsOptions: {
@@ -172,7 +172,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         performance: {
           removeConsole: true,
         },
@@ -230,7 +230,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         performance: {
           removeConsole: ['log', 'warn'],
         },
@@ -291,7 +291,7 @@ describe('plugin-minimize', () => {
 
     const rsbuild = await createStubRsbuild({
       plugins: [pluginMinimize()],
-      rsbuildConfig: {
+      config: {
         output: {
           charset: 'utf8',
         },

--- a/packages/core/tests/moduleFederation.test.ts
+++ b/packages/core/tests/moduleFederation.test.ts
@@ -6,7 +6,7 @@ describe('plugin-module-federation', () => {
   it('should set module federation config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks(), pluginModuleFederation()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-experience',
@@ -41,7 +41,7 @@ describe('plugin-module-federation', () => {
   it('should set environment module federation config correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks(), pluginModuleFederation()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-experience',
@@ -81,7 +81,7 @@ describe('plugin-module-federation', () => {
   it('should set module federation and environment chunkSplit config correctly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks(), pluginModuleFederation()],
-      rsbuildConfig: {
+      config: {
         moduleFederation: {
           options: {
             name: 'remote',

--- a/packages/core/tests/nodeAddons.test.ts
+++ b/packages/core/tests/nodeAddons.test.ts
@@ -5,7 +5,7 @@ describe('plugin-node-addons', () => {
   it('should add node addons rule properly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginNodeAddons()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
         },
@@ -20,7 +20,7 @@ describe('plugin-node-addons', () => {
   it('should not add node addons rule when target is web', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginNodeAddons()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web',
         },
@@ -35,7 +35,7 @@ describe('plugin-node-addons', () => {
   it('should not add node addons rule when target is web-worker', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginNodeAddons()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web-worker',
         },

--- a/packages/core/tests/output.test.ts
+++ b/packages/core/tests/output.test.ts
@@ -15,7 +15,7 @@ describe('plugin-output', () => {
   it('should allow to custom server directory with distPath.root', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
           distPath: {
@@ -32,7 +32,7 @@ describe('plugin-output', () => {
   it('should allow to set distPath.js and distPath.css to empty string', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             js: '',
@@ -49,7 +49,7 @@ describe('plugin-output', () => {
   it('should allow to custom async js path via distPath.jsAsync', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             jsAsync: 'custom/js',
@@ -67,7 +67,7 @@ describe('plugin-output', () => {
   it('should allow to use filename.js to modify filename', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           filename: {
             js: 'foo.js',
@@ -84,7 +84,7 @@ describe('plugin-output', () => {
   it('output config should works when target is node', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
           distPath: {
@@ -105,7 +105,7 @@ describe('plugin-output', () => {
   it('should allow to use copy plugin', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           copy: {
             patterns: [
@@ -125,7 +125,7 @@ describe('plugin-output', () => {
   it('should allow to use copy plugin with multiple config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         output: {
           copy: [
             {
@@ -154,7 +154,7 @@ describe('plugin-output', () => {
     rstest.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createStubRsbuild({
       plugins: [pluginOutput()],
-      rsbuildConfig: {
+      config: {
         dev: {
           assetPrefix: 'http://example-<port>.com:<port>/',
         },
@@ -168,7 +168,7 @@ describe('plugin-output', () => {
   it('should replace `<port>` placeholder with server.port', async () => {
     rstest.stubEnv('NODE_ENV', 'development');
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         server: { port: 4000 },
         dev: {
           assetPrefix: 'http://example-<port>.com:<port>/',
@@ -183,7 +183,7 @@ describe('plugin-output', () => {
   it('should replace `<port>` placeholder of `output.assetPrefix` with default port', async () => {
     rstest.stubEnv('NODE_ENV', 'production');
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         output: {
           assetPrefix: 'http://example.com:<port>/',
         },

--- a/packages/core/tests/resolve.test.ts
+++ b/packages/core/tests/resolve.test.ts
@@ -26,7 +26,7 @@ describe('plugin-resolve', () => {
   it('should allow to customize extensions', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
-      rsbuildConfig: {
+      config: {
         resolve: {
           extensions: ['.ts', '.js'],
         },
@@ -40,7 +40,7 @@ describe('plugin-resolve', () => {
   it('should not apply tsConfigPath when aliasStrategy is "prefer-alias"', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
-      rsbuildConfig: {
+      config: {
         resolve: {
           aliasStrategy: 'prefer-alias',
         },
@@ -55,7 +55,7 @@ describe('plugin-resolve', () => {
   it('should allow to use resolve.alias to configure alias', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias: {
             foo: 'bar',
@@ -73,7 +73,7 @@ describe('plugin-resolve', () => {
   it('should allow resolve.alias to be a function', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginResolve()],
-      rsbuildConfig: {
+      config: {
         resolve: {
           alias() {
             return {

--- a/packages/core/tests/splitChunks.test.ts
+++ b/packages/core/tests/splitChunks.test.ts
@@ -9,7 +9,7 @@ describe('plugin-split-chunks', () => {
   it('should set split-by-experience config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-experience',
@@ -28,7 +28,7 @@ describe('plugin-split-chunks', () => {
   it('should set split-by-experience config correctly when polyfill is off', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-experience',
@@ -47,7 +47,7 @@ describe('plugin-split-chunks', () => {
   it('should set split-by-module config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-module',
@@ -66,7 +66,7 @@ describe('plugin-split-chunks', () => {
   it('should set single-vendor config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'single-vendor',
@@ -85,7 +85,7 @@ describe('plugin-split-chunks', () => {
   it('should set single-size config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-size',
@@ -106,7 +106,7 @@ describe('plugin-split-chunks', () => {
   it('should set all-in-one config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'all-in-one',
@@ -125,7 +125,7 @@ describe('plugin-split-chunks', () => {
   it('should set custom config', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'custom',
@@ -148,7 +148,7 @@ describe('plugin-split-chunks', () => {
   it('should allow forceSplitting to be an object', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'custom',
@@ -173,7 +173,7 @@ describe('plugin-split-chunks', () => {
   it('should not split chunks when target is node', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginSplitChunks()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
         },

--- a/packages/core/tests/swc.test.ts
+++ b/packages/core/tests/swc.test.ts
@@ -107,7 +107,7 @@ describe('plugin-swc', () => {
 
   it('should allow to use `tools.swc` to configure swc-loader options', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           swc: {
             jsc: {
@@ -128,7 +128,7 @@ describe('plugin-swc', () => {
 
   it('should allow to use `tools.swc` to be function type', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         tools: {
           swc() {
             return {
@@ -151,7 +151,7 @@ describe('plugin-swc', () => {
 
   it('should apply environment config correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {
             source: {
@@ -194,15 +194,15 @@ describe('plugin-swc', () => {
   });
 });
 
-async function matchConfigSnapshot(rsbuildConfig: RsbuildConfig) {
-  rsbuildConfig.source ||= {};
-  rsbuildConfig.source.entry = {
+async function matchConfigSnapshot(config: RsbuildConfig) {
+  config.source ||= {};
+  config.source.entry = {
     main: './src/index.js',
   };
 
   const rsbuild = await createStubRsbuild({
     plugins: [pluginSwc(), pluginEntry()],
-    rsbuildConfig,
+    config,
   });
 
   const {

--- a/packages/core/tests/target.test.ts
+++ b/packages/core/tests/target.test.ts
@@ -26,7 +26,7 @@ describe('plugin-target', () => {
   test.each(cases)('%j', async (item) => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginTarget()],
-      rsbuildConfig: {
+      config: {
         output: {
           target: item.target,
           overrideBrowserslist: item.browserslist || undefined,

--- a/packages/core/tests/wasm.test.ts
+++ b/packages/core/tests/wasm.test.ts
@@ -5,7 +5,7 @@ describe('plugin-wasm', () => {
   it('should add wasm rule properly', async () => {
     const rsbuild = await createStubRsbuild({
       plugins: [pluginWasm()],
-      rsbuildConfig: {
+      config: {
         output: {
           distPath: {
             wasm: 'static/wasm',

--- a/packages/plugin-babel/tests/index.test.ts
+++ b/packages/plugin-babel/tests/index.test.ts
@@ -6,7 +6,7 @@ describe('plugins/babel', () => {
   it('babel-loader should works with builtin:swc-loader', async () => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginBabel()],
         source: {
           include: [/node_modules[\\/]query-string[\\/]/],
@@ -25,7 +25,7 @@ describe('plugins/babel', () => {
   it('should apply environment config correctly', async () => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginBabel()],
         environments: {
           web: {
@@ -66,7 +66,7 @@ describe('plugins/babel', () => {
   it('should set babel-loader', async () => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginBabel()],
         performance: {
           buildCache: false,
@@ -81,7 +81,7 @@ describe('plugins/babel', () => {
   it('should set babel-loader when config is add', async () => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginBabel({
             babelLoaderOptions: (config) => {

--- a/packages/plugin-less/tests/index.test.ts
+++ b/packages/plugin-less/tests/index.test.ts
@@ -5,7 +5,7 @@ import { pluginLess } from '../src';
 describe('plugin-less', () => {
   it('should add less-loader', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginLess()],
       },
     });
@@ -16,7 +16,7 @@ describe('plugin-less', () => {
 
   it('should add less-loader and css-loader when injectStyles', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginLess()],
         output: {
           injectStyles: true,
@@ -30,7 +30,7 @@ describe('plugin-less', () => {
 
   it('should add less-loader with tools.less', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginLess({
             lessLoaderOptions: {
@@ -49,7 +49,7 @@ describe('plugin-less', () => {
 
   it('should add less-loader with excludes', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginLess({
             lessLoaderOptions(_config, { addExcludes }) {
@@ -75,7 +75,7 @@ describe('plugin-less', () => {
 
     const mockPlugin = new MockPlugin({ foo: 'bar' });
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginLess({
             lessLoaderOptions: {
@@ -95,7 +95,7 @@ describe('plugin-less', () => {
 
   it('should allow to add multiple less rules', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginLess({
             include: [/a\.less/, /b\.less/],
@@ -114,7 +114,7 @@ describe('plugin-less', () => {
 
   it('should be compatible with Rsbuild < 1.3.0', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           {
             name: 'rsbuild-plugin-test',

--- a/packages/plugin-preact/tests/index.test.ts
+++ b/packages/plugin-preact/tests/index.test.ts
@@ -12,7 +12,7 @@ describe('plugins/preact', () => {
   it('should apply react aliases by default', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginPreact()],
       },
     });
@@ -24,7 +24,7 @@ describe('plugins/preact', () => {
   it('should not apply react aliases if reactAliasesEnabled is false', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginPreact({
             reactAliasesEnabled: false,

--- a/packages/plugin-react/tests/features.test.ts
+++ b/packages/plugin-react/tests/features.test.ts
@@ -4,7 +4,7 @@ import { pluginReact } from '../src';
 describe('splitChunks', () => {
   it('should apply antd/semi/... splitChunks rule when pkg is installed', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         performance: {},
       },
     });
@@ -18,7 +18,7 @@ describe('splitChunks', () => {
 
   it('should not apply splitChunks rule when strategy is not split-by-experience', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'single-vendor',
@@ -36,7 +36,7 @@ describe('splitChunks', () => {
 
   it('should apply splitChunks.react/router plugin option when strategy is split-by-experience', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'split-by-experience',

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -40,9 +40,7 @@ describe('plugins/react', () => {
   });
 
   it('should set `parser.javascript.jsx` to `true` when using `preserve` react runtime', async () => {
-    const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
-    });
+    const rsbuild = await createStubRsbuild();
 
     rsbuild.addPlugins([
       pluginReact({

--- a/packages/plugin-react/tests/index.test.ts
+++ b/packages/plugin-react/tests/index.test.ts
@@ -4,7 +4,7 @@ import { pluginReact } from '../src';
 describe('plugins/react', () => {
   it('should work with swc-loader', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         mode: 'development',
       },
     });
@@ -17,7 +17,7 @@ describe('plugins/react', () => {
 
   it('should configuring `tools.swc` to override react runtime', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         mode: 'development',
         tools: {
           swc: {
@@ -40,7 +40,7 @@ describe('plugins/react', () => {
   });
 
   it('should set `parser.javascript.jsx` to `true` when using `preserve` react runtime', async () => {
-    const rsbuild = await createStubRsbuild();
+    const rsbuild = await createStubRsbuild({});
 
     rsbuild.addPlugins([
       pluginReact({
@@ -55,7 +55,7 @@ describe('plugins/react', () => {
 
   it('should not apply react refresh when dev.hmr is false', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         dev: {
           hmr: false,
         },
@@ -71,7 +71,7 @@ describe('plugins/react', () => {
 
   it('should set transpilation scope for react refresh plugin correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         mode: 'development',
         source: {
           include: [/foo/, /bar/],
@@ -89,7 +89,7 @@ describe('plugins/react', () => {
 
   it('should not apply react refresh when target is node', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'node',
         },
@@ -105,7 +105,7 @@ describe('plugins/react', () => {
 
   it('should not apply react refresh when target is web-worker', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         output: {
           target: 'web-worker',
         },
@@ -121,7 +121,7 @@ describe('plugins/react', () => {
 
   it('should not apply splitChunks rule when strategy is not split-by-experience', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         performance: {
           chunkSplit: {
             strategy: 'single-vendor',
@@ -139,7 +139,7 @@ describe('plugins/react', () => {
 
   it('should allow to custom jsxImportSource', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {},
+      config: {},
     });
 
     rsbuild.addPlugins([
@@ -158,7 +158,7 @@ describe('plugins/react', () => {
     process.env.NODE_ENV = 'production';
 
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig: {
+      config: {
         environments: {
           web: {},
           web1: {},

--- a/packages/plugin-sass/tests/index.test.ts
+++ b/packages/plugin-sass/tests/index.test.ts
@@ -5,7 +5,7 @@ import { pluginSass } from '../src';
 describe('plugin-sass', () => {
   it('should add sass-loader', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSass()],
       },
     });
@@ -16,7 +16,7 @@ describe('plugin-sass', () => {
 
   it('should add sass-loader and css-loader when injectStyles', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSass()],
         output: {
           injectStyles: true,
@@ -30,7 +30,7 @@ describe('plugin-sass', () => {
 
   it('should add sass-loader with excludes', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginSass({
             sassLoaderOptions(_config, { addExcludes }) {
@@ -47,7 +47,7 @@ describe('plugin-sass', () => {
 
   it('should allow to use legacy API and mute deprecation warnings', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginSass({
             sassLoaderOptions: {
@@ -64,7 +64,7 @@ describe('plugin-sass', () => {
 
   it('should allow to add multiple sass rules', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginSass({
             include: [/a\.scss/, /b\.scss/],
@@ -83,7 +83,7 @@ describe('plugin-sass', () => {
 
   it('should be compatible with Rsbuild < 1.3.0', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           {
             name: 'rsbuild-plugin-test',

--- a/packages/plugin-solid/tests/index.test.ts
+++ b/packages/plugin-solid/tests/index.test.ts
@@ -12,7 +12,7 @@ describe('plugin-solid', () => {
 
   it('should apply solid preset correctly', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig,
+      config: rsbuildConfig,
       plugins: [pluginSolid(), pluginBabel()],
     });
     const config = await rsbuild.unwrapConfig();
@@ -22,7 +22,7 @@ describe('plugin-solid', () => {
 
   it('should allow to configure solid preset options', async () => {
     const rsbuild = await createStubRsbuild({
-      rsbuildConfig,
+      config: rsbuildConfig,
       plugins: [
         pluginSolid({
           solidPresetOptions: {

--- a/packages/plugin-stylus/tests/index.test.ts
+++ b/packages/plugin-stylus/tests/index.test.ts
@@ -5,7 +5,7 @@ import { pluginStylus } from '../src';
 describe('plugin-stylus', () => {
   it('should add stylus loader config correctly', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginStylus()],
       },
     });
@@ -16,7 +16,7 @@ describe('plugin-stylus', () => {
 
   it('should allow to configure stylus options', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginStylus({
             stylusOptions: {
@@ -32,7 +32,7 @@ describe('plugin-stylus', () => {
 
   it('should be compatible with Rsbuild < 1.3.0', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           {
             name: 'rsbuild-plugin-test',

--- a/packages/plugin-svelte/tests/index.test.ts
+++ b/packages/plugin-svelte/tests/index.test.ts
@@ -6,7 +6,7 @@ describe('plugin-svelte', () => {
   it('should add svelte loader and resolve config properly', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSvelte()],
       },
     });
@@ -19,7 +19,7 @@ describe('plugin-svelte', () => {
   it('should add rule for `.svelte.js` and `.svelte.ts` as expected', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSvelte()],
       },
     });
@@ -34,7 +34,7 @@ describe('plugin-svelte', () => {
     process.env.NODE_ENV = 'production';
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSvelte()],
       },
     });
@@ -46,7 +46,7 @@ describe('plugin-svelte', () => {
   it('should turn off HMR by hand correctly', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         dev: {
           hmr: false,
         },
@@ -60,7 +60,7 @@ describe('plugin-svelte', () => {
   it('should override default svelte-loader options throw options.svelteLoaderOptions', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginSvelte({
             svelteLoaderOptions: {
@@ -77,7 +77,7 @@ describe('plugin-svelte', () => {
   it('should support pass custom preprocess options', async () => {
     const rsbuild = await createRsbuild({
       cwd: __dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginSvelte({
             preprocessOptions: {

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -56,7 +56,7 @@ describe('svgr', () => {
   it.each(cases)('$name', async (item) => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
-      rsbuildConfig: {
+      config: {
         plugins: [pluginSvgr(item.pluginConfig), pluginReact()],
       },
     });

--- a/packages/plugin-vue/tests/index.test.ts
+++ b/packages/plugin-vue/tests/index.test.ts
@@ -5,7 +5,7 @@ import { pluginVue } from '../src';
 describe('plugin-vue', () => {
   it('should add vue-loader and VueLoaderPlugin correctly', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginVue()],
       },
     });
@@ -18,7 +18,7 @@ describe('plugin-vue', () => {
 
   it('should allow to configure vueLoader options', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [
           pluginVue({
             vueLoaderOptions: {
@@ -34,7 +34,7 @@ describe('plugin-vue', () => {
 
   it('should define feature flags correctly', async () => {
     const rsbuild = await createRsbuild({
-      rsbuildConfig: {
+      config: {
         plugins: [pluginVue()],
       },
     });


### PR DESCRIPTION
## Summary

The commit renames all instances of `rsbuildConfig` to `config` in test files to make them shorter.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6245

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
