### PR TITLE
fix: asset URL resolution for public path prefixes

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -208,7 +208,7 @@ export async function createContext(
     callerName: options.callerName,
     bundlerType,
     environments: {},
-    publicPathPathnames: [],
+    publicPathnames: [],
     hooks: initHooks(),
     config: { ...rsbuildConfig },
     originalConfig: userConfig,

--- a/packages/core/src/helpers/path.ts
+++ b/packages/core/src/helpers/path.ts
@@ -46,11 +46,11 @@ export const getCompiledPath = (packageName: string): string =>
 export const ensureAbsolutePath = (base: string, filePath: string): string =>
   isAbsolute(filePath) ? filePath : join(base, filePath);
 
-export const getPathnameFromUrl = (publicPath: string): string => {
+export const getPathnameFromUrl = (url: string): string => {
   try {
-    return publicPath ? new URL(publicPath).pathname : publicPath;
+    return url ? new URL(url, 'http://localhost').pathname : url;
   } catch {
-    return publicPath;
+    return url;
   }
 };
 

--- a/packages/core/src/server/devServer.ts
+++ b/packages/core/src/server/devServer.ts
@@ -200,7 +200,7 @@ export async function createDevServer<
       : [getPublicPathFromCompiler(compiler)];
 
     const { base } = config.server;
-    context.publicPathPathnames = publicPaths
+    context.publicPathnames = publicPaths
       .map(getPathnameFromUrl)
       .map((prefix) =>
         base && base !== '/' ? stripBase(prefix, base) : prefix,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -108,5 +108,5 @@ export type InternalContext = RsbuildContext & {
    * Pathnames derived from public paths, stripped of `server.base`.
    * Used for static asset serving.
    */
-  publicPathPathnames: string[];
+  publicPathnames: string[];
 };


### PR DESCRIPTION
## Summary

Fix asset URL resolution for public path prefixes:

1. First, resolve paths that match the public prefix for more accurate resolution
2. Then, resolve fallback paths without public prefix matching

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
