### PR TITLE
chore: update Rslint v0.1.4 and refactor types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.3.8",
     "@rsbuild/config": "workspace:*",
-    "@rslint/core": "^0.1.13",
+    "@rslint/core": "^0.1.14",
     "@rstest/core": "^0.7.0",
     "@scripts/test-helper": "workspace:*",
     "@types/node": "^24.10.1",

--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -19,12 +19,13 @@ import type {
   Rspack,
 } from '../types';
 
-type SizeMap = {
-  [fileName: string]: {
+type SizeMap = Record<
+  string,
+  {
     size: number;
     gzippedSize?: number;
-  };
-};
+  }
+>;
 
 type SizeSnapshot = {
   files: SizeMap;
@@ -32,9 +33,7 @@ type SizeSnapshot = {
   totalGzipSize: number;
 };
 
-type SizeSnapshots = {
-  [environmentName: string]: SizeSnapshot;
-};
+type SizeSnapshots = Record<string, SizeSnapshot>;
 
 type FormattedAsset = {
   name: string;

--- a/packages/core/src/provider/createCompiler.ts
+++ b/packages/core/src/provider/createCompiler.ts
@@ -126,7 +126,7 @@ export async function createCompiler(options: InitConfigsOptions): Promise<{
     }
   };
 
-  const lazyModules: Set<string> = new Set();
+  const lazyModules = new Set<string>();
 
   // Collect lazy compiled modules from the infrastructure logs
   compiler.hooks.infrastructureLog.tap(HOOK_NAME, (name, _, args) => {

--- a/packages/core/src/server/environment.ts
+++ b/packages/core/src/server/environment.ts
@@ -102,12 +102,7 @@ export const createCacheableFunction = <T>(
     utils: ServerUtils,
   ) => Promise<T> | T,
 ) => {
-  const cache = new WeakMap<
-    Rspack.Stats,
-    {
-      [entryName: string]: T;
-    }
-  >();
+  const cache = new WeakMap<Rspack.Stats, Record<string, T>>();
 
   return async (
     stats: Rspack.Stats,

--- a/packages/core/src/server/helper.ts
+++ b/packages/core/src/server/helper.ts
@@ -349,7 +349,7 @@ export const getServerConfig = async ({
 
 const getIpv4Interfaces = () => {
   const interfaces = os.networkInterfaces();
-  const ipv4Interfaces: Map<string, os.NetworkInterfaceInfo> = new Map();
+  const ipv4Interfaces = new Map<string, os.NetworkInterfaceInfo>();
 
   for (const key of Object.keys(interfaces)) {
     for (const detail of interfaces[key]!) {

--- a/packages/core/src/server/socketServer.ts
+++ b/packages/core/src/server/socketServer.ts
@@ -75,21 +75,21 @@ const parseQueryString = (req: IncomingMessage) => {
 export class SocketServer {
   private wsServer!: Ws.Server;
 
-  private readonly socketsMap: Map<string, Set<Ws>> = new Map();
+  private readonly socketsMap = new Map<string, Set<Ws>>();
 
   private readonly options: DevConfig;
 
   private readonly context: InternalContext;
 
-  private initialChunksMap: Map<string, Set<string>> = new Map();
+  private initialChunksMap = new Map<string, Set<string>>();
 
   private heartbeatTimer: NodeJS.Timeout | null = null;
 
   private getOutputFileSystem: () => Rspack.OutputFileSystem;
 
-  private reportedBrowserLogs: Set<string> = new Set();
+  private reportedBrowserLogs = new Set<string>();
 
-  private currentHash: Map<string, string> = new Map();
+  private currentHash = new Map<string, string>();
 
   constructor(
     context: InternalContext,
@@ -408,7 +408,7 @@ export class SocketServer {
     // web-infra-dev/rspack#6633
     // when initial-chunks change, reload the page
     // e.g: ['index.js'] -> ['index.js', 'lib-polyfill.js']
-    const newInitialChunks: Set<string> = new Set();
+    const newInitialChunks = new Set<string>();
     if (stats.entrypoints) {
       for (const entrypoint of Object.values(stats.entrypoints)) {
         const { chunks } = entrypoint;

--- a/packages/core/src/server/watchFiles.ts
+++ b/packages/core/src/server/watchFiles.ts
@@ -125,7 +125,7 @@ export async function createChokidar(
 ): Promise<FSWatcher> {
   const chokidar = requireCompiledPackage('chokidar');
 
-  const watchFiles: Set<string> = new Set();
+  const watchFiles = new Set<string>();
 
   const globPatterns = pathOrGlobs.filter((pathOrGlob) => {
     if (isGlob(pathOrGlob)) {

--- a/packages/core/src/types/config.ts
+++ b/packages/core/src/types/config.ts
@@ -1184,9 +1184,7 @@ export type ManifestData = {
   /**
    * Maps each entry name to its associated output files.
    */
-  entries: {
-    [entryName: string]: ManifestByEntry;
-  };
+  entries: Record<string, ManifestByEntry>;
   /**
    * Subresource Integrity (SRI) hashes for emitted assets.
    * The key is the asset file path, and the value is its integrity hash.
@@ -1733,8 +1731,9 @@ export type ProgressBarConfig = {
 
 export type RequestHandler = Connect.NextHandleFunction;
 
-export type EnvironmentAPI = {
-  [name: string]: {
+export type EnvironmentAPI = Record<
+  string,
+  {
     /**
      * Get stats info about current environment.
      */
@@ -1757,8 +1756,8 @@ export type EnvironmentAPI = {
      * Provides some context information about the current environment
      */
     context: EnvironmentContext;
-  };
-};
+  }
+>;
 
 export type SetupMiddlewaresContext = Pick<
   RsbuildDevServer,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,8 +1,8 @@
-export * from './config';
-export * from './context';
-export * from './hooks';
-export * from './plugin';
-export * from './rsbuild';
-export * from './rspack';
-export * from './thirdParty';
-export * from './utils';
+export type * from './config';
+export type * from './context';
+export type * from './hooks';
+export type * from './plugin';
+export type * from './rsbuild';
+export type * from './rspack';
+export type * from './thirdParty';
+export type * from './utils';

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -199,6 +199,7 @@ export type PluginManager = Pick<
 };
 
 export type RsbuildPluginApplyFn = (
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   this: void,
   /**
    * The original Rsbuild configuration object (before plugin processing)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: workspace:*
         version: link:scripts/config
       '@rslint/core':
-        specifier: ^0.1.13
-        version: 0.1.13
+        specifier: ^0.1.14
+        version: 0.1.14
       '@rstest/core':
         specifier: ^0.7.0
         version: 0.7.0
@@ -2333,37 +2333,37 @@ packages:
       typescript:
         optional: true
 
-  '@rslint/core@0.1.13':
-    resolution: {integrity: sha512-4K/5/aZFS4sz4fZ2hdNFFLTwgpnxTkaDo1vC+fBltDMe9G0Jp0ELhesM1nbYPa3f+JsN8xE8BU8XseJjW6igYQ==}
+  '@rslint/core@0.1.14':
+    resolution: {integrity: sha512-rT69n4xtqZMUYu9cjNBH4esmstUqKGsURh2IcTurXrZRKqiXgpT9j1PwTh59cnfj2tf9MzPKzh74fAdxe7a/Vw==}
     hasBin: true
 
-  '@rslint/darwin-arm64@0.1.13':
-    resolution: {integrity: sha512-UpZWLD6B9pZ+uXjZ0i+nkXbZKHPatd/6FNroF7q6qRSnFdix+moxaqgzhHg+9Eq4rnVc7aL1VmduRTh40bH7xg==}
+  '@rslint/darwin-arm64@0.1.14':
+    resolution: {integrity: sha512-YkRlGwudeDPTurYHVMXZbLrZv/GN/9gKm2oLCGSvI+oSjS+iwUGGnuqgdXbS9LzpO3tiKa+TZQ0sDkS8WRjf/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rslint/darwin-x64@0.1.13':
-    resolution: {integrity: sha512-o9BocB82RglcoI0Cnz3Stx5SdBTzjZb3ZY+EFcsom4RTEna2QVlQhG4Y5NogicfzPJvudvnl2RREPuNuWiBTpw==}
+  '@rslint/darwin-x64@0.1.14':
+    resolution: {integrity: sha512-+efbAUcm9sVeNmM8J8laS+rrcBg/FAie+otoiEhM2n6i6P/u7sVdLAkkmhpv1M6Br+x7y61UqOcRj4savftB3A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rslint/linux-arm64@0.1.13':
-    resolution: {integrity: sha512-4vBIDkFS9e1239VNbwWe5c35D9pxM0RrxXidVV2jmv2/O0kOrcKdx0m+n6RiD/0EHfboe8dUd2AleRQpHiDZqQ==}
+  '@rslint/linux-arm64@0.1.14':
+    resolution: {integrity: sha512-CY4wa4VN+ZrWDWYXIZezOGuzHDpWOgugpoRDIVRMrvT3dev+gmgoq6B8c2wVddK0WsMJGb3S65CixNe3CL5AXA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rslint/linux-x64@0.1.13':
-    resolution: {integrity: sha512-HQG/GeN5YggyPUJIvdbVrIqSiiR/X+NSKSCpw719Ttbl9Vw6juk4tUskCjIDVgl5lhpfiqArn4gVT4EPNSd7XQ==}
+  '@rslint/linux-x64@0.1.14':
+    resolution: {integrity: sha512-jggaHv29dVAOfRJ6uNuu5VYz9o4V5BLQGQtriZ+t9yitqraFTMerGZ4YPZUYJnvGaLuJzABWPY+MKvwTwViiwQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rslint/win32-arm64@0.1.13':
-    resolution: {integrity: sha512-oxfgWQMePJ6QjhG1Q7M527D2neunbuUpYy/HFDS8kdhTYPuHRsMUG2I5eIkdoumBC36FuGWKRaKJBZuKfWwskg==}
+  '@rslint/win32-arm64@0.1.14':
+    resolution: {integrity: sha512-2g5C7Ag9ZDPGxSGupxqu4F52mWgAxaBLe+BHnrdWOoIliwX1Gf6DKbEB3yniEb+OYYuJa0YxB73pvfCno0G+Jw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rslint/win32-x64@0.1.13':
-    resolution: {integrity: sha512-fxUw0sYpuy+Op1096/zddo4fqNBOC//NOp3c85uiLie3SMyQ3HtPp4dnW7e9CLmc6EcXr24fMkQI0BEHHpN7Ow==}
+  '@rslint/win32-x64@0.1.14':
+    resolution: {integrity: sha512-PeHSLSyrwfq8RSwBSL9d8CfbyiuvOunYeIcHV/wHf0bAtqZjWEPlvMl5e11HzHzQPEfB1UiyQCkguzoVtC0qwQ==}
     cpu: [x64]
     os: [win32]
 
@@ -7843,31 +7843,31 @@ snapshots:
     transitivePeerDependencies:
       - '@typescript/native-preview'
 
-  '@rslint/core@0.1.13':
+  '@rslint/core@0.1.14':
     optionalDependencies:
-      '@rslint/darwin-arm64': 0.1.13
-      '@rslint/darwin-x64': 0.1.13
-      '@rslint/linux-arm64': 0.1.13
-      '@rslint/linux-x64': 0.1.13
-      '@rslint/win32-arm64': 0.1.13
-      '@rslint/win32-x64': 0.1.13
+      '@rslint/darwin-arm64': 0.1.14
+      '@rslint/darwin-x64': 0.1.14
+      '@rslint/linux-arm64': 0.1.14
+      '@rslint/linux-x64': 0.1.14
+      '@rslint/win32-arm64': 0.1.14
+      '@rslint/win32-x64': 0.1.14
 
-  '@rslint/darwin-arm64@0.1.13':
+  '@rslint/darwin-arm64@0.1.14':
     optional: true
 
-  '@rslint/darwin-x64@0.1.13':
+  '@rslint/darwin-x64@0.1.14':
     optional: true
 
-  '@rslint/linux-arm64@0.1.13':
+  '@rslint/linux-arm64@0.1.14':
     optional: true
 
-  '@rslint/linux-x64@0.1.13':
+  '@rslint/linux-x64@0.1.14':
     optional: true
 
-  '@rslint/win32-arm64@0.1.13':
+  '@rslint/win32-arm64@0.1.14':
     optional: true
 
-  '@rslint/win32-x64@0.1.13':
+  '@rslint/win32-x64@0.1.14':
     optional: true
 
   '@rspack-canary/binding-darwin-arm64@1.6.7-canary-63b4dae2-20251204065915':

--- a/rslint.json
+++ b/rslint.json
@@ -38,7 +38,12 @@
       "@typescript-eslint/no-implied-eval": "off",
       "@typescript-eslint/prefer-promise-reject-errors": "off",
       "@typescript-eslint/no-empty-function": "off",
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/consistent-type-definitions": "off",
+      "@typescript-eslint/ban-ts-comment": "off",
+      "@typescript-eslint/consistent-type-imports": "off",
+      "@typescript-eslint/consistent-return": "off",
+      "@typescript-eslint/consistent-generic-constructors": "off"
     }
   }
 ]


### PR DESCRIPTION
## Summary

- update @rslint/core to v0.1.14
- refactor type declarations to use Record and type exports
- simplify Set and Map type annotations
- disable some new rules

## Related Links

- https://github.com/web-infra-dev/rslint/releases/tag/v0.1.14

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
