### PR TITLE
test(e2e): remove redundant cwd declarations

### DIFF
--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -2,45 +2,46 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
+rspackTest(
+  'HMR should work by default',
+  async ({ cwd, page, dev, editFile }) => {
+    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
+      recursive: true,
+    });
 
-rspackTest('HMR should work by default', async ({ page, dev, editFile }) => {
-  await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-    recursive: true,
-  });
-
-  await dev({
-    config: {
-      source: {
-        entry: {
-          index: join(cwd, 'test-temp-src/index.ts'),
+    await dev({
+      config: {
+        source: {
+          entry: {
+            index: join(cwd, 'test-temp-src/index.ts'),
+          },
         },
       },
-    },
-  });
+    });
 
-  const locator = page.locator('#test');
-  await expect(locator).toHaveText('Hello Rsbuild!');
-  await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
+    const locator = page.locator('#test');
+    await expect(locator).toHaveText('Hello Rsbuild!');
+    await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-  const locatorKeep = page.locator('#test-keep');
-  const keepNum = await locatorKeep.innerHTML();
+    const locatorKeep = page.locator('#test-keep');
+    const keepNum = await locatorKeep.innerHTML();
 
-  await editFile('test-temp-src/App.tsx', (code) =>
-    code.replace('Hello Rsbuild', 'Hello Test'),
-  );
+    await editFile('test-temp-src/App.tsx', (code) =>
+      code.replace('Hello Rsbuild', 'Hello Test'),
+    );
 
-  await expect(locator).toHaveText('Hello Test!');
+    await expect(locator).toHaveText('Hello Test!');
 
-  // #test-keep should remain unchanged when app.tsx HMR
-  expect(await locatorKeep.innerHTML()).toBe(keepNum);
+    // #test-keep should remain unchanged when app.tsx HMR
+    expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
-  await editFile(
-    'test-temp-src/App.css',
-    () => `#test {
+    await editFile(
+      'test-temp-src/App.css',
+      () => `#test {
   color: rgb(0, 0, 255);
 }`,
-  );
+    );
 
-  await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
-});
+    await expect(locator).toHaveCSS('color', 'rgb(0, 0, 255)');
+  },
+);

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'HMR should work when setting dev.port and dev.client.host',
-  async ({ page, dev, editFile }) => {
+  async ({ cwd, page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'HMR should work when dev.client.port is `<port>`',
-  async ({ page, dev, editFile }) => {
+  async ({ cwd, page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'HMR should work after fixing compilation error',
-  async ({ page, dev, editFile }) => {
+  async ({ cwd, page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, gotoPage, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'should allow to create multiple HMR connections',
-  async ({ page: page1, context, devOnly, editFile }) => {
+  async ({ cwd, page: page1, context, devOnly, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/hmr/rebuild-logs/index.test.ts
+++ b/e2e/cases/hmr/rebuild-logs/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'should print changed files in logs',
-  async ({ page, dev, editFile }) => {
+  async ({ cwd, page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });
@@ -32,7 +30,7 @@ rspackTest(
   },
 );
 
-rspackTest('should print removed files in logs', async ({ page, dev }) => {
+rspackTest('should print removed files in logs', async ({ cwd, page, dev }) => {
   await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
     recursive: true,
   });

--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'should reconnect WebSocket server as expected',
-  async ({ page, dev, devOnly, editFile }) => {
+  async ({ cwd, page, dev, devOnly, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/output/clean-dist-path/index.test.ts
+++ b/e2e/cases/output/clean-dist-path/index.test.ts
@@ -9,11 +9,7 @@ const testDeepDistFile = join(cwd, 'dist/foo/bar/test.json');
 
 test('should clean dist path by default', async ({ build }) => {
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
-
-  await build({
-    cwd,
-  });
-
+  await build();
   expect(fs.existsSync(testDistFile)).toBeFalsy();
 });
 
@@ -55,7 +51,6 @@ test('should not clean dist path if it is outside root', async ({ build }) => {
   await fse.outputFile(testOutsideFile, `{ "test": 1 }`);
 
   const rsbuild = await build({
-    cwd,
     config: {
       output: {
         distPath: {
@@ -80,7 +75,6 @@ test('should allow to disable cleanDistPath', async ({ build }) => {
   await fse.outputFile(testDistFile, `{ "test": 1 }`);
 
   await build({
-    cwd,
     config: {
       output: {
         cleanDistPath: false,
@@ -100,7 +94,6 @@ test('should allow to use `cleanDistPath.keep` to keep some files', async ({
   await fse.outputFile(testDeepDistFile, `{ "test": 1 }`);
 
   await build({
-    cwd,
     config: {
       output: {
         cleanDistPath: {

--- a/e2e/cases/performance/remove-console/index.test.ts
+++ b/e2e/cases/performance/remove-console/index.test.ts
@@ -1,8 +1,6 @@
 import type { BuildResult } from '@e2e/helper';
 import { expect, getFileContent, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 const expectConsoleType = async (
   rsbuild: Awaited<BuildResult>,
   consoleType: Record<string, boolean>,
@@ -17,7 +15,6 @@ const expectConsoleType = async (
 
 test('should remove specified console correctly', async ({ build }) => {
   const rsbuild = await build({
-    cwd,
     config: {
       performance: {
         removeConsole: ['log', 'warn'],
@@ -35,7 +32,6 @@ test('should remove specified console correctly', async ({ build }) => {
 
 test('should remove all console correctly', async ({ build }) => {
   const rsbuild = await build({
-    cwd,
     config: {
       performance: {
         removeConsole: true,

--- a/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
@@ -2,11 +2,9 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'HMR should work when Fast Refresh is disabled',
-  async ({ page, dev, editFile }) => {
+  async ({ cwd, page, dev, editFile }) => {
     await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
       recursive: true,
     });

--- a/e2e/cases/print-file-size/basic/index.test.ts
+++ b/e2e/cases/print-file-size/basic/index.test.ts
@@ -1,7 +1,5 @@
 import { expect, test, toPosixPath } from '@e2e/helper';
 
-const cwd = __dirname;
-
 function extractFileSizeLogs(logs: string[]) {
   const result: string[] = [];
 
@@ -40,9 +38,7 @@ test.describe('should print file size correctly', async () => {
   test('should print file size after building by default', async ({
     build,
   }) => {
-    const rsbuild = await build({
-      cwd,
-    });
+    const rsbuild = await build();
 
     expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
 File (web)                             Size       Gzip
@@ -58,7 +54,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
     build,
   }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         output: {
           filenameHash: false,
@@ -99,7 +94,6 @@ dist/static/js/lib-react.js   X.X kB   X.X kB
     build,
   }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: false,
@@ -114,7 +108,6 @@ dist/static/js/lib-react.js   X.X kB   X.X kB
     build,
   }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -130,7 +123,6 @@ Total size (web): X.X kB (X.X kB gzipped)`);
 
   test('printFileSize.total: false should work', async ({ build }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -153,7 +145,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
     build,
   }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         output: {
           distPath: {
@@ -175,7 +166,6 @@ File (web)                                                 Size       Gzip
 
   test('should allow to disable gzip-compressed size', async ({ build }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -197,7 +187,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB
 
   test('should allow to filter assets by name', async ({ build }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -216,7 +205,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
 
   test('should allow to filter assets by size', async ({ build }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -233,7 +221,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB`);
 
   test('should allow to custom exclude function', async ({ build }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {
@@ -257,9 +244,7 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
   test('should not calculate gzip size if the asset is not compressible', async ({
     build,
   }) => {
-    const rsbuild = await build({
-      cwd,
-    });
+    const rsbuild = await build();
 
     expect(extractFileSizeLogs(rsbuild.logs)).toEqual(`
 File (web)                             Size       Gzip
@@ -275,7 +260,6 @@ dist/static/js/lib-react.[[hash]].js   X.X kB   X.X kB
     build,
   }) => {
     const rsbuild = await build({
-      cwd,
       config: {
         performance: {
           printFileSize: {

--- a/e2e/cases/print-file-size/with-error/index.test.ts
+++ b/e2e/cases/print-file-size/with-error/index.test.ts
@@ -1,10 +1,7 @@
 import { expect, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 test('should not print file size if has errors', async ({ build }) => {
   const rsbuild = await build({
-    cwd,
     catchBuildError: true,
   });
   expect(rsbuild.buildError).toBeTruthy();

--- a/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
+++ b/e2e/cases/server/history-api-fallback/historyApiFallback.test.ts
@@ -1,8 +1,5 @@
-import { join } from 'node:path';
 import { expect, rspackTest, test } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
-
-const cwd = __dirname;
 
 rspackTest(
   'should provide history api fallback for dev server correctly',
@@ -12,7 +9,7 @@ rspackTest(
         plugins: [pluginReact()],
         source: {
           entry: {
-            main: join(cwd, 'src/index.jsx'),
+            main: './src/index.jsx',
           },
         },
         server: {
@@ -39,13 +36,11 @@ test('should provide history api fallback for preview server correctly', async (
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       plugins: [pluginReact()],
       source: {
         entry: {
-          main: join(cwd, 'src/index.jsx'),
+          main: './src/index.jsx',
         },
       },
       server: {

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -53,7 +53,7 @@ test('should access /main with query or hash success', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },
@@ -83,7 +83,7 @@ test('should access /main.html success when entry is main', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },
@@ -105,7 +105,7 @@ test('should access /main success when entry is main', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },
@@ -129,7 +129,7 @@ test('should access /main success when entry is main and use memoryFs', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },
@@ -151,7 +151,7 @@ test('should access /main success when entry is main and set assetPrefix', async
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
       dev: {
@@ -176,7 +176,7 @@ test('should access /main success when entry is main and outputPath is /main/ind
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
       html: {
@@ -198,7 +198,7 @@ test('should return 404 when page is not found', async ({ page, devOnly }) => {
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },
@@ -219,7 +219,7 @@ test('should access /html/main success when entry is main and outputPath is /htm
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
       output: {
@@ -254,7 +254,7 @@ test('should access /main success when modify publicPath in compiler', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
       plugins: [
@@ -291,7 +291,7 @@ test('should access /main success when distPath is absolute', async ({
     config: {
       source: {
         entry: {
-          main: join(cwd, 'src/index.js'),
+          main: './src/index.js',
         },
       },
     },

--- a/e2e/cases/server/print-urls/index.test.ts
+++ b/e2e/cases/server/print-urls/index.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 const NETWORK_LOG_REGEX =
   /➜\s{2}Network:\s{2}http:\/\/\d{1,3}(?:\.\d{1,3}){3}:\d+/;
 
@@ -109,8 +107,6 @@ test('should listen only on localhost in preview', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       server: {
         host: 'localhost',
@@ -131,8 +127,6 @@ test('should not print server urls when HTML is disabled', async ({
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       tools: {
         htmlPlugin: false,
@@ -148,8 +142,6 @@ test('should print server urls when HTML is disabled but printUrls is a custom f
   buildPreview,
 }) => {
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       tools: {
         htmlPlugin: false,

--- a/e2e/cases/server/public-dir-with-multi-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-multi-template/index.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 test('should serve publicDir with templates for dev server correctly', async ({
   page,
   devOnly,
@@ -24,9 +22,7 @@ test('should serve publicDir with templates for preview server correctly', async
   page,
   buildPreview,
 }) => {
-  const rsbuild = await buildPreview({
-    cwd,
-  });
+  const rsbuild = await buildPreview();
 
   const res = await page.goto(`http://localhost:${rsbuild.port}/aa.txt`);
   expect((await res?.body())?.toString().trim()).toBe('aaaa');

--- a/e2e/cases/server/public-dir-with-template/index.test.ts
+++ b/e2e/cases/server/public-dir-with-template/index.test.ts
@@ -1,7 +1,5 @@
 import { expect, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 test('should serve publicDir with template for dev server correctly', async ({
   page,
   devOnly,
@@ -20,9 +18,7 @@ test('should serve publicDir with template for preview server correctly', async 
   page,
   buildPreview,
 }) => {
-  const rsbuild = await buildPreview({
-    cwd,
-  });
+  const rsbuild = await buildPreview();
 
   const res = await page.goto(`http://localhost:${rsbuild.port}/aa.txt`);
   expect((await res?.body())?.toString().trim()).toBe('aaaa');

--- a/e2e/cases/server/public-dir/publicDir.test.ts
+++ b/e2e/cases/server/public-dir/publicDir.test.ts
@@ -2,8 +2,6 @@ import path, { join } from 'node:path';
 import { expect, getDistFiles, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
-const cwd = __dirname;
-
 test('should serve publicDir for dev server correctly', async ({
   page,
   devOnly,
@@ -144,8 +142,6 @@ test('should serve publicDir for preview server correctly', async ({
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       output: {
         distPath: {
@@ -168,7 +164,6 @@ test('should copy publicDir to the environment distDir when multiple environment
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await build({
-    cwd,
     config: {
       environments: {
         web1: {
@@ -222,7 +217,6 @@ test('should copy publicDir to the node distDir when copyOnBuild is specified as
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await build({
-    cwd,
     config: {
       server: {
         publicDir: {
@@ -258,7 +252,6 @@ test('should copy publicDir to root dist when environment dist path has a parent
   fse.removeSync(join(__dirname, 'dist-build-web'));
 
   const rsbuild = await build({
-    cwd,
     config: {
       environments: {
         web1: {
@@ -300,8 +293,6 @@ test('should serve publicDir for preview server with assetPrefix correctly', asy
   await fse.outputFile(join(__dirname, 'public', 'test-temp-file.txt'), 'a');
 
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       dev: {
         assetPrefix: '/dev/',
@@ -330,8 +321,6 @@ test('should serve multiple publicDir for preview server correctly', async ({
   await fse.outputFile(join(__dirname, 'test-temp-dir2', 'b.txt'), 'b');
 
   const rsbuild = await buildPreview({
-    cwd,
-
     config: {
       server: {
         publicDir: [{ name: 'test-temp-dir1' }, { name: 'test-temp-dir2' }],


### PR DESCRIPTION
## Summary

- Remove hardcoded cwd declarations from test files and use the `cwd` provided by test context
- Simplify test configurations by removing redundant cwd options in build calls
- Update entry paths to use relative paths instead of `join`

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
