### PR TITLE
test(e2e): standardize file content assertions using helper functions

### DIFF
--- a/e2e/cases/css/inject-styles-lightningcss/index.test.ts
+++ b/e2e/cases/css/inject-styles-lightningcss/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should use lightningcss-loader to transform and minify CSS when injectStyles is true',
@@ -9,12 +9,10 @@ rspackTest(
     const files = rsbuild.getDistFiles();
 
     // should inline minified CSS
-    const indexJsFile = Object.keys(files).find(
-      (file) => file.includes('index.') && file.endsWith('.js'),
-    )!;
+    const indexJs = getFileContent(files, 'index.js');
 
     expect(
-      files[indexJsFile].includes(
+      indexJs.includes(
         '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;user-select:none;background:linear-gradient(#fff,#000);transition:all .5s}}',
       ),
     ).toBeTruthy();

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 const fixtures = __dirname;
 
@@ -15,15 +15,11 @@ rspackTest(
     expect(cssFiles.length).toBe(0);
 
     // should inline minified CSS
-    const indexJsFile = Object.keys(files).find(
-      (file) => file.includes('index.') && file.endsWith('.js'),
-    )!;
+    const indexJs = getFileContent(files, 'index.js');
 
+    expect(indexJs.includes('html,body{margin:0;padding:0}')).toBeTruthy();
     expect(
-      files[indexJsFile].includes('html,body{margin:0;padding:0}'),
-    ).toBeTruthy();
-    expect(
-      files[indexJsFile].includes(
+      indexJs.includes(
         '.description{text-align:center;font-size:16px;line-height:1.5}',
       ),
     ).toBeTruthy();
@@ -97,12 +93,10 @@ rspackTest(
     expect(cssFiles.length).toBe(0);
 
     // should inline CSS
-    const indexJsFile = Object.keys(files).find(
-      (file) => file.includes('index.') && file.endsWith('.js'),
-    )!;
+    const indexJs = getFileContent(files, 'index.js');
 
     expect(
-      files[indexJsFile].includes(`html, body {
+      indexJs.includes(`html, body {
   margin: 0;
   padding: 0;
 }`),

--- a/e2e/cases/css/lightningcss-disabled/index.test.ts
+++ b/e2e/cases/css/lightningcss-disabled/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow to disable the built-in lightningcss loader',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content = getFileContent(files, '.css');
 
     expect(content).not.toContain('-webkit-');
     expect(content).not.toContain('-ms-');

--- a/e2e/cases/css/lightningcss-prefixes/index.test.ts
+++ b/e2e/cases/css/lightningcss-prefixes/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should add vendor prefixes by current browserslist',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content = getFileContent(files, '.css');
 
     expect(content).toEqual(
       '@media (-webkit-min-device-pixel-ratio:2),(min-resolution:2dppx){.item{-webkit-user-select:none;-ms-user-select:none;user-select:none;background:-webkit-linear-gradient(#000,#fff);background:linear-gradient(#fff,#000);-webkit-transition:all .5s;transition:all .5s}}',
@@ -21,10 +20,7 @@ rspackTest(
     const rsbuild = await dev();
 
     const distFiles = rsbuild.getDistFiles();
-    const content =
-      distFiles[
-        Object.keys(distFiles).find((file) => file.endsWith('css/index.css'))!
-      ];
+    const content = getFileContent(distFiles, 'css/index.css');
     expect(content).toContain(
       `@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 2dppx) {
   .item {

--- a/e2e/cases/css/nested-npm-import/index.test.ts
+++ b/e2e/cases/css/nested-npm-import/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should compile nested npm import correctly', async ({ build }) => {
   fs.cpSync(
@@ -12,9 +12,9 @@ rspackTest('should compile nested npm import correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
+  const cssContent = getFileContent(files, '.css');
 
-  expect(files[cssFiles]).toEqual(
+  expect(cssContent).toEqual(
     '#b{color:#ff0}#c{color:green}#a{font-size:10px}html{font-size:18px}',
   );
 });

--- a/e2e/cases/css/postcss-config-ts/index.test.ts
+++ b/e2e/cases/css/postcss-config-ts/index.test.ts
@@ -1,14 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should load postcss.config.ts correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexCssFile = Object.keys(files).find(
-    (file) => file.includes('index.') && file.endsWith('.css'),
-  )!;
-
-  const indexCssContent = files[indexCssFile];
+  const indexCssContent = getFileContent(files, 'index.css');
   expect(indexCssContent).toContain(
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}',
   );

--- a/e2e/cases/css/postcss-function-options-merge/index.test.ts
+++ b/e2e/cases/css/postcss-function-options-merge/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should merge `postcssOptions` function with `postcss.config.ts` as expected', async ({
   build,
@@ -11,15 +11,11 @@ test('should merge `postcssOptions` function with `postcss.config.ts` as expecte
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}}';
 
   const files = rsbuild.getDistFiles();
-  const fooCssFile = Object.keys(files).find(
-    (file) => file.includes('foo.') && file.endsWith('.css'),
-  )!;
-  expect(files[fooCssFile]).toContain(fooCssExpected);
-  expect(files[fooCssFile]).not.toContain(barCssExpected);
+  const fooCss = getFileContent(files, 'foo.css');
+  expect(fooCss).toContain(fooCssExpected);
+  expect(fooCss).not.toContain(barCssExpected);
 
-  const barCssFile = Object.keys(files).find(
-    (file) => file.includes('bar.') && file.endsWith('.css'),
-  )!;
-  expect(files[barCssFile]).toContain(barCssExpected);
-  expect(files[barCssFile]).not.toContain(fooCssExpected);
+  const barCss = getFileContent(files, 'bar.css');
+  expect(barCss).toContain(barCssExpected);
+  expect(barCss).not.toContain(fooCssExpected);
 });

--- a/e2e/cases/css/postcss-function-options/index.test.ts
+++ b/e2e/cases/css/postcss-function-options/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow to use `postcssOptions` function to apply different postcss config for different files', async ({
   build,
@@ -11,15 +11,11 @@ test('should allow to use `postcssOptions` function to apply different postcss c
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}}';
 
   const files = rsbuild.getDistFiles();
-  const fooCssFile = Object.keys(files).find(
-    (file) => file.includes('foo.') && file.endsWith('.css'),
-  )!;
-  expect(files[fooCssFile]).toContain(fooCssExpected);
-  expect(files[fooCssFile]).not.toContain(barCssExpected);
+  const fooCss = getFileContent(files, 'foo.css');
+  expect(fooCss).toContain(fooCssExpected);
+  expect(fooCss).not.toContain(barCssExpected);
 
-  const barCssFile = Object.keys(files).find(
-    (file) => file.includes('bar.') && file.endsWith('.css'),
-  )!;
-  expect(files[barCssFile]).toContain(barCssExpected);
-  expect(files[barCssFile]).not.toContain(fooCssExpected);
+  const barCss = getFileContent(files, 'bar.css');
+  expect(barCss).toContain(barCssExpected);
+  expect(barCss).not.toContain(fooCssExpected);
 });

--- a/e2e/cases/css/relative-import/index.test.ts
+++ b/e2e/cases/css/relative-import/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should compile CSS relative imports correctly',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content = getFileContent(files, '.css');
 
     expect(content).toContain(
       '.foo{color:red}.bar{color:#00f}.baz{color:green}',

--- a/e2e/cases/css/resolve-alias/index.test.ts
+++ b/e2e/cases/css/resolve-alias/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should compile CSS with alias correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toMatch(
     /\.the-a-class{color:red;background-image:url\(\/static\/image\/icon\.\w{8}\.png\)}\.the-b-class{color:#00f;background-image:url\(\/static\/image\/icon\.\w{8}\.png\)}\.the-c-class{color:#ff0;background-image:url\(\/static\/image\/icon\.\w{8}\.png\)}/,

--- a/e2e/cases/css/resolve-ts-paths/index.test.ts
+++ b/e2e/cases/css/resolve-ts-paths/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should resolve ts paths correctly in SCSS file',
@@ -7,8 +7,7 @@ rspackTest(
 
     const files = rsbuild.getDistFiles();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content = getFileContent(files, '.css');
 
     expect(content).toContain('background-image:url(/static/image/icon');
   },

--- a/e2e/cases/css/resolve-url-loader/index.test.ts
+++ b/e2e/cases/css/resolve-url-loader/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should resolve relative asset correctly in SCSS file', async ({
   build,
@@ -6,8 +6,7 @@ test('should resolve relative asset correctly in SCSS file', async ({
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toContain('background-image:url(/static/image/icon');
 });

--- a/e2e/cases/html/app-icon/index.test.ts
+++ b/e2e/cases/html/app-icon/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 
 test('should emit apple-touch-icon to dist path', async ({ build }) => {
   const rsbuild = await build({
@@ -11,13 +11,11 @@ test('should emit apple-touch-icon to dist path', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const appleIcon = findFile(files, 'static/image/icon.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
-  ).toBeTruthy();
+  expect(appleIcon.endsWith('static/image/icon.png')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="/static/image/icon.png">',
@@ -39,21 +37,14 @@ test('should emit manifest.webmanifest to dist path', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const appleIcon = findFile(files, 'static/image/icon.png');
+  const largeIcon = findFile(files, 'static/image/image.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
-  ).toBeTruthy();
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/image.png')),
-  ).toBeTruthy();
+  expect(appleIcon.endsWith('static/image/icon.png')).toBeTruthy();
+  expect(largeIcon.endsWith('static/image/image.png')).toBeTruthy();
 
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-  expect(manifestPath).toBeTruthy();
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.webmanifest');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="/static/image/icon.png">',
@@ -64,7 +55,7 @@ test('should emit manifest.webmanifest to dist path', async ({ build }) => {
   );
   expect(html).toContain('<link rel="manifest" href="/manifest.webmanifest">');
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       { src: '/static/image/icon.png', sizes: '180x180', type: 'image/png' },
@@ -89,19 +80,15 @@ test('should allow to specify URL as icon', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.webmanifest');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="192x192" href="https://example.com/icon-192.png">',
   );
   expect(html).toContain('<link rel="manifest" href="/manifest.webmanifest">');
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       {
@@ -146,24 +133,16 @@ test('should allow to specify target for each icon', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const appleIcon = findFile(files, 'static/image/icon.png');
+  const largeIcon = findFile(files, 'static/image/image.png');
+  const svgIcon = findFile(files, 'static/image/circle.svg');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
-  ).toBeTruthy();
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/image.png')),
-  ).toBeTruthy();
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/circle.svg')),
-  ).toBeTruthy();
+  expect(appleIcon.endsWith('static/image/icon.png')).toBeTruthy();
+  expect(largeIcon.endsWith('static/image/image.png')).toBeTruthy();
+  expect(svgIcon.endsWith('static/image/circle.svg')).toBeTruthy();
 
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-  expect(manifestPath).toBeTruthy();
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.webmanifest');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="/static/image/icon.png">',
@@ -177,7 +156,7 @@ test('should allow to specify target for each icon', async ({ build }) => {
   );
   expect(html).toContain('<link rel="manifest" href="/manifest.webmanifest">');
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       {
@@ -215,12 +194,9 @@ test('should allow to specify purpose for each icon', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-  expect(manifestPath).toBeTruthy();
+  const manifestPath = findFile(files, 'manifest.webmanifest');
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       {
@@ -256,17 +232,12 @@ test('should allow to customize manifest filename', async ({ build }) => {
   });
 
   const files = rsbuild.getDistFiles();
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.json'),
-  );
-  expect(manifestPath).toBeTruthy();
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.json');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="manifest" href="/manifest.json">');
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       { src: '/static/image/icon.png', sizes: '180x180', type: 'image/png' },
@@ -294,21 +265,14 @@ test('should append dev.assetPrefix to icon URL', async ({ dev }) => {
   });
 
   const files = rsbuild.getDistFiles();
+  const appleIcon = findFile(files, 'static/image/icon.png');
+  const largeIcon = findFile(files, 'static/image/image.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
-  ).toBeTruthy();
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/image.png')),
-  ).toBeTruthy();
+  expect(appleIcon.endsWith('static/image/icon.png')).toBeTruthy();
+  expect(largeIcon.endsWith('static/image/image.png')).toBeTruthy();
 
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-  expect(manifestPath).toBeTruthy();
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.webmanifest');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="http://localhost:3000/static/image/icon.png">',
@@ -317,7 +281,7 @@ test('should append dev.assetPrefix to icon URL', async ({ dev }) => {
     '<link rel="manifest" href="http://localhost:3000/manifest.webmanifest">',
   );
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       {
@@ -352,21 +316,14 @@ test('should append output.assetPrefix to icon URL', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const appleIcon = findFile(files, 'static/image/icon.png');
+  const largeIcon = findFile(files, 'static/image/image.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/icon.png')),
-  ).toBeTruthy();
-  expect(
-    Object.keys(files).some((file) => file.endsWith('static/image/image.png')),
-  ).toBeTruthy();
+  expect(appleIcon.endsWith('static/image/icon.png')).toBeTruthy();
+  expect(largeIcon.endsWith('static/image/image.png')).toBeTruthy();
 
-  const manifestPath = Object.keys(files).find((file) =>
-    file.endsWith('manifest.webmanifest'),
-  );
-  expect(manifestPath).toBeTruthy();
-
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const manifestPath = findFile(files, 'manifest.webmanifest');
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="https://example.com/static/image/icon.png">',
@@ -375,7 +332,7 @@ test('should append output.assetPrefix to icon URL', async ({ build }) => {
     '<link rel="manifest" href="https://example.com/manifest.webmanifest">',
   );
 
-  expect(JSON.parse(files[manifestPath!])).toEqual({
+  expect(JSON.parse(files[manifestPath])).toEqual({
     name: 'My Website',
     icons: [
       {
@@ -413,8 +370,7 @@ test('should apply asset prefix to apple-touch-icon URL', async ({ build }) => {
 
   expect(bundlerConfigs[0].output?.publicPath).toBe('https://www.example.com/');
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="apple-touch-icon" sizes="180x180" href="https://www.example.com/static/image/icon.png">',

--- a/e2e/cases/html/cross-origin/index.test.ts
+++ b/e2e/cases/html/cross-origin/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should not apply crossOrigin by default', async ({ build }) => {
   const rsbuild = await build({
@@ -9,8 +9,7 @@ test('should not apply crossOrigin by default', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).not.toContain('crossorigin');
 });
@@ -30,8 +29,7 @@ test('should apply crossOrigin when crossorigin is "anonymous" and not same orig
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('crossorigin="anonymous"></script>');
 });

--- a/e2e/cases/html/custom-filename/index.test.ts
+++ b/e2e/cases/html/custom-filename/index.test.ts
@@ -1,15 +1,12 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should allow to custom HTML filename', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const fooFile = Object.keys(files).find((item) =>
-    item.includes('custom-foo.html'),
-  );
-  const barFile = Object.keys(files).find((item) =>
-    item.includes('custom-bar.html'),
-  );
-  expect(fooFile).toBeTruthy();
-  expect(barFile).toBeTruthy();
+  const fooFile = findFile(files, 'custom-foo.html');
+  const barFile = findFile(files, 'custom-bar.html');
+
+  expect(fooFile.endsWith('custom-foo.html')).toBeTruthy();
+  expect(barFile.endsWith('custom-bar.html')).toBeTruthy();
 });

--- a/e2e/cases/html/favicon/index.test.ts
+++ b/e2e/cases/html/favicon/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, getFileContent, test } from '@e2e/helper';
 
 test('should emit local favicon to dist path', async ({ build }) => {
   const rsbuild = await build({
@@ -11,13 +11,11 @@ test('should emit local favicon to dist path', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const icon = findFile(files, 'icon.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('/icon.png')),
-  ).toBeTruthy();
+  expect(icon.endsWith('/icon.png')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="icon" href="/icon.png">');
 });
@@ -33,13 +31,11 @@ test('should allow `html.favicon` to be an absolute path', async ({
     },
   });
   const files = rsbuild.getDistFiles();
+  const icon = findFile(files, 'icon.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('/icon.png')),
-  ).toBeTruthy();
+  expect(icon.endsWith('/icon.png')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="icon" href="/icon.png">');
 });
@@ -53,13 +49,11 @@ test('should add type attribute for SVG favicon', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
+  const icon = findFile(files, 'mobile.svg');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('/mobile.svg')),
-  ).toBeTruthy();
+  expect(icon.endsWith('/mobile.svg')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="icon" href="/mobile.svg" type="image/svg+xml">',
@@ -79,8 +73,7 @@ test('should apply asset prefix to favicon URL', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     '<link rel="icon" href="https://www.example.com/icon.png">',
@@ -97,8 +90,7 @@ test('should allow favicon to be a CDN URL', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="icon" href="https://foo.com/icon.png">');
 });
@@ -125,14 +117,12 @@ test('should generate favicon via function correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain(
     '<link rel="icon" href="https://example.com/foo.ico">',
   );
 
-  const barHtml =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  const barHtml = getFileContent(files, 'bar.html');
   expect(barHtml).toContain(
     '<link rel="icon" href="https://example.com/bar.ico">',
   );
@@ -154,15 +144,11 @@ test('should allow to custom favicon dist path with a relative path', async ({
     },
   });
   const files = rsbuild.getDistFiles();
+  const faviconFile = findFile(files, 'static/favicon/icon.png');
 
-  expect(
-    Object.keys(files).some((file) =>
-      file.endsWith('/static/favicon/icon.png'),
-    ),
-  ).toBeTruthy();
+  expect(faviconFile.endsWith('/static/favicon/icon.png')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="icon" href="/static/favicon/icon.png">');
 });
@@ -183,13 +169,11 @@ test('should allow to custom favicon dist path with a relative path starting wit
     },
   });
   const files = rsbuild.getDistFiles();
+  const faviconFile = findFile(files, 'custom/icon.png');
 
-  expect(
-    Object.keys(files).some((file) => file.endsWith('/custom/icon.png')),
-  ).toBeTruthy();
+  expect(faviconFile.endsWith('/custom/icon.png')).toBeTruthy();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<link rel="icon" href="/custom/icon.png">');
 });

--- a/e2e/cases/html/filename-hash/index.test.ts
+++ b/e2e/cases/html/filename-hash/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should allow to generate HTML with filename hash using filename.html', async ({
   build,
@@ -14,11 +14,9 @@ test('should allow to generate HTML with filename hash using filename.html', asy
   });
 
   const files = rsbuild.getDistFiles();
-  const htmlFilename = Object.keys(files).find((item) =>
-    item.endsWith('.html'),
-  );
+  const htmlFilename = findFile(files, '.html');
 
-  expect(/index.\w+.html/.test(htmlFilename!)).toBeTruthy();
+  expect(/index.\w+.html/.test(htmlFilename)).toBeTruthy();
 });
 
 test('should allow to generate HTML with filename hash using tools.htmlPlugin', async ({
@@ -36,9 +34,7 @@ test('should allow to generate HTML with filename hash using tools.htmlPlugin', 
   });
 
   const files = rsbuild.getDistFiles();
-  const htmlFilename = Object.keys(files).find((item) =>
-    item.endsWith('.html'),
-  );
+  const htmlFilename = findFile(files, '.html');
 
-  expect(/index.\w+.html/.test(htmlFilename!)).toBeTruthy();
+  expect(/index.\w+.html/.test(htmlFilename)).toBeTruthy();
 });

--- a/e2e/cases/html/html-tags/basic/index.test.ts
+++ b/e2e/cases/html/html-tags/basic/index.test.ts
@@ -1,12 +1,11 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should inject tags correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
 
   expect(indexHtml.includes('<script src="/foo.js"></script>')).toBeTruthy();
   expect(

--- a/e2e/cases/html/html-tags/function-usage/index.test.ts
+++ b/e2e/cases/html/html-tags/function-usage/index.test.ts
@@ -1,4 +1,9 @@
-import { expect, normalizeNewlines, rspackTest } from '@e2e/helper';
+import {
+  expect,
+  getFileContent,
+  normalizeNewlines,
+  rspackTest,
+} from '@e2e/helper';
 
 rspackTest(
   'should inject tags with function usage correctly',
@@ -6,8 +11,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const indexHtml =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const indexHtml = getFileContent(files, 'index.html');
 
     expect(normalizeNewlines(indexHtml)).toEqual(
       `<!doctype html><html><head><script src="/foo.js"></script><script src="/bar.js"></script><script src="/baz.js"></script><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script></head><body><div id="root"></div></body></html>`,

--- a/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
+++ b/e2e/cases/html/html-tags/modify-by-entry/index.test.ts
@@ -1,14 +1,12 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow to inject tags by entry name', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const fooHTML =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHTML = getFileContent(files, 'foo.html');
   expect(fooHTML.match(/src="https:\/\/www\.cdn\.com\/foo\.js/)).toBeTruthy();
 
-  const barHTML =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  const barHTML = getFileContent(files, 'bar.html');
   expect(barHTML.match(/src="https:\/\/www\.cdn\.com\/bar\.js/)).toBeTruthy();
 });

--- a/e2e/cases/html/inject/index.test.ts
+++ b/e2e/cases/html/inject/index.test.ts
@@ -1,5 +1,11 @@
 import path from 'node:path';
-import { expect, normalizeNewlines, rspackTest, test } from '@e2e/helper';
+import {
+  expect,
+  getFileContent,
+  normalizeNewlines,
+  rspackTest,
+  test,
+} from '@e2e/helper';
 import { pluginRem } from '@rsbuild/plugin-rem';
 
 test('should preserve the expected script injection order', async ({
@@ -20,8 +26,7 @@ test('should preserve the expected script injection order', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   // rem => normal resource => template custom resource
   expect(
@@ -53,14 +58,12 @@ rspackTest('should set inject via function correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(normalizeNewlines(fooHtml)).toEqual(
     `<!doctype html><html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"></head><body><div id="root"></div><script defer src="/static/js/foo.js"></script></body></html>`,
   );
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
   expect(normalizeNewlines(indexHtml)).toEqual(
     `<!doctype html><html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src="/static/js/index.js"></script><link href="/static/css/index.css" rel="stylesheet"></head><body><div id="root"></div></body></html>`,
   );

--- a/e2e/cases/html/meta/index.test.ts
+++ b/e2e/cases/html/meta/index.test.ts
@@ -1,4 +1,9 @@
-import { expect, normalizeNewlines, rspackTest } from '@e2e/helper';
+import {
+  expect,
+  getFileContent,
+  normalizeNewlines,
+  rspackTest,
+} from '@e2e/helper';
 
 rspackTest(
   'should not inject charset meta if template already contains it',
@@ -6,8 +11,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const html =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const html = getFileContent(files, 'index.html');
     expect(normalizeNewlines(html)).toEqual(`<!doctype html>
 <html>
   <head>

--- a/e2e/cases/html/minify/index.test.ts
+++ b/e2e/cases/html/minify/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should minify template success when inlineScripts & inlineStyles',
@@ -7,8 +7,7 @@ rspackTest(
 
     const files = rsbuild.getDistFiles();
 
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.html'))!];
+    const content = getFileContent(files, '.html');
 
     expect(content.includes('html,body{margin:0;padding:0}')).toBeTruthy();
     expect(

--- a/e2e/cases/html/script-loading/index.test.ts
+++ b/e2e/cases/html/script-loading/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
 
 rspackTest('should apply defer by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<script defer src="');
 });
@@ -20,8 +19,7 @@ test('should remove defer when scriptLoading is "blocking"', async ({
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<script src="');
 });
@@ -35,8 +33,7 @@ test('should allow to set scriptLoading to "module"', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain('<script type="module" src="');
 });

--- a/e2e/cases/html/template-conditional-statement/index.test.ts
+++ b/e2e/cases/html/template-conditional-statement/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should render conditional statement correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
 
   // Basic if statement (showBasic: true)
   expect(indexHtml).toContain('Basic if true');

--- a/e2e/cases/html/template-escape/index.test.ts
+++ b/e2e/cases/html/template-escape/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should escape template parameters correctly', async ({ build }) => {
   const rsbuild = await build({
@@ -12,12 +12,10 @@ test('should escape template parameters correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain('&lt;div&gt;escape me&lt;/div&gt;');
 
-  const barHtml =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  const barHtml = getFileContent(files, 'bar.html');
   expect(barHtml).toContain('<div>escape me</div>');
 });
 
@@ -36,12 +34,10 @@ test('should allow to passing undefined to template parameters', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain('<div id="test"></div>');
 
-  const barHtml =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  const barHtml = getFileContent(files, 'bar.html');
   expect(barHtml).toContain('<div id="test"></div>');
 
   expect(rsbuild.buildError).toBeFalsy();

--- a/e2e/cases/html/template-loop-statement/index.test.ts
+++ b/e2e/cases/html/template-loop-statement/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should render loop statements correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
 
   // Basic for loop
   expect(indexHtml).toContain('<div id="for">');

--- a/e2e/cases/html/template-no-head/index.test.ts
+++ b/e2e/cases/html/template-no-head/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 // https://github.com/web-infra-dev/rsbuild/issues/4924
 rspackTest(
@@ -7,8 +7,7 @@ rspackTest(
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
 
-    const indexHtml =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const indexHtml = getFileContent(files, 'index.html');
     expect(indexHtml).toContain(
       '<!doctype html><head><title>Rsbuild App</title><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><script defer src=',
     );

--- a/e2e/cases/html/template-with-script/index.test.ts
+++ b/e2e/cases/html/template-with-script/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 // see: https://github.com/rspack-contrib/html-rspack-plugin/issues/14
 test('should compile template with es template correctly', async ({
@@ -7,8 +7,7 @@ test('should compile template with es template correctly', async ({
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
   // biome-ignore lint/suspicious/noTemplateCurlyInString: should ignore string
   expect(indexHtml).toContain("const baseUrl = match ? `${match[0]}/` : '/'");
 });

--- a/e2e/cases/html/template/index.test.ts
+++ b/e2e/cases/html/template/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should set template via function correctly', async ({ build }) => {
   const rsbuild = await build({
@@ -26,12 +26,10 @@ test('should set template via function correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain('<div id="test-template">foo</div>');
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
   expect(indexHtml).toContain('<div id="test-template">text</div>');
 });
 
@@ -86,11 +84,9 @@ test('should set template via tools.htmlPlugin correctly', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain('<div id="test-template">foo</div>');
 
-  const indexHtml =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const indexHtml = getFileContent(files, 'index.html');
   expect(indexHtml).toContain('<div id="test-template">text</div>');
 });

--- a/e2e/cases/html/title/index.test.ts
+++ b/e2e/cases/html/title/index.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate default title correctly', async ({ build }) => {
   const rsbuild = await build({
@@ -12,8 +12,7 @@ test('should generate default title correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).toContain('<title>Rsbuild App</title>');
 });
 
@@ -32,8 +31,7 @@ test('should allow setting empty title to unset the default title', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).not.toContain('<title>');
 });
 
@@ -50,8 +48,7 @@ test('should generate title correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).toContain('<title>foo</title>');
 });
 
@@ -71,8 +68,7 @@ test('should generate title correctly when using custom HTML template', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).toContain('<title>foo</title>');
 });
 
@@ -92,8 +88,7 @@ test('should generate title correctly when using htmlPlugin.options.title', asyn
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).toContain('<title>foo</title>');
 });
 
@@ -115,12 +110,10 @@ test('should generate title via function correctly', async ({ build }) => {
   });
   const files = rsbuild.getDistFiles();
 
-  const fooHtml =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const fooHtml = getFileContent(files, 'foo.html');
   expect(fooHtml).toContain('<title>foo</title>');
 
-  const barHtml =
-    files[Object.keys(files).find((file) => file.endsWith('bar.html'))!];
+  const barHtml = getFileContent(files, 'bar.html');
   expect(barHtml).toContain('<title>bar</title>');
 });
 
@@ -140,7 +133,6 @@ test('should not inject title if template already contains a title', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('foo.html'))!];
+  const html = getFileContent(files, 'foo.html');
   expect(html).toContain('<title>Page Title</title>');
 });

--- a/e2e/cases/node-addons/index.test.ts
+++ b/e2e/cases/node-addons/index.test.ts
@@ -1,21 +1,14 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
 
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 import fse, { remove } from 'fs-extra';
 
 test('should compile Node addons correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const addonFile = Object.keys(files).find((file) =>
-    file.endsWith('test.darwin.node'),
-  );
-
-  expect(addonFile?.includes('/test.darwin.node')).toBeTruthy();
-
-  expect(
-    fs.existsSync(join(__dirname, 'dist', 'test.darwin.node')),
-  ).toBeTruthy();
+  const addonFile = findFile(files, 'test.darwin.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
   // the `test.darwin.node` is only compatible with darwin
   if (process.platform === 'darwin') {
@@ -56,13 +49,8 @@ test('should compile Node addons in the node_modules correctly', async ({
   });
 
   const files = rsbuild.getDistFiles();
-  const addonFile = Object.keys(files).find((file) =>
-    file.endsWith('other.node'),
-  );
-
-  expect(addonFile?.includes('/other.node')).toBeTruthy();
-
-  expect(fs.existsSync(join(__dirname, 'dist', 'other.node'))).toBeTruthy();
+  const addonFile = findFile(files, 'other.node');
+  expect(fs.existsSync(addonFile)).toBeTruthy();
 
   if (process.platform === 'darwin') {
     const { default: content } = await import('./dist/index.js' as string);

--- a/e2e/cases/optimization/css-minify-always/index.test.ts
+++ b/e2e/cases/optimization/css-minify-always/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should minimize CSS correctly by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toEqual(
     '.a{text-align:center;text-align:center;font-size:1.5rem;line-height:1.5}.b{text-align:center;background:#fafafa;font-size:1.5rem;line-height:1.5}',

--- a/e2e/cases/optimization/css-minify-options/index.test.ts
+++ b/e2e/cases/optimization/css-minify-options/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow to custom CSS minify options', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toEqual('.bar{color:green}');
 });

--- a/e2e/cases/optimization/css-minify/index.test.ts
+++ b/e2e/cases/optimization/css-minify/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow to minify CSS in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toEqual(
     '.a{text-align:center;text-align:center;font-size:1.5rem;line-height:1.5}.b{text-align:center;background:#fafafa;font-size:1.5rem;line-height:1.5}',

--- a/e2e/cases/optimization/js-minify-always/index.test.ts
+++ b/e2e/cases/optimization/js-minify-always/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow to minify JS in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles();
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.js'))!];
+  const content = getFileContent(files, '.js');
 
   expect(content).toContain('function(){console.log("main")}');
 });

--- a/e2e/cases/output/charset/index.test.ts
+++ b/e2e/cases/output/charset/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
 
 const utf8Str = `你好 world! I'm 🦀`;
 const asciiStr = `\\u{4F60}\\u{597D} world! I'm \\u{1F980}`;
@@ -28,9 +28,10 @@ rspackTest(
     expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
     const files = rsbuild.getDistFiles();
-    const [, content] = Object.entries(files).find(
-      ([name]) => name.endsWith('.js') && name.includes('static/js/index'),
-    )!;
+    const content = getFileContent(
+      files,
+      (name) => name.endsWith('.js') && name.includes('static/js/index'),
+    );
 
     expect(content.includes(asciiStr)).toBeTruthy();
   },
@@ -62,9 +63,10 @@ test('should use utf8 charset in dev by default', async ({ page, dev }) => {
   expect(await page.evaluate('window.testB')).toStrictEqual(expectedObject);
 
   const files = rsbuild.getDistFiles();
-  const [, content] = Object.entries(files).find(
-    ([name]) => name.endsWith('.js') && name.includes('static/js/index'),
-  )!;
+  const content = getFileContent(
+    files,
+    (name) => name.endsWith('.js') && name.includes('static/js/index'),
+  );
 
   expect(content.includes(utf8Str)).toBeTruthy();
 });

--- a/e2e/cases/output/externals/index.test.ts
+++ b/e2e/cases/output/externals/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 test('should treat specified modules as externals', async ({
@@ -46,7 +46,6 @@ test('should not externalize dependencies when target is web worker', async ({
   });
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.js'))!];
+  const content = getFileContent(files, '.js');
   expect(content.includes('MyReact')).toBeFalsy();
 });

--- a/e2e/cases/output/inline-chunk/index.test.ts
+++ b/e2e/cases/output/inline-chunk/index.test.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 import type { RspackChain } from '@rsbuild/core';
 
 // use source-map for easy to test. By default, Rsbuild use hidden-source-map
@@ -378,10 +378,7 @@ test('should update source mapping URL in build', async ({ build }) => {
   });
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
-  const indexHtml =
-    files[
-      Object.keys(files).find((fileName) => fileName.endsWith('/index.html'))!
-    ];
+  const indexHtml = getFileContent(files, '/index.html');
 
   expect(
     indexHtml.includes(

--- a/e2e/cases/output/legal-comments/index.test.ts
+++ b/e2e/cases/output/legal-comments/index.test.ts
@@ -1,4 +1,10 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import {
+  expect,
+  findFile,
+  getFileContent,
+  rspackTest,
+  test,
+} from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 rspackTest('legalComments linked (default)', async ({ page, buildPreview }) => {
@@ -17,24 +23,17 @@ rspackTest('legalComments linked (default)', async ({ page, buildPreview }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const LicenseContent =
-    files[
-      Object.keys(files).find(
-        (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
-      )!
-    ];
+  const LicenseContent = getFileContent(
+    files,
+    (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
+  );
 
   expect(LicenseContent.includes('@preserve AAAA')).toBeTruthy();
   expect(LicenseContent.includes('@license BBB')).toBeTruthy();
   expect(LicenseContent.includes('Legal Comment CCC')).toBeTruthy();
   expect(LicenseContent.includes('Foo Bar')).toBeFalsy();
 
-  const JsContent =
-    files[
-      Object.keys(files).find(
-        (file) => file.includes('js/index') && file.endsWith('.js'),
-      )!
-    ];
+  const JsContent = getFileContent(files, 'index.js');
 
   expect(JsContent.includes('Foo Bar')).toBeFalsy();
 });
@@ -61,18 +60,17 @@ test('should omit legal comments when legalComments is set to "none"', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const LicenseFile = Object.keys(files).find(
-    (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
-  )!;
+  expect(() =>
+    findFile(
+      files,
+      (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
+    ),
+  ).toThrow();
 
-  expect(LicenseFile).toBeUndefined();
-
-  const JsContent =
-    files[
-      Object.keys(files).find(
-        (file) => file.includes('js/index') && file.endsWith('.js'),
-      )!
-    ];
+  const JsContent = getFileContent(
+    files,
+    (file) => file.includes('js/index') && file.endsWith('.js'),
+  );
 
   expect(JsContent.includes('@license BBB')).toBeFalsy();
 });
@@ -99,18 +97,17 @@ test('should inline legal comments when legalComments is set to "inline"', async
 
   const files = rsbuild.getDistFiles();
 
-  const LicenseFile = Object.keys(files).find(
-    (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
-  )!;
+  expect(() =>
+    findFile(
+      files,
+      (file) => file.includes('js/index') && file.endsWith('.LICENSE.txt'),
+    ),
+  ).toThrow();
 
-  expect(LicenseFile).toBeUndefined();
-
-  const JsContent =
-    files[
-      Object.keys(files).find(
-        (file) => file.includes('js/index') && file.endsWith('.js'),
-      )!
-    ];
+  const JsContent = getFileContent(
+    files,
+    (file) => file.includes('js/index') && file.endsWith('.js'),
+  );
 
   expect(JsContent.includes('@license BBB')).toBeTruthy();
   expect(JsContent.includes('Foo Bar')).toBeFalsy();

--- a/e2e/cases/output/manifest-async-chunks/index.test.ts
+++ b/e2e/cases/output/manifest-async-chunks/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate manifest for async chunks correctly', async ({
   build,
@@ -7,8 +7,7 @@ test('should generate manifest for async chunks correctly', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
 
   expect(manifestContent).toBeDefined();
 

--- a/e2e/cases/output/manifest-generate/index.test.ts
+++ b/e2e/cases/output/manifest-generate/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 import type { RsbuildConfig } from '@rsbuild/core';
 
 const config: RsbuildConfig = {
@@ -28,10 +28,7 @@ test('should generate custom manifest data in build', async ({ build }) => {
   });
 
   const files = rsbuild.getDistFiles();
-  const manifestContent =
-    files[
-      Object.keys(files).find((file) => file.endsWith('my-manifest.json'))!
-    ];
+  const manifestContent = getFileContent(files, 'my-manifest.json');
   const manifest = JSON.parse(manifestContent);
 
   expect(manifest.filesCount).toBe(2);
@@ -50,10 +47,7 @@ test('should generate custom manifest data in dev', async ({ dev }) => {
   });
 
   const files = rsbuild.getDistFiles();
-  const manifestContent =
-    files[
-      Object.keys(files).find((file) => file.endsWith('my-manifest.json'))!
-    ];
+  const manifestContent = getFileContent(files, 'my-manifest.json');
   const manifest = JSON.parse(manifestContent);
 
   expect(manifest.filesCount).toBe(2);

--- a/e2e/cases/output/manifest-single-vendor/index.test.ts
+++ b/e2e/cases/output/manifest-single-vendor/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate manifest with single vendor as expected', async ({
   build,
@@ -7,8 +7,7 @@ test('should generate manifest with single vendor as expected', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
 
   expect(manifestContent).toBeDefined();
 

--- a/e2e/cases/output/manifest/index.test.ts
+++ b/e2e/cases/output/manifest/index.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
 
 test('should generate manifest file in output', async ({ build }) => {
   const rsbuild = await build({
@@ -19,8 +19,7 @@ test('should generate manifest file in output', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
 
   expect(manifestContent).toBeDefined();
 
@@ -78,8 +77,7 @@ test('should generate manifest file when target is node', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
 
   expect(manifestContent).toBeDefined();
 
@@ -115,8 +113,7 @@ test('should always write manifest to disk when in dev', async ({ dev }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
 
   expect(manifestContent).toBeDefined();
 });
@@ -140,8 +137,7 @@ test('should allow to filter files in manifest', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const manifestContent =
-    files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+  const manifestContent = getFileContent(files, 'manifest.json');
   const manifest = JSON.parse(manifestContent);
 
   // main.js
@@ -175,8 +171,7 @@ rspackTest(
 
     const files = rsbuild.getDistFiles();
 
-    const manifestContent =
-      files[Object.keys(files).find((file) => file.endsWith('manifest.json'))!];
+    const manifestContent = getFileContent(files, 'manifest.json');
     const manifest = JSON.parse(manifestContent);
 
     expect(Object.keys(manifest.allFiles).length).toBe(3);

--- a/e2e/cases/output/source-map/index.test.ts
+++ b/e2e/cases/output/source-map/index.test.ts
@@ -1,6 +1,12 @@
 import { readFileSync } from 'node:fs';
 import path, { join } from 'node:path';
-import { type Build, expect, mapSourceMapPositions, test } from '@e2e/helper';
+import {
+  type Build,
+  expect,
+  getFileContent,
+  mapSourceMapPositions,
+  test,
+} from '@e2e/helper';
 import type { Rspack } from '@rsbuild/core';
 
 const cwd = __dirname;
@@ -31,10 +37,8 @@ async function testSourceMapType(
     path.join(__dirname, 'src/App.jsx'),
     'utf-8',
   );
-  const outputCode =
-    files[Object.keys(files).find((file) => file.endsWith('index.js'))!];
-  const sourceMap =
-    files[Object.keys(files).find((file) => file.endsWith('index.js.map'))!];
+  const outputCode = getFileContent(files, 'index.js');
+  const sourceMap = getFileContent(files, 'index.js.map');
 
   const AppContentIndex = outputCode.indexOf('Hello Rsbuild!');
   const indexContentIndex = outputCode.indexOf('window.test');
@@ -153,12 +157,7 @@ test('should generate source map correctly in dev', async ({ dev }) => {
   const rsbuild = await dev();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const jsMapPath = Object.keys(files).find((files) =>
-    files.endsWith('.js.map'),
-  );
-  expect(jsMapPath).not.toBeUndefined();
-  const jsMapContent = files[jsMapPath!];
-  const jsMap = JSON.parse(jsMapContent);
+  const jsMap = JSON.parse(getFileContent(files, '.js.map'));
   expect(jsMap.sources.length).toBeGreaterThan(1);
   expect(jsMap.file).toEqual('static/js/index.js');
   expect(jsMap.sourcesContent).toContain(

--- a/e2e/cases/performance/dns-prefetch/index.test.ts
+++ b/e2e/cases/performance/dns-prefetch/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate dnsPrefetch link when dnsPrefetch is defined', async ({
   build,
@@ -6,9 +6,7 @@ test('should generate dnsPrefetch link when dnsPrefetch is defined', async ({
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  const content = getFileContent(files, '.html');
 
   expect(
     content.includes('<link rel="dns-prefetch" href="http://aaaa.com">'),

--- a/e2e/cases/performance/external-helpers/index.test.ts
+++ b/e2e/cases/performance/external-helpers/index.test.ts
@@ -1,15 +1,8 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should externalHelpers by default', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles({ sourceMaps: true });
-
-  const content =
-    files[
-      Object.keys(files).find(
-        (file) => file.includes('static/js') && file.endsWith('.js.map'),
-      )!
-    ];
-
+  const content = getFileContent(files, 'static/js/index.js.map');
   expect(content).toContain('@swc/helpers');
 });

--- a/e2e/cases/performance/moment-locale/index.test.ts
+++ b/e2e/cases/performance/moment-locale/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should retain Moment locales when removeMomentLocale is false (default)', async ({
   build,
@@ -30,11 +30,10 @@ test('should retain Moment locales when removeMomentLocale is false (default)', 
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const fileName = Object.keys(files).find(
+  const momentMapFile = getFileContent(
+    files,
     (file) => file.includes('moment-js') && file.endsWith('.js.map'),
   );
-
-  const momentMapFile = files[fileName!];
 
   expect(momentMapFile.includes('moment/locale')).toBeTruthy();
 });
@@ -70,11 +69,10 @@ test('should remove Moment locales when removeMomentLocale is true', async ({
 
   const files = rsbuild.getDistFiles({ sourceMaps: true });
 
-  const fileName = Object.keys(files).find(
+  const momentMapFile = getFileContent(
+    files,
     (file) => file.includes('moment-js') && file.endsWith('.js.map'),
   );
-
-  const momentMapFile = files[fileName!];
 
   expect(momentMapFile.includes('moment/locale')).toBeFalsy();
 });

--- a/e2e/cases/performance/preconnect/index.test.ts
+++ b/e2e/cases/performance/preconnect/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate preconnect link when preconnect is defined', async ({
   build,
@@ -7,9 +7,7 @@ test('should generate preconnect link when preconnect is defined', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  const content = getFileContent(files, '.html');
 
   expect(
     content.includes('<link rel="preconnect" href="http://aaaa.com">'),

--- a/e2e/cases/performance/resource-hints-prefetch/index.test.ts
+++ b/e2e/cases/performance/resource-hints-prefetch/index.test.ts
@@ -1,5 +1,11 @@
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import {
+  expect,
+  findFile,
+  getFileContent,
+  rspackTest,
+  test,
+} from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
@@ -26,13 +32,12 @@ test('should generate prefetch link when prefetch is defined', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find(
+  const asyncFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(3);
@@ -68,13 +73,12 @@ test('should generate prefetch link correctly when assetPrefix do not have a pro
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find(
+  const asyncFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   expect(
     content.includes(
@@ -104,12 +108,10 @@ test('should generate prefetch link with include', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find((file) =>
+  const asyncFileName = findFile(files, (file) =>
     file.includes('/static/image/image'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
@@ -142,12 +144,10 @@ test('should generate prefetch link with include array', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find((file) =>
+  const asyncFileName = findFile(files, (file) =>
     file.includes('/static/image/image'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // image.png, test.js
   expect(content.match(/rel="prefetch"/g)?.length).toBe(2);
@@ -180,12 +180,10 @@ test('should generate prefetch link with exclude array', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find((file) =>
+  const asyncFileName = findFile(files, (file) =>
     file.includes('/static/image/image'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
@@ -221,16 +219,14 @@ test('should generate prefetch link by config (distinguish html)', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('page1.html'),
-  )!;
+  const content = getFileContent(files, 'page1.html');
 
   // icon.png、test.js, test.css, image.png
   expect(content.match(/rel="prefetch"/g)?.length).toBe(4);
 
-  const assetFileName = Object.keys(files).find((file) =>
+  const assetFileName = findFile(files, (file) =>
     file.includes('/static/image/'),
-  )!;
+  );
 
   expect(
     content.includes(
@@ -240,9 +236,7 @@ test('should generate prefetch link by config (distinguish html)', async ({
     ),
   ).toBeTruthy();
 
-  const [, content2] = Object.entries(files).find(([name]) =>
-    name.endsWith('page2.html'),
-  )!;
+  const content2 = getFileContent(files, 'page2.html');
 
   // test.js, test.css, image.png
   expect(content2.match(/rel="prefetch"/g)?.length).toBe(3);
@@ -270,9 +264,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const [, content] = Object.entries(files).find(([name]) =>
-      name.endsWith('.html'),
-    )!;
+    const content = getFileContent(files, '.html');
 
     // image.png
     expect(content.match(/rel="prefetch"/g)?.length).toBe(1);
@@ -307,9 +299,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const [, content] = Object.entries(files).find(([name]) =>
-      name.endsWith('.html'),
-    )!;
+    const content = getFileContent(files, '.html');
 
     // image.png
     expect(content.match(/rel="prefetch"/g)?.length).toBe(1);

--- a/e2e/cases/performance/resource-hints-preload/index.test.ts
+++ b/e2e/cases/performance/resource-hints-preload/index.test.ts
@@ -1,5 +1,11 @@
 import { join } from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
+import {
+  expect,
+  findFile,
+  getFileContent,
+  rspackTest,
+  test,
+} from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
 const fixtures = __dirname;
@@ -23,13 +29,12 @@ test('should generate preload link when preload is defined', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find(
+  const asyncFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
@@ -63,15 +68,14 @@ test('should generate preload link with duplicate', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const initialFileName = Object.keys(files).find(
+  const initialFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/') &&
       !file.includes('/static/js/async/') &&
       !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   expect(
     content.includes(
@@ -105,13 +109,12 @@ test('should generate preload link with crossOrigin', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find(
+  const asyncFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
@@ -147,13 +150,12 @@ test('should generate preload link without crossOrigin when same origin', async 
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find(
+  const asyncFileName = findFile(
+    files,
     (file) =>
       file.includes('/static/js/async/') && !file.endsWith('.LICENSE.txt'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // test.js, test.css, image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(3);
@@ -186,12 +188,10 @@ test('should generate preload link with include', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find((file) =>
+  const asyncFileName = findFile(files, (file) =>
     file.includes('/static/image/image'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // image.png
   expect(content.match(/rel="preload"/g)?.length).toBe(1);
@@ -224,12 +224,10 @@ test('should generate preload link with include array', async ({ build }) => {
 
   const files = rsbuild.getDistFiles();
 
-  const asyncFileName = Object.keys(files).find((file) =>
+  const asyncFileName = findFile(files, (file) =>
     file.includes('/static/image/image'),
-  )!;
-  const [, content] = Object.entries(files).find(([name]) =>
-    name.endsWith('.html'),
-  )!;
+  );
+  const content = getFileContent(files, '.html');
 
   // image.png, test.js
   expect(content.match(/rel="preload"/g)?.length).toBe(2);
@@ -265,9 +263,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const [, content] = Object.entries(files).find(([name]) =>
-      name.endsWith('.html'),
-    )!;
+    const content = getFileContent(files, '.html');
 
     // image.png
     expect(content.match(/rel="preload" as="/g)?.length).toBe(1);
@@ -302,9 +298,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const [, content] = Object.entries(files).find(([name]) =>
-      name.endsWith('.html'),
-    )!;
+    const content = getFileContent(files, '.html');
 
     // image.png
     expect(content.match(/rel="preload" as="/g)?.length).toBe(1);

--- a/e2e/cases/performance/split-chunk-by-module/index.test.ts
+++ b/e2e/cases/performance/split-chunk-by-module/index.test.ts
@@ -1,5 +1,5 @@
 import { basename } from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should generate module chunks when chunkSplit is "split-by-module"', async ({
   build,
@@ -10,10 +10,10 @@ test('should generate module chunks when chunkSplit is "split-by-module"', async
 
   const files = rsbuild.getDistFiles();
 
-  const [reactFile] = Object.entries(files).find(
-    ([name, content]) =>
-      name.includes('npm.react') && content.includes('React'),
-  )!;
+  const reactFile = findFile(
+    files,
+    (name) => name.includes('npm.react') && files[name].includes('React'),
+  );
   expect(reactFile).toBeTruthy();
 
   const jsFiles = Object.keys(files)

--- a/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
+++ b/e2e/cases/performance/split-chunk-single-vendor/index.test.ts
@@ -1,5 +1,5 @@
 import { basename } from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({
   build,
@@ -8,9 +8,10 @@ test('should generate vendor chunk when chunkSplit is "single-vendor"', async ({
 
   const files = rsbuild.getDistFiles();
 
-  const [vendorFile] = Object.entries(files).find(
-    ([name, content]) => name.includes('vendor') && content.includes('React'),
-  )!;
+  const vendorFile = findFile(
+    files,
+    (name) => name.includes('vendor') && files[name].includes('React'),
+  );
   expect(vendorFile).toBeTruthy();
 
   const jsFiles = Object.keys(files)

--- a/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-html/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 import type { RsbuildPlugin } from '@rsbuild/core';
 
 rspackTest('should allow plugin to modify HTML content', async ({ build }) => {
@@ -24,11 +24,7 @@ rspackTest('should allow plugin to modify HTML content', async ({ build }) => {
   });
 
   const files = rsbuild.getDistFiles();
-  const indexHTML = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.html'),
-  );
-
-  const html = files[indexHTML!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html.includes('<div>index.html</div>')).toBeTruthy();
   expect(html.includes('<div>assets: 2</div>')).toBeTruthy();
@@ -60,11 +56,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const indexHTML = Object.keys(files).find(
-      (file) => file.includes('index') && file.endsWith('.html'),
-    );
-
-    const html = files[indexHTML!];
+    const html = getFileContent(files, 'index.html');
 
     expect(html.includes('foo')).toBeFalsy();
     expect(html.includes('bar')).toBeTruthy();

--- a/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags-meta/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow plugin to modify HTML tags with metadata',
@@ -6,11 +6,7 @@ rspackTest(
     const rsbuild = await build();
 
     const files = rsbuild.getDistFiles();
-    const indexHTML = Object.keys(files).find(
-      (file) => file.includes('index') && file.endsWith('.html'),
-    );
-
-    const html = files[indexHTML!];
+    const html = getFileContent(files, 'index.html');
 
     expect(
       html.includes(

--- a/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-modify-tags/index.test.ts
@@ -1,13 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow plugin to modify HTML tags', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const indexHTML = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.html'),
-  );
-
-  const html = files[indexHTML!];
+  const html = getFileContent(files, 'index.html');
 
   expect(
     html.includes(

--- a/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-by-targets/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest('should process assets when target is web', async ({ build }) => {
   const rsbuild = await build({
@@ -10,10 +10,7 @@ rspackTest('should process assets when target is web', async ({ build }) => {
   });
 
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.js'),
-  );
-  expect(indexJs).toBeFalsy();
+  expect(() => findFile(files, 'index.js')).toThrow();
 });
 
 rspackTest(
@@ -28,9 +25,7 @@ rspackTest(
     });
 
     const files = rsbuild.getDistFiles();
-    const indexJs = Object.keys(files).find(
-      (file) => file.includes('index') && file.endsWith('.js'),
-    );
+    const indexJs = findFile(files, 'index.js');
     expect(indexJs).toBeTruthy();
   },
 );

--- a/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets-with-html-child-compiler/index.test.ts
@@ -1,16 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.js'),
-  );
-  const indexCss = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.css'),
-  );
+  const indexJs = findFile(files, 'index.js');
 
   expect(indexJs).toBeTruthy();
-  expect(indexCss).toBeFalsy();
+  expect(() => findFile(files, 'index.css')).toThrow();
 });

--- a/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-process-assets/index.test.ts
@@ -1,16 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow plugin to process assets', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.js'),
-  );
-  const indexCss = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.css'),
-  );
+  const indexJs = findFile(files, 'index.js');
 
   expect(indexJs).toBeTruthy();
-  expect(indexCss).toBeFalsy();
+  expect(() => findFile(files, 'index.css')).toThrow();
 });

--- a/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-environments/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow plugin to transform code by environments', async ({
   build,
@@ -6,17 +6,19 @@ test('should allow plugin to transform code by environments', async ({
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const webJs = Object.keys(files).find(
+  const webJs = getFileContent(
+    files,
     (file) =>
       file.includes('index') &&
       !file.includes('server') &&
       file.endsWith('.js'),
   );
-  const nodeJs = Object.keys(files).find(
+  const nodeJs = getFileContent(
+    files,
     (file) =>
       file.includes('index') && file.includes('server') && file.endsWith('.js'),
   );
 
-  expect(files[webJs!].includes('environments is web')).toBeTruthy();
-  expect(files[nodeJs!].includes('environments is node')).toBeTruthy();
+  expect(webJs.includes('environments is web')).toBeTruthy();
+  expect(nodeJs.includes('environments is node')).toBeTruthy();
 });

--- a/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-by-targets/index.test.ts
@@ -1,20 +1,22 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should allow plugin to transform code by targets', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const webJs = Object.keys(files).find(
+  const webJs = getFileContent(
+    files,
     (file) =>
       file.includes('index') &&
       !file.includes('server') &&
       file.endsWith('.js'),
   );
-  const nodeJs = Object.keys(files).find(
+  const nodeJs = getFileContent(
+    files,
     (file) =>
       file.includes('index') && file.includes('server') && file.endsWith('.js'),
   );
 
-  expect(files[webJs!].includes('target is web')).toBeTruthy();
-  expect(files[nodeJs!].includes('target is node')).toBeTruthy();
+  expect(webJs.includes('target is web')).toBeTruthy();
+  expect(nodeJs.includes('target is node')).toBeTruthy();
 });

--- a/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-import-module/index.test.ts
@@ -1,14 +1,12 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow plugin to transform code and call `importModule`',
   async ({ build }) => {
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
-    const indexCss = Object.keys(files).find(
-      (file) => file.includes('index') && file.endsWith('.css'),
-    );
+    const indexCss = getFileContent(files, 'index.css');
 
-    expect(files[indexCss!].includes('#00f')).toBeTruthy();
+    expect(indexCss.includes('#00f')).toBeTruthy();
   },
 );

--- a/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform-merge-source-map/index.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {
   expect,
   getDistFiles,
+  getFileContent,
   mapSourceMapPositions,
   rspackTest,
 } from '@e2e/helper';
@@ -12,10 +13,8 @@ const expectSourceMap = async (files: Record<string, string>) => {
     path.join(__dirname, 'src/index.ts'),
     'utf-8',
   );
-  const outputCode =
-    files[Object.keys(files).find((file) => file.endsWith('index.js'))!];
-  const sourceMap =
-    files[Object.keys(files).find((file) => file.endsWith('index.js.map'))!];
+  const outputCode = getFileContent(files, 'index.js');
+  const sourceMap = getFileContent(files, 'index.js.map');
 
   const argsPosition = outputCode.indexOf('"args"');
   const helloPosition = outputCode.indexOf('"hello"');

--- a/e2e/cases/plugin-api/plugin-transform/index.test.ts
+++ b/e2e/cases/plugin-api/plugin-transform/index.test.ts
@@ -1,20 +1,14 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should allow plugin to transform code', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.js'),
-  );
-  const indexCss = Object.keys(files).find(
-    (file) => file.includes('index') && file.endsWith('.css'),
-  );
-  const helloTxt = Object.keys(files).find((file) =>
-    file.includes('hello.txt'),
-  );
+  const indexJs = getFileContent(files, 'index.js');
+  const indexCss = getFileContent(files, 'index.css');
+  const helloTxt = getFileContent(files, 'hello.txt');
 
-  expect(files[indexJs!].includes('world')).toBeTruthy();
-  expect(files[indexCss!].includes('#00f')).toBeTruthy();
-  expect(files[helloTxt!].includes('hello world')).toBeTruthy();
+  expect(indexJs.includes('world')).toBeTruthy();
+  expect(indexCss.includes('#00f')).toBeTruthy();
+  expect(helloTxt.includes('hello world')).toBeTruthy();
 });

--- a/e2e/cases/plugin-less/inline-js/index.test.ts
+++ b/e2e/cases/plugin-less/inline-js/index.test.ts
@@ -1,9 +1,9 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should compile less inline js correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
+  const cssContent = getFileContent(files, '.css');
 
-  expect(files[cssFiles]).toEqual('body{opacity:.2}');
+  expect(cssContent).toEqual('body{opacity:.2}');
 });

--- a/e2e/cases/plugin-less/npm-import/index.test.ts
+++ b/e2e/cases/plugin-less/npm-import/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should compile less npm import correctly', async ({ build }) => {
   fs.cpSync(
@@ -13,7 +13,7 @@ test('should compile less npm import correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
+  const cssContent = getFileContent(files, '.css');
 
-  expect(files[cssFiles]).toEqual('html{height:100%}body{color:red}');
+  expect(cssContent).toEqual('html{height:100%}body{color:red}');
 });

--- a/e2e/cases/plugin-less/parallel/index.test.ts
+++ b/e2e/cases/plugin-less/parallel/index.test.ts
@@ -1,12 +1,12 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should compile less with `parallel` option in build',
   async ({ build }) => {
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
-    const cssFiles = Object.keys(files).find((file) => file.endsWith('.css'))!;
-    expect(files[cssFiles]).toEqual(
+    const cssContent = getFileContent(files, '.css');
+    expect(cssContent).toEqual(
       'body{background-color:red;font-size:16px}div{font-size:14px}h1{font-size:18px;font-weight:700}p{font-size:15px}',
     );
   },

--- a/e2e/cases/plugin-stylus/basic/index.test.ts
+++ b/e2e/cases/plugin-stylus/basic/index.test.ts
@@ -1,11 +1,10 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should compile stylus correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
 
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toMatch(
     /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,

--- a/e2e/cases/plugin-stylus/environment/index.test.ts
+++ b/e2e/cases/plugin-stylus/environment/index.test.ts
@@ -1,12 +1,11 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow to configure Stylus plugin for specific environment',
   async ({ build }) => {
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
-    const content =
-      files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+    const content = getFileContent(files, '.css');
 
     expect(content).toMatch(
       /body{color:red;font:14px Arial,sans-serif}\.title-class-\w{6}{font-size:14px}/,

--- a/e2e/cases/plugin-stylus/rem/index.test.ts
+++ b/e2e/cases/plugin-stylus/rem/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should compile stylus and rem correctly', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const content =
-    files[Object.keys(files).find((file) => file.endsWith('.css'))!];
+  const content = getFileContent(files, '.css');
 
   expect(content).toMatch(
     /body{color:red;font:\.28rem Arial,sans-serif}\.title-class-\w{6}{font-size:\.28rem}/,

--- a/e2e/cases/plugin-svgr/svgo-minify-id-prefix/index.test.ts
+++ b/e2e/cases/plugin-svgr/svgo-minify-id-prefix/index.test.ts
@@ -1,15 +1,13 @@
-import { readFileSync } from 'node:fs';
-
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should add id prefix after svgo minification', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
+  const content = getFileContent(
+    files,
     (file) => file.includes('/index.') && file.endsWith('.js'),
   );
-  const content = readFileSync(indexJs!, 'utf-8');
 
   expect(
     content.includes('"linearGradient",{id:"idPrefix_svg__a"'),

--- a/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
+++ b/e2e/cases/plugin-svgr/svgo-minify-view-box/index.test.ts
@@ -1,14 +1,12 @@
-import { readFileSync } from 'node:fs';
-
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should preserve viewBox after svgo minification', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const indexJs = Object.keys(files).find(
+  const content = getFileContent(
+    files,
     (file) => file.includes('/index.') && file.endsWith('.js'),
   );
-  const content = readFileSync(indexJs!, 'utf-8');
 
   expect(
     content.includes('width:120,height:120,viewBox:"0 0 120 120"'),

--- a/e2e/cases/polyfill/helper.ts
+++ b/e2e/cases/polyfill/helper.ts
@@ -1,9 +1,21 @@
 import { type FilesMap, findFile } from '@e2e/helper';
 
+const isPolyfillMap = (file: string) =>
+  file.includes('lib-polyfill') && file.endsWith('.js.map');
+
 export const getPolyfillContent = (files: FilesMap) => {
   let polyfillFileName: string | undefined;
+
   try {
-    polyfillFileName = findFile(files, 'lib-polyfill.js.map');
-  } catch {}
-  return files[polyfillFileName ?? findFile(files, 'index.js.map')];
+    polyfillFileName = findFile(files, isPolyfillMap);
+  } catch {
+    polyfillFileName = undefined;
+  }
+
+  const indexFileName = findFile(
+    files,
+    (file) => file.includes('index') && file.endsWith('.js.map'),
+  );
+
+  return files[polyfillFileName ?? indexFileName];
 };

--- a/e2e/cases/security/nonce-basic/index.test.ts
+++ b/e2e/cases/security/nonce-basic/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest('should apply nonce to script and style tags', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
   expect(html).toContain(`<script defer nonce="CSP_NONCE_PLACEHOLDER">`);
   expect(html).toContain(`<style nonce="CSP_NONCE_PLACEHOLDER">body{`);
 });
@@ -37,15 +36,11 @@ rspackTest('should apply environment nonce', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('dist/index.html'))!];
+  const html = getFileContent(files, 'dist/index.html');
   expect(html).toContain(`<script defer nonce="CSP_NONCE_PLACEHOLDER">`);
   expect(html).toContain(`<style nonce="CSP_NONCE_PLACEHOLDER">body{`);
 
-  const html1 =
-    files[
-      Object.keys(files).find((file) => file.endsWith('dist1/index.html'))!
-    ];
+  const html1 = getFileContent(files, 'dist1/index.html');
   expect(html1).toContain(`<script defer nonce="CSP_NONCE_PLACEHOLDER1">`);
   expect(html1).toContain(`<style nonce="CSP_NONCE_PLACEHOLDER1">body{`);
 });

--- a/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
+++ b/e2e/cases/security/nonce-dynamic-chunk/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 declare global {
   interface Window {
@@ -44,8 +44,7 @@ test('should apply nonce to preload script tags', async ({ build }) => {
     },
   });
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
 
   expect(html).toContain(
     `rel="preload" as="script" nonce="CSP_NONCE_PLACEHOLDER">`,

--- a/e2e/cases/security/nonce-with-rem/index.test.ts
+++ b/e2e/cases/security/nonce-with-rem/index.test.ts
@@ -1,10 +1,9 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should inject rem runtime code with nonce', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const html =
-    files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+  const html = getFileContent(files, 'index.html');
   expect(html).toContain(
     `<script nonce="CSP_NONCE_PLACEHOLDER">function setRootPixel`,
   );

--- a/e2e/cases/security/sri-algotithm/index.test.ts
+++ b/e2e/cases/security/sri-algotithm/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'generate integrity using sha512 algorithm',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await buildPreview();
 
     const files = rsbuild.getDistFiles();
-    const html =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const html = getFileContent(files, 'index.html');
 
     expect(html).toMatch(
       /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha512-[A-Za-z0-9+/=]+"/,

--- a/e2e/cases/security/sri-basic/index.test.ts
+++ b/e2e/cases/security/sri-basic/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest, test } from '@e2e/helper';
+import { expect, getFileContent, rspackTest, test } from '@e2e/helper';
 
 rspackTest(
   'should generate integrity attributes for script and style tags in build',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await buildPreview();
 
     const files = rsbuild.getDistFiles();
-    const html =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const html = getFileContent(files, 'index.html');
 
     expect(html).toMatch(
       /<script defer src="\/static\/js\/index\.\w{8}\.js" integrity="sha384-[A-Za-z0-9+/=]+"/,

--- a/e2e/cases/security/sri-preload/index.test.ts
+++ b/e2e/cases/security/sri-preload/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'generate integrity for preload tags in build',
@@ -6,8 +6,7 @@ rspackTest(
     const rsbuild = await buildPreview();
 
     const files = rsbuild.getDistFiles();
-    const html =
-      files[Object.keys(files).find((file) => file.endsWith('index.html'))!];
+    const html = getFileContent(files, 'index.html');
 
     expect(html).toMatch(
       /<link href="\/static\/js\/async\/foo\.\w{8}\.js" rel="preload" as="script" integrity="sha384-[A-Za-z0-9+/=]+"/,

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 const cwd = __dirname;
 
@@ -278,8 +278,7 @@ test('should access /main success when modify publicPath in compiler', async ({
   await expect(locator).toHaveText('Hello Rsbuild!');
 
   const files = rsbuild.getDistFiles();
-  const htmlContent =
-    files[Object.keys(files).find((file) => file.endsWith('main.html'))!];
+  const htmlContent = getFileContent(files, 'main.html');
 
   expect(htmlContent.includes('/aaaa/static/js/main.js')).toBeTruthy();
 });

--- a/e2e/cases/tailwindcss/basic/index.test.ts
+++ b/e2e/cases/tailwindcss/basic/index.test.ts
@@ -1,14 +1,10 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate tailwindcss utilities correctly', async ({ build }) => {
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexCssFile = Object.keys(files).find(
-    (file) => file.includes('index.') && file.endsWith('.css'),
-  )!;
-
-  const indexCssContent = files[indexCssFile];
+  const indexCssContent = getFileContent(files, 'index.css');
   expect(indexCssContent).toContain(
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}',
   );

--- a/e2e/cases/tailwindcss/mjs/index.test.ts
+++ b/e2e/cases/tailwindcss/mjs/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, getFileContent, test } from '@e2e/helper';
 
 test('should generate tailwindcss utilities with mjs config correctly', async ({
   build,
@@ -6,11 +6,7 @@ test('should generate tailwindcss utilities with mjs config correctly', async ({
   const rsbuild = await build();
 
   const files = rsbuild.getDistFiles();
-  const indexCssFile = Object.keys(files).find(
-    (file) => file.includes('index.') && file.endsWith('.css'),
-  )!;
-
-  const indexCssContent = files[indexCssFile];
+  const indexCssContent = getFileContent(files, 'index.css');
   expect(indexCssContent).toContain(
     '.text-3xl{font-size:var(--text-3xl);line-height:var(--tw-leading,var(--text-3xl--line-height))}',
   );

--- a/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
+++ b/e2e/cases/tailwindcss/vendor-prefix/index.test.ts
@@ -1,16 +1,14 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should generate tailwindcss utilities with vendor prefixes correctly',
   async ({ build }) => {
     const rsbuild = await build();
     const files = rsbuild.getDistFiles();
-    const indexCssFile = Object.keys(files).find(
-      (file) => file.includes('index.') && file.endsWith('.css'),
-    )!;
+    const indexCss = getFileContent(files, 'index.css');
 
-    expect(files[indexCssFile]).toContain('-webkit-user-select: none;');
-    expect(files[indexCssFile]).toContain('-ms-user-select: none;');
-    expect(files[indexCssFile]).toContain('user-select: none;');
+    expect(indexCss).toContain('-webkit-user-select: none;');
+    expect(indexCss).toContain('-ms-user-select: none;');
+    expect(indexCss).toContain('user-select: none;');
   },
 );

--- a/e2e/cases/wasm/wasm-async/index.test.ts
+++ b/e2e/cases/wasm/wasm-async/index.test.ts
@@ -1,12 +1,10 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should allow to dynamic import a Wasm file', async ({ build }) => {
   const rsbuild = await build();
   const files = rsbuild.getDistFiles();
-  const wasmFile = Object.keys(files).find((file) =>
-    file.endsWith('.module.wasm'),
-  );
+  const wasmFile = findFile(files, '.module.wasm');
 
   expect(wasmFile).toBeTruthy();
-  expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
+  expect(/static[\\/]wasm/g.test(wasmFile)).toBeTruthy();
 });

--- a/e2e/cases/wasm/wasm-basic/index.test.ts
+++ b/e2e/cases/wasm/wasm-basic/index.test.ts
@@ -1,15 +1,13 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should allow to import a Wasm file', async ({ page, buildPreview }) => {
   const rsbuild = await buildPreview();
   const files = rsbuild.getDistFiles();
 
-  const wasmFile = Object.keys(files).find((file) =>
-    file.endsWith('.module.wasm'),
-  );
+  const wasmFile = findFile(files, '.module.wasm');
 
   expect(wasmFile).toBeTruthy();
-  expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
+  expect(/static[\\/]wasm/g.test(wasmFile)).toBeTruthy();
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);

--- a/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash-disabled/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should not allow to disable filename hash of Wasm files',
@@ -6,10 +6,8 @@ rspackTest(
     const rsbuild = await buildPreview();
     const files = rsbuild.getDistFiles();
 
-    const wasmFile = Object.keys(files).find((file) =>
-      file.endsWith('module.wasm'),
-    );
+    const wasmFile = findFile(files, 'module.wasm');
 
-    expect(/[a-f0-9]{8}\.module\.wasm/.test(wasmFile!)).toBeTruthy();
+    expect(/[a-f0-9]{8}\.module\.wasm/.test(wasmFile)).toBeTruthy();
   },
 );

--- a/e2e/cases/wasm/wasm-filename-hash/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename-hash/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow to custom the filename hash of Wasm files',
@@ -6,10 +6,8 @@ rspackTest(
     const rsbuild = await buildPreview();
     const files = rsbuild.getDistFiles();
 
-    const wasmFile = Object.keys(files).find((file) =>
-      file.endsWith('module.wasm'),
-    );
+    const wasmFile = findFile(files, 'module.wasm');
 
-    expect(/[a-f0-9]{16}\.module\.wasm/.test(wasmFile!)).toBeTruthy();
+    expect(/[a-f0-9]{16}\.module\.wasm/.test(wasmFile)).toBeTruthy();
   },
 );

--- a/e2e/cases/wasm/wasm-filename/index.test.ts
+++ b/e2e/cases/wasm/wasm-filename/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, rspackTest } from '@e2e/helper';
+import { expect, findFile, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow to custom the filename of Wasm files',
@@ -6,9 +6,7 @@ rspackTest(
     const rsbuild = await buildPreview();
     const files = rsbuild.getDistFiles();
 
-    const wasmFile = Object.keys(files).find((file) =>
-      file.endsWith('factorial.wasm'),
-    );
+    const wasmFile = findFile(files, 'factorial.wasm');
 
     expect(wasmFile).toBeTruthy();
   },

--- a/e2e/cases/wasm/wasm-url/index.test.ts
+++ b/e2e/cases/wasm/wasm-url/index.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@e2e/helper';
+import { expect, findFile, test } from '@e2e/helper';
 
 test('should allow to use new URL to get path of a Wasm file', async ({
   page,
@@ -7,12 +7,10 @@ test('should allow to use new URL to get path of a Wasm file', async ({
   const rsbuild = await buildPreview();
   const files = rsbuild.getDistFiles();
 
-  const wasmFile = Object.keys(files).find((file) =>
-    file.endsWith('.module.wasm'),
-  );
+  const wasmFile = findFile(files, '.module.wasm');
 
   expect(wasmFile).toBeTruthy();
-  expect(/static[\\/]wasm/g.test(wasmFile!)).toBeTruthy();
+  expect(/static[\\/]wasm/g.test(wasmFile)).toBeTruthy();
 
   await page.waitForFunction(() => {
     return Boolean(document.querySelector('#root')?.innerHTML);

--- a/e2e/helper/utils.ts
+++ b/e2e/helper/utils.ts
@@ -8,6 +8,7 @@ import glob, {
   convertPathToPattern,
   type Options as GlobOptions,
 } from 'fast-glob';
+import color from 'picocolors';
 import type { Page } from 'playwright';
 import sourceMap from 'source-map';
 import { expect } from './fixture';
@@ -268,7 +269,7 @@ export type FindFileOptions = {
   ignoreHash?: boolean;
 };
 
-const HASH_PATTERN = /\.[0-9a-z]{6,}(?=\.)/gi;
+const HASH_PATTERN = /\.[0-9a-z]{8,}(?=\.)/gi;
 
 const toMatcherFn = (matcher: FileMatcher): ((file: string) => boolean) => {
   if (typeof matcher === 'function') {
@@ -297,7 +298,9 @@ export const findFile = (
     }
   }
 
-  throw new Error(`Unable to find file matching ${matcher.toString()}`);
+  throw new Error(
+    `Unable to find file matching "${color.cyan(matcher.toString())}"`,
+  );
 };
 
 /** Return the content of the first matching file from a files map */


### PR DESCRIPTION
## Summary

Standardize file content assertions using helper functions for better error messages and consistency.

## Related Links

https://github.com/web-infra-dev/rsbuild/pull/6248

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
