### PR TITLE
refactor: simplify stats error formatting logic

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -1,4 +1,4 @@
-import type { StatsCompilation, StatsError } from '@rspack/core';
+import type { StatsError } from '@rspack/core';
 import color from '../../compiled/picocolors/index.js';
 
 const formatFileName = (fileName: string) => {
@@ -191,24 +191,20 @@ const hintNodePolyfill = (message: string): string => {
   return message;
 };
 
-// Cleans up Rspack error messages.
-function formatMessage(stats: StatsError | string, verbose?: boolean) {
+// Formats Rspack stats error to readable message
+export function formatStatsError(stats: StatsError, verbose?: boolean): string {
   let lines: string[] = [];
   let message: string;
 
   // Stats error object
-  if (typeof stats === 'object') {
-    const fileName = resolveFileName(stats);
-    const mainMessage = stats.message;
-    const details =
-      verbose && stats.details ? `\nDetails: ${stats.details}\n` : '';
-    const stack = verbose && stats.stack ? `\n${stats.stack}` : '';
-    const moduleTrace = resolveModuleTrace(stats);
+  const fileName = resolveFileName(stats);
+  const mainMessage = stats.message;
+  const details =
+    verbose && stats.details ? `\nDetails: ${stats.details}\n` : '';
+  const stack = verbose && stats.stack ? `\n${stats.stack}` : '';
+  const moduleTrace = resolveModuleTrace(stats);
 
-    message = `${fileName}${mainMessage}${details}${stack}${moduleTrace}`;
-  } else {
-    message = stats;
-  }
+  message = `${fileName}${mainMessage}${details}${stack}${moduleTrace}`;
 
   // Remove inner error message
   const innerError = '-- inner error --';
@@ -233,22 +229,4 @@ function formatMessage(stats: StatsError | string, verbose?: boolean) {
   message = lines.join('\n');
 
   return message.trim();
-}
-
-export function formatStatsMessages(
-  stats: Pick<StatsCompilation, 'errors' | 'warnings'>,
-  verbose?: boolean,
-): {
-  errors: string[];
-  warnings: string[];
-} {
-  const formattedErrors =
-    stats.errors?.map((error) => formatMessage(error, verbose)) || [];
-  const formattedWarnings =
-    stats.warnings?.map((warning) => formatMessage(warning, verbose)) || [];
-
-  return {
-    errors: formattedErrors,
-    warnings: formattedWarnings,
-  };
 }

--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -3,7 +3,7 @@ import color from '../../compiled/picocolors/index.js';
 import { logger } from '../logger';
 import type { Rspack } from '../types';
 import { isMultiCompiler } from './';
-import { formatStatsMessages } from './format.js';
+import { formatStatsError } from './format';
 
 function formatErrorMessage(errors: string[]) {
   const title = color.bold(
@@ -98,27 +98,16 @@ export function formatStats(
   const verbose = logger.level === 'verbose';
 
   if (hasErrors) {
-    const { errors } = formatStatsMessages(
-      {
-        errors: getAllStatsErrors(statsData),
-        warnings: [],
-      },
-      verbose,
-    );
-
+    const statsErrors = getAllStatsErrors(statsData) ?? [];
+    const errors = statsErrors.map((item) => formatStatsError(item, verbose));
     return {
       message: formatErrorMessage(errors),
       level: 'error',
     };
   }
 
-  const { warnings } = formatStatsMessages(
-    {
-      errors: [],
-      warnings: getAllStatsWarnings(statsData),
-    },
-    verbose,
-  );
+  const statsWarnings = getAllStatsWarnings(statsData) ?? [];
+  const warnings = statsWarnings.map((item) => formatStatsError(item, verbose));
 
   if (warnings.length) {
     const title = color.bold(

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -6,7 +6,7 @@ import {
   getAllStatsWarnings,
   getStatsOptions,
 } from '../helpers';
-import { formatStatsMessages } from '../helpers/format';
+import { formatStatsError } from '../helpers/format';
 import { logger } from '../logger';
 import type { DevConfig, InternalContext, Rspack } from '../types';
 import { formatBrowserErrorLog } from './browserLogs';
@@ -434,11 +434,8 @@ export class SocketServer {
     }
 
     if (statsJson.errorsCount) {
-      const errors = getAllStatsErrors(statsJson);
-      const { errors: formattedErrors } = formatStatsMessages({
-        errors,
-        warnings: [],
-      });
+      const statsErrors = getAllStatsErrors(statsJson) ?? [];
+      const formattedErrors = statsErrors.map((item) => formatStatsError(item));
 
       this.sockWrite(
         {
@@ -454,11 +451,11 @@ export class SocketServer {
     }
 
     if (statsJson.warningsCount) {
-      const warnings = getAllStatsWarnings(statsJson);
-      const { warnings: formattedWarnings } = formatStatsMessages({
-        warnings,
-        errors: [],
-      });
+      const statsWarnings = getAllStatsWarnings(statsJson) ?? [];
+      const formattedWarnings = statsWarnings.map((item) =>
+        formatStatsError(item),
+      );
+
       this.sockWrite(
         {
           type: 'warnings',


### PR DESCRIPTION
## Summary

- Simplify stats error formatting logic
- Replace `formatStatsMessages` with `formatStatsError` for direct error formatting

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
