### PR TITLE
test: add browser logs test case for error forwarding

### DIFF
--- a/e2e/cases/server/browser-logs/index.test.ts
+++ b/e2e/cases/server/browser-logs/index.test.ts
@@ -1,0 +1,6 @@
+import { test } from '@e2e/helper';
+
+test('should forward browser error logs to terminal', async ({ dev }) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog('error   [browser] Uncaught Error: test');
+});

--- a/e2e/cases/server/browser-logs/src/index.js
+++ b/e2e/cases/server/browser-logs/src/index.js
@@ -1,0 +1,1 @@
+throw new Error('test');


### PR DESCRIPTION
## Summary

Add a basic test case to verify that browser error logs are properly forwarded to the terminal.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6251

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
