### PR TITLE
fix: skip browser error logs when build fails

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,6 @@ compiled
 doc_build
 pnpm-lock.yaml
 
-# Avoid CSS syntax error
-**/less/inline-js/**/*.less
+# Avoid syntax error
+e2e/cases/plugin-less/inline-js/src/*.less
+e2e/cases/browser-logs/skip-build-error/src/**

--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,8 @@
       "!**/compiled",
       "!**/*.vue",
       "!**/*.svelte",
-      "!**/template-lit-*/src/my-element.*"
+      "!**/template-lit-*/src/my-element.*",
+      "!e2e/cases/browser-logs/skip-build-error/src"
     ],
     "ignoreUnknown": true
   },

--- a/e2e/cases/browser-logs/skip-build-error/index.test.ts
+++ b/e2e/cases/browser-logs/skip-build-error/index.test.ts
@@ -1,0 +1,10 @@
+import { rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should skip browser error logs if build failed',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    await rsbuild.expectLog('Module build failed');
+    rsbuild.expectNoLog('[browser]');
+  },
+);

--- a/e2e/cases/browser-logs/skip-build-error/src/index.js
+++ b/e2e/cases/browser-logs/skip-build-error/src/index.js
@@ -1,0 +1,1 @@
+'syntax error

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -274,7 +274,9 @@ export class SocketServer {
         if (
           message.type === 'client-error' &&
           // Do not report browser error when using webpack
-          this.context.bundlerType === 'rspack'
+          this.context.bundlerType === 'rspack' &&
+          // Do not report browser error when build failed
+          !this.context.buildState.hasErrors
         ) {
           reportRuntimeError(message, this.context, this.getOutputFileSystem());
         }


### PR DESCRIPTION
## Summary

Prevent reporting browser error logs when the build has failed to avoid confusion and redundant error messages.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6251

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
