### PR TITLE
docs(create-rsbuild): add config documentation link to all templates

### DIFF
--- a/packages/create-rsbuild/template-lit-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-lit-js/rsbuild.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from '@rsbuild/core';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   html: {
     template: './src/index.html',

--- a/packages/create-rsbuild/template-lit-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-lit-ts/rsbuild.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rsbuild/core';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   html: {
     template: './src/index.html',

--- a/packages/create-rsbuild/template-preact-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-preact-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginPreact } from '@rsbuild/plugin-preact';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginPreact()],
 });

--- a/packages/create-rsbuild/template-preact-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-preact-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginPreact } from '@rsbuild/plugin-preact';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginPreact()],
 });

--- a/packages/create-rsbuild/template-react-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-react-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
 });

--- a/packages/create-rsbuild/template-react-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-react-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
 });

--- a/packages/create-rsbuild/template-react18-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-react18-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
 });

--- a/packages/create-rsbuild/template-react18-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-react18-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginReact } from '@rsbuild/plugin-react';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
 });

--- a/packages/create-rsbuild/template-solid-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-solid-js/rsbuild.config.js
@@ -3,6 +3,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [
     pluginBabel({

--- a/packages/create-rsbuild/template-solid-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-solid-ts/rsbuild.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@rsbuild/core';
 import { pluginBabel } from '@rsbuild/plugin-babel';
 import { pluginSolid } from '@rsbuild/plugin-solid';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [
     pluginBabel({

--- a/packages/create-rsbuild/template-svelte-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-svelte-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginSvelte()],
 });

--- a/packages/create-rsbuild/template-svelte-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-svelte-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginSvelte } from '@rsbuild/plugin-svelte';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginSvelte()],
 });

--- a/packages/create-rsbuild/template-vanilla-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-vanilla-js/rsbuild.config.js
@@ -1,4 +1,5 @@
 // @ts-check
 import { defineConfig } from '@rsbuild/core';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({});

--- a/packages/create-rsbuild/template-vanilla-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-vanilla-ts/rsbuild.config.ts
@@ -1,3 +1,4 @@
 import { defineConfig } from '@rsbuild/core';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({});

--- a/packages/create-rsbuild/template-vue2-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-vue2-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginVue2()],
 });

--- a/packages/create-rsbuild/template-vue2-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-vue2-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue2 } from '@rsbuild/plugin-vue2';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginVue2()],
 });

--- a/packages/create-rsbuild/template-vue3-js/rsbuild.config.js
+++ b/packages/create-rsbuild/template-vue3-js/rsbuild.config.js
@@ -2,6 +2,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginVue()],
 });

--- a/packages/create-rsbuild/template-vue3-ts/rsbuild.config.ts
+++ b/packages/create-rsbuild/template-vue3-ts/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@rsbuild/core';
 import { pluginVue } from '@rsbuild/plugin-vue';
 
+// Docs: https://rsbuild.rs/config/
 export default defineConfig({
   plugins: [pluginVue()],
 });


### PR DESCRIPTION
## Summary

This pull request adds a documentation comment to the top of each `rsbuild.config` file in all templates.
## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
