### PR TITLE
fix: print the more concise module name if it exists

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -9,6 +9,10 @@ const formatFileName = (fileName: string) => {
 };
 
 function resolveFileName(stats: StatsError) {
+  if (stats.moduleName) {
+    return formatFileName(stats.moduleName);
+  }
+
   // Get the real source file path with stats.moduleIdentifier.
   // e.g. moduleIdentifier is "builtin:react-refresh-loader!/Users/x/src/App.jsx"
   if (stats.moduleIdentifier) {
@@ -22,8 +26,8 @@ function resolveFileName(stats: StatsError) {
     }
   }
 
-  // fallback to file or moduleName if moduleIdentifier parse failed
-  const file = stats.file || stats.moduleName;
+  // fallback to file if moduleIdentifier parse failed
+  const file = stats.file;
   return file ? formatFileName(file) : '';
 }
 

--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -9,12 +9,14 @@ const formatFileName = (fileName: string) => {
 };
 
 function resolveFileName(stats: StatsError) {
+  // `moduleName` is the readable relative path of the source file
+  // e.g. "./src/App.jsx"
   if (stats.moduleName) {
     return formatFileName(stats.moduleName);
   }
 
-  // Get the real source file path with stats.moduleIdentifier.
-  // e.g. moduleIdentifier is "builtin:react-refresh-loader!/Users/x/src/App.jsx"
+  // `moduleIdentifier` is the absolute path with inline loaders
+  // e.g. "builtin:react-refresh-loader!/Users/x/src/App.jsx"
   if (stats.moduleIdentifier) {
     const regex = /(?:!|^)([^!]+)$/;
     const matched = stats.moduleIdentifier.match(regex);
@@ -26,7 +28,7 @@ function resolveFileName(stats: StatsError) {
     }
   }
 
-  // fallback to file if moduleIdentifier parse failed
+  // fallback to `file` if `moduleName` and `moduleIdentifier` do not exist
   const file = stats.file;
   return file ? formatFileName(file) : '';
 }


### PR DESCRIPTION
## Summary

Print the `stats.moduleName` (the readable relative path) if present, improving clarity and accuracy in file name reporting.

### Before

<img width="849" height="338" alt="Screenshot 2025-09-29 at 13 41 06" src="https://github.com/user-attachments/assets/ed78596d-ef22-4002-85fc-1671a5d69385" />

### After

<img width="861" height="337" alt="Screenshot 2025-09-29 at 13 40 49" src="https://github.com/user-attachments/assets/4e175b15-264c-4522-8ff9-14735c6e8c5d" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
