### PR TITLE
test(e2e): fix flaky cache directory tests

### DIFF
--- a/e2e/cases/cache/cache-directory/index.test.ts
+++ b/e2e/cases/cache/cache-directory/index.test.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { expect, test } from '@e2e/helper';
+import { expect, expectFile, test } from '@e2e/helper';
 import fse from 'fs-extra';
 
 const cacheDirectory = path.resolve(
@@ -31,7 +31,7 @@ test('should use `buildCache.cacheDirectory` as expected in dev', async ({
     },
   });
 
-  expect(fs.existsSync(customDirectory)).toBeTruthy();
+  await expectFile(customDirectory);
   expect(fs.existsSync(cacheDirectory)).toBeFalsy();
 });
 
@@ -54,6 +54,6 @@ test('should use `buildCache.cacheDirectory` as expected in build', async ({
     },
   });
 
-  expect(fs.existsSync(customDirectory)).toBeTruthy();
+  await expectFile(customDirectory);
   expect(fs.existsSync(cacheDirectory)).toBeFalsy();
 });


### PR DESCRIPTION
## Summary

Refactor tests to use separate paths for dev/build. Clean up test setup by removing directories in beforeAll hook.

Fix:

<img width="1122" height="143" alt="Screenshot 2025-12-09 at 13 20 16" src="https://github.com/user-attachments/assets/25d25981-9f03-4b93-a3a5-7b01cdd8487c" />

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
