### PR TITLE
chore: update create-rstack to 1.7.14 and quick start doc

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -29,7 +29,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "create-rstack": "1.7.13"
+    "create-rstack": "1.7.14"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,8 +763,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.7.13
-        version: 1.7.13
+        specifier: 1.7.14
+        version: 1.7.14
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3634,8 +3634,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.7.13:
-    resolution: {integrity: sha512-0u+7yjecV7dlZMeqmAc5q1LAT5EwIW6sYDlu/TebMxusJDzBP+J94dvTKk+glz6yS1W4kBcyEhCERGSpMpRL+A==}
+  create-rstack@1.7.14:
+    resolution: {integrity: sha512-AN8oqOIoa+KCMdzTgoSqhafanQZopjNbiaaG9EdNJd67mhuCRfFr5e1JUJ1l5X+EJDb18D0gzz+pYPZbOWDiKg==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9270,7 +9270,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-rstack@1.7.13: {}
+  create-rstack@1.7.14: {}
 
   cron-parser@4.9.0:
     dependencies:

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -113,7 +113,7 @@ npx -y create-rsbuild@latest my-app --template react
 npx -y create-rsbuild@latest my-app -t react
 
 # Specify multiple tools
-npx -y create-rsbuild@latest my-app -t react --tools eslint --tools prettier
+npx -y create-rsbuild@latest my-app -t react --tools eslint,prettier
 ```
 
 All CLI flags supported by `create-rsbuild`:
@@ -126,7 +126,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
-  --tools <tool>        select additional tools (biome, eslint, prettier)
+  --tools <tool>        select additional tools (biome, eslint, prettier, storybook)
   --override            override files in target directory
   --packageName <name>  specify the package name
 

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -113,7 +113,7 @@ npx -y create-rsbuild --dir my-app --template react
 npx -y create-rsbuild -d my-app -t react
 
 # 指定多个 tools
-npx -y create-rsbuild -d my-app -t react --tools eslint --tools prettier
+npx -y create-rsbuild -d my-app -t react --tools eslint,prettier
 ```
 
 `create-rsbuild` 完整的 CLI 选项如下：
@@ -126,7 +126,7 @@ Options:
   -h, --help            display help for command
   -d, --dir <dir>       create project in specified directory
   -t, --template <tpl>  specify the template to use
-  --tools <tool>        select additional tools (biome, eslint, prettier)
+  --tools <tool>        select additional tools (biome, eslint, prettier, storybook)
   --override            override files in target directory
   --packageName <name>  specify the package name
 


### PR DESCRIPTION
## Summary

- Bump create-rstack dependency from 1.7.13 to 1.7.14
- Change tools flag syntax from multiple `--tools` flags to comma-separated list
- Add storybook to available tools list in documentation

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.14

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
