### PR TITLE
fix(source-map): correct sources in CSS source map

### DIFF
--- a/e2e/cases/source-map/basic/index.test.ts
+++ b/e2e/cases/source-map/basic/index.test.ts
@@ -197,7 +197,7 @@ rspackTest(
 
     const cssSourceMap = findFile(files, 'index.css.map');
     const cssSourceContent = readFileSync(
-      join(__dirname, './src/index.css'),
+      join(cwd, './src/index.css'),
       'utf-8',
     );
 

--- a/packages/core/src/plugins/sourceMap.ts
+++ b/packages/core/src/plugins/sourceMap.ts
@@ -25,12 +25,6 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
   name: 'rsbuild:source-map',
 
   setup(api) {
-    // Use project-relative POSIX paths in source maps:
-    // - Prevents leaking absolute system paths
-    // - Keeps maps portable across environments
-    // - Matches source map spec and debugger expectations
-    const DEFAULT_SOURCE_MAP_TEMPLATE = '[relative-resource-path]';
-
     const enableCssSourceMap = (config: NormalizedEnvironmentConfig) => {
       const { sourceMap } = config.output;
       return typeof sourceMap === 'object' && sourceMap.css;
@@ -42,6 +36,13 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
       const devtool = getDevtool(config);
       chain.devtool(devtool);
 
+      // Use project-relative POSIX paths by default in source maps:
+      // - Prevents leaking absolute system paths
+      // - Keeps maps portable across environments
+      // - Matches source map spec and debugger expectations
+      let filenameTemplate: Rspack.DevtoolModuleFilenameTemplate =
+        '[relative-resource-path]';
+
       if (
         (isDev && target === 'web') ||
         // webpack does not support [relative-resource-path]
@@ -49,13 +50,10 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
       ) {
         // Use POSIX-style absolute paths in source maps during development
         // This ensures VS Code and browser debuggers can correctly resolve breakpoints
-        chain.output.devtoolModuleFilenameTemplate(
-          (info: { absoluteResourcePath: string }) =>
-            toPosixPath(info.absoluteResourcePath),
-        );
-      } else {
-        chain.output.devtoolModuleFilenameTemplate(DEFAULT_SOURCE_MAP_TEMPLATE);
+        filenameTemplate = (info) => toPosixPath(info.absoluteResourcePath);
       }
+
+      chain.output.devtoolModuleFilenameTemplate(filenameTemplate);
 
       // When JS source map is disabled, but CSS source map is enabled,
       // add `SourceMapDevToolPlugin` to let Rspack generate CSS source map.
@@ -64,7 +62,7 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
           {
             test: /\.css$/,
             filename: '[file].map[query]',
-            moduleFilenameTemplate: sourceMapFilenameTemplate,
+            moduleFilenameTemplate: filenameTemplate,
           },
         ]);
       }


### PR DESCRIPTION
## Summary

Ensure the `sources` are relative paths when disabling JS source maps and enabling CSS source maps.

## Related Links

- blocked by https://github.com/web-infra-dev/rspack/issues/12020

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
