### PR TITLE
docs(quick-start): update template table with integration guide links

### DIFF
--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -52,17 +52,17 @@ After creating the application, follow these steps:
 
 When creating an application, you can choose from the following templates provided by `create-rsbuild`:
 
-| Template | Description                     | Optional Features |
-| -------- | ------------------------------- | ----------------- |
-| vanilla  | Vanilla JavaScript              | TypeScript        |
-| react    | [React 19](https://react.dev/)  | TypeScript        |
-| react18  | [React 18](https://react.dev/)  | TypeScript        |
-| vue      | [Vue 3](https://vuejs.org/)     | TypeScript        |
-| vue2     | [Vue 2](https://v2.vuejs.org/)  | TypeScript        |
-| lit      | [Lit](https://lit.dev/)         | TypeScript        |
-| preact   | [Preact](https://preactjs.com/) | TypeScript        |
-| svelte   | [Svelte 5](https://svelte.dev/) | TypeScript        |
-| solid    | [Solid](https://solidjs.com/)   | TypeScript        |
+| Template | Official docs                   | Rsbuild integration guide               |
+| -------- | ------------------------------- | --------------------------------------- |
+| vanilla  | Native JavaScript               | -                                       |
+| react    | [React 19](https://react.dev/)  | [Using React](/guide/framework/react)   |
+| react18  | [React 18](https://react.dev/)  | [Using React](/guide/framework/react)   |
+| vue      | [Vue 3](https://vuejs.org/)     | [Using Vue](/guide/framework/vue)       |
+| vue2     | [Vue 2](https://v2.vuejs.org/)  | [Using Vue](/guide/framework/vue)       |
+| lit      | [Lit](https://lit.dev/)         | -                                       |
+| preact   | [Preact](https://preactjs.com/) | [Using Preact](/guide/framework/preact) |
+| svelte   | [Svelte](https://svelte.dev/)   | [Using Svelte](/guide/framework/svelte) |
+| solid    | [Solid](https://solidjs.com/)   | [Using Solid](/guide/framework/solid)   |
 
 `create-rsbuild` provides basic templates. You can find more templates at:
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -50,19 +50,19 @@ import { PackageManagerTabs } from '@theme';
 
 ### 模板
 
-在创建应用时，你可以选择 `create-rsbuild` 提供的下列模板：
+在创建应用时，你可以选择 `create-rsbuild` 提供的下列模板，查看集成指南了解更多信息。
 
-| 模板    | 描述                            | 可选功能   |
-| ------- | ------------------------------- | ---------- |
-| vanilla | 原生 JavaScript                 | TypeScript |
-| react   | [React 19](https://react.dev/)  | TypeScript |
-| react18 | [React 18](https://react.dev/)  | TypeScript |
-| vue     | [Vue 3](https://vuejs.org/)     | TypeScript |
-| vue2    | [Vue 2](https://v2.vuejs.org/)  | TypeScript |
-| lit     | [Lit](https://lit.dev/)         | TypeScript |
-| preact  | [Preact](https://preactjs.com/) | TypeScript |
-| svelte  | [Svelte 5](https://svelte.dev/) | TypeScript |
-| solid   | [Solid](https://solidjs.com/)   | TypeScript |
+| 模板    | 官方文档                        | Rsbuild 集成指南                       |
+| ------- | ------------------------------- | -------------------------------------- |
+| vanilla | 原生 JavaScript                 | -                                      |
+| react   | [React 19](https://react.dev/)  | [使用 React](/guide/framework/react)   |
+| react18 | [React 18](https://react.dev/)  | [使用 React](/guide/framework/react)   |
+| vue     | [Vue 3](https://vuejs.org/)     | [使用 Vue](/guide/framework/vue)       |
+| vue2    | [Vue 2](https://v2.vuejs.org/)  | [使用 Vue](/guide/framework/vue)       |
+| lit     | [Lit](https://lit.dev/)         | -                                      |
+| preact  | [Preact](https://preactjs.com/) | [使用 Preact](/guide/framework/preact) |
+| svelte  | [Svelte](https://svelte.dev/)   | [使用 Svelte](/guide/framework/svelte) |
+| solid   | [Solid](https://solidjs.com/)   | [使用 Solid](/guide/framework/solid)   |
 
 `create-rsbuild` 提供了开箱即用的基础模板，你还可以通过以下方式获取更丰富的模板：
 


### PR DESCRIPTION
## Summary

Add links to framework integration guides in the template tables. The changes provide users with direct access to framework-specific setup instructions.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
