### PR TITLE
ci: disable package manager cache in GitHub workflows

### DIFF
--- a/.github/workflows/ecosystem-ci.yml
+++ b/.github/workflows/ecosystem-ci.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Get CI Result
         id: eco-ci-result

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       # Update npm to the latest version to enable OIDC
       - name: Update npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
@@ -97,6 +98,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'
@@ -145,6 +147,7 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
+          package-manager-cache: false
 
       - name: Install Dependencies
         if: steps.changes.outputs.changed == 'true'


### PR DESCRIPTION
## Summary

Although the Rsbuild repository uses pnpm, actions/setup-node automatically enables caching (see https://github.com/web-infra-dev/rsbuild/actions/runs/18767609069/job/53545564346?pr=6423), which is inconsistent with its documentation.

This PR explicitly disables caching to avoid this issue.

## Related Links

https://github.com/actions/setup-node?tab=readme-ov-file#breaking-changes-in-v6

<img width="1762" height="318" alt="image" src="https://github.com/user-attachments/assets/05440cec-4910-473c-9111-6348f9abef71" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
