### PR TITLE
fix: render TS errors on error overlay

### DIFF
--- a/e2e/cases/server/overlay-type-errors/index.test.ts
+++ b/e2e/cases/server/overlay-type-errors/index.test.ts
@@ -1,20 +1,8 @@
 import { expect, test } from '@e2e/helper';
+import type { Page } from 'playwright';
 
-// TODO: fixme
-test.skip('should display type errors on overlay correctly', async ({
-  page,
-  dev,
-  logHelper,
-}) => {
-  const { addLog, expectLog } = logHelper;
-  page.on('console', (consoleMessage) => {
-    addLog(consoleMessage.text());
-  });
-
-  await dev();
-
-  await expectLog('TS2322:');
-
+const expectErrorOverlay = async (page: Page) => {
+  await page.waitForSelector('rsbuild-error-overlay', { state: 'attached' });
   const errorOverlay = page.locator('rsbuild-error-overlay');
   await expect(errorOverlay.locator('.title')).toHaveText('Build failed');
 
@@ -30,4 +18,23 @@ test.skip('should display type errors on overlay correctly', async ({
   expect(
     linkText?.endsWith('/src/index.ts:3:1') && linkText.startsWith('.'),
   ).toBeTruthy();
+};
+
+test('should display type errors on overlay correctly', async ({
+  page,
+  dev,
+  logHelper,
+}) => {
+  const { addLog, expectLog } = logHelper;
+  page.on('console', (consoleMessage) => {
+    addLog(consoleMessage.text());
+  });
+
+  await dev();
+  await expectLog('TS2322:');
+  await expectErrorOverlay(page);
+
+  // The error overlay should be rendered after reloading the page
+  page.reload();
+  await expectErrorOverlay(page);
 });

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -196,6 +196,23 @@ export class SocketServer {
   }
 
   /**
+   * Send error messages to the client and render error overlay
+   */
+  public sendError(errors: Rspack.StatsError[], token: string): void {
+    const formattedErrors = errors.map((item) => formatStatsError(item));
+    this.sockWrite(
+      {
+        type: 'errors',
+        data: {
+          text: formattedErrors,
+          html: genOverlayHTML(formattedErrors, this.context.rootPath),
+        },
+      },
+      token,
+    );
+  }
+
+  /**
    * Write message to each socket
    * @param message - The message to send
    * @param token - The token of the socket to send the message to,
@@ -421,18 +438,7 @@ export class SocketServer {
     }
 
     if (errors.length > 0) {
-      const errorMessages = errors.map((item) => formatStatsError(item));
-
-      this.sockWrite(
-        {
-          type: 'errors',
-          data: {
-            text: errorMessages,
-            html: genOverlayHTML(errorMessages, this.context.rootPath),
-          },
-        },
-        token,
-      );
+      this.sendError(errors, token);
       return;
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in https://github.com/web-infra-dev/rsbuild/pull/6301.

The [ts-checker-rspack-plugin](https://github.com/rspack-contrib/ts-checker-rspack-plugin) asynchronously pushes TypeScript errors to `compilation.errors` and triggers the `done` hook again, see https://github.com/rspack-contrib/ts-checker-rspack-plugin/blob/1f6ccaf1b5fdeb84d5a5c9f781661b760fc4a6e5/src/hooks/intercept-done-to-get-dev-server-tap.ts#L15-L23.

In previous implementations, Rsbuild would call `stats.toJson()` multiple times and send all TS errors to the client, which introduced extra performance overhead.

In the new implementation introduced by this PR, we detect newly added TS errors on the current compilation and send only the new ones to the error overlay, resulting in better performance.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
