### PR TITLE
docs: add `manifest.prefix` option documentation

### DIFF
--- a/website/docs/en/config/output/manifest.mdx
+++ b/website/docs/en/config/output/manifest.mdx
@@ -254,7 +254,7 @@ const files = [
 - **Type:** `boolean`
 - **Default:** `true`
 
-Controls whether the generated manifest includes the static asset prefix in file paths. The prefix is taken from [dev.assetPrefix](/config/output/asset-prefix) and [output.assetPrefix](/config/output/asset-prefix).
+Controls whether the generated manifest includes the static asset prefix in file paths. The prefix is taken from [dev.assetPrefix](/config/dev/asset-prefix) and [output.assetPrefix](/config/output/asset-prefix).
 
 When `prefix` is set to `true` (the default), the manifest will include the full asset prefix.
 

--- a/website/docs/zh/config/output/manifest.mdx
+++ b/website/docs/zh/config/output/manifest.mdx
@@ -254,7 +254,7 @@ const files = [
 - **类型：** `boolean`
 - **默认值：** `true`
 
-控制是否在 manifest 中的文件路径前添加静态资源前缀，即 [dev.assetPrefix](/config/output/asset-prefix) 和 [output.assetPrefix](/config/output/asset-prefix)。
+控制是否在 manifest 中的文件路径前添加静态资源前缀，即 [dev.assetPrefix](/config/dev/asset-prefix) 和 [output.assetPrefix](/config/output/asset-prefix)。
 
 当 `prefix` 为 `true`（默认值）时，生成的 manifest 会包含完整的资源前缀。
 


### PR DESCRIPTION
## Summary

Add documentation for the new `prefix` option in manifest configuration, which controls whether to include asset prefix in file paths.

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6681

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
