### PR TITLE
build(core): enable advanced ESM

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -91,6 +91,9 @@ export default defineConfig({
     {
       id: 'esm_index',
       format: 'esm',
+      experiments: {
+        advancedEsm: true,
+      },
       syntax: 'es2022',
       plugins: [pluginFixDtsTypes],
       dts: {
@@ -111,6 +114,9 @@ export default defineConfig({
     {
       id: 'esm_loaders',
       format: 'esm',
+      experiments: {
+        advancedEsm: true,
+      },
       syntax: 'es2022',
       source: {
         entry: {
@@ -142,6 +148,9 @@ export default defineConfig({
     {
       id: 'esm_client',
       format: 'esm',
+      experiments: {
+        advancedEsm: true,
+      },
       syntax: 'es2017',
       source: {
         entry: {


### PR DESCRIPTION
## Summary

Enable Rslib's advanced ESM features for all ESM builds of `@rsbuild/core`.

## Before

```bash
File (esm_index)         Size
dist/0~range-parser.js   2.4 kB
dist/0~open.js           18.3 kB
dist/index.js            495.2 kB

                Total:   515.9 kB


File (esm_loaders)            Size
dist/ignoreCssLoader.mjs      0.19 kB
dist/transformLoader.mjs      2.1 kB
dist/transformRawLoader.mjs   2.1 kB

                     Total:   4.5 kB
```

## After

```bash
File (esm_index)         Size
dist/0~range-parser.js   2.3 kB
dist/rslib-runtime.js    2.3 kB
dist/0~open.js           14.9 kB
dist/index.js            489.7 kB

                Total:   509.2 kB


File (esm_loaders)            Size
dist/ignoreCssLoader.mjs      0.13 kB
dist/223.mjs                  0.55 kB
dist/transformLoader.mjs      1.6 kB
dist/transformRawLoader.mjs   1.7 kB

                     Total:   4.0 kB
```

## Related Links

- https://rspack.rs/blog/announcing-1-6#improved-esm-output

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
