### PR TITLE
security: enable pnpm's no-downgrade trustPolicy

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,3 +21,4 @@ patchedDependencies:
 
 strictPeerDependencies: false
 engineStrict: true
+trustPolicy: no-downgrade


### PR DESCRIPTION
## Summary

Enable pnpm's new `no-downgrade` trustPolicy. This helps prevent installing potentially compromised versions of a package.

## Related Links

- https://pnpm.io/settings#trustpolicy

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
