### PR TITLE
chore: update prebundle to v1.5.0 and migrate config to TS

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -12,7 +12,7 @@
     ],
     "prebundle": [
       "{projectRoot}/package.json",
-      "{projectRoot}/prebundle.config.mjs"
+      "{projectRoot}/prebundle.config.ts"
     ]
   },
   "targetDefaults": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
     "postcss": "^8.5.6",
     "postcss-load-config": "6.0.1",
     "postcss-loader": "8.2.0",
-    "prebundle": "1.4.2",
+    "prebundle": "1.5.0",
     "range-parser": "^1.2.1",
     "reduce-configs": "^1.1.1",
     "rslog": "^1.3.0",

--- a/packages/core/prebundle.config.ts
+++ b/packages/core/prebundle.config.ts
@@ -1,8 +1,11 @@
-// @ts-check
 import fs from 'node:fs';
 import { join } from 'node:path';
+import type { Config } from 'prebundle';
 
-function replaceFileContent(filePath, replaceFn) {
+function replaceFileContent(
+  filePath: string,
+  replaceFn: (content: string) => string,
+) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const newContent = replaceFn(content);
   if (newContent !== content) {
@@ -10,7 +13,6 @@ function replaceFileContent(filePath, replaceFn) {
   }
 }
 
-/** @type {import('prebundle').Config} */
 export default {
   prettier: true,
   externals: {
@@ -179,4 +181,4 @@ export type SourceMapGenerator = unknown;
       },
     },
   ],
-};
+} satisfies Config;

--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -4,7 +4,7 @@ import { nodeMinifyConfig } from '@rsbuild/config/rslib.config.ts';
 import type { Rspack, rsbuild } from '@rslib/core';
 import { defineConfig } from '@rslib/core';
 import pkgJson from './package.json' with { type: 'json' };
-import prebundleConfig from './prebundle.config.mjs';
+import prebundleConfig from './prebundle.config.ts';
 
 export const define = {
   RSBUILD_VERSION: JSON.stringify(pkgJson.version),

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -44,7 +44,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.12",
     "babel-loader": "10.0.0",
-    "prebundle": "1.4.2",
+    "prebundle": "1.5.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/packages/plugin-babel/prebundle.config.ts
+++ b/packages/plugin-babel/prebundle.config.ts
@@ -1,5 +1,5 @@
-// @ts-check
-/** @type {import('prebundle').Config} */
+import type { Config } from 'prebundle';
+
 export default {
   prettier: true,
   dependencies: [
@@ -11,4 +11,4 @@ export default {
       },
     },
   ],
-};
+} satisfies Config;

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -40,7 +40,7 @@
     "@types/less": "^3.0.8",
     "less": "4.3.0",
     "less-loader": "^12.3.0",
-    "prebundle": "1.4.2",
+    "prebundle": "1.5.0",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {

--- a/packages/plugin-less/prebundle.config.ts
+++ b/packages/plugin-less/prebundle.config.ts
@@ -1,8 +1,11 @@
 import fs from 'node:fs';
-// @ts-check
 import { join } from 'node:path';
+import type { Config } from 'prebundle';
 
-function replaceFileContent(filePath, replaceFn) {
+function replaceFileContent(
+  filePath: string,
+  replaceFn: (content: string) => string,
+) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const newContent = replaceFn(content);
   if (newContent !== content) {
@@ -10,7 +13,6 @@ function replaceFileContent(filePath, replaceFn) {
   }
 }
 
-/** @type {import('prebundle').Config} */
 export default {
   prettier: true,
   dependencies: [
@@ -41,4 +43,4 @@ export default {
       },
     },
   ],
-};
+} satisfies Config;

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.12",
     "@types/sass-loader": "^8.0.10",
-    "prebundle": "1.4.2",
+    "prebundle": "1.5.0",
     "resolve-url-loader": "^5.0.0",
     "sass-loader": "^16.0.6",
     "typescript": "^5.9.3"

--- a/packages/plugin-sass/prebundle.config.ts
+++ b/packages/plugin-sass/prebundle.config.ts
@@ -1,8 +1,11 @@
-// @ts-check
 import fs from 'node:fs';
 import { join } from 'node:path';
+import type { Config } from 'prebundle';
 
-function replaceFileContent(filePath, replaceFn) {
+function replaceFileContent(
+  filePath: string,
+  replaceFn: (content: string) => string,
+) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const newContent = replaceFn(content);
   if (newContent !== content) {
@@ -10,7 +13,6 @@ function replaceFileContent(filePath, replaceFn) {
   }
 }
 
-/** @type {import('prebundle').Config} */
 export default {
   prettier: true,
   dependencies: [
@@ -41,4 +43,4 @@ export default {
       },
     },
   ],
-};
+} satisfies Config;

--- a/packages/plugin-svgr/package.json
+++ b/packages/plugin-svgr/package.json
@@ -42,7 +42,7 @@
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^22.18.12",
     "file-loader": "6.2.0",
-    "prebundle": "1.4.2",
+    "prebundle": "1.5.0",
     "svgo": "^3.3.2",
     "typescript": "^5.9.3",
     "url-loader": "4.1.1"

--- a/packages/plugin-svgr/prebundle.config.ts
+++ b/packages/plugin-svgr/prebundle.config.ts
@@ -1,8 +1,7 @@
-// @ts-check
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { Config } from 'prebundle';
 
-/** @type {import('prebundle').Config} */
 export default {
   prettier: true,
   dependencies: [
@@ -32,4 +31,4 @@ export default {
       },
     },
   ],
-};
+} satisfies Config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -713,8 +713,8 @@ importers:
         specifier: 8.2.0
         version: 8.2.0(patch_hash=7434af0286aadb1ef0e2daed0d97ebc69f717990e106d650e6e515683e89988a)(@rspack/core@1.6.0-beta.1(@swc/helpers@0.5.17))(postcss@8.5.6)(typescript@5.9.3)(webpack@5.102.1)
       prebundle:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       range-parser:
         specifier: ^1.2.1
         version: 1.2.1
@@ -838,8 +838,8 @@ importers:
         specifier: 10.0.0
         version: 10.0.0(@babel/core@7.28.5)(webpack@5.102.1)
       prebundle:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -872,8 +872,8 @@ importers:
         specifier: ^12.3.0
         version: 12.3.0(@rspack/core@1.5.8(@swc/helpers@0.5.17))(less@4.3.0)(webpack@5.102.1)
       prebundle:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -968,8 +968,8 @@ importers:
         specifier: ^8.0.10
         version: 8.0.10
       prebundle:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       resolve-url-loader:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1104,8 +1104,8 @@ importers:
         specifier: 6.2.0
         version: 6.2.0(patch_hash=c76c890d2d68ffdf70bfbc9cb235e0389df929be2e1917766b8946b1de0a8c30)(webpack@5.102.1)
       prebundle:
-        specifier: 1.4.2
-        version: 1.4.2(typescript@5.9.3)
+        specifier: 1.5.0
+        version: 1.5.0(typescript@5.9.3)
       svgo:
         specifier: ^3.3.2
         version: 3.3.2
@@ -3253,8 +3253,8 @@ packages:
     peerDependencies:
       react: '>=18.3.1'
 
-  '@vercel/ncc@0.38.3':
-    resolution: {integrity: sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==}
+  '@vercel/ncc@0.38.4':
+    resolution: {integrity: sha512-8LwjnlP39s08C08J5NstzriPvW1SP8Zfpp1BvC2sI35kPeZnHfxVkCwu4/+Wodgnd60UtT1n8K8zw+Mp7J9JmQ==}
     hasBin: true
 
   '@vercel/oidc@3.0.3':
@@ -5568,8 +5568,8 @@ packages:
   preact@10.27.2:
     resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
 
-  prebundle@1.4.2:
-    resolution: {integrity: sha512-XurCQRE/Irns5mqH7V7VC5C7auIfz431DtBdOhfReb+ypsBdrLO6V5pVjwgrzVJwOx3jbjTvPXUHiw9LqalZPw==}
+  prebundle@1.5.0:
+    resolution: {integrity: sha512-LSSMKEdfKfpBFggevmoe+gjM9un1U9yFk5TE1G+fmOo9JaPpblimQk+Q3PQYJd6jWFMTyCKoJ5gREAMZBBEMjA==}
     hasBin: true
 
   prettier@3.6.2:
@@ -8957,7 +8957,7 @@ snapshots:
       react: 19.2.0
       unhead: 2.0.19
 
-  '@vercel/ncc@0.38.3': {}
+  '@vercel/ncc@0.38.4': {}
 
   '@vercel/oidc@3.0.3': {}
 
@@ -11648,9 +11648,9 @@ snapshots:
 
   preact@10.27.2: {}
 
-  prebundle@1.4.2(typescript@5.9.3):
+  prebundle@1.5.0(typescript@5.9.3):
     dependencies:
-      '@vercel/ncc': 0.38.3
+      '@vercel/ncc': 0.38.4
       prettier: 3.6.2
       rollup: 4.52.5
       rollup-plugin-dts: 6.2.3(rollup@4.52.5)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Upgrade prebundle dependency from 1.4.2 to 1.5.0
- Convert prebundle config files from `.mjs` to `.ts` format

## Related Links

https://github.com/rspack-contrib/prebundle/releases/tag/v1.5.0

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
