### PR TITLE
perf: use COPYFILE_FICLONE mode when copying files

### DIFF
--- a/e2e/helper/fixture.ts
+++ b/e2e/helper/fixture.ts
@@ -5,7 +5,7 @@ import {
   execSync,
   exec as nodeExec,
 } from 'node:child_process';
-import { promises } from 'node:fs';
+import { constants as fsConstants, promises } from 'node:fs';
 import path from 'node:path';
 import base, { expect } from '@playwright/test';
 import fse from 'fs-extra';
@@ -302,6 +302,7 @@ export const test = base.extend<RsbuildFixture>({
       await fse.remove(targetDir);
       await promises.cp(path.join(cwd, 'src'), targetDir, {
         recursive: true,
+        mode: fsConstants.COPYFILE_FICLONE,
       });
       return targetDir;
     };

--- a/packages/core/src/plugins/server.ts
+++ b/packages/core/src/plugins/server.ts
@@ -62,10 +62,11 @@ export const pluginServer = (): RsbuildPlugin => ({
                 });
               }
 
-              return fs.promises.cp(publicDir, distPath, {
+              await fs.promises.cp(publicDir, distPath, {
                 recursive: true,
                 // dereference symlinks
                 dereference: true,
+                mode: fs.constants.COPYFILE_FICLONE,
               });
             }),
           );


### PR DESCRIPTION
## Summary

Leverage `fs.constants.COPYFILE_FICLONE` in `fs.cp` to take advantage of copy-on-write optimizations

This allows faster file copying when supported by the underlying file system, while gracefully falling back to normal copying on unsupported platforms.

## Related Links

- https://github.com/nodejs/node/issues/47861
- https://nodejs.org/api/fs.html#fspromisescpsrc-dest-options

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
