### PR TITLE
test(e2e): replace manual src copying with copySrcDir helper

### DIFF
--- a/e2e/cases/browser-logs/dedupe-log/index.test.ts
+++ b/e2e/cases/browser-logs/dedupe-log/index.test.ts
@@ -1,19 +1,16 @@
-import path, { join } from 'node:path';
+import { join } from 'node:path';
 import { gotoPage, rspackTest } from '@e2e/helper';
-import fse from 'fs-extra';
 
 rspackTest(
   'should not output the same browser log',
-  async ({ devOnly, page, editFile }) => {
-    const tempDir = path.join(__dirname, 'test-temp-src');
-    const srcDir = path.join(__dirname, 'src');
-    await fse.copy(srcDir, tempDir);
+  async ({ devOnly, page, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await devOnly({
       config: {
         source: {
           entry: {
-            index: join(tempDir, 'index.js'),
+            index: join(tempSrc, 'index.js'),
           },
         },
       },
@@ -32,7 +29,7 @@ rspackTest(
     rsbuild.clearLogs();
 
     // after rebuild, logs can be printed again
-    await editFile(join(tempDir, 'index.js'), (content) =>
+    await editFile(join(tempSrc, 'index.js'), (content) =>
       content.replace('value', 'value2'),
     );
     await rsbuild.expectLog('Error: value2 is #test2');

--- a/e2e/cases/cli/build-watch-options/index.test.ts
+++ b/e2e/cases/cli/build-watch-options/index.test.ts
@@ -4,14 +4,11 @@ import fse from 'fs-extra';
 
 rspackTest(
   'should allow to custom watch options for build watch',
-  async ({ execCli, logHelper }) => {
-    const srcDir = path.join(__dirname, 'src');
-    const tempDir = path.join(__dirname, 'test-temp-src');
+  async ({ execCli, logHelper, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
     const distIndexFile = path.join(__dirname, 'dist/static/js/index.js');
-    const fooFile = path.join(tempDir, 'foo.js');
-    const barFile = path.join(tempDir, 'bar.js');
-
-    await fse.copy(srcDir, tempDir);
+    const fooFile = path.join(tempSrc, 'foo.js');
+    const barFile = path.join(tempSrc, 'bar.js');
 
     execCli('build --watch');
     const { expectLog, expectNoLog, expectBuildEnd, clearLogs } = logHelper;

--- a/e2e/cases/css/inject-styles/index.test.ts
+++ b/e2e/cases/css/inject-styles/index.test.ts
@@ -1,8 +1,5 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, findFile, getFileContent, rspackTest } from '@e2e/helper';
-
-const fixtures = __dirname;
 
 rspackTest(
   'should inline style when `injectStyles` is enabled',
@@ -35,18 +32,14 @@ rspackTest(
 
 rspackTest(
   'HMR should work well when `injectStyles` is enabled',
-  async ({ page, dev, editFile }) => {
-    await fs.promises.cp(
-      join(fixtures, 'src'),
-      join(fixtures, 'test-temp-src'),
-      { recursive: true },
-    );
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     await dev({
       config: {
         source: {
           entry: {
-            index: join(fixtures, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
       },
@@ -63,7 +56,7 @@ rspackTest(
     const locatorKeep = page.locator('#test-keep');
     const keepNum = await locatorKeep.innerHTML();
 
-    await editFile('test-temp-src/App.module.less', (code) =>
+    await editFile(join(tempSrc, 'App.module.less'), (code) =>
       code.replace('20px', '40px'),
     );
 

--- a/e2e/cases/hmr/basic/index.test.ts
+++ b/e2e/cases/hmr/basic/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work by default',
-  async ({ cwd, page, dev, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     await dev({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
       },
@@ -26,7 +23,7 @@ rspackTest(
     const locatorKeep = page.locator('#test-keep');
     const keepNum = await locatorKeep.innerHTML();
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
 
@@ -36,7 +33,7 @@ rspackTest(
     expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     await editFile(
-      'test-temp-src/App.css',
+      join(tempSrc, 'App.css'),
       () => `#test {
   color: rgb(0, 0, 255);
 }`,

--- a/e2e/cases/hmr/client-host/index.test.ts
+++ b/e2e/cases/hmr/client-host/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work when setting dev.port and dev.client.host',
-  async ({ cwd, page, dev, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     await dev({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
         dev: {
@@ -27,7 +24,7 @@ rspackTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
 

--- a/e2e/cases/hmr/client-port-placeholder/index.test.ts
+++ b/e2e/cases/hmr/client-port-placeholder/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work when dev.client.port is `<port>`',
-  async ({ cwd, page, dev, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     await dev({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
         dev: {
@@ -27,7 +24,7 @@ rspackTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
 

--- a/e2e/cases/hmr/error-recovery/index.test.ts
+++ b/e2e/cases/hmr/error-recovery/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work after fixing compilation error',
-  async ({ cwd, page, dev, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await dev({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
       },
@@ -22,7 +19,7 @@ rspackTest(
     const locator = page.locator('#test');
     await expect(locator).toHaveText('Hello Rsbuild!');
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace(
         '<div id="test">Hello Rsbuild!</div>',
         '<div id="test">Hello Rsbuild!</div',
@@ -31,7 +28,7 @@ rspackTest(
 
     await rsbuild.expectLog('Module build failed');
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace(
         '<div id="test">Hello Rsbuild!</div',
         '<div id="test">Hello Rsbuild2!</div>',

--- a/e2e/cases/hmr/multiple-connection/index.test.ts
+++ b/e2e/cases/hmr/multiple-connection/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, gotoPage, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should allow to create multiple HMR connections',
-  async ({ cwd, page: page1, context, devOnly, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page: page1, context, devOnly, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await devOnly({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
       },
@@ -34,7 +31,7 @@ rspackTest(
     const keepNum1 = await locatorKeep1.innerHTML();
     const keepNum2 = await locatorKeep2.innerHTML();
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
 

--- a/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
+++ b/e2e/cases/hmr/multiple-environment-shared-module/index.test.ts
@@ -1,14 +1,10 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, gotoPage, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should perform HMR for multiple environments with shared module',
-  async ({ cwd, page, devOnly, editFile }) => {
-    const tempSrc = join(cwd, 'test-temp-src');
-    await fs.promises.cp(join(cwd, 'src'), tempSrc, {
-      recursive: true,
-    });
+  async ({ page, devOnly, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await devOnly({
       config: {
@@ -42,7 +38,7 @@ rspackTest(
     await expectValue('bar:hello');
 
     // edit shared module
-    await editFile('test-temp-src/shared.js', (code) =>
+    await editFile(join(tempSrc, 'shared.js'), (code) =>
       code.replace('hello', 'world'),
     );
     await gotoPage(page, rsbuild, 'foo');
@@ -51,14 +47,14 @@ rspackTest(
     await expectValue('bar:world');
 
     // edit foo entry module
-    await editFile('test-temp-src/foo.js', (code) =>
+    await editFile(join(tempSrc, 'foo.js'), (code) =>
       code.replace('foo', 'foo2'),
     );
     await gotoPage(page, rsbuild, 'foo');
     await expectValue('foo2:world');
 
     // edit bar entry module
-    await editFile('test-temp-src/bar.js', (code) =>
+    await editFile(join(tempSrc, 'bar.js'), (code) =>
       code.replace('bar', 'bar2'),
     );
     await gotoPage(page, rsbuild, 'bar');

--- a/e2e/cases/hmr/reconnect/index.test.ts
+++ b/e2e/cases/hmr/reconnect/index.test.ts
@@ -1,16 +1,13 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should reconnect WebSocket server as expected',
-  async ({ cwd, page, dev, devOnly, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, devOnly, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const entry = {
-      index: join(cwd, 'test-temp-src/index.ts'),
+      index: join(tempSrc, 'index.ts'),
     };
 
     const rsbuild = await dev({
@@ -31,7 +28,7 @@ rspackTest(
       },
     });
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
     await expect(locator).toHaveText('Hello Test!');

--- a/e2e/cases/hmr/unaffected-environment/index.test.ts
+++ b/e2e/cases/hmr/unaffected-environment/index.test.ts
@@ -1,14 +1,10 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, gotoPage, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should not affect other unchanged environments during HMR',
-  async ({ cwd, page: page1, devOnly, editFile, context }) => {
-    const tempSrc = join(cwd, 'test-temp-src');
-    await fs.promises.cp(join(cwd, 'src'), tempSrc, {
-      recursive: true,
-    });
+  async ({ page: page1, devOnly, editFile, copySrcDir, context }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await devOnly({
       config: {
@@ -43,7 +39,7 @@ rspackTest(
     await expect(button).toHaveText('count: 1');
 
     // edit foo.js
-    await editFile('test-temp-src/foo.js', (code) =>
+    await editFile(join(tempSrc, 'foo.js'), (code) =>
       code.replace('hello world', 'changed'),
     );
     await expect(page1.locator('body')).toHaveText('changed');

--- a/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
+++ b/e2e/cases/plugin-react/disable-fast-refresh/index.test.ts
@@ -1,19 +1,16 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'HMR should work when Fast Refresh is disabled',
-  async ({ cwd, page, dev, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     await dev({
       config: {
         source: {
           entry: {
-            index: join(cwd, 'test-temp-src/index.ts'),
+            index: join(tempSrc, 'index.ts'),
           },
         },
       },
@@ -23,7 +20,7 @@ rspackTest(
     await expect(locator).toHaveText('Hello Rsbuild!');
     await expect(locator).toHaveCSS('color', 'rgb(255, 0, 0)');
 
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
     await expect(locator).toHaveText('Hello Test!');

--- a/e2e/cases/resolve/extension-alias-js/index.test.ts
+++ b/e2e/cases/resolve/extension-alias-js/index.test.ts
@@ -1,8 +1,6 @@
 import fs from 'node:fs';
 import { join } from 'node:path';
-
 import { expect, test } from '@e2e/helper';
-import { remove } from 'fs-extra';
 
 test('should allow to import TS files with .js extension', async ({
   page,
@@ -15,31 +13,21 @@ test('should allow to import TS files with .js extension', async ({
 test('should resolve the .js file first if both .js and .ts exist', async ({
   page,
   buildPreview,
+  copySrcDir,
 }) => {
-  await fs.promises.cp(
-    join(__dirname, 'src'),
-    join(__dirname, 'test-temp-src'),
-    {
-      recursive: true,
-    },
-  );
+  const tempSrc = await copySrcDir();
 
-  fs.writeFileSync(
-    join(__dirname, 'test-temp-src/foo.js'),
-    'export const foo = "js";',
-  );
+  fs.writeFileSync(join(tempSrc, 'foo.js'), 'export const foo = "js";');
 
   await buildPreview({
     config: {
       source: {
         entry: {
-          index: join(__dirname, 'test-temp-src/index.ts'),
+          index: join(tempSrc, 'index.ts'),
         },
       },
     },
   });
 
   expect(await page.evaluate(() => window.test)).toBe('js');
-
-  await remove(join(__dirname, 'test-temp-src'));
 });

--- a/e2e/cases/server/environments-hmr/index.test.ts
+++ b/e2e/cases/server/environments-hmr/index.test.ts
@@ -1,16 +1,11 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest } from '@e2e/helper';
 import { pluginReact } from '@rsbuild/plugin-react';
 
-const cwd = __dirname;
-
 rspackTest(
   'Multiple environments HMR should work correctly',
-  async ({ dev, page, context, editFile }) => {
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+  async ({ dev, page, context, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
 
     const rsbuild = await dev({
       config: {
@@ -19,7 +14,7 @@ rspackTest(
           web: {
             source: {
               entry: {
-                index: join(cwd, 'test-temp-src/index.ts'),
+                index: join(tempSrc, 'index.ts'),
               },
             },
           },
@@ -31,7 +26,7 @@ rspackTest(
             },
             source: {
               entry: {
-                main: join(cwd, 'test-temp-src/web1.js'),
+                main: join(tempSrc, 'web1.js'),
               },
             },
             output: {
@@ -60,7 +55,7 @@ rspackTest(
     const keepNum = await locatorKeep.innerHTML();
 
     // web1 live reload correctly and should not trigger index update
-    await editFile('test-temp-src/web1.js', (code) =>
+    await editFile(join(tempSrc, 'web1.js'), (code) =>
       code.replace('(web1)', '(web1-new)'),
     );
 
@@ -68,7 +63,7 @@ rspackTest(
     expect(await locatorKeep.innerHTML()).toBe(keepNum);
 
     // index HMR correctly
-    await editFile('test-temp-src/App.tsx', (code) =>
+    await editFile(join(tempSrc, 'App.tsx'), (code) =>
       code.replace('Hello Rsbuild', 'Hello Test'),
     );
 

--- a/e2e/cases/server/html-fallback/index.test.ts
+++ b/e2e/cases/server/html-fallback/index.test.ts
@@ -1,7 +1,4 @@
-import { join } from 'node:path';
 import { expect, getFileContent, test } from '@e2e/helper';
-
-const cwd = __dirname;
 
 test('should access / success and htmlFallback success by default', async ({
   page,

--- a/e2e/cases/server/overlay/index.test.ts
+++ b/e2e/cases/server/overlay/index.test.ts
@@ -1,18 +1,14 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, test } from '@e2e/helper';
-
-const cwd = __dirname;
 
 test('should show overlay correctly', async ({
   page,
   dev,
   editFile,
   logHelper,
+  copySrcDir,
 }) => {
-  await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-    recursive: true,
-  });
+  const tempSrc = await copySrcDir();
 
   const { expectLog, addLog } = logHelper;
 
@@ -24,7 +20,7 @@ test('should show overlay correctly', async ({
     config: {
       source: {
         entry: {
-          index: join(cwd, 'test-temp-src/index.tsx'),
+          index: join(tempSrc, 'index.tsx'),
         },
       },
     },
@@ -35,7 +31,7 @@ test('should show overlay correctly', async ({
   const errorOverlay = page.locator('rsbuild-error-overlay');
   expect(await errorOverlay.locator('.title').count()).toBe(0);
 
-  await editFile('test-temp-src/App.tsx', (code) =>
+  await editFile(join(tempSrc, 'App.tsx'), (code) =>
     code.replace('</div>', '</aaaaa>'),
   );
 

--- a/e2e/cases/server/reload-html/index.test.ts
+++ b/e2e/cases/server/reload-html/index.test.ts
@@ -1,26 +1,21 @@
-import fs from 'node:fs';
 import { join } from 'node:path';
 import { expect, rspackTest, test } from '@e2e/helper';
 
-const cwd = __dirname;
-
 rspackTest(
   'should reload page when HTML template changed',
-  async ({ page, dev, editFile }) => {
+  async ({ page, dev, editFile, copySrcDir }) => {
     // Failed to run this case on Windows
     if (process.platform === 'win32') {
       test.skip();
     }
 
-    await fs.promises.cp(join(cwd, 'src'), join(cwd, 'test-temp-src'), {
-      recursive: true,
-    });
+    const tempSrc = await copySrcDir();
 
     await dev();
 
     await expect(page).toHaveTitle('Foo');
 
-    await editFile('test-temp-src/index.html', (code) =>
+    await editFile(join(tempSrc, 'index.html'), (code) =>
       code.replace('Foo', 'Bar'),
     );
     // expect page title to be 'Bar' after HTML template changed

--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -8,6 +8,7 @@ import {
 import { promises } from 'node:fs';
 import path from 'node:path';
 import base, { expect } from '@playwright/test';
+import fse from 'fs-extra';
 import { RSBUILD_BIN_PATH } from './constants';
 import {
   type Build,
@@ -71,6 +72,10 @@ type RsbuildFixture = {
    * The fixture auto-closes after the test.
    */
   buildPreview: Build;
+  /**
+   * Copies the source directory to a temporary directory for testing purposes.
+   */
+  copySrcDir: () => Promise<string>;
   /**
    * Start the dev server and auto-navigate the Playwright page.
    * Uses the test file's cwd.
@@ -289,6 +294,18 @@ export const test = base.extend<RsbuildFixture>({
       ).toString();
     };
     await use(execCliSync);
+  },
+
+  copySrcDir: async ({ cwd }, use) => {
+    const copySrcDir = async () => {
+      const targetDir = path.join(cwd, 'test-temp-src');
+      await fse.remove(targetDir);
+      await promises.cp(path.join(cwd, 'src'), targetDir, {
+        recursive: true,
+      });
+      return targetDir;
+    };
+    await use(copySrcDir);
   },
 });
 


### PR DESCRIPTION
## Summary

Replace repetitive manual file copying operations with the new `copySrcDir` test helper across multiple e2e test files to improve maintainability and reduce code duplication.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
