### PR TITLE
feat: improve error overlay readability by enabling line wrapping

### DIFF
--- a/packages/core/src/server/overlay.ts
+++ b/packages/core/src/server/overlay.ts
@@ -95,7 +95,8 @@ export function genOverlayHTML(errors: string[], root?: string) {
   margin: 0;
   font-size: 14px;
   font-family: inherit;
-  overflow-x: scroll;
+  white-space: pre-wrap;
+  word-break: break-all;
   scrollbar-width: none;
 }
 .content::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

The overlay now uses `word-break: break-all` so long stack traces and paths wrap automatically. This aligns the display with typical terminal behavior and removes the need for horizontal scrolling, making errors easier to read at a glance.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
