### PR TITLE
ci: pin node version to 22.20 in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22.20
+          node-version: '22.20'
           package-manager-cache: false
 
       - name: Install Dependencies
@@ -97,7 +97,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22.20
+          node-version: '22.20'
           package-manager-cache: false
 
       - name: Install Dependencies
@@ -146,7 +146,7 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22.20
+          node-version: '22.20'
           package-manager-cache: false
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary

Temporary pin Node version to 22.20 as the `ut (windows-latest)` CI job fails with Node 22.21:

- https://github.com/web-infra-dev/rsbuild/actions/runs/18767609069/job/53545564346
- https://github.com/web-infra-dev/rsbuild/actions/runs/18772235480/job/53558924955
- https://github.com/web-infra-dev/rsbuild/actions/runs/18751006482/job/53490332365
- https://github.com/web-infra-dev/rsbuild/actions/runs/18772660135/job/53560167075

We need to further investigate the root cause of this issue.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
