### PR TITLE
feat(server): make URLs with the same label more compact

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -156,17 +156,21 @@ function getURLMessages(
   }
 
   let message = '';
+  let prevLabel = '';
   const maxNameLength = Math.max(...routes.map((r) => r.entryName.length));
   urls.forEach(({ label, url }, index) => {
-    if (index > 0) {
-      message += '\n';
+    if (prevLabel !== label) {
+      if (index > 0) {
+        message += '\n';
+      }
+      message += `  ➜  ${label}\n`;
+      prevLabel = label;
     }
-    message += `  ➜  ${label}\n`;
 
-    for (const r of routes) {
+    for (const { entryName, pathname } of routes) {
       message += `  ${color.dim('-')}  ${color.dim(
-        r.entryName.padEnd(maxNameLength + 4),
-      )}${color.cyan(normalizeUrl(`${url}${r.pathname}`))}\n`;
+        entryName.padEnd(maxNameLength + 4),
+      )}${color.cyan(normalizeUrl(`${url}${pathname}`))}\n`;
     }
   });
 


### PR DESCRIPTION
## Summary

Track previous label to avoid duplicate labels in the printed URLs.

### Before

<img width="656" height="395" alt="Screenshot 2025-10-12 at 19 02 54" src="https://github.com/user-attachments/assets/434eadb2-1b82-4a15-8dcc-4ed864086d16" />

### After

<img width="648" height="354" alt="Screenshot 2025-10-12 at 19 17 26" src="https://github.com/user-attachments/assets/a49f6571-e40e-4452-bc90-7eaa1b2e8c32" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
