### PR TITLE
fix: add workaround for virtual modules build log

### DIFF
--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -69,6 +69,12 @@ function printBuildLog(
     : null;
 
   if (removedFiles?.length) {
+    // workaround for https://github.com/web-infra-dev/rspack/issues/11694
+    if (removedFiles.every((item) => item.includes('virtual'))) {
+      logger.start(`building ${color.dim('virtual modules')}`);
+      return;
+    }
+
     const fileInfo = formatFileList(removedFiles, context.rootPath);
     logger.start(`building ${color.dim(`removed ${fileInfo}`)}`);
     return;


### PR DESCRIPTION
## Summary

Add workaround for virtual modules build log to prevent misleading build log output.

## Related Links

- https://github.com/web-infra-dev/rspack/issues/11694

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
