### PR TITLE
Revert "build(core): enable advanced ESM (#6513)"

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -91,9 +91,6 @@ export default defineConfig({
     {
       id: 'esm_index',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2022',
       plugins: [pluginFixDtsTypes],
       dts: {
@@ -114,9 +111,6 @@ export default defineConfig({
     {
       id: 'esm_loaders',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2022',
       source: {
         entry: {
@@ -148,9 +142,6 @@ export default defineConfig({
     {
       id: 'esm_client',
       format: 'esm',
-      experiments: {
-        advancedEsm: true,
-      },
       syntax: 'es2017',
       source: {
         entry: {


### PR DESCRIPTION
## Summary

This reverts PR https://github.com/web-infra-dev/rsbuild/pull/6513 because the `advancedEsm` introduced some unexpected exports:

<img width="836" height="683" alt="Screenshot 2025-11-07 at 08 06 41" src="https://github.com/user-attachments/assets/ac4e33ef-1844-48ae-83bc-6603810472c4" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
