### PR TITLE
fix: use proper API to preserve source maps of inlined chunks

### DIFF
--- a/packages/core/src/plugins/inlineChunk.ts
+++ b/packages/core/src/plugins/inlineChunk.ts
@@ -250,16 +250,17 @@ export const pluginInlineChunk = (): RsbuildPlugin => ({
 
         const { devtool } = compiler.options;
 
+        const hasSourceMap =
+          devtool !== 'hidden-source-map' && devtool !== false;
         for (const name of inlinedAssets) {
-          // If the source map reference is removed,
-          // we do not need to preserve the source map of inlined files
-          if (devtool === 'hidden-source-map' || devtool === false) {
-            compilation.deleteAsset(name);
-          } else {
-            // use delete instead of compilation.deleteAsset
-            // because we want to preserve the related files such as source map
-            delete compilation.assets[name];
+          // Preserve source maps of inlined assets. Setting `related.sourceMap` to `null` prevents
+          // `deleteAsset` from removing the source map file.
+          if (hasSourceMap) {
+            compilation.updateAsset(name, compilation.assets[name], {
+              related: { sourceMap: null },
+            });
           }
+          compilation.deleteAsset(name);
         }
 
         inlinedAssets.clear();


### PR DESCRIPTION
## Summary

Use `updateAsset` to preserve source maps of inlined chunks.

Calling `compilation.deleteAsset(name)` is not recommended and may lead to unexpected behavior.

## Related Links

- https://github.com/web-infra-dev/rspack/blob/main/tests/rspack-test/configCases/assets/prevent-related-deletion/rspack.config.js

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
