### PR TITLE
chore: remove Rspack config schema env variable

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from '@playwright/test';
 
-// Enable Rspack's config schema validation
-process.env.RSPACK_CONFIG_VALIDATE = 'strict';
 process.env.PROVIDE_TYPE ||= 'rspack';
 // https://playwright.dev/docs/service-workers-experimental
 process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS = '1';

--- a/packages/core/src/plugins/basic.ts
+++ b/packages/core/src/plugins/basic.ts
@@ -111,12 +111,6 @@ export const pluginBasic = (): RsbuildPlugin => ({
             },
           });
         }
-
-        // Disable Rspack's config schema validation to improve performance.
-        // Rsbuild has ensured that the built-in Rspack configuration is correct
-        // through TypeScript, so we no longer need to perform schema validation
-        // at runtime. This can be manually enabled via `RSPACK_CONFIG_VALIDATE=strict'
-        process.env.RSPACK_CONFIG_VALIDATE ||= 'loose-silent';
       },
     );
   },

--- a/website/docs/en/guide/migration/rsbuild-0-x.mdx
+++ b/website/docs/en/guide/migration/rsbuild-0-x.mdx
@@ -92,15 +92,6 @@ export default {
 };
 ```
 
-## [Important] Rspack config validation
-
-Rsbuild now enables Rspack's scheme validation by default to ensure the Rspack configuration is correct.
-
-- If there is a type error in the Rspack config object, an error will be thrown and the build will be aborted.
-- If there are extra fields in the Rspack config object, an error will be thrown, but the build will not fail.
-
-> For more details, see [Rspack - RSPACK_CONFIG_VALIDATE](https://rspack.rs/guide/migration/webpack#updating-configuration).
-
 ## source.alias
 
 Removed `target` param for `source.alias` function, use [environments](/config/environments) config instead.

--- a/website/docs/zh/guide/migration/rsbuild-0-x.mdx
+++ b/website/docs/zh/guide/migration/rsbuild-0-x.mdx
@@ -92,15 +92,6 @@ export default {
 };
 ```
 
-## [重要] Rspack 配置校验
-
-Rsbuild 现在默认启用 Rspack 的 scheme 校验，以确保 Rspack 配置的正确性。
-
-- 当 Rspack 配置的类型错误时，会抛出错误并终止构建。
-- 当 Rspack 配置中存在多余的字段时，会抛出错误，但不会终止构建。
-
-> 详见 [Rspack - RSPACK_CONFIG_VALIDATE](https://rspack.rs/zh/guide/migration/webpack#%E4%BF%AE%E6%94%B9%E9%85%8D%E7%BD%AE)。
-
 ## source.alias
 
 移除 `source.alias` 函数的 `target` 参数，改用 [environments](/config/environments) 配置。


### PR DESCRIPTION
## Summary

Remove the `RSPACK_CONFIG_VALIDATE` variable, it is no longer used since Rspack v1.6.0-beta.1.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11897

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
