### PR TITLE
feat: enhance browser logs with source file locations

### DIFF
--- a/e2e/cases/browser-logs/error/index.test.ts
+++ b/e2e/cases/browser-logs/error/index.test.ts
@@ -1,6 +1,7 @@
 import { test } from '@e2e/helper';
 
-const EXPECTED_LOG = 'error   [browser] Uncaught Error: test';
+const EXPECTED_LOG =
+  'error   [browser] Uncaught Error: test (src/index.js:1:0)';
 
 test('should forward browser error logs to terminal by default', async ({
   dev,

--- a/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
+++ b/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
@@ -13,16 +13,16 @@ test('should forward browser unhandled rejection logs to terminal', async ({
     'error   [browser] Uncaught (in promise) {"name":"Custom","message":"custom message"}',
   );
   await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) Error: reason',
+    'error   [browser] Uncaught (in promise) Error: reason (src/index.js:7:0)',
   );
   await rsbuild.expectLog(
     'error   [browser] Uncaught (in promise) AbortError: Aborted',
   );
   await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) Error: Thrown in async',
+    'error   [browser] Uncaught (in promise) Error: Thrown in async (src/index.js:12:0)',
   );
   await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason',
+    'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason (src/index.js:17:0)',
   );
   await rsbuild.expectLog(
     'error   [browser] Uncaught (in promise) AggregateError: All promises were rejected',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -94,6 +94,7 @@
     "rspack-chain": "^1.4.1",
     "rspack-manifest-plugin": "5.1.0",
     "sirv": "^3.0.2",
+    "stacktrace-parser": "^0.1.11",
     "style-loader": "3.3.4",
     "tinyglobby": "0.2.14",
     "typescript": "^5.9.2",

--- a/packages/core/prebundle.config.mjs
+++ b/packages/core/prebundle.config.mjs
@@ -23,6 +23,7 @@ export default {
     'connect',
     'rspack-manifest-plugin',
     'html-rspack-plugin',
+    'source-map',
     'mrmime',
     'memfs',
     'tinyglobby',

--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -21,7 +21,7 @@ function decode(input: string): string {
   return qsUnescape(input);
 }
 
-export function getFilenameFromUrl(
+export function getFileFromUrl(
   url: string,
   outputFileSystem: OutputFileSystem,
   environments: Record<string, EnvironmentContext>,

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -5,7 +5,7 @@ import rangeParser from 'range-parser';
 import { logger } from '../../logger';
 import type { EnvironmentContext, RequestHandler } from '../../types';
 import { escapeHtml } from './escapeHtml';
-import { getFilenameFromUrl } from './getFilenameFromUrl';
+import { getFileFromUrl } from './getFileFromUrl';
 import type { Context, OutputFileSystem, ServerResponse } from './index';
 import { memorize } from './memorize';
 import { parseTokenList } from './parseTokenList';
@@ -334,11 +334,7 @@ export function wrapper(
         return;
       }
 
-      const resolved = getFilenameFromUrl(
-        req.url,
-        outputFileSystem,
-        environments,
-      );
+      const resolved = getFileFromUrl(req.url, outputFileSystem, environments);
 
       if (!resolved) {
         await goNext();

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -197,11 +197,11 @@ export async function createDevServer<
       : [getPublicPathFromCompiler(compiler)];
 
     const buildManager = new BuildManager({
+      context,
       config,
       compiler,
       publicPaths: publicPaths,
       resolvedPort: port,
-      environments: context.environments,
     });
 
     await buildManager.init();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -732,6 +732,9 @@ importers:
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
+      stacktrace-parser:
+        specifier: ^0.1.11
+        version: 0.1.11
       style-loader:
         specifier: 3.3.4
         version: 3.3.4(webpack@5.101.3)
@@ -1837,6 +1840,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jsonjoy.com/base64@1.1.2':
     resolution: {integrity: sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==}
@@ -6286,6 +6292,10 @@ packages:
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
 
+  stacktrace-parser@0.1.11:
+    resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
+    engines: {node: '>=6'}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -6569,6 +6579,10 @@ packages:
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+
+  type-fest@0.7.1:
+    resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
+    engines: {node: '>=8'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -7414,23 +7428,28 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.12':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/source-map@0.3.6':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.29':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -12534,6 +12553,10 @@ snapshots:
 
   stackframe@1.3.4: {}
 
+  stacktrace-parser@0.1.11:
+    dependencies:
+      type-fest: 0.7.1
+
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
@@ -12703,7 +12726,7 @@ snapshots:
 
   terser-webpack-plugin@5.3.14(webpack@5.101.3):
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
@@ -12794,6 +12817,8 @@ snapshots:
   type-detect@4.1.0: {}
 
   type-fest@0.21.3: {}
+
+  type-fest@0.7.1: {}
 
   type-is@1.6.18:
     dependencies:


### PR DESCRIPTION
## Summary

Add stacktrace parsing and source map support to display original file locations in browser error logs:

<img width="1758" height="899" alt="Screenshot 2025-09-26 at 14 13 00" src="https://github.com/user-attachments/assets/00d56446-a4c5-49b0-87f3-9349c70ed9f8" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6251

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
