### PR TITLE
ci: update macOS version to latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # run ut on macOS, as SWC cases will fail on Ubuntu CI
-        os: [macos-14, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Use macos-latest instead of macos-14.

## Related Links

https://github.com/actions/runner-images/tree/main/images/macos

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
