### PR TITLE
feat: display browser runtime errors in the terminal

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -1,6 +1,7 @@
 import type {
+  ClientMessage,
+  ClientMessageRuntimeError,
   SocketMessage,
-  SocketMessageRuntimeError,
 } from '../server/socketServer';
 import type { NormalizedClientConfig } from '../types';
 
@@ -154,7 +155,7 @@ let reconnectCount = 0;
 let pingIntervalId: ReturnType<typeof setInterval>;
 
 const isSocketReady = () => socket && socket.readyState === socket.OPEN;
-const socketSend = (data: unknown) => {
+const socketSend = (data: ClientMessage) => {
   if (isSocketReady()) {
     socket!.send(JSON.stringify(data));
   }
@@ -240,10 +241,10 @@ function onSocketError() {
   }
 }
 
-const errorMessages: SocketMessageRuntimeError[] = [];
+const errorMessages: ClientMessageRuntimeError[] = [];
 
 function onRuntimeError(event: ErrorEvent) {
-  const message: SocketMessageRuntimeError = {
+  const message: ClientMessageRuntimeError = {
     type: 'runtime-error',
     message: event.message,
   };


### PR DESCRIPTION
## Summary

When building web applications with coding agents, we need to provide the LLM with enough context. One current limitation is that the agent cannot observe runtime errors occurring in the browser.

This PR addresses that by forwarding browser runtime errors to the socket server via WebSocket and logging them in the terminal, enabling the agent to access richer context for analysis and decision-making.

<img width="503" height="172" alt="Screenshot 2025-09-25 at 15 43 32" src="https://github.com/user-attachments/assets/dc061364-3369-4349-93d4-3a6c0902c885" />

## TODO

- Capture `unhandledrejection` events
- Display error stacks
- Add an option to disable this behavior
- Add test cases
- Update documentation

## Related links

- https://x.com/RobKnight__/status/1937724464395092137

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
