### PR TITLE
fix: prioritize custom file path in error logs

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -10,8 +10,9 @@ const formatFileName = (fileName: string) => {
 
 function resolveFileName(stats: StatsError) {
   const file =
-    // `file` is a custom file path related to the stats error
-    // It should be output first
+    // `file` is a custom file path related to the stats error. For example,
+    // ts-checker-rspack-plugin sets the module path of type errors to this field.
+    // It should be output first as it provides the most specific error location.
     stats.file ||
     // `moduleName` is the readable relative path of the source file
     // e.g. "./src/App.jsx"

--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -9,10 +9,16 @@ const formatFileName = (fileName: string) => {
 };
 
 function resolveFileName(stats: StatsError) {
-  // `moduleName` is the readable relative path of the source file
-  // e.g. "./src/App.jsx"
-  if (stats.moduleName) {
-    return formatFileName(stats.moduleName);
+  const file =
+    // `file` is a custom file path related to the stats error
+    // It should be output first
+    stats.file ||
+    // `moduleName` is the readable relative path of the source file
+    // e.g. "./src/App.jsx"
+    stats.moduleName;
+
+  if (file) {
+    return formatFileName(file);
   }
 
   // `moduleIdentifier` is the absolute path with inline loaders
@@ -28,9 +34,7 @@ function resolveFileName(stats: StatsError) {
     }
   }
 
-  // fallback to `file` if `moduleName` and `moduleIdentifier` do not exist
-  const file = stats.file;
-  return file ? formatFileName(file) : '';
+  return '';
 }
 
 function resolveModuleTrace(stats: StatsError) {


### PR DESCRIPTION
## Summary

Checks for `stats.file` first before falling back to `stats.moduleName` for better error reporting. This ensures custom file paths take precedence over module names when available.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
