### PR TITLE
docs(website): fix edit page link config

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -168,29 +168,20 @@ export default defineConfig({
         content: 'https://bsky.app/profile/rspack.rs',
       },
     ],
+    editLink: {
+      docRepoBaseUrl:
+        'https://github.com/web-infra-dev/rsbuild/tree/main/website/docs',
+    },
     locales: [
       {
         lang: 'en',
         label: 'English',
         description,
-        editLink: {
-          docRepoBaseUrl:
-            'https://github.com/web-infra-dev/rsbuild/tree/main/website/docs',
-          text: '📝 Edit this page on GitHub',
-        },
       },
       {
         lang: 'zh',
         label: '简体中文',
-        outlineTitle: '目录',
-        prevPageText: '上一页',
-        nextPageText: '下一页',
         description: '由 Rspack 驱动的构建工具',
-        editLink: {
-          docRepoBaseUrl:
-            'https://github.com/web-infra-dev/rsbuild/tree/main/website/docs',
-          text: '📝 在 GitHub 上编辑此页',
-        },
       },
     ],
   },


### PR DESCRIPTION
## Summary

Fix the edit page link config (changed in Rspress v2.0.0-rc.0)

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6341

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
