### PR TITLE
docs: update TransformResult type to include Buffer

### DIFF
--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -464,8 +464,9 @@ type TransformContext = {
 
 type TransformResult =
   | string
+  | Buffer
   | {
-      code: string;
+      code: string | Buffer;
       map?: string | Rspack.sources.RawSourceMap | null;
     };
 

--- a/website/docs/zh/plugins/dev/core.mdx
+++ b/website/docs/zh/plugins/dev/core.mdx
@@ -464,8 +464,9 @@ type TransformContext = {
 
 type TransformResult =
   | string
+  | Buffer
   | {
-      code: string;
+      code: string | Buffer;
       map?: string | Rspack.sources.RawSourceMap | null;
     };
 


### PR DESCRIPTION
## Summary

Update documentation to include Buffer as a possible type for `TransformResult`.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6522

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
