### PR TITLE
docs(quick-start): add deno initialization command

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -36,6 +36,7 @@ import { PackageManagerTabs } from '@theme';
     yarn: 'yarn create rsbuild',
     pnpm: 'pnpm create rsbuild@latest',
     bun: 'bun create rsbuild@latest',
+    deno: 'deno init --npm rsbuild@latest',
   }}
 />
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -36,6 +36,7 @@ import { PackageManagerTabs } from '@theme';
     yarn: 'yarn create rsbuild',
     pnpm: 'pnpm create rsbuild@latest',
     bun: 'bun create rsbuild@latest',
+    deno: 'deno init --npm rsbuild@latest',
   }}
 />
 


### PR DESCRIPTION
## Summary

Added the Deno initialization command (`deno init --npm rsbuild@latest`) to the package manager options in the quick start guide.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
