### PR TITLE
perf: speed up accessing stats info

### DIFF
--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -68,14 +68,23 @@ export const getStatsAssetsOptions = (): Rspack.StatsOptions => ({
   groupAssetsByEmitStatus: false,
 });
 
-export const getAssetsFromStats = (
-  stats: Rspack.Stats,
-): Rspack.StatsAsset[] => {
-  const statsJson = stats.toJson({
-    all: false,
-    ...getStatsAssetsOptions(),
-  });
-  return statsJson.assets || [];
+export type RsbuildAsset = {
+  /**
+   * The name of the asset.
+   * @example 'index.html', 'static/js/index.[hash].js'
+   */
+  name: string;
+  /**
+   * The size of the asset in bytes.
+   */
+  size: number;
+};
+
+export const getAssetsFromStats = (stats: Rspack.Stats): RsbuildAsset[] => {
+  return Object.entries(stats.compilation.assets).map(([name, value]) => ({
+    name,
+    size: value.size(),
+  }));
 };
 
 function getStatsOptions(
@@ -101,11 +110,6 @@ function getStatsOptions(
       hash: true,
       // for HMR to compare the entrypoints
       entrypoints: true,
-    };
-  } else if (action === 'build') {
-    defaultOptions = {
-      ...defaultOptions,
-      ...getStatsAssetsOptions(),
     };
   }
 

--- a/packages/core/src/server/middlewares.ts
+++ b/packages/core/src/server/middlewares.ts
@@ -339,7 +339,7 @@ export const viewingServedFilesMiddleware: (params: {
 
         for (const asset of assets) {
           list.push(
-            `<li><a target="_blank" href="${asset?.name}">${asset?.name}</a></li>`,
+            `<li><a target="_blank" href="${asset.name}">${asset.name}</a></li>`,
           );
         }
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -21,6 +21,7 @@ import type {
 import type RspackChain from '../../compiled/rspack-chain';
 import type { FileDescriptor } from '../../compiled/rspack-manifest-plugin';
 import type { BundleAnalyzerPlugin } from '../../compiled/webpack-bundle-analyzer/index.js';
+import type { RsbuildAsset } from '../helpers/stats.js';
 import type { RsbuildDevServer } from '../server/devServer';
 import type {
   EnvironmentContext,
@@ -598,17 +599,7 @@ export type BuildCacheOptions = {
   buildDependencies?: string[];
 };
 
-export type PrintFileSizeAsset = {
-  /**
-   * The name of the asset.
-   * @example 'index.html', 'static/js/index.[hash].js'
-   */
-  name: string;
-  /**
-   * The size of the asset in bytes.
-   */
-  size: number;
-};
+export type PrintFileSizeAsset = RsbuildAsset;
 
 export type PrintFileSizeOptions = {
   /**

--- a/packages/core/src/types/rsbuild.ts
+++ b/packages/core/src/types/rsbuild.ts
@@ -368,7 +368,7 @@ export type RsbuildMode = 'development' | 'production' | 'none';
 
 export type RsbuildStatsItem = Pick<
   Rspack.StatsCompilation,
-  'errors' | 'warnings' | 'time' | 'entrypoints' | 'hash' | 'assets'
+  'errors' | 'warnings' | 'time' | 'entrypoints' | 'hash'
 >;
 
 /**


### PR DESCRIPTION
## Summary

As Rsbuild only needs the name and size of the assets from the Rspack stats object, using `compilation.assets` is much faster than using the `stats.toJson({ assets: true })`.

### Before

<img width="653" height="283" alt="Screenshot 2025-10-23 at 14 31 56" src="https://github.com/user-attachments/assets/a4635416-78c0-4306-be48-5759362bf498" />

### After

<img width="646" height="310" alt="Screenshot 2025-10-23 at 14 27 38" src="https://github.com/user-attachments/assets/c54ac038-7dbb-4626-8039-0fbadb381cf6" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
