### PR TITLE
feat: enhance `api.transform` typing with conditional types

### DIFF
--- a/packages/core/src/initPlugins.ts
+++ b/packages/core/src/initPlugins.ts
@@ -149,7 +149,7 @@ export function initPluginAPI({
   };
 
   let transformId = 0;
-  const transformer: Record<string, TransformHandler> = {};
+  const transformer: Record<string, TransformHandler<boolean>> = {};
   const processAssetsFns: {
     environment?: string;
     descriptor: ProcessAssetsDescriptor;

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -304,11 +304,12 @@ type TransformResult =
       map?: string | Rspack.RawSourceMap | null;
     };
 
-export type TransformContext = {
+export type TransformContext<Raw extends boolean = false> = {
   /**
    * The code of the module.
+   * When `raw` is true, this will be a Buffer instead of a string.
    */
-  code: string;
+  code: Raw extends true ? Buffer : string;
   /**
    * The directory path of the currently processed module,
    * which changes with the location of each processed module.
@@ -370,8 +371,8 @@ export type TransformContext = {
   resolve: Rspack.LoaderContext['resolve'];
 };
 
-export type TransformHandler = (
-  context: TransformContext,
+export type TransformHandler<Raw extends boolean = false> = (
+  context: TransformContext<Raw>,
 ) => MaybePromise<TransformResult>;
 
 export type TransformDescriptor = {
@@ -449,9 +450,9 @@ export type TransformDescriptor = {
   order?: HookOrder;
 };
 
-export type TransformHook = (
-  descriptor: TransformDescriptor,
-  handler: TransformHandler,
+export type TransformHook = <T extends TransformDescriptor>(
+  descriptor: T,
+  handler: TransformHandler<T['raw'] extends true ? true : false>,
 ) => void;
 
 export type ProcessAssetsStage =


### PR DESCRIPTION
## Summary

Previously, the `code` property of `api.transform` was always typed as `string | Buffer`, requiring type checking even when the raw mode was known at compile time:

```ts
api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
  if (Buffer.isBuffer(code)) {
    // 
  }
});
```

This PR implemented conditional typing that provides precise types based on the `raw` option:

```ts
// When raw: true, code is definitively Buffer
api.transform({ test: /\.node$/, raw: true }, ({ code }) => {
  // code is typed as Buffer
  emitFile(name, code);
});
```

## Related Links

close https://github.com/web-infra-dev/rsbuild/pull/6017

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
