### PR TITLE
docs: align config JSDoc defaults with docs

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -589,7 +589,7 @@ export type SriOptions = {
   /**
    * Whether to enable SRI.
    * `'auto'` means it's enabled in production mode and disabled in development mode.
-   * @default undefined
+   * @default false
    */
   enable?: boolean | 'auto';
 };


### PR DESCRIPTION
## Summary
- align configuration JSDoc defaults such as security.sri and performance options with latest documentation
- document default values for preload/prefetch resource hints and data URI limits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691940b5520c83278691b52d44e35afb)