### PR TITLE
test(e2e): move plugins config into config object in test cases

### DIFF
--- a/e2e/cases/assets/inline-query-auto/index.test.ts
+++ b/e2e/cases/assets/inline-query-auto/index.test.ts
@@ -1,14 +1,10 @@
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should inline small assets automatically', async ({
   page,
   buildPreview,
 }) => {
-  await buildPreview({
-    plugins: [pluginReact()],
-  });
-
+  await buildPreview();
   await expect(
     page.evaluate(
       `document.getElementById('test-img').src.startsWith('data:image/png')`,

--- a/e2e/cases/assets/inline-query-auto/rsbuild.config.ts
+++ b/e2e/cases/assets/inline-query-auto/rsbuild.config.ts
@@ -3,12 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  output: {
-    filenameHash: false,
-  },
-  performance: {
-    chunkSplit: {
-      strategy: 'split-by-module',
-    },
-  },
 });

--- a/e2e/cases/assets/inline-query-false/index.test.ts
+++ b/e2e/cases/assets/inline-query-false/index.test.ts
@@ -1,14 +1,10 @@
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should disable asset inlining with `?__inline=false`', async ({
   page,
   buildPreview,
 }) => {
-  await buildPreview({
-    plugins: [pluginReact()],
-  });
-
+  await buildPreview();
   await expect(
     page.evaluate(
       `document.getElementById('test-img').src.includes('static/image/icon')`,

--- a/e2e/cases/assets/inline-query-false/rsbuild.config.ts
+++ b/e2e/cases/assets/inline-query-false/rsbuild.config.ts
@@ -3,12 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  output: {
-    filenameHash: false,
-  },
-  performance: {
-    chunkSplit: {
-      strategy: 'split-by-module',
-    },
-  },
 });

--- a/e2e/cases/assets/inline-query/index.test.ts
+++ b/e2e/cases/assets/inline-query/index.test.ts
@@ -1,11 +1,7 @@
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should inline assets with `?inline`', async ({ page, buildPreview }) => {
-  await buildPreview({
-    plugins: [pluginReact()],
-  });
-
+  await buildPreview();
   await expect(
     page.evaluate(
       `document.getElementById('test-img').src.startsWith('data:image/png')`,

--- a/e2e/cases/assets/inline-query/rsbuild.config.ts
+++ b/e2e/cases/assets/inline-query/rsbuild.config.ts
@@ -3,12 +3,4 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
-  output: {
-    filenameHash: false,
-  },
-  performance: {
-    chunkSplit: {
-      strategy: 'split-by-module',
-    },
-  },
 });

--- a/e2e/cases/css/css-modules-dom/index.test.ts
+++ b/e2e/cases/css/css-modules-dom/index.test.ts
@@ -1,13 +1,10 @@
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should inject styles and not emit CSS files when output.injectStyles is true', async ({
   page,
   buildPreview,
 }) => {
-  const rsbuild = await buildPreview({
-    plugins: [pluginReact()],
-  });
+  const rsbuild = await buildPreview();
 
   // injectStyles worked
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/css/css-modules-dom/rsbuild.config.ts
+++ b/e2e/cases/css/css-modules-dom/rsbuild.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginLess } from '@rsbuild/plugin-less';
+import { pluginReact } from '@rsbuild/plugin-react';
 import { pluginSass } from '@rsbuild/plugin-sass';
 
 export default defineConfig({
-  plugins: [pluginLess(), pluginSass()],
+  plugins: [pluginLess(), pluginSass(), pluginReact()],
   output: {
     injectStyles: true,
   },

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -6,12 +6,12 @@ test('should preserve the expected script injection order', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [
-      pluginRem({
-        inlineRuntime: false,
-      }),
-    ],
     config: {
+      plugins: [
+        pluginRem({
+          inlineRuntime: false,
+        }),
+      ],
       html: {
         inject: false,
         template: './static/index.html',

--- a/e2e/cases/output/data-uri-limit/assets.test.ts
+++ b/e2e/cases/output/data-uri-limit/assets.test.ts
@@ -41,8 +41,10 @@ const cases = [
 for (const item of cases) {
   test(item.name, async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginReact()],
-      config: item.config || {},
+      config: {
+        ...(item.config || {}),
+        plugins: [pluginReact()],
+      },
     });
 
     if (item.expected === 'url') {

--- a/e2e/cases/output/externals/index.test.ts
+++ b/e2e/cases/output/externals/index.test.ts
@@ -6,8 +6,8 @@ test('should treat specified modules as externals', async ({
   buildPreview,
 }) => {
   await buildPreview({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       output: {
         externals: {
           './aaa': 'aa',
@@ -34,8 +34,8 @@ test('should not externalize dependencies when target is web worker', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       output: {
         target: 'web-worker',
         externals: {

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -3,8 +3,8 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 rspackTest('legalComments linked (default)', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -44,8 +44,8 @@ test('should omit legal comments when legalComments is set to "none"', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -82,8 +82,8 @@ test('should inline legal comments when legalComments is set to "inline"', async
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -8,8 +8,8 @@ test('should generate prefetch link when prefetch is defined', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -50,8 +50,8 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -87,8 +87,8 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
 
 test('should generate prefetch link with include', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -125,8 +125,8 @@ test('should generate prefetch link with include', async ({ build }) => {
 
 test('should generate prefetch link with include array', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -163,8 +163,8 @@ test('should generate prefetch link with include array', async ({ build }) => {
 
 test('should generate prefetch link with exclude array', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -203,8 +203,8 @@ test('should generate prefetch link by config (distinguish html)', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           page1: join(fixtures, 'src/page1/index.ts'),
@@ -252,8 +252,8 @@ rspackTest(
   'should not generate prefetch link for inlined assets',
   async ({ build }) => {
     const rsbuild = await build({
-      plugins: [pluginReact()],
       config: {
+        plugins: [pluginReact()],
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),
@@ -283,8 +283,8 @@ rspackTest(
   'should not generate prefetch link for inlined assets with test option',
   async ({ build }) => {
     const rsbuild = await build({
-      plugins: [pluginReact()],
       config: {
+        plugins: [pluginReact()],
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -8,8 +8,8 @@ test('should generate preload link when preload is defined', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -45,8 +45,8 @@ test('should generate preload link when preload is defined', async ({
 
 test('should generate preload link with duplicate', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -84,8 +84,8 @@ test('should generate preload link with duplicate', async ({ build }) => {
 
 test('should generate preload link with crossOrigin', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -129,8 +129,8 @@ test('should generate preload link without crossOrigin when same origin', async 
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -169,8 +169,8 @@ test('should generate preload link without crossOrigin when same origin', async 
 
 test('should generate preload link with include', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -207,8 +207,8 @@ test('should generate preload link with include', async ({ build }) => {
 
 test('should generate preload link with include array', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(fixtures, 'src/page1/index.ts'),
@@ -247,8 +247,8 @@ rspackTest(
   'should not generate preload link for inlined assets',
   async ({ build }) => {
     const rsbuild = await build({
-      plugins: [pluginReact()],
       config: {
+        plugins: [pluginReact()],
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),
@@ -278,8 +278,8 @@ rspackTest(
   'should not generate preload link for inlined assets with test option',
   async ({ build }) => {
     const rsbuild = await build({
-      plugins: [pluginReact()],
       config: {
+        plugins: [pluginReact()],
         source: {
           entry: {
             main: join(fixtures, 'src/page1/index.ts'),

--- a/e2e/cases/performance/split-chunk-by-module/index.test.ts
+++ b/e2e/cases/performance/split-chunk-by-module/index.test.ts
@@ -1,13 +1,11 @@
 import { basename } from 'node:path';
-
 import { expect, test } from '@e2e/helper';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should generate module chunks when chunkSplit is "split-by-module"', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
+    config: {},
   });
 
   const files = rsbuild.getDistFiles();

--- a/e2e/cases/plugin-api/async-plugin/index.test.ts
+++ b/e2e/cases/plugin-api/async-plugin/index.test.ts
@@ -26,7 +26,9 @@ rspackTest(
   'should allow to register async plugin in plugins field',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [asyncPlugin()],
+      config: {
+        plugins: [asyncPlugin()],
+      },
     });
 
     const testEl = page.locator('#test-el');

--- a/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-environments/index.test.ts
@@ -14,23 +14,25 @@ rspackTest(
 
 rspackTest('should filter environments correctly', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [
-      {
-        name: 'my-plugin-node',
-        setup(api: RsbuildPluginAPI) {
-          api.processAssets(
-            { stage: 'summarize', environments: ['node'] },
-            ({ assets, compilation }) => {
-              for (const key of Object.keys(assets)) {
-                if (key.endsWith('.js')) {
-                  compilation.deleteAsset(key);
+    config: {
+      plugins: [
+        {
+          name: 'my-plugin-node',
+          setup(api: RsbuildPluginAPI) {
+            api.processAssets(
+              { stage: 'summarize', environments: ['node'] },
+              ({ assets, compilation }) => {
+                for (const key of Object.keys(assets)) {
+                  if (key.endsWith('.js')) {
+                    compilation.deleteAsset(key);
+                  }
                 }
-              }
-            },
-          );
+              },
+            );
+          },
         },
-      },
-    ],
+      ],
+    },
   });
 
   expect(existsSync(join(rsbuild.distPath, 'static/index.js'))).toBeFalsy();

--- a/e2e/cases/plugin-babel/basic/index.test.ts
+++ b/e2e/cases/plugin-babel/basic/index.test.ts
@@ -5,13 +5,15 @@ rspackTest(
   'should run babel with babel plugin correctly',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [
-        pluginBabel({
-          babelLoaderOptions: (_, { addPlugins }) => {
-            addPlugins([require('./plugins/myBabelPlugin')]);
-          },
-        }),
-      ],
+      config: {
+        plugins: [
+          pluginBabel({
+            babelLoaderOptions: (_, { addPlugins }) => {
+              addPlugins([require('./plugins/myBabelPlugin')]);
+            },
+          }),
+        ],
+      },
     });
 
     expect(await page.evaluate('window.b')).toBe(10);
@@ -26,14 +28,14 @@ rspackTest(
         source: {
           exclude: [/aa/],
         },
+        plugins: [
+          pluginBabel({
+            babelLoaderOptions: (_, { addPlugins }) => {
+              addPlugins([require('./plugins/myBabelPlugin')]);
+            },
+          }),
+        ],
       },
-      plugins: [
-        pluginBabel({
-          babelLoaderOptions: (_, { addPlugins }) => {
-            addPlugins([require('./plugins/myBabelPlugin')]);
-          },
-        }),
-      ],
     });
 
     expect(await page.evaluate('window.b')).toBe(10);

--- a/e2e/cases/plugin-babel/decorator/index.test.ts
+++ b/e2e/cases/plugin-babel/decorator/index.test.ts
@@ -5,7 +5,9 @@ rspackTest(
   'should support legacy decorators and source.decorators.version in TypeScript',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginBabel()],
+      config: {
+        plugins: [pluginBabel()],
+      },
     });
 
     expect(await page.evaluate('window.aaa')).toBe('hello');
@@ -18,8 +20,8 @@ rspackTest(
   'should support legacy decorators and source.decorators.version in JavaScript',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginBabel()],
       config: {
+        plugins: [pluginBabel()],
         source: {
           entry: {
             index: './src/jsIndex.js',

--- a/e2e/cases/plugin-react/split-chunk/index.test.ts
+++ b/e2e/cases/plugin-react/split-chunk/index.test.ts
@@ -3,7 +3,9 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should split react chunks correctly', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
+    config: {
+      plugins: [pluginReact()],
+    },
   });
 
   const files = rsbuild.getDistFiles();
@@ -16,8 +18,8 @@ test('should not split react chunks when strategy is `all-in-one`', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -34,8 +36,8 @@ test('should not split react chunks when strategy is `all-in-one`', async ({
 
 test('should not override user defined cache groups', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginReact()],
     config: {
+      plugins: [pluginReact()],
       performance: {
         chunkSplit: {
           override: {

--- a/e2e/cases/plugin-solid/index.test.ts
+++ b/e2e/cases/plugin-solid/index.test.ts
@@ -22,7 +22,9 @@ const buildFixture = (
   return build({
     cwd: root,
     runServer: true,
-    plugins,
+    config: {
+      plugins,
+    },
   });
 };
 

--- a/e2e/cases/plugin-svelte/hmr/index.test.ts
+++ b/e2e/cases/plugin-svelte/hmr/index.test.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
-import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
 rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
   const cwd = __dirname;
@@ -11,9 +10,7 @@ rspackTest('HMR should work properly', async ({ page, dev, editFile }) => {
     fs.readFileSync(path.join(cwd, 'src/B.svelte'), 'utf-8'),
   );
 
-  await dev({
-    plugins: [pluginSvelte()],
-  });
+  await dev();
 
   const a = page.locator('#A');
   const b = page.locator('#B');

--- a/e2e/cases/plugin-vue/split-chunks/index.test.ts
+++ b/e2e/cases/plugin-vue/split-chunks/index.test.ts
@@ -3,7 +3,9 @@ import { pluginVue } from '@rsbuild/plugin-vue';
 
 test('should split vue chunks correctly', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginVue()],
+    config: {
+      plugins: [pluginVue()],
+    },
   });
 
   const files = rsbuild.getDistFiles();
@@ -16,8 +18,8 @@ test('should not split vue chunks when strategy is `all-in-one`', async ({
   build,
 }) => {
   const rsbuild = await build({
-    plugins: [pluginVue()],
     config: {
+      plugins: [pluginVue()],
       performance: {
         chunkSplit: {
           strategy: 'all-in-one',
@@ -34,8 +36,8 @@ test('should not split vue chunks when strategy is `all-in-one`', async ({
 
 test('should not override user defined cache groups', async ({ build }) => {
   const rsbuild = await build({
-    plugins: [pluginVue()],
     config: {
+      plugins: [pluginVue()],
       performance: {
         chunkSplit: {
           override: {

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -8,8 +8,8 @@ rspackTest(
   'should provide history api fallback for dev server correctly',
   async ({ page, devOnly }) => {
     const rsbuild = await devOnly({
-      plugins: [pluginReact()],
       config: {
+        plugins: [pluginReact()],
         source: {
           entry: {
             main: join(cwd, 'src/index.jsx'),
@@ -40,9 +40,9 @@ test('should provide history api fallback for preview server correctly', async (
 }) => {
   const rsbuild = await buildPreview({
     cwd,
-    plugins: [pluginReact()],
 
     config: {
+      plugins: [pluginReact()],
       source: {
         entry: {
           main: join(cwd, 'src/index.jsx'),

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -257,17 +257,17 @@ test('should access /main success when modify publicPath in compiler', async ({
           main: join(cwd, 'src/index.js'),
         },
       },
-    },
-    plugins: [
-      {
-        name: 'foo',
-        setup(api: any) {
-          api.modifyBundlerChain((chain: any) => {
-            chain.output.publicPath('/aaaa/');
-          });
+      plugins: [
+        {
+          name: 'foo',
+          setup(api: any) {
+            api.modifyBundlerChain((chain: any) => {
+              chain.output.publicPath('/aaaa/');
+            });
+          },
         },
-      },
-    ],
+      ],
+    },
   });
 
   const url = new URL(`http://localhost:${rsbuild.port}/main`);

--- a/e2e/cases/server/preview/index.test.ts
+++ b/e2e/cases/server/preview/index.test.ts
@@ -24,7 +24,9 @@ test('should allow plugin to modify preview server config', async ({
   };
 
   const result = await buildPreview({
-    plugins: [plugin],
+    config: {
+      plugins: [plugin],
+    },
   });
 
   expect(result.port).toEqual(PORT);

--- a/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-2022-03/index.test.ts
@@ -16,7 +16,9 @@ rspackTest(
   'should run stage 3 decorators correctly with babel-plugin',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginBabel()],
+      config: {
+        plugins: [pluginBabel()],
+      },
     });
 
     expect(await page.evaluate('window.message')).toBe('hello');
@@ -36,8 +38,8 @@ test.fail(
             index: './src/decoratorBeforeExport.js',
           },
         },
+        plugins: [pluginBabel()],
       },
-      plugins: [pluginBabel()],
     });
 
     expect(await page.evaluate('window.message')).toBe('hello');

--- a/e2e/cases/syntax-es/decorator-config/index.test.ts
+++ b/e2e/cases/syntax-es/decorator-config/index.test.ts
@@ -35,7 +35,9 @@ rspackTest(
   'should use legacy decorators with babel-plugin',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginBabel()],
+      config: {
+        plugins: [pluginBabel()],
+      },
     });
 
     expect(await page.evaluate('window.aaa')).toBe('hello');
@@ -48,8 +50,8 @@ rspackTest(
   'should allow to use stage 3 decorators with babel-plugin',
   async ({ page, buildPreview }) => {
     await buildPreview({
-      plugins: [pluginBabel()],
       config: {
+        plugins: [pluginBabel()],
         source: {
           decorators: {
             version: '2022-03',


### PR DESCRIPTION
## Summary

This change standardizes the test configuration by moving `plugins` from the root level into the `config` object. It improves consistency across all test cases.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
