### PR TITLE
docs: add `'auto'` value of `loader` option in `loadConfig`

### DIFF
--- a/website/docs/en/api/javascript-api/core.mdx
+++ b/website/docs/en/api/javascript-api/core.mdx
@@ -133,7 +133,7 @@ function loadConfig(params?: {
   path?: string;
   meta?: Record<string, unknown>;
   envMode?: string;
-  loader?: 'jiti' | 'native';
+  loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
   content: RsbuildConfig;
   filePath: string | null;

--- a/website/docs/zh/api/javascript-api/core.mdx
+++ b/website/docs/zh/api/javascript-api/core.mdx
@@ -133,7 +133,7 @@ function loadConfig(params?: {
   path?: string;
   meta?: Record<string, unknown>;
   envMode?: string;
-  loader?: 'jiti' | 'native';
+  loader?: 'auto' | 'jiti' | 'native';
 }): Promise<{
   content: RsbuildConfig;
   filePath: string | null;


### PR DESCRIPTION
## Summary

This pull request makes a small update to the documentation for the `loadConfig` function in both the English and Chinese API reference files. The change adds a new option, `'auto'`, to the `loader` parameter, clarifying the available choices for configuration loading.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
