### PR TITLE
fix: skip browser error reporting for webpack

### DIFF
--- a/e2e/cases/browser-logs/basic-error/index.test.ts
+++ b/e2e/cases/browser-logs/basic-error/index.test.ts
@@ -1,16 +1,17 @@
-import { test } from '@e2e/helper';
+import { rspackTest } from '@e2e/helper';
 
 const EXPECTED_LOG =
   'error   [browser] Uncaught Error: test (src/index.js:1:0)';
 
-test('should forward browser error logs to terminal by default', async ({
-  dev,
-}) => {
-  const rsbuild = await dev();
-  await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
-});
+rspackTest(
+  'should forward browser error logs to terminal by default',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    await rsbuild.expectLog(EXPECTED_LOG, { posix: true });
+  },
+);
 
-test('should disable forwarding browser error logs', async ({ dev }) => {
+rspackTest('should disable forwarding browser error logs', async ({ dev }) => {
   const rsbuild = await dev({
     config: {
       dev: {

--- a/e2e/cases/browser-logs/dedupe-log/index.test.ts
+++ b/e2e/cases/browser-logs/dedupe-log/index.test.ts
@@ -1,17 +1,17 @@
-import { gotoPage, test } from '@e2e/helper';
+import { gotoPage, rspackTest } from '@e2e/helper';
 
-test('should not output the same error log consecutively', async ({
-  devOnly,
-  page,
-}) => {
-  const rsbuild = await devOnly();
-  await gotoPage(page, rsbuild, '/', { hash: 'test1' });
-  await rsbuild.expectLog('Uncaught Error: #test1');
-  rsbuild.clearLogs();
+rspackTest(
+  'should not output the same error log consecutively',
+  async ({ devOnly, page }) => {
+    const rsbuild = await devOnly();
+    await gotoPage(page, rsbuild, '/', { hash: 'test1' });
+    await rsbuild.expectLog('Uncaught Error: #test1');
+    rsbuild.clearLogs();
 
-  await page.reload();
-  await gotoPage(page, rsbuild, '/', { hash: 'test2' });
-  await page.reload();
-  await rsbuild.expectLog('Uncaught Error: #test2');
-  rsbuild.expectNoLog('Uncaught Error: #test1');
-});
+    await page.reload();
+    await gotoPage(page, rsbuild, '/', { hash: 'test2' });
+    await page.reload();
+    await rsbuild.expectLog('Uncaught Error: #test2');
+    rsbuild.expectNoLog('Uncaught Error: #test1');
+  },
+);

--- a/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
+++ b/e2e/cases/browser-logs/unhandled-rejection/index.test.ts
@@ -1,30 +1,33 @@
-import { test } from '@e2e/helper';
+import { rspackTest } from '@e2e/helper';
 
-test('should forward browser unhandled rejection logs to terminal', async ({
-  dev,
-}) => {
-  const rsbuild = await dev();
-  await rsbuild.expectLog('error   [browser] Uncaught (in promise) 404');
-  await rsbuild.expectLog('error   [browser] Uncaught (in promise) false');
-  await rsbuild.expectLog('error   [browser] Uncaught (in promise) null');
-  await rsbuild.expectLog('error   [browser] Uncaught (in promise) undefined');
-  await rsbuild.expectLog('error   [browser] Uncaught (in promise) string');
-  await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) {"name":"Custom","message":"custom message"}',
-  );
-  await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) Error: reason (src/index.js:7:0)',
-    { posix: true },
-  );
-  await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) AbortError: Aborted',
-  );
-  await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) Error: Thrown in async (src/index.js:11:0)',
-    { posix: true },
-  );
-  await rsbuild.expectLog(
-    'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason (src/index.js:16:0)',
-    { posix: true },
-  );
-});
+rspackTest(
+  'should forward browser unhandled rejection logs to terminal',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    await rsbuild.expectLog('error   [browser] Uncaught (in promise) 404');
+    await rsbuild.expectLog('error   [browser] Uncaught (in promise) false');
+    await rsbuild.expectLog('error   [browser] Uncaught (in promise) null');
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) undefined',
+    );
+    await rsbuild.expectLog('error   [browser] Uncaught (in promise) string');
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) {"name":"Custom","message":"custom message"}',
+    );
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) Error: reason (src/index.js:7:0)',
+      { posix: true },
+    );
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) AbortError: Aborted',
+    );
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) Error: Thrown in async (src/index.js:11:0)',
+      { posix: true },
+    );
+    await rsbuild.expectLog(
+      'error   [browser] Uncaught (in promise) AbortError: signal is aborted without reason (src/index.js:16:0)',
+      { posix: true },
+    );
+  },
+);

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -271,7 +271,11 @@ export class SocketServer {
           typeof data === 'string' ? data : data.toString(),
         );
 
-        if (message.type === 'runtime-error') {
+        if (
+          message.type === 'runtime-error' &&
+          // Do not report browser error when using webpack
+          this.context.bundlerType === 'rspack'
+        ) {
           reportRuntimeError(message, this.context, this.getOutputFileSystem());
         }
       } catch {}


### PR DESCRIPTION
## Summary

Although Rsbuild is still compatible with webpack, the newly added browser log feature does not need to support webpack as it will increase the workload.

This pull request ensures that runtime errors are only reported when the bundler is Rspack.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
