### PR TITLE
docs: update zh documentation for `client.logLevel`

### DIFF
--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -87,7 +87,9 @@ During the HMR process, the page will make GET requests to get hot-update files,
 
 Hot-update files are considered to be static assets. If you need to configure the URL for hot-update files, please use the [dev.assetPrefix](/config/dev/asset-prefix) option.
 
-## Error overlay
+## Options
+
+### overlay
 
 The `dev.client.overlay` option allows you to choose whether or not to enable the error overlay feature.
 
@@ -111,7 +113,10 @@ export default {
 The error overlay feature requires the current browser to support [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components). If the browser does not support it, the overlay will not be displayed.
 :::
 
-## Log level
+### logLevel
+
+- **Type:** `'info' | 'warn' | 'error' | 'silent'`
+- **Default:** Inherits from root [logLevel](/config/log-level), defaults to `info`
 
 The `dev.client.logLevel` option controls the log level for Rsbuild's client-side messages in the browser console.
 
@@ -119,15 +124,21 @@ The `dev.client.logLevel` option controls the log level for Rsbuild's client-sid
 export default {
   dev: {
     client: {
-      logLevel: 'warn', // 'info' | 'warn' | 'error' | 'silent'
+      logLevel: 'warn',
     },
   },
 };
 ```
+
+Optional values:
 
 - `'info'` - Shows all messages (default).
 - `'warn'` - Shows warnings and errors only.
 - `'error'` - Shows only errors.
 - `'silent'` - Suppresses all Rsbuild client logs.
 
-If not set, it inherits from the root [`logLevel`](/config/root#loglevel) config.
+## Version history
+
+| Version | Changes                 |
+| ------- | ----------------------- |
+| v1.6.13 | Added `logLevel` option |

--- a/website/docs/en/config/log-level.mdx
+++ b/website/docs/en/config/log-level.mdx
@@ -6,6 +6,10 @@
 
 Sets the Rsbuild log level. Defaults to `info`.
 
+:::tip
+This option also affects Rsbuild's log output in the browser. You can override this behavior through the [client.logLevel](/config/dev/client#loglevel) option.
+:::
+
 ## Example
 
 When `logLevel` is set to `warn`, Rsbuild only outputs warning and error logs:

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -83,15 +83,17 @@ export default {
 
 hot-update 文件属于静态资源，如果你需要配置 hot-update 文件的 URL，请使用 [dev.assetPrefix](/config/dev/asset-prefix) 选项。
 
-## Error overlay
+## 选项
 
-通过 `dev.client.overlay` 选项，可以选择是否启用 error overlay。
+### overlay
 
-默认情况下，当编译发生错误时，Rsbuild会在浏览器中显示 error overlay，并提供错误信息和错误堆栈：
+通过 `dev.client.overlay` 选项，可以选择是否启用错误浮层。
+
+默认情况下，当编译发生错误时，Rsbuild会在浏览器中显示错误浮层，并提供错误信息和错误堆栈：
 
 ![error overlay](https://assets.rspack.rs/rsbuild/assets/rsbuild-error-overlay.png)
 
-如果需要禁用 error overlay，可以将其设置为 `false`：
+如果需要禁用错误浮层，可以将其设置为 `false`：
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -104,5 +106,35 @@ export default {
 ```
 
 :::tip
-Error overlay 功能需要当前浏览器版本支持 [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)。在不支持的浏览器中，overlay 不会展示。
+错误浮层功能需要当前浏览器版本支持 [Web Components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components)。在不支持的浏览器中，overlay 不会展示。
 :::
+
+### logLevel
+
+- **类型:** `'info' | 'warn' | 'error' | 'silent'`
+- **默认值:** 继承自根级的 [logLevel](/config/log-level)，默认是 `info`
+
+`dev.client.logLevel` 用于控制 Rsbuild 在浏览器控制台输出的客户端日志级别。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      logLevel: 'warn',
+    },
+  },
+};
+```
+
+可选值有：
+
+- `'info'` - 显示所有日志（默认）
+- `'warn'` - 仅显示警告和错误
+- `'error'` - 仅显示错误
+- `'silent'` - 不显示任何 Rsbuild 客户端日志
+
+## 版本历史
+
+| 版本    | 更新内容             |
+| ------- | -------------------- |
+| v1.6.13 | 新增 `logLevel` 选项 |

--- a/website/docs/zh/config/log-level.mdx
+++ b/website/docs/zh/config/log-level.mdx
@@ -6,6 +6,10 @@
 
 指定 Rsbuild 的日志级别，默认值为 `info`。
 
+:::tip
+这个选项同样会影响 Rsbuild 的浏览器端日志输出。你可以通过 [client.logLevel](/config/dev/client#loglevel) 选项对该行为进行覆盖。
+:::
+
 ## 示例
 
 将 `logLevel` 配置为 `warn` 后，Rsbuild 只会输出 `warn` 和 `error` 级别的日志：


### PR DESCRIPTION
## Summary

- Update zh documentation for `client.logLevel`
- Add tip about browser log level inheritance in `logLevel` config

## Related Links

- https://github.com/web-infra-dev/rsbuild/pull/6712

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
