### PR TITLE
fix(hmr): HMR for multiple environments with shared modules

### DIFF
--- a/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
+++ b/e2e/cases/hmr/client-multiple-environment/rsbuild.config.ts
@@ -1,14 +1,11 @@
-import { join } from 'node:path';
 import { defineConfig } from '@rsbuild/core';
-import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
-  plugins: [pluginReact()],
   environments: {
     foo: {
       source: {
         entry: {
-          foo: join(__dirname, 'foo.js'),
+          foo: './src/foo.js',
         },
       },
       dev: {
@@ -20,7 +17,7 @@ export default defineConfig({
     bar: {
       source: {
         entry: {
-          bar: join(__dirname, 'bar.js'),
+          bar: './src/bar.js',
         },
       },
       dev: {

--- a/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
+++ b/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { expect, gotoPage, rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should perform HMR for multiple environments with shared module',
+  async ({ cwd, page, devOnly, editFile }) => {
+    const tempSrc = join(cwd, 'test-temp-src');
+    await fs.promises.cp(join(cwd, 'src'), tempSrc, {
+      recursive: true,
+    });
+
+    const rsbuild = await devOnly({
+      config: {
+        environments: {
+          foo: {
+            source: {
+              entry: {
+                foo: join(tempSrc, 'foo.js'),
+              },
+            },
+          },
+          bar: {
+            source: {
+              entry: {
+                bar: join(tempSrc, 'bar.js'),
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const expectValue = async (value: string) => {
+      const locator = page.locator('body');
+      await expect(locator).toHaveText(value);
+    };
+
+    await gotoPage(page, rsbuild, 'foo');
+    await expectValue('foo:hello');
+    await gotoPage(page, rsbuild, 'bar');
+    await expectValue('bar:hello');
+
+    // edit shared module
+    await editFile('test-temp-src/shared.js', (code) =>
+      code.replace('hello', 'world'),
+    );
+    await gotoPage(page, rsbuild, 'foo');
+    await expectValue('foo:world');
+    await gotoPage(page, rsbuild, 'bar');
+    await expectValue('bar:world');
+
+    // edit foo entry module
+    await editFile('test-temp-src/foo.js', (code) =>
+      code.replace('foo', 'foo2'),
+    );
+    await gotoPage(page, rsbuild, 'foo');
+    await expectValue('foo2:world');
+
+    // edit bar entry module
+    await editFile('test-temp-src/bar.js', (code) =>
+      code.replace('bar', 'bar2'),
+    );
+    await gotoPage(page, rsbuild, 'bar');
+    await expectValue('bar2:world');
+  },
+);

--- a/e2e/cases/hmr/multiple-environment-shared-module/src/bar.js
+++ b/e2e/cases/hmr/multiple-environment-shared-module/src/bar.js
@@ -1,0 +1,3 @@
+import { value } from './shared';
+
+document.body.innerHTML = `bar:${value}`;

--- a/e2e/cases/hmr/multiple-environment-shared-module/src/foo.js
+++ b/e2e/cases/hmr/multiple-environment-shared-module/src/foo.js
@@ -1,0 +1,3 @@
+import { value } from './shared';
+
+document.body.innerHTML = `foo:${value}`;

--- a/e2e/cases/hmr/multiple-environment-shared-module/src/shared.js
+++ b/e2e/cases/hmr/multiple-environment-shared-module/src/shared.js
@@ -1,0 +1,1 @@
+export const value = 'hello';

--- a/packages/compat/webpack/src/createCompiler.ts
+++ b/packages/compat/webpack/src/createCompiler.ts
@@ -48,6 +48,7 @@ export async function createCompiler(options: InitConfigsOptions) {
     context.buildState.stats = stats;
     context.buildState.status = 'done';
     context.buildState.hasErrors = hasErrors;
+    context.socketServer?.onBuildDone();
 
     const { message, level } = helpers.formatStats(stats, hasErrors);
 

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -186,6 +186,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
       context.buildState.stats = stats;
       context.buildState.status = 'done';
       context.buildState.hasErrors = hasErrors;
+      context.socketServer?.onBuildDone();
 
       const printTime = (statsItem: RsbuildStatsItem, index: number) => {
         if (statsItem.time) {

--- a/packages/core/src/server/assets-middleware/index.ts
+++ b/packages/core/src/server/assets-middleware/index.ts
@@ -154,8 +154,6 @@ export const setupServerHooks = ({
       socketServer.sendError(statsErrors, token);
       return;
     }
-
-    socketServer.onBuildDone(token);
   });
 };
 

--- a/packages/core/src/server/buildManager.ts
+++ b/packages/core/src/server/buildManager.ts
@@ -57,6 +57,7 @@ export class BuildManager {
       config.dev,
       () => this.outputFileSystem,
     );
+    this.context.socketServer = this.socketServer;
   }
 
   public async init(): Promise<void> {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -186,14 +186,16 @@ export class SocketServer {
     });
   }
 
-  public onBuildDone(token: string): void {
+  public onBuildDone(): void {
     this.reportedBrowserLogs.clear();
 
     if (!this.socketsMap.size) {
       return;
     }
 
-    this.sendStats({ token });
+    for (const token of this.socketsMap.keys()) {
+      this.sendStats({ token });
+    }
   }
 
   /**

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -1,4 +1,5 @@
 import type { Hooks } from '../hooks';
+import type { SocketServer } from '../server/socketServer';
 import type { NormalizedConfig, RsbuildConfig } from './config';
 import type { EnvironmentContext } from './hooks';
 import type { RsbuildPluginAPI } from './plugin';
@@ -101,4 +102,6 @@ export type InternalContext = RsbuildContext & {
   specifiedEnvironments?: string[];
   /** Build state information */
   buildState: BuildState;
+  /** The socket server instance. */
+  socketServer?: SocketServer;
 };


### PR DESCRIPTION
## Summary

Fix HMR support for multiple environments with shared modules.

This regression was introduced in [#6301](https://github.com/web-infra-dev/rsbuild/pull/6301). When both the `done` hook of the `MultiCompiler` and the individual `done` hooks of compiler A and compiler B are registered, the execution order becomes:

```
compiler A done() → MultiCompiler done() → compiler B done()
```

This leads to unintended behavior.

This PR resolves the issue by calling `socketServer.onBuildDone` within the MultiCompiler’s `done()` hook.

## Related Links

- https://github.com/web-infra-dev/rsbuild/issues/6325

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
