### PR TITLE
fix: apply LiteralUnion to more types for better type safety

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1485,7 +1485,7 @@ export type AppIconItem = {
    * the default value.
    * @see https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/icons#purpose
    */
-  purpose?: string;
+  purpose?: LiteralUnion<'any' | 'maskable' | 'monochrome', string>;
 };
 
 export type AppIcon = {

--- a/packages/core/src/types/thirdParty.ts
+++ b/packages/core/src/types/thirdParty.ts
@@ -8,6 +8,7 @@ import type Connect from '../../compiled/connect/index.js';
 import type HtmlRspackPlugin from '../../compiled/html-rspack-plugin/index.js';
 import type { AcceptedPlugin, ProcessOptions } from '../../compiled/postcss';
 import type { Rspack } from './rspack';
+import type { LiteralUnion } from './utils';
 
 export type { Connect };
 
@@ -182,7 +183,10 @@ export interface CSSLoaderOptions {
   /**
    * Allows to enable/disable CSS Modules or ICSS and setup configuration:
    */
-  modules?: boolean | string | CSSLoaderModulesOptions;
+  modules?:
+    | boolean
+    | LiteralUnion<'local' | 'global' | 'pure' | 'icss', string>
+    | CSSLoaderModulesOptions;
   /**
    * By default generation of source maps depends on the devtool option.
    */
@@ -237,7 +241,9 @@ export interface StyleLoaderOptions {
    *
    * @default 'head'
    */
-  insert?: string | ((element: HTMLElement) => void);
+  insert?:
+    | LiteralUnion<'head' | 'body', string>
+    | ((element: HTMLElement) => void);
   /**
    * Allows to setup absolute path to custom function that allows to override default behavior styleTagTransform.
    */

--- a/website/docs/en/config/html/app-icon.mdx
+++ b/website/docs/en/config/html/app-icon.mdx
@@ -7,7 +7,7 @@ type AppIconItem = {
   src: string;
   size: number;
   target?: 'apple-touch-icon' | 'web-app-manifest';
-  purpose?: string;
+  purpose?: 'any' | 'maskable' | 'monochrome' | string;
 };
 
 type AppIcon = {

--- a/website/docs/zh/config/html/app-icon.mdx
+++ b/website/docs/zh/config/html/app-icon.mdx
@@ -7,7 +7,7 @@ type AppIconItem = {
   src: string;
   size: number;
   target?: 'apple-touch-icon' | 'web-app-manifest';
-  purpose?: string;
+  purpose?: 'any' | 'maskable' | 'monochrome' | string;
 };
 
 type AppIcon = {


### PR DESCRIPTION
## Summary

Updates some type definitions to use the `LiteralUnion` type for better type safety.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
