### PR TITLE
fix: avoid treating scoped paths as globs

### DIFF
--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -111,7 +111,7 @@ function prepareWatchOptions(
   };
 }
 
-const GLOB_REGEX = /[*?{}[\]()!@+|]/;
+const GLOB_REGEX = /[*?{}[\]()!+|]/;
 /**
  * A simple glob pattern checker.
  * This can help us to avoid unnecessary tinyglobby import and call.


### PR DESCRIPTION
## Summary
- prevent watch file glob detection from misclassifying paths containing '@' so scoped directories still get watched

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692251a807c883278ef6d5a2db63102f)