### PR TITLE
fix(esm): no need to set library type for web target

### DIFF
--- a/packages/core/src/plugins/esm.ts
+++ b/packages/core/src/plugins/esm.ts
@@ -16,6 +16,13 @@ export const pluginEsm = (): RsbuildPlugin => ({
         chain.optimization.runtimeChunk(true);
       }
 
+      if (target === 'node') {
+        chain.output.library({
+          ...chain.output.get('library'),
+          type: 'module',
+        });
+      }
+
       if (target === 'web-worker') {
         throw new Error(
           '[rsbuild:config] `output.module` is not supported for web-worker target.',
@@ -26,11 +33,7 @@ export const pluginEsm = (): RsbuildPlugin => ({
         .module(true)
         .chunkFormat('module')
         .chunkLoading('import')
-        .workerChunkLoading('import')
-        .library({
-          ...chain.output.get('library'),
-          type: 'module',
-        });
+        .workerChunkLoading('import');
 
       chain.experiments({
         ...chain.get('experiments'),


### PR DESCRIPTION
## Summary

This change removes the `output.library.type: 'module'` config when target is `web`.

The `library.type: 'module'` option is only needed when building libraries or Node.js applications. For web applications, it has no effect and may even cause unintended behavior.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
