### PR TITLE
docs: polish english phrasing in config pages

### DIFF
--- a/website/docs/en/community/index.mdx
+++ b/website/docs/en/community/index.mdx
@@ -10,7 +10,7 @@ For more details, see [Releases](/community/releases/index).
 
 The development of Rsbuild is driven by ByteDance's Rspack team and community contributors.
 
-For information about the team members, please refer to [Rspack - Core team](https://rspack.rs/misc/team/core-team).
+For details about the team members, see [Rspack - Core team](https://rspack.rs/misc/team/core-team).
 
 ## Communication
 
@@ -23,18 +23,18 @@ You can communicate with the developers of Rsbuild through the following channel
 
 ## Resources
 
-Check out [awesome-rstack](https://github.com/web-infra-dev/awesome-rstack) to discover more community resources related to Rstack.
+Explore [awesome-rstack](https://github.com/web-infra-dev/awesome-rstack) to find more community resources related to Rstack.
 
 ## Contribution
 
-Contributions to Rsbuild are welcomed!
+Contributions to Rsbuild are welcome!
 
 Please refer to the [Rsbuild Contribution Guide](https://github.com/web-infra-dev/rsbuild/blob/main/CONTRIBUTING.md).
 
 ## Blogs
 
-Please visit [Rspack - Blog](https://rspack.rs/blog/index) to read our latest articles and announcements.
+Visit [Rspack - Blog](https://rspack.rs/blog/index) to read our latest articles and announcements.
 
 ## Examples
 
-Please visit [rspack-contrib/rstack-examples](https://github.com/rspack-contrib/rstack-examples) to view or contribute to the example projects of Rsbuild.
+Visit [rspack-contrib/rstack-examples](https://github.com/rspack-contrib/rstack-examples) to explore or contribute to Rsbuild example projects.

--- a/website/docs/en/config/mode.mdx
+++ b/website/docs/en/config/mode.mdx
@@ -5,7 +5,7 @@
 
 Specify the build mode for Rsbuild, as each mode has different default behavior and optimizations. For example, the `production` mode will minify code by default.
 
-The value of Rsbuild `mode` is also be passed to the [mode](https://rspack.rs/config/mode) configuration of Rspack.
+The value of Rsbuild `mode` is also passed to the [mode](https://rspack.rs/config/mode) configuration of Rspack.
 
 :::tip
 The value of `mode` does not affect the loading results of the `.env` file, as the `.env` file is resolved before the Rsbuild configuration file.

--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -1,6 +1,6 @@
 # plugins
 
-Used to register Rsbuild plugins.
+Registers Rsbuild plugins.
 
 - **Type:**
 
@@ -21,7 +21,7 @@ type RsbuildPlugins = (
 
 ## Example
 
-For example, register the [Sass plugin](/plugins/list/plugin-sass) in Rsbuild.
+For example, to register the [Sass plugin](/plugins/list/plugin-sass) in Rsbuild:
 
 - Installing the plugin:
 
@@ -42,13 +42,13 @@ export default defineConfig({
 
 ## Execution order
 
-By default, plugins are executed in the order they appear in the `plugins` array. Built-in Rsbuild plugins are executed before user-registered plugins.
+By default, plugins run in the order they appear in the `plugins` array, and built-in Rsbuild plugins run before user-registered plugins.
 
-When a plugin internally uses fields that control the order, such as `pre` and `post`, the execution order is adjusted based on them. See [Pre Plugins](/plugins/dev/core#pre-pluginss) for more details.
+If a plugin defines ordering fields such as `pre` or `post`, Rsbuild adjusts the execution order accordingly. See [Pre Plugins](/plugins/dev/core#pre-pluginss) for more details.
 
 ## Conditional registration
 
-The falsy value in the `plugins` array will be ignored, which allows you to conveniently register plugins based on some judgment conditions:
+Falsy values in the `plugins` array are ignored, which lets you register plugins conditionally:
 
 ```ts title="rsbuild.config.ts"
 const isProd = process.env.NODE_ENV === 'production';
@@ -80,7 +80,7 @@ export default {
 
 ## Nested plugins
 
-Rsbuild also supports adding nested plugins. You can pass in an array containing multiple plugins, similar to a plugin preset collection. This is particularly useful for implementing complex functionalities that require a combination of multiple plugins (such as framework integration).
+Rsbuild also supports nested plugins. You can pass an array that contains multiple plugins, similar to a plugin preset. This is useful for complex features that combine several plugins, such as framework integrations.
 
 ```ts title="rsbuild.config.ts"
 function myPlugin() {
@@ -126,7 +126,7 @@ export default defineConfig({
 
 ## Plugin registration phase
 
-It should be noted that plugin registration can only be performed during the Rsbuild initialization phase. You cannot dynamically add other plugins within a plugin through the plugin API:
+Plugin registration only runs during the Rsbuild initialization phase. You cannot dynamically add other plugins within a plugin through the plugin API:
 
 ```ts title="rsbuild.config.ts"
 // Wrong
@@ -195,7 +195,7 @@ export default defineConfig({
 ```
 
 :::tip
-When using the transform hook in unplugin, please use the `transformInclude` hook to match the specified module. When the transform hook matches the `.html` module, it will replace the default EJS transformation of the [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin).
+When you use the transform hook in unplugin, also use the `transformInclude` hook to target specific modules. If the transform hook matches an `.html` module, it replaces the default EJS transform from the [html-rspack-plugin](https://github.com/rspack-contrib/html-rspack-plugin).
 :::
 
 > Please ensure that the version of `unplugin` package is >= v1.6.0.


### PR DESCRIPTION
## Summary
- refine wording in the plugins configuration page to improve clarity while keeping original meaning
- fix a grammatical issue in the mode configuration page
- polish community page sentences for more natural English

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917b38a8dc883279330c271507140f1)