### PR TITLE
fix: reset hasBuildErrors flag correctly

### DIFF
--- a/packages/core/src/client/hmr.ts
+++ b/packages/core/src/client/hmr.ts
@@ -41,8 +41,8 @@ function clearBuildErrors() {
   // Clean up outdated compile errors
   if (console.clear && hasBuildErrors) {
     console.clear();
+    hasBuildErrors = false;
   }
-  hasBuildErrors = false;
 }
 
 let createOverlay: undefined | ((html: string) => void);


### PR DESCRIPTION
## Summary

This pull request makes a minor update to the `clearBuildErrors` function. The change ensures that the `hasBuildErrors` flag is properly reset.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
