### PR TITLE
chore: remove unnecessary lazyBarrel config

### DIFF
--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -101,7 +101,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
 
           chain.experiments({
             ...chain.get('experiments'),
-            lazyBarrel: true,
             inlineEnum: isProd,
             inlineConst: isProd,
             typeReexportsPresence: true,

--- a/packages/core/tests/__snapshots__/basic.test.ts.snap
+++ b/packages/core/tests/__snapshots__/basic.test.ts.snap
@@ -7,7 +7,6 @@ exports[`plugin-basic > should apply basic config correctly in development 1`] =
   "experiments": {
     "inlineConst": false,
     "inlineEnum": false,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -57,7 +56,6 @@ exports[`plugin-basic > should apply basic config correctly in production 1`] = 
   "experiments": {
     "inlineConst": true,
     "inlineEnum": true,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -13,7 +13,6 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
     "asyncWebAssembly": true,
     "inlineConst": false,
     "inlineEnum": false,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -13,7 +13,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
     "asyncWebAssembly": true,
     "inlineConst": false,
     "inlineEnum": false,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -529,7 +528,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
     "asyncWebAssembly": true,
     "inlineConst": true,
     "inlineEnum": true,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1068,7 +1066,6 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
     "asyncWebAssembly": true,
     "inlineConst": false,
     "inlineEnum": false,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,
@@ -1498,7 +1495,6 @@ exports[`tools.rspack > should match snapshot 1`] = `
     "asyncWebAssembly": true,
     "inlineConst": false,
     "inlineEnum": false,
-    "lazyBarrel": true,
     "rspackFuture": {
       "bundlerInfo": {
         "force": false,

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1426,7 +1426,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "asyncWebAssembly": true,
       "inlineConst": false,
       "inlineEnum": false,
-      "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,
@@ -1882,7 +1881,6 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
       "asyncWebAssembly": true,
       "inlineConst": false,
       "inlineEnum": false,
-      "lazyBarrel": true,
       "rspackFuture": {
         "bundlerInfo": {
           "force": false,


### PR DESCRIPTION
## Summary

The `experiments.lazyBarrel` config has been enabled by default in Rspack v1.6.0-beta.0, so it's no longer needed.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11841

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
