### PR TITLE
refactor: simplify helper used by the Node addons plugin

### DIFF
--- a/packages/core/src/plugins/nodeAddons.ts
+++ b/packages/core/src/plugins/nodeAddons.ts
@@ -3,20 +3,8 @@ import { color } from '../helpers';
 import type { RsbuildPlugin } from '../types';
 
 const getFilename = (resourcePath: string) => {
-  let basename = '';
-
-  if (resourcePath) {
-    const parsed = path.parse(resourcePath);
-    if (parsed.dir) {
-      basename = parsed.name;
-    }
-  }
-
-  if (basename) {
-    return `${basename}.node`;
-  }
-
-  return null;
+  const name = resourcePath && path.parse(resourcePath).name;
+  return name ? `${name}.node` : null;
 };
 
 export const pluginNodeAddons = (): RsbuildPlugin => ({
@@ -38,7 +26,7 @@ export const pluginNodeAddons = (): RsbuildPlugin => ({
 
         return `
 try {
-const path = require("path");
+const path = require("node:path");
 process.dlopen(module, path.join(__dirname, "${name}"));
 } catch (error) {
 throw new Error('Failed to load Node.js addon: "${name}"\\n' + error);


### PR DESCRIPTION
## Summary

This PR simplifies the `getFilename` helper used by the Node addons plugin.

The previous implementation returned a basename only when `parsed.dir` was truthy. This added an unnecessary condition and could incorrectly reject valid paths that contain only a filename without a directory segment.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
