### PR TITLE
fix: mark custom compiler option as deprecated

### DIFF
--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -19,6 +19,7 @@ export type Bundler = 'rspack' | 'webpack';
 export type StartDevServerOptions = {
   /**
    * Using a custom Rspack Compiler object.
+   * @deprecated This is no longer supported and will be removed in a future version.
    */
   compiler?: Compiler | MultiCompiler;
   /**
@@ -57,6 +58,7 @@ export type BuildOptions = {
   watch?: boolean;
   /**
    * Using a custom Rspack Compiler object.
+   * @deprecated This is no longer supported and will be removed in a future version.
    */
   compiler?: Compiler | MultiCompiler;
 };

--- a/website/docs/en/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/en/api/javascript-api/dev-server-api.mdx
@@ -161,10 +161,6 @@ type RsbuildDevServer = {
 
 type CreateDevServerOptions = {
   /**
-   * Using a custom Rspack Compiler object.
-   */
-  compiler?: Compiler | MultiCompiler;
-  /**
    * Whether to get port silently and not print any logs.
    * @default false
    */

--- a/website/docs/en/api/javascript-api/instance.mdx
+++ b/website/docs/en/api/javascript-api/instance.mdx
@@ -183,10 +183,6 @@ type BuildOptions = {
    * @default false
    */
   watch?: boolean;
-  /**
-   * Using a custom Rspack Compiler object.
-   */
-  compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<{
@@ -282,21 +278,6 @@ if (stats) {
 }
 ```
 
-### Custom compiler
-
-In some cases, you may want to use a custom compiler:
-
-```ts
-import { rspack } from '@rsbuild/core';
-
-const compiler = rspack({
-  // ...
-});
-await rsbuild.build({
-  compiler,
-});
-```
-
 ## rsbuild.startDevServer
 
 Starts the local dev server. This method will:
@@ -308,10 +289,6 @@ Starts the local dev server. This method will:
 
 ```ts
 type StartDevServerOptions = {
-  /**
-   * Using a custom Rspack Compiler object.
-   */
-  compiler?: Compiler | MultiCompiler;
   /**
    * Whether to get port silently and not print any logs.
    * @default false
@@ -397,21 +374,6 @@ When the default startup port is occupied, Rsbuild automatically increments the 
 ```ts
 await rsbuild.startDevServer({
   getPortSilently: true,
-});
-```
-
-### Custom compiler
-
-In some cases, you may want to use a custom compiler:
-
-```ts
-import { rspack } from '@rsbuild/core';
-
-const compiler = rspack({
-  // ...
-});
-await rsbuild.startDevServer({
-  compiler,
 });
 ```
 

--- a/website/docs/zh/api/javascript-api/dev-server-api.mdx
+++ b/website/docs/zh/api/javascript-api/dev-server-api.mdx
@@ -160,10 +160,6 @@ type RsbuildDevServer = {
 
 type CreateDevServerOptions = {
   /**
-   * 自定义 Compiler 对象
-   */
-  compiler?: Compiler | MultiCompiler;
-  /**
    * 是否在启动时静默获取端口号，不输出任何日志
    * @default false
    */

--- a/website/docs/zh/api/javascript-api/instance.mdx
+++ b/website/docs/zh/api/javascript-api/instance.mdx
@@ -206,10 +206,6 @@ type BuildOptions = {
    * @default false
    */
   watch?: boolean;
-  /**
-   * 使用自定义的 Rspack Compiler 对象
-   */
-  compiler?: Compiler | MultiCompiler;
 };
 
 function Build(options?: BuildOptions): Promise<{
@@ -305,21 +301,6 @@ if (stats) {
 }
 ```
 
-### 自定义 Compiler
-
-个别情况下，你可能希望使用自定义的 compiler：
-
-```ts
-import { rspack } from '@rsbuild/core';
-
-const compiler = rspack({
-  // ...
-});
-await rsbuild.build({
-  compiler,
-});
-```
-
 ## rsbuild.startDevServer
 
 启动本地 dev server。该方法会：
@@ -331,10 +312,6 @@ await rsbuild.build({
 
 ```ts
 type StartDevServerOptions = {
-  /**
-   * 使用自定义的 Rspack Compiler 对象
-   */
-  compiler?: Compiler | MultiCompiler;
   /**
    * 是否在启动时静默获取端口号，不输出任何日志
    * @default false
@@ -420,21 +397,6 @@ await server.close();
 ```ts
 await rsbuild.startDevServer({
   getPortSilently: true,
-});
-```
-
-### 自定义 Compiler
-
-个别情况下，你可能希望使用自定义的 compiler：
-
-```ts
-import { rspack } from '@rsbuild/core';
-
-const compiler = rspack({
-  // ...
-});
-await rsbuild.startDevServer({
-  compiler,
 });
 ```
 


### PR DESCRIPTION
## Summary

- Mark compiler option as deprecated. The `compiler` option in the JavaScript API has been unreliable for a long time. Maintaining full compatibility for custom compilers is difficult, since many parts of Rsbuild’s internals are tightly coupled to its built-in compiler. Deprecating this option will help prevent new users from depending on it.
- Remove the deprecated `compiler` option from  documentation.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
