### PR TITLE
feat: hint assets emit name conflict

### DIFF
--- a/e2e/cases/assets/filename-conflict-hint/index.test.ts
+++ b/e2e/cases/assets/filename-conflict-hint/index.test.ts
@@ -1,0 +1,16 @@
+import { expect, rspackTest } from '@e2e/helper';
+
+rspackTest(
+  'should print output.filename hints as expected',
+  async ({ build }) => {
+    const rsbuild = await build({
+      catchBuildError: true,
+    });
+
+    expect(rsbuild.buildError).toBeTruthy();
+
+    await rsbuild.expectLog(
+      'You may need to adjust output.filename configuration to prevent name conflicts.',
+    );
+  },
+);

--- a/e2e/cases/assets/filename-conflict-hint/rsbuild.config.ts
+++ b/e2e/cases/assets/filename-conflict-hint/rsbuild.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    filename: {
+      image: 'image.png',
+    },
+    dataUriLimit: 0,
+  },
+});

--- a/e2e/cases/assets/filename-conflict-hint/src/index.js
+++ b/e2e/cases/assets/filename-conflict-hint/src/index.js
@@ -1,0 +1,4 @@
+import icon from '@e2e/assets/icon.png';
+import image from '@e2e/assets/image.png';
+
+console.log(icon, image);

--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -141,6 +141,18 @@ function hintUnknownFiles(message: string): string {
   return message;
 }
 
+const hintAssetsConflict = (message: string): string => {
+  const hint = 'Multiple assets emit different content to the same filename';
+
+  if (message.indexOf(hint) === -1) {
+    return message;
+  }
+
+  const extraMessage = `You may need to adjust ${color.yellow('output.filename')} configuration to prevent name conflicts. (See ${color.yellow('https://rsbuild.rs/config/output/filename')})`;
+
+  return `${message}\n${extraMessage}`;
+};
+
 /**
  * Add node polyfill tip when failed to resolve node built-in modules.
  */
@@ -250,6 +262,7 @@ export function formatStatsError(stats: StatsError): string {
 
   message = hintUnknownFiles(message);
   message = hintNodePolyfill(message);
+  message = hintAssetsConflict(message);
 
   let lines = message.split('\n');
 


### PR DESCRIPTION
## Summary

Enhance hint for assets emit name conflict

<img width="1826" height="304" alt="image" src="https://github.com/user-attachments/assets/5d5b3e18-4934-4cbf-8930-5243b196ad50" />


## Related Links

- https://github.com/web-infra-dev/rslib/pull/1332

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
