### PR TITLE
fix(fileSize): simplify gzip size coloring

### DIFF
--- a/packages/core/src/plugins/fileSize.ts
+++ b/packages/core/src/plugins/fileSize.ts
@@ -124,7 +124,7 @@ const getAssetColor = (size: number) => {
   if (size > 100 * 1000) {
     return color.yellow;
   }
-  return color.green;
+  return (input: string) => input;
 };
 
 function getHeader(


### PR DESCRIPTION
## Summary

Remove default green color from gzip size and only mark oversized bundles in red or yellow.

This reduces visual noise and focus on real size changes.

### Before

<img width="777" height="135" alt="Screenshot 2025-12-10 at 22 30 07" src="https://github.com/user-attachments/assets/efc70047-49d3-45cf-aaf2-68228a4bc12b" />

### After

<img width="777" height="122" alt="Screenshot 2025-12-10 at 22 30 59" src="https://github.com/user-attachments/assets/c59b5e2d-0be3-4ec8-a2c9-b4fe6fe4cdd4" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
