### PR TITLE
docs: add documentation link to rstest config file

### DIFF
--- a/packages/create-rsbuild/template-rstest/react-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/react-js/rstest.config.js
@@ -1,6 +1,7 @@
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
   testEnvironment: 'jsdom',

--- a/packages/create-rsbuild/template-rstest/react-js/tests/index.test.jsx
+++ b/packages/create-rsbuild/template-rstest/react-js/tests/index.test.jsx
@@ -2,7 +2,7 @@ import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/react';
 import App from '../src/App';
 
-test('Renders the main page', () => {
+test('renders the main page', () => {
   const testMessage = 'Rsbuild with React';
   render(<App />);
   expect(screen.getByText(testMessage)).toBeInTheDocument();

--- a/packages/create-rsbuild/template-rstest/react-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/react-ts/rstest.config.ts
@@ -1,6 +1,7 @@
 import { pluginReact } from '@rsbuild/plugin-react';
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [pluginReact()],
   testEnvironment: 'jsdom',

--- a/packages/create-rsbuild/template-rstest/react-ts/tests/index.test.tsx
+++ b/packages/create-rsbuild/template-rstest/react-ts/tests/index.test.tsx
@@ -2,7 +2,7 @@ import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/react';
 import App from '../src/App';
 
-test('Renders the main page', () => {
+test('renders the main page', () => {
   const testMessage = 'Rsbuild with React';
   render(<App />);
   expect(screen.getByText(testMessage)).toBeInTheDocument();

--- a/packages/create-rsbuild/template-rstest/vanilla-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/vanilla-js/rstest.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   testEnvironment: 'jsdom',
   setupFiles: ['./rstest.setup.js'],

--- a/packages/create-rsbuild/template-rstest/vanilla-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/vanilla-ts/rstest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   testEnvironment: 'jsdom',
   setupFiles: ['./rstest.setup.ts'],

--- a/packages/create-rsbuild/template-rstest/vue-js/rstest.config.js
+++ b/packages/create-rsbuild/template-rstest/vue-js/rstest.config.js
@@ -1,6 +1,7 @@
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [
     pluginVue({

--- a/packages/create-rsbuild/template-rstest/vue-js/tests/index.test.js
+++ b/packages/create-rsbuild/template-rstest/vue-js/tests/index.test.js
@@ -2,7 +2,7 @@ import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/vue';
 import App from '../src/App.vue';
 
-test('Renders the main page', () => {
+test('renders the main page', () => {
   const testMessage = 'Rsbuild with Vue';
   render(App);
   expect(screen.getByText(testMessage)).toBeInTheDocument();

--- a/packages/create-rsbuild/template-rstest/vue-ts/rstest.config.ts
+++ b/packages/create-rsbuild/template-rstest/vue-ts/rstest.config.ts
@@ -1,6 +1,7 @@
 import { pluginVue } from '@rsbuild/plugin-vue';
 import { defineConfig } from '@rstest/core';
 
+// Docs: https://rstest.rs/config/
 export default defineConfig({
   plugins: [
     pluginVue({

--- a/packages/create-rsbuild/template-rstest/vue-ts/tests/index.test.ts
+++ b/packages/create-rsbuild/template-rstest/vue-ts/tests/index.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@rstest/core';
 import { render, screen } from '@testing-library/vue';
 import App from '../src/App.vue';
 
-test('Renders the main page', () => {
+test('renders the main page', () => {
   const testMessage = 'Rsbuild with Vue';
   render(App);
   expect(screen.getByText(testMessage)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Added a documentation comment with a link to the configuration docs at the top of each `rstest.config` file across all template projects.

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
