### PR TITLE
release: v1.6.8

### DIFF
--- a/packages/compat/webpack/package.json
+++ b/packages/compat/webpack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/webpack",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "homepage": "https://rsbuild.rs",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsbuild/core",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "The Rspack-based build tool.",
   "homepage": "https://rsbuild.rs",
   "bugs": {

--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rsbuild",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Create a new Rsbuild project",
   "homepage": "https://rsbuild.rs",
   "repository": {


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
### New Features 🎉
* feat: improve build time printing by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6607
* feat: improve build time logs with error state by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6608
* feat(plugin-api): add build time to environment compile hook by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6584
* feat: add order option to control PostCSS plugin insertion position by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6622
* feat: add integrity field to manifest when sri is enabled by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6634
### Bug Fixes 🐞
* fix(create-rsbuild): use current package manager in templates by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6612
* fix: improve browserslist cache key by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6620
* fix: open base url when no routes are available by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6630
* fix: improve error handling when loading addons failed by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6631
### Refactor 🔨
* refactor: simplify helper used by the Node addons plugin by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6626
### Document 📖
* docs: fix JSX import source reference in documentation by @htoooth in https://github.com/web-infra-dev/rsbuild/pull/6614
* docs(meta): add open graph tags example by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6615
* docs: fix outdated plugin order link by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6617
* docs: improve environment and compatibility wording by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6621
* docs: refine webpack migration wording by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6629
* docs: add detailed JSDoc to manifest data types by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6632
### Other Changes
* chore(deps): update dependency core-js to ~3.47.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6609
* chore(deps): update dependency prebundle to v1.6.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6610
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6611
* chore(deps): update dependency nano-staged to ^0.9.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6618
* chore(deps): update actions/checkout action to v6 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6619
* test(e2e): improve test cases for postcss plugins by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6623
* chore(deps): update module-federation to 0.21.5 and remove unused packages by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6624
* chore(deps): update dependency nx to ^22.1.1 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6627
* chore(deps): update dependency webpack to ^5.103.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6628
* chore: remove unused getStatsAssetsOptions function by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6633
* chore(deps): update pnpm to v10.23.0 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6637
* chore(deps): update all patch dependencies by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6636
* chore(deps): update dependency open to v11 by @renovate[bot] in https://github.com/web-infra-dev/rsbuild/pull/6638
* release: v1.6.8 by @chenjiahan in https://github.com/web-infra-dev/rsbuild/pull/6640

## New Contributors
* @htoooth made their first contribution in https://github.com/web-infra-dev/rsbuild/pull/6614

**Full Changelog**: https://github.com/web-infra-dev/rsbuild/compare/v1.6.7...v1.6.8