### PR TITLE
perf(dev-server): make asset middleware file lookup async

### DIFF
--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -6,7 +6,7 @@
  * Copyright JS Foundation and other contributors
  * https://github.com/webpack/webpack-dev-middleware/blob/master/LICENSE
  */
-import type { Stats as FSStats, ReadStream } from 'node:fs';
+import type { ReadStream } from 'node:fs';
 import { createRequire } from 'node:module';
 import type { Compiler, MultiCompiler, Watching } from '@rspack/core';
 import { applyToCompiler, isMultiCompiler } from '../../helpers';
@@ -17,6 +17,7 @@ import type {
   NormalizedDevConfig,
   NormalizedEnvironmentConfig,
   RequestHandler,
+  Rspack,
 } from '../../types';
 import { resolveHostname } from './../hmrFallback';
 import type { SocketServer } from '../socketServer';
@@ -28,14 +29,12 @@ const noop = () => {};
 
 export type MultiWatching = ReturnType<MultiCompiler['watch']>;
 
-// TODO: refine types to match underlying fs-like implementations
-export type OutputFileSystem = {
+export type OutputFileSystem = Rspack.OutputFileSystem & {
+  // TODO: can be removed after Rspack adding this type
   createReadStream?: (
     p: string,
     opts: { start: number; end: number },
   ) => ReadStream;
-  statSync?: (p: string) => FSStats;
-  readFileSync?: (p: string) => Buffer;
 };
 
 export type Options = {

--- a/packages/core/src/server/assets-middleware/middleware.ts
+++ b/packages/core/src/server/assets-middleware/middleware.ts
@@ -325,7 +325,11 @@ export function createMiddleware(
         return;
       }
 
-      const resolved = getFileFromUrl(req.url, outputFileSystem, environments);
+      const resolved = await getFileFromUrl(
+        req.url,
+        outputFileSystem,
+        environments,
+      );
 
       if (!resolved) {
         await goNext();

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -59,7 +59,7 @@ const resolveSourceLocation = async (
   }
 
   const { file, column, lineNumber } = frame;
-  const sourceMapInfo = getFileFromUrl(
+  const sourceMapInfo = await getFileFromUrl(
     `${file}.map`,
     fs as OutputFileSystem,
     environments,


### PR DESCRIPTION
## Summary

- use async stats from Rspack output fs to avoid sync bottlenecks
 -align OutputFileSystem typing and update middleware/browser logs to await lookups

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
