### PR TITLE
perf: reduce `stats.hasErrors()` calls

### DIFF
--- a/packages/compat/webpack/src/build.ts
+++ b/packages/compat/webpack/src/build.ts
@@ -52,7 +52,7 @@ export const build = async (
     compiler.run((err, stats) => {
       if (err) {
         reject(err);
-      } else if (stats?.hasErrors()) {
+      } else if (context.buildState.hasErrors) {
         reject(new Error('webpack build failed.'));
       }
       // If there is a compilation error, the close method should not be called.

--- a/packages/core/src/createRsbuild.ts
+++ b/packages/core/src/createRsbuild.ts
@@ -82,7 +82,7 @@ function applyDefaultPlugins(
     pluginTarget(),
     pluginOutput(),
     pluginResolve(),
-    pluginFileSize(),
+    pluginFileSize(context),
     // cleanOutput plugin should before the html plugin
     pluginCleanOutput(),
     pluginAsset(),

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -10,6 +10,7 @@ import { JS_REGEX } from '../constants';
 import { color, getAssetsFromStats } from '../helpers';
 import { logger } from '../logger';
 import type {
+  InternalContext,
   PrintFileSizeAsset,
   PrintFileSizeOptions,
   RsbuildPlugin,
@@ -284,13 +285,13 @@ async function printFileSizes(
   return logs;
 }
 
-export const pluginFileSize = (): RsbuildPlugin => ({
+export const pluginFileSize = (context: InternalContext): RsbuildPlugin => ({
   name: 'rsbuild:file-size',
 
   setup(api) {
     api.onAfterBuild(async ({ stats, environments, isFirstCompile }) => {
       // No need to print file sizes if there is any compilation error
-      if (!stats || stats.hasErrors() || !isFirstCompile) {
+      if (!stats || context.buildState.hasErrors || !isFirstCompile) {
         return;
       }
 

--- a/packages/core/src/provider/build.ts
+++ b/packages/core/src/provider/build.ts
@@ -70,7 +70,7 @@ export const build = async (
 
         if (err) {
           reject(err);
-        } else if (stats?.hasErrors()) {
+        } else if (context.buildState.hasErrors) {
           reject(new Error(RSPACK_BUILD_ERROR));
         } else {
           resolve({ stats });


### PR DESCRIPTION
## Summary

Use `context.buildState.hasErrors` instead of `stats.hasErrors()`, which will reduce the overhead slightly.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
