### PR TITLE
fix(core): improve error file location formatting

### DIFF
--- a/e2e/cases/plugin-vue/sfc-build-error/index.test.ts
+++ b/e2e/cases/plugin-vue/sfc-build-error/index.test.ts
@@ -1,6 +1,7 @@
 import { rspackTest } from '@e2e/helper';
 
-const EXPECTED_FILE = 'File: ./src/App.vue.js?vue&type=script&lang=js:1:0-312';
+const EXPECTED_FILE =
+  /File: \.\/src\/App\.vue\.js\?vue&type=script&lang=js:1:0-\d+/;
 const EXPECTED_ERROR = `× ESModulesLinkingError: export 'default' (reexported as 'default') was not found`;
 
 rspackTest('should display Vue compilation error in dev', async ({ dev }) => {

--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -2,17 +2,21 @@ import type { StatsError } from '@rspack/core';
 import { removeLoaderChainDelimiter } from './stats';
 import { color } from './vendors';
 
-const formatFileName = (fileName: string) => {
+const formatFileName = (fileName: string, stats: StatsError) => {
   // File name may be empty when the error is not related to a file.
   // For example, when an invalid entry is provided.
   if (!fileName) {
     return '';
   }
 
+  if (/:\d+:\d+/.test(fileName)) {
+    return `File: ${color.cyan(fileName)}\n`;
+  }
+  if (stats.loc) {
+    return `File: ${color.cyan(`${fileName}:${stats.loc}`)}\n`;
+  }
   // add default column add lines for linking
-  return /:\d+:\d+/.test(fileName)
-    ? `File: ${color.cyan(fileName)}\n`
-    : `File: ${color.cyan(`${fileName}:1:1`)}\n`;
+  return `File: ${color.cyan(`${fileName}:1:1`)}\n`;
 };
 
 function resolveFileName(stats: StatsError) {
@@ -228,8 +232,7 @@ export function formatStatsError(stats: StatsError, verbose?: boolean): string {
     verbose && stats.details ? `\nDetails: ${stats.details}\n` : '';
   const stack = verbose && stats.stack ? `\n${stats.stack}` : '';
   const moduleTrace = formatModuleTrace(stats, fileName) ?? '';
-  const loc = stats.loc ? `:${stats.loc}` : '';
-  message = `${formatFileName(fileName + loc)}${mainMessage}${details}${stack}${moduleTrace}`;
+  message = `${formatFileName(fileName, stats)}${mainMessage}${details}${stack}${moduleTrace}`;
 
   // Remove inner error message
   const innerError = '-- inner error --';


### PR DESCRIPTION
## Summary

- If the `fileName` already includes `loc`, do not append `stats.loc`.
- Fix the Windows e2e case.

## Related

- https://github.com/web-infra-dev/rsbuild/pull/6540

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
