### PR TITLE
feat: add order option to control PostCSS plugin insertion position

### DIFF
--- a/packages/core/src/plugins/css.ts
+++ b/packages/core/src/plugins/css.ts
@@ -21,6 +21,7 @@ import type {
   RsbuildPlugin,
   Rspack,
   RspackChain,
+  ToolsPostCSSContext,
 } from '../types';
 import { parseMinifyOptions } from './minimize';
 
@@ -147,9 +148,15 @@ const getPostcssLoaderOptions = async ({
 }): Promise<PostCSSLoaderOptions> => {
   const extraPlugins: AcceptedPlugin[] = [];
 
-  const utils = {
-    addPlugins(plugins: AcceptedPlugin | AcceptedPlugin[]) {
-      extraPlugins.push(...castArray(plugins));
+  const context: ToolsPostCSSContext = {
+    addPlugins(plugins: AcceptedPlugin | AcceptedPlugin[], options = {}) {
+      const { order = 'post' } = options;
+      const list = castArray(plugins);
+      if (order === 'pre') {
+        extraPlugins.unshift(...list);
+      } else {
+        extraPlugins.push(...list);
+      }
     },
   };
 
@@ -167,7 +174,7 @@ const getPostcssLoaderOptions = async ({
   const finalOptions = reduceConfigsWithContext({
     initial: defaultOptions,
     config: config.tools.postcss,
-    ctx: utils,
+    ctx: context,
   });
 
   finalOptions.postcssOptions ||= {};

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -64,9 +64,24 @@ export type ToolsBundlerChainConfig = OneOrMany<
   (chain: RspackChain, utils: ModifyBundlerChainUtils) => MaybePromise<void>
 >;
 
+export type ToolsPostCSSContext = {
+  addPlugins: (
+    plugins: LoosePostCSSPlugin | LoosePostCSSPlugin[],
+    options?: {
+      /**
+       * Controls where the plugin is placed relative to the existing PostCSS plugins.
+       * - `pre`: Insert the plugin before all existing plugins.
+       * - `post`: Insert the plugin after all existing plugins.
+       * @default `post`
+       */
+      order?: 'pre' | 'post';
+    },
+  ) => void;
+};
+
 export type ToolsPostCSSLoaderConfig = ConfigChainWithContext<
   PostCSSLoaderOptions,
-  { addPlugins: (plugins: LoosePostCSSPlugin | LoosePostCSSPlugin[]) => void }
+  ToolsPostCSSContext
 >;
 
 export type ToolsCSSLoaderConfig = ConfigChain<CSSLoaderOptions>;

--- a/website/docs/en/config/tools/postcss.mdx
+++ b/website/docs/en/config/tools/postcss.mdx
@@ -94,7 +94,20 @@ export default {
 
 ### addPlugins
 
-- **Type:** `(plugins: PostCSSPlugin | PostCSSPlugin[]) => void`
+- **Type:**
+
+```ts
+type AddPlugins = (
+  plugins: PostCSSPlugin | PostCSSPlugin[],
+  options?: {
+    /**
+     * Controls where the plugin is placed relative to the existing PostCSS plugins.
+     * @default 'post'
+     */
+    order?: 'pre' | 'post';
+  },
+) => void;
+```
 
 For adding additional PostCSS plugins, You can pass in a single PostCSS plugin, or an array of PostCSS plugins.
 
@@ -106,6 +119,18 @@ export default {
       addPlugins(require('postcss-preset-env'));
       // Add multiple PostCSS Plugins
       addPlugins([require('postcss-preset-env'), require('postcss-import')]);
+    },
+  },
+};
+```
+
+To add plugins before the existing plugins, set `order` option to `pre`:
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    postcss: (config, { addPlugins }) => {
+      addPlugins(require('postcss-preset-env'), { order: 'pre' });
     },
   },
 };

--- a/website/docs/zh/config/tools/postcss.mdx
+++ b/website/docs/zh/config/tools/postcss.mdx
@@ -94,7 +94,18 @@ export default {
 
 ### addPlugins
 
-- **类型：** `(plugins: PostCSSPlugin | PostCSSPlugin[]) => void`
+```ts
+type AddPlugins = (
+  plugins: PostCSSPlugin | PostCSSPlugin[],
+  options?: {
+    /**
+     * 控制插件在现有 PostCSS 插件列表中的添加位置
+     * @default 'post'
+     */
+    order?: 'pre' | 'post';
+  },
+) => void;
+```
 
 用于添加额外的 PostCSS 插件，你可以传入单个 PostCSS 插件，也可以传入 PostCSS 插件数组。
 
@@ -106,6 +117,18 @@ export default {
       addPlugins(require('postcss-preset-env'));
       // 批量添加插件
       addPlugins([require('postcss-preset-env'), require('postcss-import')]);
+    },
+  },
+};
+```
+
+要在已有的插件之前添加插件，设置 `order` 选项为 `pre`：
+
+```ts title="rsbuild.config.ts"
+export default {
+  tools: {
+    postcss: (config, { addPlugins }) => {
+      addPlugins(require('postcss-preset-env'), { order: 'pre' });
     },
   },
 };


### PR DESCRIPTION
## Summary

Allow specifying 'pre' or 'post' when adding PostCSS plugins to control their position relative to existing plugins. This provides more flexibility in plugin ordering.

Update both documentation and implementation to support this feature. The default behavior remains unchanged ('post').

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
