### PR TITLE
test(e2e): add progress bar config coverage

### DIFF
--- a/e2e/cases/config/progress-bar/index.test.ts
+++ b/e2e/cases/config/progress-bar/index.test.ts
@@ -1,0 +1,24 @@
+import { expect, rspackTest } from '@e2e/helper';
+import { createRsbuild } from '@rsbuild/core';
+
+rspackTest('should enable progress plugin when dev.progressBar is set', async () => {
+  const rsbuild = await createRsbuild({
+    cwd: import.meta.dirname,
+    config: {
+      dev: {
+        progressBar: {
+          id: 'custom-progress',
+        },
+      },
+    },
+  });
+
+  const { bundlerConfigs } = await rsbuild.inspectConfig({ verbose: true });
+
+  expect(
+    bundlerConfigs.some(
+      (config) =>
+        config.includes('ProgressPlugin') && config.includes('custom-progress'),
+    ),
+  ).toBeTruthy();
+});

--- a/e2e/cases/config/progress-bar/src/index.ts
+++ b/e2e/cases/config/progress-bar/src/index.ts
@@ -1,0 +1,1 @@
+console.log('progress case');


### PR DESCRIPTION
## Summary
- add a new e2e case exercising the dev.progressBar configuration
- verify the generated bundler config includes the progress plugin with the custom id

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691940de0a188327a67baf5120d7b163)