### PR TITLE
docs: update webpack loader repository links

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -62,7 +62,7 @@ export const getLightningCSSLoaderOptions = (
 // If the target is not `web` and the modules option of css-loader is enabled,
 // we must enable exportOnlyLocals to only exports the modules identifier mappings.
 // Otherwise, the compiled CSS code may contain invalid code, such as `new URL`.
-// https://github.com/webpack-contrib/css-loader#exportonlylocals
+// https://github.com/webpack/css-loader#exportonlylocals
 export const normalizeCssLoaderOptions = (
   options: CSSLoaderOptions,
   exportOnlyLocals: boolean,
@@ -419,7 +419,7 @@ export const pluginCss = (): RsbuildPlugin => ({
           rule.sideEffects(true);
 
           // Enable preferRelative by default, which is consistent with the default behavior of css-loader
-          // see: https://github.com/webpack-contrib/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234
+          // see: https://github.com/webpack/css-loader/blob/579fc13/src/plugins/postcss-import-parser.js#L234
           rule.resolve.preferRelative(true);
         });
 

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -173,15 +173,15 @@ export interface ToolsConfig {
    */
   bundlerChain?: ToolsBundlerChainConfig;
   /**
-   * Modify the options of [css-loader](https://github.com/webpack-contrib/css-loader).
+   * Modify the options of [css-loader](https://github.com/webpack/css-loader).
    */
   cssLoader?: ToolsCSSLoaderConfig;
   /**
-   * Modify the options of [postcss-loader](https://github.com/webpack-contrib/postcss-loader).
+   * Modify the options of [postcss-loader](https://github.com/webpack/postcss-loader).
    */
   postcss?: ToolsPostCSSLoaderConfig;
   /**
-   * Modify the options of [style-loader](https://github.com/webpack-contrib/style-loader).
+   * Modify the options of [style-loader](https://github.com/webpack/style-loader).
    */
   styleLoader?: ToolsStyleLoaderConfig;
   /**

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -73,7 +73,7 @@ export type LessLoaderOptions = {
 export type PluginLessOptions = {
   /**
    * Options passed to less-loader.
-   * @see https://github.com/webpack-contrib/less-loader
+   * @see https://github.com/webpack/less-loader
    */
   lessLoaderOptions?: ConfigChainWithContext<
     LessLoaderOptions,

--- a/packages/plugin-sass/src/types.ts
+++ b/packages/plugin-sass/src/types.ts
@@ -32,7 +32,7 @@ export type SassLoaderOptions = Omit<
 export type PluginSassOptions = {
   /**
    * Options passed to sass-loader.
-   * @see https://github.com/webpack-contrib/sass-loader
+   * @see https://github.com/webpack/sass-loader
    */
   sassLoaderOptions?: ConfigChainWithContext<
     SassLoaderOptions,

--- a/website/docs/en/community/releases/v0-7.mdx
+++ b/website/docs/en/community/releases/v0-7.mdx
@@ -58,7 +58,7 @@ Comparison of build times for Rsbuild 0.6 and 0.7 when compiling Bootstrap's Sas
 
 This improvement is due to Rsbuild's default use of [sass-embedded](https://npmjs.com/package/sass-embedded), a JavaScript wrapper around the native Dart Sass executable that provides a consistent API and superior performance.
 
-Rsbuild has also enabled the latest sass-loader's [modern-compiler](https://github.com/webpack-contrib/sass-loader/releases/tag/v14.2.0) API. This can enable Sass's shared resources feature, which allows the same compiler process to be reused when compiling multiple files, improving build performance.
+Rsbuild has also enabled the latest sass-loader's [modern-compiler](https://github.com/webpack/sass-loader/releases/tag/v14.2.0) API. This can enable Sass's shared resources feature, which allows the same compiler process to be reused when compiling multiple files, improving build performance.
 
 ## Better CSS supports
 

--- a/website/docs/en/config/output/css-modules.mdx
+++ b/website/docs/en/config/output/css-modules.mdx
@@ -4,7 +4,7 @@
 
 Configure custom CSS Modules settings.
 
-The CSS Modules feature in Rsbuild is based on the `modules` option of css-loader. You can refer to [css-loader - modules](https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#modules) to learn more.
+The CSS Modules feature in Rsbuild is based on the `modules` option of css-loader. You can refer to [css-loader - modules](https://github.com/webpack/css-loader?tab=readme-ov-file#modules) to learn more.
 
 ## cssModules.auto
 

--- a/website/docs/en/config/performance/bundle-analyze.mdx
+++ b/website/docs/en/config/performance/bundle-analyze.mdx
@@ -2,7 +2,7 @@
 
 - **Type:** `Object | undefined`
 
-Used to enable the [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) plugin to analyze the size of the output.
+Used to enable the [webpack-bundle-analyzer](https://github.com/webpack/webpack-bundle-analyzer) plugin to analyze the size of the output.
 
 By default, Rsbuild does not enable `webpack-bundle-analyzer`. When this feature is enabled, the default configuration is as follows:
 

--- a/website/docs/en/config/performance/profile.mdx
+++ b/website/docs/en/config/performance/profile.mdx
@@ -7,7 +7,7 @@ Whether to capture timing information for each module, the same as the [profile]
 
 When enabled:
 
-- Rsbuild will automatically generate a `dist/stats.json` file through [bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer).
+- Rsbuild will automatically generate a `dist/stats.json` file through [bundle analyzer](https://github.com/webpack/webpack-bundle-analyzer).
 - Rspack will include build-time information when generating stats.json or other statistics files.
 
 ## Example

--- a/website/docs/en/config/tools/css-loader.mdx
+++ b/website/docs/en/config/tools/css-loader.mdx
@@ -9,7 +9,7 @@ const defaultOptions = {
 };
 ```
 
-Rsbuild uses [css-loader](https://github.com/webpack-contrib/css-loader) by default to handle CSS resources. You can modify the options of css-loader through `tools.cssLoader`.
+Rsbuild uses [css-loader](https://github.com/webpack/css-loader) by default to handle CSS resources. You can modify the options of css-loader through `tools.cssLoader`.
 
 :::tip
 To modify the options related to CSS Modules, it is recommended to use the [output.cssModules](/config/output/css-modules) config first.

--- a/website/docs/en/config/tools/postcss.mdx
+++ b/website/docs/en/config/tools/postcss.mdx
@@ -12,7 +12,7 @@ const defaultOptions = {
 };
 ```
 
-Rsbuild integrates PostCSS by default. You can configure [postcss-loader](https://github.com/webpack-contrib/postcss-loader) through `tools.postcss`.
+Rsbuild integrates PostCSS by default. You can configure [postcss-loader](https://github.com/webpack/postcss-loader) through `tools.postcss`.
 
 ## Function type
 

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -366,7 +366,7 @@ export default {
 
 Remove the internal Rspack plugin, the parameter is the `constructor.name` of the plugin.
 
-For example, remove the internal [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer):
+For example, remove the internal [webpack-bundle-analyzer](https://github.com/webpack/webpack-bundle-analyzer):
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/en/config/tools/style-loader.mdx
+++ b/website/docs/en/config/tools/style-loader.mdx
@@ -3,7 +3,7 @@
 - **Type:** `Object | Function`
 - **Default:** `{}`
 
-The config of [style-loader](https://github.com/webpack-contrib/style-loader) can be set through `tools.styleLoader`.
+The config of [style-loader](https://github.com/webpack/style-loader) can be set through `tools.styleLoader`.
 
 It is worth noting that Rsbuild does not enable `style-loader` by default. You can use [output.injectStyles](/config/output/inject-styles) config to enable it.
 

--- a/website/docs/en/plugins/list/plugin-less.mdx
+++ b/website/docs/en/plugins/list/plugin-less.mdx
@@ -4,7 +4,7 @@ import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less" />
 
-Use [Less](https://lesscss.org/) as the CSS preprocessor, implemented based on [less-loader](https://github.com/webpack-contrib/less-loader).
+Use [Less](https://lesscss.org/) as the CSS preprocessor, implemented based on [less-loader](https://github.com/webpack/less-loader).
 
 ## Quick start
 
@@ -43,7 +43,7 @@ To customize the compilation behavior of Less, use the following options.
 
 ### lessLoaderOptions
 
-You can modify the config of [less-loader](https://github.com/webpack-contrib/less-loader) via `lessLoaderOptions`.
+You can modify the config of [less-loader](https://github.com/webpack/less-loader) via `lessLoaderOptions`.
 
 - **Type:** `Object | Function`
 - **Default:**

--- a/website/docs/en/plugins/list/plugin-sass.mdx
+++ b/website/docs/en/plugins/list/plugin-sass.mdx
@@ -4,7 +4,7 @@ import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass" />
 
-Use [Sass](https://sass-lang.com/) as the CSS preprocessor, implemented based on [sass-loader](https://github.com/webpack-contrib/sass-loader).
+Use [Sass](https://sass-lang.com/) as the CSS preprocessor, implemented based on [sass-loader](https://github.com/webpack/sass-loader).
 
 ## Quick start
 
@@ -43,7 +43,7 @@ To customize the compilation behavior of Sass, use the following options.
 
 ### sassLoaderOptions
 
-Modify the config of [sass-loader](https://github.com/webpack-contrib/sass-loader).
+Modify the config of [sass-loader](https://github.com/webpack/sass-loader).
 
 - **Type:** `Object | Function`
 - **Default:**
@@ -141,7 +141,7 @@ Sass provides several implementations, including [sass](https://npmjs.com/packag
 
 Rsbuild uses the latest `sass-embedded` implementation by default. `sass-embedded` is a JavaScript wrapper around the native Dart Sass executable, providing a consistent API and optimal performance.
 
-To use a different Sass implementation instead of the built-in `sass-embedded` included in Rsbuild, install the preferred Sass implementation in your project and specify it using the `sass-loader`'s [implementation](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#implementation) option.
+To use a different Sass implementation instead of the built-in `sass-embedded` included in Rsbuild, install the preferred Sass implementation in your project and specify it using the `sass-loader`'s [implementation](https://github.com/webpack/sass-loader?tab=readme-ov-file#implementation) option.
 
 ```ts
 pluginSass({

--- a/website/docs/zh/community/releases/v0-7.mdx
+++ b/website/docs/zh/community/releases/v0-7.mdx
@@ -58,7 +58,7 @@ export default config;
 
 这得益于 Rsbuild 默认启用了 [sass-embedded](https://npmjs.com/package/sass-embedded)，sass-embedded 是一个围绕原生 Dart Sass 可执行文件的 JavaScript wrapper，具备一致的 API 和更优秀的性能。
 
-此外，Rsbuild 还启用了 `sass-loader` 最新的 [modern-compiler](https://github.com/webpack-contrib/sass-loader/releases/tag/v14.2.0) API，这能够开启 Sass 的 shared resources 能力，在编译多个文件时重复利用相同的 compiler 进程，从而提升构建速度。
+此外，Rsbuild 还启用了 `sass-loader` 最新的 [modern-compiler](https://github.com/webpack/sass-loader/releases/tag/v14.2.0) API，这能够开启 Sass 的 shared resources 能力，在编译多个文件时重复利用相同的 compiler 进程，从而提升构建速度。
 
 ## 更好的 CSS 支持
 

--- a/website/docs/zh/config/output/css-modules.mdx
+++ b/website/docs/zh/config/output/css-modules.mdx
@@ -4,7 +4,7 @@
 
 用于自定义 CSS Modules 配置。
 
-Rsbuild 的 CSS Modules 功能是基于 css-loader 的 `modules` 选项实现的，你可以参考 [css-loader - modules](https://github.com/webpack-contrib/css-loader?tab=readme-ov-file#modules) 来了解更多。
+Rsbuild 的 CSS Modules 功能是基于 css-loader 的 `modules` 选项实现的，你可以参考 [css-loader - modules](https://github.com/webpack/css-loader?tab=readme-ov-file#modules) 来了解更多。
 
 ## cssModules.auto
 

--- a/website/docs/zh/config/performance/bundle-analyze.mdx
+++ b/website/docs/zh/config/performance/bundle-analyze.mdx
@@ -2,7 +2,7 @@
 
 - **类型：** `Object | undefined`
 
-用于开启 [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) 插件来分析产物体积。
+用于开启 [webpack-bundle-analyzer](https://github.com/webpack/webpack-bundle-analyzer) 插件来分析产物体积。
 
 默认情况下，Rsbuild 不会开启 `webpack-bundle-analyzer`。当开启该功能后，内部的默认配置如下:
 

--- a/website/docs/zh/config/performance/profile.mdx
+++ b/website/docs/zh/config/performance/profile.mdx
@@ -7,7 +7,7 @@
 
 开启后：
 
-- Rsbuild 会通过 [bundle analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) 自动生成 `dist/stats.json` 文件。
+- Rsbuild 会通过 [bundle analyzer](https://github.com/webpack/webpack-bundle-analyzer) 自动生成 `dist/stats.json` 文件。
 - Rspack 在生成 stats.json 等统计文件时，会将构建的耗时信息也包含进去。
 
 ## 示例

--- a/website/docs/zh/config/tools/css-loader.mdx
+++ b/website/docs/zh/config/tools/css-loader.mdx
@@ -10,7 +10,7 @@ const defaultOptions = {
 };
 ```
 
-Rsbuild 默认使用 [css-loader](https://github.com/webpack-contrib/css-loader) 来处理 CSS 资源。你可以通过 `tools.cssLoader` 来修改 css-loader 的选项。
+Rsbuild 默认使用 [css-loader](https://github.com/webpack/css-loader) 来处理 CSS 资源。你可以通过 `tools.cssLoader` 来修改 css-loader 的选项。
 
 :::tip
 如果你需要修改 CSS Modules 相关的选项，推荐优先使用 [output.cssModules](/config/output/css-modules) 配置项。

--- a/website/docs/zh/config/tools/postcss.mdx
+++ b/website/docs/zh/config/tools/postcss.mdx
@@ -12,7 +12,7 @@ const defaultOptions = {
 };
 ```
 
-Rsbuild 默认集成 PostCSS，你可以通过 `tools.postcss` 对 [postcss-loader](https://github.com/webpack-contrib/postcss-loader) 进行配置。
+Rsbuild 默认集成 PostCSS，你可以通过 `tools.postcss` 对 [postcss-loader](https://github.com/webpack/postcss-loader) 进行配置。
 
 ## Function 类型
 

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -366,7 +366,7 @@ export default {
 
 删除内部的 Rspack 插件，参数为该插件的 `constructor.name`。
 
-例如，删除内部的 [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)：
+例如，删除内部的 [webpack-bundle-analyzer](https://github.com/webpack/webpack-bundle-analyzer)：
 
 ```ts title="rsbuild.config.ts"
 export default {

--- a/website/docs/zh/config/tools/style-loader.mdx
+++ b/website/docs/zh/config/tools/style-loader.mdx
@@ -3,7 +3,7 @@
 - **类型：** `Object | Function`
 - **默认值：** `{}`
 
-通过 `tools.styleLoader` 可以设置 [style-loader](https://github.com/webpack-contrib/style-loader) 的配置项。
+通过 `tools.styleLoader` 可以设置 [style-loader](https://github.com/webpack/style-loader) 的配置项。
 
 值得注意的是，Rsbuild 默认不会开启 `style-loader`，你可以通过 [output.injectStyles](/config/output/inject-styles) 配置项来开启它。
 

--- a/website/docs/zh/plugins/list/plugin-less.mdx
+++ b/website/docs/zh/plugins/list/plugin-less.mdx
@@ -4,7 +4,7 @@ import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-less" />
 
-使用 [Less](https://lesscss.org/) 作为 CSS 预处理器，基于 [less-loader](https://github.com/webpack-contrib/less-loader) 实现。
+使用 [Less](https://lesscss.org/) 作为 CSS 预处理器，基于 [less-loader](https://github.com/webpack/less-loader) 实现。
 
 ## 快速开始
 
@@ -43,7 +43,7 @@ export default {
 
 ### lessLoaderOptions
 
-修改 [less-loader](https://github.com/webpack-contrib/less-loader) 的配置。
+修改 [less-loader](https://github.com/webpack/less-loader) 的配置。
 
 - **类型：** `Object | Function`
 - **默认值：**

--- a/website/docs/zh/plugins/list/plugin-sass.mdx
+++ b/website/docs/zh/plugins/list/plugin-sass.mdx
@@ -4,7 +4,7 @@ import { SourceCode } from '@rspress/core/theme';
 
 <SourceCode href="https://github.com/web-infra-dev/rsbuild/tree/main/packages/plugin-sass" />
 
-使用 [Sass](https://sass-lang.com/) 作为 CSS 预处理器，基于 [sass-loader](https://github.com/webpack-contrib/sass-loader) 实现。
+使用 [Sass](https://sass-lang.com/) 作为 CSS 预处理器，基于 [sass-loader](https://github.com/webpack/sass-loader) 实现。
 
 ## 快速开始
 
@@ -43,7 +43,7 @@ export default {
 
 ### sassLoaderOptions
 
-修改 [sass-loader](https://github.com/webpack-contrib/sass-loader) 的配置。
+修改 [sass-loader](https://github.com/webpack/sass-loader) 的配置。
 
 - **类型：** `Object | Function`
 - **默认值：**
@@ -141,7 +141,7 @@ Sass 提供了多种实现，包括 [sass](https://npmjs.com/package/sass)、[sa
 
 Rsbuild 默认使用最新的 `sass-embedded` 实现。`sass-embedded` 是一个围绕原生 Dart Sass 可执行文件的 JavaScript wrapper，具备一致的 API 和最佳的性能。
 
-如果你需要使用其他 Sass 实现，而不是使用 Rsbuild 内置的 `sass-embedded`，可以在项目中安装需要使用的 Sass 实现，并通过 `sass-loader` 的 [implementation](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#implementation) 选项来设置。
+如果你需要使用其他 Sass 实现，而不是使用 Rsbuild 内置的 `sass-embedded`，可以在项目中安装需要使用的 Sass 实现，并通过 `sass-loader` 的 [implementation](https://github.com/webpack/sass-loader?tab=readme-ov-file#implementation) 选项来设置。
 
 ```ts
 pluginSass({
@@ -157,7 +157,7 @@ pluginSass({
 
 ### 选择 Sass API
 
-Rsbuild 默认使用最新的 `modern-compiler` API，如果你依赖了 Sass 的 `legacy` API，可以将 sass-loader 的 [api](https://github.com/webpack-contrib/sass-loader?tab=readme-ov-file#api) 选项设置为 `legacy`，以兼容一些废弃的 Sass 写法。
+Rsbuild 默认使用最新的 `modern-compiler` API，如果你依赖了 Sass 的 `legacy` API，可以将 sass-loader 的 [api](https://github.com/webpack/sass-loader?tab=readme-ov-file#api) 选项设置为 `legacy`，以兼容一些废弃的 Sass 写法。
 
 ```ts
 pluginSass({


### PR DESCRIPTION
## Summary

Update all GitHub repository links for webpack loaders and plugins from `webpack-contrib` to `webpack` organization. This change reflects the recent migration of these packages to the main webpack organization.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
