### PR TITLE
docs: refine webpack migration wording

### DIFF
--- a/website/docs/en/guide/migration/webpack.mdx
+++ b/website/docs/en/guide/migration/webpack.mdx
@@ -49,7 +49,7 @@ export default defineConfig({
 
 Webpack projects often include complex `webpack.config.js` configuration files.
 
-After migrating to Rsbuild, most webpack configurations—such as output, resolve, and module.rules—are built in and no longer require manual setup.
+After migrating to Rsbuild, most webpack configurations (such as output, resolve, and module.rules) are built-in and no longer require manual setup.
 
 For the few webpack configurations that need to be migrated, you can choose the following options:
 


### PR DESCRIPTION
## Summary
- polish the webpack migration guide wording for clearer instructions

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692170dfa9a4832780b5ed47542e79a1)