### PR TITLE
docs: improve environment and compatibility wording

### DIFF
--- a/website/docs/en/guide/advanced/browser-compatibility.mdx
+++ b/website/docs/en/guide/advanced/browser-compatibility.mdx
@@ -20,7 +20,7 @@ A polyfill is code that provides the functionality of newer features to older br
 
 ## Background knowledge
 
-Before dealing with compatibility issues, it is recommended that you understand the following background knowledge to better handle related issues.
+Before tackling compatibility issues, we recommend understanding the following background so you can handle them effectively.
 
 ### Syntax downgrade and API downgrade
 
@@ -47,7 +47,7 @@ const foo = {};
 foo?.bar();
 ```
 
-When we run this code in a low version of Node.js, the following error message will appear:
+When this code runs in an older version of Node.js, the following error message appears:
 
 ```bash
 SyntaxError: Unexpected token.
@@ -59,7 +59,7 @@ SyntaxError: Unexpected token.
    at node.js:814:3
 ```
 
-It's obvious from the error message that this is a syntax error, meaning this syntax is not supported in older versions of the engine.
+The error makes it clear that this is a syntax issue, meaning older versions of the engine do not support this syntax.
 
 **Syntax cannot be supported by polyfills or shims**. To run syntax that's not originally supported in an older browser, you need to transpile the code into syntax the older engine can support.
 
@@ -87,7 +87,7 @@ var str = 'Hello world!';
 console.log(str.notExistedMethod());
 ```
 
-The above code has correct syntax and can be converted to AST correctly in the first stage of engine runtime, but when it actually runs, the method `notExistedMethod` does not exist on `String.prototype`, so an error is reported:
+The above code uses valid syntax and can be converted to an AST during the first stage of engine runtime, but when it actually runs, the method `notExistedMethod` does not exist on `String.prototype`, so an error is reported:
 
 ```bash
 Uncaught TypeError: str.notExistedMethod is not a function
@@ -100,7 +100,7 @@ With ECMAScript iterations, new methods are added to built-in objects. For examp
 'abc'.replaceAll('abc', 'xyz');
 ```
 
-To solve the problem that `String.prototype` lacks `replaceAll` in older browsers, we can extend the `String.prototype` object in older browsers and add the `replaceAll` method to it. For example:
+To address the lack of `replaceAll` in older browsers, we can extend the `String.prototype` object and add the `replaceAll` method to it. For example:
 
 ```js
 // The implementation of this polyfill does not necessarily conform to the standard, it is only used as an example.

--- a/website/docs/en/guide/advanced/environments.mdx
+++ b/website/docs/en/guide/advanced/environments.mdx
@@ -2,7 +2,7 @@
 
 Rsbuild supports building outputs for multiple environments at the same time. You can use [environments](/config/environments) to build multiple environments in parallel and set a different Rsbuild config for each environment.
 
-## What is environment
+## What is an environment
 
 The `environment` refers to the runtime environment for build output. Common environments include browsers, Node.js, and Workers. Rsbuild allows you to define custom environment names and set build options for each environment individually.
 
@@ -13,7 +13,7 @@ You can also define different environments for the same build target, for exampl
 - Define `rsc` and `ssr` environments, both targeting `node`, used separately for React Server Components and SSR.
 - Define `desktop` and `mobile` environments, both targeting `web`, used separately for desktop and mobile browsers.
 
-Without the `environments` configuration, you would need to define multiple configurations for these scenarios and run multiple independent Rsbuild builds. With the `environments` configuration, you can complete the build for multiple outputs in a single Rsbuild run (Rsbuild achieves this using Rspack's [MultiCompiler](https://rspack.rs/api/javascript-api/compiler#multicompiler)).
+Without the `environments` configuration, you would need to define multiple configurations for these scenarios and run multiple independent Rsbuild builds. With `environments`, you can build every output in a single Rsbuild run (Rsbuild achieves this using Rspack's [MultiCompiler](https://rspack.rs/api/javascript-api/compiler#multicompiler)).
 
 In Rsbuild, each `environment` is associated with an Rsbuild configuration, an Rspack configuration, and a set of build outputs. Rsbuild plugin developers can customize the build process for a specified environment based on the `environment` name, such as modifying Rsbuild or Rspack configurations, registering or removing plugins, adjusting Rspack rules, and viewing assets information.
 
@@ -95,7 +95,7 @@ config inspection completed, generated files:
 
 ## Default environment
 
-When environments is not specified, Rsbuild creates an environment by default with the same name as the current target type (the value of [output.target](/config/output/target)).
+When `environments` is not specified, Rsbuild creates an environment by default with the same name as the current target type (the value of [output.target](/config/output/target)).
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -119,9 +119,9 @@ export default {
 };
 ```
 
-## Build specified environment
+## Build a specific environment
 
-By default, Rsbuild will build all environments in the Rsbuild configuration when you execute `rsbuild dev` or `rsbuild build`. You can build only the specified environment via `--environment <name>`.
+By default, Rsbuild will build all environments in the Rsbuild configuration when you execute `rsbuild dev` or `rsbuild build`. You can build only the specified environments with `--environment <name>`.
 
 ```bash
 # Build for all environments by default
@@ -133,7 +133,7 @@ rsbuild dev --environment web
 # Build for the web and ssr environments
 rsbuild dev --environment web --environment node
 
-# Build multiple environments can be shortened to:
+# Building multiple environments can be shortened to:
 rsbuild dev --environment web,node
 ```
 


### PR DESCRIPTION
## Summary
- polish the multi-environment build guide with clearer explanations and headings
- clarify syntax and runtime error descriptions in the browser compatibility guide

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fac8e590c8327b3b633f6c8854e7b)