### PR TITLE
feat: exposes environments in `tools.rspack`

### DIFF
--- a/packages/compat/webpack/src/webpackConfig.ts
+++ b/packages/compat/webpack/src/webpackConfig.ts
@@ -64,6 +64,7 @@ async function modifyWebpackConfig(
 async function getChainUtils(
   target: RsbuildTarget,
   environment: EnvironmentContext,
+  environments: Record<string, EnvironmentContext>,
   helpers: RsbuildProviderHelpers,
 ): Promise<ModifyWebpackChainUtils> {
   const { default: webpack } = await import('webpack');
@@ -74,7 +75,7 @@ async function getChainUtils(
   };
 
   return {
-    ...helpers.getChainUtils(target, environment),
+    ...helpers.getChainUtils(target, environment, environments),
     name: nameMap[target] || '',
     webpack,
     HtmlWebpackPlugin: helpers.getHTMLPlugin(),
@@ -95,6 +96,7 @@ export async function generateWebpackConfig({
   const chainUtils = await getChainUtils(
     target,
     context.environments[environment],
+    context.environments,
     helpers,
   );
   const { default: webpack } = await import('webpack');

--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -322,12 +322,13 @@ export async function initConfigs({
   const normalizedConfig = await initRsbuildConfig({ context, pluginManager });
 
   const rspackConfigs = await Promise.all(
-    Object.entries(normalizedConfig.environments).map(([environment, config]) =>
-      generateRspackConfig({
-        target: config.output.target,
-        context,
-        environment,
-      }),
+    Object.entries(normalizedConfig.environments).map(
+      ([environmentName, config]) =>
+        generateRspackConfig({
+          target: config.output.target,
+          context,
+          environmentName,
+        }),
     ),
   );
 

--- a/packages/core/src/provider/rspackConfig.ts
+++ b/packages/core/src/provider/rspackConfig.ts
@@ -130,12 +130,14 @@ export function getConfigUtils(
 export function getChainUtils(
   target: RsbuildTarget,
   environment: EnvironmentContext,
+  environments: Record<string, EnvironmentContext>,
 ): ModifyChainUtils {
   const nodeEnv = getNodeEnv();
 
   return {
     rspack,
     environment,
+    environments,
     env: nodeEnv,
     target,
     isDev: environment.config.mode === 'development',
@@ -177,13 +179,17 @@ function validateRspackConfig(config: Rspack.Configuration) {
 export async function generateRspackConfig({
   target,
   context,
-  environment,
+  environmentName,
 }: {
-  environment: string;
   target: RsbuildTarget;
   context: InternalContext;
+  environmentName: string;
 }): Promise<Rspack.Configuration> {
-  const chainUtils = getChainUtils(target, context.environments[environment]);
+  const chainUtils = getChainUtils(
+    target,
+    context.environments[environmentName],
+    context.environments,
+  );
   const {
     BannerPlugin,
     DefinePlugin,

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -96,7 +96,7 @@ export type InternalContext = RsbuildContext & {
    * can be used in all environments.
    */
   getPluginAPI?: (environment?: string) => RsbuildPluginAPI;
-  /** The environment context. */
+  /** Context information for all environments. */
   environments: Record<string, EnvironmentContext>;
   /** Only build specified environment. */
   specifiedEnvironments?: string[];

--- a/packages/core/src/types/hooks.ts
+++ b/packages/core/src/types/hooks.ts
@@ -30,6 +30,9 @@ export type OnCloseBuildFn = () => MaybePromise<void>;
 
 export type OnBeforeBuildFn<B = 'rspack'> = (
   params: CompileCommonParams & {
+    /**
+     * Context information for all environments.
+     */
     environments: Record<string, EnvironmentContext>;
     bundlerConfigs?: B extends 'rspack'
       ? Rspack.Configuration[]
@@ -39,6 +42,9 @@ export type OnBeforeBuildFn<B = 'rspack'> = (
 
 export type OnBeforeDevCompileFn<B = 'rspack'> = (
   params: CompileCommonParams & {
+    /**
+     * Context information for all environments.
+     */
     environments: Record<string, EnvironmentContext>;
     bundlerConfigs?: B extends 'rspack'
       ? Rspack.Configuration[]
@@ -56,6 +62,9 @@ export type OnAfterEnvironmentCompileFn = (
 export type OnAfterBuildFn = (
   params: CompileCommonParams & {
     stats?: Rspack.Stats | Rspack.MultiStats;
+    /**
+     * Context information for all environments.
+     */
     environments: Record<string, EnvironmentContext>;
   },
 ) => MaybePromise<void>;
@@ -65,6 +74,9 @@ export type OnCloseDevServerFn = () => MaybePromise<void>;
 export type OnAfterDevCompileFn = (params: {
   isFirstCompile: boolean;
   stats: Rspack.Stats | Rspack.MultiStats;
+  /**
+   * Context information for all environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
@@ -79,7 +91,7 @@ export type OnBeforeStartDevServerFn = (params: {
    */
   server: RsbuildDevServer;
   /**
-   * A read-only object that provides some context information about different environments.
+   * Context information for all environments.
    */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<(() => void) | void>;
@@ -94,17 +106,26 @@ export type Routes = {
 export type OnAfterStartDevServerFn = (params: {
   port: number;
   routes: Routes;
+  /**
+   * Context information for all environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnAfterStartProdServerFn = (params: {
   port: number;
   routes: Routes;
+  /**
+   * Context information for all environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
 export type OnBeforeCreateCompilerFn<B = 'rspack'> = (params: {
   bundlerConfigs: B extends 'rspack' ? Rspack.Configuration[] : WebpackConfig[];
+  /**
+   * Context information for all environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
@@ -112,6 +133,9 @@ export type OnAfterCreateCompilerFn<
   Compiler = Rspack.Compiler | Rspack.MultiCompiler,
 > = (params: {
   compiler: Compiler;
+  /**
+   * Context information for all environments.
+   */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;
 
@@ -276,6 +300,10 @@ export type ModifyChainUtils = {
    * The environment context for current build.
    */
   environment: EnvironmentContext;
+  /**
+   * Context information for all environments.
+   */
+  environments: Record<string, EnvironmentContext>;
   /**
    * The Rspack instance, same as `import { rspack } from '@rsbuild/core'`.
    */

--- a/website/docs/en/config/tools/bundler-chain.mdx
+++ b/website/docs/en/config/tools/bundler-chain.mdx
@@ -170,13 +170,29 @@ export default {
 
 - **Type:** [EnvironmentContext](/api/javascript-api/environment-api#environment-context)
 
-Context information about the current environment.
+Context information for the current environment.
 
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
     bundlerChain: (chain, { environment }) => {
       console.log(environment);
+    },
+  },
+};
+```
+
+### environments
+
+- **Type:** `Record<string, EnvironmentContext>`
+
+Context information for all environments.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain: (chain, { environments }) => {
+      console.log(environments);
     },
   },
 };

--- a/website/docs/en/config/tools/rspack.mdx
+++ b/website/docs/en/config/tools/rspack.mdx
@@ -222,13 +222,29 @@ export default {
 
 - **Type:** [EnvironmentContext](/api/javascript-api/environment-api#environment-context)
 
-Context information about the current environment.
+Context information for the current environment.
 
 ```ts title="rsbuild.config.ts"
 export default {
   tools: {
     rspack: (config, { environment }) => {
       console.log(environment);
+    },
+  },
+};
+```
+
+### environments
+
+- **Type:** `Record<string, EnvironmentContext>`
+
+Context information for all environments.
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: (chain, { environments }) => {
+      console.log(environments);
     },
   },
 };

--- a/website/docs/en/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/en/shared/onBeforeStartDevServer.mdx
@@ -11,7 +11,7 @@ type OnBeforeStartDevServerFn = (params: {
    */
   server: RsbuildDevServer;
   /**
-   * A read-only object that provides some context information about different environments.
+   * Context information for all environments.
    */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;

--- a/website/docs/zh/config/tools/bundler-chain.mdx
+++ b/website/docs/zh/config/tools/bundler-chain.mdx
@@ -182,6 +182,22 @@ export default {
 };
 ```
 
+### environments
+
+- **类型：** `Record<string, EnvironmentContext>`
+
+所有环境的上下文信息。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    bundlerChain: (chain, { environments }) => {
+      console.log(environments);
+    },
+  },
+};
+```
+
 ### HtmlPlugin
 
 - **类型：** `typeof import('html-rspack-plugin')`

--- a/website/docs/zh/config/tools/rspack.mdx
+++ b/website/docs/zh/config/tools/rspack.mdx
@@ -234,6 +234,22 @@ export default {
 };
 ```
 
+### environments
+
+- **类型：** `Record<string, EnvironmentContext>`
+
+所有环境的上下文信息。
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    rspack: (chain, { environments }) => {
+      console.log(environments);
+    },
+  },
+};
+```
+
 ### HtmlPlugin
 
 - **类型：** `typeof import('html-rspack-plugin')`

--- a/website/docs/zh/shared/onBeforeStartDevServer.mdx
+++ b/website/docs/zh/shared/onBeforeStartDevServer.mdx
@@ -11,7 +11,7 @@ type OnBeforeStartDevServerFn = (params: {
    */
   server: RsbuildDevServer;
   /**
-   * A read-only object that provides some context information about different environments.
+   * Context information for all environments.
    */
   environments: Record<string, EnvironmentContext>;
 }) => MaybePromise<void>;


### PR DESCRIPTION
## Summary

Currently, `tools.rspack` can access the current environment's context, but in some cases it may need to access all environment contexts.

This PR exposes `environments` in `tools.rspack` and `tools.bundlerChain`:

- Add `environments` parameter to chain utils functions
- Update documentation to include `environments` context

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
