### PR TITLE
fix: open base url when no routes are available

### DIFF
--- a/packages/core/src/server/open.ts
+++ b/packages/core/src/server/open.ts
@@ -210,6 +210,8 @@ export async function open({
     if (routes.length) {
       // auto open the first one
       urls.push(`${baseUrl}${routes[0].pathname}`);
+    } else {
+      urls.push(baseUrl);
     }
   } else {
     urls.push(


### PR DESCRIPTION
## Summary
- ensure dev/preview browser opening falls back to the base URL when no routes are provided

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fad9a54b08327b07a959e66d2efa2)