### PR TITLE
fix(server): replace unescape with decodeURIComponent

### DIFF
--- a/packages/core/src/server/assets-middleware/getFileFromUrl.ts
+++ b/packages/core/src/server/assets-middleware/getFileFromUrl.ts
@@ -1,11 +1,18 @@
 import type { Stats as FSStats } from 'node:fs';
 import path from 'node:path';
-import { unescape as qsUnescape } from 'node:querystring';
 import { getPathnameFromUrl } from '../../helpers/path';
 import type { InternalContext } from '../../types';
 import type { OutputFileSystem } from './index';
 
 const UP_PATH_REGEXP = /(?:^|[\\/])\.\.(?:[\\/]|$)/;
+
+function decodePath(input: string) {
+  try {
+    return decodeURIComponent(input);
+  } catch {
+    return input;
+  }
+}
 
 /**
  * Resolves URL to file path with security checks and retrieves file from
@@ -18,7 +25,7 @@ export async function getFileFromUrl(
 ): Promise<
   { filename: string; fsStats: FSStats } | { errorCode: number } | undefined
 > {
-  const pathname = qsUnescape(getPathnameFromUrl(url));
+  const pathname = decodePath(getPathnameFromUrl(url));
 
   if (!pathname) {
     return;


### PR DESCRIPTION
## Summary

Replace `unescape` with `decodeURIComponent`, from Node.js documentation:

> The `querystring.unescape()` method is used by `querystring.parse()` and is generally not expected to be used directly.

> By default, the `querystring.unescape()` method will attempt to use the JavaScript built-in `decodeURIComponent()` method to decode. If that fails, a safer equivalent that does not throw on malformed URLs will be used.

## Related Links

- https://nodejs.org/api/querystring.html?utm_source=chatgpt.com#querystringunescapestr

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
