### PR TITLE
test(hmr): refactor live-reload tests to use temp directory

### DIFF
--- a/e2e/cases/hmr/live-reload/index.test.ts
+++ b/e2e/cases/hmr/live-reload/index.test.ts
@@ -1,23 +1,21 @@
-import fs from 'node:fs';
 import path from 'node:path';
-import { expect, rspackTest, test } from '@e2e/helper';
-
-const appFile = path.join(import.meta.dirname, 'src/App.jsx');
-let appCode: string;
-
-test.beforeEach(() => {
-  appCode = fs.readFileSync(appFile, 'utf-8');
-});
-
-test.afterEach(() => {
-  // recover the source code
-  fs.writeFileSync(appFile, appCode, 'utf-8');
-});
+import { expect, rspackTest } from '@e2e/helper';
 
 rspackTest(
   'should fallback to live-reload when dev.hmr is false',
-  async ({ page, dev, editFile }) => {
-    await dev();
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
+    const appFile = path.join(tempSrc, 'App.jsx');
+    await dev({
+      config: {
+        source: {
+          entry: {
+            index: path.join(tempSrc, 'index.js'),
+          },
+        },
+      },
+    });
+
     const testEl = page.locator('#test');
     await expect(testEl).toHaveText('Hello Rsbuild!');
     await editFile(appFile, (code) => code.replace('Rsbuild', 'Live Reload'));
@@ -27,9 +25,16 @@ rspackTest(
 
 rspackTest(
   'should not reload page when live-reload is disabled',
-  async ({ page, dev, editFile }) => {
+  async ({ page, dev, editFile, copySrcDir }) => {
+    const tempSrc = await copySrcDir();
+    const appFile = path.join(tempSrc, 'App.jsx');
     await dev({
       config: {
+        source: {
+          entry: {
+            index: path.join(tempSrc, 'index.js'),
+          },
+        },
         dev: {
           liveReload: false,
         },


### PR DESCRIPTION
## Summary

Refactor live reload tests to use `copySrcDir` helper to create temporary test directory instead of modifying original source files directly. This improves test isolation and reliability.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
