### PR TITLE
chore: remove pnpm trust policy config

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,10 +21,3 @@ patchedDependencies:
 
 strictPeerDependencies: false
 engineStrict: true
-trustPolicy: no-downgrade
-trustPolicyExclude:
-  # For ecosystem CI and Renovate
-  - semver@5.7.2 || 6.3.1
-  - chokidar@4.0.3
-  - rxjs@7.8.2
-  - 'ua-parser-js@1.0.41'


### PR DESCRIPTION
## Summary

Remove pnpm trust policy config as this feature breaks rspack-ecosystem-ci.

## Related Links

- https://github.com/web-infra-dev/rspack/actions/runs/19847529481/job/56870397008#step:8:884

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
