### PR TITLE
fix: handle ANSI escape codes in node polyfill hint

### DIFF
--- a/packages/core/src/helpers/format.ts
+++ b/packages/core/src/helpers/format.ts
@@ -1,4 +1,5 @@
 import { sep } from 'node:path';
+import { stripVTControlCharacters as stripAnsi } from 'node:util';
 import type { StatsError } from '@rspack/core';
 import { isVerbose } from '../logger';
 import { removeLoaderChainDelimiter } from './stats';
@@ -207,7 +208,7 @@ const hintNodePolyfill = (message: string): string => {
     return message;
   }
 
-  const matchArray = message.match(/Can't resolve '(\w+)'/);
+  const matchArray = stripAnsi(message).match(/Can't resolve '(\w+)'/);
   if (!matchArray) {
     return message;
   }


### PR DESCRIPTION
## Summary

Strip ANSI control characters before matching error message to ensure consistent pattern matching.

## Related Links

- https://github.com/web-infra-dev/rspack/actions/runs/19852363945/job/56882262616
- https://github.com/web-infra-dev/rspack/pull/12348

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
