### PR TITLE
feat: apply CSS transformation for inlined CSS in Node bundles

### DIFF
--- a/e2e/cases/css/inline-query-node-target/index.test.ts
+++ b/e2e/cases/css/inline-query-node-target/index.test.ts
@@ -1,0 +1,28 @@
+import { expect, rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should transform inlined CSS via lightningcss if target is node in dev',
+  async ({ devOnly }) => {
+    await devOnly();
+
+    // @ts-ignore
+    const { style } = await import('./dist-dev/index.js');
+    expect(style).toContain(`.foo {
+  -webkit-transition: all .5s;
+  transition: all .5s;
+}`);
+  },
+);
+
+rspackTest(
+  'should transform inlined CSS via lightningcss if target is node in build',
+  async ({ build }) => {
+    await build();
+
+    // @ts-ignore
+    const { style } = await import('./dist-build/index.js');
+    expect(style).toContain(
+      '.foo{-webkit-transition:all .5s;transition:all .5s}',
+    );
+  },
+);

--- a/e2e/cases/css/inline-query-node-target/rsbuild.config.ts
+++ b/e2e/cases/css/inline-query-node-target/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    target: 'node',
+    module: true,
+    overrideBrowserslist: ['Android >= 4.0'],
+    distPath: process.env.NODE_ENV === 'production' ? 'dist-build' : 'dist-dev',
+  },
+  dev: {
+    writeToDisk: true,
+  },
+});

--- a/e2e/cases/css/inline-query-node-target/src/foo.css
+++ b/e2e/cases/css/inline-query-node-target/src/foo.css
@@ -1,0 +1,3 @@
+.foo {
+  transition: all 0.5s;
+}

--- a/e2e/cases/css/inline-query-node-target/src/index.js
+++ b/e2e/cases/css/inline-query-node-target/src/index.js
@@ -1,0 +1,3 @@
+import style from './foo.css?inline';
+
+export { style };

--- a/packages/core/tests/__snapshots__/css.test.ts.snap
+++ b/packages/core/tests/__snapshots__/css.test.ts.snap
@@ -133,7 +133,7 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
-              "importLoaders": 0,
+              "importLoaders": 1,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -160,9 +160,18 @@ exports[`plugin-css injectStyles > should apply ignoreCssLoader when injectStyle
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
               "exportType": "string",
-              "importLoaders": 0,
+              "importLoaders": 1,
               "modules": false,
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "node >= 16",
+              ],
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/default.test.ts.snap
+++ b/packages/core/tests/__snapshots__/default.test.ts.snap
@@ -1136,7 +1136,7 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
           {
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
-              "importLoaders": 0,
+              "importLoaders": 1,
               "modules": {
                 "auto": true,
                 "exportGlobals": false,
@@ -1163,9 +1163,18 @@ exports[`applyDefaultPlugins > should apply default plugins correctly when targe
             "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
             "options": {
               "exportType": "string",
-              "importLoaders": 0,
+              "importLoaders": 1,
               "modules": false,
               "sourceMap": false,
+            },
+          },
+          {
+            "loader": "builtin:lightningcss-loader",
+            "options": {
+              "errorRecovery": true,
+              "targets": [
+                "node >= 16",
+              ],
             },
           },
         ],

--- a/packages/core/tests/__snapshots__/environments.test.ts.snap
+++ b/packages/core/tests/__snapshots__/environments.test.ts.snap
@@ -1966,7 +1966,7 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
             {
               "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
               "options": {
-                "importLoaders": 0,
+                "importLoaders": 1,
                 "modules": {
                   "auto": true,
                   "exportGlobals": false,
@@ -1993,9 +1993,18 @@ exports[`environment config > tools.rspack / bundlerChain can be configured in e
               "loader": "<ROOT>/packages/core/compiled/css-loader/index.js",
               "options": {
                 "exportType": "string",
-                "importLoaders": 0,
+                "importLoaders": 1,
                 "modules": false,
                 "sourceMap": false,
+              },
+            },
+            {
+              "loader": "builtin:lightningcss-loader",
+              "options": {
+                "errorRecovery": true,
+                "targets": [
+                  "node >= 16",
+                ],
               },
             },
           ],


### PR DESCRIPTION
## Summary

This change enables `postcss-loader` and `lightningcss-loader` for `.css?inline` files when building Node bundles.

Previously, CSS transformations only applied to web bundles, but `.css?inline` is also valid in SSR builds. Applying CSS transformation on the server side ensures that inline CSS content is processed consistently between Web and Node bundles, preventing mismatches during SSR hydration.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
