### PR TITLE
docs: update browserLogs  for stackTrace option

### DIFF
--- a/website/docs/en/config/dev/browser-logs.mdx
+++ b/website/docs/en/config/dev/browser-logs.mdx
@@ -1,7 +1,16 @@
 # dev.browserLogs
 
-- **Type:** `boolean`
-- **Default:** `true`
+- **Type:**
+
+```ts
+type BrowserLogs =
+  | boolean
+  | {
+      stackTrace?: 'summary' | 'full' | 'none';
+    };
+```
+
+- **Default:** `{ stackTrace: 'summary' }`
 
 Controls whether to forward browser runtime errors to the terminal.
 
@@ -27,6 +36,41 @@ error   [browser] Uncaught TypeError: Cannot read properties of undefined (readi
  at handleClick (src/App.jsx:3:0)
 ```
 
+## Options
+
+### stackTrace
+
+- **Type:** `'summary' | 'full' | 'none'`
+- **Default:** `'summary'`
+
+Controls how the error stack trace is displayed in the terminal when forwarding browser errors.
+
+- `'summary'` – Show only the first frame (e.g. `(src/App.jsx:3:0)`).
+- `'full'` – Print the full stack trace with all frames.
+- `'none'` – Hide stack traces.
+
+For example, setting `stackTrace` to `'full'`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    browserLogs: {
+      stackTrace: 'full',
+    },
+  },
+};
+```
+
+The full stack trace will be like:
+
+```bash
+error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name')
+    at handleClick (src/App.jsx:6:0)
+    at someFunction (src/App.jsx:12:0)
+    at App (src/App.jsx:6:0)
+    ...
+```
+
 ## Disabling
 
 Set `dev.browserLogs` to `false` to disable this behavior.
@@ -41,6 +85,7 @@ export default {
 
 ## Version history
 
-| Version | Changes           |
-| ------- | ----------------- |
-| v1.5.13 | Added this option |
+| Version | Changes                   |
+| ------- | ------------------------- |
+| v1.5.13 | Added this option         |
+| v1.6.0  | Added `stackTrace` option |

--- a/website/docs/zh/config/dev/browser-logs.mdx
+++ b/website/docs/zh/config/dev/browser-logs.mdx
@@ -1,8 +1,16 @@
 # dev.browserLogs
 
-- **类型：** `boolean`
-- **默认值：** `true`
-- **版本：** 新增于 v1.5.13
+- **类型：**
+
+```ts
+type BrowserLogs =
+  | boolean
+  | {
+      stackTrace?: 'summary' | 'full' | 'none';
+    };
+```
+
+- **默认值：** `{ stackTrace: 'summary' }`
 
 控制是否将浏览器运行时错误转发到终端。
 
@@ -28,6 +36,41 @@ error   [browser] Uncaught TypeError: Cannot read properties of undefined (readi
  at handleClick (src/App.jsx:3:0)
 ```
 
+## 选项
+
+### stackTrace
+
+- **类型：** `'summary' | 'full' | 'none'`
+- **默认值：** `'summary'`
+
+控制在将浏览器错误转发到终端时，错误堆栈的显示方式。
+
+- `'summary'` —— 仅显示首个堆栈帧（例如 `(src/App.jsx:3:0)`）。
+- `'full'` —— 显示完整的堆栈信息，包含所有堆栈帧。
+- `'none'` —— 不显示任何堆栈信息。
+
+例如，将 `stackTrace` 设置为 `'full'`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    browserLogs: {
+      stackTrace: 'full',
+    },
+  },
+};
+```
+
+完整的错误堆栈如下：
+
+```bash
+error   [browser] Uncaught TypeError: Cannot read properties of undefined (reading 'name')
+    at handleClick (src/App.jsx:6:0)
+    at someFunction (src/App.jsx:12:0)
+    at App (src/App.jsx:6:0)
+    ...
+```
+
 ## 禁用
 
 将 `dev.browserLogs` 设置为 `false` 可以禁用此行为。
@@ -42,6 +85,7 @@ export default {
 
 ## 版本历史
 
-| 版本   | 变更内容   |
-| ------ | ---------- |
-| v1.3.0 | 新增该选项 |
+| 版本    | 变更内容               |
+| ------- | ---------------------- |
+| v1.5.13 | 新增该选项             |
+| v1.6.0  | 新增 `stackTrace` 选项 |


### PR DESCRIPTION
## Summary

Add documentation for the new `stackTrace` option in `dev.browserLogs`, including type definitions, usage examples, and version history updates.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
