### PR TITLE
fix: print hint when stats.errors is disabled

### DIFF
--- a/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
+++ b/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
@@ -2,14 +2,14 @@ import { test } from '@e2e/helper';
 
 const EXPECTED_LOG = `Build failed. No errors reported since Rspack's "stats.errors" is disabled.`;
 
-test('should print hint if stats.errors is disabled after dev failed', async ({
+test('should print a hint if stats.errors is disabled after a dev failure', async ({
   dev,
 }) => {
   const rsbuild = await dev();
   await rsbuild.expectLog(EXPECTED_LOG);
 });
 
-test('should print hint if stats.errors is disabled after build failed', async ({
+test('should print a hint if stats.errors is disabled after a build failure', async ({
   build,
 }) => {
   const rsbuild = await build({

--- a/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
+++ b/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
@@ -1,0 +1,19 @@
+import { test } from '@e2e/helper';
+
+const EXPECTED_LOG = `Build failed. No errors reported since Rspack's "stats.errors" is disabled.`;
+
+test('should print hint if stats.errors is disabled after dev failed', async ({
+  dev,
+}) => {
+  const rsbuild = await dev();
+  await rsbuild.expectLog(EXPECTED_LOG);
+});
+
+test('should print hint if stats.errors is disabled after build failed', async ({
+  build,
+}) => {
+  const rsbuild = await build({
+    catchBuildError: true,
+  });
+  await rsbuild.expectLog(EXPECTED_LOG);
+});

--- a/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
+++ b/e2e/cases/diagnostic/disable-stats-errors/index.test.ts
@@ -1,19 +1,21 @@
-import { test } from '@e2e/helper';
+import { rspackTest } from '@e2e/helper';
 
 const EXPECTED_LOG = `Build failed. No errors reported since Rspack's "stats.errors" is disabled.`;
 
-test('should print a hint if stats.errors is disabled after a dev failure', async ({
-  dev,
-}) => {
-  const rsbuild = await dev();
-  await rsbuild.expectLog(EXPECTED_LOG);
-});
+rspackTest(
+  'should print a hint if stats.errors is disabled after a dev failure',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    await rsbuild.expectLog(EXPECTED_LOG);
+  },
+);
 
-test('should print a hint if stats.errors is disabled after a build failure', async ({
-  build,
-}) => {
-  const rsbuild = await build({
-    catchBuildError: true,
-  });
-  await rsbuild.expectLog(EXPECTED_LOG);
-});
+rspackTest(
+  'should print a hint if stats.errors is disabled after a build failure',
+  async ({ build }) => {
+    const rsbuild = await build({
+      catchBuildError: true,
+    });
+    await rsbuild.expectLog(EXPECTED_LOG);
+  },
+);

--- a/e2e/cases/diagnostic/disable-stats-errors/rsbuild.config.ts
+++ b/e2e/cases/diagnostic/disable-stats-errors/rsbuild.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      stats: {
+        errors: false,
+      },
+    },
+  },
+});

--- a/e2e/cases/diagnostic/disable-stats-errors/src/index.js
+++ b/e2e/cases/diagnostic/disable-stats-errors/src/index.js
@@ -1,0 +1,1 @@
+import './non-existent-file.js';

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -19,8 +19,8 @@ import {
 import { type ExtendedLogHelper, proxyConsole } from './logs';
 
 function makeBox(title: string) {
-  const header = `╭──────────────  Logs from: "${title}" ──────────────╮`;
-  const footer = `╰──────────────  Logs from: "${title}" ──────────────╯`;
+  const header = `╭────────────  Logs from: "${title}" ────────────╮`;
+  const footer = `╰────────────  Logs from: "${title}" ────────────╯`;
   return {
     header: `\n${header}\n`,
     footer: `${footer}\n`,

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -42,7 +42,7 @@ export async function createCompiler(options: InitConfigsOptions) {
       compiler,
       context.action,
     );
-    const hasErrors = helpers.getStatsErrors(stats).length > 0;
+    const hasErrors = statsInstance.hasErrors();
 
     context.buildState.stats = stats;
     context.buildState.status = 'done';

--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -5,16 +5,14 @@ import { isMultiCompiler } from './';
 import { formatStatsError } from './format';
 
 function formatErrorMessage(errors: string[]) {
+  if (!errors.length) {
+    return `Build failed. No errors reported since Rspack's "stats.errors" is disabled.`;
+  }
+
   const title = color.bold(
     color.red(errors.length > 1 ? 'Build errors: ' : 'Build error: '),
   );
-
-  if (!errors.length) {
-    return `${title}\n${color.yellow(`For more details, please set 'stats.errors: true' `)}`;
-  }
-
   const text = `${errors.join('\n\n')}\n`;
-
   return `${title}\n${text}`;
 }
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -3,7 +3,6 @@ import {
   color,
   formatStats,
   getRsbuildStats,
-  getStatsErrors,
   isSatisfyRspackVersion,
   prettyTime,
   rspackMinVersion,
@@ -187,7 +186,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     HOOK_NAME,
     (statsInstance: Rspack.Stats | Rspack.MultiStats) => {
       const stats = getRsbuildStats(statsInstance, compiler, context.action);
-      const hasErrors = getStatsErrors(stats).length > 0;
+      const hasErrors = statsInstance.hasErrors();
 
       context.buildState.stats = stats;
       context.buildState.status = 'done';

--- a/packages/core/src/provider/helpers.ts
+++ b/packages/core/src/provider/helpers.ts
@@ -3,12 +3,7 @@
  */
 
 export { modifyBundlerChain } from '../configChain';
-export {
-  formatStats,
-  getRsbuildStats,
-  getStatsErrors,
-  prettyTime,
-} from '../helpers';
+export { formatStats, getRsbuildStats, prettyTime } from '../helpers';
 export { registerBuildHook, registerDevHook } from '../hooks';
 export { inspectConfig } from '../inspectConfig';
 export {


### PR DESCRIPTION
## Summary

This PR fixes a regression introduced in https://github.com/web-infra-dev/rsbuild/pull/6301.

Use `statsInstance.hasErrors()` so build still mark failures when `stats.errors` is `false`; emit a clear hint when no errors are reported because stats were suppressed and cover it with a new diagnostic e2e case.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
