### PR TITLE
docs: refine asset prefix guidance

### DIFF
--- a/website/docs/en/config/dev/asset-prefix.mdx
+++ b/website/docs/en/config/dev/asset-prefix.mdx
@@ -5,7 +5,7 @@
 
 Set the URL prefix of static assets in [development mode](/config/mode).
 
-`assetPrefix` will affect the URLs of most of the static assets, including JavaScript files, CSS files, images, videos, etc. If an incorrect value is specified, you'll receive 404 errors while loading these resources.
+`assetPrefix` affects most static asset URLs, including JavaScript files, CSS files, images, videos, etc. If it is set incorrectly, these resources may return 404 errors.
 
 This config is only used in `development` mode. In `production` mode or `none` mode, use [output.assetPrefix](/config/output/asset-prefix) to configure the URL prefix.
 
@@ -15,7 +15,7 @@ The default value of `dev.assetPrefix` is the same as [server.base](/config/serv
 
 When `server.base` is `/foo`, `index.html` and other static assets can be accessed through `http://localhost:3000/foo/`.
 
-It should be noted that when customizing the `dev.assetPrefix` option, if you want static assets to be normally accessible through the Rsbuild dev server, `dev.assetPrefix` should contain the same URL prefix as `server.base`. For example:
+When you customize `dev.assetPrefix`, keep its URL prefix consistent with `server.base` so assets stay accessible through the Rsbuild dev server. For example:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -103,9 +103,9 @@ export default {
 
 ## Path types
 
-assetPrefix can be set to the following types of paths:
+The `assetPrefix` option accepts the following path types:
 
-- **absolute path**: This is the most common practice, can be specific server paths, like `/assets/`.
+- **absolute path**: The most common choice, including specific server paths like `/assets/`.
 - **'auto'**: Rspack will automatically calculate the path and generate relative paths based on file location.
 
 :::tip

--- a/website/docs/en/config/output/asset-prefix.mdx
+++ b/website/docs/en/config/output/asset-prefix.mdx
@@ -5,7 +5,7 @@
 
 In [production mode](/config/mode), use this option to configure the URL prefix for static assets, such as a CDN URL.
 
-`assetPrefix` affects the URLs of most static assets, including JavaScript files, CSS files, images, videos, etc. If an incorrect value is specified, you'll receive 404 errors while loading these resources.
+`assetPrefix` affects the URLs of most static assets, including JavaScript files, CSS files, images, videos, etc. If it is set incorrectly, these resources may return 404 errors.
 
 This configuration is only used in `production` mode or `none` mode. In `development` mode, use [dev.assetPrefix](/config/dev/asset-prefix) to configure the URL prefix.
 
@@ -54,7 +54,7 @@ The default value of `output.assetPrefix` is the same as [server.base](/config/s
 
 When `server.base` is `/foo`, `index.html` and static assets can be accessed through `http://localhost:3000/foo/`.
 
-It should be noted that when customizing the `output.assetPrefix` option, if you want static assets to be accessible normally during [Rsbuild preview](/guide/basic/cli#rsbuild-preview), `output.assetPrefix` should contain the same URL prefix as `server.base`. For example:
+When you customize `output.assetPrefix`, keep its URL prefix consistent with `server.base` so assets load correctly during [Rsbuild preview](/guide/basic/cli#rsbuild-preview). For example:
 
 ```ts title="rsbuild.config.ts"
 export default {
@@ -69,9 +69,9 @@ export default {
 
 ## Path types
 
-assetPrefix can be set to the following types of paths:
+The `assetPrefix` option accepts the following path types:
 
-- **absolute path**: This is the most common practice, which can be specific server paths like `/assets/`, or CDN paths like `https://cdn.example.com/assets/`.
+- **absolute path**: The most common choice, including specific server paths like `/assets/` or CDN paths like `https://cdn.example.com/assets/`.
 - **relative path**: For example, `./assets/`.
 - **'auto'**: Rspack will automatically calculate the path and generate relative paths based on file location.
 

--- a/website/docs/en/plugins/dev/core.mdx
+++ b/website/docs/en/plugins/dev/core.mdx
@@ -186,7 +186,7 @@ const pluginBar = {
 
 For example, if you register both the Foo and Bar plugins mentioned above, the Foo plugin will not take effect because the Bar plugin declares the removal of the Foo plugin.
 
-It should be noted that if the current plugin is registered as a [specific environment plugin](/guide/advanced/environments#add-plugins-for-specified-environment), only the removal of plugins in the same environment is supported, and global plugins cannot be removed.
+If the current plugin is registered as a [specific environment plugin](/guide/advanced/environments#add-plugins-for-specified-environment), you can only remove plugins in that environment; global plugins remain in place.
 
 ## api.context
 


### PR DESCRIPTION
## Summary
- clarify assetPrefix behavior and alignment with server.base in production and development docs
- improve wording for supported assetPrefix path types
- clarify plugin removal limits for environment-specific plugins

## Testing
- not run (docs changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ad3ee2ebc83278d4759017e9a109a)