### PR TITLE
fix: handle status message in gzip middleware

### DIFF
--- a/packages/core/src/server/gzipMiddleware.ts
+++ b/packages/core/src/server/gzipMiddleware.ts
@@ -94,7 +94,9 @@ export const gzipMiddleware = ({
         res.statusMessage = reason;
       } else if (reason) {
         for (const [key, value] of Object.entries(reason)) {
-          res.setHeader(key, value);
+          if (value !== undefined) {
+            res.setHeader(key, value);
+          }
         }
       }
       writeHeadStatus = status;


### PR DESCRIPTION
## Summary
- correctly handle statusMessage and headers when overriding writeHead in the gzip middleware

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928178c7f408327925afb87441b2a61)