### PR TITLE
docs: add reconnect option for dev client config

### DIFF
--- a/website/docs/en/config/dev/client.mdx
+++ b/website/docs/en/config/dev/client.mdx
@@ -137,6 +137,28 @@ Optional values:
 - `'error'` - Shows only errors.
 - `'silent'` - Suppresses all Rsbuild client logs.
 
+### reconnect
+
+- **Type:** `number`
+- **Default:** `100`
+
+Controls the maximum number of automatic reconnection attempts after the WebSocket connection is disconnected.
+
+When the connection is lost, Rsbuild will retry the connection at increasing time intervals. Once the maximum number of attempts is reached, it will stop reconnecting. After a successful reconnection, HMR and related features will be restored automatically.
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      // Retry up to 3 times
+      reconnect: 3,
+    },
+  },
+};
+```
+
+Setting this value to `0` disables automatic reconnection. In this case, the connection can only be restored by manually refreshing the page.
+
 ## Version history
 
 | Version | Changes                 |

--- a/website/docs/zh/config/dev/client.mdx
+++ b/website/docs/zh/config/dev/client.mdx
@@ -133,6 +133,28 @@ export default {
 - `'error'` - 仅显示错误
 - `'silent'` - 不显示任何 Rsbuild 客户端日志
 
+### reconnect
+
+- **类型：** `number`
+- **默认值：** `100`
+
+用于控制 WebSocket 连接断开后的最大自动重连次数。
+
+当连接中断时，Rsbuild 会按递增的时间间隔进行重连尝试。达到最大次数后将停止重连。重连成功后，HMR 和相关功能会自动恢复。
+
+```ts title="rsbuild.config.ts"
+export default {
+  dev: {
+    client: {
+      // 最多自动重连 3 次
+      reconnect: 3,
+    },
+  },
+};
+```
+
+将该值设为 `0` 可禁用自动重连，此时连接断开后只能通过手动刷新页面恢复。
+
 ## 版本历史
 
 | 版本    | 更新内容             |


### PR DESCRIPTION
## Summary

Add documentation for the `reconnect` option in dev client configuration, which controls WebSocket reconnection attempts during development.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [x] Documentation updated (or not required).
