### PR TITLE
chore(ci): update pnpm trust policy exclusions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,9 +50,9 @@
     "simple-git-hooks": "^2.13.1",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@10.22.0",
   "engines": {
     "node": ">=22.18.0",
-    "pnpm": ">=10.21.0"
+    "pnpm": ">=10.22.0"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,6 @@ patchedDependencies:
 strictPeerDependencies: false
 engineStrict: true
 trustPolicy: no-downgrade
+trustPolicyExclude:
+  # For Rspack ecosystem CI
+  - semver@6.3.1


### PR DESCRIPTION
## Summary

Update pnpm to version 10.22.0 and add `semver@6.3.1` to trust policy exclusions for Rspack ecosystem CI

## Related Links

- https://github.com/pnpm/pnpm/releases/tag/v10.22.0
- https://github.com/web-infra-dev/rspack/actions/runs/19321269189/job/55263388759#step:8:880

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
