### PR TITLE
docs: clarify unsupported options in environments config

### DIFF
--- a/website/docs/en/config/environments.mdx
+++ b/website/docs/en/config/environments.mdx
@@ -7,28 +7,6 @@ Rsbuild supports building outputs for multiple environments. You can use `enviro
 - **Type:**
 
 ```ts
-interface EnvironmentConfig {
-  plugins?: RsbuildPlugins;
-  dev?: Pick<
-    DevConfig,
-    | 'hmr'
-    | 'client'
-    | 'liveReload'
-    | 'assetPrefix'
-    | 'progressBar'
-    | 'lazyCompilation'
-    | 'writeToDisk'
-  >;
-  html?: HtmlConfig;
-  tools?: ToolsConfig;
-  source?: SourceConfig;
-  output?: OutputConfig;
-  resolve?: ResolveConfig;
-  security?: SecurityConfig;
-  performance?: PerformanceConfig;
-  moduleFederation?: ModuleFederationConfig;
-}
-
 type Environments = {
   [name: string]: EnvironmentConfig;
 };
@@ -36,9 +14,16 @@ type Environments = {
 
 - **Default:** `undefined`
 
-:::tip
-`environments` does not support configuring `server` options and some `dev` options, because multiple environments share the same server instance.
-:::
+## Available options
+
+`EnvironmentConfig` is a subset of the Rsbuild configuration, supporting most options.
+
+Since multiple environments share the same server instance, the following options are currently not supported in `EnvironmentConfig`:
+
+- `server.*`
+- `dev.watchFiles`
+- `dev.cliShortcuts`
+- `dev.setupMiddlewares`
 
 ## Example
 

--- a/website/docs/zh/config/environments.mdx
+++ b/website/docs/zh/config/environments.mdx
@@ -7,28 +7,6 @@ Rsbuild 支持同时为多个环境构建产物。你可以使用 `environments`
 - **类型：**
 
 ```ts
-interface EnvironmentConfig {
-  plugins?: RsbuildPlugins;
-  dev?: Pick<
-    DevConfig,
-    | 'hmr'
-    | 'client'
-    | 'liveReload'
-    | 'assetPrefix'
-    | 'progressBar'
-    | 'lazyCompilation'
-    | 'writeToDisk'
-  >;
-  html?: HtmlConfig;
-  tools?: ToolsConfig;
-  source?: SourceConfig;
-  output?: OutputConfig;
-  resolve?: ResolveConfig;
-  security?: SecurityConfig;
-  performance?: PerformanceConfig;
-  moduleFederation?: ModuleFederationConfig;
-}
-
 type Environments = {
   [name: string]: EnvironmentConfig;
 };
@@ -36,9 +14,16 @@ type Environments = {
 
 - **默认值：** `undefined`
 
-:::tip
-`environments` 中不支持配置 `server` 选项以及一部分 `dev` 选项，因为多个 environment 共享同一个 server 实例。
-:::
+## 可用选项
+
+`EnvironmentConfig` 是 Rsbuild 配置的一个子集，支持大部分配置项。
+
+由于多个 environment 共享同一个 server 实例，以下选项暂不支持在 `EnvironmentConfig` 中配置：
+
+- `server.*`
+- `dev.watchFiles`
+- `dev.cliShortcuts`
+- `dev.setupMiddlewares`
 
 ## 示例
 


### PR DESCRIPTION
## Summary

Remove verbose `environments` interface definition and explicitly list unsupported options in docs.

The change makes it clearer which configurations cannot be used with multiple environments due to shared server instance constraints.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
