### PR TITLE
refactor: simplify build dependencies merging

### DIFF
--- a/packages/core/src/plugins/cache.ts
+++ b/packages/core/src/plugins/cache.ts
@@ -69,7 +69,7 @@ async function getBuildDependencies(
   context: Readonly<RsbuildContext>,
   config: NormalizedEnvironmentConfig,
   environmentContext: EnvironmentContext,
-  userBuildDependencies?: string[],
+  additionalDependencies?: string[],
 ) {
   const rootPackageJson = join(context.rootPath, 'package.json');
   const browserslistConfig = join(context.rootPath, '.browserslistrc');
@@ -103,8 +103,8 @@ async function getBuildDependencies(
     buildDependencies.tailwindcss = [tailwindConfig];
   }
 
-  if (userBuildDependencies) {
-    buildDependencies.userBuildDependencies = userBuildDependencies;
+  if (additionalDependencies) {
+    buildDependencies.additional = additionalDependencies;
   }
 
   return buildDependencies;


### PR DESCRIPTION
## Summary

Updates the build dependency handling logic in the caching plugin, simplifying how additional build dependencies are passed and stored.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
