### PR TITLE
fix: improve browserslist cache key

### DIFF
--- a/packages/core/src/createContext.ts
+++ b/packages/core/src/createContext.ts
@@ -27,7 +27,7 @@ const browsersListCache = new Map<string, string[]>();
 
 export function getBrowserslist(path: string): string[] | null {
   const env = process.env.NODE_ENV;
-  const cacheKey = path + env;
+  const cacheKey = `${path}:${env ?? ''}`;
 
   if (browsersListCache.has(cacheKey)) {
     return browsersListCache.get(cacheKey)!;


### PR DESCRIPTION
## Summary
- Updated the browserslist cache key to separate path and environment values, preventing collisions between different project paths or NODE_ENV combinations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919d46e75bc8327927808d0fdda7fdd)