### PR TITLE
fix: use sequential config generation to ensure deterministic results

### DIFF
--- a/packages/core/src/provider/initConfigs.ts
+++ b/packages/core/src/provider/initConfigs.ts
@@ -321,16 +321,20 @@ export async function initConfigs({
 }> {
   const normalizedConfig = await initRsbuildConfig({ context, pluginManager });
 
-  const rspackConfigs = await Promise.all(
-    Object.entries(normalizedConfig.environments).map(
-      ([environmentName, config]) =>
-        generateRspackConfig({
-          target: config.output.target,
-          context,
-          environmentName,
-        }),
-    ),
-  );
+  const rspackConfigs: Rspack.Configuration[] = [];
+
+  // Generate Rspack configs sequentially to ensure deterministic ordering and stable results
+  for (const [environmentName, config] of Object.entries(
+    normalizedConfig.environments,
+  )) {
+    rspackConfigs.push(
+      await generateRspackConfig({
+        target: config.output.target,
+        context,
+        environmentName,
+      }),
+    );
+  }
 
   // write Rsbuild config and Rspack config to disk in debug mode
   if (isDebug()) {


### PR DESCRIPTION
## Summary

This change replaces `Promise.all` with sequential execution when generating multiple Rspack configurations. Running the tasks one by one guarantees a stable and deterministic order, preventing subtle variations that can occur when configs are produced in parallel.

## Related Links

Fix unstable Modern.js snapshots: https://github.com/web-infra-dev/modern.js/actions/runs/19753239342/job/56600092091?pr=7926

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
