### PR TITLE
docs: polish quick start wording

### DIFF
--- a/website/docs/en/guide/start/features.mdx
+++ b/website/docs/en/guide/start/features.mdx
@@ -1,6 +1,6 @@
 # Features
 
-All the main features that Rsbuild supports.
+Overview of the main features supported by Rsbuild.
 
 ## JavaScript
 

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -2,7 +2,7 @@
 
 ## Online examples
 
-We provide online examples based on Rsbuild. These examples demonstrate Rspack's build performance and Rsbuild's development experience:
+We provide online examples built with Rsbuild. These examples showcase Rspack's build performance and the Rsbuild development experience:
 
 - [StackBlitz example](https://stackblitz.com/~/github.com/rspack-contrib/rsbuild-stackblitz-example)
 - [CodeSandbox example](https://codesandbox.io/p/github/rspack-contrib/rsbuild-codesandbox-example)
@@ -11,7 +11,7 @@ We provide online examples based on Rsbuild. These examples demonstrate Rspack's
 
 Rsbuild supports using [Node.js](https://nodejs.org/), [Deno](https://deno.com/), or [Bun](https://bun.sh/) as the JavaScript runtime.
 
-You can refer to the following installation guides and choose a runtime:
+Use the following installation guides to choose a runtime:
 
 - [Install Node.js](https://nodejs.org/en/download)
 - [Install Bun](https://bun.com/docs/installation)
@@ -42,7 +42,7 @@ import { PackageManagerTabs } from '@theme';
 
 Follow the prompts to choose from available options. During setup, you can select whether to add optional tools like TypeScript and ESLint.
 
-After creating the application, follow these steps:
+After creating the application, complete these steps:
 
 - Run `git init` to initialize a Git repository.
 - Run `npm install` (or your package manager's install command) to install dependencies.
@@ -210,7 +210,7 @@ export default {
   />
 </a>
 
-Rsbuild core package, providing CLI commands and JavaScript API.
+Core Rsbuild package that provides the CLI commands and JavaScript API.
 
 ### create-rsbuild
 


### PR DESCRIPTION
## Summary
- refine quick start guidance wording for clarity on online examples, install steps, and post-creation actions
- adjust description of the @rsbuild/core package for concise context
- update features overview intro to read more naturally

## Testing
- pnpm lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693143c92d54832798281e28e48e12bd)