### PR TITLE
test(e2e): add case for package.json imports resolution

### DIFF
--- a/e2e/cases/resolve/node-imports-field/index.test.ts
+++ b/e2e/cases/resolve/node-imports-field/index.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from '@e2e/helper';
+
+test('should resolve package.json imports field in dev', async ({ page, dev }) => {
+  await dev();
+
+  const app = page.locator('#app');
+  await expect(app).toHaveText('imports field works');
+});
+
+test('should resolve package.json imports field in build', async ({
+  page,
+  buildPreview,
+}) => {
+  await buildPreview();
+
+  const app = page.locator('#app');
+  await expect(app).toHaveText('imports field works');
+});

--- a/e2e/cases/resolve/node-imports-field/package.json
+++ b/e2e/cases/resolve/node-imports-field/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@e2e/resolve-node-imports-field",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "imports": {
+    "#app/*": "./src/*.js"
+  }
+}

--- a/e2e/cases/resolve/node-imports-field/src/foo.js
+++ b/e2e/cases/resolve/node-imports-field/src/foo.js
@@ -1,0 +1,1 @@
+export const message = 'imports field works';

--- a/e2e/cases/resolve/node-imports-field/src/index.js
+++ b/e2e/cases/resolve/node-imports-field/src/index.js
@@ -1,0 +1,7 @@
+import { message } from '#app/foo';
+
+const app = document.createElement('div');
+app.id = 'app';
+app.textContent = message;
+
+document.body.appendChild(app);


### PR DESCRIPTION
## Summary
- add a new resolve e2e fixture that exercises the Node.js `package.json` imports field
- verify the `#app/*` import alias resolves correctly in both dev and build

## Testing
- pnpm lint (not run: `pnpm` is not available in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69321dcd0e108327a7c5666e6644b202)