### PR TITLE
chore(socket): rename message types for better clarity

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -1,7 +1,7 @@
 import type {
   ClientMessage,
-  ClientMessageRuntimeError,
-  SocketMessage,
+  ClientMessageError,
+  ServerMessage,
 } from '../server/socketServer';
 import type { NormalizedClientConfig } from '../types';
 
@@ -183,7 +183,7 @@ function onOpen() {
 }
 
 function onMessage(e: MessageEvent<string>) {
-  const message: SocketMessage = JSON.parse(e.data);
+  const message: ServerMessage = JSON.parse(e.data);
 
   switch (message.type) {
     case 'hash':
@@ -241,11 +241,11 @@ function onSocketError() {
   }
 }
 
-const errorMessages: ClientMessageRuntimeError[] = [];
+const errorMessages: ClientMessageError[] = [];
 
 function sendRuntimeError(message: string, stack?: string) {
-  const messageInfo: ClientMessageRuntimeError = {
-    type: 'runtime-error',
+  const messageInfo: ClientMessageError = {
+    type: 'client-error',
     message,
     stack,
   };

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -7,7 +7,7 @@ import { logger } from '../logger';
 import type { EnvironmentContext, InternalContext, Rspack } from '../types';
 import { getFileFromUrl } from './assets-middleware/getFileFromUrl';
 import type { OutputFileSystem } from './assets-middleware/index';
-import type { ClientMessageRuntimeError } from './socketServer';
+import type { ClientMessageError } from './socketServer';
 
 /**
  * Maps a position in compiled code to its original source position using
@@ -116,7 +116,7 @@ let lastRuntimeErrorLog: string;
  * source location information.
  */
 export const reportRuntimeError = async (
-  message: ClientMessageRuntimeError,
+  message: ClientMessageError,
   context: InternalContext,
   fs: Rspack.OutputFileSystem,
 ): Promise<void> => {

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -39,15 +39,15 @@ import {
 import { createHttpServer } from './httpServer';
 import { notFoundMiddleware, optionsFallbackMiddleware } from './middlewares';
 import { open } from './open';
-import type { SocketMessage } from './socketServer';
+import type { ServerMessage } from './socketServer';
 import { setupWatchFiles, type WatchFilesResult } from './watchFiles';
 
 type HTTPServer = Server | Http2SecureServer;
 
-type ExtractSocketMessageData<T extends SocketMessage['type']> =
-  Extract<SocketMessage, { type: T }> extends { data: infer D } ? D : undefined;
+type ExtractSocketMessageData<T extends ServerMessage['type']> =
+  Extract<ServerMessage, { type: T }> extends { data: infer D } ? D : undefined;
 
-export type SockWrite = <T extends SocketMessage['type']>(
+export type SockWrite = <T extends ServerMessage['type']>(
   type: T,
   data?: ExtractSocketMessageData<T>,
 ) => void;
@@ -362,7 +362,7 @@ export async function createDevServer<
     buildManager?.socketServer.sockWrite({
       type,
       data,
-    } as SocketMessage);
+    } as ServerMessage);
 
   const devServerAPI: RsbuildDevServer = {
     port,


### PR DESCRIPTION
## Summary

Rename 'SocketMessage' to 'ServerMessage' and 'ClientMessageRuntimeError' to 'ClientMessageError' to better reflect their purpose and improve code readability.

Also update related type names and references across the codebase.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
