### PR TITLE
feat(create-rsbuild): improve tools descriptions

### DIFF
--- a/packages/create-rsbuild/package.json
+++ b/packages/create-rsbuild/package.json
@@ -29,7 +29,7 @@
     "bump": "pnpx bumpp --no-tag"
   },
   "dependencies": {
-    "create-rstack": "1.7.17"
+    "create-rstack": "1.7.19"
   },
   "devDependencies": {
     "@rsbuild/core": "workspace:*",

--- a/packages/create-rsbuild/src/index.ts
+++ b/packages/create-rsbuild/src/index.ts
@@ -118,16 +118,11 @@ create({
   mapESLintTemplate,
   extraTools: [
     {
-      value: 'storybook',
-      label: 'Add Storybook for component development',
-      command: 'npm create storybook@latest -- --skip-install --features docs',
-    },
-    {
       value: 'rstest',
-      label: 'Add Rstest for unit testing',
+      label: 'Rstest - testing',
+      order: 'pre',
       action: ({ templateName, distFolder, addAgentsMdSearchDirs }) => {
         const rstestTemplate = mapRstestTemplate(templateName);
-
         const toolFolder = path.join(__dirname, '..', 'template-rstest');
         const subFolder = path.join(toolFolder, rstestTemplate);
 
@@ -136,9 +131,13 @@ create({
           to: distFolder,
           isMergePackageJson: true,
         });
-
         addAgentsMdSearchDirs(toolFolder);
       },
+    },
+    {
+      value: 'storybook',
+      label: 'Storybook - component development',
+      command: 'npm create storybook@latest -- --skip-install --features docs',
     },
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -763,8 +763,8 @@ importers:
   packages/create-rsbuild:
     dependencies:
       create-rstack:
-        specifier: 1.7.17
-        version: 1.7.17
+        specifier: 1.7.19
+        version: 1.7.19
     devDependencies:
       '@rsbuild/core':
         specifier: workspace:*
@@ -3695,8 +3695,8 @@ packages:
       typescript:
         optional: true
 
-  create-rstack@1.7.17:
-    resolution: {integrity: sha512-sW9GQ3tsFjK5m9UZWDNd3t+Ck7/ps/QEpiiAYDEA3VpQB3uYVnXYm/G/+SnHcaZczMp3uQpXVq00cynU4JHdLw==}
+  create-rstack@1.7.19:
+    resolution: {integrity: sha512-zPRcwIWuGQ7wE7J+TAjWLlAKeGgAVQ6Ps0LCWa6L4sSPKm2KB9JtQHZuKltP91W5NS0qz5ScYIIaDa/bh09kRg==}
 
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
@@ -9384,7 +9384,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  create-rstack@1.7.17: {}
+  create-rstack@1.7.19: {}
 
   cron-parser@4.9.0:
     dependencies:


### PR DESCRIPTION
## Summary

* Upgraded the `create-rstack` dependency from `1.7.17` to `1.7.19`
* Improved tools descriptions and order

### Before

<img width="740" height="167" alt="Screenshot 2025-12-13 at 12 39 25" src="https://github.com/user-attachments/assets/735a23fc-1af2-4770-be5a-f3f133331d13" />

### After

<img width="739" height="159" alt="Screenshot 2025-12-13 at 12 55 46" src="https://github.com/user-attachments/assets/e0ff088f-778e-462a-ba3a-8c22e45c5837" />

## Related Links

- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.18
- https://github.com/rspack-contrib/create-rstack/releases/tag/v1.7.19

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
