### PR TITLE
chore: remove unused getStatsAssetsOptions function

### DIFF
--- a/packages/core/src/helpers/stats.ts
+++ b/packages/core/src/helpers/stats.ts
@@ -58,16 +58,6 @@ export const getStatsWarnings = ({
   return [];
 };
 
-export const getStatsAssetsOptions = (): Rspack.StatsOptions => ({
-  assets: true,
-  cachedAssets: true,
-  groupAssetsByInfo: false,
-  groupAssetsByPath: false,
-  groupAssetsByChunk: false,
-  groupAssetsByExtension: false,
-  groupAssetsByEmitStatus: false,
-});
-
 export type RsbuildAsset = {
   /**
    * The name of the asset.


### PR DESCRIPTION
## Summary

The `getStatsAssetsOptions` function was not being used anywhere in the codebase and was safe to remove to reduce code clutter.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
