### PR TITLE
fix: include env in app icon cache key

### DIFF
--- a/packages/core/src/plugins/appIcon.ts
+++ b/packages/core/src/plugins/appIcon.ts
@@ -37,7 +37,8 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
       lookup: (extension: string) => string | undefined,
     ): AppIconItem & IconExtra => {
       const { src, size } = icon;
-      const cached = iconFormatMap.get(src);
+      const cacheKey = `${distDir}|${publicPath}|${src}`;
+      const cached = iconFormatMap.get(cacheKey);
 
       if (cached) {
         return cached;
@@ -54,7 +55,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
           mimeType: lookup(src),
         };
 
-        iconFormatMap.set(src, formatted);
+        iconFormatMap.set(cacheKey, formatted);
         return formatted;
       }
 
@@ -76,7 +77,7 @@ export const pluginAppIcon = (): RsbuildPlugin => ({
         mimeType: lookup(absolutePath),
       };
 
-      iconFormatMap.set(src, formatted);
+      iconFormatMap.set(cacheKey, formatted);
       return formatted;
     };
 


### PR DESCRIPTION
## Summary
- include public path and dist directory in app icon cache keys to avoid stale URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938b662780c83279299b82873430764)