### PR TITLE
fix: throw when no free port is found

### DIFF
--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -296,6 +296,14 @@ export const getPort = async ({
     }
   }
 
+  if (!found) {
+    throw new Error(
+      `${color.dim('[rsbuild:server]')} Failed to find an available port after ${
+        tryLimits + 1
+      } attempts, starting from ${color.yellow(original)}.`,
+    );
+  }
+
   if (port !== original) {
     if (strictPort) {
       throw new Error(


### PR DESCRIPTION
## Summary
- throw an explicit error if getPort cannot locate an available port instead of returning an unavailable value

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69343394a7c08327a712624f5cd82650)