### PR TITLE
refactor: replace any type with unknown in type definitions

### DIFF
--- a/e2e/helper/logs.ts
+++ b/e2e/helper/logs.ts
@@ -148,7 +148,7 @@ export const proxyConsole = ({
     restores.push(() => {
       console[type] = method;
     });
-    console[type] = (...args: any[]) => {
+    console[type] = (...args: unknown[]) => {
       const logMessage = args
         .map((arg) => {
           if (typeof arg === 'string') {

--- a/packages/plugin-less/src/index.ts
+++ b/packages/plugin-less/src/index.ts
@@ -11,7 +11,7 @@ import { reduceConfigsWithContext } from 'reduce-configs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-export const isPlainObject = (obj: unknown): obj is Record<string, any> => {
+export const isPlainObject = (obj: unknown): obj is Record<string, unknown> => {
   return (
     obj !== null &&
     typeof obj === 'object' &&

--- a/packages/plugin-react/src/splitChunks.ts
+++ b/packages/plugin-react/src/splitChunks.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import type { SplitReactChunkOptions } from './index.js';
 
-const isPlainObject = (obj: unknown): obj is Record<string, any> =>
+const isPlainObject = (obj: unknown): obj is Record<string, unknown> =>
   obj !== null &&
   typeof obj === 'object' &&
   Object.prototype.toString.call(obj) === '[object Object]';

--- a/packages/plugin-sass/src/helpers.ts
+++ b/packages/plugin-sass/src/helpers.ts
@@ -26,9 +26,10 @@ function unpatchGlobalLocation() {
   }
 }
 
-type CompilerTapFn<CallBack extends (...args: any[]) => void = () => void> = {
-  tap: (name: string, cb: CallBack) => void;
-};
+type CompilerTapFn<CallBack extends (...args: unknown[]) => void = () => void> =
+  {
+    tap: (name: string, cb: CallBack) => void;
+  };
 
 export function patchCompilerGlobalLocation(compiler: {
   hooks: {
@@ -45,6 +46,11 @@ export function patchCompilerGlobalLocation(compiler: {
   compiler.hooks.done.tap('PatchGlobalLocation', unpatchGlobalLocation);
 }
 
+type ResolveUrlJoinItem = {
+  uri: string;
+  [key: string]: unknown;
+};
+
 /**
  * fix resolve-url-loader can't deal with resolve.alias config
  *
@@ -58,13 +64,15 @@ export const getResolveUrlJoinFn = (): ((...args: unknown[]) => void) => {
     defaultJoinGenerator,
   } = resolveUrlHelpers;
 
-  const rsbuildGenerator = asGenerator((item: any, ...rest: any[]) => {
-    // only handle relative path (not absolutely accurate, but can meet common scenarios)
-    if (!item.uri.startsWith('.')) {
-      return [null];
-    }
-    return defaultJoinGenerator(item, ...rest);
-  });
+  const rsbuildGenerator = asGenerator(
+    (item: ResolveUrlJoinItem, ...rest: unknown[]) => {
+      // only handle relative path (not absolutely accurate, but can meet common scenarios)
+      if (!item.uri.startsWith('.')) {
+        return [null];
+      }
+      return defaultJoinGenerator(item, ...rest);
+    },
+  );
   return createJoinFunction(
     'rsbuild-resolve-join-fn',
     createJoinImplementation(rsbuildGenerator),

--- a/packages/plugin-svelte/src/index.ts
+++ b/packages/plugin-svelte/src/index.ts
@@ -21,9 +21,9 @@ export interface SvelteLoaderOptions {
   hotOptions?: {
     /** Preserve local component state */
     preserveLocalState?: boolean;
-    [key: string]: any;
+    [key: string]: unknown;
   };
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 export type PluginSvelteOptions = {

--- a/packages/plugin-vue/src/splitChunks.ts
+++ b/packages/plugin-vue/src/splitChunks.ts
@@ -1,7 +1,7 @@
 import type { RsbuildPluginAPI, Rspack } from '@rsbuild/core';
 import type { SplitVueChunkOptions } from './index.js';
 
-const isPlainObject = (obj: unknown): obj is Record<string, any> =>
+const isPlainObject = (obj: unknown): obj is Record<string, unknown> =>
   obj !== null &&
   typeof obj === 'object' &&
   Object.prototype.toString.call(obj) === '[object Object]';


### PR DESCRIPTION
## Summary

Replace usage of `any` type with `unknown` in various type definitions across multiple plugins to improve type safety and maintainability. 

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
