### PR TITLE
chore: add build state tracking to internal context

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -212,5 +212,9 @@ export async function createContext(
     config: { ...rsbuildConfig },
     originalConfig: userConfig,
     specifiedEnvironments,
+    buildState: {
+      status: 'idle',
+      hasErrors: false,
+    },
   };
 }

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -61,6 +61,15 @@ export type RsbuildContext = {
   callerName: string;
 };
 
+export type BuildStatus = 'idle' | 'building' | 'done';
+
+export type BuildState = {
+  /** Current build status */
+  status: BuildStatus;
+  /** Whether there are build errors */
+  hasErrors: boolean;
+};
+
 /** The inner context. */
 export type InternalContext = RsbuildContext & {
   /** All hooks. */
@@ -81,4 +90,6 @@ export type InternalContext = RsbuildContext & {
   environments: Record<string, EnvironmentContext>;
   /** Only build specified environment. */
   specifiedEnvironments?: string[];
+  /** Build state information */
+  buildState: BuildState;
 };


### PR DESCRIPTION
## Summary

Track build status and errors in the internal context to provide better build state visibility. This is the basis for subsequent improvements to browser logs and assets middleware.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
