### PR TITLE
docs: add web workers browser compatibility tips

### DIFF
--- a/website/docs/en/config/output/polyfill.mdx
+++ b/website/docs/en/config/output/polyfill.mdx
@@ -33,6 +33,10 @@ export default {
 };
 ```
 
+:::tip
+It should be noted that when you bundle page with Web Workers, the `entry` mode is not applicable to Web Workers because the Web Workers thread is isolated from the main thread (page), and the `usage` mode can be used at this time.
+:::
+
 ### off
 
 With `output.polyfill` set to `'off'`, Rsbuild doesn't inject polyfills. You need to handle code compatibility yourself.

--- a/website/docs/en/guide/basic/web-workers.mdx
+++ b/website/docs/en/guide/basic/web-workers.mdx
@@ -98,6 +98,18 @@ worker.postMessage(10);
 
 For detailed discussions on cross-domain issues, please refer to [Discussions - webpack 5 web worker support for CORS?](https://github.com/webpack/webpack/discussions/14648)
 
+### Browser compatibility
+
+It should be noted that when you bundle page with Web Workers, the [entry mode](/guide/advanced/browser-compatibility#entry-mode) is not applicable to Web Workers because the Web Workers thread is isolated from the main thread (page), and the [usage mode](/guide/advanced/browser-compatibility#usage-mode) can be used at this time.
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    polyfill: 'usage',
+  },
+};
+```
+
 ## Standalone build
 
 Rsbuild supports standalone building of Web Workers bundles. When you need to configure independent build options for Web Workers or provide Web Workers for use by other applications, you can use the following methods.

--- a/website/docs/zh/config/output/polyfill.mdx
+++ b/website/docs/zh/config/output/polyfill.mdx
@@ -33,6 +33,10 @@ export default {
 };
 ```
 
+:::tip
+需要注意的是，当你将页面与 Web Workers 一起打包时，由于 Web Workers 线程与主线程（页面）环境隔离，`entry` 方案对 Web Workers 并不适用，此时可以使用 `usage` 方案。
+:::
+
 ### off
 
 当 `output.polyfill` 配置为 `'off'` 时，Rsbuild 不会注入 polyfills，你需要自行处理代码的兼容性。

--- a/website/docs/zh/guide/basic/web-workers.mdx
+++ b/website/docs/zh/guide/basic/web-workers.mdx
@@ -98,6 +98,18 @@ worker.postMessage(10);
 
 关于跨域问题的详细讨论可参考 [Discussions - webpack 5 web worker support for CORS?](https://github.com/webpack/webpack/discussions/14648)
 
+### 浏览器兼容性
+
+当你将页面与 Web Workers 一起打包时，需要注意的是，由于 Web Workers 线程与主线程（页面）环境隔离，Rsbuild 所提供的 polyfill [entry 方案](/guide/advanced/browser-compatibility#entry-方案) 对 Web Workers 并不适用，此时可以使用 [usage 方案](/guide/advanced/browser-compatibility#usage-方案)。
+
+```ts title="rsbuild.config.ts"
+export default {
+  output: {
+    polyfill: 'usage',
+  },
+};
+```
+
 ## 独立构建
 
 Rsbuild 支持独立构建 Web Workers 产物。当你需要为 Web Workers 配置独立的构建选项，或将 Web Workers 提供给其他应用使用时，可以使用以下方法。


### PR DESCRIPTION
## Summary

When bundle page with Web Workers, the `entry` mode is not applicable to Web Workers because the Web Workers thread is isolated from the main thread (page), and the `usage` mode can be used at this time.

```ts title="rsbuild.config.ts"
export default {
  output: {
    polyfill: 'usage',
  },
};
```

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
