### PR TITLE
fix: update hmr import paths to include .js extension

### DIFF
--- a/packages/core/rslib.config.ts
+++ b/packages/core/rslib.config.ts
@@ -164,7 +164,7 @@ export default defineConfig({
       },
       output: {
         target: 'web',
-        externals: ['./hmr'],
+        externals: ['./hmr.js'],
         distPath: {
           root: './dist/client',
         },

--- a/packages/core/src/client/overlay.ts
+++ b/packages/core/src/client/overlay.ts
@@ -1,4 +1,4 @@
-import { registerOverlay } from './hmr';
+import { registerOverlay } from './hmr.js';
 
 const {
   HTMLElement = class {} as typeof globalThis.HTMLElement,


### PR DESCRIPTION
## Summary

Update the hmr import path to include `.js` extension as `@rsbuild/core` package includes the `type: "module"` field.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
