### PR TITLE
docs: output assetPrefix 'auto' documentation and typescript definition

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1,3 +1,7 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { SecureServerSessionOptions } from 'node:http2';
+import type { ServerOptions as HttpsServerOptions } from 'node:https';
+import type { URL } from 'node:url';
 import type {
   Configuration,
   CopyRspackPluginOptions,
@@ -8,10 +12,6 @@ import type {
   SwcJsMinimizerRspackPluginOptions,
   SwcLoaderOptions,
 } from '@rspack/core';
-import type { IncomingMessage, ServerResponse } from 'node:http';
-import type { SecureServerSessionOptions } from 'node:http2';
-import type { ServerOptions as HttpsServerOptions } from 'node:https';
-import type { URL } from 'node:url';
 import type { ChokidarOptions } from '../../compiled/chokidar/index.js';
 import type cors from '../../compiled/cors/index.js';
 import type {


### PR DESCRIPTION
## Summary

Modify output.assetPrefix type to include 'auto' as an option in the jsdocs and typescript types

## Related Links

Fixing what was left missing in [this change](https://github.com/web-infra-dev/rsbuild/commit/bb81fb03eba6d4669cc2f231c0dfe8b9b215edc7)

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
