### PR TITLE
docs: polish css-in-js wording

### DIFF
--- a/website/docs/en/guide/styling/css-in-js.mdx
+++ b/website/docs/en/guide/styling/css-in-js.mdx
@@ -4,9 +4,9 @@ This document outlines how to use common CSS-in-JS libraries in Rsbuild.
 
 Although the examples are based on React, some CSS-in-JS libraries (such as [vanilla-extract](#vanilla-extract)) also support other frameworks.
 
-### Using Emotion
+### Use Emotion
 
-Rsbuild supports compiling [Emotion](https://github.com/emotion-js/emotion), you can add the following configuration to use:
+Rsbuild supports compiling [Emotion](https://github.com/emotion-js/emotion). Add the following configuration to enable it:
 
 - [swcReactOptions.importSource](/plugins/list/plugin-react#swcreactoptions)
 - [@swc/plugin-emotion](https://npmjs.com/package/@swc/plugin-emotion)
@@ -59,15 +59,15 @@ export default defineConfig({
 });
 ```
 
-Please note, you must select the SWC plugin that matches the current version of `@swc/core` for SWC to work, see [tools.swc](/config/tools/swc).
+Make sure to choose the SWC plugin version that matches your current `@swc/core` version so SWC can run correctly. See [tools.swc](/config/tools/swc).
 
 > Refer to this example: [styled-jsx](https://github.com/rspack-contrib/rstack-examples/tree/main/rsbuild/styled-jsx).
 
 ### Use vanilla-extract
 
-Rsbuild supports [@vanilla-extract/webpack-plugin](https://npmjs.com/package/@vanilla-extract/webpack-plugin). You can add the following config to use [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract):
+Rsbuild supports [@vanilla-extract/webpack-plugin](https://npmjs.com/package/@vanilla-extract/webpack-plugin). Add the following config to use [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract):
 
-Currently, Rspack has an [HMR issue](https://github.com/web-infra-dev/rsbuild/issues/6049) when using `splitChunks` together with `@vanilla-extract/webpack-plugin`. In development mode, you can use a special `splitChunks` configuration to work around this issue.
+Currently, Rspack has an [HMR issue](https://github.com/web-infra-dev/rsbuild/issues/6049) when `splitChunks` is used with `@vanilla-extract/webpack-plugin`. In development mode, you can use a dedicated `splitChunks` configuration to avoid the issue.
 
 ```ts title="rsbuild.config.ts"
 import { defineConfig } from '@rsbuild/core';
@@ -119,7 +119,7 @@ export const containerStyle = style({
 });
 ```
 
-Since `logoUrl` is already a resolved path pointing to the dist directory, `css-loader` doesn't need to process it again. Disable CSS URL processing via [tools.cssLoader.url](/config/tools/css-loader) to avoid module resolution errors:
+Since `logoUrl` already resolves to the dist directory, `css-loader` doesn't need to process it again. Disable CSS URL processing via [tools.cssLoader.url](/config/tools/css-loader) to avoid module resolution errors:
 
 ```ts title="rsbuild.config.ts"
 export default defineConfig({
@@ -157,7 +157,7 @@ export default defineConfig({
 
 ### Use styled-components
 
-[styled-components](https://github.com/styled-components/styled-components) is a runtime library, you can use it directly without any additional configuration.
+[styled-components](https://github.com/styled-components/styled-components) is a runtime library, so you can use it directly without additional configuration.
 
 Rsbuild supports compiling styled-components, improving the debugging experience and adding SSR support to styled-components.
 


### PR DESCRIPTION
## Summary
- Improve CSS-in-JS guide wording for clearer instructions
- Keep headings in sentence case and clarify plugin guidance

## Testing
- Not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693143c92d54832798281e28e48e12bd)