### PR TITLE
chore: update comments for pathinfo

### DIFF
--- a/packages/core/src/plugins/output.ts
+++ b/packages/core/src/plugins/output.ts
@@ -116,9 +116,8 @@ export const pluginOutput = (): RsbuildPlugin => ({
               : posix.join(jsAsyncPath, jsFilename),
           )
           .publicPath(publicPath)
-          // disable pathinfo to improve compile performance
-          // the path info is useless in most cases
-          // see: https://webpack.js.org/guides/build-performance/#output-without-path-info
+          // `pathinfo` is disabled because Rspack's `moduleId` in development mode already
+          // contains the path information. Disabling it helps produce cleaner output.
           .pathinfo(false)
           // since webpack v5.54.0+, hashFunction supports xxhash64 as a faster algorithm
           // which will be used as default when experiments.futureDefaults is enabled.


### PR DESCRIPTION
## Summary

Updated comment to clarify why `pathinfo` is disabled, referencing Rspack's `moduleId` behavior in development mode.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
