### PR TITLE
refactor(stats): improve stats error and warning handling

### DIFF
--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -1,4 +1,4 @@
-import { logger, type Rspack } from '@rsbuild/core';
+import { logger, type RsbuildStats, type Rspack } from '@rsbuild/core';
 import WebpackMultiStats from 'webpack/lib/MultiStats.js';
 import { type InitConfigsOptions, initConfigs } from './initConfigs.js';
 
@@ -36,17 +36,18 @@ export async function createCompiler(options: InitConfigsOptions) {
   });
 
   compiler.hooks.done.tap(HOOK_NAME, (stats) => {
-    const hasErrors = stats.hasErrors();
-    context.buildState.hasErrors = hasErrors;
-    context.buildState.status = 'done';
-
     const statsOptions = helpers.getStatsOptions(compiler);
     const statsJson = stats.toJson({
       moduleTrace: true,
       children: true,
-      preset: 'errors-warnings',
+      errors: true,
+      warnings: true,
       ...statsOptions,
-    });
+    }) as RsbuildStats;
+
+    const hasErrors = helpers.getStatsErrors(statsJson).length > 0;
+    context.buildState.hasErrors = hasErrors;
+    context.buildState.status = 'done';
 
     const { message, level } = helpers.formatStats(statsJson, hasErrors);
 

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -35,9 +35,9 @@ export async function createCompiler(options: InitConfigsOptions) {
     context.buildState.hasErrors = false;
   });
 
-  compiler.hooks.done.tap(HOOK_NAME, (stats) => {
+  compiler.hooks.done.tap(HOOK_NAME, (statsInstance) => {
     const statsOptions = helpers.getStatsOptions(compiler);
-    const statsJson = stats.toJson({
+    const stats = statsInstance.toJson({
       moduleTrace: true,
       children: true,
       errors: true,
@@ -45,11 +45,11 @@ export async function createCompiler(options: InitConfigsOptions) {
       ...statsOptions,
     }) as RsbuildStats;
 
-    const hasErrors = helpers.getStatsErrors(statsJson).length > 0;
+    const hasErrors = helpers.getStatsErrors(stats).length > 0;
     context.buildState.hasErrors = hasErrors;
     context.buildState.status = 'done';
 
-    const { message, level } = helpers.formatStats(statsJson, hasErrors);
+    const { message, level } = helpers.formatStats(stats, hasErrors);
 
     if (level === 'error') {
       logger.error(message);

--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -18,12 +18,6 @@ function formatErrorMessage(errors: string[]) {
   return `${title}\n${text}`;
 }
 
-export const hasStatsErrors = (stats: RsbuildStats): boolean =>
-  getStatsErrors(stats).length > 0;
-
-export const hasStatsWarnings = (stats: RsbuildStats): boolean =>
-  getStatsWarnings(stats).length > 0;
-
 /**
  * If stats has errors, return stats errors directly
  * If stats has no errors, return child errors, as some errors exist in both

--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -1,7 +1,6 @@
-import type { StatsCompilation } from '@rspack/core';
 import color from '../../compiled/picocolors/index.js';
 import { logger } from '../logger';
-import type { Rspack } from '../types';
+import type { RsbuildStats, Rspack } from '../types';
 import { isMultiCompiler } from './';
 import { formatStatsError } from './format';
 
@@ -19,19 +18,52 @@ function formatErrorMessage(errors: string[]) {
   return `${title}\n${text}`;
 }
 
-export const getAllStatsErrors = (
-  statsData: StatsCompilation,
-): Rspack.StatsError[] | undefined => {
-  // stats error + childCompiler error
-  // only append child errors when stats error does not exist, because some errors will exist in both stats and childCompiler
-  if (statsData.errorsCount && statsData.errors?.length === 0) {
-    return statsData.children?.reduce<Rspack.StatsError[]>(
-      (errors, curr) => errors.concat(curr.errors || []),
+export const hasStatsErrors = (stats: RsbuildStats): boolean =>
+  getStatsErrors(stats).length > 0;
+
+export const hasStatsWarnings = (stats: RsbuildStats): boolean =>
+  getStatsWarnings(stats).length > 0;
+
+/**
+ * If stats has errors, return stats errors directly
+ * If stats has no errors, return child errors, as some errors exist in both
+ * stats and childCompiler
+ */
+export const getStatsErrors = ({
+  errors,
+  children,
+}: RsbuildStats): Rspack.StatsError[] => {
+  if (errors !== undefined && errors.length > 0) {
+    return errors;
+  }
+
+  if (children) {
+    return children.reduce<Rspack.StatsError[]>(
+      (errors, ret) => (ret.errors ? errors.concat(ret.errors) : errors),
       [],
     );
   }
 
-  return statsData.errors;
+  return [];
+};
+
+export const getStatsWarnings = ({
+  warnings,
+  children,
+}: RsbuildStats): Rspack.StatsError[] => {
+  if (warnings !== undefined && warnings.length > 0) {
+    return warnings;
+  }
+
+  if (children) {
+    return children.reduce<Rspack.StatsError[]>(
+      (warnings, ret) =>
+        ret.warnings ? warnings.concat(ret.warnings) : warnings,
+      [],
+    );
+  }
+
+  return [];
 };
 
 export const getAssetsFromStats = (
@@ -49,19 +81,6 @@ export const getAssetsFromStats = (
   });
 
   return statsJson.assets || [];
-};
-
-export const getAllStatsWarnings = (
-  statsData: StatsCompilation,
-): Rspack.StatsError[] | undefined => {
-  if (statsData.warningsCount && statsData.warnings?.length === 0) {
-    return statsData.children?.reduce<Rspack.StatsError[]>(
-      (warnings, curr) => warnings.concat(curr.warnings || []),
-      [],
-    );
-  }
-
-  return statsData.warnings;
 };
 
 export function getStatsOptions(
@@ -88,7 +107,7 @@ export function getStatsOptions(
 }
 
 export function formatStats(
-  statsData: Rspack.StatsCompilation,
+  stats: RsbuildStats,
   hasErrors: boolean,
 ): {
   message?: string;
@@ -98,7 +117,7 @@ export function formatStats(
   const verbose = logger.level === 'verbose';
 
   if (hasErrors) {
-    const statsErrors = getAllStatsErrors(statsData) ?? [];
+    const statsErrors = getStatsErrors(stats);
     const errors = statsErrors.map((item) => formatStatsError(item, verbose));
     return {
       message: formatErrorMessage(errors),
@@ -106,7 +125,7 @@ export function formatStats(
     };
   }
 
-  const statsWarnings = getAllStatsWarnings(statsData) ?? [];
+  const statsWarnings = getStatsWarnings(stats);
   const warnings = statsWarnings.map((item) => formatStatsError(item, verbose));
 
   if (warnings.length) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -175,6 +175,7 @@ export type {
   RsbuildPlugins,
   RsbuildProvider,
   RsbuildProviderHelpers,
+  RsbuildStats,
   RsbuildTarget,
   RspackChain,
   RspackRule,

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -2,8 +2,8 @@ import { sep } from 'node:path';
 import {
   color,
   formatStats,
+  getStatsErrors,
   getStatsOptions,
-  hasStatsErrors,
   isSatisfyRspackVersion,
   prettyTime,
   rspackMinVersion,
@@ -201,7 +201,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
         ...statsOptions,
       }) as RsbuildStats;
 
-      const hasErrors = hasStatsErrors(stats);
+      const hasErrors = getStatsErrors(stats).length > 0;
 
       context.buildState.status = 'done';
       context.buildState.hasErrors = hasErrors;

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -202,7 +202,6 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
       }) as RsbuildStats;
 
       const hasErrors = getStatsErrors(stats).length > 0;
-
       context.buildState.status = 'done';
       context.buildState.hasErrors = hasErrors;
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -1,9 +1,9 @@
 import { sep } from 'node:path';
-import type { StatsCompilation } from '@rspack/core';
 import {
   color,
   formatStats,
   getStatsOptions,
+  hasStatsErrors,
   isSatisfyRspackVersion,
   prettyTime,
   rspackMinVersion,
@@ -11,7 +11,12 @@ import {
 import { registerDevHook } from '../hooks';
 import { logger } from '../logger';
 import { rspack } from '../rspack';
-import type { InternalContext, Rspack } from '../types';
+import type {
+  InternalContext,
+  RsbuildStats,
+  RsbuildStatsItem,
+  Rspack,
+} from '../types';
 import { type InitConfigsOptions, initConfigs } from './initConfigs';
 
 // keep the last 3 parts of the path to make logs clean
@@ -184,24 +189,26 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
   compiler.hooks.done.tap(
     HOOK_NAME,
-    (stats: Rspack.Stats | Rspack.MultiStats) => {
-      const hasErrors = stats.hasErrors();
-      context.buildState.hasErrors = hasErrors;
-      context.buildState.status = 'done';
-
+    (statsInstance: Rspack.Stats | Rspack.MultiStats) => {
       const statsOptions = getStatsOptions(compiler);
-      const statsJson = stats.toJson({
+      const stats = statsInstance.toJson({
         children: true,
         moduleTrace: true,
         // get the compilation time
         timings: true,
-        preset: 'errors-warnings',
+        errors: true,
+        warnings: true,
         ...statsOptions,
-      });
+      }) as RsbuildStats;
 
-      const printTime = (c: StatsCompilation, index: number) => {
-        if (c.time) {
-          const time = prettyTime(c.time / 1000);
+      const hasErrors = hasStatsErrors(stats);
+
+      context.buildState.status = 'done';
+      context.buildState.hasErrors = hasErrors;
+
+      const printTime = (statsItem: RsbuildStatsItem, index: number) => {
+        if (statsItem.time) {
+          const time = prettyTime(statsItem.time / 1000);
           const { name } = rspackConfigs[index];
 
           // When using multi compiler, print name to distinguish different compilers
@@ -212,16 +219,16 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
 
       if (!hasErrors) {
         // only print children compiler time when multi compiler
-        if (isMultiCompiler && statsJson.children?.length) {
-          statsJson.children.forEach((c, index) => {
+        if (isMultiCompiler && stats.children?.length) {
+          stats.children.forEach((c, index) => {
             printTime(c, index);
           });
         } else {
-          printTime(statsJson, 0);
+          printTime(stats, 0);
         }
       }
 
-      const { message, level } = formatStats(statsJson, hasErrors);
+      const { message, level } = formatStats(stats, hasErrors);
 
       if (level === 'error') {
         logger.error(message);

--- a/packages/core/src/provider/helpers.ts
+++ b/packages/core/src/provider/helpers.ts
@@ -3,7 +3,12 @@
  */
 
 export { modifyBundlerChain } from '../configChain';
-export { formatStats, getStatsOptions, prettyTime } from '../helpers';
+export {
+  formatStats,
+  getStatsErrors,
+  getStatsOptions,
+  prettyTime,
+} from '../helpers';
 export { registerBuildHook, registerDevHook } from '../hooks';
 export { inspectConfig } from '../inspectConfig';
 export {

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -365,3 +365,15 @@ export type RsbuildEntry = Record<
 >;
 
 export type RsbuildMode = 'development' | 'production' | 'none';
+
+export type RsbuildStatsItem = Pick<
+  Rspack.StatsCompilation,
+  'errors' | 'warnings' | 'time'
+>;
+
+/**
+ * A subset of Rspack's StatsCompilation with only the fields we need
+ */
+export type RsbuildStats = RsbuildStatsItem & {
+  children: RsbuildStatsItem[];
+};


### PR DESCRIPTION
## Summary

- introduce `RsbuildStats` type to better represent used stats fields
- remove redundant stats options (`errorsCount`, `warningsCount`) and simplify condition checks

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
