### PR TITLE
release: v1.6.0

### DIFF
--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0",
   "homepage": "https://rsbuild.rs",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.6.0-beta.1",
+  "version": "1.6.0",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "repository": {

--- a/packages/plugin-preact/package.json
+++ b/packages/plugin-preact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/plugin-preact",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Preact plugin for Rsbuild",
   "repository": {
     "type": "git",


### PR DESCRIPTION

## What's Changed
### New Features 🎉
* feat(server): make URLs with the same label more compact by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6349
* feat: support shorter string value for `output.distPath` by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6352
* feat(create-rsbuild): enable ts check for JS config files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6353
* feat: experimental support for ESM web applications by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6356
* feat: add default favicon resolution from public dir by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6362
* feat(deps): update @rspack/core to v1.6.0-beta.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6364
* feat(create-rsbuild): add default favicon by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6367
* feat(plugin-vue): supersede vue-loader with rspack-vue-loader by @fi3ework in https://github.com/web-infra-dev/rsbuild/pull/6390
* feat: enhance browser error log for undefined process.env by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6401
* feat(deps): update @rspack/core to v1.6.0-beta.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6402
* feat: add stack trace control for browser logs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6425
* feat: add full stack trace option for browser logs by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6427
* feat(browser-logs): add method name to error stack summary by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6433
* feat: support JSON imports with raw query by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6438
* feat(create-rsbuild): add AGENTS.md by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6440
* feat(deps): update @rspack/core to v1.6.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6465
### Performance 🚀
* perf(build): merge stats.toJson calls by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6351
* perf(build): enable unsafe fast drop in non-watch mode by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6404
* perf(CLI): change default config loader from jiti to auto by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6406
* perf: lazy load open module to improve startup time by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6407
* perf: speed up accessing stats info by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6414
* perf(server): lazy load range-parser by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6423
* perf: skip assets traversal if source map is disabled by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6457
* perf: use COPYFILE_FICLONE mode when copying files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6461
### Bug Fixes 🐞
* fix: ensure `output.distPath` can be merged correctly by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6369
* fix(core): normalize paths for include/exclude rules on Windows by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6380
* fix(esm): no need to set library type for web target by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6399
* fix(server): replace unescape with decodeURIComponent by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6408
* fix(dev-server): improve error page display by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6412
* fix(types): add LiteralUnion type and apply to assetPrefix by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6416
* fix: apply LiteralUnion to more types for better type safety by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6419
* fix(browser-logs): simplify file paths for full stack trace by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6434
* fix: removing loader chain delimiter from error file name by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6447
* fix(browserLogs): correct source path resolution by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6449
* fix(browser-logs): correct source map path handling for relative paths by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6452
* fix: use relative paths in source maps by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6450
* fix: source map source path when using multiple environments by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6456
* fix(ssr): correct inspect offset when loading bundles by @9aoy in https://github.com/web-infra-dev/rsbuild/pull/6464
### Refactor 🔨
* refactor(server): improve publicDir normalization by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6360
* refactor: simplify public directory path formatting by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6363
* refactor(server): refactor error handling using http code enum by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6409
* refactor(assets-middleware): remove unused utility functions by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6411
* refactor(server): simplify error page by removing headers handling by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6413
### Document 📖
* docs: improve documentation clarity and naturalness by @Copilot in https://github.com/web-infra-dev/rsbuild/pull/6354
* docs: add `'auto'` value of `loader` option in `loadConfig` by @Timeless0911 in https://github.com/web-infra-dev/rsbuild/pull/6355
* docs: improve script loading documentation clarity by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6357
* docs: clarify scriptLoading behavior for existing script tags by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6358
* docs: add version history tables to config files by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6359
* docs: update config file examples with title by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6368
* docs: update `html.favicon` default values by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6378
* docs: update html template documentation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6379
* docs: add section about extending plugin API by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6397
* docs: update `output.module` for web target by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6398
* docs: improve English clarity and natural flow in documentation by @Copilot in https://github.com/web-infra-dev/rsbuild/pull/6382
* docs: output assetPrefix 'auto' documentation and typescript definition by @davide97g in https://github.com/web-infra-dev/rsbuild/pull/6410
* docs: fix TanStack Router link by @xiaohp in https://github.com/web-infra-dev/rsbuild/pull/6417
* docs: improve browser logs documentation by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6418
* docs: improve clarity in documentation files by @Copilot in https://github.com/web-infra-dev/rsbuild/pull/6429
* docs: update browserLogs  for stackTrace option by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6439
* docs(env-vars): add section for accessing env mode in client code by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6446
* docs: update webpack loader repository links by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6448
* docs: improve documentation clarity and naturalness by @Copilot in https://github.com/web-infra-dev/rsbuild/pull/6460
### Other Changes
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6350
* chore(types): add Optional utility type and simplify config types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6361
* chore(deps): update module federation to v0.20.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6344
* release: v1.6.0-beta.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6366
* chore(deps): update dependency svelte to ^5.40.1 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6370
* chore(deps): update actions/setup-node action to v6 - autoclosed by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6371
* chore: remove unnecessary lazyBarrel config by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6373
* chore(deps): update dependency vue-router to ^4.6.3 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6376
* docs: improve English clarity in documentation files by @Copilot in https://github.com/web-infra-dev/rsbuild/pull/6377
* ci: update macOS version to latest by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6381
* chore(deps): update dependency svelte to ^5.41.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6385
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6384
* chore(example): fix JSX file extensions by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6386
* chore(deps): update dependency rslog to ^1.3.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6387
* test(e2e): remove Rspack config validation cases by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6389
* release: @rsbuild/plugin-vue v1.2.0 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6391
* chore(deps): update module federation to v0.21.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6395
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6392
* chore(deps): update dependency @rsbuild/plugin-check-syntax to ^1.5.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6393
* chore(deps): update dependency @rsbuild/plugin-vue to ^1.2.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6394
* chore: remove Rspack config schema env variable by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6403
* release: 1.6.0-beta.1 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6405
* ci: remove redundant pnpm installation from ecosystem ci by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6420
* chore: lock file maintenance by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6421
* ci: remove pnpm cache by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6422
* ci: disable package manager cache in GitHub workflows by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6424
* ci: pin node version to 22.20 in test workflow by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6428
* chore(deps): update dependency @rslib/core to v0.16.1 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6431
* chore(deps): update dependency @biomejs/biome to ^2.3.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6430
* chore(deps): update pnpm to v10.19.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6436
* chore(deps): update dependency nx to v22 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6437
* chore(deps): update dependency @babel/preset-typescript to ^7.28.5 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6443
* chore(deps): update dependency @shikijs/transformers to ^3.14.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6444
* chore(deps): update dependency svelte to ^5.42.2 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6445
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6442
* chore(deps): update dependency @rstest/core to ^0.6.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6453
* chore(deps): update swc monorepo to ^9.5.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6454
* chore(deps): update dependency launch-editor-middleware to ^2.12.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6455
* chore: update prebundle to v1.5.0 and migrate config to TS by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6459
* chore(deps): update dependency memfs to ^4.50.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6463
