### PR TITLE
fix: replace the deprecated url.parse in assets middleware

### DIFF
--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -1,39 +1,27 @@
 import type { Stats as FSStats } from 'node:fs';
 import path from 'node:path';
 import { unescape as qsUnescape } from 'node:querystring';
-import { parse } from 'node:url';
 import type { EnvironmentContext } from '../../types';
 import type { OutputFileSystem } from './index';
-import { memorize } from './memorize';
-
-// TODO: type the cache options instead of using any for the second parameter
-const memoizedParse = memorize(parse, undefined, (value: any) => {
-  if (value.pathname) {
-    value.pathname = decode(value.pathname);
-  }
-
-  return value;
-});
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
-
-function decode(input: string): string {
-  return qsUnescape(input);
-}
 
 export function getFileFromUrl(
   url: string,
   outputFileSystem: OutputFileSystem,
   environments: Record<string, EnvironmentContext>,
 ): { filename: string; fsStats: FSStats } | { errorCode: number } | undefined {
-  let urlObject: URL;
+  let pathname: string | undefined;
+
   try {
-    urlObject = memoizedParse(url, false, true) as URL;
+    const urlObject = new URL(url, 'http://localhost');
+    if (urlObject.pathname) {
+      pathname = qsUnescape(urlObject.pathname);
+    }
   } catch {
     return;
   }
 
-  const { pathname } = urlObject;
   if (!pathname) {
     return;
   }


### PR DESCRIPTION
## Summary

Replace the deprecated url.parse and memoized function with direct URL constructor.

`url.parse` has been deprecated since Node 24:

<img width="1064" height="174" alt="Screenshot 2025-09-29 at 16 02 31" src="https://github.com/user-attachments/assets/627e454a-8d90-4f2a-a867-fe7a820bc6f2" />

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/5696

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
