### PR TITLE
fix(sourceMap): use absolute paths in dev for VS Code debugging

### DIFF
--- a/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
+++ b/packages/compat/webpack/tests/__snapshots__/default.test.ts.snap
@@ -289,7 +289,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/compat/webpack/tests/dist",

--- a/packages/core/tests/__snapshots__/builder.test.ts.snap
+++ b/packages/core/tests/__snapshots__/builder.test.ts.snap
@@ -405,7 +405,7 @@ exports[`should use Rspack as the default bundler > apply Rspack correctly 1`] =
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/dist",

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -405,7 +405,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/core/tests/dist",
@@ -1927,7 +1927,7 @@ exports[`tools.rspack > should match snapshot 1`] = `
   "output": {
     "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
     "chunkFilename": "static/js/async/[name].js",
-    "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
+    "devtoolModuleFilenameTemplate": [Function],
     "filename": "static/js/[name].js",
     "hashFunction": "xxhash64",
     "path": "<ROOT>/packages/core/tests/dist",

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1836,7 +1836,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
     "output": {
       "assetModuleFilename": "static/assets/[name].[contenthash:8][ext]",
       "chunkFilename": "static/js/async/[name].js",
-      "devtoolModuleFilenameTemplate": "[absolute-resource-path]",
+      "devtoolModuleFilenameTemplate": [Function],
       "filename": "static/js/[name].js",
       "hashFunction": "xxhash64",
       "path": "<ROOT>/dist",


### PR DESCRIPTION
## Summary

Ensure VS Code and browser debuggers can correctly resolve breakpoints by using POSIX-style absolute paths in source maps during web development.

## Related Links

- https://x.com/mrromro/status/1985290786271887481
- https://github.com/web-infra-dev/rsbuild/pull/6450
- https://github.com/rspack-contrib/rstack-examples/blob/58120c67e835ef14c5730bdad5ffbfafc350c95a/rspack/source-map-with-vscode-debugging/rspack.config.js#L13

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
