### PR TITLE
perf(hmr): no need to get assets info

### DIFF
--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -88,6 +88,8 @@ export class SocketServer {
 
   private reportedBrowserLogs: Set<string> = new Set();
 
+  private currentHash: Map<string, string> = new Map();
+
   constructor(
     context: InternalContext,
     options: DevConfig,
@@ -332,7 +334,7 @@ export class SocketServer {
       return null;
     }
 
-    const defaultStats: Record<string, boolean> = {
+    const defaultStats: Rspack.StatsOptions = {
       all: false,
       hash: true,
       assets: true,
@@ -383,7 +385,7 @@ export class SocketServer {
     const newInitialChunks: Set<string> = new Set();
     if (statsJson.entrypoints) {
       for (const entrypoint of Object.values(statsJson.entrypoints)) {
-        const chunks = entrypoint.chunks;
+        const { chunks } = entrypoint;
 
         if (!Array.isArray(chunks)) {
           continue;
@@ -411,19 +413,22 @@ export class SocketServer {
       return;
     }
 
-    const shouldEmit =
-      !force &&
-      statsJson &&
-      !statsJson.errorsCount &&
-      statsJson.assets &&
-      statsJson.assets.every((asset: any) => !asset.emitted);
-
-    if (shouldEmit) {
-      this.sockWrite({ type: 'ok' }, token);
-      return;
-    }
-
     if (statsJson.hash) {
+      const prevHash = this.currentHash.get(token);
+      this.currentHash.set(token, statsJson.hash);
+
+      // If build hash is not changed and there is no error or warning, skip emit
+      const shouldEmit =
+        !force &&
+        !statsJson.errorsCount &&
+        !statsJson.warningsCount &&
+        prevHash === statsJson.hash;
+
+      if (shouldEmit) {
+        this.sockWrite({ type: 'ok' }, token);
+        return;
+      }
+
       this.sockWrite(
         {
           type: 'hash',
@@ -469,7 +474,6 @@ export class SocketServer {
     }
 
     this.sockWrite({ type: 'ok' }, token);
-    return;
   }
 
   // send message to connecting socket

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -337,7 +337,6 @@ export class SocketServer {
     const defaultStats: Rspack.StatsOptions = {
       all: false,
       hash: true,
-      assets: true,
       warnings: true,
       warningsCount: true,
       errors: true,


### PR DESCRIPTION
## Summary

When using `stats.toJson` in Rspack, enabling the `assets: true` option introduces noticeable Rust-JS communication overhead — typically a few milliseconds for small applications, but potentially several hundred milliseconds for large ones.

This PR avoids that overhead by checking `stats.hash` instead of relying on `asset.emitted`.

### Before

<img width="507" height="207" alt="Screenshot 2025-10-01 at 22 05 15" src="https://github.com/user-attachments/assets/72068fbb-ccd0-4c1e-9285-25cc57cc69f6" />

### After

<img width="503" height="187" alt="Screenshot 2025-10-01 at 22 04 46" src="https://github.com/user-attachments/assets/3b9e25fd-2449-4f4d-8293-8bbb57963849" />

## Related Links

- https://github.com/webpack/webpack-dev-server/pull/3906

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
