### PR TITLE
feat: add `dev.browserLogs` configuration

### DIFF
--- a/e2e/cases/server/browser-logs/index.test.ts
+++ b/e2e/cases/server/browser-logs/index.test.ts
@@ -1,6 +1,21 @@
 import { test } from '@e2e/helper';
 
-test('should forward browser error logs to terminal', async ({ dev }) => {
+const EXPECTED_LOG = 'error   [browser] Uncaught Error: test';
+
+test('should forward browser error logs to terminal by default', async ({
+  dev,
+}) => {
   const rsbuild = await dev();
-  await rsbuild.expectLog('error   [browser] Uncaught Error: test');
+  await rsbuild.expectLog(EXPECTED_LOG);
+});
+
+test('should disable forwarding browser error logs', async ({ dev, page }) => {
+  const rsbuild = await dev({
+    config: {
+      dev: {
+        browserLogs: false,
+      },
+    },
+  });
+  rsbuild.expectNoLog(EXPECTED_LOG);
 });

--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -290,7 +290,7 @@ function reloadPage() {
   }
 }
 
-if (typeof window !== 'undefined') {
+if (RSBUILD_DEV_BROWSER_LOGS && typeof window !== 'undefined') {
   window.addEventListener('error', onRuntimeError);
 }
 

--- a/packages/core/src/defaultConfig.ts
+++ b/packages/core/src/defaultConfig.ts
@@ -44,6 +44,7 @@ const require = createRequire(import.meta.url);
 const getDefaultDevConfig = (): NormalizedDevConfig => ({
   hmr: true,
   liveReload: true,
+  browserLogs: true,
   watchFiles: [],
   // Temporary placeholder, default: `${server.base}`
   assetPrefix: DEFAULT_ASSET_PREFIX,

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -7,6 +7,7 @@ declare global {
   const RSBUILD_SERVER_HOST: string;
   const RSBUILD_SERVER_PORT: number;
   const RSBUILD_DEV_LIVE_RELOAD: boolean;
+  const RSBUILD_DEV_BROWSER_LOGS: boolean;
   const RSBUILD_WEB_SOCKET_TOKEN: string;
   const Deno: unknown;
 }

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -28,6 +28,7 @@ const allowedEnvironmentDevKeys: AllowedEnvironmentDevKeys[] = [
   'hmr',
   'client',
   'liveReload',
+  'browserLogs',
   'writeToDisk',
   'assetPrefix',
   'progressBar',

--- a/packages/core/src/server/compilationMiddleware.ts
+++ b/packages/core/src/server/compilationMiddleware.ts
@@ -131,6 +131,7 @@ function applyHMREntry({
     RSBUILD_SERVER_HOST: JSON.stringify(resolvedHost),
     RSBUILD_SERVER_PORT: JSON.stringify(resolvedPort),
     RSBUILD_DEV_LIVE_RELOAD: config.dev.liveReload,
+    RSBUILD_DEV_BROWSER_LOGS: config.dev.browserLogs,
   }).apply(compiler);
 
   for (const clientPath of clientPaths) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1720,6 +1720,13 @@ export type WriteToDisk = boolean | ((filename: string) => boolean);
 
 export interface DevConfig {
   /**
+   * Enables forwarding of browser runtime errors to the terminal. When `true`, the dev
+   * client listens for window `error` events in the browser and send them to the dev server,
+   * where they are printed in the terminal (prefixed with `[browser]`).
+   * @default true
+   */
+  browserLogs?: boolean;
+  /**
    * Whether to enable Hot Module Replacement.
    * @default true
    */
@@ -1790,7 +1797,12 @@ export type NormalizedDevConfig = Omit<DevConfig, 'watchFiles'> &
   Required<
     Pick<
       DevConfig,
-      'hmr' | 'liveReload' | 'assetPrefix' | 'writeToDisk' | 'cliShortcuts'
+      | 'hmr'
+      | 'liveReload'
+      | 'assetPrefix'
+      | 'writeToDisk'
+      | 'cliShortcuts'
+      | 'browserLogs'
     >
   > & {
     watchFiles: WatchFiles[];
@@ -1866,6 +1878,7 @@ export type AllowedEnvironmentDevKeys =
   | 'hmr'
   | 'client'
   | 'liveReload'
+  | 'browserLogs'
   | 'assetPrefix'
   | 'progressBar'
   | 'lazyCompilation'

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -4,6 +4,7 @@ exports[`environment config > should normalize environment config correctly 1`] 
 {
   "dev": {
     "assetPrefix": "/",
+    "browserLogs": true,
     "cliShortcuts": false,
     "client": {
       "host": "",
@@ -150,6 +151,7 @@ exports[`environment config > should normalize environment config correctly 2`] 
 {
   "dev": {
     "assetPrefix": "/foo",
+    "browserLogs": true,
     "cliShortcuts": false,
     "client": {
       "host": "",
@@ -297,6 +299,7 @@ exports[`environment config > should print environment config when inspect confi
   "ssr": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -443,6 +446,7 @@ exports[`environment config > should print environment config when inspect confi
   "web": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -609,6 +613,7 @@ exports[`environment config > should support modify environment config by api.mo
   "ssr": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -755,6 +760,7 @@ exports[`environment config > should support modify environment config by api.mo
   "web": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -902,6 +908,7 @@ exports[`environment config > should support modify environment config by api.mo
   "web1": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -1052,6 +1059,7 @@ exports[`environment config > should support modify single environment config by
   "ssr": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",
@@ -1198,6 +1206,7 @@ exports[`environment config > should support modify single environment config by
   "web": {
     "dev": {
       "assetPrefix": "/",
+      "browserLogs": true,
       "cliShortcuts": false,
       "client": {
         "host": "",


### PR DESCRIPTION
## Summary

Add `dev.browserLogs` configuration to control forwarding browser errors to terminal.

## Related Link

https://github.com/web-infra-dev/rsbuild/pull/6251

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
