### PR TITLE
docs: align dev config JSDoc with documentation

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1738,8 +1738,18 @@ export type NormalizedClientConfig = Optional<
 export type { ChokidarOptions };
 
 export type WatchFiles = {
+  /**
+   * Paths of the files or directories to watch, supports glob syntax.
+   */
   paths: string | string[];
+  /**
+   * Watch options passed to [chokidar](https://github.com/paulmillr/chokidar).
+   */
   options?: ChokidarOptions;
+  /**
+   * Specifies whether to reload the page or restart the dev server when files change.
+   * @default 'reload-page'
+   */
   type?: 'reload-page' | 'reload-server';
 };
 
@@ -1765,8 +1775,9 @@ export type BrowserLogsStackTrace = 'summary' | 'full' | 'none';
 export interface DevConfig {
   /**
    * Controls whether to forward browser runtime errors to the terminal. When `true`, the dev
-   * client listens for window `error` events in the browser and send them to the dev server,
-   * where they are printed in the terminal (prefixed with `[browser]`).
+   * client listens for `window.error` events and unhandled Promise rejections in the browser,
+   * then sends them to the dev server where they are printed in the terminal (prefixed with
+   * `[browser]`).
    * @default { stackTrace: 'summary' }
    */
   browserLogs?:
@@ -1796,6 +1807,7 @@ export interface DevConfig {
    * Set the URL prefix of static assets in development mode,
    * similar to the [output.publicPath](https://rspack.rs/config/output#outputpublicpath)
    * config of Rspack.
+   * @default `server.base`
    */
   assetPrefix?: LiteralUnion<'auto', string> | boolean;
   /**
@@ -1809,6 +1821,7 @@ export interface DevConfig {
   client?: ClientConfig;
   /**
    * Whether to enable CLI shortcuts.
+   * @default true when using Rsbuild CLI, otherwise false
    */
   cliShortcuts?:
     | boolean
@@ -1830,6 +1843,7 @@ export interface DevConfig {
       };
   /**
    * Used to add custom middleware to the dev server.
+   * @default undefined
    */
   setupMiddlewares?: SetupMiddlewaresFn | SetupMiddlewaresFn[];
   /**
@@ -1840,11 +1854,12 @@ export interface DevConfig {
   /**
    * Watch specified files and directories for changes. When a file change is detected,
    * it can trigger a page reload or restart the dev server.
+   * @default undefined
    */
   watchFiles?: WatchFiles | WatchFiles[];
   /**
-   * Enable lazy compilation.
-   * @default false
+   * Enable lazy compilation (compilation on demand).
+   * @default { imports: true, entries: false }
    */
   lazyCompilation?: boolean | Rspack.LazyCompilationOptions;
 }


### PR DESCRIPTION
## Summary
- update dev configuration JSDoc to match current documentation defaults
- clarify lazy compilation, asset prefix, CLI shortcuts, and watch files comments

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918242b56d88327a5474c3ca13250ad)