### PR TITLE
fix: handle empty file name in error formatting

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -2,6 +2,12 @@ import type { StatsError } from '@rspack/core';
 import { color } from './vendors';
 
 const formatFileName = (fileName: string) => {
+  // File name may be empty when the error is not related to a file.
+  // For example, when an invalid entry is provided.
+  if (!fileName) {
+    return '';
+  }
+
   // add default column add lines for linking
   return /:\d+:\d+/.test(fileName)
     ? `File: ${color.cyan(fileName)}\n`


### PR DESCRIPTION
## Summary

Add null check for file name in `formatFileName` helper to prevent errors when the error is not file-related (e.g., invalid entry cases)

### Before

<img width="1159" height="179" alt="Screenshot 2025-10-09 at 19 22 55" src="https://github.com/user-attachments/assets/383233b4-7bb9-453f-b5b9-5a97409780b8" />

### After

<img width="1155" height="148" alt="Screenshot 2025-10-09 at 19 25 33" src="https://github.com/user-attachments/assets/e7e8b671-7994-438f-a522-efcabc16d631" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
