### PR TITLE
docs: polish English phrasing in basic guides

### DIFF
--- a/website/docs/en/guide/basic/server.mdx
+++ b/website/docs/en/guide/basic/server.mdx
@@ -103,7 +103,7 @@ export default {
 
 ## Rspack dev server
 
-Rsbuild has a built-in lightweight dev server that differs from the dev servers in Rspack CLI or webpack CLI, with different configuration options.
+Rsbuild includes its own lightweight dev server, which differs from the servers in Rspack CLI and webpack CLI and offers its own configuration options.
 
 ### Comparison
 

--- a/website/docs/en/guide/basic/static-deploy.mdx
+++ b/website/docs/en/guide/basic/static-deploy.mdx
@@ -1,6 +1,6 @@
 # Deploy static site
 
-This section introduces how to deploy the build outputs of Rsbuild as a static site.
+This section explains how to deploy Rsbuild build outputs as a static site.
 
 ## Background information
 
@@ -32,7 +32,7 @@ The preview command is only used for local preview. Do not use it for production
 
 ### Output directory
 
-Rsbuild's build outputs typically include HTML, JS, CSS, and other assets, and are output to the `dist` directory by default. The name and structure of the dist directory can be changed using some configuration options. See the [Output Files](/guide/basic/output-files) section for more information.
+Rsbuild's build outputs typically include HTML, JS, CSS, and other assets, and are output to the `dist` directory by default. You can change the name and structure of the dist directory with configuration options. See the [Output Files](/guide/basic/output-files) section for more information.
 
 ```bash
 dist
@@ -50,7 +50,7 @@ We can divide the build output into two parts: **HTML files** and **static asset
 - HTML files refer to files with the `.html` suffix in the output directory, which usually need to be deployed on the server.
 - Static assets are located in the `static` directory of the output folder, which contains assets such as JavaScript, CSS, and images. They can be deployed either on the server or on a CDN.
 
-If the static assets are deployed in a subdirectory of the server, set [output.assetPrefix](/config/output/asset-prefix) as the base path:
+If you deploy static assets to a subdirectory on the server, set [output.assetPrefix](/config/output/asset-prefix) as the base path:
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';
@@ -62,7 +62,7 @@ export default defineConfig({
 });
 ```
 
-If you want to place these static assets on a CDN for better performance rather than directly on the server with the HTML, set [output.assetPrefix](/config/output/asset-prefix) to the CDN address to ensure the application can properly reference these static assets.
+If you want to place these static assets on a CDN for better performance instead of serving them with the HTML from the server, set [output.assetPrefix](/config/output/asset-prefix) to the CDN address to ensure the application can properly reference these static assets.
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';

--- a/website/docs/en/guide/basic/wasm-assets.mdx
+++ b/website/docs/en/guide/basic/wasm-assets.mdx
@@ -37,7 +37,7 @@ console.log(wasmURL.pathname); // "/static/wasm/[contenthash:8].module.wasm"
 
 ## Output directory
 
-When a `.wasm` asset is imported, it will be output by Rsbuild to the `dist/static/wasm` directory by default.
+When you import a `.wasm` asset, Rsbuild outputs it to the `dist/static/wasm` directory by default.
 
 You can change the output directory for `.wasm` files using the [output.distPath](/config/output/dist-path) configuration:
 


### PR DESCRIPTION
## Summary
- improve clarity in the static deployment guide, especially around dist structure and asset prefixes
- refine the dev server description to better distinguish Rsbuild from other CLIs
- simplify wording about WebAssembly asset output locations

## Testing
- not run (docs only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69245068f4a48327aa9f542fd8ad18b7)