### PR TITLE
fix(create-rsbuild): use current package manager in templates

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -29,7 +29,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "create-rstack": "1.7.7"
+    "create-rstack": "1.7.8"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/create-rsbuild/template-common/AGENTS.md
+++ b/packages/create-rsbuild/template-common/AGENTS.md
@@ -4,9 +4,9 @@ You are an expert in JavaScript, Rsbuild, and web application development. You w
 
 ## Commands
 
-- `npm run dev` - Start the dev server
-- `npm run build` - Build the app for production
-- `npm run preview` - Preview the production build locally
+- `{{ packageManager }} run dev` - Start the dev server
+- `{{ packageManager }} run build` - Build the app for production
+- `{{ packageManager }} run preview` - Preview the production build locally
 
 ## Docs
 

--- a/packages/create-rsbuild/template-common/README.md
+++ b/packages/create-rsbuild/template-common/README.md
@@ -5,7 +5,7 @@
 Install the dependencies:
 
 ```bash
-pnpm install
+{{ packageManager }} install
 ```
 
 ## Get started
@@ -13,19 +13,19 @@ pnpm install
 Start the dev server, and the app will be available at [http://localhost:3000](http://localhost:3000).
 
 ```bash
-pnpm dev
+{{ packageManager }} run dev
 ```
 
 Build the app for production:
 
 ```bash
-pnpm build
+{{ packageManager }} run build
 ```
 
 Preview the production build locally:
 
 ```bash
-pnpm preview
+{{ packageManager }} run preview
 ```
 
 ## Learn more

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,8 +761,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.7.7
-        version: 1.7.7
+        specifier: 1.7.8
+        version: 1.7.8
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3897,8 +3897,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.7.7:
-    resolution: {integrity: sha512-mZHKC+56IahOrz9FS21vhRayRjJkrfpN+emXVHczqUN3h8yJyOqu1JJkkYhQBd28rbZR1GjWD+Q0bE8MrcW1GQ==}
+  create-rstack@1.7.8:
+    resolution: {integrity: sha512-B8+cOGs0Gsk2i3ZVJweMsFFU50vXlNYzkWOiVQBoMs02Ui/6hQcqB4d+jmTEgwvdb5gJmX2Rcr9J6l+Ld1yCQQ==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9663,7 +9663,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-rstack@1.7.7: {}
+  create-rstack@1.7.8: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

- update dependency `create-rstack` to v1.7.8
- replace hardcoded package manager commands with template variables in documentation files

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.8

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
