### PR TITLE
fix(browser-logs): simplify file paths for full stack trace

### DIFF
--- a/e2e/cases/browser-logs/stack-trace-full/index.test.ts
+++ b/e2e/cases/browser-logs/stack-trace-full/index.test.ts
@@ -3,7 +3,7 @@ import { rspackTest } from '@e2e/helper';
 // Omitted some parts of the stack trace as they are not static
 const EXPECTED_LOG = `error   [browser] Uncaught Error: foo
     at foo (src/foo.js:2:0)
-    at ./src/index.js (src/index.js:3:0)
+    at src/index.js:3:0
     at __webpack_require__ (http://localhost`;
 
 rspackTest('should display formatted full stack trace', async ({ dev }) => {

--- a/packages/core/src/server/browserLogs.ts
+++ b/packages/core/src/server/browserLogs.ts
@@ -15,6 +15,15 @@ import type { OutputFileSystem } from './assets-middleware/index';
 import type { ClientMessageError } from './socketServer';
 
 /**
+ * Determines whether a given string is a valid method name
+ * extracted from a browser error stack trace.
+ * Excludes file paths such as "./src/App.tsx"
+ */
+const isValidMethodName = (methodName: string) => {
+  return methodName !== '<unknown>' && !/[\\/]/.test(methodName);
+};
+
+/**
  * Maps a position in compiled code to its original source position using
  * source maps.
  */
@@ -176,7 +185,7 @@ const formatFullStack = async (
     const { methodName } = frame;
     const parts: (string | undefined)[] = [];
 
-    if (methodName !== '<unknown>') {
+    if (isValidMethodName(methodName)) {
       parts.push(methodName);
     }
 
@@ -238,8 +247,7 @@ export const formatBrowserErrorLog = async (
 
         let suffix = '';
 
-        // exclude unknown method name and file path like `./src/App.tsx`
-        if (methodName !== '<unknown>' && !/[\\/]/.test(methodName)) {
+        if (isValidMethodName(methodName)) {
           suffix += ` at ${methodName}`;
         }
         if (location) {


### PR DESCRIPTION
## Summary

Simplify file paths when printing browser logs with full stack trace:

```diff
- at ./src/index.js (src/index.js:3:0)
+ at src/index.js:3:0
```

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
