### PR TITLE
test(e2e): print original logs when expectLog failed

### DIFF
--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -65,7 +65,7 @@ export const createLogHelper = () => {
         const expect = color.yellow(pattern.toString());
         reject(
           new Error(
-            `${title}\nExpect: ${expect}\nGet:\n${color.cyan(logs.join('\n'))}`,
+            `${title}\nExpect: ${expect}\nGet:\n${originalLogs.join('\n')}`,
           ),
         );
       }, 5000);


### PR DESCRIPTION
## Summary

When `expectLog` method failed, the colored logs were making it harder to read the actual error output in test failures. 

Using the original logs improves readability and debugging.

### Before

<img width="700" height="549" alt="Screenshot 2025-09-25 at 18 45 40" src="https://github.com/user-attachments/assets/4561e7a7-fadf-4f84-8e5f-cdf97be283fd" />

### After

<img width="700" height="505" alt="Screenshot 2025-09-25 at 18 46 10" src="https://github.com/user-attachments/assets/e0cd1d7c-a095-449c-ba8e-343ff5218104" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
