### PR TITLE
refactor(server): make filename helper independent of assets middleware context

### DIFF
--- a/packages/core/src/server/assets-middleware/setupHooks.ts
+++ b/packages/core/src/server/assets-middleware/setupHooks.ts
@@ -1,29 +1,27 @@
-import type { Compiler, MultiCompiler, MultiStats, Stats } from '@rspack/core';
-import type { Context, WithOptional } from './index';
+import type { Compiler, MultiCompiler } from '@rspack/core';
+import type { Context } from './index';
 
 export function setupHooks(
-  context: WithOptional<Context, 'watching' | 'outputFileSystem'>,
+  context: Context,
   compiler: Compiler | MultiCompiler,
 ): void {
   function invalid() {
-    context.stats = undefined;
+    context.ready = false;
   }
 
-  function done(stats: Stats | MultiStats) {
-    context.stats = stats;
+  function done() {
+    context.ready = true;
 
     process.nextTick(() => {
-      const { stats, callbacks } = context;
-
-      if (!stats) {
+      if (!context.ready) {
         return;
       }
 
-      context.callbacks = [];
-
+      const { callbacks } = context;
       callbacks.forEach((callback) => {
         callback();
       });
+      context.callbacks = [];
     });
   }
 

--- a/packages/core/src/server/assets-middleware/setupOutputFileSystem.ts
+++ b/packages/core/src/server/assets-middleware/setupOutputFileSystem.ts
@@ -2,13 +2,14 @@ import type {
   Compiler,
   OutputFileSystem as RspackOutputFileSystem,
 } from '@rspack/core';
-import type { Options, OutputFileSystem } from './index';
+import type { OutputFileSystem } from './index';
+import type { ResolvedWriteToDisk } from './setupWriteToDisk';
 
 export async function setupOutputFileSystem(
-  options: Options,
+  writeToDisk: ResolvedWriteToDisk,
   compilers: Compiler[],
 ): Promise<OutputFileSystem> {
-  if (options.writeToDisk !== true) {
+  if (writeToDisk !== true) {
     const { createFsFromVolume, Volume } = await import(
       '../../../compiled/memfs/index.js'
     );

--- a/packages/core/src/server/buildManager.ts
+++ b/packages/core/src/server/buildManager.ts
@@ -2,10 +2,7 @@ import fs from 'node:fs';
 import { isMultiCompiler } from '../helpers';
 import { getPathnameFromUrl } from '../helpers/path';
 import type { EnvironmentContext, NormalizedConfig, Rspack } from '../types';
-import {
-  type AssetsMiddleware,
-  getAssetsMiddleware,
-} from './assets-middleware';
+import { type AssetsMiddleware, assetsMiddleware } from './assets-middleware';
 import { stripBase } from './helper';
 import { SocketServer } from './socketServer';
 
@@ -110,7 +107,7 @@ export class BuildManager {
   private async setupCompilationMiddleware(): Promise<void> {
     const { config, publicPaths, environments } = this;
 
-    const middleware = await getAssetsMiddleware({
+    const middleware = await assetsMiddleware({
       config,
       compiler: this.compiler,
       socketServer: this.socketServer,


### PR DESCRIPTION
## Summary

This PR makes the `getFilenameFromUrl` helper independent of assets middleware context. This allows it to be used to parse source map files from browser log stacks. Also simplifies context handling by removing unused stats and using ready flag.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
