### PR TITLE
feat(create-rsbuild): allow to omit --dir flag

### DIFF
--- a/e2e/cases/create-rsbuild/helper.ts
+++ b/e2e/cases/create-rsbuild/helper.ts
@@ -30,7 +30,7 @@ export const createAndValidate = async (
   const dir = path.join(cwd, name);
   await fse.remove(dir);
 
-  let command = `node ${CREATE_RSBUILD_BIN_PATH} -d ${name} -t ${template}`;
+  let command = `node ${CREATE_RSBUILD_BIN_PATH} ${name} -t ${template}`;
   if (tools.length) {
     const toolsCmd = tools.map((tool) => `--tools ${tool}`).join(' ');
     command += ` ${toolsCmd}`;

--- a/e2e/cases/create-rsbuild/tsTemplates.test.ts
+++ b/e2e/cases/create-rsbuild/tsTemplates.test.ts
@@ -7,6 +7,7 @@ rspackTest('should create react-ts project as expected', async () => {
   expect(pkgJson.dependencies['react-dom']).toBeTruthy();
   expect(pkgJson.devDependencies['@rsbuild/plugin-react']).toBeTruthy();
 });
+
 rspackTest('should create react18-ts project as expected', async () => {
   const { pkgJson } = await createAndValidate(__dirname, 'react18-ts');
   expect(pkgJson.dependencies.react.startsWith('^18')).toBeTruthy();

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -29,7 +29,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "create-rstack": "1.7.1"
+    "create-rstack": "1.7.3"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,8 +761,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.7.1
-        version: 1.7.1
+        specifier: 1.7.3
+        version: 1.7.3
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3893,8 +3893,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.7.1:
-    resolution: {integrity: sha512-QqWum6q0zDqDwAyqI16jPhyiA6ERN5REwv4KxXaD7WY/n6IRDHu1U+vHe80MML65WPmQ399XMHJPmAha+phKGw==}
+  create-rstack@1.7.3:
+    resolution: {integrity: sha512-6EtWXj/mJbJz/KfEK4Vxw3h+tRitu5WAHH+qPx+fv5VBElAjbgEUeAKVL0ydxxDIvUhiV7GlRVJcE4zDuG20fA==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9743,7 +9743,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-rstack@1.7.1: {}
+  create-rstack@1.7.3: {}
 
   cron-parser@4.9.0:
     dependencies:

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -100,33 +100,33 @@ To create an application in the current directory, set the target folder to `.`:
 
 ### Non-interactive mode
 
-[create-rsbuild](https://npmjs.com/package/create-rsbuild) provides several CLI options. With these options, you can skip interactive prompts and create an app directly in non-interactive mode.
+[create-rsbuild](https://npmjs.com/package/create-rsbuild) supports a non-interactive mode through command-line options. This mode lets you skip all prompts and create a project directly, which is useful for scripts, CI, and coding agents.
 
 For example, the following command creates a React app in the `my-app` directory:
 
 ```bash
-npx -y create-rsbuild --dir my-app --template react
+npx -y create-rsbuild@latest my-app --template react
 
 # Using abbreviations
-npx -y create-rsbuild -d my-app -t react
+npx -y create-rsbuild@latest my-app -t react
 
 # Specify multiple tools
-npx -y create-rsbuild -d my-app -t react --tools eslint --tools prettier
+npx -y create-rsbuild@latest my-app -t react --tools eslint --tools prettier
 ```
 
 All CLI flags supported by `create-rsbuild`:
 
 ```
-Usage: create-rsbuild [options]
+Usage: create-rsbuild [dir] [options]
 
 Options:
 
-  -h, --help       display help for command
-  -d, --dir        create project in specified directory
-  -t, --template   specify the template to use
-  --tools          select additional tools (biome, eslint, prettier)
-  --override       override files in target directory
-  --package-name   specify the package name
+  -h, --help            display help for command
+  -d, --dir <dir>       create project in specified directory
+  -t, --template <tpl>  specify the template to use
+  --tools <tool>        select additional tools (biome, eslint, prettier)
+  --override            override files in target directory
+  --packageName <name>  specify the package name
 
 Templates:
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -100,7 +100,7 @@ Biome 提供与 ESLint 和 Prettier 相似的代码检查和格式化功能。�
 
 ### 非交互模式
 
-[create-rsbuild](https://npmjs.com/package/create-rsbuild) 提供了一些 CLI 选项。通过这些选项，你可以跳过交互式提示，直接以非交互模式创建应用。
+[create-rsbuild](https://npmjs.com/package/create-rsbuild) 支持通过命令行选项进入非交互模式。使用该模式可以跳过所有提示，直接创建项目，适合脚本、CI 以及 coding agents 等自动化场景。
 
 例如，以下命令将在 `my-app` 目录中创建一个 React 应用：
 
@@ -117,16 +117,16 @@ npx -y create-rsbuild -d my-app -t react --tools eslint --tools prettier
 `create-rsbuild` 完整的 CLI 选项如下：
 
 ```
-Usage: create-rsbuild [options]
+Usage: create-rsbuild [dir] [options]
 
 Options:
 
-  -h, --help       display help for command
-  -d, --dir        create project in specified directory
-  -t, --template   specify the template to use
-  --tools          select additional tools (biome, eslint, prettier)
-  --override       override files in target directory
-  --package-name   specify the package name
+  -h, --help            display help for command
+  -d, --dir <dir>       create project in specified directory
+  -t, --template <tpl>  specify the template to use
+  --tools <tool>        select additional tools (biome, eslint, prettier)
+  --override            override files in target directory
+  --packageName <name>  specify the package name
 
 Templates:
 


### PR DESCRIPTION
## Summary

- Update create-rstack dependency from 1.7.1 to 1.7.3
- Remove redundant -d flag in create-rsbuild command
- Improve CLI documentation for non-interactive mode

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.3

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
