### PR TITLE
perf(build): enable unsafe fast drop in non-watch mode

### DIFF
--- a/packages/core/src/cli/commands.ts
+++ b/packages/core/src/cli/commands.ts
@@ -123,6 +123,10 @@ export function setupCommands(): void {
     )
     .action(async (options: BuildOptions) => {
       try {
+        if (!options.watch) {
+          process.env.RSPACK_UNSAFE_FAST_DROP = 'true';
+        }
+
         const rsbuild = await init({
           cliOptions: options,
           isBuildWatch: options.watch,

--- a/packages/core/src/env.d.ts
+++ b/packages/core/src/env.d.ts
@@ -11,3 +11,12 @@ declare global {
   const RSBUILD_WEB_SOCKET_TOKEN: string;
   const Deno: unknown;
 }
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    /**
+     * @experimental
+     */
+    RSPACK_UNSAFE_FAST_DROP?: string;
+  }
+}

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -105,6 +105,11 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     ? rspack(rspackConfigs)
     : rspack(rspackConfigs[0]);
 
+  // Enable unsafe fast drop in non-watch mode to improve performance
+  if (process.env.RSPACK_UNSAFE_FAST_DROP === 'true') {
+    compiler.unsafeFastDrop = true;
+  }
+
   let isVersionLogged = false;
   let isCompiling = false;
 


### PR DESCRIPTION
## Summary

Enable Rspack's unsafe fast drop when running `rspack build` to improve build performance.

### Before

<img width="847" height="101" alt="Screenshot 2025-10-22 at 16 00 46" src="https://github.com/user-attachments/assets/5f8307a7-f252-47be-8475-504b280ea7d3" />

### After

<img width="842" height="103" alt="Screenshot 2025-10-22 at 16 00 51" src="https://github.com/user-attachments/assets/d939c16d-201d-415f-b6b2-79857a771298" />

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11920

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
