### PR TITLE
chore(deps): update babel-plugin-react-compiler to stable v1.0.0

### DIFF
--- a/e2e/cases/plugin-react/react-compiler-babel/package.json
+++ b/e2e/cases/plugin-react/react-compiler-babel/package.json
@@ -7,6 +7,6 @@
     "react-dom": "^19.2.0"
   },
   "devDependencies": {
-    "babel-plugin-react-compiler": "^19.1.0-rc.3"
+    "babel-plugin-react-compiler": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
         version: 19.2.0(react@19.2.0)
     devDependencies:
       babel-plugin-react-compiler:
-        specifier: ^19.1.0-rc.3
-        version: 19.1.0-rc.3
+        specifier: ^1.0.0
+        version: 1.0.0
 
   e2e/cases/plugin-svelte:
     dependencies:
@@ -3571,8 +3571,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  babel-plugin-react-compiler@19.1.0-rc.3:
-    resolution: {integrity: sha512-mjRn69WuTz4adL0bXGx8Rsyk1086zFJeKmes6aK0xPuK3aaXmDJdLHqwKKMrpm6KAI1MCoUK72d2VeqQbu8YIA==}
+  babel-plugin-react-compiler@1.0.0:
+    resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
   babel-plugin-vue-jsx-hmr@1.0.0:
     resolution: {integrity: sha512-XRq+XTD4bub6HkavELMhihvLX2++JkSBAxRXlqQK32b+Tb0S9PEqxrDSMpOEZ1iGyOaJZj9Y0uU/FzICdyL9MA==}
@@ -9393,9 +9393,9 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.2
 
-  babel-plugin-react-compiler@19.1.0-rc.3:
+  babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   babel-plugin-vue-jsx-hmr@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Update babel-plugin-react-compiler to stable v1.0.0.

## Related Links

https://www.reddit.com/r/reactjs/comments/1o12no7/react_compiler_100_released/

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
