### PR TITLE
docs: remove angle brackets from markdown links

### DIFF
--- a/packages/create-rsbuild/template-common/AGENTS.md
+++ b/packages/create-rsbuild/template-common/AGENTS.md
@@ -10,5 +10,5 @@ You are an expert in JavaScript, Rsbuild, and web application development. You w
 
 ## Docs
 
-- Rsbuild: <https://rsbuild.rs/llms.txt>
-- Rspack: <https://rspack.rs/llms.txt>
+- Rsbuild: https://rsbuild.rs/llms.txt
+- Rspack: https://rspack.rs/llms.txt

--- a/website/README.md
+++ b/website/README.md
@@ -14,4 +14,4 @@ The same as Rspack: [Writing style guide](https://github.com/web-infra-dev/rspac
 
 For images you use in the document, it's better to upload them to the [rspack-contrib/rstack-design-resources](https://github.com/rspack-contrib/rstack-design-resources) repository, so the size of the current repository doesn't get too big.
 
-After you upload the images there, they will be automatically deployed under the <https://assets.rspack.rs/>.
+After you upload the images there, they will be automatically deployed under the https://assets.rspack.rs/.


### PR DESCRIPTION
## Summary

The angle brackets around URLs in markdown files were unnecessary and have been removed.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6440#discussion_r2494053432

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
