### PR TITLE
ci: remove pnpm cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,6 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
       # Update npm to the latest version to enable OIDC
       - name: Update npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,6 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
@@ -146,7 +145,6 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
-          cache: 'pnpm'
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Motivation:

- We recently encountered some issues with cache causing the Windows unit testing CI to fail (https://github.com/web-infra-dev/rsbuild/actions/runs/18751006482/job/53490332365)
- After comparison, enabling on the cache did not make Rsbuild CI run faster

From https://pnpm.io/continuous-integration:

> In all the provided configuration files the store is cached. However, this is not required, and it is not guaranteed that caching the store will make installation faster. So feel free to not cache the pnpm store in your job.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
