### PR TITLE
fix(plugin-svgr): disable React refresh for transformed SVG

### DIFF
--- a/packages/plugin-svgr/src/index.ts
+++ b/packages/plugin-svgr/src/index.ts
@@ -284,12 +284,27 @@ export const pluginSvgr = (options: PluginSvgrOptions = {}): RsbuildPlugin => ({
             continue;
           }
 
+          let loaderOptions = use.get('options');
+
+          // disable React refresh runtime for SVGR transformed components
+          if (jsUseId === CHAIN_ID.USE.SWC) {
+            loaderOptions = deepmerge(loaderOptions, {
+              jsc: {
+                transform: {
+                  react: {
+                    refresh: false,
+                  },
+                },
+              },
+            });
+          }
+
           rule
             .oneOf(oneOfId)
             .use(jsUseId)
             .before(CHAIN_ID.USE.SVGR)
             .loader(use.get('loader'))
-            .options(use.get('options'));
+            .options(loaderOptions);
         }
 
         return true;

--- a/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-svgr/tests/__snapshots__/index.test.ts.snap
@@ -53,7 +53,7 @@ exports[`svgr > configure SVGR options 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -159,7 +159,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -233,7 +233,7 @@ exports[`svgr > exportType default / mixedImport false 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -338,7 +338,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -412,7 +412,7 @@ exports[`svgr > exportType default / mixedImport true 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -517,7 +517,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -591,7 +591,7 @@ exports[`svgr > exportType named / mixedImport false 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -696,7 +696,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },
@@ -770,7 +770,7 @@ exports[`svgr > exportType named / mixedImport true 1`] = `
                 "decoratorVersion": "2022-03",
                 "legacyDecorator": false,
                 "react": {
-                  "development": false,
+                  "development": true,
                   "refresh": false,
                   "runtime": "automatic",
                 },

--- a/packages/plugin-svgr/tests/index.test.ts
+++ b/packages/plugin-svgr/tests/index.test.ts
@@ -57,6 +57,7 @@ describe('svgr', () => {
     const rsbuild = await createRsbuild({
       cwd: import.meta.dirname,
       config: {
+        mode: 'development',
         plugins: [pluginSvgr(item.pluginConfig), pluginReact()],
       },
     });


### PR DESCRIPTION
## Summary

When using SVGR with SWC, React refresh runtime can cause issues with SVG components. This change disables React refresh specifically for SVGR transformed components to prevent potential problems.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
