### PR TITLE
fix: remove runtimeChunk config for ESM web app

### DIFF
--- a/packages/core/src/plugins/esm.ts
+++ b/packages/core/src/plugins/esm.ts
@@ -11,11 +11,6 @@ export const pluginEsm = (): RsbuildPlugin => ({
         return;
       }
 
-      if (target === 'web') {
-        // Temporary solution to fix the issue of runtime chunk not loaded as expected.
-        chain.optimization.runtimeChunk(true);
-      }
-
       if (target === 'node') {
         chain.output.library({
           ...chain.output.get('library'),


### PR DESCRIPTION
## Summary

Remove `runtimeChunk: true` config for ESM web app, it is no longer needed as Rspack has fixed related issues.

## Related Links

- https://github.com/web-infra-dev/rspack/pull/11945
- resolve https://github.com/web-infra-dev/rsbuild/issues/6537

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
