### PR TITLE
docs: add detailed JSDoc to manifest data types

### DIFF
--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1159,13 +1159,13 @@ export type ManifestByEntry = {
     /** Async CSS files for this entry. */
     css?: string[];
   };
+  /** HTML files generated for this entry, if any. */
+  html?: string[];
   /**
    * Additional assets associated with this entry.
    * For example images、fonts、source maps and other non JS or CSS files.
    */
   assets?: string[];
-  /** HTML files generated for this entry, if any. */
-  html?: string[];
 };
 
 export type ManifestData = {

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -55,25 +55,43 @@ The manifest file will be output with the following structure by default:
 type FilePath = string;
 
 type ManifestList = {
+  /**
+   * A flat list of all emitted asset files.
+   */
+  allFiles: FilePath[];
+  /**
+   * Maps each entry name to its associated output files.
+   */
   entries: {
-    /** The key is the entry name, from Rsbuild's source.entry config. */
     [entryName: string]: {
+      /**
+       * Files that are required during the initial load of the entry.
+       */
       initial?: {
+        /** Initial JavaScript files for this entry. */
         js?: FilePath[];
+        /** Initial CSS files for this entry. */
         css?: FilePath[];
       };
+      /**
+       * Files that may be loaded asynchronously.
+       * Usually code-split chunks or lazily loaded chunks.
+       */
       async?: {
+        /** Async JavaScript files for this entry. */
         js?: FilePath[];
+        /** Async CSS files for this entry. */
         css?: FilePath[];
       };
-      /** HTML files related to the current entry */
+      /** HTML files generated for this entry, if any. */
       html?: FilePath[];
-      /** other assets (e.g., png, svg, source map) related to the current entry */
+      /**
+       * Additional assets associated with this entry.
+       * For example images、fonts、source maps and other non JS or CSS files.
+       */
       assets?: FilePath[];
     };
   };
-  /** Flatten all assets */
-  allFiles: FilePath[];
 };
 ```
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -55,25 +55,43 @@ manifest 文件默认输出的结构为：
 type FilePath = string;
 
 type ManifestList = {
+  /**
+   * 所有构建产物文件的扁平列表
+   */
+  allFiles: FilePath[];
+  /**
+   * 将每个入口名称映射到其关联的输出文件
+   */
   entries: {
-    /** key 为 entry 名称，对应 Rsbuild 的 source.entry 配置 */
     [entryName: string]: {
+      /**
+       * 入口在初始加载阶段所需的文件
+       */
       initial?: {
+        /** 当前入口的初始 JavaScript 文件 */
         js?: FilePath[];
+        /** 当前入口的初始 CSS 文件 */
         css?: FilePath[];
       };
+      /**
+       * 异步加载的文件
+       * 通常是代码分割的 chunk 或懒加载的资源
+       */
       async?: {
+        /** 当前入口的异步 JavaScript 文件 */
         js?: FilePath[];
+        /** 当前入口的异步 CSS 文件 */
         css?: FilePath[];
       };
-      /** 当前 entry 关联的 HTML 页面 */
+      /** 当前入口生成的 HTML 文件（如果有） */
       html?: FilePath[];
-      /** 和当前 entry 相关的其他资源（如 png、svg、source map 等） */
+      /**
+       * 与当前入口关联的其他资源
+       * 例如图片、字体、source map 以及其他非 JS 或 CSS 文件
+       */
       assets?: FilePath[];
     };
   };
-  /** 铺平的所有 assets */
-  allFiles: FilePath[];
 };
 ```
 


### PR DESCRIPTION
## Summary

Add detailed JSDoc to ManifestByEntry and ManifestData types to clarify the purpose and structure of each property.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
