### PR TITLE
chore: simplify source map template to string literal

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -289,7 +289,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/compat/webpack/tests/dist",
@@ -677,7 +677,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when produ
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].[contenthash:8].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].[contenthash:8].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/compat/webpack/tests/dist",
@@ -1067,7 +1067,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "[name].js",
     "hashFunction": "xxhash64",
     "library": {
@@ -1431,7 +1431,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].[contenthash:8].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].[contenthash:8].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/compat/webpack/tests/dist",

--- a/packages/core/src/plugins/sourceMap.ts
+++ b/packages/core/src/plugins/sourceMap.ts
@@ -26,11 +26,7 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
   name: 'rsbuild:source-map',
 
   setup(api) {
-    const sourceMapFilenameTemplate = ({
-      absoluteResourcePath,
-    }: {
-      absoluteResourcePath: string;
-    }) => absoluteResourcePath;
+    const DEFAULT_SOURCE_MAP_TEMPLATE = '[absolute-resource-path]';
 
     const enableCssSourceMap = (config: NormalizedEnvironmentConfig) => {
       const { sourceMap } = config.output;
@@ -43,7 +39,7 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
 
       chain
         .devtool(devtool)
-        .output.devtoolModuleFilenameTemplate(sourceMapFilenameTemplate);
+        .output.devtoolModuleFilenameTemplate(DEFAULT_SOURCE_MAP_TEMPLATE);
 
       // When JS source map is disabled, but CSS source map is enabled,
       // add `SourceMapDevToolPlugin` to let Rspack generate CSS source map.
@@ -77,7 +73,7 @@ export const pluginSourceMap = (): RsbuildPlugin => ({
         // which means users want to customize it, skip the default processing.
         if (
           compilation.outputOptions.devtoolModuleFilenameTemplate !==
-          sourceMapFilenameTemplate
+          DEFAULT_SOURCE_MAP_TEMPLATE
         ) {
           return;
         }

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -405,7 +405,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/dist",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -405,7 +405,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/core/tests/dist",
@@ -962,7 +962,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when prod 
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].[contenthash:8].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].[contenthash:8].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/core/tests/dist",
@@ -1444,7 +1444,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "[name].js",
     "hashFunction": "xxhash64",
     "library": {
@@ -1927,7 +1927,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": [Function],
+    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/core/tests/dist",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1836,7 +1836,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "output": {
       "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
       "chunkFilename": "static/js/async/[name].js",
-      "devtoolModuleFilenameTemplate": [Function],
+      "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
       "filename": "static/js/[name].js",
       "hashFunction": "xxhash64",
       "path": "<ROOT>/dist",
@@ -2267,7 +2267,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "output": {
       "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
       "chunkFilename": "[name].js",
-      "devtoolModuleFilenameTemplate": [Function],
+      "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
       "filename": "bundle.js",
       "hashFunction": "xxhash64",
       "library": {


### PR DESCRIPTION
## Summary

Replace the `devtoolModuleFilenameTemplate` function with a string literal `[absolute-resource-path]` to simplify the config.

## Related Links

- https://rspack.rs/config/output#outputdevtoolmodulefilenametemplate

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
