### PR TITLE
release: create-rsbuild v1.6.1

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "repository": {


### PR DESCRIPTION
## Summary

Release create-rsbuild v1.6.1 to update `create-rstack` to v1.7.1

- https://github.com/web-infra-dev/rsbuild/pull/6467
- https://github.com/web-infra-dev/rsbuild/pull/6468
- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.1
