### PR TITLE
perf: lazy load open module to improve startup time

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -1,4 +1,3 @@
-import { apps, default as baseOpen } from 'open';
 import { STATIC_PATH } from '../constants';
 import { castArray, color } from '../helpers';
 import { canParse } from '../helpers/url';
@@ -98,6 +97,11 @@ async function openBrowser(url: string): Promise<boolean> {
       logger.debug(err);
     }
   }
+
+  const { apps, default: baseOpen } = await import(
+    /** webpackChunkName: "open" */
+    'open'
+  );
 
   // Fallback to open
   // It will always open new tab


### PR DESCRIPTION
## Summary

The `open` package is only used when the `dev --open` flag is passed. Lazy loading this module can improve startup time.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
