### PR TITLE
fix(types): add LiteralUnion type and apply to assetPrefix

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -51,6 +51,7 @@ import type {
   ConfigChain,
   ConfigChainMergeContext,
   ConfigChainWithContext,
+  LiteralUnion,
   MaybePromise,
   OneOrMany,
   Optional,
@@ -1193,7 +1194,7 @@ export interface OutputConfig {
    * `auto` means use a relative path based on file location.
    * @default `server.base`
    */
-  assetPrefix?: string | 'auto';
+  assetPrefix?: LiteralUnion<'auto', string>;
   /**
    * Set the size threshold to inline static assets such as images and fonts.
    * By default, static assets will be Base64 encoded and inline into the page if
@@ -1734,7 +1735,7 @@ export interface DevConfig {
    * similar to the [output.publicPath](https://rspack.rs/config/output#outputpublicpath)
    * config of Rspack.
    */
-  assetPrefix?: string | boolean;
+  assetPrefix?: LiteralUnion<'auto', string> | boolean;
   /**
    * Whether to render progress bars to display the build progress.
    * @default false

--- a/packages/core/src/types/utils.ts
+++ b/packages/core/src/types/utils.ts
@@ -6,6 +6,9 @@ export type MaybePromise<T> = T | Promise<T>;
 
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
+// https://github.com/microsoft/TypeScript/issues/29729
+export type LiteralUnion<T extends U, U> = T | (U & Record<never, never>);
+
 /**
  * Creates a type with readonly properties at the first and second levels only.
  */


### PR DESCRIPTION
## Summary

- Add LiteralUnion utility type to handle string literal unions with fallback types.
- Use it for `assetPrefix` to improve type safety.

## Related Links

- https://github.com/microsoft/TypeScript/issues/29729

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
