### PR TITLE
docs(env-vars): add section for accessing env mode in client code

### DIFF
--- a/website/docs/en/guide/advanced/env-vars.mdx
+++ b/website/docs/en/guide/advanced/env-vars.mdx
@@ -265,6 +265,28 @@ We recommend using `--env-mode` to set the env mode instead of modifying `proces
 
 :::
 
+#### Accessing in client code
+
+By default, Rsbuild does not inject the env mode into client code. You can manually define a global identifier using [source.define](#using-define) to make it available in the client code:
+
+```js title="rsbuild.config.js"
+export default ({ envMode }) => ({
+  source: {
+    define: {
+      ENV_MODE: JSON.stringify(envMode),
+    },
+  },
+});
+```
+
+Then you can access it in client code:
+
+```js title="src/index.js"
+if (ENV_MODE === 'my-mode') {
+  // ...
+}
+```
+
 ### Env directory
 
 By default, the `.env` file is located in the root directory of the project. You can specify the env directory by using the `--env-dir <dir>` option in the CLI.

--- a/website/docs/zh/guide/advanced/env-vars.mdx
+++ b/website/docs/zh/guide/advanced/env-vars.mdx
@@ -267,6 +267,28 @@ Rsbuild 会按照以下顺序读取这些文件，并合并它们的内容。如
 
 :::
 
+#### 在 client 代码中访问
+
+Rsbuild 默认不会将 Env 模式注入到 client 代码中，但你可以通过 [source.define](#使用-define) 手动定义一个全局标识符，使其在 client 代码中可用：
+
+```js title="rsbuild.config.js"
+export default ({ envMode }) => ({
+  source: {
+    define: {
+      ENV_MODE: JSON.stringify(envMode),
+    },
+  },
+});
+```
+
+在 client 代码中即可访问该值：
+
+```js title="src/index.js"
+if (ENV_MODE === 'my-mode') {
+  // ...
+}
+```
+
 ### Env 目录
 
 默认情况下，`.env` 文件位于项目的根目录。你可以通过 CLI 的 `--env-dir <dir>` 选项来指定 env 目录。


### PR DESCRIPTION
## Summary

Explain how to use `source.define` to make env mode available in client code

## Related Links

resolve https://github.com/web-infra-dev/rsbuild/issues/6432

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
