### PR TITLE
docs: fix outdated plugin order link

### DIFF
--- a/website/docs/en/config/plugins.mdx
+++ b/website/docs/en/config/plugins.mdx
@@ -42,9 +42,9 @@ export default defineConfig({
 
 ## Execution order
 
-By default, plugins run in the order they appear in the `plugins` array, and built-in Rsbuild plugins run before user-registered plugins.
+By default, plugins run in the order they appear in the `plugins` array. Built-in Rsbuild plugins always execute before user-defined plugins.
 
-If a plugin defines ordering fields such as `pre` or `post`, Rsbuild adjusts the execution order accordingly. See [Pre Plugins](/plugins/dev/core#pre-pluginss) for more details.
+If a plugin specifies ordering controls such as the `enforce` property, the final execution sequence will be adjusted accordingly. See the [`enforce` property](/plugins/dev/core#enforce-property) for details.
 
 ## Conditional registration
 

--- a/website/docs/zh/config/plugins.mdx
+++ b/website/docs/zh/config/plugins.mdx
@@ -42,9 +42,9 @@ export default defineConfig({
 
 ## 执行顺序
 
-默认情况下，插件会按照 `plugins` 数组的顺序依次执行，Rsbuild 内置插件的执行时机早于用户注册的插件。
+默认情况下，插件会按照 `plugins` 数组中的顺序依次执行，Rsbuild 内置插件的执行时机早于用户注册的插件。
 
-当插件内部使用了控制顺序的相关字段，比如 `pre`、`post` 时，执行顺序会基于它们进行调整，详见 [前置插件](/plugins/dev/core#前置插件)。
+如果插件使用了控制执行顺序的字段，比如 `enforce` 属性时，则最终的执行顺序会根据这些字段进行调整，详见 [`enforce` 属性](/plugins/dev/core#enforce-属性)。
 
 ## 条件注册
 


### PR DESCRIPTION
## Summary

Fix the outdated plugin order link and description in the `plugin` config documentation.

We now recommend using the `enforce` property instead of the `pre` and `post` options.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
