### PR TITLE
feat: add integrity field to manifest when sri is enabled

### DIFF
--- a/e2e/cases/output/manifest-integrity/index.test.ts
+++ b/e2e/cases/output/manifest-integrity/index.test.ts
@@ -1,0 +1,32 @@
+import { expect, getFileContent, rspackTest } from '@e2e/helper';
+import type { ManifestData } from '@rsbuild/core';
+
+rspackTest(
+  'should generate manifest file with integrity in build',
+  async ({ build }) => {
+    const rsbuild = await build();
+    const files = rsbuild.getDistFiles();
+    const manifestContent = getFileContent(files, 'manifest.json');
+    const manifest = JSON.parse(manifestContent) as ManifestData;
+    manifest.allFiles.forEach((item) => {
+      if (item.endsWith('.js')) {
+        expect(manifest.integrity[item]).toBeTruthy();
+      }
+    });
+  },
+);
+
+rspackTest(
+  'should generate manifest file with integrity in dev',
+  async ({ dev }) => {
+    const rsbuild = await dev();
+    const files = rsbuild.getDistFiles();
+    const manifestContent = getFileContent(files, 'manifest.json');
+    const manifest = JSON.parse(manifestContent) as ManifestData;
+    manifest.allFiles.forEach((item) => {
+      if (item.endsWith('.js')) {
+        expect(manifest.integrity[item]).toBeTruthy();
+      }
+    });
+  },
+);

--- a/e2e/cases/output/manifest-integrity/rsbuild.config.ts
+++ b/e2e/cases/output/manifest-integrity/rsbuild.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@rsbuild/core';
+
+export default defineConfig({
+  output: {
+    manifest: true,
+    filenameHash: false,
+  },
+  security: {
+    sri: {
+      enable: true,
+    },
+  },
+});

--- a/e2e/cases/output/manifest-integrity/src/index.ts
+++ b/e2e/cases/output/manifest-integrity/src/index.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+console.log('hello!', React);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -93,7 +93,7 @@
     "reduce-configs": "^1.1.1",
     "rslog": "^1.3.0",
     "rspack-chain": "^1.4.1",
-    "rspack-manifest-plugin": "5.1.0",
+    "rspack-manifest-plugin": "5.2.0",
     "sirv": "^3.0.2",
     "stacktrace-parser": "^0.1.11",
     "style-loader": "3.3.4",

--- a/packages/core/src/plugins/manifest.ts
+++ b/packages/core/src/plugins/manifest.ts
@@ -34,8 +34,13 @@ const generateManifest =
     const chunkEntries = new Map<string, FileDescriptor[]>();
     const licenseMap = new Map<string, string>();
     const publicPath = getPublicPathFromCompiler(compilation);
+    const integrity: Record<string, string> = {};
 
     const allFiles = files.map((file) => {
+      if (file.integrity) {
+        integrity[file.path] = file.integrity;
+      }
+
       if (file.chunk) {
         const entryNames = recursiveChunkEntryNames(file.chunk);
 
@@ -144,6 +149,7 @@ const generateManifest =
     const manifestData: ManifestData = {
       allFiles,
       entries: manifestEntries,
+      integrity,
     };
 
     if (manifestOptions.generate) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1179,6 +1179,12 @@ export type ManifestData = {
   entries: {
     [entryName: string]: ManifestByEntry;
   };
+  /**
+   * Subresource Integrity (SRI) hashes for emitted assets.
+   * The key is the asset file path, and the value is its integrity hash.
+   * This field is available only when the `security.sri` option is enabled.
+   */
+  integrity: Record<string, string>;
 };
 
 export type ManifestObjectConfig = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -728,8 +728,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       rspack-manifest-plugin:
-        specifier: 5.1.0
-        version: 5.1.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))
+        specifier: 5.2.0
+        version: 5.2.0(@rspack/core@1.6.4(@swc/helpers@0.5.17))
       sirv:
         specifier: ^3.0.2
         version: 3.0.2
@@ -5807,9 +5807,8 @@ packages:
   rspack-chain@1.4.1:
     resolution: {integrity: sha512-cKkRjUXl2fhQzYwQD7aux+Og1WtjuWFG5XjtOZldjYiRanRoz9OrmbRf4s2kCOgxNplPWP946mqG5hAIzY/V0w==}
 
-  rspack-manifest-plugin@5.1.0:
-    resolution: {integrity: sha512-XAt1VOfRt6gcNlekB7rpiYK0MuC8VuWRrM2F33Eu83B/fmEVJUNVMDxZJhqJ0NMDJNxq80404j+NAfzlYQCjrw==}
-    engines: {node: '>=14'}
+  rspack-manifest-plugin@5.2.0:
+    resolution: {integrity: sha512-W4fIoDE7cGiN7iBh2Zs71W/P+iRSvUi2jIcyzcvDvjgoPbqYw15AL0bZMgQ88OzEocYwtFcsn/iQFFv8h+XRAg==}
     peerDependencies:
       '@rspack/core': 0.x || 1.x
     peerDependenciesMeta:
@@ -11857,7 +11856,7 @@ snapshots:
       deepmerge: 4.3.1
       javascript-stringify: 2.1.0
 
-  rspack-manifest-plugin@5.1.0(@rspack/core@1.6.4(@swc/helpers@0.5.17)):
+  rspack-manifest-plugin@5.2.0(@rspack/core@1.6.4(@swc/helpers@0.5.17)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:

--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -91,6 +91,12 @@ type ManifestList = {
        */
       assets?: FilePath[];
     };
+    /**
+     * Subresource Integrity (SRI) hashes for emitted assets.
+     * The key is the asset file path, and the value is its integrity hash.
+     * This field is available only when the `security.sri` option is enabled.
+     */
+    integrity: Record<string, string>;
   };
 };
 ```

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -91,6 +91,12 @@ type ManifestList = {
        */
       assets?: FilePath[];
     };
+    /**
+     * 所有产物文件的子资源完整性（SRI）哈希值
+     * key 为文件路径，value 为对应的完整性哈希
+     * 仅在启用 `security.sri` 选项时才会生成该字段
+     */
+    integrity: Record<string, string>;
   };
 };
 ```


### PR DESCRIPTION
## Summary

Add Subresource Integrity (SRI) hashes to the manifest file for emitted assets when the security.sri option is enabled.

This includes updating the manifest plugin, adding test cases, and documenting the new integrity field in documentation.

## Related Links

- resolve https://github.com/web-infra-dev/rsbuild/issues/6090
- https://github.com/rspack-contrib/rspack-manifest-plugin/releases/tag/v5.2.0

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
