### PR TITLE
fix: treat protocol-relative paths as URLs

### DIFF
--- a/packages/core/src/helpers/url.ts
+++ b/packages/core/src/helpers/url.ts
@@ -11,7 +11,7 @@ export const addTrailingSlash = (s: string): string =>
 
 // Determine if the string is a URL
 export const isURL = (str: string): boolean =>
-  str.startsWith('http') || str.startsWith('//:');
+  str.startsWith('http') || str.startsWith('//');
 
 export const urlJoin = (base: string, path: string) => {
   const [urlProtocol, baseUrl] = base.split('://');


### PR DESCRIPTION
## Summary
- ensure protocol-relative asset paths are identified as URLs

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917b44f04f88327a2d7d6cc7c33db25)